### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-translator.yml
+++ b/.github/workflows/issue-translator.yml
@@ -19,6 +19,7 @@ on:
   issues:
     types: [ opened ]
 
+permissions:
   contents: read
   issues: write
 


### PR DESCRIPTION
Potential fix for [https://github.com/rustfs/rustfs/security/code-scanning/7](https://github.com/rustfs/rustfs/security/code-scanning/7)

To fix the problem, add a `permissions` block at the workflow level (at the same indentation as `name:` and `on:`), specifying the minimum set of permissions required by the workflow. In this case, the user wanted `contents: read` and `issues: write` (as written, albeit in the wrong place). Remove any invalid `permissions`-like entries (lines 22 and 23) from under the `on:` block, and add a correctly placed `permissions:` block just before or after `on:`. No imports or extra methods are needed for this YAML fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
