### PR TITLE
fix: separate RELEASE tag and VERSION in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,11 @@ RUN ARCH=$(cat /tmp/arch) && \
         DOWNLOAD_URL="$LATEST_RELEASE_URL"; \
     else \
         # For specific versions, construct the GitHub release URL directly
-        VERSION="v${RELEASE#v}"; \
+        # RELEASE is the GitHub release tag (e.g., "1.0.0-alpha.42")
+        # VERSION is the version in filename (e.g., "v1.0.0-alpha.42")
+        VERSION="v${RELEASE}"; \
         PACKAGE_NAME="rustfs-linux-${ARCH}-${VERSION}.zip"; \
-        DOWNLOAD_URL="https://github.com/rustfs/rustfs/releases/download/${VERSION}/${PACKAGE_NAME}"; \
+        DOWNLOAD_URL="https://github.com/rustfs/rustfs/releases/download/${RELEASE}/${PACKAGE_NAME}"; \
     fi && \
     echo "Downloading ${PACKAGE_NAME} from ${DOWNLOAD_URL}" >&2 && \
     curl -f -L "${DOWNLOAD_URL}" -o rustfs.zip && \


### PR DESCRIPTION
- RELEASE: GitHub release tag without 'v' prefix (e.g., 1.0.0-alpha.42)
- VERSION: filename version with 'v' prefix (e.g., v1.0.0-alpha.42)
- Download URL uses RELEASE for path, VERSION for filename
- Fixes incorrect URL generation that was adding extra 'v' prefix

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
