### PR TITLE
Temporarily build latest from alpha

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -162,7 +162,14 @@ jobs:
                 if [[ "$version" == *"alpha"* ]] || [[ "$version" == *"beta"* ]] || [[ "$version" == *"rc"* ]]; then
                   build_type="prerelease"
                   is_prerelease=true
-                  echo "🧪 Building Docker image for prerelease: $version"
+                  # TODO: 临时修改 - 当前允许 alpha 版本也创建 latest 标签
+                  # 等版本稳定后，需要移除下面这行，恢复原有逻辑（只有稳定版本才创建 latest）
+                  if [[ "$version" == *"alpha"* ]]; then
+                    create_latest=true
+                    echo "🧪 Building Docker image for prerelease: $version (临时允许创建 latest 标签)"
+                  else
+                    echo "🧪 Building Docker image for prerelease: $version"
+                  fi
                 else
                   build_type="release"
                   create_latest=true
@@ -208,7 +215,14 @@ jobs:
               v*alpha*|v*beta*|v*rc*|*alpha*|*beta*|*rc*)
                 build_type="prerelease"
                 is_prerelease=true
-                echo "🧪 Building with prerelease version: $input_version"
+                # TODO: 临时修改 - 当前允许 alpha 版本也创建 latest 标签
+                # 等版本稳定后，需要移除下面的 if 块，恢复原有逻辑
+                if [[ "$input_version" == *"alpha"* ]]; then
+                  create_latest=true
+                  echo "🧪 Building with prerelease version: $input_version (临时允许创建 latest 标签)"
+                else
+                  echo "🧪 Building with prerelease version: $input_version"
+                fi
                 ;;
               # Release versions (match after prereleases, more general)
               v[0-9]*|[0-9]*.*.*)
@@ -316,7 +330,9 @@ jobs:
 
           # Add channel tags for prereleases and latest for stable
           if [[ "$CREATE_LATEST" == "true" ]]; then
-            # Stable release
+            # TODO: 临时修改 - 当前 alpha 版本也会创建 latest 标签
+            # 等版本稳定后，这里的逻辑保持不变，但上游的 CREATE_LATEST 设置需要恢复
+            # Stable release (以及临时的 alpha 版本)
             TAGS="$TAGS,${{ env.REGISTRY_DOCKERHUB }}:latest"
           elif [[ "$BUILD_TYPE" == "prerelease" ]]; then
             # Prerelease channel tags (alpha, beta, rc)
@@ -413,7 +429,13 @@ jobs:
             "prerelease")
               echo "🧪 Prerelease Docker image has been built with ${VERSION} tags"
               echo "⚠️  This is a prerelease image - use with caution"
-              echo "🚫 Latest tag NOT created for prerelease"
+              # TODO: 临时修改 - alpha 版本当前会创建 latest 标签
+              # 等版本稳定后，需要恢复下面的提示信息
+              if [[ "$VERSION" == *"alpha"* ]] && [[ "$CREATE_LATEST" == "true" ]]; then
+                echo "🏷️  Latest tag has been created for alpha version (临时措施)"
+              else
+                echo "🚫 Latest tag NOT created for prerelease"
+              fi
               ;;
             *)
               echo "❌ Unexpected build type: $BUILD_TYPE"


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [x] Other: CI/CD Configuration Update

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
This PR temporarily modifies the Docker CI/CD workflow (`.github/workflows/docker.yml`) to allow `alpha` versions to also build and push the `latest` Docker image tag. This enables users to easily pull the most recent alpha version without needing the full version string. All changes are marked with `TODO` comments for future reversion when stable releases resume pushing `latest`.

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update (CI/CD configuration)
- [x] Other impact: Docker image tagging behavior for alpha versions changed.

## Additional Notes
This is a temporary measure to address the current alpha release cycle. The `TODO` comments indicate the specific lines that need to be reverted once the project stabilizes and `latest` tagging should only apply to stable releases.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ef10dc8-f234-43cf-96ab-8fe064e10731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ef10dc8-f234-43cf-96ab-8fe064e10731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

