### PR TITLE
refactor: replace `lazy_static` with `LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,25 +2146,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -2172,12 +2169,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -5148,17 +5145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_debug"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5169,15 +5155,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -5518,9 +5495,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -7703,9 +7680,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "78eaea1f52c56d57821be178b2d47e09ff26481a6042e8e042fcb0ced068b470"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -7912,9 +7889,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824daba0a34f8c5c5392295d381e0800f88fd986ba291699f8785f05fa344c1e"
+checksum = "1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7933,9 +7910,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6543c0572a4dbc125c23e6f54963ea9ba002294fd81dd4012c204219b0dcaa"
+checksum = "4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",
@@ -8527,7 +8504,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "flexi_logger",
- "lazy_static",
  "nu-ansi-term 0.50.1",
  "nvml-wrapper",
  "opentelemetry",
@@ -8931,9 +8907,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3s"
-version = "0.12.0-minio-preview.2"
+version = "0.12.0-minio-preview.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0170817b5885b82d945f855969ddabe062067e019f7c0b2e28ddd2d0de70626b"
+checksum = "24c7be783f8b2bb5aba553462bf7e9ee95655bb27cbd6a0b0a93af2e719b1eec"
 dependencies = [
  "arrayvec",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.42", features = ["derive", "env"] }
 const-str = { version = "0.6.4", features = ["std", "proc"] }
 crc32fast = "1.5.0"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.7", features = ["html_reports"] }
 dashmap = "6.1.0"
 datafusion = "46.0.1"
 derive_builder = "0.20.2"
@@ -210,7 +210,7 @@ rfd = { version = "0.15.4", default-features = false, features = [
     "xdg-portal",
     "tokio",
 ] }
-rmcp = { version = "0.3.1" }
+rmcp = { version = "0.3.2" }
 rmp = "0.8.14"
 rmp-serde = "1.3.0"
 rsa = "0.9.8"

--- a/crates/ecstore/benches/comparison_benchmark.rs
+++ b/crates/ecstore/benches/comparison_benchmark.rs
@@ -32,8 +32,9 @@
 //! cargo bench --bench comparison_benchmark shard_analysis
 //! ```
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rustfs_ecstore::erasure_coding::Erasure;
+use std::hint::black_box;
 use std::time::Duration;
 
 /// Performance test data configuration

--- a/crates/ecstore/benches/comparison_benchmark.rs
+++ b/crates/ecstore/benches/comparison_benchmark.rs
@@ -32,7 +32,7 @@
 //! cargo bench --bench comparison_benchmark shard_analysis
 //! ```
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rustfs_ecstore::erasure_coding::Erasure;
 use std::hint::black_box;
 use std::time::Duration;

--- a/crates/ecstore/benches/erasure_benchmark.rs
+++ b/crates/ecstore/benches/erasure_benchmark.rs
@@ -43,8 +43,8 @@
 //! - Both encoding and decoding operations
 //! - SIMD optimization for different shard sizes
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use rustfs_ecstore::erasure_coding::{calc_shard_size, Erasure};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rustfs_ecstore::erasure_coding::{Erasure, calc_shard_size};
 use std::hint::black_box;
 use std::time::Duration;
 

--- a/crates/ecstore/benches/erasure_benchmark.rs
+++ b/crates/ecstore/benches/erasure_benchmark.rs
@@ -43,8 +43,9 @@
 //! - Both encoding and decoding operations
 //! - SIMD optimization for different shard sizes
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use rustfs_ecstore::erasure_coding::{Erasure, calc_shard_size};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rustfs_ecstore::erasure_coding::{calc_shard_size, Erasure};
+use std::hint::black_box;
 use std::time::Duration;
 
 /// Benchmark configuration structure

--- a/crates/filemeta/benches/xl_meta_bench.rs
+++ b/crates/filemeta/benches/xl_meta_bench.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use criterion::{criterion_group, criterion_main, Criterion};
-use rustfs_filemeta::{test_data::*, FileMeta};
+use criterion::{Criterion, criterion_group, criterion_main};
+use rustfs_filemeta::{FileMeta, test_data::*};
 use std::hint::black_box;
 
 fn bench_create_real_xlmeta(c: &mut Criterion) {

--- a/crates/filemeta/benches/xl_meta_bench.rs
+++ b/crates/filemeta/benches/xl_meta_bench.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use rustfs_filemeta::{FileMeta, test_data::*};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rustfs_filemeta::{test_data::*, FileMeta};
+use std::hint::black_box;
 
 fn bench_create_real_xlmeta(c: &mut Criterion) {
     c.bench_function("create_real_xlmeta", |b| b.iter(|| black_box(create_real_xlmeta().unwrap())));

--- a/crates/obs/Cargo.toml
+++ b/crates/obs/Cargo.toml
@@ -41,7 +41,6 @@ rustfs-utils = { workspace = true, features = ["ip", "path"] }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 flexi_logger = { workspace = true, features = ["trc", "kv"] }
-lazy_static = { workspace = true }
 nu-ansi-term = { workspace = true }
 nvml-wrapper = { workspace = true, optional = true }
 opentelemetry = { workspace = true }

--- a/crates/obs/src/metrics/audit.rs
+++ b/crates/obs/src/metrics/audit.rs
@@ -17,7 +17,7 @@
 /// audit related metric descriptors
 ///
 /// This module contains the metric descriptors for the audit subsystem.
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 const TARGET_ID: &str = "target_id";

--- a/crates/obs/src/metrics/audit.rs
+++ b/crates/obs/src/metrics/audit.rs
@@ -12,35 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// audit related metric descriptors
 ///
 /// This module contains the metric descriptors for the audit subsystem.
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
 const TARGET_ID: &str = "target_id";
 
-lazy_static::lazy_static! {
-    pub static ref AUDIT_FAILED_MESSAGES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::AuditFailedMessages,
-            "Total number of messages that failed to send since start",
-            &[TARGET_ID],
-            subsystems::AUDIT
-        );
+pub static AUDIT_FAILED_MESSAGES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::AuditFailedMessages,
+        "Total number of messages that failed to send since start",
+        &[TARGET_ID],
+        subsystems::AUDIT,
+    )
+});
 
-    pub static ref AUDIT_TARGET_QUEUE_LENGTH_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::AuditTargetQueueLength,
-            "Number of unsent messages in queue for target",
-            &[TARGET_ID],
-            subsystems::AUDIT
-        );
+pub static AUDIT_TARGET_QUEUE_LENGTH_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::AuditTargetQueueLength,
+        "Number of unsent messages in queue for target",
+        &[TARGET_ID],
+        subsystems::AUDIT,
+    )
+});
 
-    pub static ref AUDIT_TOTAL_MESSAGES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::AuditTotalMessages,
-            "Total number of messages sent since start",
-            &[TARGET_ID],
-            subsystems::AUDIT
-        );
-}
+pub static AUDIT_TOTAL_MESSAGES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::AuditTotalMessages,
+        "Total number of messages sent since start",
+        &[TARGET_ID],
+        subsystems::AUDIT,
+    )
+});

--- a/crates/obs/src/metrics/bucket.rs
+++ b/crates/obs/src/metrics/bucket.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// bucket level s3 metric descriptor
-use crate::metrics::{new_counter_md, new_gauge_md, new_histogram_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, new_histogram_md, subsystems};
 use std::sync::LazyLock;
 
 pub static BUCKET_API_TRAFFIC_SENT_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/bucket.rs
+++ b/crates/obs/src/metrics/bucket.rs
@@ -12,71 +12,80 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// bucket level s3 metric descriptor
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, new_histogram_md, subsystems};
+use crate::metrics::{new_counter_md, new_gauge_md, new_histogram_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref BUCKET_API_TRAFFIC_SENT_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiTrafficSentBytes,
-            "Total number of bytes received for a bucket",
-            &["bucket", "type"],
-            subsystems::BUCKET_API
-        );
+pub static BUCKET_API_TRAFFIC_SENT_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiTrafficSentBytes,
+        "Total number of bytes received for a bucket",
+        &["bucket", "type"],
+        subsystems::BUCKET_API,
+    )
+});
 
-    pub static ref BUCKET_API_TRAFFIC_RECV_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiTrafficRecvBytes,
-            "Total number of bytes sent for a bucket",
-            &["bucket", "type"],
-            subsystems::BUCKET_API
-        );
+pub static BUCKET_API_TRAFFIC_RECV_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiTrafficRecvBytes,
+        "Total number of bytes sent for a bucket",
+        &["bucket", "type"],
+        subsystems::BUCKET_API,
+    )
+});
 
-    pub static ref BUCKET_API_REQUESTS_IN_FLIGHT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ApiRequestsInFlightTotal,
-            "Total number of requests currently in flight for a bucket",
-            &["bucket", "name", "type"],
-            subsystems::BUCKET_API
-        );
+pub static BUCKET_API_REQUESTS_IN_FLIGHT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ApiRequestsInFlightTotal,
+        "Total number of requests currently in flight for a bucket",
+        &["bucket", "name", "type"],
+        subsystems::BUCKET_API,
+    )
+});
 
-    pub static ref BUCKET_API_REQUESTS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequestsTotal,
-            "Total number of requests for a bucket",
-            &["bucket", "name", "type"],
-            subsystems::BUCKET_API
-        );
+pub static BUCKET_API_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequestsTotal,
+        "Total number of requests for a bucket",
+        &["bucket", "name", "type"],
+        subsystems::BUCKET_API,
+    )
+});
 
-    pub static ref BUCKET_API_REQUESTS_CANCELED_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequestsCanceledTotal,
-            "Total number of requests canceled by the client for a bucket",
-            &["bucket", "name", "type"],
-            subsystems::BUCKET_API
-        );
+pub static BUCKET_API_REQUESTS_CANCELED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequestsCanceledTotal,
+        "Total number of requests canceled by the client for a bucket",
+        &["bucket", "name", "type"],
+        subsystems::BUCKET_API,
+    )
+});
 
-    pub static ref BUCKET_API_REQUESTS_4XX_ERRORS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequests4xxErrorsTotal,
-            "Total number of requests with 4xx errors for a bucket",
-            &["bucket", "name", "type"],
-            subsystems::BUCKET_API
-        );
+pub static BUCKET_API_REQUESTS_4XX_ERRORS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequests4xxErrorsTotal,
+        "Total number of requests with 4xx errors for a bucket",
+        &["bucket", "name", "type"],
+        subsystems::BUCKET_API,
+    )
+});
 
-    pub static ref BUCKET_API_REQUESTS_5XX_ERRORS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequests5xxErrorsTotal,
-            "Total number of requests with 5xx errors for a bucket",
-            &["bucket", "name", "type"],
-            subsystems::BUCKET_API
-        );
+pub static BUCKET_API_REQUESTS_5XX_ERRORS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequests5xxErrorsTotal,
+        "Total number of requests with 5xx errors for a bucket",
+        &["bucket", "name", "type"],
+        subsystems::BUCKET_API,
+    )
+});
 
-    pub static ref BUCKET_API_REQUESTS_TTFB_SECONDS_DISTRIBUTION_MD: MetricDescriptor =
-        new_histogram_md(
-            MetricName::ApiRequestsTTFBSecondsDistribution,
-            "Distribution of time to first byte across API calls for a bucket",
-            &["bucket", "name", "le", "type"],
-            subsystems::BUCKET_API
-        );
-}
+pub static BUCKET_API_REQUESTS_TTFB_SECONDS_DISTRIBUTION_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_histogram_md(
+        MetricName::ApiRequestsTTFBSecondsDistribution,
+        "Distribution of time to first byte across API calls for a bucket",
+        &["bucket", "name", "le", "type"],
+        subsystems::BUCKET_API,
+    )
+});

--- a/crates/obs/src/metrics/bucket_replication.rs
+++ b/crates/obs/src/metrics/bucket_replication.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Bucket copy metric descriptor
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// Bucket level replication metric descriptor

--- a/crates/obs/src/metrics/bucket_replication.rs
+++ b/crates/obs/src/metrics/bucket_replication.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Bucket copy metric descriptor
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
 /// Bucket level replication metric descriptor
 pub const BUCKET_L: &str = "bucket";
@@ -24,159 +27,176 @@ pub const TARGET_ARN_L: &str = "targetArn";
 /// Replication range
 pub const RANGE_L: &str = "range";
 
-lazy_static::lazy_static! {
-    pub static ref BUCKET_REPL_LAST_HR_FAILED_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::LastHourFailedBytes,
-            "Total number of bytes failed at least once to replicate in the last hour on a bucket",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_LAST_HR_FAILED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::LastHourFailedBytes,
+        "Total number of bytes failed at least once to replicate in the last hour on a bucket",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_LAST_HR_FAILED_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::LastHourFailedCount,
-            "Total number of objects which failed replication in the last hour on a bucket",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_LAST_HR_FAILED_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::LastHourFailedCount,
+        "Total number of objects which failed replication in the last hour on a bucket",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_LAST_MIN_FAILED_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::LastMinFailedBytes,
-            "Total number of bytes failed at least once to replicate in the last full minute on a bucket",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_LAST_MIN_FAILED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::LastMinFailedBytes,
+        "Total number of bytes failed at least once to replicate in the last full minute on a bucket",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_LAST_MIN_FAILED_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::LastMinFailedCount,
-            "Total number of objects which failed replication in the last full minute on a bucket",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_LAST_MIN_FAILED_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::LastMinFailedCount,
+        "Total number of objects which failed replication in the last full minute on a bucket",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_LATENCY_MS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::LatencyMilliSec,
-            "Replication latency on a bucket in milliseconds",
-            &[BUCKET_L, OPERATION_L, RANGE_L, TARGET_ARN_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_LATENCY_MS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::LatencyMilliSec,
+        "Replication latency on a bucket in milliseconds",
+        &[BUCKET_L, OPERATION_L, RANGE_L, TARGET_ARN_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_PROXIED_DELETE_TAGGING_REQUESTS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedDeleteTaggingRequestsTotal,
-            "Number of DELETE tagging requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_PROXIED_DELETE_TAGGING_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedDeleteTaggingRequestsTotal,
+        "Number of DELETE tagging requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_PROXIED_GET_REQUESTS_FAILURES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedGetRequestsFailures,
-            "Number of failures in GET requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_PROXIED_GET_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedGetRequestsFailures,
+        "Number of failures in GET requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_PROXIED_GET_REQUESTS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedGetRequestsTotal,
-            "Number of GET requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_PROXIED_GET_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedGetRequestsTotal,
+        "Number of GET requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    // TODO - add a metric for the number of PUT requests proxied to replication target
-    pub static ref BUCKET_REPL_PROXIED_GET_TAGGING_REQUESTS_FAILURES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedGetTaggingRequestFailures,
-            "Number of failures in GET tagging requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+// TODO - add a metric for the number of PUT requests proxied to replication target
+pub static BUCKET_REPL_PROXIED_GET_TAGGING_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedGetTaggingRequestFailures,
+        "Number of failures in GET tagging requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_PROXIED_GET_TAGGING_REQUESTS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedGetTaggingRequestsTotal,
-            "Number of GET tagging requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_PROXIED_GET_TAGGING_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedGetTaggingRequestsTotal,
+        "Number of GET tagging requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_PROXIED_HEAD_REQUESTS_FAILURES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedHeadRequestsFailures,
-            "Number of failures in HEAD requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_PROXIED_HEAD_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedHeadRequestsFailures,
+        "Number of failures in HEAD requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_PROXIED_HEAD_REQUESTS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedHeadRequestsTotal,
-            "Number of HEAD requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_PROXIED_HEAD_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedHeadRequestsTotal,
+        "Number of HEAD requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    // TODO - add a metric for the number of PUT requests proxied to replication target
-    pub static ref BUCKET_REPL_PROXIED_PUT_TAGGING_REQUESTS_FAILURES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedPutTaggingRequestFailures,
-            "Number of failures in PUT tagging requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+// TODO - add a metric for the number of PUT requests proxied to replication target
+pub static BUCKET_REPL_PROXIED_PUT_TAGGING_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedPutTaggingRequestFailures,
+        "Number of failures in PUT tagging requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_PROXIED_PUT_TAGGING_REQUESTS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedPutTaggingRequestsTotal,
-            "Number of PUT tagging requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_PROXIED_PUT_TAGGING_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedPutTaggingRequestsTotal,
+        "Number of PUT tagging requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_SENT_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::SentBytes,
-            "Total number of bytes replicated to the target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_SENT_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::SentBytes,
+        "Total number of bytes replicated to the target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_SENT_COUNT_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::SentCount,
-            "Total number of objects replicated to the target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_SENT_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::SentCount,
+        "Total number of objects replicated to the target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_TOTAL_FAILED_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::TotalFailedBytes,
-            "Total number of bytes failed at least once to replicate since server start",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_TOTAL_FAILED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::TotalFailedBytes,
+        "Total number of bytes failed at least once to replicate since server start",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    pub static ref BUCKET_REPL_TOTAL_FAILED_COUNT_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::TotalFailedCount,
-            "Total number of objects which failed replication since server start",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
+pub static BUCKET_REPL_TOTAL_FAILED_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::TotalFailedCount,
+        "Total number of objects which failed replication since server start",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
 
-    // TODO - add a metric for the number of DELETE requests proxied to replication target
-    pub static ref BUCKET_REPL_PROXIED_DELETE_TAGGING_REQUESTS_FAILURES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProxiedDeleteTaggingRequestFailures,
-            "Number of failures in DELETE tagging requests proxied to replication target",
-            &[BUCKET_L],
-            subsystems::BUCKET_REPLICATION
-        );
-}
+// TODO - add a metric for the number of DELETE requests proxied to replication target
+pub static BUCKET_REPL_PROXIED_DELETE_TAGGING_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProxiedDeleteTaggingRequestFailures,
+        "Number of failures in DELETE tagging requests proxied to replication target",
+        &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});

--- a/crates/obs/src/metrics/cluster_config.rs
+++ b/crates/obs/src/metrics/cluster_config.rs
@@ -12,23 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Metric descriptors related to cluster configuration
-use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
+use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
 
-lazy_static::lazy_static! {
-    pub static ref CONFIG_RRS_PARITY_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ConfigRRSParity,
-            "Reduced redundancy storage class parity",
-            &[],
-            subsystems::CLUSTER_CONFIG
-        );
+use std::sync::LazyLock;
 
-    pub static ref CONFIG_STANDARD_PARITY_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ConfigStandardParity,
-            "Standard storage class parity",
-            &[],
-            subsystems::CLUSTER_CONFIG
-        );
-}
+pub static CONFIG_RRS_PARITY_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ConfigRRSParity,
+        "Reduced redundancy storage class parity",
+        &[],
+        subsystems::CLUSTER_CONFIG,
+    )
+});
+
+pub static CONFIG_STANDARD_PARITY_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ConfigStandardParity,
+        "Standard storage class parity",
+        &[],
+        subsystems::CLUSTER_CONFIG,
+    )
+});

--- a/crates/obs/src/metrics/cluster_config.rs
+++ b/crates/obs/src/metrics/cluster_config.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Metric descriptors related to cluster configuration
-use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/cluster_erasure_set.rs
@@ -12,100 +12,112 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Erasure code set related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
+use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
 /// The label for the pool ID
 pub const POOL_ID_L: &str = "pool_id";
 /// The label for the pool ID
 pub const SET_ID_L: &str = "set_id";
 
-lazy_static::lazy_static! {
-    pub static ref ERASURE_SET_OVERALL_WRITE_QUORUM_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetOverallWriteQuorum,
-            "Overall write quorum across pools and sets",
-            &[],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_OVERALL_WRITE_QUORUM_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetOverallWriteQuorum,
+        "Overall write quorum across pools and sets",
+        &[],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_OVERALL_HEALTH_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetOverallHealth,
-            "Overall health across pools and sets (1=healthy, 0=unhealthy)",
-            &[],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_OVERALL_HEALTH_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetOverallHealth,
+        "Overall health across pools and sets (1=healthy, 0=unhealthy)",
+        &[],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_READ_QUORUM_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetReadQuorum,
-            "Read quorum for the erasure set in a pool",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_READ_QUORUM_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetReadQuorum,
+        "Read quorum for the erasure set in a pool",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_WRITE_QUORUM_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetWriteQuorum,
-            "Write quorum for the erasure set in a pool",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_WRITE_QUORUM_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetWriteQuorum,
+        "Write quorum for the erasure set in a pool",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_ONLINE_DRIVES_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetOnlineDrivesCount,
-            "Count of online drives in the erasure set in a pool",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_ONLINE_DRIVES_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetOnlineDrivesCount,
+        "Count of online drives in the erasure set in a pool",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_HEALING_DRIVES_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetHealingDrivesCount,
-            "Count of healing drives in the erasure set in a pool",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_HEALING_DRIVES_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetHealingDrivesCount,
+        "Count of healing drives in the erasure set in a pool",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_HEALTH_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetHealth,
-            "Health of the erasure set in a pool (1=healthy, 0=unhealthy)",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_HEALTH_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetHealth,
+        "Health of the erasure set in a pool (1=healthy, 0=unhealthy)",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_READ_TOLERANCE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetReadTolerance,
-            "No of drive failures that can be tolerated without disrupting read operations",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_READ_TOLERANCE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetReadTolerance,
+        "No of drive failures that can be tolerated without disrupting read operations",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_WRITE_TOLERANCE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetWriteTolerance,
-            "No of drive failures that can be tolerated without disrupting write operations",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_WRITE_TOLERANCE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetWriteTolerance,
+        "No of drive failures that can be tolerated without disrupting write operations",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_READ_HEALTH_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetReadHealth,
-            "Health of the erasure set in a pool for read operations (1=healthy, 0=unhealthy)",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
+pub static ERASURE_SET_READ_HEALTH_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetReadHealth,
+        "Health of the erasure set in a pool for read operations (1=healthy, 0=unhealthy)",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});
 
-    pub static ref ERASURE_SET_WRITE_HEALTH_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ErasureSetWriteHealth,
-            "Health of the erasure set in a pool for write operations (1=healthy, 0=unhealthy)",
-            &[POOL_ID_L, SET_ID_L],
-            subsystems::CLUSTER_ERASURE_SET
-        );
-}
+pub static ERASURE_SET_WRITE_HEALTH_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ErasureSetWriteHealth,
+        "Health of the erasure set in a pool for write operations (1=healthy, 0=unhealthy)",
+        &[POOL_ID_L, SET_ID_L],
+        subsystems::CLUSTER_ERASURE_SET,
+    )
+});

--- a/crates/obs/src/metrics/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/cluster_erasure_set.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Erasure code set related metric descriptors
-use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// The label for the pool ID

--- a/crates/obs/src/metrics/cluster_health.rs
+++ b/crates/obs/src/metrics/cluster_health.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Cluster health-related metric descriptors
-use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 pub static HEALTH_DRIVES_OFFLINE_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/cluster_health.rs
+++ b/crates/obs/src/metrics/cluster_health.rs
@@ -12,31 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Cluster health-related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
+use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref HEALTH_DRIVES_OFFLINE_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::HealthDrivesOfflineCount,
-            "Count of offline drives in the cluster",
-            &[],
-            subsystems::CLUSTER_HEALTH
-        );
+pub static HEALTH_DRIVES_OFFLINE_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::HealthDrivesOfflineCount,
+        "Count of offline drives in the cluster",
+        &[],
+        subsystems::CLUSTER_HEALTH,
+    )
+});
 
-    pub static ref HEALTH_DRIVES_ONLINE_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::HealthDrivesOnlineCount,
-            "Count of online drives in the cluster",
-            &[],
-            subsystems::CLUSTER_HEALTH
-        );
+pub static HEALTH_DRIVES_ONLINE_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::HealthDrivesOnlineCount,
+        "Count of online drives in the cluster",
+        &[],
+        subsystems::CLUSTER_HEALTH,
+    )
+});
 
-    pub static ref HEALTH_DRIVES_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::HealthDrivesCount,
-            "Count of all drives in the cluster",
-            &[],
-            subsystems::CLUSTER_HEALTH
-        );
-}
+pub static HEALTH_DRIVES_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::HealthDrivesCount,
+        "Count of all drives in the cluster",
+        &[],
+        subsystems::CLUSTER_HEALTH,
+    )
+});

--- a/crates/obs/src/metrics/cluster_iam.rs
+++ b/crates/obs/src/metrics/cluster_iam.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// IAM related metric descriptors
-use crate::metrics::{new_counter_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, subsystems};
 use std::sync::LazyLock;
 
 pub static LAST_SYNC_DURATION_MILLIS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/cluster_iam.rs
+++ b/crates/obs/src/metrics/cluster_iam.rs
@@ -12,87 +12,98 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// IAM related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, subsystems};
+use crate::metrics::{new_counter_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref LAST_SYNC_DURATION_MILLIS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::LastSyncDurationMillis,
-            "Last successful IAM data sync duration in milliseconds",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static LAST_SYNC_DURATION_MILLIS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::LastSyncDurationMillis,
+        "Last successful IAM data sync duration in milliseconds",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref PLUGIN_AUTHN_SERVICE_FAILED_REQUESTS_MINUTE_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::PluginAuthnServiceFailedRequestsMinute,
-            "When plugin authentication is configured, returns failed requests count in the last full minute",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static PLUGIN_AUTHN_SERVICE_FAILED_REQUESTS_MINUTE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::PluginAuthnServiceFailedRequestsMinute,
+        "When plugin authentication is configured, returns failed requests count in the last full minute",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref PLUGIN_AUTHN_SERVICE_LAST_FAIL_SECONDS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::PluginAuthnServiceLastFailSeconds,
-            "When plugin authentication is configured, returns time (in seconds) since the last failed request to the service",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static PLUGIN_AUTHN_SERVICE_LAST_FAIL_SECONDS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::PluginAuthnServiceLastFailSeconds,
+        "When plugin authentication is configured, returns time (in seconds) since the last failed request to the service",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref PLUGIN_AUTHN_SERVICE_LAST_SUCC_SECONDS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::PluginAuthnServiceLastSuccSeconds,
-            "When plugin authentication is configured, returns time (in seconds) since the last successful request to the service",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static PLUGIN_AUTHN_SERVICE_LAST_SUCC_SECONDS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::PluginAuthnServiceLastSuccSeconds,
+        "When plugin authentication is configured, returns time (in seconds) since the last successful request to the service",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref PLUGIN_AUTHN_SERVICE_SUCC_AVG_RTT_MS_MINUTE_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::PluginAuthnServiceSuccAvgRttMsMinute,
-            "When plugin authentication is configured, returns average round-trip-time of successful requests in the last full minute",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static PLUGIN_AUTHN_SERVICE_SUCC_AVG_RTT_MS_MINUTE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::PluginAuthnServiceSuccAvgRttMsMinute,
+        "When plugin authentication is configured, returns average round-trip-time of successful requests in the last full minute",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref PLUGIN_AUTHN_SERVICE_SUCC_MAX_RTT_MS_MINUTE_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::PluginAuthnServiceSuccMaxRttMsMinute,
-            "When plugin authentication is configured, returns maximum round-trip-time of successful requests in the last full minute",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static PLUGIN_AUTHN_SERVICE_SUCC_MAX_RTT_MS_MINUTE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::PluginAuthnServiceSuccMaxRttMsMinute,
+        "When plugin authentication is configured, returns maximum round-trip-time of successful requests in the last full minute",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref PLUGIN_AUTHN_SERVICE_TOTAL_REQUESTS_MINUTE_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::PluginAuthnServiceTotalRequestsMinute,
-            "When plugin authentication is configured, returns total requests count in the last full minute",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static PLUGIN_AUTHN_SERVICE_TOTAL_REQUESTS_MINUTE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::PluginAuthnServiceTotalRequestsMinute,
+        "When plugin authentication is configured, returns total requests count in the last full minute",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref SINCE_LAST_SYNC_MILLIS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::SinceLastSyncMillis,
-            "Time (in milliseconds) since last successful IAM data sync.",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static SINCE_LAST_SYNC_MILLIS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::SinceLastSyncMillis,
+        "Time (in milliseconds) since last successful IAM data sync.",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref SYNC_FAILURES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::SyncFailures,
-            "Number of failed IAM data syncs since server start.",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
+pub static SYNC_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::SyncFailures,
+        "Number of failed IAM data syncs since server start.",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});
 
-    pub static ref SYNC_SUCCESSES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::SyncSuccesses,
-            "Number of successful IAM data syncs since server start.",
-            &[],
-            subsystems::CLUSTER_IAM
-        );
-}
+pub static SYNC_SUCCESSES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::SyncSuccesses,
+        "Number of successful IAM data syncs since server start.",
+        &[],
+        subsystems::CLUSTER_IAM,
+    )
+});

--- a/crates/obs/src/metrics/cluster_notification.rs
+++ b/crates/obs/src/metrics/cluster_notification.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Notify the relevant metric descriptor
-use crate::metrics::{new_counter_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, subsystems};
 use std::sync::LazyLock;
 
 pub static NOTIFICATION_CURRENT_SEND_IN_PROGRESS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/cluster_notification.rs
+++ b/crates/obs/src/metrics/cluster_notification.rs
@@ -12,39 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Notify the relevant metric descriptor
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, subsystems};
+use crate::metrics::{new_counter_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref NOTIFICATION_CURRENT_SEND_IN_PROGRESS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::NotificationCurrentSendInProgress,
-            "Number of concurrent async Send calls active to all targets",
-            &[],
-            subsystems::NOTIFICATION
-        );
+pub static NOTIFICATION_CURRENT_SEND_IN_PROGRESS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::NotificationCurrentSendInProgress,
+        "Number of concurrent async Send calls active to all targets",
+        &[],
+        subsystems::NOTIFICATION,
+    )
+});
 
-    pub static ref NOTIFICATION_EVENTS_ERRORS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::NotificationEventsErrorsTotal,
-            "Events that were failed to be sent to the targets",
-            &[],
-            subsystems::NOTIFICATION
-        );
+pub static NOTIFICATION_EVENTS_ERRORS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::NotificationEventsErrorsTotal,
+        "Events that were failed to be sent to the targets",
+        &[],
+        subsystems::NOTIFICATION,
+    )
+});
 
-    pub static ref NOTIFICATION_EVENTS_SENT_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::NotificationEventsSentTotal,
-            "Total number of events sent to the targets",
-            &[],
-            subsystems::NOTIFICATION
-        );
+pub static NOTIFICATION_EVENTS_SENT_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::NotificationEventsSentTotal,
+        "Total number of events sent to the targets",
+        &[],
+        subsystems::NOTIFICATION,
+    )
+});
 
-    pub static ref NOTIFICATION_EVENTS_SKIPPED_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::NotificationEventsSkippedTotal,
-            "Events that were skipped to be sent to the targets due to the in-memory queue being full",
-            &[],
-            subsystems::NOTIFICATION
-        );
-}
+pub static NOTIFICATION_EVENTS_SKIPPED_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::NotificationEventsSkippedTotal,
+        "Events that were skipped to be sent to the targets due to the in-memory queue being full",
+        &[],
+        subsystems::NOTIFICATION,
+    )
+});

--- a/crates/obs/src/metrics/cluster_usage.rs
+++ b/crates/obs/src/metrics/cluster_usage.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Descriptors of metrics related to cluster object and bucket usage
-use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// Bucket labels

--- a/crates/obs/src/metrics/cluster_usage.rs
+++ b/crates/obs/src/metrics/cluster_usage.rs
@@ -12,134 +12,148 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Descriptors of metrics related to cluster object and bucket usage
-use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
+use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
 /// Bucket labels
 pub const BUCKET_LABEL: &str = "bucket";
 /// Range labels
 pub const RANGE_LABEL: &str = "range";
 
-lazy_static::lazy_static! {
-    pub static ref USAGE_SINCE_LAST_UPDATE_SECONDS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageSinceLastUpdateSeconds,
-            "Time since last update of usage metrics in seconds",
-            &[],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
+pub static USAGE_SINCE_LAST_UPDATE_SECONDS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageSinceLastUpdateSeconds,
+        "Time since last update of usage metrics in seconds",
+        &[],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-    pub static ref USAGE_TOTAL_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageTotalBytes,
-            "Total cluster usage in bytes",
-            &[],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
+pub static USAGE_TOTAL_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageTotalBytes,
+        "Total cluster usage in bytes",
+        &[],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-    pub static ref USAGE_OBJECTS_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageObjectsCount,
-            "Total cluster objects count",
-            &[],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
+pub static USAGE_OBJECTS_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageObjectsCount,
+        "Total cluster objects count",
+        &[],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-    pub static ref USAGE_VERSIONS_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageVersionsCount,
-            "Total cluster object versions (including delete markers) count",
-            &[],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
+pub static USAGE_VERSIONS_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageVersionsCount,
+        "Total cluster object versions (including delete markers) count",
+        &[],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-    pub static ref USAGE_DELETE_MARKERS_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageDeleteMarkersCount,
-            "Total cluster delete markers count",
-            &[],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
+pub static USAGE_DELETE_MARKERS_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageDeleteMarkersCount,
+        "Total cluster delete markers count",
+        &[],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-    pub static ref USAGE_BUCKETS_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketsCount,
-            "Total cluster buckets count",
-            &[],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
+pub static USAGE_BUCKETS_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketsCount,
+        "Total cluster buckets count",
+        &[],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-    pub static ref USAGE_OBJECTS_DISTRIBUTION_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageSizeDistribution,
-            "Cluster object size distribution",
-            &[RANGE_LABEL],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
+pub static USAGE_OBJECTS_DISTRIBUTION_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageSizeDistribution,
+        "Cluster object size distribution",
+        &[RANGE_LABEL],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-    pub static ref USAGE_VERSIONS_DISTRIBUTION_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageVersionCountDistribution,
-            "Cluster object version count distribution",
-            &[RANGE_LABEL],
-            subsystems::CLUSTER_USAGE_OBJECTS
-        );
-}
+pub static USAGE_VERSIONS_DISTRIBUTION_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageVersionCountDistribution,
+        "Cluster object version count distribution",
+        &[RANGE_LABEL],
+        subsystems::CLUSTER_USAGE_OBJECTS,
+    )
+});
 
-lazy_static::lazy_static! {
-    pub static ref USAGE_BUCKET_TOTAL_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketTotalBytes,
-            "Total bucket size in bytes",
-            &[BUCKET_LABEL],
-            subsystems::CLUSTER_USAGE_BUCKETS
-        );
+pub static USAGE_BUCKET_TOTAL_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketTotalBytes,
+        "Total bucket size in bytes",
+        &[BUCKET_LABEL],
+        subsystems::CLUSTER_USAGE_BUCKETS,
+    )
+});
 
-    pub static ref USAGE_BUCKET_OBJECTS_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketObjectsCount,
-            "Total objects count in bucket",
-            &[BUCKET_LABEL],
-            subsystems::CLUSTER_USAGE_BUCKETS
-        );
+pub static USAGE_BUCKET_OBJECTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketObjectsCount,
+        "Total objects count in bucket",
+        &[BUCKET_LABEL],
+        subsystems::CLUSTER_USAGE_BUCKETS,
+    )
+});
 
-    pub static ref USAGE_BUCKET_VERSIONS_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketVersionsCount,
-            "Total object versions (including delete markers) count in bucket",
-            &[BUCKET_LABEL],
-            subsystems::CLUSTER_USAGE_BUCKETS
-        );
+pub static USAGE_BUCKET_VERSIONS_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketVersionsCount,
+        "Total object versions (including delete markers) count in bucket",
+        &[BUCKET_LABEL],
+        subsystems::CLUSTER_USAGE_BUCKETS,
+    )
+});
 
-    pub static ref USAGE_BUCKET_DELETE_MARKERS_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketDeleteMarkersCount,
-            "Total delete markers count in bucket",
-            &[BUCKET_LABEL],
-            subsystems::CLUSTER_USAGE_BUCKETS
-        );
+pub static USAGE_BUCKET_DELETE_MARKERS_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketDeleteMarkersCount,
+        "Total delete markers count in bucket",
+        &[BUCKET_LABEL],
+        subsystems::CLUSTER_USAGE_BUCKETS,
+    )
+});
 
-    pub static ref USAGE_BUCKET_QUOTA_TOTAL_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketQuotaTotalBytes,
-            "Total bucket quota in bytes",
-            &[BUCKET_LABEL],
-            subsystems::CLUSTER_USAGE_BUCKETS
-        );
+pub static USAGE_BUCKET_QUOTA_TOTAL_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketQuotaTotalBytes,
+        "Total bucket quota in bytes",
+        &[BUCKET_LABEL],
+        subsystems::CLUSTER_USAGE_BUCKETS,
+    )
+});
 
-    pub static ref USAGE_BUCKET_OBJECT_SIZE_DISTRIBUTION_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketObjectSizeDistribution,
-            "Bucket object size distribution",
-            &[RANGE_LABEL, BUCKET_LABEL],
-            subsystems::CLUSTER_USAGE_BUCKETS
-        );
+pub static USAGE_BUCKET_OBJECT_SIZE_DISTRIBUTION_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketObjectSizeDistribution,
+        "Bucket object size distribution",
+        &[RANGE_LABEL, BUCKET_LABEL],
+        subsystems::CLUSTER_USAGE_BUCKETS,
+    )
+});
 
-    pub static ref USAGE_BUCKET_OBJECT_VERSION_COUNT_DISTRIBUTION_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::UsageBucketObjectVersionCountDistribution,
-            "Bucket object version count distribution",
-            &[RANGE_LABEL, BUCKET_LABEL],
-            subsystems::CLUSTER_USAGE_BUCKETS
-        );
-}
+pub static USAGE_BUCKET_OBJECT_VERSION_COUNT_DISTRIBUTION_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::UsageBucketObjectVersionCountDistribution,
+        "Bucket object version count distribution",
+        &[RANGE_LABEL, BUCKET_LABEL],
+        subsystems::CLUSTER_USAGE_BUCKETS,
+    )
+});

--- a/crates/obs/src/metrics/ilm.rs
+++ b/crates/obs/src/metrics/ilm.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// ILM-related metric descriptors
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 pub static ILM_EXPIRY_PENDING_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/ilm.rs
+++ b/crates/obs/src/metrics/ilm.rs
@@ -12,47 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// ILM-related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref ILM_EXPIRY_PENDING_TASKS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::IlmExpiryPendingTasks,
-            "Number of pending ILM expiry tasks in the queue",
-            &[],
-            subsystems::ILM
-        );
+pub static ILM_EXPIRY_PENDING_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::IlmExpiryPendingTasks,
+        "Number of pending ILM expiry tasks in the queue",
+        &[],
+        subsystems::ILM,
+    )
+});
 
-    pub static ref ILM_TRANSITION_ACTIVE_TASKS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::IlmTransitionActiveTasks,
-            "Number of active ILM transition tasks",
-            &[],
-            subsystems::ILM
-        );
+pub static ILM_TRANSITION_ACTIVE_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::IlmTransitionActiveTasks,
+        "Number of active ILM transition tasks",
+        &[],
+        subsystems::ILM,
+    )
+});
 
-    pub static ref ILM_TRANSITION_PENDING_TASKS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::IlmTransitionPendingTasks,
-            "Number of pending ILM transition tasks in the queue",
-            &[],
-            subsystems::ILM
-        );
+pub static ILM_TRANSITION_PENDING_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::IlmTransitionPendingTasks,
+        "Number of pending ILM transition tasks in the queue",
+        &[],
+        subsystems::ILM,
+    )
+});
 
-    pub static ref ILM_TRANSITION_MISSED_IMMEDIATE_TASKS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::IlmTransitionMissedImmediateTasks,
-            "Number of missed immediate ILM transition tasks",
-            &[],
-            subsystems::ILM
-        );
+pub static ILM_TRANSITION_MISSED_IMMEDIATE_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::IlmTransitionMissedImmediateTasks,
+        "Number of missed immediate ILM transition tasks",
+        &[],
+        subsystems::ILM,
+    )
+});
 
-    pub static ref ILM_VERSIONS_SCANNED_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::IlmVersionsScanned,
-            "Total number of object versions checked for ILM actions since server start",
-            &[],
-            subsystems::ILM
-        );
-}
+pub static ILM_VERSIONS_SCANNED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::IlmVersionsScanned,
+        "Total number of object versions checked for ILM actions since server start",
+        &[],
+        subsystems::ILM,
+    )
+});

--- a/crates/obs/src/metrics/logger_webhook.rs
+++ b/crates/obs/src/metrics/logger_webhook.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// A descriptor for metrics related to webhook logs
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// Define label constants for webhook metrics

--- a/crates/obs/src/metrics/logger_webhook.rs
+++ b/crates/obs/src/metrics/logger_webhook.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// A descriptor for metrics related to webhook logs
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
 /// Define label constants for webhook metrics
 /// name label
@@ -21,31 +24,32 @@ pub const NAME_LABEL: &str = "name";
 /// endpoint label
 pub const ENDPOINT_LABEL: &str = "endpoint";
 
-lazy_static::lazy_static! {
-    // The label used by all webhook metrics
-    static ref ALL_WEBHOOK_LABELS: [&'static str; 2] = [NAME_LABEL, ENDPOINT_LABEL];
+// The label used by all webhook metrics
+static ALL_WEBHOOK_LABELS: [&str; 2] = [NAME_LABEL, ENDPOINT_LABEL];
 
-    pub static ref WEBHOOK_FAILED_MESSAGES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::WebhookFailedMessages,
-            "Number of messages that failed to send",
-            &ALL_WEBHOOK_LABELS[..],
-            subsystems::LOGGER_WEBHOOK
-        );
+pub static WEBHOOK_FAILED_MESSAGES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::WebhookFailedMessages,
+        "Number of messages that failed to send",
+        &ALL_WEBHOOK_LABELS[..],
+        subsystems::LOGGER_WEBHOOK,
+    )
+});
 
-    pub static ref WEBHOOK_QUEUE_LENGTH_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::WebhookQueueLength,
-            "Webhook queue length",
-            &ALL_WEBHOOK_LABELS[..],
-            subsystems::LOGGER_WEBHOOK
-        );
+pub static WEBHOOK_QUEUE_LENGTH_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::WebhookQueueLength,
+        "Webhook queue length",
+        &ALL_WEBHOOK_LABELS[..],
+        subsystems::LOGGER_WEBHOOK,
+    )
+});
 
-    pub static ref WEBHOOK_TOTAL_MESSAGES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::WebhookTotalMessages,
-            "Total number of messages sent to this target",
-            &ALL_WEBHOOK_LABELS[..],
-            subsystems::LOGGER_WEBHOOK
-        );
-}
+pub static WEBHOOK_TOTAL_MESSAGES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::WebhookTotalMessages,
+        "Total number of messages sent to this target",
+        &ALL_WEBHOOK_LABELS[..],
+        subsystems::LOGGER_WEBHOOK,
+    )
+});

--- a/crates/obs/src/metrics/logger_webhook.rs
+++ b/crates/obs/src/metrics/logger_webhook.rs
@@ -25,7 +25,7 @@ pub const NAME_LABEL: &str = "name";
 pub const ENDPOINT_LABEL: &str = "endpoint";
 
 // The label used by all webhook metrics
-static ALL_WEBHOOK_LABELS: [&str; 2] = [NAME_LABEL, ENDPOINT_LABEL];
+const ALL_WEBHOOK_LABELS: [&str; 2] = [NAME_LABEL, ENDPOINT_LABEL];
 
 pub static WEBHOOK_FAILED_MESSAGES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(

--- a/crates/obs/src/metrics/replication.rs
+++ b/crates/obs/src/metrics/replication.rs
@@ -12,111 +12,125 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Copy the relevant metric descriptor
-use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
+#![allow(dead_code)]
 
-lazy_static::lazy_static! {
-    pub static ref REPLICATION_AVERAGE_ACTIVE_WORKERS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationAverageActiveWorkers,
-            "Average number of active replication workers",
-            &[],
-            subsystems::REPLICATION
-        );
+/// Metrics for replication subsystem
+use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-    pub static ref REPLICATION_AVERAGE_QUEUED_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationAverageQueuedBytes,
-            "Average number of bytes queued for replication since server start",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_AVERAGE_ACTIVE_WORKERS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationAverageActiveWorkers,
+        "Average number of active replication workers",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_AVERAGE_QUEUED_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationAverageQueuedCount,
-            "Average number of objects queued for replication since server start",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_AVERAGE_QUEUED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationAverageQueuedBytes,
+        "Average number of bytes queued for replication since server start",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_AVERAGE_DATA_TRANSFER_RATE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationAverageDataTransferRate,
-            "Average replication data transfer rate in bytes/sec",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_AVERAGE_QUEUED_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationAverageQueuedCount,
+        "Average number of objects queued for replication since server start",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_CURRENT_ACTIVE_WORKERS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationCurrentActiveWorkers,
-            "Total number of active replication workers",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_AVERAGE_DATA_TRANSFER_RATE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationAverageDataTransferRate,
+        "Average replication data transfer rate in bytes/sec",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_CURRENT_DATA_TRANSFER_RATE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationCurrentDataTransferRate,
-            "Current replication data transfer rate in bytes/sec",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_CURRENT_ACTIVE_WORKERS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationCurrentActiveWorkers,
+        "Total number of active replication workers",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_LAST_MINUTE_QUEUED_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationLastMinuteQueuedBytes,
-            "Number of bytes queued for replication in the last full minute",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_CURRENT_DATA_TRANSFER_RATE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationCurrentDataTransferRate,
+        "Current replication data transfer rate in bytes/sec",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_LAST_MINUTE_QUEUED_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationLastMinuteQueuedCount,
-            "Number of objects queued for replication in the last full minute",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_LAST_MINUTE_QUEUED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationLastMinuteQueuedBytes,
+        "Number of bytes queued for replication in the last full minute",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_MAX_ACTIVE_WORKERS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationMaxActiveWorkers,
-            "Maximum number of active replication workers seen since server start",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_LAST_MINUTE_QUEUED_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationLastMinuteQueuedCount,
+        "Number of objects queued for replication in the last full minute",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_MAX_QUEUED_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationMaxQueuedBytes,
-            "Maximum number of bytes queued for replication since server start",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_MAX_ACTIVE_WORKERS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationMaxActiveWorkers,
+        "Maximum number of active replication workers seen since server start",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_MAX_QUEUED_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationMaxQueuedCount,
-            "Maximum number of objects queued for replication since server start",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_MAX_QUEUED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationMaxQueuedBytes,
+        "Maximum number of bytes queued for replication since server start",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_MAX_DATA_TRANSFER_RATE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationMaxDataTransferRate,
-            "Maximum replication data transfer rate in bytes/sec seen since server start",
-            &[],
-            subsystems::REPLICATION
-        );
+pub static REPLICATION_MAX_QUEUED_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationMaxQueuedCount,
+        "Maximum number of objects queued for replication since server start",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
 
-    pub static ref REPLICATION_RECENT_BACKLOG_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ReplicationRecentBacklogCount,
-            "Total number of objects seen in replication backlog in the last 5 minutes",
-            &[],
-            subsystems::REPLICATION
-        );
-}
+pub static REPLICATION_MAX_DATA_TRANSFER_RATE_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationMaxDataTransferRate,
+        "Maximum replication data transfer rate in bytes/sec seen since server start",
+        &[],
+        subsystems::REPLICATION,
+    )
+});
+
+pub static REPLICATION_RECENT_BACKLOG_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ReplicationRecentBacklogCount,
+        "Total number of objects seen in replication backlog in the last 5 minutes",
+        &[],
+        subsystems::REPLICATION,
+    )
+});

--- a/crates/obs/src/metrics/replication.rs
+++ b/crates/obs/src/metrics/replication.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Metrics for replication subsystem
-use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 pub static REPLICATION_AVERAGE_ACTIVE_WORKERS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/request.rs
+++ b/crates/obs/src/metrics/request.rs
@@ -14,7 +14,7 @@
 
 #![allow(dead_code)]
 
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName, MetricSubsystem};
+use crate::metrics::{MetricDescriptor, MetricName, MetricSubsystem, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 pub static API_REJECTED_AUTH_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/request.rs
+++ b/crates/obs/src/metrics/request.rs
@@ -12,126 +12,142 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::metrics::{MetricDescriptor, MetricName, MetricSubsystem, new_counter_md, new_gauge_md, subsystems};
+#![allow(dead_code)]
 
-lazy_static::lazy_static! {
-    pub static ref API_REJECTED_AUTH_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRejectedAuthTotal,
-            "Total number of requests rejected for auth failure",
-            &["type"],
-            subsystems::API_REQUESTS
-        );
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName, MetricSubsystem};
+use std::sync::LazyLock;
 
-    pub static ref API_REJECTED_HEADER_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRejectedHeaderTotal,
-            "Total number of requests rejected for invalid header",
-            &["type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REJECTED_AUTH_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRejectedAuthTotal,
+        "Total number of requests rejected for auth failure",
+        &["type"],
+        subsystems::API_REQUESTS,
+    )
+});
 
-    pub static ref API_REJECTED_TIMESTAMP_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRejectedTimestampTotal,
-            "Total number of requests rejected for invalid timestamp",
-            &["type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REJECTED_HEADER_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRejectedHeaderTotal,
+        "Total number of requests rejected for invalid header",
+        &["type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REJECTED_INVALID_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRejectedInvalidTotal,
-            "Total number of invalid requests",
-            &["type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REJECTED_TIMESTAMP_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRejectedTimestampTotal,
+        "Total number of requests rejected for invalid timestamp",
+        &["type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_WAITING_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ApiRequestsWaitingTotal,
-            "Total number of requests in the waiting queue",
-            &["type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REJECTED_INVALID_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRejectedInvalidTotal,
+        "Total number of invalid requests",
+        &["type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_INCOMING_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ApiRequestsIncomingTotal,
-            "Total number of incoming requests",
-            &["type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_WAITING_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ApiRequestsWaitingTotal,
+        "Total number of requests in the waiting queue",
+        &["type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_IN_FLIGHT_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ApiRequestsInFlightTotal,
-            "Total number of requests currently in flight",
-            &["name", "type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_INCOMING_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ApiRequestsIncomingTotal,
+        "Total number of incoming requests",
+        &["type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequestsTotal,
-            "Total number of requests",
-            &["name", "type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_IN_FLIGHT_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ApiRequestsInFlightTotal,
+        "Total number of requests currently in flight",
+        &["name", "type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_ERRORS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequestsErrorsTotal,
-            "Total number of requests with (4xx and 5xx) errors",
-            &["name", "type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequestsTotal,
+        "Total number of requests",
+        &["name", "type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_5XX_ERRORS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequests5xxErrorsTotal,
-            "Total number of requests with 5xx errors",
-            &["name", "type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_ERRORS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequestsErrorsTotal,
+        "Total number of requests with (4xx and 5xx) errors",
+        &["name", "type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_4XX_ERRORS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequests4xxErrorsTotal,
-            "Total number of requests with 4xx errors",
-            &["name", "type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_5XX_ERRORS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequests5xxErrorsTotal,
+        "Total number of requests with 5xx errors",
+        &["name", "type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_CANCELED_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequestsCanceledTotal,
-            "Total number of requests canceled by the client",
-            &["name", "type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_4XX_ERRORS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequests4xxErrorsTotal,
+        "Total number of requests with 4xx errors",
+        &["name", "type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_REQUESTS_TTFB_SECONDS_DISTRIBUTION_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiRequestsTTFBSecondsDistribution,
-            "Distribution of time to first byte across API calls",
-            &["name", "type", "le"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_CANCELED_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequestsCanceledTotal,
+        "Total number of requests canceled by the client",
+        &["name", "type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_TRAFFIC_SENT_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiTrafficSentBytes,
-            "Total number of bytes sent",
-            &["type"],
-            MetricSubsystem::ApiRequests
-        );
+pub static API_REQUESTS_TTFB_SECONDS_DISTRIBUTION_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiRequestsTTFBSecondsDistribution,
+        "Distribution of time to first byte across API calls",
+        &["name", "type", "le"],
+        MetricSubsystem::ApiRequests,
+    )
+});
 
-    pub static ref API_TRAFFIC_RECV_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ApiTrafficRecvBytes,
-            "Total number of bytes received",
-            &["type"],
-            MetricSubsystem::ApiRequests
-        );
-}
+pub static API_TRAFFIC_SENT_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiTrafficSentBytes,
+        "Total number of bytes sent",
+        &["type"],
+        MetricSubsystem::ApiRequests,
+    )
+});
+
+pub static API_TRAFFIC_RECV_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ApiTrafficRecvBytes,
+        "Total number of bytes received",
+        &["type"],
+        MetricSubsystem::ApiRequests,
+    )
+});

--- a/crates/obs/src/metrics/scanner.rs
+++ b/crates/obs/src/metrics/scanner.rs
@@ -12,55 +12,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Scanner-related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref SCANNER_BUCKET_SCANS_FINISHED_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ScannerBucketScansFinished,
-            "Total number of bucket scans finished since server start",
-            &[],
-            subsystems::SCANNER
-        );
+pub static SCANNER_BUCKET_SCANS_FINISHED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ScannerBucketScansFinished,
+        "Total number of bucket scans finished since server start",
+        &[],
+        subsystems::SCANNER,
+    )
+});
 
-    pub static ref SCANNER_BUCKET_SCANS_STARTED_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ScannerBucketScansStarted,
-            "Total number of bucket scans started since server start",
-            &[],
-            subsystems::SCANNER
-        );
+pub static SCANNER_BUCKET_SCANS_STARTED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ScannerBucketScansStarted,
+        "Total number of bucket scans started since server start",
+        &[],
+        subsystems::SCANNER,
+    )
+});
 
-    pub static ref SCANNER_DIRECTORIES_SCANNED_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ScannerDirectoriesScanned,
-            "Total number of directories scanned since server start",
-            &[],
-            subsystems::SCANNER
-        );
+pub static SCANNER_DIRECTORIES_SCANNED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ScannerDirectoriesScanned,
+        "Total number of directories scanned since server start",
+        &[],
+        subsystems::SCANNER,
+    )
+});
 
-    pub static ref SCANNER_OBJECTS_SCANNED_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ScannerObjectsScanned,
-            "Total number of unique objects scanned since server start",
-            &[],
-            subsystems::SCANNER
-        );
+pub static SCANNER_OBJECTS_SCANNED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ScannerObjectsScanned,
+        "Total number of unique objects scanned since server start",
+        &[],
+        subsystems::SCANNER,
+    )
+});
 
-    pub static ref SCANNER_VERSIONS_SCANNED_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ScannerVersionsScanned,
-            "Total number of object versions scanned since server start",
-            &[],
-            subsystems::SCANNER
-        );
+pub static SCANNER_VERSIONS_SCANNED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ScannerVersionsScanned,
+        "Total number of object versions scanned since server start",
+        &[],
+        subsystems::SCANNER,
+    )
+});
 
-    pub static ref SCANNER_LAST_ACTIVITY_SECONDS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ScannerLastActivitySeconds,
-            "Time elapsed (in seconds) since last scan activity.",
-            &[],
-            subsystems::SCANNER
-        );
-}
+pub static SCANNER_LAST_ACTIVITY_SECONDS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ScannerLastActivitySeconds,
+        "Time elapsed (in seconds) since last scan activity.",
+        &[],
+        subsystems::SCANNER,
+    )
+});

--- a/crates/obs/src/metrics/scanner.rs
+++ b/crates/obs/src/metrics/scanner.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Scanner-related metric descriptors
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 pub static SCANNER_BUCKET_SCANS_FINISHED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {

--- a/crates/obs/src/metrics/system_cpu.rs
+++ b/crates/obs/src/metrics/system_cpu.rs
@@ -14,7 +14,7 @@
 
 #![allow(dead_code)]
 
-use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 /// CPU system-related metric descriptors
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/system_cpu.rs
+++ b/crates/obs/src/metrics/system_cpu.rs
@@ -12,71 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
+use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
 /// CPU system-related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref SYS_CPU_AVG_IDLE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPUAvgIdle,
-            "Average CPU idle time",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
+pub static SYS_CPU_AVG_IDLE_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::SysCPUAvgIdle, "Average CPU idle time", &[], subsystems::SYSTEM_CPU));
 
-    pub static ref SYS_CPU_AVG_IOWAIT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPUAvgIOWait,
-            "Average CPU IOWait time",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
+pub static SYS_CPU_AVG_IOWAIT_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::SysCPUAvgIOWait, "Average CPU IOWait time", &[], subsystems::SYSTEM_CPU));
 
-    pub static ref SYS_CPU_LOAD_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPULoad,
-            "CPU load average 1min",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
+pub static SYS_CPU_LOAD_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::SysCPULoad, "CPU load average 1min", &[], subsystems::SYSTEM_CPU));
 
-    pub static ref SYS_CPU_LOAD_PERC_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPULoadPerc,
-            "CPU load average 1min (percentage)",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
+pub static SYS_CPU_LOAD_PERC_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::SysCPULoadPerc,
+        "CPU load average 1min (percentage)",
+        &[],
+        subsystems::SYSTEM_CPU,
+    )
+});
 
-    pub static ref SYS_CPU_NICE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPUNice,
-            "CPU nice time",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
+pub static SYS_CPU_NICE_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::SysCPUNice, "CPU nice time", &[], subsystems::SYSTEM_CPU));
 
-    pub static ref SYS_CPU_STEAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPUSteal,
-            "CPU steal time",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
+pub static SYS_CPU_STEAL_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::SysCPUSteal, "CPU steal time", &[], subsystems::SYSTEM_CPU));
 
-    pub static ref SYS_CPU_SYSTEM_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPUSystem,
-            "CPU system time",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
+pub static SYS_CPU_SYSTEM_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::SysCPUSystem, "CPU system time", &[], subsystems::SYSTEM_CPU));
 
-    pub static ref SYS_CPU_USER_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::SysCPUUser,
-            "CPU user time",
-            &[],
-            subsystems::SYSTEM_CPU
-        );
-}
+pub static SYS_CPU_USER_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::SysCPUUser, "CPU user time", &[], subsystems::SYSTEM_CPU));

--- a/crates/obs/src/metrics/system_drive.rs
+++ b/crates/obs/src/metrics/system_drive.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Drive-related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
 /// drive related labels
 pub const DRIVE_LABEL: &str = "drive";
@@ -26,185 +29,185 @@ pub const DRIVE_INDEX_LABEL: &str = "drive_index";
 /// API label
 pub const API_LABEL: &str = "api";
 
-lazy_static::lazy_static! {
-    /// All drive-related labels
-    static ref ALL_DRIVE_LABELS: [&'static str; 4] = [DRIVE_LABEL, POOL_INDEX_LABEL, SET_INDEX_LABEL, DRIVE_INDEX_LABEL];
-}
+/// All drive-related labels
+pub static ALL_DRIVE_LABELS: [&str; 4] = [DRIVE_LABEL, POOL_INDEX_LABEL, SET_INDEX_LABEL, DRIVE_INDEX_LABEL];
 
-lazy_static::lazy_static! {
-    pub static ref DRIVE_USED_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveUsedBytes,
-            "Total storage used on a drive in bytes",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_USED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveUsedBytes,
+        "Total storage used on a drive in bytes",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_FREE_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveFreeBytes,
-            "Total storage free on a drive in bytes",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_FREE_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveFreeBytes,
+        "Total storage free on a drive in bytes",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_TOTAL_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveTotalBytes,
-            "Total storage available on a drive in bytes",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_TOTAL_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveTotalBytes,
+        "Total storage available on a drive in bytes",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_USED_INODES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveUsedInodes,
-            "Total used inodes on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_USED_INODES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveUsedInodes,
+        "Total used inodes on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_FREE_INODES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveFreeInodes,
-            "Total free inodes on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_FREE_INODES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveFreeInodes,
+        "Total free inodes on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_TOTAL_INODES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveTotalInodes,
-            "Total inodes available on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_TOTAL_INODES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveTotalInodes,
+        "Total inodes available on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_TIMEOUT_ERRORS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::DriveTimeoutErrorsTotal,
-            "Total timeout errors on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_TIMEOUT_ERRORS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::DriveTimeoutErrorsTotal,
+        "Total timeout errors on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_IO_ERRORS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::DriveIOErrorsTotal,
-            "Total I/O errors on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_IO_ERRORS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::DriveIOErrorsTotal,
+        "Total I/O errors on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_AVAILABILITY_ERRORS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::DriveAvailabilityErrorsTotal,
-            "Total availability errors (I/O errors, timeouts) on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_AVAILABILITY_ERRORS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::DriveAvailabilityErrorsTotal,
+        "Total availability errors (I/O errors, timeouts) on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_WAITING_IO_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveWaitingIO,
-            "Total waiting I/O operations on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_WAITING_IO_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveWaitingIO,
+        "Total waiting I/O operations on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_API_LATENCY_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveAPILatencyMicros,
-            "Average last minute latency in µs for drive API storage operations",
-            &[&ALL_DRIVE_LABELS[..], &[API_LABEL]].concat(),
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_API_LATENCY_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveAPILatencyMicros,
+        "Average last minute latency in µs for drive API storage operations",
+        &[&ALL_DRIVE_LABELS[..], &[API_LABEL]].concat(),
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_HEALTH_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveHealth,
-            "Drive health (0 = offline, 1 = healthy, 2 = healing)",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_HEALTH_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveHealth,
+        "Drive health (0 = offline, 1 = healthy, 2 = healing)",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_OFFLINE_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveOfflineCount,
-            "Count of offline drives",
-            &[],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_OFFLINE_COUNT_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::DriveOfflineCount, "Count of offline drives", &[], subsystems::SYSTEM_DRIVE));
 
-    pub static ref DRIVE_ONLINE_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveOnlineCount,
-            "Count of online drives",
-            &[],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_ONLINE_COUNT_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::DriveOnlineCount, "Count of online drives", &[], subsystems::SYSTEM_DRIVE));
 
-    pub static ref DRIVE_COUNT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveCount,
-            "Count of all drives",
-            &[],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_COUNT_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::DriveCount, "Count of all drives", &[], subsystems::SYSTEM_DRIVE));
 
-    pub static ref DRIVE_READS_PER_SEC_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveReadsPerSec,
-            "Reads per second on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_READS_PER_SEC_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveReadsPerSec,
+        "Reads per second on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_READS_KB_PER_SEC_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveReadsKBPerSec,
-            "Kilobytes read per second on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_READS_KB_PER_SEC_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveReadsKBPerSec,
+        "Kilobytes read per second on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_READS_AWAIT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveReadsAwait,
-            "Average time for read requests served on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_READS_AWAIT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveReadsAwait,
+        "Average time for read requests served on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_WRITES_PER_SEC_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveWritesPerSec,
-            "Writes per second on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_WRITES_PER_SEC_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveWritesPerSec,
+        "Writes per second on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_WRITES_KB_PER_SEC_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveWritesKBPerSec,
-            "Kilobytes written per second on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_WRITES_KB_PER_SEC_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveWritesKBPerSec,
+        "Kilobytes written per second on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_WRITES_AWAIT_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DriveWritesAwait,
-            "Average time for write requests served on a drive",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
+pub static DRIVE_WRITES_AWAIT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DriveWritesAwait,
+        "Average time for write requests served on a drive",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});
 
-    pub static ref DRIVE_PERC_UTIL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::DrivePercUtil,
-            "Percentage of time the disk was busy",
-            &ALL_DRIVE_LABELS[..],
-            subsystems::SYSTEM_DRIVE
-        );
-}
+pub static DRIVE_PERC_UTIL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::DrivePercUtil,
+        "Percentage of time the disk was busy",
+        &ALL_DRIVE_LABELS[..],
+        subsystems::SYSTEM_DRIVE,
+    )
+});

--- a/crates/obs/src/metrics/system_drive.rs
+++ b/crates/obs/src/metrics/system_drive.rs
@@ -30,7 +30,7 @@ pub const DRIVE_INDEX_LABEL: &str = "drive_index";
 pub const API_LABEL: &str = "api";
 
 /// All drive-related labels
-pub static ALL_DRIVE_LABELS: [&str; 4] = [DRIVE_LABEL, POOL_INDEX_LABEL, SET_INDEX_LABEL, DRIVE_INDEX_LABEL];
+pub const ALL_DRIVE_LABELS: [&str; 4] = [DRIVE_LABEL, POOL_INDEX_LABEL, SET_INDEX_LABEL, DRIVE_INDEX_LABEL];
 
 pub static DRIVE_USED_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_gauge_md(

--- a/crates/obs/src/metrics/system_drive.rs
+++ b/crates/obs/src/metrics/system_drive.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 
 /// Drive-related metric descriptors
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// drive related labels

--- a/crates/obs/src/metrics/system_memory.rs
+++ b/crates/obs/src/metrics/system_memory.rs
@@ -20,7 +20,7 @@
 /// These descriptors are initialized lazily using `std::sync::LazyLock` to ensure
 /// they are only created when actually needed, improving performance and reducing
 /// startup overhead.
-use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// Total memory available on the node

--- a/crates/obs/src/metrics/system_memory.rs
+++ b/crates/obs/src/metrics/system_memory.rs
@@ -12,71 +12,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Memory-related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
+///
+/// This module provides a set of metric descriptors for system memory statistics.
+/// These descriptors are initialized lazily using `std::sync::LazyLock` to ensure
+/// they are only created when actually needed, improving performance and reducing
+/// startup overhead.
+use crate::metrics::{new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref MEM_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemTotal,
-            "Total memory on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
+/// Total memory available on the node
+pub static MEM_TOTAL_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::MemTotal, "Total memory on the node", &[], subsystems::SYSTEM_MEMORY));
 
-    pub static ref MEM_USED_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemUsed,
-            "Used memory on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
+/// Memory currently in use on the node
+pub static MEM_USED_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::MemUsed, "Used memory on the node", &[], subsystems::SYSTEM_MEMORY));
 
-    pub static ref MEM_USED_PERC_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemUsedPerc,
-            "Used memory percentage on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
+/// Percentage of total memory currently in use
+pub static MEM_USED_PERC_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::MemUsedPerc,
+        "Used memory percentage on the node",
+        &[],
+        subsystems::SYSTEM_MEMORY,
+    )
+});
 
-    pub static ref MEM_FREE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemFree,
-            "Free memory on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
+/// Memory not currently in use and available for allocation
+pub static MEM_FREE_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::MemFree, "Free memory on the node", &[], subsystems::SYSTEM_MEMORY));
 
-    pub static ref MEM_BUFFERS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemBuffers,
-            "Buffers memory on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
+/// Memory used for file buffers by the kernel
+pub static MEM_BUFFERS_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::MemBuffers, "Buffers memory on the node", &[], subsystems::SYSTEM_MEMORY));
 
-    pub static ref MEM_CACHE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemCache,
-            "Cache memory on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
+/// Memory used for caching file data by the kernel
+pub static MEM_CACHE_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::MemCache, "Cache memory on the node", &[], subsystems::SYSTEM_MEMORY));
 
-    pub static ref MEM_SHARED_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemShared,
-            "Shared memory on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
+/// Memory shared between multiple processes
+pub static MEM_SHARED_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::MemShared, "Shared memory on the node", &[], subsystems::SYSTEM_MEMORY));
 
-    pub static ref MEM_AVAILABLE_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::MemAvailable,
-            "Available memory on the node",
-            &[],
-            subsystems::SYSTEM_MEMORY
-        );
-}
+/// Estimate of memory available for new applications without swapping
+pub static MEM_AVAILABLE_MD: LazyLock<MetricDescriptor> =
+    LazyLock::new(|| new_gauge_md(MetricName::MemAvailable, "Available memory on the node", &[], subsystems::SYSTEM_MEMORY));

--- a/crates/obs/src/metrics/system_network.rs
+++ b/crates/obs/src/metrics/system_network.rs
@@ -12,47 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(dead_code)]
+
 /// Network-related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+///
+/// These metrics capture internode network communication statistics including:
+/// - Error counts for connection and general internode calls
+/// - Network dial performance metrics
+/// - Data transfer volume in both directions
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref INTERNODE_ERRORS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::InternodeErrorsTotal,
-            "Total number of failed internode calls",
-            &[],
-            subsystems::SYSTEM_NETWORK_INTERNODE
-        );
+/// Total number of failed internode calls counter
+pub static INTERNODE_ERRORS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::InternodeErrorsTotal,
+        "Total number of failed internode calls",
+        &[],
+        subsystems::SYSTEM_NETWORK_INTERNODE,
+    )
+});
 
-    pub static ref INTERNODE_DIAL_ERRORS_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::InternodeDialErrorsTotal,
-            "Total number of internode TCP dial timeouts and errors",
-            &[],
-            subsystems::SYSTEM_NETWORK_INTERNODE
-        );
+/// TCP dial timeouts and errors counter
+pub static INTERNODE_DIAL_ERRORS_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::InternodeDialErrorsTotal,
+        "Total number of internode TCP dial timeouts and errors",
+        &[],
+        subsystems::SYSTEM_NETWORK_INTERNODE,
+    )
+});
 
-    pub static ref INTERNODE_DIAL_AVG_TIME_NANOS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::InternodeDialAvgTimeNanos,
-            "Average dial time of internode TCP calls in nanoseconds",
-            &[],
-            subsystems::SYSTEM_NETWORK_INTERNODE
-        );
+/// Average dial time gauge in nanoseconds
+pub static INTERNODE_DIAL_AVG_TIME_NANOS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::InternodeDialAvgTimeNanos,
+        "Average dial time of internode TCP calls in nanoseconds",
+        &[],
+        subsystems::SYSTEM_NETWORK_INTERNODE,
+    )
+});
 
-    pub static ref INTERNODE_SENT_BYTES_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::InternodeSentBytesTotal,
-            "Total number of bytes sent to other peer nodes",
-            &[],
-            subsystems::SYSTEM_NETWORK_INTERNODE
-        );
+/// Outbound network traffic counter in bytes
+pub static INTERNODE_SENT_BYTES_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::InternodeSentBytesTotal,
+        "Total number of bytes sent to other peer nodes",
+        &[],
+        subsystems::SYSTEM_NETWORK_INTERNODE,
+    )
+});
 
-    pub static ref INTERNODE_RECV_BYTES_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::InternodeRecvBytesTotal,
-            "Total number of bytes received from other peer nodes",
-            &[],
-            subsystems::SYSTEM_NETWORK_INTERNODE
-        );
-}
+/// Inbound network traffic counter in bytes
+pub static INTERNODE_RECV_BYTES_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::InternodeRecvBytesTotal,
+        "Total number of bytes received from other peer nodes",
+        &[],
+        subsystems::SYSTEM_NETWORK_INTERNODE,
+    )
+});

--- a/crates/obs/src/metrics/system_network.rs
+++ b/crates/obs/src/metrics/system_network.rs
@@ -20,7 +20,7 @@
 /// - Error counts for connection and general internode calls
 /// - Network dial performance metrics
 /// - Data transfer volume in both directions
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// Total number of failed internode calls counter

--- a/crates/obs/src/metrics/system_process.rs
+++ b/crates/obs/src/metrics/system_process.rs
@@ -19,7 +19,7 @@
 /// This module defines various system process metrics used for monitoring
 /// the RustFS process performance, resource usage, and system integration.
 /// Metrics are implemented using std::sync::LazyLock for thread-safe lazy initialization.
-use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 
 /// Number of current READ locks on this peer

--- a/crates/obs/src/metrics/system_process.rs
+++ b/crates/obs/src/metrics/system_process.rs
@@ -12,143 +12,182 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// process related metric descriptors
-use crate::metrics::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
+#![allow(dead_code)]
 
-lazy_static::lazy_static! {
-    pub static ref PROCESS_LOCKS_READ_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessLocksReadTotal,
-            "Number of current READ locks on this peer",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Process related metric descriptors
+///
+/// This module defines various system process metrics used for monitoring
+/// the RustFS process performance, resource usage, and system integration.
+/// Metrics are implemented using std::sync::LazyLock for thread-safe lazy initialization.
+use crate::metrics::{new_counter_md, new_gauge_md, subsystems, MetricDescriptor, MetricName};
+use std::sync::LazyLock;
 
-    pub static ref PROCESS_LOCKS_WRITE_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessLocksWriteTotal,
-            "Number of current WRITE locks on this peer",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Number of current READ locks on this peer
+pub static PROCESS_LOCKS_READ_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessLocksReadTotal,
+        "Number of current READ locks on this peer",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_CPU_TOTAL_SECONDS_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProcessCPUTotalSeconds,
-            "Total user and system CPU time spent in seconds",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Number of current WRITE locks on this peer
+pub static PROCESS_LOCKS_WRITE_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessLocksWriteTotal,
+        "Number of current WRITE locks on this peer",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_GO_ROUTINE_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessGoRoutineTotal,
-            "Total number of go routines running",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total user and system CPU time spent in seconds
+pub static PROCESS_CPU_TOTAL_SECONDS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProcessCPUTotalSeconds,
+        "Total user and system CPU time spent in seconds",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_IO_RCHAR_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProcessIORCharBytes,
-            "Total bytes read by the process from the underlying storage system including cache, /proc/[pid]/io rchar",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total number of go routines running
+pub static PROCESS_GO_ROUTINE_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessGoRoutineTotal,
+        "Total number of go routines running",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_IO_READ_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProcessIOReadBytes,
-            "Total bytes read by the process from the underlying storage system, /proc/[pid]/io read_bytes",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total bytes read by the process from the underlying storage system including cache
+pub static PROCESS_IO_RCHAR_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProcessIORCharBytes,
+        "Total bytes read by the process from the underlying storage system including cache, /proc/[pid]/io rchar",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_IO_WCHAR_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProcessIOWCharBytes,
-            "Total bytes written by the process to the underlying storage system including page cache, /proc/[pid]/io wchar",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total bytes read by the process from the underlying storage system
+pub static PROCESS_IO_READ_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProcessIOReadBytes,
+        "Total bytes read by the process from the underlying storage system, /proc/[pid]/io read_bytes",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_IO_WRITE_BYTES_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProcessIOWriteBytes,
-            "Total bytes written by the process to the underlying storage system, /proc/[pid]/io write_bytes",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total bytes written by the process to the underlying storage system including page cache
+pub static PROCESS_IO_WCHAR_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProcessIOWCharBytes,
+        "Total bytes written by the process to the underlying storage system including page cache, /proc/[pid]/io wchar",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_START_TIME_SECONDS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessStartTimeSeconds,
-            "Start time for RustFS process in seconds since Unix epoc",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total bytes written by the process to the underlying storage system
+pub static PROCESS_IO_WRITE_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProcessIOWriteBytes,
+        "Total bytes written by the process to the underlying storage system, /proc/[pid]/io write_bytes",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_UPTIME_SECONDS_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessUptimeSeconds,
-            "Uptime for RustFS process in seconds",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Start time for RustFS process in seconds since Unix epoch
+pub static PROCESS_START_TIME_SECONDS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessStartTimeSeconds,
+        "Start time for RustFS process in seconds since Unix epoch",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_FILE_DESCRIPTOR_LIMIT_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessFileDescriptorLimitTotal,
-            "Limit on total number of open file descriptors for the RustFS Server process",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Uptime for RustFS process in seconds
+pub static PROCESS_UPTIME_SECONDS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessUptimeSeconds,
+        "Uptime for RustFS process in seconds",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_FILE_DESCRIPTOR_OPEN_TOTAL_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessFileDescriptorOpenTotal,
-            "Total number of open file descriptors by the RustFS Server process",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Limit on total number of open file descriptors for the RustFS Server process
+pub static PROCESS_FILE_DESCRIPTOR_LIMIT_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessFileDescriptorLimitTotal,
+        "Limit on total number of open file descriptors for the RustFS Server process",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_SYSCALL_READ_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProcessSyscallReadTotal,
-            "Total read SysCalls to the kernel. /proc/[pid]/io syscr",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total number of open file descriptors by the RustFS Server process
+pub static PROCESS_FILE_DESCRIPTOR_OPEN_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessFileDescriptorOpenTotal,
+        "Total number of open file descriptors by the RustFS Server process",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_SYSCALL_WRITE_TOTAL_MD: MetricDescriptor =
-        new_counter_md(
-            MetricName::ProcessSyscallWriteTotal,
-            "Total write SysCalls to the kernel. /proc/[pid]/io syscw",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total read SysCalls to the kernel
+pub static PROCESS_SYSCALL_READ_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProcessSyscallReadTotal,
+        "Total read SysCalls to the kernel. /proc/[pid]/io syscr",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_RESIDENT_MEMORY_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessResidentMemoryBytes,
-            "Resident memory size in bytes",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Total write SysCalls to the kernel
+pub static PROCESS_SYSCALL_WRITE_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::ProcessSyscallWriteTotal,
+        "Total write SysCalls to the kernel. /proc/[pid]/io syscw",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_VIRTUAL_MEMORY_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessVirtualMemoryBytes,
-            "Virtual memory size in bytes",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
+/// Resident memory size in bytes
+pub static PROCESS_RESIDENT_MEMORY_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessResidentMemoryBytes,
+        "Resident memory size in bytes",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
 
-    pub static ref PROCESS_VIRTUAL_MEMORY_MAX_BYTES_MD: MetricDescriptor =
-        new_gauge_md(
-            MetricName::ProcessVirtualMemoryMaxBytes,
-            "Maximum virtual memory size in bytes",
-            &[],
-            subsystems::SYSTEM_PROCESS
-        );
-}
+/// Virtual memory size in bytes
+pub static PROCESS_VIRTUAL_MEMORY_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessVirtualMemoryBytes,
+        "Virtual memory size in bytes",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});
+
+/// Maximum virtual memory size in bytes
+pub static PROCESS_VIRTUAL_MEMORY_MAX_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::ProcessVirtualMemoryMaxBytes,
+        "Maximum virtual memory size in bytes",
+        &[],
+        subsystems::SYSTEM_PROCESS,
+    )
+});


### PR DESCRIPTION
Replace `lazy_static` with `LazyLock`.

Compile time may reduce a little.

See https://github.com/rust-lang-nursery/lazy-static.rs/issues/214

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [X] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [X] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [X] Code is formatted with `cargo fmt --all`
- [X] Passed `cargo clippy --all-targets --all-features -- -D warnings`
- [X] Passed `cargo check --all-targets`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
