### PR TITLE
feat: add latest version support for release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,6 +363,26 @@ jobs:
           echo "Uploading ${{ steps.package.outputs.package_file }} to $OSS_PATH..."
           $OSSUTIL_BIN cp "${{ steps.package.outputs.package_file }}" "$OSS_PATH" --force
 
+          # For release and prerelease builds, also create a latest version
+          if [[ "$BUILD_TYPE" == "release" ]] || [[ "$BUILD_TYPE" == "prerelease" ]]; then
+            # Extract platform and arch from package name
+            PACKAGE_NAME="${{ steps.package.outputs.package_name }}"
+
+            # Create latest version filename
+            # Convert from rustfs-linux-x86_64-v1.0.0 to rustfs-linux-x86_64-latest
+            LATEST_NAME=$(echo "$PACKAGE_NAME" | sed 's/-v[0-9].*$/-latest/')
+            LATEST_FILE="${LATEST_NAME}.zip"
+
+            # Copy the original file to latest version
+            cp "${{ steps.package.outputs.package_file }}" "$LATEST_FILE"
+
+            # Upload the latest version
+            echo "Uploading latest version: $LATEST_FILE to $OSS_PATH..."
+            $OSSUTIL_BIN cp "$LATEST_FILE" "$OSS_PATH" --force
+
+            echo "✅ Latest version uploaded: $LATEST_FILE"
+          fi
+
           echo "✅ Upload completed successfully"
 
   # Build summary


### PR DESCRIPTION
## Summary

This PR adds automatic creation of latest version files for release and prerelease builds, significantly simplifying the installation script experience.

## Changes

- **🎯 Latest Version Support**: Automatically create `latest` version files for release and prerelease builds
- **📦 Simplified Installation**: Installation scripts can now use direct `latest` URLs without version detection
- **🔄 Naming Convention**: Support `rustfs-linux-{arch}-latest.zip` naming convention
- **✨ Enhanced UX**: Improve build artifact management and user experience

## Technical Details

### Before
- Installation scripts needed to call GitHub API to get latest version
- Complex version detection logic required
- URLs like: `rustfs-linux-x86_64-v1.0.0.zip`

### After
- Direct latest URLs available: `rustfs-linux-x86_64-latest.zip`
- No API calls needed for installation scripts
- Both versioned and latest files coexist

## Example Usage

Installation scripts can now use fixed URLs:
```bash
# x86_64 Linux
PKG_URL="https://dl.rustfs.com/artifacts/rustfs/release/rustfs-linux-x86_64-latest.zip"

# aarch64 Linux
PKG_URL="https://dl.rustfs.com/artifacts/rustfs/release/rustfs-linux-aarch64-latest.zip"
```

## Impact

- **✅ Simplified Installation**: Users can always get the latest version with a fixed URL
- **🔧 Maintained Flexibility**: Specific versions still available for CI/CD
- **📈 Better UX**: Faster and more reliable installation process
- **🌍 Cross-Platform**: Works consistently across all supported architectures

## Testing

The changes have been tested with the existing build workflow and maintain backward compatibility.

## Breaking Changes

None. This is a purely additive change that enhances the existing functionality.