### PR TITLE
Feat/region

### DIFF
--- a/crates/ecstore/src/global.rs
+++ b/crates/ecstore/src/global.rs
@@ -62,7 +62,9 @@ static ref globalDeploymentIDPtr: OnceLock<Uuid> = OnceLock::new();
 pub static ref GLOBAL_BOOT_TIME: OnceCell<SystemTime> = OnceCell::new();
 pub static ref GLOBAL_LocalNodeName: String = "127.0.0.1:9000".to_string();
 pub static ref GLOBAL_LocalNodeNameHex: String = rustfs_utils::crypto::hex(GLOBAL_LocalNodeName.as_bytes());
-pub static ref GLOBAL_NodeNamesHex: HashMap<String, ()> = HashMap::new();}
+pub static ref GLOBAL_NodeNamesHex: HashMap<String, ()> = HashMap::new();
+pub static ref GLOBAL_REGION: OnceLock<String> = OnceLock::new();
+}
 
 static GLOBAL_ACTIVE_CRED: OnceLock<Credentials> = OnceLock::new();
 
@@ -182,3 +184,11 @@ pub async fn update_erasure_type(setup_type: SetupType) {
 // }
 
 type TypeLocalDiskSetDrives = Vec<Vec<Vec<Option<DiskStore>>>>;
+
+pub fn set_global_region(region: String) {
+    GLOBAL_REGION.set(region).unwrap();
+}
+
+pub fn get_global_region() -> Option<String> {
+    GLOBAL_REGION.get().cloned()
+}

--- a/rustfs/src/config/mod.rs
+++ b/rustfs/src/config/mod.rs
@@ -86,6 +86,9 @@ pub struct Opt {
 
     #[arg(long, env = "RUSTFS_LICENSE")]
     pub license: Option<String>,
+
+    #[arg(long, env = "RUSTFS_REGION")]
+    pub region: Option<String>,
 }
 
 // lazy_static::lazy_static! {

--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -174,6 +174,10 @@ async fn setup_tls_acceptor(tls_path: &str) -> Result<Option<TlsAcceptor>> {
 async fn run(opt: config::Opt) -> Result<()> {
     debug!("opt: {:?}", &opt);
 
+    if let Some(region) = opt.region {
+        rustfs_ecstore::global::set_global_region(region);
+    }
+
     let server_addr = parse_and_resolve_address(opt.address.as_str()).map_err(Error::other)?;
     let server_port = server_addr.port();
     let server_address = server_addr.to_string();

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -703,6 +703,12 @@ impl S3 for FS {
             .await
             .map_err(ApiError::from)?;
 
+        if let Some(region) = rustfs_ecstore::global::get_global_region() {
+            return Ok(S3Response::new(GetBucketLocationOutput {
+                location_constraint: Some(BucketLocationConstraint::from(region)),
+            }));
+        }
+
         let output = GetBucketLocationOutput::default();
         Ok(S3Response::new(output))
     }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -100,6 +100,8 @@ export RUSTFS_NS_SCANNER_INTERVAL=60  # 对象扫描间隔时间，单位为秒
 
 export RUSTFS_COMPRESSION_ENABLED=true # 是否启用压缩
 
+#export RUSTFS_REGION="us-east-1"
+
 # 事件消息配置
 #export RUSTFS_EVENT_CONFIG="./deploy/config/event.example.toml"
 


### PR DESCRIPTION
## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
Add region configuration support to RustFS, enabling users to specify and retrieve bucket location regions through command-line arguments or environment variables.

### Key Changes:
- **Global Region Management**: Added `GLOBAL_REGION` static variable with setter/getter functions in `ecstore/global.rs`
- **Configuration Support**: Extended `Opt` struct to accept `--region` parameter or `RUSTFS_REGION` environment variable
- **S3 API Compliance**: Implemented region return logic in `get_bucket_location()` method to properly respond with configured region
- **Runtime Integration**: Added region initialization during server startup in `main.rs`
- **Documentation**: Updated run script with region configuration example

### Files Modified:
- `crates/ecstore/src/global.rs` - Added global region state management
- `rustfs/src/config/mod.rs` - Added region configuration option
- `rustfs/src/main.rs` - Added region initialization logic
- `rustfs/src/storage/ecfs.rs` - Enhanced bucket location API response
- `scripts/run.sh` - Added region configuration example

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Code is formatted with `cargo fmt --all`
- [x] Passed `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Passed `cargo check --all-targets`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact: Enhances S3 API compliance for multi-region scenarios

## Additional Notes
This enhancement improves S3 API compatibility by allowing proper region configuration and response. The implementation follows the existing pattern of global configuration management and maintains backward compatibility - if no region is specified, the system behaves as before.

Usage examples:
```bash
# Via command line
./rustfs --region us-west-2

# Via environment variable
export RUSTFS_REGION=us-west-2
./rustfs
```

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.