### PR TITLE
feat: support conditional writes

### DIFF
--- a/crates/ecstore/src/error.rs
+++ b/crates/ecstore/src/error.rs
@@ -187,6 +187,9 @@ pub enum StorageError {
 
     #[error("Lock error: {0}")]
     Lock(#[from] rustfs_lock::LockError),
+
+    #[error("Precondition failed")]
+    PreconditionFailed,
 }
 
 impl StorageError {
@@ -416,6 +419,7 @@ impl Clone for StorageError {
             StorageError::Lock(e) => StorageError::Lock(e.clone()),
             StorageError::InsufficientReadQuorum(a, b) => StorageError::InsufficientReadQuorum(a.clone(), b.clone()),
             StorageError::InsufficientWriteQuorum(a, b) => StorageError::InsufficientWriteQuorum(a.clone(), b.clone()),
+            StorageError::PreconditionFailed => StorageError::PreconditionFailed,
         }
     }
 }
@@ -481,6 +485,7 @@ impl StorageError {
             StorageError::Lock(_) => 0x38,
             StorageError::InsufficientReadQuorum(_, _) => 0x39,
             StorageError::InsufficientWriteQuorum(_, _) => 0x3A,
+            StorageError::PreconditionFailed => 0x3B,
         }
     }
 
@@ -548,6 +553,7 @@ impl StorageError {
             0x38 => Some(StorageError::Lock(rustfs_lock::LockError::internal("Generic lock error".to_string()))),
             0x39 => Some(StorageError::InsufficientReadQuorum(Default::default(), Default::default())),
             0x3A => Some(StorageError::InsufficientWriteQuorum(Default::default(), Default::default())),
+            0x3B => Some(StorageError::PreconditionFailed),
             _ => None,
         }
     }

--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -61,6 +61,7 @@ use glob::Pattern;
 use http::HeaderMap;
 use md5::{Digest as Md5Digest, Md5};
 use rand::{Rng, seq::SliceRandom};
+use regex::Regex;
 use rustfs_common::heal_channel::{DriveState, HealChannelPriority, HealItemType, HealOpts, HealScanMode, send_heal_disk};
 use rustfs_filemeta::headers::RESERVED_METADATA_PREFIX_LOWER;
 use rustfs_filemeta::{
@@ -3218,6 +3219,40 @@ impl SetDisks {
         obj?;
         Ok(())
     }
+
+    async fn check_write_precondition(&self, bucket: &str, object: &str, mut opts: ObjectOptions) -> Option<StorageError> {
+        let http_preconditions = opts.http_preconditions.unwrap();
+        opts.http_preconditions = None;
+
+        // Never claim a lock twice, to avoid deadlock
+        opts.no_lock = !opts.no_lock;
+        let oi = self.get_object_info(bucket, object, &opts).await;
+
+        match oi {
+            Ok(oi) => {
+                if should_prevent_write(&oi, http_preconditions.if_none_match, http_preconditions.if_match) {
+                    return Some(StorageError::PreconditionFailed);
+                }
+            }
+
+            Err(StorageError::VersionNotFound(_, _, _))
+            | Err(StorageError::ObjectNotFound(_, _))
+            | Err(StorageError::ErasureReadQuorum) => {
+                // When the object is not found,
+                // - if If-Match is set, we should return 404 NotFound
+                // - if If-None-Match is set, we should be able to proceed with the request
+                if http_preconditions.if_match.is_some() {
+                    return Some(StorageError::ObjectNotFound(bucket.to_string(), object.to_string()));
+                }
+            }
+
+            Err(e) => {
+                return Some(e);
+            }
+        }
+
+        None
+    }
 }
 
 #[async_trait::async_trait]
@@ -3333,6 +3368,12 @@ impl ObjectIO for SetDisks {
                 return Err(Error::other("can not get lock. please retry".to_string()));
             }
             _object_lock_guard = guard_opt;
+        }
+
+        if let Some(http_preconditions) = opts.http_preconditions.clone() {
+            if let Some(err) = self.check_write_precondition(bucket, object, opts.clone()).await {
+                return Err(err);
+            }
         }
 
         let mut user_defined = opts.user_defined.clone();
@@ -5123,6 +5164,12 @@ impl StorageAPI for SetDisks {
         let disks = disks.clone();
         // let disks = Self::shuffle_disks(&disks, &fi.erasure.distribution);
 
+        if let Some(http_preconditions) = opts.http_preconditions.clone() {
+            if let Some(err) = self.check_write_precondition(bucket, object, opts.clone()).await {
+                return Err(err);
+            }
+        }
+
         let part_path = format!("{}/{}/", upload_id_path, fi.data_dir.unwrap_or(Uuid::nil()));
 
         let part_meta_paths = uploaded_parts
@@ -5942,13 +5989,45 @@ fn get_complete_multipart_md5(parts: &[CompletePart]) -> String {
     format!("{:x}-{}", hasher.finalize(), parts.len())
 }
 
+pub fn canonicalize_etag(etag: &str) -> String {
+    let re = Regex::new("\"*?([^\"]*?)\"*?$").unwrap();
+    re.replace_all(etag, "$1").to_string()
+}
+
+pub fn e_tag_matches(etag: &str, condition: &str) -> bool {
+    if condition.trim() == "*" {
+        return true;
+    }
+    canonicalize_etag(etag) == canonicalize_etag(condition)
+}
+
+pub fn should_prevent_write(oi: &ObjectInfo, if_none_match: Option<String>, if_match: Option<String>) -> bool {
+    match &oi.etag {
+        Some(etag) => {
+            if let Some(if_none_match) = if_none_match {
+                if e_tag_matches(etag, &if_none_match) {
+                    return true;
+                }
+            }
+            if let Some(if_match) = if_match {
+                if !e_tag_matches(etag, &if_match) {
+                    return true;
+                }
+            }
+            false
+        }
+        // Fail the check if we can't obtain the etag of the object
+        None => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::disk::CHECK_PART_UNKNOWN;
     use crate::disk::CHECK_PART_VOLUME_NOT_FOUND;
     use crate::disk::error::DiskError;
-    use crate::store_api::CompletePart;
+    use crate::store_api::{CompletePart, ObjectInfo};
     use rustfs_filemeta::ErasureInfo;
     use std::collections::HashMap;
     use time::OffsetDateTime;
@@ -6372,5 +6451,55 @@ mod tests {
         let result2 = SetDisks::shuffle_disks(&disks, &empty_distribution);
         assert_eq!(result2.len(), 3);
         assert!(result2.iter().all(|d| d.is_none()));
+    }
+
+    #[test]
+    fn test_etag_matches() {
+        assert!(e_tag_matches("abc", "abc"));
+        assert!(e_tag_matches("\"abc\"", "abc"));
+        assert!(e_tag_matches("\"abc\"", "*"));
+    }
+
+    #[test]
+    fn test_should_block_write() {
+        let oi = ObjectInfo {
+            etag: Some("abc".to_string()),
+            ..Default::default()
+        };
+        let if_none_match = Some("abc".to_string());
+        let if_match = None;
+        assert!(should_prevent_write(&oi, if_none_match, if_match));
+
+        let oi = ObjectInfo {
+            etag: Some("abc".to_string()),
+            ..Default::default()
+        };
+        let if_none_match = Some("*".to_string());
+        let if_match = None;
+        assert!(should_prevent_write(&oi, if_none_match, if_match));
+
+        let oi = ObjectInfo {
+            etag: Some("abc".to_string()),
+            ..Default::default()
+        };
+        let if_none_match = None;
+        let if_match = Some("def".to_string());
+        assert!(should_prevent_write(&oi, if_none_match, if_match));
+
+        let oi = ObjectInfo {
+            etag: Some("abc".to_string()),
+            ..Default::default()
+        };
+        let if_none_match = None;
+        let if_match = Some("*".to_string());
+        assert!(!should_prevent_write(&oi, if_none_match, if_match));
+
+        let oi = ObjectInfo {
+            etag: Some("abc".to_string()),
+            ..Default::default()
+        };
+        let if_none_match = Some("def".to_string());
+        let if_match = None;
+        assert!(!should_prevent_write(&oi, if_none_match, if_match));
     }
 }

--- a/crates/ecstore/src/store_api.rs
+++ b/crates/ecstore/src/store_api.rs
@@ -284,6 +284,12 @@ impl HTTPRangeSpec {
 }
 
 #[derive(Debug, Default, Clone)]
+pub struct HTTPPreconditions {
+    pub if_match: Option<String>,
+    pub if_none_match: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
 pub struct ObjectOptions {
     // Use the maximum parity (N/2), used when saving server configuration files
     pub max_parity: bool,
@@ -306,6 +312,7 @@ pub struct ObjectOptions {
     pub user_defined: HashMap<String, String>,
     pub preserve_etag: Option<String>,
     pub metadata_chg: bool,
+    pub http_preconditions: Option<HTTPPreconditions>,
 
     pub replication_request: bool,
     pub delete_marker: bool,

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -81,6 +81,7 @@ impl From<StorageError> for ApiError {
             StorageError::DataMovementOverwriteErr(_, _, _) => S3ErrorCode::InvalidArgument,
             StorageError::ObjectExistsAsDirectory(_, _) => S3ErrorCode::InvalidArgument,
             StorageError::InvalidPart(_, _, _) => S3ErrorCode::InvalidPart,
+            StorageError::PreconditionFailed => S3ErrorCode::PreconditionFailed,
             _ => S3ErrorCode::InternalError,
         };
 

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -21,6 +21,7 @@ use crate::error::ApiError;
 use crate::storage::access::ReqInfo;
 use crate::storage::options::copy_dst_opts;
 use crate::storage::options::copy_src_opts;
+use crate::storage::options::get_complete_multipart_upload_opts;
 use crate::storage::options::{extract_metadata_from_mime_with_object_name, get_opts};
 use bytes::Bytes;
 use chrono::DateTime;
@@ -1812,7 +1813,7 @@ impl S3 for FS {
 
         let Some(multipart_upload) = multipart_upload else { return Err(s3_error!(InvalidPart)) };
 
-        let opts = &ObjectOptions::default();
+        let opts = &get_complete_multipart_upload_opts(&req.headers).map_err(ApiError::from)?;
 
         let mut uploaded_parts = Vec::new();
 

--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -16,7 +16,7 @@ use http::{HeaderMap, HeaderValue};
 use rustfs_ecstore::bucket::versioning_sys::BucketVersioningSys;
 use rustfs_ecstore::error::Result;
 use rustfs_ecstore::error::StorageError;
-use rustfs_ecstore::store_api::ObjectOptions;
+use rustfs_ecstore::store_api::{HTTPPreconditions, ObjectOptions};
 use rustfs_utils::path::is_dir_object;
 use std::collections::HashMap;
 use std::sync::LazyLock;
@@ -105,6 +105,20 @@ pub async fn get_opts(
     Ok(opts)
 }
 
+fn fill_conditional_writes_opts_from_header(headers: &HeaderMap<HeaderValue>, opts: &mut ObjectOptions) {
+    if headers.contains_key("If-None-Match") || headers.contains_key("If-Match") {
+        let mut preconditions = HTTPPreconditions::default();
+        if let Some(if_none_match) = headers.get("If-None-Match") {
+            preconditions.if_none_match = Some(if_none_match.to_str().unwrap().to_string());
+        }
+        if let Some(if_match) = headers.get("If-Match") {
+            preconditions.if_match = Some(if_match.to_str().unwrap().to_string());
+        }
+
+        opts.http_preconditions = Some(preconditions);
+    }
+}
+
 /// Creates options for putting an object in a bucket.
 pub async fn put_opts(
     bucket: &str,
@@ -140,6 +154,16 @@ pub async fn put_opts(
     };
     opts.version_suspended = version_suspended;
     opts.versioned = versioned;
+
+    fill_conditional_writes_opts_from_header(headers, &mut opts);
+
+    Ok(opts)
+}
+
+pub fn get_complete_multipart_upload_opts(headers: &HeaderMap<HeaderValue>) -> Result<ObjectOptions> {
+    let mut opts = ObjectOptions::default();
+
+    fill_conditional_writes_opts_from_header(headers, &mut opts);
 
     Ok(opts)
 }


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
#406 

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

When executing `PutObject` and `CompleteMultipartUpload`, if the `If-None-Match` or `If-Match` header is set, check the etag of the object before proceeding. The implementation strategy comes from MinIO.

I've done some tests with the following settings:
* Single-node and multi-node setup
* `PutObject` and `CompleteMultipartUpload`
* Various combination of If-None-Match and If-Match values

Looks good for now.

Any further tests and comments are welcome!

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
