### PR TITLE
Fix: Redis Service Allows Unauthorized Privilege Escalation in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ version: '3.8'
 services:
   # RustFS main service
   rustfs:
+    security_opt:
+      - "no-new-privileges:true"
     image: rustfs/rustfs:latest
     container_name: rustfs-server
     build:


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'rustfs' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
- **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
- **Severity:** HIGH
- **File:** docker-compose.yml
- **Lines Affected:** 19 - 19

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `docker-compose.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.