### PR TITLE
fix docker compose running with no such file error

### DIFF
--- a/.docker/observability/docker-compose.yml
+++ b/.docker/observability/docker-compose.yml
@@ -14,18 +14,27 @@
 
 services:
 
+  tempo-init:
+    image: busybox:latest
+    command: ["sh", "-c", "chown -R 10001:10001 /var/tempo"]
+    volumes:
+      - ./tempo-data:/var/tempo
+    user: root
+    networks:
+      - otel-network
+    restart: "no"
+
   tempo:
     image: grafana/tempo:latest
-    #user: root # The container must be started with root to execute chown in the script
-    #entrypoint: [ "/etc/tempo/entrypoint.sh" ]  # Specify a custom entry point
+    user: "10001" # The container must be started with root to execute chown in the script
     command: [ "-config.file=/etc/tempo.yaml" ] # This is passed as a parameter to the entry point script
     volumes:
-      - ./tempo-entrypoint.sh:/etc/tempo/entrypoint.sh # Mount entry point script
-      - ./tempo.yaml:/etc/tempo.yaml
+      - ./tempo.yaml:/etc/tempo.yaml:ro
       - ./tempo-data:/var/tempo
     ports:
       - "3200:3200" # tempo
       - "24317:4317" # otlp grpc
+    restart: unless-stopped
     networks:
       - otel-network
 
@@ -94,4 +103,4 @@ networks:
     driver: bridge
     name: "network_otel_config"
     driver_opts:
-      com.docker.network.enable_ipv6: "true"    
+      com.docker.network.enable_ipv6: "true"

--- a/.docker/observability/tempo-entrypoint.sh
+++ b/.docker/observability/tempo-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-# Run as root to fix directory permissions
-chown -R 10001:10001 /var/tempo
-
-# Use su-exec (a lightweight sudo/gosu alternative, commonly used in Alpine mirroring)
-# Switch to user 10001 and execute the original command (CMD) passed to the script
-# "$@" represents all parameters passed to this script, i.e. command in docker-compose
-exec su-exec 10001:10001 /tempo "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - rustfs_data_1:/data/rustfs1
       - rustfs_data_2:/data/rustfs2
       - rustfs_data_3:/data/rustfs3
-      - ./logs:/app/logs
+      - logs_data:/app/logs
     networks:
       - rustfs-network
     restart: unless-stopped
@@ -95,7 +95,7 @@ services:
     command:
       - --config=/etc/otelcol-contrib/otel-collector.yml
     volumes:
-      - ./.docker/observability/otel-collector.yml:/etc/otelcol-contrib/otel-collector.yml:ro
+      - ./.docker/observability/otel-collector-config.yaml:/etc/otelcol-contrib/otel-collector.yml:ro
     ports:
       - "4317:4317" # OTLP gRPC receiver
       - "4318:4318" # OTLP HTTP receiver
@@ -218,4 +218,6 @@ volumes:
   grafana_data:
     driver: local
   redis_data:
+    driver: local
+  logs_data:
     driver: local

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,4 +56,5 @@ if [ "${RUSTFS_ACCESS_KEY}" = "rustfsadmin" ] || [ "${RUSTFS_SECRET_KEY}" = "rus
 fi
 
 echo "Starting: $*"
+set -- "$@" $LOCAL_VOLUMES
 exec "$@"


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

When using the current `docker-compose.yml` file to run rustfs instance in docker container, always show below error:

```
Initializing mount directories: /data/rustfs0 /data/rustfs1 /data/rustfs2 /data/rustfs3 /logs
!!!WARNING: Using default RUSTFS_ACCESS_KEY or RUSTFS_SECRET_KEY. Override them in production!
Starting: /usr/bin/rustfs
Error: Custom { kind: Other, error: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" }) }
```

After debugging, the error was caused by the `RUSTFS_VOLUMES` env variable.  For `RUSTFS_VOLUME` env variable, the value is `/data/rustfs0,/data/rustfs1,/data/rustfs2,/data/rustfs3`, `entrypoint.sh` script already handle this env var and splits it into four parts and use the new var `LOCAL_VOLUME`, but the final start step still use `RUSTFS_VOLUMES`. 

By the way, current `docker-compose.yaml` uses `./logs:/app/logs` volume, but `./logs` doesn't exist in the codebase (it should not exist in codebase), so use `logs_data` volume instead.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
