### PR TITLE
Add Helm chart-releaser workflow for GitHub Pages

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,34 @@
+name: Release Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'helm/**'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for automatic Helm chart releases using chart-releaser
- Charts will be published to GitHub Pages for public consumption

## Manual Setup Required

After merging this PR, the following manual steps are required to complete the setup:

### 1. Create the gh-pages branch

```bash
git checkout --orphan gh-pages
git rm -rf .
git commit --allow-empty -m "Initial gh-pages branch"
git push origin gh-pages
git checkout main
```

### 2. Configure GitHub Pages

1. Go to **Settings > Pages**
2. Under "Build and deployment":
   - Source: **Deploy from a branch**
   - Branch: **gh-pages** / **/ (root)**
3. Click **Save**

### 3. Usage

Once configured, users can add the chart repository:

```bash
helm repo add rustfs https://rustfs.github.io/rustfs
helm repo update
helm install rustfs rustfs/rustfs
```

## How it works

- The workflow triggers on pushes to `main` that modify files in `helm/**`
- chart-releaser packages the chart and creates a GitHub release
- The chart index is automatically updated in the gh-pages branch
- Users can then install charts directly from the GitHub Pages URL

## Test plan

- [ ] Merge this PR
- [ ] Create gh-pages branch as described above
- [ ] Configure GitHub Pages in repository settings
- [ ] Make a change to the helm chart and push to main
- [ ] Verify the workflow runs and creates a release
- [ ] Verify the chart is installable via `helm repo add`