### PR TITLE
feat: change default listen to IPv4 and add panic recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10085,6 +10085,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tokio",

--- a/crates/utils/src/net.rs
+++ b/crates/utils/src/net.rs
@@ -18,10 +18,11 @@ use futures::{Stream, StreamExt};
 use hyper::client::conn::http2::Builder;
 use hyper_util::rt::TokioExecutor;
 use lazy_static::lazy_static;
+use std::net::Ipv4Addr;
 use std::{
     collections::HashSet,
     fmt::Display,
-    net::{IpAddr, Ipv6Addr, SocketAddr, TcpListener, ToSocketAddrs},
+    net::{IpAddr, SocketAddr, TcpListener, ToSocketAddrs},
 };
 use transform_stream::AsyncTryStream;
 use url::{Host, Url};
@@ -201,7 +202,7 @@ pub fn parse_and_resolve_address(addr_str: &str) -> std::io::Result<SocketAddr> 
         } else {
             port
         };
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), final_port)
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), final_port)
     } else {
         let mut addr = check_local_server_addr(addr_str)?; // assume check_local_server_addr is available here
         if addr.port() == 0 {
@@ -477,12 +478,12 @@ mod test {
     fn test_parse_and_resolve_address() {
         // Test port-only format
         let result = parse_and_resolve_address(":8080").unwrap();
-        assert_eq!(result.ip(), IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(result.ip(), IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
         assert_eq!(result.port(), 8080);
 
         // Test port-only format with port 0 (should get available port)
         let result = parse_and_resolve_address(":0").unwrap();
-        assert_eq!(result.ip(), IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(result.ip(), IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
         assert!(result.port() > 0);
 
         // Test localhost with port

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -94,6 +94,7 @@ tower-http = { workspace = true, features = [
     "compression-deflate",
     "compression-gzip",
     "cors",
+    "catch-panic",
 ] }
 urlencoding = { workspace = true }
 uuid = { workspace = true }

--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -77,6 +77,7 @@ use tokio::net::TcpListener;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio_rustls::TlsAcceptor;
 use tonic::{Request, Status, metadata::MetadataValue};
+use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{Span, debug, error, info, instrument, warn};
@@ -336,6 +337,7 @@ async fn run(opt: config::Opt) -> Result<()> {
 
         let hybrid_service = TowerToHyperService::new(
             tower::ServiceBuilder::new()
+                .layer(CatchPanicLayer::new())
                 .layer(
                     TraceLayer::new_for_http()
                         .make_span_with(|request: &HttpRequest<_>| {


### PR DESCRIPTION
# feat: change default listen to IPv4 and add panic recovery

## 📋 Changes

- Change default network listen address from IPv6 (`::`) to IPv4 (`0.0.0.0`)
- Add `CatchPanicLayer` to prevent server crashes from unhandled panics
- Enable `catch-panic` feature in `tower-http` dependencies
- Update network address parsing tests to reflect IPv4 change

## 🎯 Purpose

This change improves compatibility and stability by:
- Using IPv4 as the default listen address for better cross-platform compatibility
- Adding panic recovery middleware to handle unexpected errors gracefully
- Preventing server crashes due to unhandled panics in request processing

## 🔧 Technical Details

- Modified `crates/utils/src/net.rs` to use `Ipv4Addr::new(0, 0, 0, 0)` instead of `Ipv6Addr::UNSPECIFIED`
- Added `CatchPanicLayer` to the service stack in `rustfs/src/main.rs`
- Updated `Cargo.toml` to include `catch-panic` feature
- Updated related tests to match the new IPv4 default

## ✅ Testing

- Unit tests updated and passing
- Network address parsing tests reflect the new IPv4 default behavior