### PR TITLE
fix: try casting available blocks to a u64 on FreeBSD and OpenBSD

### DIFF
--- a/crates/utils/src/os/unix.rs
+++ b/crates/utils/src/os/unix.rs
@@ -25,7 +25,7 @@ fn blocks_available(stat: &Statfs) -> u64 {
     match stat.blocks_available().try_into() {
         Ok(bavail) => bavail,
         Err(e) => {
-            tracing::warn!("warning: blocks_available returned a negative value: Using 0 as fallback. {}", e);
+            tracing::warn!("blocks_available returned a negative value: Using 0 as fallback. {}", e);
             0
         }
     }
@@ -38,7 +38,7 @@ fn files_free(stat: &Statfs) -> u64 {
     match stat.files_free().try_into() {
         Ok(files_free) => files_free,
         Err(e) => {
-            tracing::warn!("warning: files_free returned a negative value: Using 0 as fallback. {}", e);
+            tracing::warn!("files_free returned a negative value: Using 0 as fallback. {}", e);
             0
         }
     }


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
#1359 

## Summary of Changes
Compilation on FreeBSD fails. This fixes it at compile time. I did not want to create runtime overhead.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
In case the type conversion fails I opted for returning 0, since this is the default behaviour on Linux and NetBSD (returning 0 instead of a negative amount).

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
