### PR TITLE
add ca-certificates in mcp-server Dockerfile

### DIFF
--- a/crates/mcp/Dockerfile
+++ b/crates/mcp/Dockerfile
@@ -12,4 +12,6 @@ WORKDIR /app
 
 COPY --from=builder /build/target/release/rustfs-mcp /app/
 
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+
 ENTRYPOINT ["/app/rustfs-mcp"]


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ x ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
I have included the installation of the ca certs on the mcp-server docker file.

Without ca certificates installed i have this issue

`thread 'main' (1) panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aws-smithy-http-client-1.1.5/src/hyper_legacy.rs:82:13:
no CA certificates found`

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
