### PR TITLE
feat: add `cargo clippy --fix --allow-dirty` to pre-commit command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ fmt-check:
 .PHONY: clippy
 clippy:
 	@echo "🔍 Running clippy checks..."
-	cargo clippy --all-targets --all-features -- -D warnings
+	cargo clippy --all-targets --all-features --fix --allow-dirty -- -D warnings
 
 .PHONY: check
 check:


### PR DESCRIPTION
## 🎯 解决问题

Resolves #277

## 📝 修改内容

在 Makefile 的 `clippy` 目标中添加了 `--fix --allow-dirty` 参数：

```makefile
cargo clippy --all-targets --all-features --fix --allow-dirty -- -D warnings
```

## ✨ 功能优势

- **自动修复**: `--fix` 参数让 clippy 自动修复可以修复的警告
- **支持脏工作树**: `--allow-dirty` 参数允许在有未提交更改的情况下运行
- **提升代码质量**: 在 pre-commit 阶段自动改善代码质量
- **减少手动工作**: 开发者无需手动修复简单的 clippy 警告

## 🧪 测试验证

✅ 已验证 `make clippy` 命令正常工作  
✅ 新参数能够正确执行  
✅ 基于最新 main 分支，无合并冲突

## 📋 变更文件

- `Makefile`: 修改 clippy 目标添加新参数

这是一个干净的 PR，只包含解决 issue #277 的必要更改，避免了之前分支的合并冲突问题。