### PR TITLE
Adding a toggle for update check

### DIFF
--- a/crates/config/src/constants/console.rs
+++ b/crates/config/src/constants/console.rs
@@ -79,3 +79,13 @@ pub const ENV_CONSOLE_AUTH_TIMEOUT: &str = "RUSTFS_CONSOLE_AUTH_TIMEOUT";
 /// Example: RUSTFS_CONSOLE_AUTH_TIMEOUT=3600
 /// Example: --console-auth-timeout 3600
 pub const DEFAULT_CONSOLE_AUTH_TIMEOUT: u64 = 3600;
+
+/// Toggle update check
+/// It controls whether to check for newer versions of rustfs
+/// Default value: true
+/// Environment variable: RUSTFS_CHECK_UPDATE
+/// Example: RUSTFS_CHECK_UPDATE=false
+pub const ENV_UPDATE_CHECK: &str = "RUSTFS_CHECK_UPDATE";
+
+/// Default value for update toggle
+pub const DEFAULT_UPDATE_CHECK: bool = true;


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
Adding `RUSTFS_CHECK_UPDATE` environment variable, defaults to `true`. It controls whether to check for newer versions of rustfs.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.

Implements https://github.com/rustfs/rustfs/issues/517

