### PR TITLE
fix(dockerfile): correct env variable names for access/secret key and improve compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apk add -U --no-cache \
 
 COPY --from=builder /rustfs /usr/local/bin/rustfs
 
-ENV RUSTFS_ROOT_USER=rustfsadmin \
-    RUSTFS_ROOT_PASSWORD=rustfsadmin \
+ENV RUSTFS_ACCESS_KEY=rustfsadmin \
+    RUSTFS_SECRET_KEY=rustfsadmin \
     RUSTFS_ADDRESS=":9000" \
     RUSTFS_CONSOLE_ADDRESS=":9001" \
     RUSTFS_CONSOLE_ENABLE=true \


### PR DESCRIPTION
## fix(dockerfile): correct env variable names for access/secret key and improve compatibility

### Description

- 修正了 Dockerfile 中环境变量名称错误的问题，将  和  替换为正确的  和 ，以保证自定义用户名和密码能够生效，解决了 [#81](https://github.com/rustfs/rustfs/issues/81) 中提到的无法自定义登录凭据的问题。
- 该修复保证了 Docker 镜像的环境变量与项目代码一致，提升了部署的兼容性和安全性。


### Breaking Changes

无

### Testing

- 本地构建镜像并通过自定义环境变量验证登录功能正常。
- 参考 [#81](https://github.com/rustfs/rustfs/issues/81) 相关问题已解决。

---

> 合并后可自定义用户名和密码，控制台和 API 均可正常登录。
