### PR TITLE
lock: dedicate unlock worker to thread runtime; robust fallback in Drop

### DIFF
--- a/crates/lock/src/guard.rs
+++ b/crates/lock/src/guard.rs
@@ -15,6 +15,8 @@
 use std::sync::Arc;
 
 use once_cell::sync::Lazy;
+use std::thread;
+use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 
 use crate::{client::LockClient, types::LockId};
@@ -25,36 +27,43 @@ struct UnlockJob {
     clients: Vec<Arc<dyn LockClient>>, // cloned Arcs; cheap and shares state
 }
 
-#[derive(Debug)]
-struct UnlockRuntime {
-    tx: mpsc::Sender<UnlockJob>,
-}
-
-// Global unlock runtime with background worker
-static UNLOCK_RUNTIME: Lazy<UnlockRuntime> = Lazy::new(|| {
+// Global unlock runtime with background worker running on a dedicated thread-bound Tokio runtime.
+// This avoids depending on the application's Tokio runtime lifetimes/cancellation scopes.
+static UNLOCK_TX: Lazy<mpsc::Sender<UnlockJob>> = Lazy::new(|| {
     // Larger buffer to reduce contention during bursts
     let (tx, mut rx) = mpsc::channel::<UnlockJob>(8192);
 
-    // Spawn background worker when first used; assumes a Tokio runtime is available
-    tokio::spawn(async move {
-        while let Some(job) = rx.recv().await {
-            // Best-effort release across clients; try all, success if any succeeds
-            let mut any_ok = false;
-            let lock_id = job.lock_id.clone();
-            for client in job.clients.into_iter() {
-                if client.release(&lock_id).await.unwrap_or(false) {
-                    any_ok = true;
-                }
-            }
-            if !any_ok {
-                tracing::warn!("LockGuard background release failed for {}", lock_id);
-            } else {
-                tracing::debug!("LockGuard background released {}", lock_id);
-            }
-        }
-    });
+    // Spawn a dedicated OS thread that owns its own Tokio runtime to process unlock jobs.
+    thread::Builder::new()
+        .name("rustfs-lock-unlocker".to_string())
+        .spawn(move || {
+            // A lightweight current-thread runtime is sufficient here.
+            let rt = Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build unlock runtime");
 
-    UnlockRuntime { tx }
+            rt.block_on(async move {
+                while let Some(job) = rx.recv().await {
+                    // Best-effort release across clients; try all, success if any succeeds
+                    let mut any_ok = false;
+                    let lock_id = job.lock_id.clone();
+                    for client in job.clients.into_iter() {
+                        if client.release(&lock_id).await.unwrap_or(false) {
+                            any_ok = true;
+                        }
+                    }
+                    if !any_ok {
+                        tracing::warn!("LockGuard background release failed for {}", lock_id);
+                    } else {
+                        tracing::debug!("LockGuard background released {}", lock_id);
+                    }
+                }
+            });
+        })
+        .expect("failed to spawn unlock worker thread");
+
+    tx
 });
 
 /// A RAII guard that releases the lock asynchronously when dropped.
@@ -99,22 +108,33 @@ impl Drop for LockGuard {
         };
 
         // Try a non-blocking send to avoid panics in Drop
-        if let Err(err) = UNLOCK_RUNTIME.tx.try_send(job) {
-            // Channel full or closed; best-effort fallback: spawn a detached task
+        if let Err(err) = UNLOCK_TX.try_send(job) {
+            // Channel full or closed; best-effort fallback using a dedicated thread runtime
             let lock_id = self.lock_id.clone();
             let clients = self.clients.clone();
-            tracing::warn!("LockGuard channel send failed ({}), spawning fallback unlock task for {}", err, lock_id);
+            let lock_id_for_log = lock_id.to_string();
+            tracing::warn!(
+                "LockGuard channel send failed ({}), spawning fallback unlock thread for {}",
+                err,
+                lock_id_for_log
+            );
 
-            // If runtime is not available, this will panic; but in RustFS we are inside Tokio contexts.
-            let handle = tokio::spawn(async move {
-                let futures_iter = clients.into_iter().map(|client| {
-                    let id = lock_id.clone();
-                    async move { client.release(&id).await.unwrap_or(false) }
+            // Use a short-lived background thread to execute the async releases on its own runtime.
+            let _ = thread::Builder::new()
+                .name("rustfs-lock-unlock-fallback".to_string())
+                .spawn(move || {
+                    let rt = Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("failed to build fallback unlock runtime");
+                    rt.block_on(async move {
+                        let futures_iter = clients.into_iter().map(|client| {
+                            let id = lock_id.clone();
+                            async move { client.release(&id).await.unwrap_or(false) }
+                        });
+                        let _ = futures::future::join_all(futures_iter).await;
+                    });
                 });
-                let _ = futures::future::join_all(futures_iter).await;
-            });
-            // Explicitly drop the JoinHandle to acknowledge detaching the task.
-            std::mem::drop(handle);
         }
     }
 }


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [-] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes

Fixed


[2025-08-22 02:43:10.001504 +08:00] ERROR [s3s::service] [/Users/liwenkai/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/s3s-0.12.0-minio-preview.3/src/service.rs:108] [tokio-runtime-worker:ThreadId(66)] duration=7.76125ms res=Response { status: 500, version: HTTP/1.1, headers: {"content-type": "application/xml"}, body: Body { once: b"<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>InternalError</Code><Message>Io error: background task failed</Message></Error>" } }

[2025-08-22 02:43:10.001651 +08:00] ERROR [s3s::service] [/Users/liwenkai/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/s3s-0.12.0-minio-preview.3/src/service.rs:108] [tokio-runtime-worker:ThreadId(43)] duration=6.021209ms res=Response { status: 500, version: HTTP/1.1, headers: {"content-type": "application/xml"}, body: Body { once: b"<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>InternalError</Code><Message>Io error: task 348454 was cancelled</Message></Error>" } }


---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
