### PR TITLE
fix: improve ossutil install logic in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,21 +236,36 @@ jobs:
           # Install ossutil (platform-specific)
           case "${{ matrix.platform }}" in
             linux)
-              curl -o ossutil-2.1.1-linux-amd64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-linux-amd64.zip
-              unzip ossutil-2.1.1-linux-amd64.zip
-              mv ossutil-2.1.1-linux-amd64/ossutil /usr/local/bin/
+              if [[ "$(uname -m)" == "arm64" ]]; then
+                curl -o ossutil-2.1.1-linux-arm64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-linux-arm64.zip
+                unzip ossutil-2.1.1-linux-arm64.zip
+                mv ossutil-2.1.1-linux-arm64/ossutil /usr/local/bin/
+                rm ossutil-2.1.1-linux-arm64
+                rm ossutil-2.1.1-linux-arm64.zip
+              else
+                curl -o ossutil-2.1.1-linux-amd64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-linux-amd64.zip
+                unzip ossutil-2.1.1-linux-amd64.zip
+                mv ossutil-2.1.1-linux-amd64/ossutil /usr/local/bin/
+                rm ossutil-2.1.1-linux-amd64
+                rm ossutil-2.1.1-linux-amd64.zip
+              fi
               chmod +x /usr/local/bin/ossutil
-              rm ossutil-2.1.1-linux-amd64
-              rm ossutil-2.1.1-linux-amd64.zip
-              OSSUTIL_BIN=ossutil
               ;;
             macos)
-              curl -o ossutil-2.1.1-mac-arm64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-mac-arm64.zip
-              unzip ossutil-2.1.1-mac-arm64.zip
-              mv ossutil-2.1.1-mac-arm64/ossutil /usr/local/bin/
+              if [[ "$(uname -m)" == "arm64" ]]; then
+                curl -o ossutil-2.1.1-mac-arm64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-mac-arm64.zip
+                unzip ossutil-2.1.1-mac-arm64.zip
+                mv ossutil-2.1.1-mac-arm64/ossutil /usr/local/bin/
+                rm ossutil-2.1.1-mac-arm64
+                rm ossutil-2.1.1-mac-arm64.zip
+              else
+                curl -o ossutil-2.1.1-mac-amd64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-mac-amd64.zip
+                unzip ossutil-2.1.1-mac-amd64.zip
+                mv ossutil-2.1.1-mac-amd64/ossutil /usr/local/bin/
+                rm ossutil-2.1.1-mac-amd64
+                rm ossutil-2.1.1-mac-amd64.zip
+              fi
               chmod +x /usr/local/bin/ossutil
-              rm ossutil-2.1.1-mac-arm64
-              rm ossutil-2.1.1-mac-arm64.zip
               OSSUTIL_BIN=ossutil
               ;;
             # windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,37 +234,36 @@ jobs:
           OSS_ENDPOINT: https://oss-cn-beijing.aliyuncs.com
         run: |
           # Install ossutil (platform-specific)
+          OSSUTIL_VERSION="2.1.1"
           case "${{ matrix.platform }}" in
             linux)
               if [[ "$(uname -m)" == "arm64" ]]; then
-                curl -o ossutil-2.1.1-linux-arm64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-linux-arm64.zip
-                unzip ossutil-2.1.1-linux-arm64.zip
-                mv ossutil-2.1.1-linux-arm64/ossutil /usr/local/bin/
-                rm ossutil-2.1.1-linux-arm64
-                rm ossutil-2.1.1-linux-arm64.zip
+                ARCH="arm64"
               else
-                curl -o ossutil-2.1.1-linux-amd64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-linux-amd64.zip
-                unzip ossutil-2.1.1-linux-amd64.zip
-                mv ossutil-2.1.1-linux-amd64/ossutil /usr/local/bin/
-                rm ossutil-2.1.1-linux-amd64
-                rm ossutil-2.1.1-linux-amd64.zip
+                ARCH="amd64"
               fi
+              OSSUTIL_ZIP="ossutil-${OSSUTIL_VERSION}-linux-${ARCH}.zip"
+              OSSUTIL_DIR="ossutil-${OSSUTIL_VERSION}-linux-${ARCH}"
+
+              curl -o "$OSSUTIL_ZIP" "https://gosspublic.alicdn.com/ossutil/v2/${OSSUTIL_VERSION}/${OSSUTIL_ZIP}"
+              unzip "$OSSUTIL_ZIP"
+              mv "${OSSUTIL_DIR}/ossutil" /usr/local/bin/
+              rm -rf "$OSSUTIL_DIR" "$OSSUTIL_ZIP"
               chmod +x /usr/local/bin/ossutil
               ;;
             macos)
               if [[ "$(uname -m)" == "arm64" ]]; then
-                curl -o ossutil-2.1.1-mac-arm64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-mac-arm64.zip
-                unzip ossutil-2.1.1-mac-arm64.zip
-                mv ossutil-2.1.1-mac-arm64/ossutil /usr/local/bin/
-                rm ossutil-2.1.1-mac-arm64
-                rm ossutil-2.1.1-mac-arm64.zip
+                ARCH="arm64"
               else
-                curl -o ossutil-2.1.1-mac-amd64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-mac-amd64.zip
-                unzip ossutil-2.1.1-mac-amd64.zip
-                mv ossutil-2.1.1-mac-amd64/ossutil /usr/local/bin/
-                rm ossutil-2.1.1-mac-amd64
-                rm ossutil-2.1.1-mac-amd64.zip
+                ARCH="amd64"
               fi
+              OSSUTIL_ZIP="ossutil-${OSSUTIL_VERSION}-mac-${ARCH}.zip"
+              OSSUTIL_DIR="ossutil-${OSSUTIL_VERSION}-mac-${ARCH}"
+
+              curl -o "$OSSUTIL_ZIP" "https://gosspublic.alicdn.com/ossutil/v2/${OSSUTIL_VERSION}/${OSSUTIL_ZIP}"
+              unzip "$OSSUTIL_ZIP"
+              mv "${OSSUTIL_DIR}/ossutil" /usr/local/bin/
+              rm -rf "$OSSUTIL_DIR" "$OSSUTIL_ZIP"
               chmod +x /usr/local/bin/ossutil
               OSSUTIL_BIN=ossutil
               ;;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,8 +235,22 @@ jobs:
         run: |
           # Install ossutil (platform-specific)
           case "${{ matrix.platform }}" in
-            linux|macos)
-              sudo -v ; curl https://gosspublic.alicdn.com/ossutil/install.sh | sudo bash
+            linux)
+              curl -o ossutil-2.1.1-linux-amd64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-linux-amd64.zip
+              unzip ossutil-2.1.1-linux-amd64.zip
+              mv ossutil-2.1.1-linux-amd64/ossutil /usr/local/bin/
+              chmod +x /usr/local/bin/ossutil
+              rm ossutil-2.1.1-linux-amd64
+              rm ossutil-2.1.1-linux-amd64.zip
+              OSSUTIL_BIN=ossutil
+              ;;
+            macos)
+              curl -o ossutil-2.1.1-mac-arm64.zip https://gosspublic.alicdn.com/ossutil/v2/2.1.1/ossutil-2.1.1-mac-arm64.zip
+              unzip ossutil-2.1.1-mac-arm64.zip
+              mv ossutil-2.1.1-mac-arm64/ossutil /usr/local/bin/
+              chmod +x /usr/local/bin/ossutil
+              rm ossutil-2.1.1-mac-arm64
+              rm ossutil-2.1.1-mac-arm64.zip
               OSSUTIL_BIN=ossutil
               ;;
             # windows)
@@ -254,7 +268,6 @@ jobs:
             echo "{\"version\":\"${VERSION}\",\"release_date\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > latest.json
             $OSSUTIL_BIN cp latest.json oss://rustfs-version/latest.json --force
           fi
-
 
   # Release management
   release:
@@ -463,5 +476,3 @@ jobs:
           else
             echo "Release $VERSION already has custom notes, skipping update to preserve manual edits"
           fi
-
-


### PR DESCRIPTION
### What was fixed
- Improved the ossutil installation logic in the GitHub Actions workflow for both Linux and macOS platforms.
- Now uses direct download and extraction for each platform, ensuring correct binary placement and permissions.

### Why
- The previous logic was not robust and could fail in some environments.
- This change makes the workflow more reliable and explicit for each platform.

### Testing
- Only the workflow file was changed. The fix will be validated by CI on PR.

---

**Please review and merge if all checks pass.**