### PR TITLE
fix: use consistent short SHA generation across workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,7 +110,8 @@ jobs:
             fi
 
             # Extract version info from commit message or use commit SHA
-            short_sha=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-7)
+            # Use Git to generate consistent short SHA (ensures uniqueness like build.yml)
+            short_sha=$(git rev-parse --short "${{ github.event.workflow_run.head_sha }}")
 
             # Determine build type based on branch and commit
             if [[ "${{ github.event.workflow_run.head_branch }}" == "main" ]]; then


### PR DESCRIPTION
## Problem

Found inconsistency in short SHA generation between build.yml and docker.yml workflows:

- **build.yml** uses: `git rev-parse --short HEAD` (standard Git approach)
- **docker.yml** used: `cut -c1-7` (forced 7-character truncation)

This inconsistency could lead to version mismatches in edge cases where Git needs more than 7 characters for uniqueness.

## Solution

- Replace manual `cut -c1-7` with `git rev-parse --short` in docker.yml
- Ensures consistent short SHA length between both workflows
- Git automatically adjusts length for uniqueness, preventing conflicts

## Changes

- Updated `.github/workflows/docker.yml` line 113 to use Git's standard short SHA generation
- Both workflows now use the same reliable method for generating short commit identifiers

## Testing

- Verified the change maintains the same 7-character output in typical cases
- Git will automatically extend length when needed for uniqueness (rare edge case)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

**Note**: This PR follows the mandatory workflow - no direct commits to main branch.