### PR TITLE
Update mod.rs

### DIFF
--- a/crates/obs/src/sinks/mod.rs
+++ b/crates/obs/src/sinks/mod.rs
@@ -79,7 +79,11 @@ pub async fn create_sinks(config: &AppConfig) -> Vec<Arc<dyn Sink>> {
             SinkConfig::File(file_config) => {
                 tracing::debug!("FileSink: Using path: {}", file_config.path);
                 match file::FileSink::new(
-                    format!("{}/{}", file_config.path.clone(), rustfs_config::DEFAULT_SINK_FILE_LOG_FILE),
+                    //format!("{}/{}", file_config.path.clone(), rustfs_config::DEFAULT_SINK_FILE_LOG_FILE),
+                    std::path::Path::new(&file_config.path)
+                        .join(rustfs_config::DEFAULT_SINK_FILE_LOG_FILE)
+                        .to_string_lossy()
+                        .to_string(),
                     file_config
                         .buffer_size
                         .unwrap_or(rustfs_config::observability::DEFAULT_SINKS_FILE_BUFFER_SIZE),


### PR DESCRIPTION
The following code uses a separator that is not compatible with Windows:

format!("{}/{}", file_config.path.clone(), rustfs_config::DEFAULT_SINK_FILE_LOG_FILE)


Change it to the following code:


std::path::Path::new(&file_config.path)
    .join(rustfs_config::DEFAULT_SINK_FILE_LOG_FILE)
    .to_string_lossy()
    .to_string()

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
