### PR TITLE
fix: Add retry mechanism for GLOBAL_CONFIG_SYS initialization

### DIFF
--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -248,6 +248,7 @@ async fn run(opt: config::Opt) -> Result<()> {
 
     while let Err(e) = GLOBAL_CONFIG_SYS.init(store.clone()).await {
         error!("GLOBAL_CONFIG_SYS.init failed {:?}", e);
+        // TODO: check error type
         retry_count += 1;
         if retry_count > 15 {
             return Err(Error::other("GLOBAL_CONFIG_SYS.init failed"));


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

This PR adds a retry mechanism to the GLOBAL_CONFIG_SYS.init() call in the main application startup process. The fix addresses scenarios where the store might not be immediately writable during system initialization.


## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
#1236 

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
