### PR TITLE
ci: fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,20 +22,6 @@ updates:
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
-    ignore:
-      - dependency-name: "s3s"
-      - dependency-name: "s3s-*"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-  - package-ecosystem: "cargo"
-    directory: "/"
-    allow:
-      - dependency-name: "s3s"
-      - dependency-name: "s3s-*"
-    schedule:
       interval: "weekly"
       day: "monday"
       timezone: "Asia/Shanghai"
@@ -45,3 +31,6 @@ updates:
         patterns:
           - "s3s"
           - "s3s-*"
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
The previous PR breaks dependabot while it seems OK for my fork repo.
+ #858 

Anyway, this PR fixes it by **updating all dependencies** weekly.
