### PR TITLE
Fix: Change `tokio::io::duplex` to `tokio::io::simplex`

### DIFF
--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -3246,7 +3246,7 @@ impl ObjectIO for SetDisks {
 
         // TODO: remote
 
-        let (rd, wd) = tokio::io::duplex(DEFAULT_READ_BUFFER_SIZE);
+        let (rd, wd) = tokio::io::simplex(DEFAULT_READ_BUFFER_SIZE);
 
         let (reader, offset, length) = GetObjectReader::new(Box::new(rd), range, &object_info, opts, &h)?;
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues

#73 

## Summary of Changes

将tokio::io::duplex修改为tokio::io::simplex。此处场景只需要单向通信，使用duplex（双工）会导致tokio产生大量多余的调度信号。在简化场景下 测试，替换后的性能应提高百分之十几。


## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Code is formatted with `cargo fmt --all`
- [x] Passed `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Passed `cargo check --all-targets`
- [] Added/updated necessary tests
- [] Documentation updated (if needed)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: No impact.

## Additional Notes

get_object过程中，异步读写的过程可以进一步精简，精简后可以预期性能有更多提升。

过多的异步读写会造成数据在内存中搬运次数增多和异步调度信号过多，导致性能下降。

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
