### PR TITLE
feat: add systemd notify support for service status

### DIFF
--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -91,7 +91,7 @@ fn print_server_info() {
 #[cfg(target_os = "linux")]
 fn notify_systemd_ready() {
     use libsystemd::daemon;
-    match daemon::notify(false, &[daemon::NotifyState::Ready(true), daemon::NotifyState::Status("Running")]) {
+    match daemon::notify(false, &[daemon::NotifyState::Ready, daemon::NotifyState::Status("Running".to_string())]) {
         Ok(sent) => {
             if sent {
                 info!("Sent systemd ready notification");


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->
## Summary
This PR adds support for `systemd` notifications to update the service status from "Starting" to "Running" once the initialization is complete.

## Changes
- Added `notify_systemd_ready` function in `rustfs/src/main.rs` which sends `READY=1` and `STATUS=Running` to systemd.
- Called `notify_systemd_ready` after the server initialization and before waiting for the shutdown signal.
- This feature is enabled only for `target_os = "linux"`.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
## Motivation
Currently, `systemctl status rustfs` shows the status as "Starting..." even after the service is fully operational. This change ensures the status correctly reflects "active (running)".

## Verification
- Verified compilation on macOS (no-op).
- Needs verification on a Linux system running systemd:
    1. Build the## Summary
This PR adds support for `systemd` notifications to update the service status from "Starting" to "Running" once the initialization is complete.

## Changes
- Added `notify_systemd_ready` function in `rustfs/src/main.rs` which sends `READY=1` and `STATUS=Running` to systemd.
- Called `notify_systemd_ready` after the server initialization and before waiting for the shutdown signal.
- This feature is enabled only for `target_os = "linux"`.

## Motivation
Currently, `systemctl status rustfs` shows the status as "Starting..." even after the service is fully operational. This change ensures the status correctly reflects "active (running)".


---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
