### PR TITLE
fix(config_handler): improve URL construction and port handling

### DIFF
--- a/rustfs/src/console.rs
+++ b/rustfs/src/console.rs
@@ -245,8 +245,11 @@ async fn config_handler(uri: Uri, Host(host): Host, headers: HeaderMap) -> impl 
                 .unwrap();
         }
     };
+
+    // port handling
     let port = uri.port().map(|p| p.as_u16()).unwrap_or(cfg.port);
-    // 避免重复添加标准端口
+
+    // avoid adding default ports (80/443)
     let url = if (scheme == "https" && port == 443) || (scheme == "http" && port == 80) {
         format!("{scheme}://{host}")
     } else {

--- a/rustfs/src/console.rs
+++ b/rustfs/src/console.rs
@@ -245,8 +245,13 @@ async fn config_handler(uri: Uri, Host(host): Host, headers: HeaderMap) -> impl 
                 .unwrap();
         }
     };
-
-    let url = format!("{}://{}:{}", scheme, host, cfg.port);
+    let port = uri.port().map(|p| p.as_u16()).unwrap_or(cfg.port);
+    // 避免重复添加标准端口
+    let url = if (scheme == "https" && port == 443) || (scheme == "http" && port == 80) {
+        format!("{scheme}://{host}")
+    } else {
+        format!("{scheme}://{host}:{port}")
+    };
     cfg.api.base_url = format!("{url}{RUSTFS_ADMIN_PREFIX}");
     cfg.s3.endpoint = url;
 


### PR DESCRIPTION
- Refactored port handling to avoid adding default ports (80/443).
- In reverse proxy scenarios, port is set by the request.

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
https://github.com/rustfs/rustfs/issues/142
## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Code is formatted with `cargo fmt --all`
- [x] Passed `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Passed `cargo check --all-targets`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
