### PR TITLE
feat(console): support accessing console endpoint via port 9000

### DIFF
--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -136,6 +136,9 @@ async fn run(opt: config::Opt) -> Result<()> {
 
     set_global_addr(&opt.address).await;
 
+    // Wait for DNS initialization to complete before network-heavy operations
+    dns_init.await.map_err(Error::other)?;
+
     // For RPC
     let (endpoint_pools, setup_type) = EndpointServerPools::from_volumes(server_address.clone().as_str(), opt.volumes.clone())
         .await
@@ -229,9 +232,6 @@ async fn run(opt: config::Opt) -> Result<()> {
 
     // Initialize event notifier
     init_event_notifier().await;
-
-    // Wait for DNS initialization to complete before network-heavy operations
-    dns_init.await.map_err(Error::other)?;
 
     let buckets_list = store
         .list_bucket(&BucketOptions {

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -128,7 +128,6 @@ pub async fn start_http_server(
 ) -> Result<tokio::sync::broadcast::Sender<()>> {
     let server_addr = parse_and_resolve_address(opt.address.as_str()).map_err(Error::other)?;
     let server_port = server_addr.port();
-    let _server_address = server_addr.to_string();
 
     // The listening address and port are obtained from the parameters
     let listener = {

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -198,7 +198,7 @@ pub async fn start_http_server(
         b.set_auth(IAMAuth::new(access_key, secret_key));
         b.set_access(store.clone());
         // When console runs on separate port, disable console routes on main endpoint
-        let console_on_endpoint = false; // Console will run separately
+        let console_on_endpoint = opt.console_enable; // Console will run separately
         b.set_route(admin::make_admin_route(console_on_endpoint)?);
 
         if !opt.server_domains.is_empty() {


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

feat(console): support accessing console endpoint via port 9000

- Added compatibility to allow console access through port 9000.
- Improved endpoint detection and routing for console service on standard and custom ports.
- Enhanced user experience for environments using port 9000 as the default access point.

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [X] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [X] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [X] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
