### PR TITLE
feat(helm): add existingSecret handling and support for extra manifests

### DIFF
--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the secret name
+*/}}
+{{- define "rustfs.secretName" -}}
+{{- if .Values.secret.existingSecret }}
+{{- .Values.secret.existingSecret }}
+{{- else }}
+{{- printf "%s-secret" (include "rustfs.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/helm/rustfs/templates/deployment.yaml
+++ b/helm/rustfs/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - configMapRef:
                 name: {{ include "rustfs.fullname" . }}-config
             - secretRef:
-                name: {{ include "rustfs.fullname" . }}-secret
+                name: {{ include "rustfs.secretName" . }}
           resources:
             requests:
               memory: {{ .Values.resources.requests.memory }}

--- a/helm/rustfs/templates/extra-manifests.yaml
+++ b/helm/rustfs/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/rustfs/templates/secret.yaml
+++ b/helm/rustfs/templates/secret.yaml
@@ -1,9 +1,10 @@
+{{- if not .Values.secret.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "rustfs.fullname" . }}-secret
+  name: {{ include "rustfs.secretName" . }}
 type: Opaque
 data:
   RUSTFS_ACCESS_KEY: {{ .Values.secret.rustfs.access_key | b64enc | quote }}
   RUSTFS_SECRET_KEY: {{ .Values.secret.rustfs.secret_key | b64enc | quote }}
-
+{{- end }}

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
             - configMapRef:
                 name: {{ include "rustfs.fullname" . }}-config
             - secretRef:
-                name: {{ include "rustfs.fullname" . }}-secret
+                name: {{ include "rustfs.secretName" . }}
           resources:
             requests:
               memory: {{ .Values.resources.requests.memory }}

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -27,6 +27,7 @@ mode:
     enabled: true
 
 secret:
+  existingSecret: ""
   rustfs:
     access_key: rustfsadmin
     secret_key: rustfsadmin
@@ -147,3 +148,5 @@ affinity: {}
 storageclass:
   name: local-path
   size: 256Mi
+
+extraManifests: []


### PR DESCRIPTION
## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
Add two features to the Helm chart:
- `secret.existingSecret`: allows referencing a pre-existing Kubernetes secret instead of creating one
- `extraManifests`: allows deploying additional arbitrary Kubernetes resources alongside the chart (like externalSecret manifests)

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

