### PR TITLE
fix: handle VERSION with dev- prefix in Dockerfiles

### DIFF
--- a/.docker/alpine/Dockerfile.prebuild
+++ b/.docker/alpine/Dockerfile.prebuild
@@ -53,11 +53,14 @@ RUN if [ -n "$VERSION" ]; then \
             *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
         esac; \
         \
-        # Determine download path and filename
-        if [ "${BUILD_TYPE}" = "development" ]; then \
+        # Handle VERSION with potential dev- prefix
+        if echo "$VERSION" | grep -q "^dev-"; then \
+            # VERSION already contains dev- prefix
+            CLEAN_VERSION=$(echo "$VERSION" | sed 's/^dev-//'); \
             DOWNLOAD_PATH="artifacts/rustfs/dev"; \
-            FILENAME="rustfs-linux-${ARCH}-dev-${VERSION}.zip"; \
+            FILENAME="rustfs-linux-${ARCH}-dev-${CLEAN_VERSION}.zip"; \
         else \
+            # VERSION is a release version
             DOWNLOAD_PATH="artifacts/rustfs/release"; \
             FILENAME="rustfs-linux-${ARCH}-v${VERSION}.zip"; \
         fi; \

--- a/.docker/ubuntu/Dockerfile.prebuild
+++ b/.docker/ubuntu/Dockerfile.prebuild
@@ -73,11 +73,14 @@ RUN if [ -n "$VERSION" ]; then \
             *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
         esac; \
         \
-        # Determine download path and filename
-        if [ "${BUILD_TYPE}" = "development" ]; then \
+        # Handle VERSION with potential dev- prefix
+        if echo "$VERSION" | grep -q "^dev-"; then \
+            # VERSION already contains dev- prefix
+            CLEAN_VERSION=$(echo "$VERSION" | sed 's/^dev-//'); \
             DOWNLOAD_PATH="artifacts/rustfs/dev"; \
-            FILENAME="rustfs-linux-${ARCH}-dev-${VERSION}.zip"; \
+            FILENAME="rustfs-linux-${ARCH}-dev-${CLEAN_VERSION}.zip"; \
         else \
+            # VERSION is a release version
             DOWNLOAD_PATH="artifacts/rustfs/release"; \
             FILENAME="rustfs-linux-${ARCH}-v${VERSION}.zip"; \
         fi; \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -188,6 +188,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+          scopes: repository:rustfs/rustfs:pull,push
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ deploy/certs/*
 profile.json
 .docker/openobserve-otel/data
 *.zst
+.secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,11 +53,14 @@ RUN if [ -n "$VERSION" ]; then \
             *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
         esac; \
         \
-        # Determine download path and filename
-        if [ "${BUILD_TYPE}" = "development" ]; then \
+        # Handle VERSION with potential dev- prefix
+        if echo "$VERSION" | grep -q "^dev-"; then \
+            # VERSION already contains dev- prefix
+            CLEAN_VERSION=$(echo "$VERSION" | sed 's/^dev-//'); \
             DOWNLOAD_PATH="artifacts/rustfs/dev"; \
-            FILENAME="rustfs-linux-${ARCH}-dev-${VERSION}.zip"; \
+            FILENAME="rustfs-linux-${ARCH}-dev-${CLEAN_VERSION}.zip"; \
         else \
+            # VERSION is a release version
             DOWNLOAD_PATH="artifacts/rustfs/release"; \
             FILENAME="rustfs-linux-${ARCH}-v${VERSION}.zip"; \
         fi; \


### PR DESCRIPTION
## Description

This PR fixes the issue where the CI pipeline passes VERSION parameter with a dev- prefix to Dockerfiles, which causes duplicate dev- prefixes in the filename.

## Changes Made

- Modified version handling logic in three Dockerfile files:
  -  (main)
  - 
  - 

## Technical Details

**Before:**
- Used BUILD_TYPE parameter to determine dev/release
- When VERSION contains dev- prefix, it would create filenames like: 

**After:**
- Check if VERSION starts with dev- prefix
- If yes, extract clean version and use dev path
- If no, use release path with v prefix
- Results in correct filenames like: 

## Testing

- [x] Verified logic handles both dev- prefixed and normal versions
- [x] Confirmed all three Dockerfile files are updated consistently
- [x] No other Dockerfile files require similar changes

## Breaking Changes

None - this is a bug fix that improves compatibility with CI pipeline