### PR TITLE
feat: disable Docker builds for development versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@
 # - Only triggers when Linux builds (x86_64 + aarch64) are successful
 # - Independent of macOS/Windows build status
 # - Uses workflow_run event for precise control
+# - Only builds Docker images for releases and prereleases (development builds are skipped)
 
 name: Docker Images
 
@@ -47,9 +48,9 @@ on:
         default: true
         type: boolean
       version:
-        description: "Version to build (latest, main-latest, dev-latest, or specific version like v1.0.0 or dev-abc123)"
+        description: "Version to build (latest for stable release, or specific version like v1.0.0, v1.0.0-alpha1)"
         required: false
-        default: "main-latest"
+        default: "latest"
         type: string
       force_rebuild:
         description: "Force rebuild even if binary exists (useful for testing)"
@@ -117,20 +118,28 @@ jobs:
             if [[ "${{ github.event.workflow_run.head_branch }}" == "main" ]]; then
               build_type="development"
               version="dev-${short_sha}"
+              # Skip Docker build for development builds
+              should_build=false
+              echo "⏭️  Skipping Docker build for development version (main branch)"
             elif [[ "${{ github.event.workflow_run.event }}" == "push" ]] && [[ "${{ github.event.workflow_run.head_branch }}" =~ ^refs/tags/ ]]; then
-              # Tag push
+              # Tag push - only build for releases and prereleases
               tag_name="${{ github.event.workflow_run.head_branch }}"
               version="${tag_name#refs/tags/}"
               if [[ "$version" == *"alpha"* ]] || [[ "$version" == *"beta"* ]] || [[ "$version" == *"rc"* ]]; then
                 build_type="prerelease"
                 is_prerelease=true
+                echo "🧪 Building Docker image for prerelease: $version"
               else
                 build_type="release"
                 create_latest=true
+                echo "🚀 Building Docker image for release: $version"
               fi
             else
               build_type="development"
               version="dev-${short_sha}"
+              # Skip Docker build for development builds
+              should_build=false
+              echo "⏭️  Skipping Docker build for development version"
             fi
 
             echo "🔄 Build triggered by workflow_run:"
@@ -160,16 +169,6 @@ jobs:
                 create_latest=true
                 echo "🚀 Building with latest stable release version"
                 ;;
-              "main-latest")
-                build_type="development"
-                version="main-latest"
-                echo "🛠️  Building with main branch latest development version"
-                ;;
-              "dev-latest")
-                build_type="development"
-                version="dev-latest"
-                echo "🛠️  Building with development latest version"
-                ;;
               v[0-9]*)
                 build_type="release"
                 create_latest=true
@@ -180,14 +179,11 @@ jobs:
                 is_prerelease=true
                 echo "🧪 Building with prerelease version: $input_version"
                 ;;
-              dev-[a-f0-9]*)
-                build_type="development"
-                echo "🔧 Building with specific development version: $input_version"
-                ;;
               *)
-                build_type="development"
-                echo "🔧 Building with custom version: $input_version"
-                echo "⚠️  Warning: Custom version format may not follow standard patterns"
+                # Invalid version for Docker build
+                should_build=false
+                echo "❌ Invalid version for Docker build: $input_version"
+                echo "⚠️  Only release versions (latest, v1.0.0) and prereleases (v1.0.0-alpha1) are supported"
                 ;;
             esac
           fi
@@ -252,20 +248,10 @@ jobs:
 
           # Convert version format for Dockerfile compatibility
           case "$VERSION" in
-            "main-latest"|"dev-latest")
-              # For latest builds, use RELEASE=latest + appropriate CHANNEL
-              DOCKER_RELEASE="latest"
-              DOCKER_CHANNEL="dev"
-              ;;
             "latest")
               # For stable latest, use RELEASE=latest + release CHANNEL
               DOCKER_RELEASE="latest"
               DOCKER_CHANNEL="release"
-              ;;
-            dev-*)
-              # For development builds (dev-abc123), pass as-is without 'v' prefix
-              DOCKER_RELEASE="${VERSION}"
-              DOCKER_CHANNEL="dev"
               ;;
             v*)
               # For versioned releases (v1.0.0), remove 'v' prefix for Dockerfile
@@ -273,7 +259,7 @@ jobs:
               DOCKER_CHANNEL="release"
               ;;
             *)
-              # For custom versions, pass as-is
+              # For other versions, pass as-is
               DOCKER_RELEASE="${VERSION}"
               DOCKER_CHANNEL="release"
               ;;
@@ -288,33 +274,25 @@ jobs:
           echo "  - Docker CHANNEL: $DOCKER_CHANNEL"
 
           # Generate tags based on build type
-          TAGS=""
+          # Only support release and prerelease builds (no development builds)
+          TAGS="${{ env.REGISTRY_DOCKERHUB }}:${VERSION}"
 
-          if [[ "$BUILD_TYPE" == "development" ]]; then
-            # Development build: dev-${short_sha} and dev
-            TAGS="${{ env.REGISTRY_DOCKERHUB }}:dev-${SHORT_SHA}"
-            TAGS="$TAGS,${{ env.REGISTRY_DOCKERHUB }}:dev"
-          else
-            # Release/Prerelease build: ${version}
-            TAGS="${{ env.REGISTRY_DOCKERHUB }}:${VERSION}"
+          # Add channel tags for prereleases and latest for stable
+          if [[ "$CREATE_LATEST" == "true" ]]; then
+            # Stable release
+            TAGS="$TAGS,${{ env.REGISTRY_DOCKERHUB }}:latest"
+          elif [[ "$BUILD_TYPE" == "prerelease" ]]; then
+            # Prerelease channel tags (alpha, beta, rc)
+            if [[ "$VERSION" == *"alpha"* ]]; then
+              CHANNEL="alpha"
+            elif [[ "$VERSION" == *"beta"* ]]; then
+              CHANNEL="beta"
+            elif [[ "$VERSION" == *"rc"* ]]; then
+              CHANNEL="rc"
+            fi
 
-            # Add channel tags for prereleases and latest for stable
-            if [[ "$CREATE_LATEST" == "true" ]]; then
-              # Stable release
-              TAGS="$TAGS,${{ env.REGISTRY_DOCKERHUB }}:latest"
-            elif [[ "$BUILD_TYPE" == "prerelease" ]]; then
-              # Prerelease channel tags (alpha, beta, rc)
-              if [[ "$VERSION" == *"alpha"* ]]; then
-                CHANNEL="alpha"
-              elif [[ "$VERSION" == *"beta"* ]]; then
-                CHANNEL="beta"
-              elif [[ "$VERSION" == *"rc"* ]]; then
-                CHANNEL="rc"
-              fi
-
-              if [[ -n "$CHANNEL" ]]; then
-                TAGS="$TAGS,${{ env.REGISTRY_DOCKERHUB }}:${CHANNEL}"
-              fi
+            if [[ -n "$CHANNEL" ]]; then
+              TAGS="$TAGS,${{ env.REGISTRY_DOCKERHUB }}:${CHANNEL}"
             fi
           fi
 
@@ -384,14 +362,10 @@ jobs:
           echo "🐳 Docker build completed successfully!"
           echo "📦 Build type: $BUILD_TYPE"
           echo "🔢 Version: $VERSION"
-          echo "🚀 Strategy: Images using pre-built binaries (supports both release and dev channels)"
+          echo "🚀 Strategy: Images using pre-built binaries (release channel only)"
           echo ""
 
           case "$BUILD_TYPE" in
-            "development")
-              echo "🛠️  Development Docker image has been built with dev-${VERSION} tags"
-              echo "⚠️  This is a development image - not suitable for production use"
-              ;;
             "release")
               echo "🚀 Release Docker image has been built with ${VERSION} tags"
               echo "✅ This image is ready for production use"
@@ -403,5 +377,8 @@ jobs:
               echo "🧪 Prerelease Docker image has been built with ${VERSION} tags"
               echo "⚠️  This is a prerelease image - use with caution"
               echo "🚫 Latest tag NOT created for prerelease"
+              ;;
+            *)
+              echo "❌ Unexpected build type: $BUILD_TYPE"
               ;;
           esac

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM alpine:latest AS build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG RELEASE=latest
-ARG CHANNEL=release
 
 # Install dependencies for downloading and verifying binaries
 RUN apk add --no-cache \
@@ -27,30 +26,19 @@ RUN case "${TARGETPLATFORM}" in \
     esac && \
     echo "ARCH=${ARCH}" > /build/arch.env
 
-# Download rustfs binary from dl.rustfs.com
+# Download rustfs binary from dl.rustfs.com (release channel only)
 RUN . /build/arch.env && \
-    BASE_URL="https://dl.rustfs.com/artifacts/rustfs" && \
+    BASE_URL="https://dl.rustfs.com/artifacts/rustfs/release" && \
     PLATFORM="linux" && \
     if [ "${RELEASE}" = "latest" ]; then \
-        # Download latest version from specified channel \
-        if [ "${CHANNEL}" = "dev" ]; then \
-            PACKAGE_NAME="rustfs-${PLATFORM}-${ARCH}-dev-latest.zip"; \
-            DOWNLOAD_URL="${BASE_URL}/dev/${PACKAGE_NAME}"; \
-            echo "📥 Downloading latest dev build: ${PACKAGE_NAME}"; \
-        else \
-            PACKAGE_NAME="rustfs-${PLATFORM}-${ARCH}-latest.zip"; \
-            DOWNLOAD_URL="${BASE_URL}/release/${PACKAGE_NAME}"; \
-            echo "📥 Downloading latest release build: ${PACKAGE_NAME}"; \
-        fi; \
-    elif [ "${CHANNEL}" = "dev" ]; then \
-        # Download specific dev version \
-        PACKAGE_NAME="rustfs-${PLATFORM}-${ARCH}-${RELEASE}.zip"; \
-        DOWNLOAD_URL="${BASE_URL}/dev/${PACKAGE_NAME}"; \
-        echo "📥 Downloading specific dev version: ${PACKAGE_NAME}"; \
+        # Download latest release version \
+        PACKAGE_NAME="rustfs-${PLATFORM}-${ARCH}-latest.zip"; \
+        DOWNLOAD_URL="${BASE_URL}/${PACKAGE_NAME}"; \
+        echo "📥 Downloading latest release build: ${PACKAGE_NAME}"; \
     else \
         # Download specific release version \
         PACKAGE_NAME="rustfs-${PLATFORM}-${ARCH}-v${RELEASE}.zip"; \
-        DOWNLOAD_URL="${BASE_URL}/release/${PACKAGE_NAME}"; \
+        DOWNLOAD_URL="${BASE_URL}/${PACKAGE_NAME}"; \
         echo "📥 Downloading specific release version: ${PACKAGE_NAME}"; \
     fi && \
     echo "🔗 Download URL: ${DOWNLOAD_URL}" && \
@@ -71,7 +59,6 @@ FROM alpine:latest
 
 # Set build arguments and labels
 ARG RELEASE=latest
-ARG CHANNEL=release
 ARG BUILD_DATE
 ARG VCS_REF
 
@@ -80,7 +67,6 @@ LABEL name="RustFS" \
     maintainer="RustFS Team <dev@rustfs.com>" \
     version="${RELEASE}" \
     release="${RELEASE}" \
-    channel="${CHANNEL}" \
     build-date="${BUILD_DATE}" \
     vcs-ref="${VCS_REF}" \
     summary="RustFS is a high-performance distributed object storage system written in Rust, compatible with S3 API." \


### PR DESCRIPTION
## Problem

Currently, the Docker workflow builds images for all types of builds including development versions (main branch commits, dev-latest, etc.). This creates unnecessary Docker images that are not intended for production use and consumes resources.

## Solution

This PR modifies both the Docker workflow and Dockerfile to only build images for releases and prereleases, completely removing all development build support:

### Changes Made

#### 1. Workflow Changes ()

- **Input Parameters**: 
  - Removed `main-latest`, `dev-latest`, and `dev-*` options from manual trigger
  - Updated description to only mention supported versions
  - Changed default from `main-latest` to `latest`

- **Automatic Builds (workflow_run)**:
  - Added filtering logic to skip Docker builds for development versions
  - Only tag pushes (releases/prereleases) will trigger Docker image builds
  - Main branch commits will be skipped with clear logging

- **Manual Builds (workflow_dispatch)**:
  - Removed support for development version builds
  - Invalid versions now fail with clear error messages
  - Only accepts `latest`, `v1.0.0`, and `v1.0.0-alpha1` formats

- **Docker Image Logic**:
  - Simplified version conversion logic (removed dev channel handling)
  - Streamlined tag generation (removed development branch)
  - Updated build summary messages

#### 2. Dockerfile Changes

- **Removed CHANNEL build argument** (no longer needed)
- **Simplified download logic** to only support release channel
- **Removed dev-specific package download paths**
- **Updated BASE_URL** to point directly to release directory
- **Removed channel label** from Docker image metadata
- **Streamlined version handling** (latest vs specific release only)

#### 3. Documentation Updates

- Updated workflow comments to reflect release-only strategy

### Supported Versions After This Change

**Manual Trigger (`workflow_dispatch`)**:
- ✅ `latest` - Latest stable release
- ✅ `v1.0.0` - Specific release version
- ✅ `v1.0.0-alpha1` - Prerelease versions
- ❌ `main-latest` - **Removed**
- ❌ `dev-latest` - **Removed** 
- ❌ `dev-abc123` - **Removed**

**Automatic Trigger (`workflow_run`)**:
- ✅ Tag pushes (v1.0.0, v1.0.0-alpha1) → Build Docker images
- ❌ Main branch commits → **Skip Docker builds**
- ❌ Other branch commits → **Skip Docker builds**

**Dockerfile Build Arguments**:
- ✅ `RELEASE=latest` - Latest stable release
- ✅ `RELEASE=1.0.0` - Specific release version
- ❌ `CHANNEL=dev` - **Removed entirely**

## Benefits

1. **Resource Efficiency**: Eliminates unnecessary Docker builds for development versions
2. **Clarity**: Clear separation between development binaries and production Docker images
3. **Simplified Workflow**: Reduced complexity in build logic and tag generation
4. **Simplified Dockerfile**: Removed dev channel complexity, faster builds
5. **Better UX**: Clear error messages for invalid version requests

## Breaking Change

⚠️ **BREAKING CHANGE**: Development Docker images are no longer built automatically.

- Projects relying on `rustfs/rustfs:dev` or similar tags will need to use release versions
- Manual builds with development versions will now fail with clear error messages
- Docker builds no longer accept `CHANNEL=dev` build argument
- This change only affects Docker images; binary builds for development versions continue as normal

## Testing

- Verified manual triggers now properly reject development versions
- Confirmed workflow_run events skip development builds
- Tag generation logic simplified and tested for release scenarios
- Dockerfile build logic tested for release-only scenarios

## Files Changed

- `.github/workflows/docker.yml` - Complete workflow refactoring
- `Dockerfile` - Removed dev channel support

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

---

Closes issue with excessive Docker image builds for development versions.