### PR TITLE
add non root user support for container deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,12 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /build/rustfs /usr/bin/rustfs
 COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /usr/bin/rustfs /entrypoint.sh && \
+RUN chmod +x /usr/bin/rustfs /entrypoint.sh
+
+RUN addgroup -g 1000 -S rustfs && \
+    adduser -u 1000 -G rustfs -S rustfs -D && \
     mkdir -p /data /logs && \
+    chown -R rustfs:rustfs /data /logs && \
     chmod 0750 /data /logs
 
 ENV RUSTFS_ADDRESS=":9000" \
@@ -82,7 +86,10 @@ ENV RUSTFS_ADDRESS=":9000" \
     RUSTFS_SINKS_FILE_PATH="/logs"
 
 EXPOSE 9000 9001
+
 VOLUME ["/data", "/logs"]
+
+USER rustfs
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
https://github.com/rustfs/rustfs/issues/804

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

Modify Dockerfile to add non root user part. Testing result is as below,

for docker container deployment

```
docker exec -it 27cd798ca835 /bin/sh
/ $ id
uid=1000(rustfs) gid=1000(rustfs) groups=1000(rustfs)
/ $ whoami
rustfs
/ $ ls -ld /data/
drwxr-x--- 3 rustfs rustfs 4096 Nov  7 12:48 /data/
/ $ ls -ld /logs/
drwxr-xr-x 2 rustfs rustfs 4096 Nov  7 13:06 /logs/
/ $ ps -ef
PID   USER     TIME  COMMAND
    1 rustfs    0:00 /usr/bin/rustfs /data
   52 rustfs    0:00 /bin/sh
   69 rustfs    0:00 ps -ef
/ $ 
```

for k8s deployment
```
 $ id
uid=1000(rustfs) gid=1000(rustfs) groups=1000(rustfs)
/ $ whoami
rustfs
/ $ ls -ld /data/
drwxr-x--- 6 rustfs rustfs 4096 Nov  7 13:10 /data/
/ $ ls -d /logs/
/logs/
/ $ ls -ld /logs/
drwxr-xr-x 2 rustfs rustfs 4096 Nov  7 13:10 /logs/
```

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
