### PR TITLE
docs: add MNMD docker-compose example, startup order and troubleshooting

### DIFF
--- a/docs/examples/mnmd/CHECKLIST.md
+++ b/docs/examples/mnmd/CHECKLIST.md
@@ -1,36 +1,46 @@
 # MNMD Docker Troubleshooting Checklist
 
 Preflight
+
 - Directories: `sudo mkdir -p /mnt/rustfs{1..4}_data{1..4}`
-- Filesystem: each `/mnt/rustfsX_dataY` must be XFS  
-  - Check: `findmnt -no FSTYPE /mnt/rustfs1_data1` -> `xfs`
-- Permissions: ensure container user can write  
-  - Quick: `sudo chown -R 1000:1000 /mnt/rustfs*_data*` (or match the image user)
+- Filesystem: each `/mnt/rustfsX_dataY` must be XFS
+    - Check: `findmnt -no FSTYPE /mnt/rustfs1_data1` -> `xfs`
+- Permissions: ensure container user can write
+    - Quick: `sudo chown -R 1000:1000 /mnt/rustfs*_data*` (or match the image user)
 - SELinux (if enabled): add `:z` to bind mounts or adjust policy
 
-Bring up
+Bring up (run from docs/examples/mnmd)
+
 - `docker compose up -d`
 - `docker ps` (4 containers up; wait for healthy)
 - Logs: `docker logs -f rustfs-node1`
 
+Entrypoint wrapper
+
+- We mount `./wait-and-start.sh:/usr/local/bin/wait-and-start.sh:ro` and set entrypoint to
+  `/bin/sh /usr/local/bin/wait-and-start.sh`
+- No need to rely on the host execute bit; if you prefer, you can `chmod +x wait-and-start.sh` and set entrypoint
+  directly to the script
+- If the image doesn't have a default CMD (or ENTRYPOINT is replaced), we fall back to `RUSTFS_CMD` (default `rustfs`).
+  Adjust it if your binary name differs.
+
 In-container checks
+
 - `docker exec -it rustfs-node1 sh -c 'ls -ld /data/rustfs*'`
-- Check FS type (bind mount reflects XFS):  
+- FS type reflects XFS:  
   `docker exec -it rustfs-node1 sh -c 'stat -f -c %T /data/rustfs1'` (expect `xfs`)
 
 Network/DNS
+
 - Service names resolve automatically on the Compose network:
   `docker exec -it rustfs-node2 getent hosts rustfs-node1`
 
 If VolumeNotFound persists
+
 - Confirm RUSTFS_VOLUMES uses `/data/rustfs{1...4}`, not `{0...4}`
 - Consider replacing brace expansion with an explicit list of all 16 endpoints
 - Ensure all 16 bind mounts exist and are writable
 
-Optional strong ordering
-- Use `wait-and-start.sh` to gate app startup:
-  - Mount the script into the container
-  - Set entrypoint/command to run the script then exec the server binary
-
 Healthcheck alternatives
+
 - If `nc` missing, switch healthcheck to `curl` or `wget` as documented

--- a/docs/examples/mnmd/README.md
+++ b/docs/examples/mnmd/README.md
@@ -3,28 +3,47 @@
 This folder contains a ready-to-use docker-compose.yml for a 4x4 MNMD deployment.
 
 Highlights
+
 - RUSTFS_VOLUMES uses 1..4 to match /data/rustfs1..4
 - Uses Docker service names (rustfs-node1..4) — no hard-coded IPs
 - Only node1 exposes 9000 externally
 - Startup order via healthcheck + depends_on
-- Optional wait-and-start.sh to gate app startup after container boot
+- wait-and-start.sh wrapped as entrypoint to gate startup and avoid race conditions
 
 Quick start
-1) Prepare host directories (XFS):
-   - Create /mnt/rustfs{1..4}_data{1..4}
-   - Ensure each is mounted as XFS
-   - Ensure the container user can write to them
 
-2) Launch:
-   - docker compose up -d
+1) Prepare host directories (XFS):
+    - Create /mnt/rustfs{1..4}_data{1..4}
+    - Ensure each is mounted as XFS
+    - Ensure the container user can write to them
+
+2) Run from THIS directory (so relative mount works):
+    - docker compose up -d
 
 3) Verify:
-   - docker ps (all 4 nodes up and healthy)
-   - docker logs -f rustfs-node1
-   - Access http://localhost:9000 (credentials as in compose)
+    - docker ps (all 4 nodes up and healthy)
+    - docker logs -f rustfs-node1
+    - Access http://localhost:9000 (credentials as in compose)
+
+About the entrypoint wrapper
+
+- The compose mounts ./wait-and-start.sh to /usr/local/bin/wait-and-start.sh and sets it as entrypoint using /bin/sh to
+  avoid relying on the execute bit on the host file.
+- The script:
+    - Ensures /data/rustfs1..4 exist
+    - Best-effort waits for peers (max 120s each, then continues)
+    - Executes the original command (CMD args passed to entrypoint)
+    - Falls back to RUSTFS_CMD when no CMD is provided (we set RUSTFS_CMD=rustfs by default)
+
+If the binary name in your image differs
+
+- Set RUSTFS_CMD to the correct command, e.g. `/usr/local/bin/rustfs --flag`
+- Or replace the service's command field to explicitly pass the desired args, which will be forwarded by the entrypoint
+  wrapper
 
 Healthcheck fallback
 If the image lacks `nc`, switch to:
+
 - curl: `curl -fsS http://127.0.0.1:9000/ || exit 1`
 - wget: `wget -qO- http://127.0.0.1:9000/ >/dev/null || exit 1`
 
@@ -37,5 +56,3 @@ http://rustfs-node2:9000/data/rustfs1 http://rustfs-node2:9000/data/rustfs2 http
 http://rustfs-node3:9000/data/rustfs1 http://rustfs-node3:9000/data/rustfs2 http://rustfs-node3:9000/data/rustfs3 http://rustfs-node3:9000/data/rustfs4 \
 http://rustfs-node4:9000/data/rustfs1 http://rustfs-node4:9000/data/rustfs2 http://rustfs-node4:9000/data/rustfs3 http://rustfs-node4:9000/data/rustfs4
 ```
-
----

--- a/docs/examples/mnmd/docker-compose.yml
+++ b/docs/examples/mnmd/docker-compose.yml
@@ -1,4 +1,16 @@
-version: "3.8"
+# Copyright 2024 RustFS Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 services:
   rustfs-node1:
@@ -6,27 +18,32 @@ services:
     container_name: rustfs-node1
     hostname: rustfs-node1
     ports:
-      - "9000:9000"   # 对外入口，仅需一个节点暴露
+      - "9000:9000"   # For external entrance, only one node is exposed
     volumes:
       - /mnt/rustfs1_data1:/data/rustfs1
       - /mnt/rustfs1_data2:/data/rustfs2
       - /mnt/rustfs1_data3:/data/rustfs3
       - /mnt/rustfs1_data4:/data/rustfs4
       - rustfs_logs1:/logs
+      - ./wait-and-start.sh:/usr/local/bin/wait-and-start.sh:ro
     environment:
-      - RUSTFS_ACCESS_KEY=rustadmin
-      - RUSTFS_SECRET_KEY=rustadmin
+      - RUSTFS_ACCESS_KEY=rustfsadmin
+      - RUSTFS_SECRET_KEY=rustfsadmin
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ENABLE=true
-      # 关键修复：{1...4} 与 /data/rustfs1..4 一致；使用服务名而不是固定IP
+      # Key fix: {1...4} consistent with /data/rustfs1..4; use service name instead of fixed IP
       - RUSTFS_VOLUMES=http://rustfs-node{1...4}:9000/data/rustfs{1...4}
       - RUST_LOG=error
+      # If the image does not have a default CMD or the original ENTRYPOINT is overwritten, the script will fall back and execute this command.
+      - RUSTFS_CMD=rustfs
     networks:
-      - rustfsnet
+      - rustfs-net
     restart: unless-stopped
+    # Use /bin/sh to call the script to avoid relying on the host file execution bit
+    entrypoint: [ "/bin/sh", "/usr/local/bin/wait-and-start.sh" ]
     healthcheck:
-      # 若镜像无 nc，可改用 curl/wget，见 README 与 CHECKLIST
-      test: ["CMD-SHELL", "nc -z localhost 9000 || exit 1"]
+      # If the image does not have nc, you can use curl/wget instead, see README and CHECKLIST
+      test: [ "CMD-SHELL", "nc -z localhost 9000 || exit 1" ]
       interval: 10s
       timeout: 3s
       retries: 15
@@ -42,21 +59,24 @@ services:
       - /mnt/rustfs2_data3:/data/rustfs3
       - /mnt/rustfs2_data4:/data/rustfs4
       - rustfs_logs2:/logs
+      - ./wait-and-start.sh:/usr/local/bin/wait-and-start.sh:ro
     environment:
-      - RUSTFS_ACCESS_KEY=rustadmin
-      - RUSTFS_SECRET_KEY=rustadmin
+      - RUSTFS_ACCESS_KEY=rustfsadmin
+      - RUSTFS_SECRET_KEY=rustfsadmin
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ENABLE=true
       - RUSTFS_VOLUMES=http://rustfs-node{1...4}:9000/data/rustfs{1...4}
       - RUST_LOG=error
+      - RUSTFS_CMD=rustfs
     networks:
-      - rustfsnet
+      - rustfs-net
     restart: unless-stopped
     depends_on:
       rustfs-node1:
         condition: service_healthy
+    entrypoint: [ "/bin/sh", "/usr/local/bin/wait-and-start.sh" ]
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9000 || exit 1"]
+      test: [ "CMD-SHELL", "nc -z localhost 9000 || exit 1" ]
       interval: 10s
       timeout: 3s
       retries: 15
@@ -72,21 +92,24 @@ services:
       - /mnt/rustfs3_data3:/data/rustfs3
       - /mnt/rustfs3_data4:/data/rustfs4
       - rustfs_logs3:/logs
+      - ./wait-and-start.sh:/usr/local/bin/wait-and-start.sh:ro
     environment:
-      - RUSTFS_ACCESS_KEY=rustadmin
-      - RUSTFS_SECRET_KEY=rustadmin
+      - RUSTFS_ACCESS_KEY=rustfsadmin
+      - RUSTFS_SECRET_KEY=rustfsadmin
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ENABLE=true
       - RUSTFS_VOLUMES=http://rustfs-node{1...4}:9000/data/rustfs{1...4}
       - RUST_LOG=error
+      - RUSTFS_CMD=rustfs
     networks:
-      - rustfsnet
+      - rustfs-net
     restart: unless-stopped
     depends_on:
       rustfs-node2:
         condition: service_healthy
+    entrypoint: [ "/bin/sh", "/usr/local/bin/wait-and-start.sh" ]
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9000 || exit 1"]
+      test: [ "CMD-SHELL", "nc -z localhost 9000 || exit 1" ]
       interval: 10s
       timeout: 3s
       retries: 15
@@ -102,21 +125,24 @@ services:
       - /mnt/rustfs4_data3:/data/rustfs3
       - /mnt/rustfs4_data4:/data/rustfs4
       - rustfs_logs4:/logs
+      - ./wait-and-start.sh:/usr/local/bin/wait-and-start.sh:ro
     environment:
-      - RUSTFS_ACCESS_KEY=rustadmin
-      - RUSTFS_SECRET_KEY=rustadmin
+      - RUSTFS_ACCESS_KEY=rustfsadmin
+      - RUSTFS_SECRET_KEY=rustfsadmin
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ENABLE=true
       - RUSTFS_VOLUMES=http://rustfs-node{1...4}:9000/data/rustfs{1...4}
       - RUST_LOG=error
+      - RUSTFS_CMD=rustfs
     networks:
-      - rustfsnet
+      - rustfs-net
     restart: unless-stopped
     depends_on:
       rustfs-node3:
         condition: service_healthy
+    entrypoint: [ "/bin/sh", "/usr/local/bin/wait-and-start.sh" ]
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9000 || exit 1"]
+      test: [ "CMD-SHELL", "nc -z localhost 9000 || exit 1" ]
       interval: 10s
       timeout: 3s
       retries: 15
@@ -129,5 +155,5 @@ volumes:
   rustfs_logs4:
 
 networks:
-  rustfsnet:
+  rustfs-net:
     driver: bridge

--- a/docs/examples/mnmd/wait-and-start.sh
+++ b/docs/examples/mnmd/wait-and-start.sh
@@ -1,7 +1,24 @@
 #!/usr/bin/env sh
+# Copyright 2024 RustFS Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
-# Ensure local data directories exist
+# current hostname
+SELF="$(hostname -s 2>/dev/null || hostname)"
+
+# Confirm that the local data directory exists
 for d in /data/rustfs1 /data/rustfs2 /data/rustfs3 /data/rustfs4; do
   if [ ! -d "$d" ]; then
     echo "[wait] missing data dir: $d"
@@ -9,9 +26,13 @@ for d in /data/rustfs1 /data/rustfs2 /data/rustfs3 /data/rustfs4; do
   fi
 done
 
-# Optional: wait for peers to accept connections (best-effort, 120s max per peer)
+# Optional: Wait for the peer port to be connectable (up to 120 seconds per peer, continue after timeout to avoid cluster waiting)
 PEERS="rustfs-node1 rustfs-node2 rustfs-node3 rustfs-node4"
 for h in $PEERS; do
+  # skip waiting for itself
+  if [ "$h" = "$SELF" ]; then
+    continue
+  fi
   i=0
   echo "[wait] waiting for $h:9000 ..."
   until nc -z "$h" 9000 2>/dev/null; do
@@ -25,4 +46,17 @@ for h in $PEERS; do
 done
 
 echo "[wait] starting app..."
-exec "$@"
+
+# Execute the incoming CMD first (the default CMD of the image will be passed in as a parameter)
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
+# If no CMD is passed in, fallback to the environment variable RUSTFS_CMD
+if [ -n "$RUSTFS_CMD" ]; then
+  # Use shell to parse string commands, allowing parameters to be included
+  exec /bin/sh -lc "$RUSTFS_CMD"
+fi
+
+echo "[wait] no CMD provided and RUSTFS_CMD is empty; nothing to run"
+exit 127


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [X] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
#618 

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->


Summary
- Add a production-ready docker-compose example for a 4 nodes x 4 drives MNMD deployment.
- Fix common misconfiguration that leads to VolumeNotFound by aligning disk indices to 1..4.
- Use Docker service names to avoid hard-coded IPs.
- Provide startup ordering via healthcheck + depends_on.
- Add a wait-and-start.sh helper (optional) for strong post-container startup gating.
- Include a step-by-step troubleshooting checklist.

What’s included
- docs/examples/mnmd/docker-compose.yml
- docs/examples/mnmd/README.md
- docs/examples/mnmd/wait-and-start.sh
- docs/examples/mnmd/CHECKLIST.md

Notes
- If the base image lacks `nc`, switch healthcheck to curl or wget as documented.
- Only one node exposes 9000 externally; all inter-node traffic stays on the Compose network.

Closes: Provides guidance to resolve rustfs/rustfs#618 (VolumeNotFound due to /data/rustfs0).

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [X] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
