### PR TITLE
refactor: replace `lazy_static` with `LazyLock`

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -517,7 +517,7 @@ let results = join_all(futures).await;
 
 ### 3. Caching Strategy
 
-- Use `lazy_static` or `OnceCell` for global caching
+- Use `LazyLock` for global caching
 - Implement LRU cache to avoid memory leaks
 
 ## Testing Guidelines

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7848,7 +7848,6 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.6.0",
  "hyper-util",
- "lazy_static",
  "libsystemd",
  "matchit",
  "mime_guess",
@@ -7940,7 +7939,6 @@ dependencies = [
 name = "rustfs-common"
 version = "0.0.5"
 dependencies = [
- "lazy_static",
  "tokio",
  "tonic",
 ]
@@ -8077,7 +8075,6 @@ dependencies = [
  "dirs",
  "hex",
  "keyring",
- "lazy_static",
  "rfd 0.15.3",
  "rust-embed",
  "rust-i18n",
@@ -8098,7 +8095,6 @@ dependencies = [
  "base64-simd",
  "futures",
  "jsonwebtoken",
- "lazy_static",
  "rand 0.9.1",
  "rustfs-crypto",
  "rustfs-ecstore",
@@ -8118,7 +8114,6 @@ name = "rustfs-lock"
 version = "0.0.5"
 dependencies = [
  "async-trait",
- "lazy_static",
  "rand 0.9.1",
  "rustfs-protos",
  "serde",
@@ -8315,7 +8310,6 @@ dependencies = [
  "datafusion",
  "derive_builder",
  "futures",
- "lazy_static",
  "parking_lot",
  "rustfs-s3select-api",
  "s3s",
@@ -8331,7 +8325,6 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "hyper 1.6.0",
- "lazy_static",
  "rand 0.9.1",
  "rustfs-utils",
  "s3s",
@@ -8358,7 +8351,6 @@ dependencies = [
  "hmac 0.12.1",
  "hyper 1.6.0",
  "hyper-util",
- "lazy_static",
  "local-ip-address",
  "lz4",
  "md-5",

--- a/cli/rustfs-gui/Cargo.toml
+++ b/cli/rustfs-gui/Cargo.toml
@@ -26,7 +26,6 @@ dioxus = { workspace = true, features = ["router"] }
 dirs = { workspace = true }
 hex = { workspace = true }
 keyring = { workspace = true }
-lazy_static = { workspace = true }
 rfd = { workspace = true }
 rust-embed = { workspace = true, features = ["interpolate-folder-path"] }
 rust-i18n = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -28,6 +28,5 @@ categories = ["web-programming", "development-tools", "data-structures"]
 workspace = true
 
 [dependencies]
-lazy_static.workspace = true
 tokio.workspace = true
 tonic = { workspace = true }

--- a/crates/common/src/globals.rs
+++ b/crates/common/src/globals.rs
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+#![allow(non_upper_case_globals)] // FIXME
 
-use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
 use tokio::sync::RwLock;
 use tonic::transport::Channel;
 
-lazy_static! {
-    pub static ref GLOBAL_Local_Node_Name: RwLock<String> = RwLock::new("".to_string());
-    pub static ref GLOBAL_Rustfs_Host: RwLock<String> = RwLock::new("".to_string());
-    pub static ref GLOBAL_Rustfs_Port: RwLock<String> = RwLock::new("9000".to_string());
-    pub static ref GLOBAL_Rustfs_Addr: RwLock<String> = RwLock::new("".to_string());
-    pub static ref GLOBAL_Conn_Map: RwLock<HashMap<String, Channel>> = RwLock::new(HashMap::new());
-}
+pub static GLOBAL_Local_Node_Name: LazyLock<RwLock<String>> = LazyLock::new(|| RwLock::new("".to_string()));
+pub static GLOBAL_Rustfs_Host: LazyLock<RwLock<String>> = LazyLock::new(|| RwLock::new("".to_string()));
+pub static GLOBAL_Rustfs_Port: LazyLock<RwLock<String>> = LazyLock::new(|| RwLock::new("9000".to_string()));
+pub static GLOBAL_Rustfs_Addr: LazyLock<RwLock<String>> = LazyLock::new(|| RwLock::new("".to_string()));
+pub static GLOBAL_Conn_Map: LazyLock<RwLock<HashMap<String, Channel>>> = LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub async fn set_global_addr(addr: &str) {
     *GLOBAL_Rustfs_Addr.write().await = addr.to_string();

--- a/crates/iam/Cargo.toml
+++ b/crates/iam/Cargo.toml
@@ -45,7 +45,6 @@ base64-simd = { workspace = true }
 jsonwebtoken = { workspace = true }
 tracing.workspace = true
 rustfs-madmin.workspace = true
-lazy_static.workspace = true
 rustfs-utils = { workspace = true, features = ["path"] }
 
 [dev-dependencies]

--- a/crates/iam/src/store/object.rs
+++ b/crates/iam/src/store/object.rs
@@ -20,7 +20,6 @@ use crate::{
     manager::{extract_jwt_claims, get_default_policyes},
 };
 use futures::future::join_all;
-use lazy_static::lazy_static;
 use rustfs_ecstore::{
     config::{
         RUSTFS_CONFIG_PREFIX,
@@ -34,25 +33,28 @@ use rustfs_ecstore::{
 use rustfs_policy::{auth::UserIdentity, policy::PolicyDoc};
 use rustfs_utils::path::{SLASH_SEPARATOR, path_join_buf};
 use serde::{Serialize, de::DeserializeOwned};
+use std::sync::LazyLock;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::broadcast::{self, Receiver as B_Receiver};
 use tokio::sync::mpsc::{self, Sender};
 use tracing::{debug, info, warn};
 
-lazy_static! {
-    pub static ref IAM_CONFIG_PREFIX: String = format!("{}/iam", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_USERS_PREFIX: String = format!("{}/iam/users/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_SERVICE_ACCOUNTS_PREFIX: String = format!("{}/iam/service-accounts/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_GROUPS_PREFIX: String = format!("{}/iam/groups/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_POLICIES_PREFIX: String = format!("{}/iam/policies/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_STS_PREFIX: String = format!("{}/iam/sts/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_POLICY_DB_PREFIX: String = format!("{}/iam/policydb/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_POLICY_DB_USERS_PREFIX: String = format!("{}/iam/policydb/users/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_POLICY_DB_STS_USERS_PREFIX: String = format!("{}/iam/policydb/sts-users/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_POLICY_DB_SERVICE_ACCOUNTS_PREFIX: String =
-        format!("{}/iam/policydb/service-accounts/", RUSTFS_CONFIG_PREFIX);
-    pub static ref IAM_CONFIG_POLICY_DB_GROUPS_PREFIX: String = format!("{}/iam/policydb/groups/", RUSTFS_CONFIG_PREFIX);
-}
+pub static IAM_CONFIG_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam"));
+pub static IAM_CONFIG_USERS_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/users/"));
+pub static IAM_CONFIG_SERVICE_ACCOUNTS_PREFIX: LazyLock<String> =
+    LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/service-accounts/"));
+pub static IAM_CONFIG_GROUPS_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/groups/"));
+pub static IAM_CONFIG_POLICIES_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/policies/"));
+pub static IAM_CONFIG_STS_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/sts/"));
+pub static IAM_CONFIG_POLICY_DB_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/policydb/"));
+pub static IAM_CONFIG_POLICY_DB_USERS_PREFIX: LazyLock<String> =
+    LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/policydb/users/"));
+pub static IAM_CONFIG_POLICY_DB_STS_USERS_PREFIX: LazyLock<String> =
+    LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/policydb/sts-users/"));
+pub static IAM_CONFIG_POLICY_DB_SERVICE_ACCOUNTS_PREFIX: LazyLock<String> =
+    LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/policydb/service-accounts/"));
+pub static IAM_CONFIG_POLICY_DB_GROUPS_PREFIX: LazyLock<String> =
+    LazyLock::new(|| format!("{RUSTFS_CONFIG_PREFIX}/iam/policydb/groups/"));
 
 const IAM_IDENTITY_FILE: &str = "identity.json";
 const IAM_POLICY_FILE: &str = "policy.json";

--- a/crates/lock/Cargo.toml
+++ b/crates/lock/Cargo.toml
@@ -30,7 +30,6 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
-lazy_static.workspace = true
 rustfs-protos.workspace = true
 rand.workspace = true
 serde.workspace = true

--- a/crates/lock/src/lib.rs
+++ b/crates/lock/src/lib.rs
@@ -14,12 +14,12 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use lazy_static::lazy_static;
 use local_locker::LocalLocker;
 use lock_args::LockArgs;
 use remote_client::RemoteClient;
 use std::io::Result;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use tokio::sync::RwLock;
 
 pub mod drwmutex;
@@ -29,9 +29,7 @@ pub mod lrwmutex;
 pub mod namespace_lock;
 pub mod remote_client;
 
-lazy_static! {
-    pub static ref GLOBAL_LOCAL_SERVER: Arc<RwLock<LocalLocker>> = Arc::new(RwLock::new(LocalLocker::new()));
-}
+pub static GLOBAL_LOCAL_SERVER: LazyLock<Arc<RwLock<LocalLocker>>> = LazyLock::new(|| Arc::new(RwLock::new(LocalLocker::new())));
 
 type LockClient = dyn Locker;
 

--- a/crates/s3select-query/Cargo.toml
+++ b/crates/s3select-query/Cargo.toml
@@ -32,7 +32,6 @@ async-trait.workspace = true
 datafusion = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
-lazy_static = { workspace = true }
 parking_lot = { workspace = true }
 s3s.workspace = true
 snafu = { workspace = true, features = ["backtrace"] }

--- a/crates/s3select-query/src/dispatcher/manager.rs
+++ b/crates/s3select-query/src/dispatcher/manager.rs
@@ -33,7 +33,6 @@ use datafusion::{
     execution::{RecordBatchStream, SendableRecordBatchStream},
 };
 use futures::{Stream, StreamExt};
-use lazy_static::lazy_static;
 use rustfs_s3select_api::{
     QueryError, QueryResult,
     query::{
@@ -48,6 +47,7 @@ use rustfs_s3select_api::{
     },
 };
 use s3s::dto::{FileHeaderInfo, SelectObjectContentInput};
+use std::sync::LazyLock;
 
 use crate::{
     execution::factory::QueryExecutionFactoryRef,
@@ -55,11 +55,9 @@ use crate::{
     sql::logical::planner::DefaultLogicalPlanner,
 };
 
-lazy_static! {
-    static ref IGNORE: FileHeaderInfo = FileHeaderInfo::from_static(FileHeaderInfo::IGNORE);
-    static ref NONE: FileHeaderInfo = FileHeaderInfo::from_static(FileHeaderInfo::NONE);
-    static ref USE: FileHeaderInfo = FileHeaderInfo::from_static(FileHeaderInfo::USE);
-}
+static IGNORE: LazyLock<FileHeaderInfo> = LazyLock::new(|| FileHeaderInfo::from_static(FileHeaderInfo::IGNORE));
+static NONE: LazyLock<FileHeaderInfo> = LazyLock::new(|| FileHeaderInfo::from_static(FileHeaderInfo::NONE));
+static USE: LazyLock<FileHeaderInfo> = LazyLock::new(|| FileHeaderInfo::from_static(FileHeaderInfo::USE));
 
 #[derive(Clone)]
 pub struct SimpleQueryDispatcher {

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -27,7 +27,6 @@ documentation = "https://docs.rs/rustfs-signer/latest/rustfs_signer/"
 
 [dependencies]
 tracing.workspace = true
-lazy_static.workspace = true
 bytes = { workspace = true }
 http.workspace = true
 time.workspace = true

--- a/crates/signer/src/request_signature_streaming.rs
+++ b/crates/signer/src/request_signature_streaming.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 use http::{HeaderMap, HeaderValue, request};
-use lazy_static::lazy_static;
-use std::collections::HashMap;
 use time::{OffsetDateTime, macros::format_description};
 
 use super::request_signature_v4::{SERVICE_TYPE_S3, get_scope, get_signature, get_signing_key};
@@ -32,15 +30,13 @@ const _CRLF_LEN: i64 = 2;
 const _TRAILER_KV_SEPARATOR: &str = ":";
 const _TRAILER_SIGNATURE: &str = "x-amz-trailer-signature";
 
-lazy_static! {
-    static ref ignored_streaming_headers: HashMap<String, bool> = {
-        let mut m = <HashMap<String, bool>>::new();
-        m.insert("authorization".to_string(), true);
-        m.insert("user-agent".to_string(), true);
-        m.insert("content-type".to_string(), true);
-        m
-    };
-}
+// static ignored_streaming_headers: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
+//     let mut m = <HashMap<String, bool>>::new();
+//     m.insert("authorization".to_string(), true);
+//     m.insert("user-agent".to_string(), true);
+//     m.insert("content-type".to_string(), true);
+//     m
+// });
 
 #[allow(dead_code)]
 fn build_chunk_string_to_sign(t: OffsetDateTime, region: &str, previous_sig: &str, chunk_check_sum: &str) -> String {

--- a/crates/signer/src/request_signature_v4.rs
+++ b/crates/signer/src/request_signature_v4.rs
@@ -16,9 +16,9 @@ use bytes::BytesMut;
 use http::HeaderMap;
 use http::Uri;
 use http::request;
-use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::fmt::Write;
+use std::sync::LazyLock;
 use time::{OffsetDateTime, macros::format_description};
 use tracing::debug;
 
@@ -32,15 +32,14 @@ pub const SIGN_V4_ALGORITHM: &str = "AWS4-HMAC-SHA256";
 pub const SERVICE_TYPE_S3: &str = "s3";
 pub const SERVICE_TYPE_STS: &str = "sts";
 
-lazy_static! {
-    static ref v4_ignored_headers: HashMap<String, bool> = {
-        let mut m = <HashMap<String, bool>>::new();
-        m.insert("accept-encoding".to_string(), true);
-        m.insert("authorization".to_string(), true);
-        m.insert("user-agent".to_string(), true);
-        m
-    };
-}
+#[allow(non_upper_case_globals)] // FIXME
+static v4_ignored_headers: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
+    let mut m = <HashMap<String, bool>>::new();
+    m.insert("accept-encoding".to_string(), true);
+    m.insert("authorization".to_string(), true);
+    m.insert("user-agent".to_string(), true);
+    m
+});
 
 pub fn get_signing_key(secret: &str, loc: &str, t: OffsetDateTime, service_type: &str) -> [u8; 32] {
     let mut s = "AWS4".to_string();

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -30,7 +30,6 @@ blake3 = { workspace = true, optional = true }
 crc32fast.workspace = true
 hex-simd = { workspace = true, optional = true }
 highway = { workspace = true, optional = true }
-lazy_static = { workspace = true, optional = true }
 local-ip-address = { workspace = true, optional = true }
 md-5 = { workspace = true, optional = true }
 netif = { workspace = true, optional = true }
@@ -77,12 +76,12 @@ workspace = true
 default = ["ip"]  # features that are enabled by default
 ip = ["dep:local-ip-address"]  # ip characteristics and their dependencies
 tls = ["dep:rustls", "dep:rustls-pemfile", "dep:rustls-pki-types"]  # tls characteristics and their dependencies
-net = ["ip", "dep:url", "dep:netif", "dep:lazy_static", "dep:futures", "dep:transform-stream", "dep:bytes", "dep:s3s", "dep:hyper", "dep:hyper-util"]  # empty network features
+net = ["ip", "dep:url", "dep:netif", "dep:futures", "dep:transform-stream", "dep:bytes", "dep:s3s", "dep:hyper", "dep:hyper-util"]  # empty network features
 io = ["dep:tokio"]
 path = []
 notify = ["dep:hyper", "dep:s3s"]  # file system notification features
 compress = ["dep:flate2", "dep:brotli", "dep:snap", "dep:lz4", "dep:zstd"]
-string = ["dep:regex", "dep:lazy_static", "dep:rand"]
+string = ["dep:regex", "dep:rand"]
 crypto = ["dep:base64-simd", "dep:hex-simd", "dep:hmac", "dep:hyper", "dep:sha1"]
 hash = ["dep:highway", "dep:md-5", "dep:sha2", "dep:blake3", "dep:serde", "dep:siphasher", "dep:hex-simd", "dep:base64-simd"]
 os = ["dep:nix", "dep:tempfile", "winapi"]  # operating system utilities

--- a/crates/utils/src/net.rs
+++ b/crates/utils/src/net.rs
@@ -17,8 +17,8 @@ use futures::pin_mut;
 use futures::{Stream, StreamExt};
 use hyper::client::conn::http2::Builder;
 use hyper_util::rt::TokioExecutor;
-use lazy_static::lazy_static;
 use std::net::Ipv6Addr;
+use std::sync::LazyLock;
 use std::{
     collections::HashSet,
     fmt::Display,
@@ -27,9 +27,7 @@ use std::{
 use transform_stream::AsyncTryStream;
 use url::{Host, Url};
 
-lazy_static! {
-    static ref LOCAL_IPS: Vec<IpAddr> = must_get_local_ips().unwrap();
-}
+static LOCAL_IPS: LazyLock<Vec<IpAddr>> = LazyLock::new(|| must_get_local_ips().unwrap());
 
 /// helper for validating if the provided arg is an ip address.
 pub fn is_socket_addr(addr: &str) -> bool {

--- a/crates/utils/src/string.rs
+++ b/crates/utils/src/string.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use lazy_static::*;
 use rand::{Rng, RngCore};
 use regex::Regex;
 use std::io::{Error, Result};
+use std::sync::LazyLock;
 
 pub fn parse_bool(str: &str) -> Result<bool> {
     match str {
@@ -116,9 +116,7 @@ pub fn match_as_pattern_prefix(pattern: &str, text: &str) -> bool {
     text.len() <= pattern.len()
 }
 
-lazy_static! {
-    static ref ELLIPSES_RE: Regex = Regex::new(r"(.*)(\{[0-9a-z]*\.\.\.[0-9a-z]*\})(.*)").unwrap();
-}
+static ELLIPSES_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(.*)(\{[0-9a-z]*\.\.\.[0-9a-z]*\})(.*)").unwrap());
 
 /// Ellipses constants
 const OPEN_BRACES: &str = "{";

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -67,7 +67,6 @@ hyper.workspace = true
 hyper-util.workspace = true
 http.workspace = true
 http-body.workspace = true
-lazy_static.workspace = true
 matchit = { workspace = true }
 mime_guess = { workspace = true }
 opentelemetry = { workspace = true }

--- a/rustfs/src/license.rs
+++ b/rustfs/src/license.rs
@@ -20,9 +20,7 @@ use std::time::UNIX_EPOCH;
 use tracing::error;
 use tracing::info;
 
-lazy_static::lazy_static! {
-    static ref LICENSE: OnceLock<Token> = OnceLock::new();
-}
+static LICENSE: OnceLock<Token> = OnceLock::new();
 
 /// Initialize the license
 pub fn init_license(license: Option<String>) {

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -36,7 +36,6 @@ use rustfs_s3select_api::server::dbms::DatabaseManagerSystem;
 // use rustfs_ecstore::store_api::RESERVED_METADATA_PREFIX;
 use futures::StreamExt;
 use http::HeaderMap;
-use lazy_static::lazy_static;
 use rustfs_ecstore::bucket::lifecycle::bucket_lifecycle_ops::validate_transition_tier;
 use rustfs_ecstore::bucket::lifecycle::lifecycle::Lifecycle;
 use rustfs_ecstore::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
@@ -102,6 +101,7 @@ use std::fmt::Debug;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use tokio::sync::mpsc;
@@ -126,12 +126,10 @@ macro_rules! try_ {
     };
 }
 
-lazy_static! {
-    static ref RUSTFS_OWNER: Owner = Owner {
-        display_name: Some("rustfs".to_owned()),
-        id: Some("c19050dbcee97fda828689dda99097a6321af2248fa760517237346e5d9c8a66".to_owned()),
-    };
-}
+static RUSTFS_OWNER: LazyLock<Owner> = LazyLock::new(|| Owner {
+    display_name: Some("rustfs".to_owned()),
+    id: Some("c19050dbcee97fda828689dda99097a6321af2248fa760517237346e5d9c8a66".to_owned()),
+});
 
 #[derive(Debug, Clone)]
 pub struct FS {

--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use http::{HeaderMap, HeaderValue};
-use lazy_static::lazy_static;
 use rustfs_ecstore::bucket::versioning_sys::BucketVersioningSys;
 use rustfs_ecstore::error::Result;
 use rustfs_ecstore::error::StorageError;
 use rustfs_ecstore::store_api::ObjectOptions;
 use rustfs_utils::path::is_dir_object;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 use uuid::Uuid;
 
 /// Creates options for deleting an object in a bucket.
@@ -214,9 +214,9 @@ pub fn extract_metadata_from_mime(headers: &HeaderMap<HeaderValue>, metadata: &m
     }
 }
 
-lazy_static! {
-    /// List of supported headers.
-    static ref SUPPORTED_HEADERS: Vec<&'static str> = vec![
+/// List of supported headers.
+static SUPPORTED_HEADERS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    vec![
         "content-type",
         "cache-control",
         "content-language",
@@ -225,9 +225,9 @@ lazy_static! {
         "x-amz-storage-class",
         "x-amz-tagging",
         "expires",
-        "x-amz-replication-status"
-    ];
-}
+        "x-amz-replication-status",
+    ]
+});
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Summary of Changes

Replace `lazy_static` with `LazyLock`.

Compile time may reduce a little.

See https://github.com/rust-lang-nursery/lazy-static.rs/issues/214

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Code is formatted with `cargo fmt --all`
- [x] Passed `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Passed `cargo check --all-targets`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
