### PR TITLE
feat: add docker usage for rustfs mcp

### DIFF
--- a/crates/mcp/Dockerfile
+++ b/crates/mcp/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.88 AS builder
+
+WORKDIR /build
+
+COPY . .
+
+RUN cargo build --release -p rustfs-mcp
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+COPY --from=builder /build/target/release/rustfs-mcp /app/
+
+ENTRYPOINT ["/app/rustfs-mcp"]

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -98,7 +98,9 @@ rustfs-mcp --log-level debug --region us-west-2
 ```
 
 ### Integration with chat client
+
 #### Option 1: Using Command Line Arguments
+
 ```json
 {
   "mcpServers": {
@@ -116,6 +118,7 @@ rustfs-mcp --log-level debug --region us-west-2
 ```
 
 #### Option 2: Using Environment Variables
+
 ```json
 {
   "mcpServers": {
@@ -130,26 +133,84 @@ rustfs-mcp --log-level debug --region us-west-2
   }
 }
 ```
+
+### Using MCP with Docker
+
+#### Docker image build
+
+Using MCP with docker will simply the usage of rustfs mcp. Building the docker image with below command:
+
+```
+docker build -f Dockerfile -t rustfs/rustfs-mcp ../../
+```
+
+Alternatively, if you want to build the image from the rustfs codebase root directory,run the command:
+
+```
+docker build -f crates/mcp/Dockerfile -t rustfs/rustfs-mcp .
+```
+
+#### IDE Configuration
+
+Adding the following content in IDE MCP settings:
+
+```
+{
+  "mcpServers": {
+    "rustfs-mcp": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "AWS_ACCESS_KEY_ID",
+        "-e",
+        "AWS_SECRET_ACCESS_KEY",
+        "-e",
+        "AWS_REGION",
+        "-e",
+        "AWS_ENDPOINT_URL",
+        "rustfs/rustfs-mcp"
+      ],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "rustfs_access_key",
+        "AWS_SECRET_ACCESS_KEY": "rustfs_secret_key",
+        "AWS_REGION": "cn-east-1",
+        "AWS_ENDPOINT_URL": "rustfs_instance_url"
+      }
+    }
+  }
+}
+```
+
+If success, MCP configure page will show the [available tools](#️-available-tools).
+
 ## 🛠️ Available Tools
 
 The MCP server exposes the following tools that AI assistants can use:
 
 ### `list_buckets`
+
 List all S3 buckets accessible with the configured credentials.
 
 **Parameters:** None
 
 ### `list_objects`
+
 List objects in an S3 bucket with optional prefix filtering.
 
 **Parameters:**
+
 - `bucket_name` (string): Name of the S3 bucket
 - `prefix` (string, optional): Prefix to filter objects
 
 ### `upload_file`
+
 Upload a local file to S3 with automatic MIME type detection.
 
 **Parameters:**
+
 - `local_file_path` (string): Path to the local file
 - `bucket_name` (string): Target S3 bucket
 - `object_key` (string): S3 object key (destination path)
@@ -158,9 +219,11 @@ Upload a local file to S3 with automatic MIME type detection.
 - `cache_control` (string, optional): Cache control header
 
 ### `get_object`
+
 Retrieve an object from S3 with two operation modes: read content directly or download to a file.
 
 **Parameters:**
+
 - `bucket_name` (string): Source S3 bucket
 - `object_key` (string): S3 object key
 - `version_id` (string, optional): Version ID for versioned objects


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [x] Other:
   - Feature Enhancement

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

Using MCP with Docker will simply the MCP usage, avoid configuring the environment. [Anthropic MCP Server](https://github.com/modelcontextprotocol/servers/) provides the docker configuration in AI IDE. So, i add the Dockerfile for rustfs-mcp, which tests with Trae successfully.

<img width="745" height="275" alt="截屏2025-08-08 16 58 23" src="https://github.com/user-attachments/assets/37db56b2-eff1-4425-9e3f-04cc48dbba25" />

By the way, updating the README and fix some markdown format.


## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Code is formatted with `cargo fmt --all`
- [ ] Passed `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Passed `cargo check --all-targets`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
