### PR TITLE
Fix: invalid type for version id maker

### DIFF
--- a/.github/s3tests/s3tests.conf
+++ b/.github/s3tests/s3tests.conf
@@ -36,10 +36,10 @@ iam path prefix = /s3-tests/
 
 [s3 main]
 # main display_name
-display_name = rustfs
+display_name = RustFS Tester
 
 # main user_id
-user_id = c19050dbcee97fda828689dda99097a6321af2248fa760517237346e5d9c8a66
+user_id = rustfsadmin
 
 # main email
 email = tester@rustfs.local

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -161,134 +161,6 @@ static RUSTFS_OWNER: LazyLock<Owner> = LazyLock::new(|| Owner {
     id: Some("c19050dbcee97fda828689dda99097a6321af2248fa760517237346e5d9c8a66".to_owned()),
 });
 
-/// Metadata key for storing object ACL
-const AMZ_OBJECT_ACL: &str = "x-amz-acl";
-
-/// Serializable ACL grant for storage
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct StoredGrant {
-    permission: String,
-    grantee_type: String,
-    grantee_id: Option<String>,
-    grantee_display_name: Option<String>,
-    grantee_uri: Option<String>,
-    grantee_email: Option<String>,
-}
-
-/// Serializable ACL for storage
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct StoredAcl {
-    owner_id: String,
-    owner_display_name: String,
-    grants: Vec<StoredGrant>,
-}
-
-impl StoredAcl {
-    /// Create default ACL with owner having FULL_CONTROL
-    fn default_acl() -> Self {
-        StoredAcl {
-            owner_id: RUSTFS_OWNER.id.clone().unwrap_or_default(),
-            owner_display_name: RUSTFS_OWNER.display_name.clone().unwrap_or_default(),
-            grants: vec![StoredGrant {
-                permission: Permission::FULL_CONTROL.to_string(),
-                grantee_type: Type::CANONICAL_USER.to_string(),
-                grantee_id: RUSTFS_OWNER.id.clone(),
-                grantee_display_name: RUSTFS_OWNER.display_name.clone(),
-                grantee_uri: None,
-                grantee_email: None,
-            }],
-        }
-    }
-
-    /// Create ACL from canned ACL string
-    /// Note: Group grants are placed before owner grant to match AWS S3 behavior
-    fn from_canned_acl(canned_acl: &str) -> Self {
-        let owner_grant = StoredGrant {
-            permission: Permission::FULL_CONTROL.to_string(),
-            grantee_type: Type::CANONICAL_USER.to_string(),
-            grantee_id: RUSTFS_OWNER.id.clone(),
-            grantee_display_name: RUSTFS_OWNER.display_name.clone(),
-            grantee_uri: None,
-            grantee_email: None,
-        };
-
-        let mut grants = vec![];
-
-        match canned_acl {
-            "public-read" => {
-                // Group grant first, then owner grant (matches AWS S3 behavior)
-                grants.push(StoredGrant {
-                    permission: Permission::READ.to_string(),
-                    grantee_type: Type::GROUP.to_string(),
-                    grantee_id: None,
-                    grantee_display_name: None,
-                    grantee_uri: Some("http://acs.amazonaws.com/groups/global/AllUsers".to_string()),
-                    grantee_email: None,
-                });
-                grants.push(owner_grant);
-            }
-            "public-read-write" => {
-                grants.push(StoredGrant {
-                    permission: Permission::READ.to_string(),
-                    grantee_type: Type::GROUP.to_string(),
-                    grantee_id: None,
-                    grantee_display_name: None,
-                    grantee_uri: Some("http://acs.amazonaws.com/groups/global/AllUsers".to_string()),
-                    grantee_email: None,
-                });
-                grants.push(StoredGrant {
-                    permission: Permission::WRITE.to_string(),
-                    grantee_type: Type::GROUP.to_string(),
-                    grantee_id: None,
-                    grantee_display_name: None,
-                    grantee_uri: Some("http://acs.amazonaws.com/groups/global/AllUsers".to_string()),
-                    grantee_email: None,
-                });
-                grants.push(owner_grant);
-            }
-            "authenticated-read" => {
-                grants.push(StoredGrant {
-                    permission: Permission::READ.to_string(),
-                    grantee_type: Type::GROUP.to_string(),
-                    grantee_id: None,
-                    grantee_display_name: None,
-                    grantee_uri: Some("http://acs.amazonaws.com/groups/global/AuthenticatedUsers".to_string()),
-                    grantee_email: None,
-                });
-                grants.push(owner_grant);
-            }
-            _ => {
-                // private or unknown - just owner with FULL_CONTROL
-                // private or unknown - just owner with FULL_CONTROL
-                grants.push(owner_grant);
-            }
-        }
-
-        StoredAcl {
-            owner_id: RUSTFS_OWNER.id.clone().unwrap_or_default(),
-            owner_display_name: RUSTFS_OWNER.display_name.clone().unwrap_or_default(),
-            grants,
-        }
-    }
-
-    /// Convert to S3 grants
-    fn to_grants(&self) -> Vec<Grant> {
-        self.grants
-            .iter()
-            .map(|g| Grant {
-                permission: Some(Permission::from(g.permission.clone())),
-                grantee: Some(Grantee {
-                    type_: Type::from(g.grantee_type.clone()),
-                    id: g.grantee_id.clone(),
-                    display_name: g.grantee_display_name.clone(),
-                    uri: g.grantee_uri.clone(),
-                    email_address: g.grantee_email.clone(),
-                }),
-            })
-            .collect()
-    }
-}
-
 /// Calculate adaptive buffer size with workload profile support.
 ///
 /// This enhanced version supports different workload profiles for optimal performance
@@ -2578,7 +2450,6 @@ impl S3 for FS {
             checksum_sha256,
             checksum_crc64nvme,
             checksum_type,
-            version_id: info.version_id.map(|v| v.to_string()),
             ..Default::default()
         };
 
@@ -3033,6 +2904,7 @@ impl S3 for FS {
         let should_encode = encoding_type.as_ref().map(|e| e.as_str() == "url").unwrap_or(false);
 
         // Helper function to encode S3 keys/prefixes (preserving /)
+        // S3 URL encoding encodes special characters but keeps '/' unencoded
         let encode_s3_name = |name: &str| -> String {
             name.split('/')
                 .map(|part| encode(part).to_string())
@@ -5407,9 +5279,9 @@ impl S3 for FS {
         let grants = vec![Grant {
             grantee: Some(Grantee {
                 type_: Type::from_static(Type::CANONICAL_USER),
-                display_name: RUSTFS_OWNER.display_name.clone(),
+                display_name: None,
                 email_address: None,
-                id: RUSTFS_OWNER.id.clone(),
+                id: None,
                 uri: None,
             }),
             permission: Some(Permission::from_static(Permission::FULL_CONTROL)),
@@ -5465,40 +5337,26 @@ impl S3 for FS {
     }
 
     async fn get_object_acl(&self, req: S3Request<GetObjectAclInput>) -> S3Result<S3Response<GetObjectAclOutput>> {
-        let GetObjectAclInput {
-            bucket, key, version_id, ..
-        } = req.input;
+        let GetObjectAclInput { bucket, key, .. } = req.input;
 
         let Some(store) = new_object_layer_fn() else {
             return Err(S3Error::with_message(S3ErrorCode::InternalError, "Not init".to_string()));
         };
 
-        let opts = ObjectOptions {
-            version_id: version_id.clone(),
-            ..Default::default()
-        };
+        if let Err(e) = store.get_object_info(&bucket, &key, &ObjectOptions::default()).await {
+            return Err(S3Error::with_message(S3ErrorCode::InternalError, format!("{e}")));
+        }
 
-        let obj_info = match store.get_object_info(&bucket, &key, &opts).await {
-            Ok(info) => info,
-            Err(e) => {
-                if rustfs_ecstore::error::is_err_object_not_found(&e) {
-                    return Err(S3Error::with_message(
-                        S3ErrorCode::NoSuchKey,
-                        "The specified key does not exist.".to_string(),
-                    ));
-                }
-                return Err(S3Error::with_message(S3ErrorCode::InternalError, format!("{e}")));
-            }
-        };
-
-        // Try to read stored ACL from object metadata
-        let stored_acl = obj_info
-            .user_defined
-            .get(AMZ_OBJECT_ACL)
-            .and_then(|acl_json| serde_json::from_str::<StoredAcl>(acl_json).ok())
-            .unwrap_or_else(StoredAcl::default_acl);
-
-        let grants = stored_acl.to_grants();
+        let grants = vec![Grant {
+            grantee: Some(Grantee {
+                type_: Type::from_static(Type::CANONICAL_USER),
+                display_name: None,
+                email_address: None,
+                id: None,
+                uri: None,
+            }),
+            permission: Some(Permission::from_static(Permission::FULL_CONTROL)),
+        }];
 
         Ok(S3Response::new(GetObjectAclOutput {
             grants: Some(grants),
@@ -5551,7 +5409,6 @@ impl S3 for FS {
             key,
             acl,
             access_control_policy,
-            version_id,
             ..
         } = req.input;
 
@@ -5559,76 +5416,31 @@ impl S3 for FS {
             return Err(S3Error::with_message(S3ErrorCode::InternalError, "Not init".to_string()));
         };
 
-        let opts = ObjectOptions {
-            version_id: version_id.clone(),
-            ..Default::default()
-        };
-
-        // Verify object exists
-        if let Err(e) = store.get_object_info(&bucket, &key, &opts).await {
-            if rustfs_ecstore::error::is_err_object_not_found(&e) {
-                return Err(S3Error::with_message(
-                    S3ErrorCode::NoSuchKey,
-                    "The specified key does not exist.".to_string(),
-                ));
-            }
+        if let Err(e) = store.get_object_info(&bucket, &key, &ObjectOptions::default()).await {
             return Err(S3Error::with_message(S3ErrorCode::InternalError, format!("{e}")));
         }
 
-        // Build StoredAcl from request
-        let stored_acl = if let Some(canned_acl) = acl {
-            StoredAcl::from_canned_acl(canned_acl.as_str())
-        } else if let Some(policy) = access_control_policy {
-            // Build from explicit access control policy
-            let mut grants = vec![];
-            if let Some(gs) = policy.grants {
-                for g in gs {
-                    if let Some(grantee) = g.grantee {
-                        grants.push(StoredGrant {
-                            permission: g.permission.map(|p| p.as_str().to_string()).unwrap_or_default(),
-                            grantee_type: grantee.type_.as_str().to_string(),
-                            grantee_id: grantee.id,
-                            grantee_display_name: grantee.display_name,
-                            grantee_uri: grantee.uri,
-                            grantee_email: grantee.email_address,
-                        });
-                    }
-                }
-            }
-            StoredAcl {
-                owner_id: policy
-                    .owner
-                    .as_ref()
-                    .and_then(|o| o.id.clone())
-                    .unwrap_or_else(|| RUSTFS_OWNER.id.clone().unwrap_or_default()),
-                owner_display_name: policy
-                    .owner
-                    .as_ref()
-                    .and_then(|o| o.display_name.clone())
-                    .unwrap_or_else(|| RUSTFS_OWNER.display_name.clone().unwrap_or_default()),
-                grants,
+        if let Some(canned_acl) = acl {
+            if canned_acl.as_str() != BucketCannedACL::PRIVATE {
+                return Err(s3_error!(NotImplemented));
             }
         } else {
-            // Default to private
-            StoredAcl::default_acl()
-        };
-        // Serialize ACL to JSON
-        let acl_json = serde_json::to_string(&stored_acl)
-            .map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, format!("Failed to serialize ACL: {e}")))?;
+            let is_full_control = access_control_policy.is_some_and(|v| {
+                v.grants.is_some_and(|gs| {
+                    //
+                    !gs.is_empty()
+                        && gs.first().is_some_and(|g| {
+                            g.to_owned()
+                                .permission
+                                .is_some_and(|p| p.as_str() == Permission::FULL_CONTROL)
+                        })
+                })
+            });
 
-        // Store ACL in object metadata
-        let mut eval_metadata = HashMap::new();
-        eval_metadata.insert(AMZ_OBJECT_ACL.to_string(), acl_json);
-
-        let update_opts = ObjectOptions {
-            version_id,
-            eval_metadata: Some(eval_metadata),
-            ..Default::default()
-        };
-        store
-            .put_object_metadata(&bucket, &key, &update_opts)
-            .await
-            .map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, format!("Failed to update ACL: {e}")))?;
+            if !is_full_control {
+                return Err(s3_error!(NotImplemented));
+            }
+        }
         Ok(S3Response::new(PutObjectAclOutput::default()))
     }
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->
invalid type for version id: 
- return "null" for next_version_id_marker when truncated

<del>return complete owner info in ACL responses and persist ACLs:</del>
<del>- Return owner DisplayName and ID in get_bucket_acl and get_object_acl</del>
<del>- Implement ACL persistence by storing ACLs in object metadata</del>
<del>- Support canned ACLs (public-read, etc.) and AccessControlPolicy</del>
<del>- Fix grant ordering to match AWS S3 behavior</del>
### reason for revert:
- Remove non-standard ACL implementation and MinIO-unsupported operations
## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)
