### PR TITLE
fix: delete all files in all object folder and version subdir (without version control)

### DIFF
--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -54,15 +54,14 @@ pub async fn del_opts(
     let versioned = BucketVersioningSys::prefix_enabled(bucket, object).await;
     let version_suspended = BucketVersioningSys::suspended(bucket).await;
 
-    let vid = if vid.is_none() {
-        headers
-            .get(RUSTFS_BUCKET_SOURCE_VERSION_ID)
-            .map(|v| v.to_str().unwrap().to_owned())
-    } else {
-        vid
-    };
-
-    let vid = vid.map(|v| v.as_str().trim().to_owned());
+    let vid = vid
+        .or_else(|| {
+            headers
+                .get(RUSTFS_BUCKET_SOURCE_VERSION_ID)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_owned())
+        })
+        .map(|v| v.trim().to_owned());
 
     if let Some(ref id) = vid {
         if *id != Uuid::nil().to_string()
@@ -173,15 +172,14 @@ pub async fn put_opts(
     let versioned = BucketVersioningSys::prefix_enabled(bucket, object).await;
     let version_suspended = BucketVersioningSys::prefix_suspended(bucket, object).await;
 
-    let vid = if vid.is_none() {
-        headers
-            .get(RUSTFS_BUCKET_SOURCE_VERSION_ID)
-            .map(|v| v.to_str().unwrap().to_owned())
-    } else {
-        vid
-    };
-
-    let vid = vid.map(|v| v.as_str().trim().to_owned());
+    let vid = vid
+        .or_else(|| {
+            headers
+                .get(RUSTFS_BUCKET_SOURCE_VERSION_ID)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_owned())
+        })
+        .map(|v| v.trim().to_owned());
 
     if let Some(ref id) = vid {
         if *id != Uuid::nil().to_string()


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
[#952](https://github.com/rustfs/rustfs/issues/952)
Without version control, deleting this object will delete all parts in one version (update the object once, so there r two version dir in object_dir)and `object_dir/xl.meta` files in the version folder under this object file, but it will not delete the empty folder `volume_dir/object_name/version_dir`. As a result, the object will be successfully deleted on the console, but it will become a folder that can no longer be deleted.

<img width="1318" height="1042" alt="image" src="https://github.com/user-attachments/assets/82d0844e-c5e4-4548-b941-e58a49ab519f" />

<img width="2070" height="416" alt="image" src="https://github.com/user-attachments/assets/d33bb81c-849e-49f7-8a2b-37fe5c572a3c" />


## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
