### PR TITLE
fix: correct YAML indentation error in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-            - name: Extract metadata and generate tags
+      - name: Extract metadata and generate tags
         id: meta
         run: |
           BUILD_TYPE="${{ needs.build-check.outputs.build_type }}"


### PR DESCRIPTION
## Summary

This PR fixes a critical YAML syntax error in the docker workflow file.

## Problem
- Line 237 in  had incorrect indentation (12 spaces instead of 6)
- The step 'Extract metadata and generate tags' was improperly nested under the previous step
- This caused YAML syntax validation to fail and would break the workflow

## Solution
- Corrected the indentation to properly align the step at the same level as other workflow steps
- Validated the fix follows proper YAML structure

## Changes
- Fixed indentation of the 'Extract metadata and generate tags' step
- No functional changes to the workflow logic

## Verification
The corrected YAML structure now properly defines each step at the correct indentation level.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Note**: This is an urgent fix for a syntax error that would prevent the workflow from running.