### PR TITLE
fix: correct Docker build logic for dev version downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,16 @@ RUN . /build/arch.env && \
             DOWNLOAD_URL="${BASE_URL}/release/${PACKAGE_NAME}"; \
             echo "📥 Downloading latest release build: ${PACKAGE_NAME}"; \
         fi; \
+    elif [ "${CHANNEL}" = "dev" ]; then \
+        # Download specific dev version \
+        PACKAGE_NAME="rustfs-${PLATFORM}-${ARCH}-${RELEASE}.zip"; \
+        DOWNLOAD_URL="${BASE_URL}/dev/${PACKAGE_NAME}"; \
+        echo "📥 Downloading specific dev version: ${PACKAGE_NAME}"; \
     else \
-        # Download specific version (always from release channel) \
+        # Download specific release version \
         PACKAGE_NAME="rustfs-${PLATFORM}-${ARCH}-v${RELEASE}.zip"; \
         DOWNLOAD_URL="${BASE_URL}/release/${PACKAGE_NAME}"; \
-        echo "📥 Downloading specific version: ${PACKAGE_NAME}"; \
+        echo "📥 Downloading specific release version: ${PACKAGE_NAME}"; \
     fi && \
     echo "🔗 Download URL: ${DOWNLOAD_URL}" && \
     curl -f -L "${DOWNLOAD_URL}" -o /build/rustfs.zip && \


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the Docker build process where development versions (dev-*) were incorrectly trying to download from the release channel with incorrect filename patterns.

## Problem

When building Docker images for development versions like , the Dockerfile was:

1. **Incorrectly using release channel**: Trying to download from  path instead of  path
2. **Adding wrong prefix**: Adding  prefix to dev versions (e.g.,  instead of )
3. **Wrong URL construction**: Resulting in 404 errors like:
   
   Instead of the correct:
   

## Solution

Enhanced the Dockerfile logic to properly handle different version types:

- **Latest versions**: Use appropriate channel (dev/release) based on CHANNEL parameter
- **Dev versions**: Download from  path without  prefix when 
- **Release versions**: Download from  path with  prefix when 

## Changes

- Fixed conditional logic in Dockerfile to check  parameter for non-latest versions
- Added proper path routing for dev vs release channels
- Maintained backward compatibility for release builds

## Testing

This fix resolves the Docker build failures seen in GitHub Actions run https://github.com/rustfs/rustfs/actions/runs/16330741184/job/46132427933

## Related Issues

Fixes Docker build failures for development versions in CI/CD pipeline.