### PR TITLE
:technologist: Fix nix develop problem with Git-Based dependecies on nix develop shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,10 @@
 
             src = ./.;
 
-            cargoLock.lockFile = ./Cargo.lock;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
 
             nativeBuildInputs = with pkgs; [
               pkg-config


### PR DESCRIPTION

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

#1137

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

while testing, I had problem with `s3s-0.13.0-alpha` package since in flake.nix we should provide the hash of package

this change

Allows Cargo's builtin Git fetch for dependencies

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
