### PR TITLE
feat(obs): optimize WriteMode selection logic in init_telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "chrono",
  "crossbeam-channel",
  "crossbeam-queue",
+ "flate2",
  "log",
  "notify-debouncer-mini",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ derive_builder = "0.20.2"
 enumset = "1.1.10"
 flatbuffers = "25.2.10"
 flate2 = "1.1.2"
-flexi_logger = { version = "0.31.2", features = ["trc", "dont_minimize_extra_stacks"] }
+flexi_logger = { version = "0.31.2", features = ["trc", "dont_minimize_extra_stacks", "compress", "kv"] }
 form_urlencoded = "1.2.2"
 futures = "0.3.31"
 futures-core = "0.3.31"

--- a/crates/config/src/observability/config.rs
+++ b/crates/config/src/observability/config.rs
@@ -29,9 +29,28 @@ pub const ENV_OBS_LOG_ROTATION_SIZE_MB: &str = "RUSTFS_OBS_LOG_ROTATION_SIZE_MB"
 pub const ENV_OBS_LOG_ROTATION_TIME: &str = "RUSTFS_OBS_LOG_ROTATION_TIME";
 pub const ENV_OBS_LOG_KEEP_FILES: &str = "RUSTFS_OBS_LOG_KEEP_FILES";
 
+/// Log pool capacity for async logging
+pub const ENV_OBS_LOG_POOL_CAPA: &str = "RUSTFS_OBS_LOG_POOL_CAPA";
+
+/// Log message capacity for async logging
+pub const ENV_OBS_LOG_MESSAGE_CAPA: &str = "RUSTFS_OBS_LOG_MESSAGE_CAPA";
+
+/// Log flush interval in milliseconds for async logging
+pub const ENV_OBS_LOG_FLUSH_MS: &str = "RUSTFS_OBS_LOG_FLUSH_MS";
+
+/// Default values for log pool
+pub const DEFAULT_OBS_LOG_POOL_CAPA: usize = 10240;
+
+/// Default values for message capacity
+pub const DEFAULT_OBS_LOG_MESSAGE_CAPA: usize = 32768;
+
+/// Default values for flush interval in milliseconds
+pub const DEFAULT_OBS_LOG_FLUSH_MS: u64 = 200;
+
+/// Audit logger queue capacity environment variable key
 pub const ENV_AUDIT_LOGGER_QUEUE_CAPACITY: &str = "RUSTFS_AUDIT_LOGGER_QUEUE_CAPACITY";
 
-// Default values for observability configuration
+/// Default values for observability configuration
 pub const DEFAULT_AUDIT_LOGGER_QUEUE_CAPACITY: usize = 10000;
 
 /// Default values for observability configuration

--- a/crates/obs/Cargo.toml
+++ b/crates/obs/Cargo.toml
@@ -40,7 +40,7 @@ rustfs-config = { workspace = true, features = ["constants", "observability"] }
 rustfs-utils = { workspace = true, features = ["ip", "path"] }
 async-trait = { workspace = true }
 chrono = { workspace = true }
-flexi_logger = { workspace = true, features = ["trc", "kv"] }
+flexi_logger = { workspace = true }
 nu-ansi-term = { workspace = true }
 nvml-wrapper = { workspace = true, optional = true }
 opentelemetry = { workspace = true }
@@ -61,6 +61,7 @@ reqwest = { workspace = true, optional = true }
 serde_json = { workspace = true }
 sysinfo = { workspace = true }
 thiserror = { workspace = true }
+
 
 # Only enable kafka features and related dependencies on Linux
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/rustfs/src/server/console.rs
+++ b/rustfs/src/server/console.rs
@@ -16,7 +16,7 @@ use crate::admin::console::static_handler;
 use crate::config::Opt;
 use axum::{Router, extract::Request, middleware, response::Json, routing::get};
 use axum_server::tls_rustls::RustlsConfig;
-use http::{HeaderValue, Method, header};
+use http::{HeaderValue, Method};
 use rustfs_config::{RUSTFS_TLS_CERT, RUSTFS_TLS_KEY};
 use rustfs_utils::net::parse_and_resolve_address;
 use serde_json::json;
@@ -230,15 +230,15 @@ async fn health_check() -> Json<serde_json::Value> {
 pub fn parse_cors_origins(origins: Option<&String>) -> CorsLayer {
     let cors_layer = CorsLayer::new()
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::OPTIONS])
-        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION, header::ACCEPT, header::ORIGIN]);
+        .allow_headers(Any);
 
     match origins {
-        Some(origins_str) if origins_str == "*" => cors_layer.allow_origin(Any),
+        Some(origins_str) if origins_str == "*" => cors_layer.allow_origin(Any).expose_headers(Any),
         Some(origins_str) => {
             let origins: Vec<&str> = origins_str.split(',').map(|s| s.trim()).collect();
             if origins.is_empty() {
                 warn!("Empty CORS origins provided, using permissive CORS");
-                cors_layer.allow_origin(Any)
+                cors_layer.allow_origin(Any).expose_headers(Any)
             } else {
                 // Parse origins with proper error handling
                 let mut valid_origins = Vec::new();
@@ -255,10 +255,10 @@ pub fn parse_cors_origins(origins: Option<&String>) -> CorsLayer {
 
                 if valid_origins.is_empty() {
                     warn!("No valid CORS origins found, using permissive CORS");
-                    cors_layer.allow_origin(Any)
+                    cors_layer.allow_origin(Any).expose_headers(Any)
                 } else {
                     info!("Console CORS origins configured: {:?}", valid_origins);
-                    cors_layer.allow_origin(AllowOrigin::list(valid_origins))
+                    cors_layer.allow_origin(AllowOrigin::list(valid_origins)).expose_headers(Any)
                 }
             }
         }

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -65,26 +65,15 @@ fn parse_cors_origins(origins: Option<&String>) -> CorsLayer {
             Method::HEAD,
             Method::OPTIONS,
         ])
-        .allow_headers([
-            http::header::CONTENT_TYPE,
-            http::header::AUTHORIZATION,
-            http::header::ACCEPT,
-            http::header::ORIGIN,
-            // Note: X_AMZ_* headers are custom and may need to be defined
-            // http::header::X_AMZ_CONTENT_SHA256,
-            // http::header::X_AMZ_DATE,
-            // http::header::X_AMZ_SECURITY_TOKEN,
-            // http::header::X_AMZ_USER_AGENT,
-            http::header::RANGE,
-        ]);
+        .allow_headers(Any);
 
     match origins {
-        Some(origins_str) if origins_str == "*" => cors_layer.allow_origin(Any),
+        Some(origins_str) if origins_str == "*" => cors_layer.allow_origin(Any).expose_headers(Any),
         Some(origins_str) => {
             let origins: Vec<&str> = origins_str.split(',').map(|s| s.trim()).collect();
             if origins.is_empty() {
                 warn!("Empty CORS origins provided, using permissive CORS");
-                cors_layer.allow_origin(Any)
+                cors_layer.allow_origin(Any).expose_headers(Any)
             } else {
                 // Parse origins with proper error handling
                 let mut valid_origins = Vec::new();
@@ -101,16 +90,16 @@ fn parse_cors_origins(origins: Option<&String>) -> CorsLayer {
 
                 if valid_origins.is_empty() {
                     warn!("No valid CORS origins found, using permissive CORS");
-                    cors_layer.allow_origin(Any)
+                    cors_layer.allow_origin(Any).expose_headers(Any)
                 } else {
                     info!("Endpoint CORS origins configured: {:?}", valid_origins);
-                    cors_layer.allow_origin(AllowOrigin::list(valid_origins))
+                    cors_layer.allow_origin(AllowOrigin::list(valid_origins)).expose_headers(Any)
                 }
             }
         }
         None => {
             debug!("No CORS origins configured for endpoint, using permissive CORS");
-            cors_layer.allow_origin(Any)
+            cors_layer.allow_origin(Any).expose_headers(Any)
         }
     }
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -64,6 +64,9 @@ export RUSTFS_OBS_LOCAL_LOGGING_ENABLED=true # Whether to enable local logging
 export RUSTFS_OBS_LOG_DIRECTORY="$current_dir/deploy/logs" # Log directory
 export RUSTFS_OBS_LOG_ROTATION_TIME="hour" # Log rotation time unit, can be "second", "minute", "hour", "day"
 export RUSTFS_OBS_LOG_ROTATION_SIZE_MB=100 # Log rotation size in MB
+export RUSTFS_OBS_LOG_POOL_CAPA=10240
+export RUSTFS_OBS_LOG_MESSAGE_CAPA=32768
+export RUSTFS_OBS_LOG_FLUSH_MS=300
 
 export RUSTFS_SINKS_FILE_PATH="$current_dir/deploy/logs"
 export RUSTFS_SINKS_FILE_BUFFER_SIZE=12


### PR DESCRIPTION
- Refactor WriteMode selection to ensure all variables moved into thread closures are owned types, preventing lifetime issues.
- Simplify and clarify WriteMode assignment for production and non-production environments.
- Improve code readability and maintainability for logger initialization.

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [X] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [X] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [X] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
