### PR TITLE
fix: make_bucket filter out the bucket if it already exists (#719)

### DIFF
--- a/crates/ecstore/src/rpc/peer_s3_client.rs
+++ b/crates/ecstore/src/rpc/peer_s3_client.rs
@@ -173,6 +173,9 @@ impl S3PeerSys {
                 Ok(_) => {
                     errors[i] = None;
                 }
+                Err(Error::VolumeExists) => {
+                    errors[i] = None;
+                }
                 Err(e) => {
                     errors[i] = Some(e);
                 }


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
