### PR TITLE
chore(ci): restore workflows before 8e0aeb4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -55,32 +55,6 @@ runs:
           pkg-config \
           libssl-dev
 
-    - name: Install mold linker (Linux)
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        # Install mold for faster linking
-        MOLD_VERSION="2.34.1"
-        ARCH=$(uname -m)
-        
-        if [[ "$ARCH" == "x86_64" ]]; then
-          MOLD_ARCH="x86_64"
-        elif [[ "$ARCH" == "aarch64" ]]; then
-          MOLD_ARCH="aarch64"
-        else
-          echo "Unsupported architecture: $ARCH"
-          exit 0
-        fi
-        
-        curl -L "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" | tar xzf -
-        sudo cp mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/mold /usr/local/bin/
-        sudo mkdir -p /usr/local/libexec
-        sudo cp mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/libexec/mold /usr/local/libexec/ || true
-        rm -rf mold-${MOLD_VERSION}-${MOLD_ARCH}-linux
-        
-        # Verify installation
-        mold --version || echo "mold installation verification failed"
-
     - name: Install protoc
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,28 +166,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64 builds on x86 runners
+          # Linux builds
           - os: ubicloud-standard-4
             target: x86_64-unknown-linux-musl
             cross: false
             platform: linux
-            arch: x86_64
+          - os: ubicloud-standard-4
+            target: aarch64-unknown-linux-musl
+            cross: true
+            platform: linux
           - os: ubicloud-standard-4
             target: x86_64-unknown-linux-gnu
             cross: false
             platform: linux
-            arch: x86_64
-          # Linux aarch64 builds on ARM runners (native compilation)
-          - os: ubicloud-standard-4-arm
-            target: aarch64-unknown-linux-musl
-            cross: false
-            platform: linux
-            arch: aarch64
-          - os: ubicloud-standard-4-arm
+          - os: ubicloud-standard-4
             target: aarch64-unknown-linux-gnu
-            cross: false
+            cross: true
             platform: linux
-            arch: aarch64
           # macOS builds
           - os: macos-latest
             target: aarch64-apple-darwin
@@ -217,7 +212,7 @@ jobs:
         with:
           rust-version: stable
           target: ${{ matrix.target }}
-          cache-shared-key: build-${{ matrix.arch }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          cache-shared-key: build-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache-save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           install-cross-tools: ${{ matrix.cross }}
@@ -264,10 +259,6 @@ jobs:
               cargo zigbuild --release --target ${{ matrix.target }} -p rustfs --bins
             fi
           else
-            # Native compilation - use mold linker on Linux for faster linking
-            if [[ "${{ matrix.platform }}" == "linux" ]]; then
-              export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=mold"
-            fi
             cargo build --release --target ${{ matrix.target }} -p rustfs --bins
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,19 +101,11 @@ jobs:
         uses: crate-ci/typos@master
 
   test-and-lint:
-    name: Test and Lint (${{ matrix.arch }})
+    name: Test and Lint
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubicloud-standard-4
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubicloud-standard-4
-    #          - arch: aarch64
-    #            runner: ubicloud-standard-4-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -122,7 +114,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           rust-version: stable
-          cache-shared-key: ci-test-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
+          cache-shared-key: ci-test-${{ hashFiles('**/Cargo.lock') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -141,19 +133,11 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   e2e-tests:
-    name: End-to-End Tests (${{ matrix.arch }})
+    name: End-to-End Tests
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubicloud-standard-4
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubicloud-standard-4
-    #          - arch: aarch64
-    #            runner: ubicloud-standard-4-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -258,21 +258,37 @@ jobs:
 
   # Build multi-arch Docker images
   # Strategy: Build images using pre-built binaries from dl.rustfs.com
-  # Optimization: Build each architecture on its native runner to avoid QEMU overhead
+  # Supports both release and dev channel binaries based on build context
   # Only runs when should_build is true (which includes workflow success check)
-  
-  # Prepare metadata for both builds
-  prepare-metadata:
-    name: Prepare Docker Metadata
+  build-docker:
+    name: Build Docker Images
     needs: build-check
     if: needs.build-check.outputs.should_build == 'true'
     runs-on: ubicloud-standard-4
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      labels: ${{ steps.meta.outputs.labels }}
-      docker_release: ${{ steps.meta.outputs.docker_release }}
-      docker_channel: ${{ steps.meta.outputs.docker_channel }}
+    timeout-minutes: 60
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata and generate tags
         id: meta
         run: |
@@ -352,143 +368,41 @@ jobs:
           echo "📋 Build type: $BUILD_TYPE"
           echo "🔖 Version: $VERSION"
 
-  # Build amd64 image on x86 runner (native build)
-  build-docker-amd64:
-    name: Build Docker Image (amd64)
-    needs: [build-check, prepare-metadata]
-    if: needs.build-check.outputs.should_build == 'true'
-    runs-on: ubicloud-standard-4
-    timeout-minutes: 30
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-      image_name: ${{ steps.build.outputs.imageid }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push (amd64)
-        id: build
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           push: ${{ needs.build-check.outputs.should_push == 'true' }}
-          labels: ${{ needs.prepare-metadata.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
-            type=gha,scope=docker-amd64
+            type=gha,scope=docker-binary
           cache-to: |
-            type=gha,mode=max,scope=docker-amd64
+            type=gha,mode=max,scope=docker-binary
           build-args: |
             BUILDTIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             VERSION=${{ needs.build-check.outputs.version }}
             BUILD_TYPE=${{ needs.build-check.outputs.build_type }}
             REVISION=${{ github.sha }}
-            RELEASE=${{ needs.prepare-metadata.outputs.docker_release }}
-            CHANNEL=${{ needs.prepare-metadata.outputs.docker_channel }}
+            RELEASE=${{ steps.meta.outputs.docker_release }}
+            CHANNEL=${{ steps.meta.outputs.docker_channel }}
             BUILDKIT_INLINE_CACHE=1
+          # Enable advanced BuildKit features for better performance
           provenance: false
           sbom: false
-          outputs: type=image,name=${{ env.REGISTRY_DOCKERHUB }},push-by-digest=true,name-canonical=true,push=${{ needs.build-check.outputs.should_push == 'true' }}
+          # Add retry mechanism by splitting the build process
+          no-cache: false
+          pull: true
 
-  # Build arm64 image on ARM runner (native build)
-  build-docker-arm64:
-    name: Build Docker Image (arm64)
-    needs: [build-check, prepare-metadata]
-    if: needs.build-check.outputs.should_build == 'true'
-    runs-on: ubicloud-standard-4-arm
-    timeout-minutes: 30
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-      image_name: ${{ steps.build.outputs.imageid }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push (arm64)
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/arm64
-          push: ${{ needs.build-check.outputs.should_push == 'true' }}
-          labels: ${{ needs.prepare-metadata.outputs.labels }}
-          cache-from: |
-            type=gha,scope=docker-arm64
-          cache-to: |
-            type=gha,mode=max,scope=docker-arm64
-          build-args: |
-            BUILDTIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-            VERSION=${{ needs.build-check.outputs.version }}
-            BUILD_TYPE=${{ needs.build-check.outputs.build_type }}
-            REVISION=${{ github.sha }}
-            RELEASE=${{ needs.prepare-metadata.outputs.docker_release }}
-            CHANNEL=${{ needs.prepare-metadata.outputs.docker_channel }}
-            BUILDKIT_INLINE_CACHE=1
-          provenance: false
-          sbom: false
-          outputs: type=image,name=${{ env.REGISTRY_DOCKERHUB }},push-by-digest=true,name-canonical=true,push=${{ needs.build-check.outputs.should_push == 'true' }}
-
-  # Merge manifests to create multi-arch image
-  merge-manifests:
-    name: Create Multi-Arch Manifest
-    needs: [build-check, prepare-metadata, build-docker-amd64, build-docker-arm64]
-    if: needs.build-check.outputs.should_build == 'true' && needs.build-check.outputs.should_push == 'true'
-    runs-on: ubicloud-standard-4
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Create and push multi-arch manifest
-        run: |
-          TAGS="${{ needs.prepare-metadata.outputs.tags }}"
-          
-          echo "🐳 Creating multi-arch manifest for tags:"
-          echo "$TAGS" | tr ',' '\n' | sed 's/^/  - /'
-          
-          # Convert comma-separated tags to array
-          IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
-          
-          # Create manifest for each tag
-          for TAG in "${TAG_ARRAY[@]}"; do
-            echo "Creating manifest for: $TAG"
-            docker buildx imagetools create \
-              -t "$TAG" \
-              "${{ env.REGISTRY_DOCKERHUB }}@${{ needs.build-docker-amd64.outputs.digest }}" \
-              "${{ env.REGISTRY_DOCKERHUB }}@${{ needs.build-docker-arm64.outputs.digest }}"
-          done
-          
-          echo "✅ Multi-arch manifest created and pushed successfully"
+  # Note: Manifest creation is no longer needed as we only build one variant
+  # Multi-arch manifests are automatically created by docker/build-push-action
 
   # Docker build summary
   docker-summary:
     name: Docker Build Summary
-    needs: [ build-check, prepare-metadata, build-docker-amd64, build-docker-arm64, merge-manifests ]
+    needs: [ build-check, build-docker ]
     if: always() && needs.build-check.outputs.should_build == 'true'
     runs-on: ubicloud-standard-4
     steps:
@@ -501,9 +415,7 @@ jobs:
           echo "🐳 Docker build completed successfully!"
           echo "📦 Build type: $BUILD_TYPE"
           echo "🔢 Version: $VERSION"
-          echo "🚀 Strategy: Native builds on each architecture (no QEMU overhead)"
-          echo "  - amd64: Built on x86 runner"
-          echo "  - arm64: Built on ARM runner"
+          echo "🚀 Strategy: Images using pre-built binaries (release channel only)"
           echo ""
 
           case "$BUILD_TYPE" in


### PR DESCRIPTION
Restore .github workflows/action.yml to the state prior to 8e0aeb4 (keeps history intact by applying a new commit on a new branch).

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
