### PR TITLE
Fix event object structure according to AWS rules

### DIFF
--- a/crates/notify/src/event.rs
+++ b/crates/notify/src/event.rs
@@ -225,7 +225,7 @@ impl Event {
 
         if !is_removed_event {
             s3_metadata.object.size = Some(args.object.size);
-            s3_metadata.object.e_tag = args.object.e_tag.clone();
+            s3_metadata.object.e_tag = args.object.etag.clone();
             s3_metadata.object.content_type = args.object.content_type.clone();
             // Filter out internal reserved metadata
             let mut user_metadata = HashMap::new();


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Nothing related

## Summary of Changes
This PR should fix the difference between notification object from *rustfs* and *AWS S3* standard
Since the code is converting keys to camelCase `e_tag` should produce `eTag`.

src: https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
I didn't run any of the tests, please takeover

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
