### PR TITLE
feat: change Docker build to download from GitHub releases instead of dl.rustfs.com

### DIFF
--- a/docker-buildx.sh
+++ b/docker-buildx.sh
@@ -150,11 +150,7 @@ build_and_push() {
     else
         print_message $RED "❌ Failed to build latest variant"
         print_message $YELLOW "💡 Note: Make sure rustfs binaries are available at:"
-        if [ "$CHANNEL" = "dev" ]; then
-            print_message $YELLOW "   https://dl.rustfs.com/artifacts/rustfs/dev/"
-        else
-            print_message $YELLOW "   https://dl.rustfs.com/artifacts/rustfs/release/"
-        fi
+        print_message $YELLOW "   https://github.com/rustfs/rustfs/releases"
         exit 1
     fi
 
@@ -183,11 +179,7 @@ build_and_push() {
         else
             print_message $RED "❌ Failed to build release variant"
             print_message $YELLOW "💡 Note: Make sure rustfs binaries are available at:"
-            if [ "$CHANNEL" = "dev" ]; then
-                print_message $YELLOW "   https://dl.rustfs.com/artifacts/rustfs/dev/"
-            else
-                print_message $YELLOW "   https://dl.rustfs.com/artifacts/rustfs/release/"
-            fi
+            print_message $YELLOW "   https://github.com/rustfs/rustfs/releases"
             exit 1
         fi
     else
@@ -248,7 +240,7 @@ done
 # Main execution
 main() {
     print_message $BLUE "🐳 RustFS Docker Buildx Build Script"
-    print_message $YELLOW "📋 Build Strategy: Uses pre-built binaries from dl.rustfs.com"
+    print_message $YELLOW "📋 Build Strategy: Uses pre-built binaries from GitHub Releases"
     print_message $YELLOW "🚀 Production images only - optimized for distribution"
     echo ""
 


### PR DESCRIPTION
## What changed 

- Modified Dockerfile to download pre-built binaries from GitHub releases
- For latest releases, use GitHub API to find the correct download URL
- For specific versions, construct the GitHub release URL directly
- Updated docker-buildx.sh script messages to reflect new download source
- This change addresses security concerns about potential tampering with binaries from dl.rustfs.com

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
