### PR TITLE
Fix/response

### DIFF
--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1003,7 +1003,7 @@ async fn gather_results(
             }
         }
 
-        if !opts.incl_deleted && entry.is_object() && entry.is_latest_delete_marker() && entry.is_object_dir() {
+        if !opts.incl_deleted && entry.is_object() && entry.is_latest_delete_marker() && !entry.is_object_dir() {
             continue;
         }
 

--- a/crates/filemeta/src/metacache.rs
+++ b/crates/filemeta/src/metacache.rs
@@ -112,8 +112,8 @@ impl MetaCacheEntry {
             return false;
         }
 
-        match FileMeta::check_xl2_v1(&self.metadata) {
-            Ok((meta, _, _)) => {
+        match FileMeta::is_indexed_meta(&self.metadata) {
+            Ok((meta, _inline_data)) => {
                 if !meta.is_empty() {
                     return FileMeta::is_latest_delete_marker(meta);
                 }

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -1895,6 +1895,11 @@ impl S3 for FS {
                     })
                     .collect(),
             ),
+            owner: Some(RUSTFS_OWNER.to_owned()),
+            initiator: Some(Initiator {
+                id: RUSTFS_OWNER.id.clone(),
+                display_name: RUSTFS_OWNER.display_name.clone(),
+            }),
             ..Default::default()
         };
         Ok(S3Response::new(output))


### PR DESCRIPTION
# fix: S3 API response improvements and delete marker handling

## Description

This PR addresses two critical issues in the S3 API implementation related to object listing and multipart upload responses:

1. **Fixed delete marker filtering logic in list_objects operation**
2. **Enhanced list_parts response to include required owner and initiator fields**

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
#466  #155

## Changes Made

### 🔧 Core Fixes

#### 1. Delete Marker Handling (`store_list_objects.rs`)
- **Issue**: Incorrect logic for filtering delete markers in object directory listings
- **Fix**: Changed condition from `entry.is_object_dir()` to `!entry.is_object_dir()` 
- **Impact**: Ensures delete markers are properly skipped when `incl_deleted` is false, preventing incorrect object visibility

#### 2. List Parts Response Enhancement (`ecfs.rs`)
- **Issue**: Missing required `owner` and `initiator` fields in ListParts response
- **Fix**: Added proper `owner` and `initiator` fields to comply with S3 API specification
- **Impact**: Ensures full compatibility with S3 clients expecting complete response metadata

### 🛠️ Supporting Infrastructure

#### 3. Metadata Processing Improvements (`filemeta.rs`)
- **Added**: New `is_indexed_meta()` function for efficient metadata parsing
- **Enhancement**: Improved metadata validation with CRC checking
- **Benefit**: Better error handling and data integrity verification

#### 4. Cache Entry Optimization (`metacache.rs`)
- **Updated**: Modified to use the new `is_indexed_meta()` function
- **Improvement**: More efficient metadata processing in cache operations
- **Result**: Better performance for metadata-heavy operations

## Technical Details

### Delete Marker Logic Fix
```rust
// Before (incorrect)
if !opts.incl_deleted && entry.is_object() && entry.is_latest_delete_marker() && entry.is_object_dir() {

// After (correct)  
if !opts.incl_deleted && entry.is_object() && entry.is_latest_delete_marker() && !entry.is_object_dir() {
```

### List Parts Response Enhancement
```rust
owner: Some(RUSTFS_OWNER.to_owned()),
initiator: Some(Initiator {
    id: RUSTFS_OWNER.id.clone(),
    display_name: RUSTFS_OWNER.display_name.clone(),
}),
```

## Testing

- [ ] Verified delete marker filtering works correctly in object listings
- [ ] Confirmed ListParts response includes all required fields
- [ ] Tested metadata parsing with new `is_indexed_meta()` function
- [ ] Ensured backward compatibility with existing functionality

## Impact

### 🐛 Bug Fixes
- Resolves incorrect object visibility when delete markers are present
- Fixes S3 client compatibility issues with incomplete ListParts responses

### 🚀 Improvements
- Enhanced metadata processing efficiency
- Better error handling and data validation
- Improved S3 API compliance

## Breaking Changes

None. All changes are backward compatible.

## Files Modified

- `crates/ecstore/src/store_list_objects.rs` - Delete marker filtering logic
- `crates/filemeta/src/filemeta.rs` - Metadata processing functions
- `crates/filemeta/src/metacache.rs` - Cache entry processing
- `rustfs/src/storage/ecfs.rs` - S3 API response formatting