### PR TITLE
Fix ./docker-compose-simple.yml file brace expansion does NOT work

### DIFF
--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -11,7 +11,7 @@ services:
       - "9000:9000" # S3 API port
       - "9001:9001" # Console port
     environment:
-      - RUSTFS_VOLUMES=/data/rustfs{0...3}
+      - RUSTFS_VOLUMES=/data/rustfs{0..3}
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001
       - RUSTFS_CONSOLE_ENABLE=true


### PR DESCRIPTION


## Type of Change
- [ ] New Feature
- [x ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues

## Summary of Changes
docker-compose-simple.yml
Line: 14

This not work:
    /data/rustfs{0...3}
Errors:
When applying compose file:
    Initializing data directories: /data/rustfs{0...3}
    mkdir -p /data/rustfs{0...3}
    mkdir: cannot create directory ‘/data/rustfs{0...3}’: Permission denied
This work:
    /data/rustfs{0..3}
It create:
    /data/rustfs0
    /data/rustfs1
    /data/rustfs2
    /data/rustfs3

Tested on bash and zsh

## Checklist
- [ x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)