### PR TITLE
fix:ListObjects and ListObjectV2 correctly handles unordered and delimiter

### DIFF
--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -513,18 +513,23 @@ fn validate_object_key(key: &str, operation: &str) -> S3Result<()> {
 /// hierarchical directory traversal (delimited listing). This validation ensures
 /// conflicting parameters are caught before processing the request.
 fn validate_list_object_unordered_with_delimiter(delimiter: Option<&Delimiter>, query_string: Option<&str>) -> S3Result<()> {
-    if delimiter.is_some() {
-        if let Some(query) = query_string {
-            if let Ok(params) = from_bytes::<ListObjectUnorderedQuery>(query.as_bytes()) {
-                if params.allow_unordered.as_deref() == Some("true") {
-                    return Err(S3Error::with_message(
-                        S3ErrorCode::InvalidArgument,
-                        "The allow-unordered parameter cannot be used when delimiter is specified.".to_string(),
-                    ));
-                }
-            }
+    if delimiter.is_none() {
+        return Ok(());
+    }
+
+    let Some(query) = query_string else {
+        return Ok(());
+    };
+
+    if let Ok(params) = from_bytes::<ListObjectUnorderedQuery>(query.as_bytes()) {
+        if params.allow_unordered.as_deref() == Some("true") {
+            return Err(S3Error::with_message(
+                S3ErrorCode::InvalidArgument,
+                "The allow-unordered parameter cannot be used when delimiter is specified.".to_string(),
+            ));
         }
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->
Fix S3 compatibility validation: properly reject the allow-unordered=true query parameter when used with Delimiter="/" in ListObjectsV2 operations, returning InvalidArgument error as required by the S3 API specification to fix the failing test_bucket_list_unordered and test_bucket_listv2_unorderedtest case.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:Improves S3 API compliance by enforcing parameter validation; expected to be backward-compatible for compliant clients.

