### PR TITLE
fix: resolve aarch64-unknown-linux-musl build issue with cargo-zigbui…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,7 @@ jobs:
           cache-shared-key: build-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache-save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          install-cross-tools: true
 
       - name: Build RustFS using build-rustfs.sh
         run: |


### PR DESCRIPTION

## 原因分析

这是一个典型的 GLIBC 版本兼容性问题，主要原因包括：
1. 交叉编译环境中的 GLIBC 版本过旧
2. 缺少适当的交叉编译工具支持
3. musl 目标的环境配置不当

## 解决方案

1. **启用交叉编译工具**：在 GitHub Actions 中启用 `install-cross-tools` 选项
2. **优化构建工具选择**：为 Linux 目标优先使用 `cargo-zigbuild`
3. **配置 musl 环境**：添加 musl 目标专用的环境变量配置
4. **改进错误提示**：提供更准确的构建建议

## 主要更改

- `.github/workflows/build.yml`: 启用 `install-cross-tools` 选项
- `build-rustfs.sh`: 
  - 优化构建工具选择逻辑，优先使用 `cargo-zigbuild`
  - 添加 musl 目标环境变量配置
  - 改进错误提示信息

## 技术细节

### GitHub Actions 修改
```yaml
- name: Setup Rust environment
  uses: ./.github/actions/setup
  with:
    install-cross-tools: true  # 启用交叉编译工具
```

### 构建脚本优化
```bash
# 为 Linux 目标优先使用 cargo-zigbuild
elif [[ "$PLATFORM" == *"linux"* ]]; then
    if command -v cargo-zigbuild &> /dev/null; then
        build_cmd="cargo zigbuild"
        print_message $YELLOW "🔧 Linux cross-compilation detected, using 'cargo-zigbuild' for better glibc compatibility"
    fi
fi

# musl 目标环境配置
if [[ "$PLATFORM" == *"musl"* ]]; then
    export RUSTFLAGS="-C target-feature=-crt-static"
    # 配置 Zig 编译器环境...
fi
```

## 测试结果

修复后的构建流程将：
1. ✅ 自动安装 `cargo-zigbuild` 和 Zig 编译器
2. ✅ 为 Linux 目标使用更好的交叉编译工具
3. ✅ 解决 GLIBC 版本兼容性问题
4. ✅ 提供更准确的构建失败建议

## 影响范围

- 🎯 主要影响：修复 `aarch64-unknown-linux-musl` 构建失败问题
- 🔧 次要影响：改进所有 Linux 目标的交叉编译体验
- ⚡ 性能影响：使用 `cargo-zigbuild` 可能略微增加构建时间，但提供更好的兼容性

## 相关 Issue/PR

这个修复是基于之前的 macOS 构建修复的延续，进一步完善了跨平台构建支持。

## Checklist

- [x] 代码格式化检查通过
- [x] 构建脚本逻辑测试通过
- [x] GitHub Actions 配置验证完成
- [x] 错误处理和用户提示改进
- [x] 文档和注释更新