### PR TITLE
Fix object tagging functionality issues #1415

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
-    "gimli",
+ "gimli",
 ]
 
 [[package]]
@@ -23,8 +23,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
-    "crypto-common 0.1.7",
-    "generic-array 0.14.7",
+ "crypto-common 0.1.7",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -33,8 +33,8 @@ version = "0.6.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a578e7d4edaef88aeb9cdd81556f4a62266ce26601317c006a79e8bc58b5af"
 dependencies = [
-    "crypto-common 0.2.0-rc.9",
-    "inout 0.2.2",
+ "crypto-common 0.2.0-rc.9",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -43,9 +43,9 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
-    "cfg-if",
-    "cipher 0.4.4",
-    "cpufeatures",
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -54,10 +54,10 @@ version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
-    "cfg-if",
-    "cipher 0.5.0-rc.3",
-    "cpufeatures",
-    "zeroize",
+ "cfg-if",
+ "cipher 0.5.0-rc.3",
+ "cpufeatures",
+ "zeroize",
 ]
 
 [[package]]
@@ -66,12 +66,12 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
-    "aead 0.5.2",
-    "aes 0.8.4",
-    "cipher 0.4.4",
-    "ctr 0.9.2",
-    "ghash 0.5.1",
-    "subtle",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
 ]
 
 [[package]]
@@ -80,13 +80,13 @@ version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f5c07f414d7dc0755870f84c7900425360288d24e0eae4836f9dee19a30fa5f"
 dependencies = [
-    "aead 0.6.0-rc.5",
-    "aes 0.9.0-rc.2",
-    "cipher 0.5.0-rc.3",
-    "ctr 0.10.0-rc.2",
-    "ghash 0.6.0-rc.3",
-    "subtle",
-    "zeroize",
+ "aead 0.6.0-rc.5",
+ "aes 0.9.0-rc.2",
+ "cipher 0.5.0-rc.3",
+ "ctr 0.10.0-rc.2",
+ "ghash 0.6.0-rc.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -95,12 +95,12 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
-    "cfg-if",
-    "const-random",
-    "getrandom 0.3.4",
-    "once_cell",
-    "version_check",
-    "zerocopy",
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
-    "equator",
+ "equator",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
-    "alloc-no-stdlib",
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
-    "cc",
+ "cc",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -172,13 +172,13 @@ version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
-    "anstyle",
-    "anstyle-parse",
-    "anstyle-query",
-    "anstyle-wincon",
-    "colorchoice",
-    "is_terminal_polyfill",
-    "utf8parse",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
-    "utf8parse",
+ "utf8parse",
 ]
 
 [[package]]
@@ -202,7 +202,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
-    "windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -211,9 +211,9 @@ version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
-    "anstyle",
-    "once_cell_polyfill",
-    "windows-sys 0.61.2",
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
 dependencies = [
-    "object 0.32.2",
+ "object 0.32.2",
 ]
 
 [[package]]
@@ -237,7 +237,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
-    "derive_arbitrary",
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -246,7 +246,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
 dependencies = [
-    "rustversion",
+ "rustversion",
 ]
 
 [[package]]
@@ -255,10 +255,10 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
-    "base64ct",
-    "blake2 0.10.6",
-    "cpufeatures",
-    "password-hash 0.5.0",
+ "base64ct",
+ "blake2 0.10.6",
+ "cpufeatures",
+ "password-hash 0.5.0",
 ]
 
 [[package]]
@@ -267,10 +267,10 @@ version = "0.6.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26e88a084142953a0415c47ddf4081eddf9a6d310012bbe92e9827d03e447f0"
 dependencies = [
-    "base64ct",
-    "blake2 0.11.0-rc.3",
-    "cpufeatures",
-    "password-hash 0.6.0-rc.8",
+ "base64ct",
+ "blake2 0.11.0-rc.3",
+ "cpufeatures",
+ "password-hash 0.6.0-rc.8",
 ]
 
 [[package]]
@@ -291,19 +291,19 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2b10dcb159faf30d3f81f6d56c1211a5bea2ca424eabe477648a44b993320e"
 dependencies = [
-    "arrow-arith",
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-cast",
-    "arrow-csv",
-    "arrow-data",
-    "arrow-ipc",
-    "arrow-json",
-    "arrow-ord",
-    "arrow-row",
-    "arrow-schema",
-    "arrow-select",
-    "arrow-string",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
@@ -312,12 +312,12 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288015089e7931843c80ed4032c5274f02b37bcb720c4a42096d50b390e70372"
 dependencies = [
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-schema",
-    "chrono",
-    "num-traits",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
 ]
 
 [[package]]
@@ -326,17 +326,17 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ca404ea6191e06bf30956394173337fa9c35f445bd447fe6c21ab944e1a23c"
 dependencies = [
-    "ahash",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-schema",
-    "chrono",
-    "chrono-tz",
-    "half",
-    "hashbrown 0.16.1",
-    "num-complex",
-    "num-integer",
-    "num-traits",
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -345,10 +345,10 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36356383099be0151dacc4245309895f16ba7917d79bdb71a7148659c9206c56"
 dependencies = [
-    "bytes",
-    "half",
-    "num-bigint",
-    "num-traits",
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -357,20 +357,20 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8e372ed52bd4ee88cc1e6c3859aa7ecea204158ac640b10e187936e7e87074"
 dependencies = [
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-ord",
-    "arrow-schema",
-    "arrow-select",
-    "atoi",
-    "base64",
-    "chrono",
-    "comfy-table",
-    "half",
-    "lexical-core",
-    "num-traits",
-    "ryu",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
 ]
 
 [[package]]
@@ -379,13 +379,13 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4100b729fe656f2e4fb32bc5884f14acf9118d4ad532b7b33c1132e4dce896"
 dependencies = [
-    "arrow-array",
-    "arrow-cast",
-    "arrow-schema",
-    "chrono",
-    "csv",
-    "csv-core",
-    "regex",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
 ]
 
 [[package]]
@@ -394,11 +394,11 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf87f4ff5fc13290aa47e499a8b669a82c5977c6a1fedce22c7f542c1fd5a597"
 dependencies = [
-    "arrow-buffer",
-    "arrow-schema",
-    "half",
-    "num-integer",
-    "num-traits",
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -407,14 +407,14 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3ca63edd2073fcb42ba112f8ae165df1de935627ead6e203d07c99445f2081"
 dependencies = [
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-schema",
-    "arrow-select",
-    "flatbuffers",
-    "lz4_flex",
-    "zstd",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+ "lz4_flex",
+ "zstd",
 ]
 
 [[package]]
@@ -423,22 +423,22 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a36b2332559d3310ebe3e173f75b29989b4412df4029a26a30cc3f7da0869297"
 dependencies = [
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-cast",
-    "arrow-data",
-    "arrow-schema",
-    "chrono",
-    "half",
-    "indexmap 2.13.0",
-    "itoa",
-    "lexical-core",
-    "memchr",
-    "num-traits",
-    "ryu",
-    "serde_core",
-    "serde_json",
-    "simdutf8",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
@@ -447,11 +447,11 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c4e0530272ca755d6814218dffd04425c5b7854b87fa741d5ff848bf50aa39"
 dependencies = [
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-schema",
-    "arrow-select",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
 ]
 
 [[package]]
@@ -460,11 +460,11 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f52788744cc71c4628567ad834cadbaeb9f09026ff1d7a4120f69edf7abd3"
 dependencies = [
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-schema",
-    "half",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
 ]
 
 [[package]]
@@ -473,8 +473,8 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb63203e8e0e54b288d0d8043ca8fa1013820822a27692ef1b78a977d879f2c"
 dependencies = [
-    "serde_core",
-    "serde_json",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
@@ -483,12 +483,12 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96d8a1c180b44ecf2e66c9a2f2bbcb8b1b6f14e165ce46ac8bde211a363411b"
 dependencies = [
-    "ahash",
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-schema",
-    "num-traits",
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
 ]
 
 [[package]]
@@ -497,15 +497,15 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8ad6a81add9d3ea30bf8374ee8329992c7fd246ffd8b7e2f48a3cea5aa0cc9a"
 dependencies = [
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-data",
-    "arrow-schema",
-    "arrow-select",
-    "memchr",
-    "num-traits",
-    "regex",
-    "regex-syntax",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -514,14 +514,14 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
-    "asn1-rs-derive",
-    "asn1-rs-impl",
-    "displaydoc",
-    "nom 7.1.3",
-    "num-traits",
-    "rusticata-macros",
-    "thiserror 2.0.17",
-    "time",
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
 ]
 
 [[package]]
@@ -530,10 +530,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
-    "synstructure 0.13.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -542,9 +542,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -553,14 +553,14 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
 dependencies = [
-    "filetime",
-    "futures-core",
-    "libc",
-    "portable-atomic",
-    "rustc-hash",
-    "tokio",
-    "tokio-stream",
-    "xattr",
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -569,10 +569,10 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
-    "concurrent-queue",
-    "event-listener-strategy",
-    "futures-core",
-    "pin-project-lite",
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -581,16 +581,16 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
-    "brotli 7.0.0",
-    "bzip2 0.5.2",
-    "flate2",
-    "futures-core",
-    "memchr",
-    "pin-project-lite",
-    "tokio",
-    "xz2",
-    "zstd",
-    "zstd-safe",
+ "brotli 7.0.0",
+ "bzip2 0.5.2",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "xz2",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -599,9 +599,9 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
-    "event-listener",
-    "event-listener-strategy",
-    "pin-project-lite",
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -610,9 +610,9 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -621,9 +621,9 @@ version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -632,7 +632,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
-    "num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -647,9 +647,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e1aca718ea7b89985790c94aad72d77533063fe00bc497bb79a7c2dae6a661"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -664,28 +664,28 @@ version = "1.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5"
 dependencies = [
-    "aws-credential-types",
-    "aws-runtime",
-    "aws-sdk-sso",
-    "aws-sdk-ssooidc",
-    "aws-sdk-sts",
-    "aws-smithy-async",
-    "aws-smithy-http",
-    "aws-smithy-json",
-    "aws-smithy-runtime",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "aws-types",
-    "bytes",
-    "fastrand",
-    "hex",
-    "http 1.4.0",
-    "ring",
-    "time",
-    "tokio",
-    "tracing",
-    "url",
-    "zeroize",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -694,10 +694,10 @@ version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
 dependencies = [
-    "aws-smithy-async",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "zeroize",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
 ]
 
 [[package]]
@@ -706,9 +706,9 @@ version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
 dependencies = [
-    "aws-lc-sys",
-    "untrusted 0.7.1",
-    "zeroize",
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -717,10 +717,10 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
 dependencies = [
-    "cc",
-    "cmake",
-    "dunce",
-    "fs_extra",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
 ]
 
 [[package]]
@@ -729,23 +729,23 @@ version = "1.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81b5b2898f6798ad58f484856768bca817e3cd9de0974c24ae0f1113fe88f1b"
 dependencies = [
-    "aws-credential-types",
-    "aws-sigv4",
-    "aws-smithy-async",
-    "aws-smithy-eventstream",
-    "aws-smithy-http",
-    "aws-smithy-runtime",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "aws-types",
-    "bytes",
-    "fastrand",
-    "http 0.2.12",
-    "http-body 0.4.6",
-    "percent-encoding",
-    "pin-project-lite",
-    "tracing",
-    "uuid",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -754,32 +754,32 @@ version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
 dependencies = [
-    "aws-credential-types",
-    "aws-runtime",
-    "aws-sigv4",
-    "aws-smithy-async",
-    "aws-smithy-checksums",
-    "aws-smithy-eventstream",
-    "aws-smithy-http",
-    "aws-smithy-json",
-    "aws-smithy-runtime",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "aws-smithy-xml",
-    "aws-types",
-    "bytes",
-    "fastrand",
-    "hex",
-    "hmac 0.12.1",
-    "http 0.2.12",
-    "http 1.4.0",
-    "http-body 0.4.6",
-    "lru",
-    "percent-encoding",
-    "regex-lite",
-    "sha2 0.10.9",
-    "tracing",
-    "url",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.12.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.10.9",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -788,20 +788,20 @@ version = "1.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee6402a36f27b52fe67661c6732d684b2635152b676aa2babbfb5204f99115d"
 dependencies = [
-    "aws-credential-types",
-    "aws-runtime",
-    "aws-smithy-async",
-    "aws-smithy-http",
-    "aws-smithy-json",
-    "aws-smithy-runtime",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "aws-types",
-    "bytes",
-    "fastrand",
-    "http 0.2.12",
-    "regex-lite",
-    "tracing",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -810,20 +810,20 @@ version = "1.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45a7f750bbd170ee3677671ad782d90b894548f4e4ae168302c57ec9de5cb3e"
 dependencies = [
-    "aws-credential-types",
-    "aws-runtime",
-    "aws-smithy-async",
-    "aws-smithy-http",
-    "aws-smithy-json",
-    "aws-smithy-runtime",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "aws-types",
-    "bytes",
-    "fastrand",
-    "http 0.2.12",
-    "regex-lite",
-    "tracing",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -832,21 +832,21 @@ version = "1.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55542378e419558e6b1f398ca70adb0b2088077e79ad9f14eb09441f2f7b2164"
 dependencies = [
-    "aws-credential-types",
-    "aws-runtime",
-    "aws-smithy-async",
-    "aws-smithy-http",
-    "aws-smithy-json",
-    "aws-smithy-query",
-    "aws-smithy-runtime",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "aws-smithy-xml",
-    "aws-types",
-    "fastrand",
-    "http 0.2.12",
-    "regex-lite",
-    "tracing",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -855,26 +855,26 @@ version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
 dependencies = [
-    "aws-credential-types",
-    "aws-smithy-eventstream",
-    "aws-smithy-http",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "bytes",
-    "crypto-bigint 0.5.5",
-    "form_urlencoded",
-    "hex",
-    "hmac 0.12.1",
-    "http 0.2.12",
-    "http 1.4.0",
-    "p256 0.11.1",
-    "percent-encoding",
-    "ring",
-    "sha2 0.10.9",
-    "subtle",
-    "time",
-    "tracing",
-    "zeroize",
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.12.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "p256 0.11.1",
+ "percent-encoding",
+ "ring",
+ "sha2 0.10.9",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -883,9 +883,9 @@ version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee19095c7c4dda59f1697d028ce704c24b2d33c6718790c7f1d5a3015b4107c"
 dependencies = [
-    "futures-util",
-    "pin-project-lite",
-    "tokio",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -894,18 +894,18 @@ version = "0.63.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
 dependencies = [
-    "aws-smithy-http",
-    "aws-smithy-types",
-    "bytes",
-    "crc-fast",
-    "hex",
-    "http 0.2.12",
-    "http-body 0.4.6",
-    "md-5 0.10.6",
-    "pin-project-lite",
-    "sha1 0.10.6",
-    "sha2 0.10.9",
-    "tracing",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5 0.10.6",
+ "pin-project-lite",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "tracing",
 ]
 
 [[package]]
@@ -914,9 +914,9 @@ version = "0.60.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650"
 dependencies = [
-    "aws-smithy-types",
-    "bytes",
-    "crc32fast",
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
 ]
 
 [[package]]
@@ -925,20 +925,20 @@ version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
-    "aws-smithy-eventstream",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "bytes",
-    "bytes-utils",
-    "futures-core",
-    "futures-util",
-    "http 0.2.12",
-    "http 1.4.0",
-    "http-body 0.4.6",
-    "percent-encoding",
-    "pin-project-lite",
-    "pin-utils",
-    "tracing",
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -947,22 +947,22 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
 dependencies = [
-    "aws-smithy-async",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "h2",
-    "http 1.4.0",
-    "hyper",
-    "hyper-rustls",
-    "hyper-util",
-    "pin-project-lite",
-    "rustls",
-    "rustls-native-certs",
-    "rustls-pki-types",
-    "tokio",
-    "tokio-rustls",
-    "tower",
-    "tracing",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -971,7 +971,7 @@ version = "0.61.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
 dependencies = [
-    "aws-smithy-types",
+ "aws-smithy-types",
 ]
 
 [[package]]
@@ -980,7 +980,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f616c3f2260612fe44cede278bafa18e73e6479c4e393e2c4518cf2a9a228a"
 dependencies = [
-    "aws-smithy-runtime-api",
+ "aws-smithy-runtime-api",
 ]
 
 [[package]]
@@ -989,8 +989,8 @@ version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5d689cf437eae90460e944a58b5668530d433b4ff85789e69d2f2a556e057d"
 dependencies = [
-    "aws-smithy-types",
-    "urlencoding",
+ "aws-smithy-types",
+ "urlencoding",
 ]
 
 [[package]]
@@ -999,22 +999,22 @@ version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a392db6c583ea4a912538afb86b7be7c5d8887d91604f50eb55c262ee1b4a5f5"
 dependencies = [
-    "aws-smithy-async",
-    "aws-smithy-http",
-    "aws-smithy-http-client",
-    "aws-smithy-observability",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "bytes",
-    "fastrand",
-    "http 0.2.12",
-    "http 1.4.0",
-    "http-body 0.4.6",
-    "http-body 1.0.1",
-    "pin-project-lite",
-    "pin-utils",
-    "tokio",
-    "tracing",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1023,15 +1023,15 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0d43d899f9e508300e587bf582ba54c27a452dd0a9ea294690669138ae14a2"
 dependencies = [
-    "aws-smithy-async",
-    "aws-smithy-types",
-    "bytes",
-    "http 0.2.12",
-    "http 1.4.0",
-    "pin-project-lite",
-    "tokio",
-    "tracing",
-    "zeroize",
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -1040,24 +1040,24 @@ version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "905cb13a9895626d49cf2ced759b062d913834c7482c38e49557eac4e6193f01"
 dependencies = [
-    "base64-simd",
-    "bytes",
-    "bytes-utils",
-    "futures-core",
-    "http 0.2.12",
-    "http 1.4.0",
-    "http-body 0.4.6",
-    "http-body 1.0.1",
-    "http-body-util",
-    "itoa",
-    "num-integer",
-    "pin-project-lite",
-    "pin-utils",
-    "ryu",
-    "serde",
-    "time",
-    "tokio",
-    "tokio-util",
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1066,7 +1066,7 @@ version = "0.60.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57"
 dependencies = [
-    "xmlparser",
+ "xmlparser",
 ]
 
 [[package]]
@@ -1075,12 +1075,12 @@ version = "1.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
 dependencies = [
-    "aws-credential-types",
-    "aws-smithy-async",
-    "aws-smithy-runtime-api",
-    "aws-smithy-types",
-    "rustc_version",
-    "tracing",
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -1089,31 +1089,31 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
-    "axum-core",
-    "bytes",
-    "form_urlencoded",
-    "futures-util",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "hyper",
-    "hyper-util",
-    "itoa",
-    "matchit 0.8.4",
-    "memchr",
-    "mime",
-    "percent-encoding",
-    "pin-project-lite",
-    "serde_core",
-    "serde_json",
-    "serde_path_to_error",
-    "serde_urlencoded",
-    "sync_wrapper",
-    "tokio",
-    "tower",
-    "tower-layer",
-    "tower-service",
-    "tracing",
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1122,17 +1122,17 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
-    "bytes",
-    "futures-core",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "mime",
-    "pin-project-lite",
-    "sync_wrapper",
-    "tower-layer",
-    "tower-service",
-    "tracing",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1141,20 +1141,20 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
-    "arc-swap",
-    "bytes",
-    "either",
-    "fs-err",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "hyper",
-    "hyper-util",
-    "pin-project-lite",
-    "rustls",
-    "rustls-pki-types",
-    "tokio",
-    "tokio-rustls",
-    "tower-service",
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1163,13 +1163,13 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
-    "addr2line",
-    "cfg-if",
-    "libc",
-    "miniz_oxide",
-    "object 0.37.3",
-    "rustc-demangle",
-    "windows-link 0.2.1",
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1202,8 +1202,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
-    "outref",
-    "vsimd",
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -1218,9 +1218,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
 dependencies = [
-    "blowfish",
-    "pbkdf2 0.12.2",
-    "sha2 0.10.9",
+ "blowfish",
+ "pbkdf2 0.12.2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1229,11 +1229,11 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
-    "autocfg",
-    "libm",
-    "num-bigint",
-    "num-integer",
-    "num-traits",
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1242,7 +1242,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -1257,7 +1257,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
-    "serde_core",
+ "serde_core",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
-    "digest 0.10.7",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "679065eb2b85a078ace42411e657bef3a6afe93a40d1b9cb04e39ca303cc3f36"
 dependencies = [
-    "digest 0.11.0-rc.5",
+ "digest 0.11.0-rc.5",
 ]
 
 [[package]]
@@ -1284,14 +1284,14 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
 dependencies = [
-    "arrayref",
-    "arrayvec",
-    "cc",
-    "cfg-if",
-    "constant_time_eq 0.4.2",
-    "cpufeatures",
-    "memmap2",
-    "rayon-core",
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures",
+ "memmap2",
+ "rayon-core",
 ]
 
 [[package]]
@@ -1300,7 +1300,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
-    "generic-array 0.14.7",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1309,8 +1309,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
 dependencies = [
-    "hybrid-array",
-    "zeroize",
+ "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -1319,7 +1319,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
-    "generic-array 0.14.7",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1328,8 +1328,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
-    "byteorder",
-    "cipher 0.4.4",
+ "byteorder",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1338,8 +1338,8 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
 dependencies = [
-    "bon-macros",
-    "rustversion",
+ "bon-macros",
+ "rustversion",
 ]
 
 [[package]]
@@ -1348,13 +1348,13 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
 dependencies = [
-    "darling 0.23.0",
-    "ident_case",
-    "prettyplease",
-    "proc-macro2",
-    "quote",
-    "rustversion",
-    "syn 2.0.114",
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1363,9 +1363,9 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
-    "alloc-no-stdlib",
-    "alloc-stdlib",
-    "brotli-decompressor 4.0.3",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 4.0.3",
 ]
 
 [[package]]
@@ -1374,9 +1374,9 @@ version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
-    "alloc-no-stdlib",
-    "alloc-stdlib",
-    "brotli-decompressor 5.0.0",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -1385,8 +1385,8 @@ version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
-    "alloc-no-stdlib",
-    "alloc-stdlib",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1395,8 +1395,8 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
-    "alloc-no-stdlib",
-    "alloc-stdlib",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1423,7 +1423,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -1432,8 +1432,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
-    "bytes",
-    "either",
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1448,7 +1448,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
-    "bytes",
+ "bytes",
 ]
 
 [[package]]
@@ -1457,7 +1457,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
-    "bzip2-sys",
+ "bzip2-sys",
 ]
 
 [[package]]
@@ -1466,7 +1466,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
-    "libbz2-rs-sys",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -1475,8 +1475,8 @@ version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
-    "cc",
-    "pkg-config",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1485,7 +1485,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
-    "serde_core",
+ "serde_core",
 ]
 
 [[package]]
@@ -1494,8 +1494,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
 dependencies = [
-    "serde",
-    "serde_core",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1504,12 +1504,12 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
-    "camino",
-    "cargo-platform",
-    "semver",
-    "serde",
-    "serde_json",
-    "thiserror 2.0.17",
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1524,7 +1524,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
-    "cipher 0.4.4",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1533,10 +1533,10 @@ version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
-    "find-msvc-tools",
-    "jobserver",
-    "libc",
-    "shlex",
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1557,9 +1557,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
-    "cfg-if",
-    "cipher 0.4.4",
-    "cpufeatures",
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1568,11 +1568,11 @@ version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
 dependencies = [
-    "cfg-if",
-    "cipher 0.5.0-rc.3",
-    "cpufeatures",
-    "rand_core 0.10.0-rc-3",
-    "zeroize",
+ "cfg-if",
+ "cipher 0.5.0-rc.3",
+ "cpufeatures",
+ "rand_core 0.10.0-rc-3",
+ "zeroize",
 ]
 
 [[package]]
@@ -1581,10 +1581,10 @@ version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c662d31454533832974f2b2b3fcbd552ed3cde94c95e614a5039d297dd97076f"
 dependencies = [
-    "aead 0.6.0-rc.5",
-    "chacha20 0.10.0-rc.6",
-    "cipher 0.5.0-rc.3",
-    "poly1305 0.9.0-rc.3",
+ "aead 0.6.0-rc.5",
+ "chacha20 0.10.0-rc.6",
+ "cipher 0.5.0-rc.3",
+ "poly1305 0.9.0-rc.3",
 ]
 
 [[package]]
@@ -1593,12 +1593,12 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
-    "iana-time-zone",
-    "js-sys",
-    "num-traits",
-    "serde",
-    "wasm-bindgen",
-    "windows-link 0.2.1",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1607,8 +1607,8 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
-    "chrono",
-    "phf 0.12.1",
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1617,9 +1617,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
-    "ciborium-io",
-    "ciborium-ll",
-    "serde",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
 ]
 
 [[package]]
@@ -1634,8 +1634,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
-    "ciborium-io",
-    "half",
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1644,8 +1644,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
-    "crypto-common 0.1.7",
-    "inout 0.1.4",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
 ]
 
 [[package]]
@@ -1654,10 +1654,10 @@ version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
 dependencies = [
-    "block-buffer 0.11.0",
-    "crypto-common 0.2.0-rc.9",
-    "inout 0.2.2",
-    "zeroize",
+ "block-buffer 0.11.0",
+ "crypto-common 0.2.0-rc.9",
+ "inout 0.2.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1666,8 +1666,8 @@ version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
-    "clap_builder",
-    "clap_derive",
+ "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1676,10 +1676,10 @@ version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
-    "anstream",
-    "anstyle",
-    "clap_lex",
-    "strsim 0.11.1",
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1688,10 +1688,10 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
-    "heck",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1706,7 +1706,7 @@ version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
-    "cc",
+ "cc",
 ]
 
 [[package]]
@@ -1727,8 +1727,8 @@ version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
 dependencies = [
-    "unicode-segmentation",
-    "unicode-width",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1737,7 +1737,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
-    "crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1758,7 +1758,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
-    "const-random-macro",
+ "const-random-macro",
 ]
 
 [[package]]
@@ -1767,9 +1767,9 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
-    "getrandom 0.2.17",
-    "once_cell",
-    "tiny-keccak",
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1778,7 +1778,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e19f68b180ebff43d6d42005c4b5f046c65fcac28369ba8b3beaad633f9ec0"
 dependencies = [
-    "const-str-proc-macro",
+ "const-str-proc-macro",
 ]
 
 [[package]]
@@ -1787,9 +1787,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3e0f24ee268386bd3ab4e04fc60df9a818ad801b5ffe592f388a6acc5053fb"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
 dependencies = [
-    "const_format_proc_macros",
+ "const_format_proc_macros",
 ]
 
 [[package]]
@@ -1807,9 +1807,9 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "unicode-xid",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1830,7 +1830,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
-    "unicode-segmentation",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1839,8 +1839,8 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
-    "core-foundation-sys",
-    "libc",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1849,8 +1849,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
-    "core-foundation-sys",
-    "libc",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1865,9 +1865,9 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0940496e5c83c54f3b753d5317daec82e8edac71c33aaa1f666d76f518de2444"
 dependencies = [
-    "hax-lib",
-    "pastey 0.1.1",
-    "rand 0.9.2",
+ "hax-lib",
+ "pastey 0.1.1",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1876,7 +1876,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
-    "cfg-if",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1885,7 +1885,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -1894,7 +1894,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
-    "crc-catalog",
+ "crc-catalog",
 ]
 
 [[package]]
@@ -1909,11 +1909,11 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
-    "crc",
-    "digest 0.10.7",
-    "rand 0.9.2",
-    "regex",
-    "rustversion",
+ "crc",
+ "digest 0.10.7",
+ "rand 0.9.2",
+ "regex",
+ "rustversion",
 ]
 
 [[package]]
@@ -1922,7 +1922,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
-    "rustc_version",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1931,7 +1931,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
-    "cfg-if",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1940,23 +1940,23 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
 dependencies = [
-    "alloca",
-    "anes",
-    "cast",
-    "ciborium",
-    "clap",
-    "criterion-plot",
-    "itertools 0.13.0",
-    "num-traits",
-    "oorandom",
-    "page_size",
-    "plotters",
-    "rayon",
-    "regex",
-    "serde",
-    "serde_json",
-    "tinytemplate",
-    "walkdir",
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
 
 [[package]]
@@ -1965,8 +1965,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
-    "cast",
-    "itertools 0.13.0",
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1975,7 +1975,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
-    "crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1984,8 +1984,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
-    "crossbeam-epoch",
-    "crossbeam-utils",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1994,7 +1994,7 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
-    "crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2003,7 +2003,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
-    "crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2024,10 +2024,10 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
-    "generic-array 0.14.7",
-    "rand_core 0.6.4",
-    "subtle",
-    "zeroize",
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2036,10 +2036,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
-    "generic-array 0.14.7",
-    "rand_core 0.6.4",
-    "subtle",
-    "zeroize",
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2048,11 +2048,11 @@ version = "0.7.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9e36ac79ac44866b74e08a0b4925f97b984e3fff17680d2c6fbce8317ab0f6"
 dependencies = [
-    "ctutils",
-    "num-traits",
-    "rand_core 0.10.0-rc-3",
-    "serdect",
-    "zeroize",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.0-rc-3",
+ "serdect",
+ "zeroize",
 ]
 
 [[package]]
@@ -2061,8 +2061,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
-    "generic-array 0.14.7",
-    "typenum",
+ "generic-array 0.14.7",
+ "typenum",
 ]
 
 [[package]]
@@ -2071,9 +2071,9 @@ version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
 dependencies = [
-    "getrandom 0.4.0-rc.0",
-    "hybrid-array",
-    "rand_core 0.10.0-rc-3",
+ "getrandom 0.4.0-rc.0",
+ "hybrid-array",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -2082,9 +2082,9 @@ version = "0.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0b07a7a616370e8b6efca0c6a25e5f4c6d02fde11f3d570e4af64d8ed7e2e9"
 dependencies = [
-    "crypto-bigint 0.7.0-rc.15",
-    "libm",
-    "rand_core 0.10.0-rc-3",
+ "crypto-bigint 0.7.0-rc.15",
+ "libm",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -2093,10 +2093,10 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
-    "csv-core",
-    "itoa",
-    "ryu",
-    "serde_core",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]
@@ -2105,7 +2105,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -2114,7 +2114,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
-    "cipher 0.4.4",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2123,7 +2123,7 @@ version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
 dependencies = [
-    "cipher 0.5.0-rc.3",
+ "cipher 0.5.0-rc.3",
 ]
 
 [[package]]
@@ -2132,7 +2132,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
 dependencies = [
-    "cmov",
+ "cmov",
 ]
 
 [[package]]
@@ -2141,14 +2141,14 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "curve25519-dalek-derive",
-    "digest 0.10.7",
-    "fiat-crypto 0.2.9",
-    "rustc_version",
-    "subtle",
-    "zeroize",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2157,13 +2157,13 @@ version = "5.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d8cfa313d59919eda35b420bd37db85bf58d6754d6f128b9949932b0c0fcce7"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "curve25519-dalek-derive",
-    "digest 0.11.0-rc.5",
-    "fiat-crypto 0.3.0",
-    "rustc_version",
-    "subtle",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.11.0-rc.5",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
 ]
 
 [[package]]
@@ -2172,9 +2172,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2183,8 +2183,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
-    "darling_core 0.14.4",
-    "darling_macro 0.14.4",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -2193,8 +2193,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
-    "darling_core 0.20.11",
-    "darling_macro 0.20.11",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -2203,8 +2203,8 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
-    "darling_core 0.21.3",
-    "darling_macro 0.21.3",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -2213,8 +2213,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
-    "darling_core 0.23.0",
-    "darling_macro 0.23.0",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -2223,12 +2223,12 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
-    "fnv",
-    "ident_case",
-    "proc-macro2",
-    "quote",
-    "strsim 0.10.0",
-    "syn 1.0.109",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2237,12 +2237,12 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
-    "fnv",
-    "ident_case",
-    "proc-macro2",
-    "quote",
-    "strsim 0.11.1",
-    "syn 2.0.114",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2251,12 +2251,12 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
-    "fnv",
-    "ident_case",
-    "proc-macro2",
-    "quote",
-    "strsim 0.11.1",
-    "syn 2.0.114",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2265,11 +2265,11 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
-    "ident_case",
-    "proc-macro2",
-    "quote",
-    "strsim 0.11.1",
-    "syn 2.0.114",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2278,9 +2278,9 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
-    "darling_core 0.14.4",
-    "quote",
-    "syn 1.0.109",
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2289,9 +2289,9 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
-    "darling_core 0.20.11",
-    "quote",
-    "syn 2.0.114",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2300,9 +2300,9 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
-    "darling_core 0.21.3",
-    "quote",
-    "syn 2.0.114",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2311,9 +2311,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
-    "darling_core 0.23.0",
-    "quote",
-    "syn 2.0.114",
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2322,12 +2322,12 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
-    "cfg-if",
-    "crossbeam-utils",
-    "hashbrown 0.14.5",
-    "lock_api",
-    "once_cell",
-    "parking_lot_core",
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2342,54 +2342,54 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
 dependencies = [
-    "arrow",
-    "arrow-schema",
-    "async-trait",
-    "bytes",
-    "bzip2 0.6.1",
-    "chrono",
-    "datafusion-catalog",
-    "datafusion-catalog-listing",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-datasource",
-    "datafusion-datasource-arrow",
-    "datafusion-datasource-csv",
-    "datafusion-datasource-json",
-    "datafusion-datasource-parquet",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-expr-common",
-    "datafusion-functions",
-    "datafusion-functions-aggregate",
-    "datafusion-functions-nested",
-    "datafusion-functions-table",
-    "datafusion-functions-window",
-    "datafusion-optimizer",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-adapter",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-optimizer",
-    "datafusion-physical-plan",
-    "datafusion-session",
-    "datafusion-sql",
-    "flate2",
-    "futures",
-    "itertools 0.14.0",
-    "log",
-    "object_store",
-    "parking_lot",
-    "parquet",
-    "rand 0.9.2",
-    "regex",
-    "rstest",
-    "sqlparser",
-    "tempfile",
-    "tokio",
-    "url",
-    "uuid",
-    "xz2",
-    "zstd",
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "bytes",
+ "bzip2 0.6.1",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-table",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "datafusion-sql",
+ "flate2",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "rand 0.9.2",
+ "regex",
+ "rstest",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+ "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -2398,23 +2398,23 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "dashmap",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-datasource",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-physical-expr",
-    "datafusion-physical-plan",
-    "datafusion-session",
-    "futures",
-    "itertools 0.14.0",
-    "log",
-    "object_store",
-    "parking_lot",
-    "tokio",
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "tokio",
 ]
 
 [[package]]
@@ -2423,22 +2423,22 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "datafusion-catalog",
-    "datafusion-common",
-    "datafusion-datasource",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-adapter",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "futures",
-    "itertools 0.14.0",
-    "log",
-    "object_store",
-    "tokio",
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "tokio",
 ]
 
 [[package]]
@@ -2447,22 +2447,22 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
 dependencies = [
-    "ahash",
-    "arrow",
-    "arrow-ipc",
-    "chrono",
-    "half",
-    "hashbrown 0.14.5",
-    "indexmap 2.13.0",
-    "libc",
-    "log",
-    "object_store",
-    "parquet",
-    "paste",
-    "recursive",
-    "sqlparser",
-    "tokio",
-    "web-time",
+ "ahash",
+ "arrow",
+ "arrow-ipc",
+ "chrono",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap 2.13.0",
+ "libc",
+ "log",
+ "object_store",
+ "parquet",
+ "paste",
+ "recursive",
+ "sqlparser",
+ "tokio",
+ "web-time",
 ]
 
 [[package]]
@@ -2471,9 +2471,9 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
 dependencies = [
-    "futures",
-    "log",
-    "tokio",
+ "futures",
+ "log",
+ "tokio",
 ]
 
 [[package]]
@@ -2482,33 +2482,33 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
 dependencies = [
-    "arrow",
-    "async-compression",
-    "async-trait",
-    "bytes",
-    "bzip2 0.6.1",
-    "chrono",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-adapter",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "datafusion-session",
-    "flate2",
-    "futures",
-    "glob",
-    "itertools 0.14.0",
-    "log",
-    "object_store",
-    "rand 0.9.2",
-    "tokio",
-    "tokio-util",
-    "url",
-    "xz2",
-    "zstd",
+ "arrow",
+ "async-compression",
+ "async-trait",
+ "bytes",
+ "bzip2 0.6.1",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "flate2",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "rand 0.9.2",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -2517,22 +2517,22 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
 dependencies = [
-    "arrow",
-    "arrow-ipc",
-    "async-trait",
-    "bytes",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-datasource",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "datafusion-session",
-    "futures",
-    "itertools 0.14.0",
-    "object_store",
-    "tokio",
+ "arrow",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
 ]
 
 [[package]]
@@ -2541,21 +2541,21 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "bytes",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-datasource",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "datafusion-session",
-    "futures",
-    "object_store",
-    "regex",
-    "tokio",
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "regex",
+ "tokio",
 ]
 
 [[package]]
@@ -2564,20 +2564,20 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "bytes",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-datasource",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "datafusion-session",
-    "futures",
-    "object_store",
-    "tokio",
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "tokio",
 ]
 
 [[package]]
@@ -2586,28 +2586,28 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d0b60ffd66f28bfb026565d62b0a6cbc416da09814766a3797bba7d85a3cd9"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "bytes",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-datasource",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-functions-aggregate-common",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-adapter",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "datafusion-pruning",
-    "datafusion-session",
-    "futures",
-    "itertools 0.14.0",
-    "log",
-    "object_store",
-    "parking_lot",
-    "parquet",
-    "tokio",
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "tokio",
 ]
 
 [[package]]
@@ -2622,18 +2622,18 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "dashmap",
-    "datafusion-common",
-    "datafusion-expr",
-    "futures",
-    "log",
-    "object_store",
-    "parking_lot",
-    "rand 0.9.2",
-    "tempfile",
-    "url",
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.2",
+ "tempfile",
+ "url",
 ]
 
 [[package]]
@@ -2642,21 +2642,21 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "chrono",
-    "datafusion-common",
-    "datafusion-doc",
-    "datafusion-expr-common",
-    "datafusion-functions-aggregate-common",
-    "datafusion-functions-window-common",
-    "datafusion-physical-expr-common",
-    "indexmap 2.13.0",
-    "itertools 0.14.0",
-    "paste",
-    "recursive",
-    "serde_json",
-    "sqlparser",
+ "arrow",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "paste",
+ "recursive",
+ "serde_json",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2665,11 +2665,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
 dependencies = [
-    "arrow",
-    "datafusion-common",
-    "indexmap 2.13.0",
-    "itertools 0.14.0",
-    "paste",
+ "arrow",
+ "datafusion-common",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "paste",
 ]
 
 [[package]]
@@ -2678,28 +2678,28 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
 dependencies = [
-    "arrow",
-    "arrow-buffer",
-    "base64",
-    "blake2 0.10.6",
-    "blake3",
-    "chrono",
-    "datafusion-common",
-    "datafusion-doc",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-expr-common",
-    "datafusion-macros",
-    "hex",
-    "itertools 0.14.0",
-    "log",
-    "md-5 0.10.6",
-    "num-traits",
-    "rand 0.9.2",
-    "regex",
-    "sha2 0.10.9",
-    "unicode-segmentation",
-    "uuid",
+ "arrow",
+ "arrow-buffer",
+ "base64",
+ "blake2 0.10.6",
+ "blake3",
+ "chrono",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "md-5 0.10.6",
+ "num-traits",
+ "rand 0.9.2",
+ "regex",
+ "sha2 0.10.9",
+ "unicode-segmentation",
+ "uuid",
 ]
 
 [[package]]
@@ -2708,19 +2708,19 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
 dependencies = [
-    "ahash",
-    "arrow",
-    "datafusion-common",
-    "datafusion-doc",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-functions-aggregate-common",
-    "datafusion-macros",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-common",
-    "half",
-    "log",
-    "paste",
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "half",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -2729,11 +2729,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
 dependencies = [
-    "ahash",
-    "arrow",
-    "datafusion-common",
-    "datafusion-expr-common",
-    "datafusion-physical-expr-common",
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
 ]
 
 [[package]]
@@ -2742,21 +2742,21 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
 dependencies = [
-    "arrow",
-    "arrow-ord",
-    "datafusion-common",
-    "datafusion-doc",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-expr-common",
-    "datafusion-functions",
-    "datafusion-functions-aggregate",
-    "datafusion-functions-aggregate-common",
-    "datafusion-macros",
-    "datafusion-physical-expr-common",
-    "itertools 0.14.0",
-    "log",
-    "paste",
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -2765,14 +2765,14 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
 dependencies = [
-    "arrow",
-    "async-trait",
-    "datafusion-catalog",
-    "datafusion-common",
-    "datafusion-expr",
-    "datafusion-physical-plan",
-    "parking_lot",
-    "paste",
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+ "paste",
 ]
 
 [[package]]
@@ -2781,16 +2781,16 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
 dependencies = [
-    "arrow",
-    "datafusion-common",
-    "datafusion-doc",
-    "datafusion-expr",
-    "datafusion-functions-window-common",
-    "datafusion-macros",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-common",
-    "log",
-    "paste",
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -2799,8 +2799,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
 dependencies = [
-    "datafusion-common",
-    "datafusion-physical-expr-common",
+ "datafusion-common",
+ "datafusion-physical-expr-common",
 ]
 
 [[package]]
@@ -2809,9 +2809,9 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
 dependencies = [
-    "datafusion-doc",
-    "quote",
-    "syn 2.0.114",
+ "datafusion-doc",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2820,18 +2820,18 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
 dependencies = [
-    "arrow",
-    "chrono",
-    "datafusion-common",
-    "datafusion-expr",
-    "datafusion-expr-common",
-    "datafusion-physical-expr",
-    "indexmap 2.13.0",
-    "itertools 0.14.0",
-    "log",
-    "recursive",
-    "regex",
-    "regex-syntax",
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "recursive",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2840,20 +2840,20 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
 dependencies = [
-    "ahash",
-    "arrow",
-    "datafusion-common",
-    "datafusion-expr",
-    "datafusion-expr-common",
-    "datafusion-functions-aggregate-common",
-    "datafusion-physical-expr-common",
-    "half",
-    "hashbrown 0.14.5",
-    "indexmap 2.13.0",
-    "itertools 0.14.0",
-    "parking_lot",
-    "paste",
-    "petgraph",
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "parking_lot",
+ "paste",
+ "petgraph",
 ]
 
 [[package]]
@@ -2862,13 +2862,13 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
 dependencies = [
-    "arrow",
-    "datafusion-common",
-    "datafusion-expr",
-    "datafusion-functions",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-common",
-    "itertools 0.14.0",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -2877,12 +2877,12 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
 dependencies = [
-    "ahash",
-    "arrow",
-    "datafusion-common",
-    "datafusion-expr-common",
-    "hashbrown 0.14.5",
-    "itertools 0.14.0",
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -2891,17 +2891,17 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
 dependencies = [
-    "arrow",
-    "datafusion-common",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-expr-common",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "datafusion-pruning",
-    "itertools 0.14.0",
-    "recursive",
+ "arrow",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "itertools 0.14.0",
+ "recursive",
 ]
 
 [[package]]
@@ -2910,29 +2910,29 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
 dependencies = [
-    "ahash",
-    "arrow",
-    "arrow-ord",
-    "arrow-schema",
-    "async-trait",
-    "chrono",
-    "datafusion-common",
-    "datafusion-common-runtime",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-functions-aggregate-common",
-    "datafusion-functions-window-common",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-common",
-    "futures",
-    "half",
-    "hashbrown 0.14.5",
-    "indexmap 2.13.0",
-    "itertools 0.14.0",
-    "log",
-    "parking_lot",
-    "pin-project-lite",
-    "tokio",
+ "ahash",
+ "arrow",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.14.5",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2941,15 +2941,15 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
 dependencies = [
-    "arrow",
-    "datafusion-common",
-    "datafusion-datasource",
-    "datafusion-expr-common",
-    "datafusion-physical-expr",
-    "datafusion-physical-expr-common",
-    "datafusion-physical-plan",
-    "itertools 0.14.0",
-    "log",
+ "arrow",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "itertools 0.14.0",
+ "log",
 ]
 
 [[package]]
@@ -2958,12 +2958,12 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
 dependencies = [
-    "async-trait",
-    "datafusion-common",
-    "datafusion-execution",
-    "datafusion-expr",
-    "datafusion-physical-plan",
-    "parking_lot",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2972,16 +2972,16 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
 dependencies = [
-    "arrow",
-    "bigdecimal",
-    "chrono",
-    "datafusion-common",
-    "datafusion-expr",
-    "indexmap 2.13.0",
-    "log",
-    "recursive",
-    "regex",
-    "sqlparser",
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "indexmap 2.13.0",
+ "log",
+ "recursive",
+ "regex",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
-    "uuid",
+ "uuid",
 ]
 
 [[package]]
@@ -3005,9 +3005,9 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3016,8 +3016,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
-    "const-oid 0.9.6",
-    "zeroize",
+ "const-oid 0.9.6",
+ "zeroize",
 ]
 
 [[package]]
@@ -3026,9 +3026,9 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
-    "const-oid 0.9.6",
-    "pem-rfc7468 0.7.0",
-    "zeroize",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3037,9 +3037,9 @@ version = "0.8.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
 dependencies = [
-    "const-oid 0.10.2",
-    "pem-rfc7468 1.0.0",
-    "zeroize",
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3048,12 +3048,12 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
-    "asn1-rs",
-    "displaydoc",
-    "nom 7.1.3",
-    "num-bigint",
-    "num-traits",
-    "rusticata-macros",
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -3062,8 +3062,8 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
-    "powerfmt",
-    "serde_core",
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -3072,9 +3072,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3083,7 +3083,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
-    "derive_builder_macro 0.12.0",
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -3092,7 +3092,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
-    "derive_builder_macro 0.20.2",
+ "derive_builder_macro 0.20.2",
 ]
 
 [[package]]
@@ -3101,10 +3101,10 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
-    "darling 0.14.4",
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3113,10 +3113,10 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
-    "darling 0.20.11",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3125,8 +3125,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
-    "derive_builder_core 0.12.0",
-    "syn 1.0.109",
+ "derive_builder_core 0.12.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3135,8 +3135,8 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
-    "derive_builder_core 0.20.2",
-    "syn 2.0.114",
+ "derive_builder_core 0.20.2",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3145,7 +3145,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
-    "derive_more-impl",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -3154,12 +3154,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
-    "convert_case",
-    "proc-macro2",
-    "quote",
-    "rustc_version",
-    "syn 2.0.114",
-    "unicode-xid",
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3168,7 +3168,7 @@ version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512ca722eff02fa73c43e5136f440c46f861d41f9dd7761c1f2817a5ca5d9ad7"
 dependencies = [
-    "cipher 0.5.0-rc.3",
+ "cipher 0.5.0-rc.3",
 ]
 
 [[package]]
@@ -3183,10 +3183,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
-    "block-buffer 0.10.4",
-    "const-oid 0.9.6",
-    "crypto-common 0.1.7",
-    "subtle",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -3195,10 +3195,10 @@ version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
 dependencies = [
-    "block-buffer 0.11.0",
-    "const-oid 0.10.2",
-    "crypto-common 0.2.0-rc.9",
-    "subtle",
+ "block-buffer 0.11.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.0-rc.9",
+ "subtle",
 ]
 
 [[package]]
@@ -3207,7 +3207,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
-    "dirs-sys",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -3216,10 +3216,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
-    "libc",
-    "option-ext",
-    "redox_users",
-    "windows-sys 0.61.2",
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3228,9 +3228,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3245,7 +3245,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
 dependencies = [
-    "phf 0.11.3",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -3264,38 +3264,38 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "e2e_test"
 version = "0.0.5"
 dependencies = [
-    "anyhow",
-    "async-trait",
-    "aws-config",
-    "aws-sdk-s3",
-    "base64",
-    "bytes",
-    "chrono",
-    "flatbuffers",
-    "futures",
-    "md5 0.8.0",
-    "rand 0.10.0-rc.6",
-    "rcgen",
-    "reqwest",
-    "rmp-serde",
-    "rustfs-common",
-    "rustfs-ecstore",
-    "rustfs-filemeta",
-    "rustfs-lock",
-    "rustfs-madmin",
-    "rustfs-protos",
-    "rustls",
-    "rustls-pemfile",
-    "serde",
-    "serde_json",
-    "serial_test",
-    "suppaftp",
-    "tokio",
-    "tonic",
-    "tracing",
-    "tracing-subscriber",
-    "url",
-    "uuid",
+ "anyhow",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
+ "base64",
+ "bytes",
+ "chrono",
+ "flatbuffers",
+ "futures",
+ "md5 0.8.0",
+ "rand 0.10.0-rc.6",
+ "rcgen",
+ "reqwest",
+ "rmp-serde",
+ "rustfs-common",
+ "rustfs-ecstore",
+ "rustfs-filemeta",
+ "rustfs-lock",
+ "rustfs-madmin",
+ "rustfs-protos",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "suppaftp",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3304,10 +3304,10 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
-    "der 0.6.1",
-    "elliptic-curve 0.12.3",
-    "rfc6979 0.3.1",
-    "signature 1.6.4",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -3316,12 +3316,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
-    "der 0.7.10",
-    "digest 0.10.7",
-    "elliptic-curve 0.13.8",
-    "rfc6979 0.4.0",
-    "signature 2.2.0",
-    "spki 0.7.3",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3330,8 +3330,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
-    "pkcs8 0.10.2",
-    "signature 2.2.0",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3340,7 +3340,7 @@ version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "594435fe09e345ee388e4e8422072ff7dfeca8729389fbd997b3f5504c44cd47"
 dependencies = [
-    "signature 3.0.0-rc.6",
+ "signature 3.0.0-rc.6",
 ]
 
 [[package]]
@@ -3349,13 +3349,13 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
-    "curve25519-dalek 4.1.3",
-    "ed25519 2.2.3",
-    "rand_core 0.6.4",
-    "serde",
-    "sha2 0.10.9",
-    "subtle",
-    "zeroize",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3364,10 +3364,10 @@ version = "3.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbef01b6e6a5f913ae480bb34ddd798ce6d358054bebf77177200ec84af61ad5"
 dependencies = [
-    "curve25519-dalek 5.0.0-pre.2",
-    "ed25519 3.0.0-rc.2",
-    "sha2 0.11.0-rc.3",
-    "subtle",
+ "curve25519-dalek 5.0.0-pre.2",
+ "ed25519 3.0.0-rc.2",
+ "sha2 0.11.0-rc.3",
+ "subtle",
 ]
 
 [[package]]
@@ -3382,18 +3382,18 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
-    "base16ct 0.1.1",
-    "crypto-bigint 0.4.9",
-    "der 0.6.1",
-    "digest 0.10.7",
-    "ff 0.12.1",
-    "generic-array 0.14.7",
-    "group 0.12.1",
-    "pkcs8 0.9.0",
-    "rand_core 0.6.4",
-    "sec1 0.3.0",
-    "subtle",
-    "zeroize",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array 0.14.7",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3402,19 +3402,19 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
-    "base16ct 0.2.0",
-    "crypto-bigint 0.5.5",
-    "digest 0.10.7",
-    "ff 0.13.1",
-    "generic-array 0.14.7",
-    "group 0.13.0",
-    "hkdf",
-    "pem-rfc7468 0.7.0",
-    "pkcs8 0.10.2",
-    "rand_core 0.6.4",
-    "sec1 0.7.3",
-    "subtle",
-    "zeroize",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "hkdf",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3423,7 +3423,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
-    "cfg-if",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3432,10 +3432,10 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
-    "once_cell",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3444,7 +3444,7 @@ version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
 dependencies = [
-    "enumset_derive",
+ "enumset_derive",
 ]
 
 [[package]]
@@ -3453,10 +3453,10 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
 dependencies = [
-    "darling 0.21.3",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3465,7 +3465,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
-    "log",
+ "log",
 ]
 
 [[package]]
@@ -3474,8 +3474,8 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
-    "env_filter",
-    "log",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -3484,7 +3484,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
 dependencies = [
-    "equator-macro",
+ "equator-macro",
 ]
 
 [[package]]
@@ -3493,9 +3493,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3510,7 +3510,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -3519,9 +3519,9 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
 dependencies = [
-    "serde",
-    "serde_core",
-    "typeid",
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]
@@ -3530,8 +3530,8 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
-    "libc",
-    "windows-sys 0.61.2",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3540,9 +3540,9 @@ version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
-    "concurrent-queue",
-    "parking",
-    "pin-project-lite",
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3551,8 +3551,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
-    "event-listener",
-    "pin-project-lite",
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3561,8 +3561,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
 dependencies = [
-    "heapless",
-    "serde",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -3577,8 +3577,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
-    "rand_core 0.6.4",
-    "subtle",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3587,8 +3587,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
-    "rand_core 0.6.4",
-    "subtle",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3609,10 +3609,10 @@ version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
-    "cfg-if",
-    "libc",
-    "libredox",
-    "windows-sys 0.60.2",
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3627,10 +3627,10 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
 dependencies = [
-    "cc",
-    "lazy_static",
-    "libc",
-    "winapi",
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3645,8 +3645,8 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
-    "bitflags 2.10.0",
-    "rustc_version",
+ "bitflags 2.10.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3655,9 +3655,9 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
-    "crc32fast",
-    "miniz_oxide",
-    "zlib-rs",
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3666,21 +3666,21 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e5335674a3a259527f97e9176a3767dcc9b220b8e29d643daeb2d6c72caf8b"
 dependencies = [
-    "chrono",
-    "crossbeam-channel",
-    "crossbeam-queue",
-    "flate2",
-    "log",
-    "notify-debouncer-mini",
-    "nu-ansi-term",
-    "regex",
-    "serde",
-    "serde_derive",
-    "serde_json",
-    "thiserror 2.0.17",
-    "toml",
-    "tracing",
-    "tracing-subscriber",
+ "chrono",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "flate2",
+ "log",
+ "notify-debouncer-mini",
+ "nu-ansi-term",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.17",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3689,9 +3689,9 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
-    "futures-core",
-    "futures-sink",
-    "spin 0.9.8",
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3700,10 +3700,10 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
-    "ahash",
-    "num_cpus",
-    "parking_lot",
-    "seize",
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
 ]
 
 [[package]]
@@ -3730,7 +3730,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
-    "percent-encoding",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3739,8 +3739,8 @@ version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
 dependencies = [
-    "autocfg",
-    "tokio",
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -3755,7 +3755,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -3764,13 +3764,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
-    "futures-channel",
-    "futures-core",
-    "futures-executor",
-    "futures-io",
-    "futures-sink",
-    "futures-task",
-    "futures-util",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -3779,8 +3779,8 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
-    "futures-core",
-    "futures-sink",
+ "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -3795,9 +3795,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
-    "futures-core",
-    "futures-task",
-    "futures-util",
+ "futures-core",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -3812,11 +3812,11 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
-    "fastrand",
-    "futures-core",
-    "futures-io",
-    "parking",
-    "pin-project-lite",
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3825,9 +3825,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3854,16 +3854,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
-    "futures-channel",
-    "futures-core",
-    "futures-io",
-    "futures-macro",
-    "futures-sink",
-    "futures-task",
-    "memchr",
-    "pin-project-lite",
-    "pin-utils",
-    "slab",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -3872,9 +3872,9 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
-    "typenum",
-    "version_check",
-    "zeroize",
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3883,9 +3883,9 @@ version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
 dependencies = [
-    "generic-array 0.14.7",
-    "rustversion",
-    "typenum",
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
 ]
 
 [[package]]
@@ -3894,11 +3894,11 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
-    "cfg-if",
-    "js-sys",
-    "libc",
-    "wasi",
-    "wasm-bindgen",
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3907,12 +3907,12 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
-    "cfg-if",
-    "js-sys",
-    "libc",
-    "r-efi",
-    "wasip2",
-    "wasm-bindgen",
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3921,11 +3921,11 @@ version = "0.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
 dependencies = [
-    "cfg-if",
-    "libc",
-    "r-efi",
-    "rand_core 0.10.0-rc-3",
-    "wasip2",
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0-rc-3",
+ "wasip2",
 ]
 
 [[package]]
@@ -3934,10 +3934,10 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
 dependencies = [
-    "proc-macro-error2",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3946,8 +3946,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
-    "opaque-debug",
-    "polyval 0.6.2",
+ "opaque-debug",
+ "polyval 0.6.2",
 ]
 
 [[package]]
@@ -3956,7 +3956,7 @@ version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
 dependencies = [
-    "polyval 0.7.0-rc.3",
+ "polyval 0.7.0-rc.3",
 ]
 
 [[package]]
@@ -3977,21 +3977,21 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590a1c28795779d5da6fda35b149d5271bcddcf2ce1709eae9e9460faf2f2aa9"
 dependencies = [
-    "async-trait",
-    "base64",
-    "bon",
-    "bytes",
-    "google-cloud-gax",
-    "http 1.4.0",
-    "reqwest",
-    "rustc_version",
-    "rustls",
-    "rustls-pemfile",
-    "serde",
-    "serde_json",
-    "thiserror 2.0.17",
-    "time",
-    "tokio",
+ "async-trait",
+ "base64",
+ "bon",
+ "bytes",
+ "google-cloud-gax",
+ "http 1.4.0",
+ "reqwest",
+ "rustc_version",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -4000,18 +4000,18 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324fb97d35103787e80a33ed41ccc43d947c376d2ece68ca53e860f5844dbe24"
 dependencies = [
-    "base64",
-    "bytes",
-    "futures",
-    "google-cloud-rpc",
-    "google-cloud-wkt",
-    "http 1.4.0",
-    "pin-project",
-    "rand 0.9.2",
-    "serde",
-    "serde_json",
-    "thiserror 2.0.17",
-    "tokio",
+ "base64",
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "pin-project",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
 ]
 
 [[package]]
@@ -4020,32 +4020,32 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75b810886ae872aca68a35ad1d4d5e8f2be39e40238116d8aff9d778f04b38"
 dependencies = [
-    "bytes",
-    "futures",
-    "google-cloud-auth",
-    "google-cloud-gax",
-    "google-cloud-rpc",
-    "google-cloud-wkt",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "hyper",
-    "opentelemetry-semantic-conventions",
-    "percent-encoding",
-    "pin-project",
-    "prost 0.14.3",
-    "prost-types",
-    "reqwest",
-    "rustc_version",
-    "serde",
-    "serde_json",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-stream",
-    "tonic",
-    "tonic-prost",
-    "tower",
-    "tracing",
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "opentelemetry-semantic-conventions",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-types",
+ "reqwest",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -4054,18 +4054,18 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498a68e2a958e8aa9938f7db2c7147aad1b5a0ff2cd47c5ba4e10cb0dcb5bfc5"
 dependencies = [
-    "async-trait",
-    "bytes",
-    "google-cloud-gax",
-    "google-cloud-gax-internal",
-    "google-cloud-type",
-    "google-cloud-wkt",
-    "lazy_static",
-    "reqwest",
-    "serde",
-    "serde_json",
-    "serde_with",
-    "tracing",
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "lazy_static",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
 ]
 
 [[package]]
@@ -4074,18 +4074,18 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c80938e704401a47fdf36b51ec10e1a99b1ec22793d607afd0e67c7b675b8b3"
 dependencies = [
-    "async-trait",
-    "bytes",
-    "google-cloud-gax",
-    "google-cloud-gax-internal",
-    "google-cloud-rpc",
-    "google-cloud-wkt",
-    "lazy_static",
-    "reqwest",
-    "serde",
-    "serde_json",
-    "serde_with",
-    "tracing",
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "lazy_static",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
 ]
 
 [[package]]
@@ -4094,12 +4094,12 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49747b7b684b804a2d1040c2cdb21238b3d568a41ab9e36c423554509112f61d"
 dependencies = [
-    "google-cloud-gax",
-    "google-cloud-longrunning",
-    "google-cloud-rpc",
-    "google-cloud-wkt",
-    "serde",
-    "tokio",
+ "google-cloud-gax",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -4108,11 +4108,11 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd10e97751ca894f9dad6be69fcef1cb72f5bc187329e0254817778fc8235030"
 dependencies = [
-    "bytes",
-    "google-cloud-wkt",
-    "serde",
-    "serde_json",
-    "serde_with",
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -4121,41 +4121,41 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043be824d1b105bfdce786c720e45cae04e66436f8e5d0168e98ca8e5715ce9f"
 dependencies = [
-    "async-trait",
-    "base64",
-    "bytes",
-    "crc32c",
-    "futures",
-    "google-cloud-auth",
-    "google-cloud-gax",
-    "google-cloud-gax-internal",
-    "google-cloud-iam-v1",
-    "google-cloud-longrunning",
-    "google-cloud-lro",
-    "google-cloud-rpc",
-    "google-cloud-type",
-    "google-cloud-wkt",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "hyper",
-    "lazy_static",
-    "md5 0.8.0",
-    "mime",
-    "percent-encoding",
-    "pin-project",
-    "prost 0.14.3",
-    "prost-types",
-    "reqwest",
-    "serde",
-    "serde_json",
-    "serde_with",
-    "sha2 0.10.9",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-stream",
-    "tonic",
-    "tracing",
-    "uuid",
+ "async-trait",
+ "base64",
+ "bytes",
+ "crc32c",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-rpc",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper",
+ "lazy_static",
+ "md5 0.8.0",
+ "mime",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.14.3",
+ "prost-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4164,11 +4164,11 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9390ac2f3f9882ff42956b25ea65b9f546c8dd44c131726d75a96bf744ec75f6"
 dependencies = [
-    "bytes",
-    "google-cloud-wkt",
-    "serde",
-    "serde_json",
-    "serde_with",
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -4177,14 +4177,14 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f270e404be7ce76a3260abe0c3c71492ab2599ccd877f3253f3dd552f48cc9"
 dependencies = [
-    "base64",
-    "bytes",
-    "serde",
-    "serde_json",
-    "serde_with",
-    "thiserror 2.0.17",
-    "time",
-    "url",
+ "base64",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -4193,9 +4193,9 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
-    "ff 0.12.1",
-    "rand_core 0.6.4",
-    "subtle",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4204,9 +4204,9 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
-    "ff 0.13.1",
-    "rand_core 0.6.4",
-    "subtle",
+ "ff 0.13.1",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4215,17 +4215,17 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
-    "atomic-waker",
-    "bytes",
-    "fnv",
-    "futures-core",
-    "futures-sink",
-    "http 1.4.0",
-    "indexmap 2.13.0",
-    "slab",
-    "tokio",
-    "tokio-util",
-    "tracing",
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -4234,10 +4234,10 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
-    "cfg-if",
-    "crunchy",
-    "num-traits",
-    "zerocopy",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4246,7 +4246,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
-    "byteorder",
+ "byteorder",
 ]
 
 [[package]]
@@ -4261,8 +4261,8 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
-    "ahash",
-    "allocator-api2",
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -4271,9 +4271,9 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
-    "allocator-api2",
-    "equivalent",
-    "foldhash 0.1.5",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -4282,12 +4282,12 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
-    "allocator-api2",
-    "equivalent",
-    "foldhash 0.2.0",
-    "rayon",
-    "serde",
-    "serde_core",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "rayon",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4296,9 +4296,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d9ba66d1739c68e0219b2b2238b5c4145f491ebf181b9c6ab561a19352ae86"
 dependencies = [
-    "hax-lib-macros",
-    "num-bigint",
-    "num-traits",
+ "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -4307,11 +4307,11 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24ba777a231a58d1bce1d68313fa6b6afcc7966adef23d60f45b8a2b9b688bf1"
 dependencies = [
-    "hax-lib-macros-types",
-    "proc-macro-error2",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "hax-lib-macros-types",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4320,11 +4320,11 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "867e19177d7425140b417cd27c2e05320e727ee682e98368f88b7194e80ad515"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "serde",
-    "serde_json",
-    "uuid",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -4333,8 +4333,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
-    "hash32",
-    "stable_deref_trait",
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4349,17 +4349,17 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
 dependencies = [
-    "bitflags 2.10.0",
-    "byteorder",
-    "heed-traits",
-    "heed-types",
-    "libc",
-    "lmdb-master-sys",
-    "once_cell",
-    "page_size",
-    "serde",
-    "synchronoise",
-    "url",
+ "bitflags 2.10.0",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
 ]
 
 [[package]]
@@ -4374,11 +4374,11 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
 dependencies = [
-    "bincode",
-    "byteorder",
-    "heed-traits",
-    "serde",
-    "serde_json",
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4405,8 +4405,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
 dependencies = [
-    "outref",
-    "vsimd",
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -4421,7 +4421,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
-    "hmac 0.12.1",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4430,7 +4430,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
-    "digest 0.10.7",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4439,7 +4439,7 @@ version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
-    "digest 0.11.0-rc.5",
+ "digest 0.11.0-rc.5",
 ]
 
 [[package]]
@@ -4448,7 +4448,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
-    "windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4457,9 +4457,9 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
-    "bytes",
-    "fnv",
-    "itoa",
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -4468,8 +4468,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
-    "bytes",
-    "itoa",
+ "bytes",
+ "itoa",
 ]
 
 [[package]]
@@ -4478,9 +4478,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
-    "bytes",
-    "http 0.2.12",
-    "pin-project-lite",
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4489,8 +4489,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
-    "bytes",
-    "http 1.4.0",
+ "bytes",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -4499,11 +4499,11 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
-    "bytes",
-    "futures-core",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "pin-project-lite",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4530,8 +4530,8 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
 dependencies = [
-    "typenum",
-    "zeroize",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -4540,21 +4540,21 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
-    "atomic-waker",
-    "bytes",
-    "futures-channel",
-    "futures-core",
-    "h2",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "httparse",
-    "httpdate",
-    "itoa",
-    "pin-project-lite",
-    "pin-utils",
-    "smallvec",
-    "tokio",
-    "want",
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
 ]
 
 [[package]]
@@ -4563,17 +4563,17 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
-    "http 1.4.0",
-    "hyper",
-    "hyper-util",
-    "log",
-    "rustls",
-    "rustls-native-certs",
-    "rustls-pki-types",
-    "tokio",
-    "tokio-rustls",
-    "tower-service",
-    "webpki-roots",
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4582,11 +4582,11 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
-    "hyper",
-    "hyper-util",
-    "pin-project-lite",
-    "tokio",
-    "tower-service",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4595,24 +4595,24 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
-    "base64",
-    "bytes",
-    "futures-channel",
-    "futures-core",
-    "futures-util",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "hyper",
-    "ipnet",
-    "libc",
-    "percent-encoding",
-    "pin-project-lite",
-    "socket2",
-    "system-configuration",
-    "tokio",
-    "tower-service",
-    "tracing",
-    "windows-registry",
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4621,13 +4621,13 @@ version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
-    "android_system_properties",
-    "core-foundation-sys",
-    "iana-time-zone-haiku",
-    "js-sys",
-    "log",
-    "wasm-bindgen",
-    "windows-core 0.62.2",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4636,7 +4636,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
-    "cc",
+ "cc",
 ]
 
 [[package]]
@@ -4645,11 +4645,11 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
-    "displaydoc",
-    "potential_utf",
-    "yoke",
-    "zerofrom",
-    "zerovec",
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -4658,11 +4658,11 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
-    "displaydoc",
-    "litemap",
-    "tinystr",
-    "writeable",
-    "zerovec",
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -4671,12 +4671,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
-    "icu_collections",
-    "icu_normalizer_data",
-    "icu_properties",
-    "icu_provider",
-    "smallvec",
-    "zerovec",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
 ]
 
 [[package]]
@@ -4691,12 +4691,12 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
-    "icu_collections",
-    "icu_locale_core",
-    "icu_properties_data",
-    "icu_provider",
-    "zerotrie",
-    "zerovec",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -4711,13 +4711,13 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
-    "displaydoc",
-    "icu_locale_core",
-    "writeable",
-    "yoke",
-    "zerofrom",
-    "zerotrie",
-    "zerovec",
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -4732,9 +4732,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
-    "idna_adapter",
-    "smallvec",
-    "utf8_iter",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -4743,8 +4743,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
-    "icu_normalizer",
-    "icu_properties",
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -4753,9 +4753,9 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
-    "autocfg",
-    "hashbrown 0.12.3",
-    "serde",
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -4764,10 +4764,10 @@ version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
-    "equivalent",
-    "hashbrown 0.16.1",
-    "serde",
-    "serde_core",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4776,16 +4776,16 @@ version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
-    "ahash",
-    "indexmap 2.13.0",
-    "is-terminal",
-    "itoa",
-    "log",
-    "num-format",
-    "once_cell",
-    "quick-xml 0.26.0",
-    "rgb",
-    "str_stack",
+ "ahash",
+ "indexmap 2.13.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.26.0",
+ "rgb",
+ "str_stack",
 ]
 
 [[package]]
@@ -4794,20 +4794,20 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d35223c50fdd26419a4ccea2c73be68bd2b29a3d7d6123ffe101c17f4c20a52a"
 dependencies = [
-    "ahash",
-    "clap",
-    "crossbeam-channel",
-    "crossbeam-utils",
-    "dashmap",
-    "env_logger",
-    "indexmap 2.13.0",
-    "itoa",
-    "log",
-    "num-format",
-    "once_cell",
-    "quick-xml 0.38.4",
-    "rgb",
-    "str_stack",
+ "ahash",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger",
+ "indexmap 2.13.0",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.38.4",
+ "rgb",
+ "str_stack",
 ]
 
 [[package]]
@@ -4816,9 +4816,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
-    "bitflags 2.10.0",
-    "inotify-sys",
-    "libc",
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4827,7 +4827,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -4836,8 +4836,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
-    "block-padding",
-    "generic-array 0.14.7",
+ "block-padding",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4846,7 +4846,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
-    "hybrid-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -4861,29 +4861,29 @@ version = "0.6.16+upstream-0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe44f2bbd99fcb302e246e2d6bcf51aeda346d02a365f80296a07a8c711b6da6"
 dependencies = [
-    "argon2 0.5.3",
-    "bcrypt-pbkdf",
-    "digest 0.11.0-rc.5",
-    "ecdsa 0.16.9",
-    "ed25519-dalek 2.2.0",
-    "hex",
-    "hmac 0.12.1",
-    "num-bigint-dig",
-    "p256 0.13.2",
-    "p384",
-    "p521",
-    "rand_core 0.6.4",
-    "rsa",
-    "sec1 0.7.3",
-    "sha1 0.10.6",
-    "sha1 0.11.0-rc.3",
-    "sha2 0.10.9",
-    "signature 2.2.0",
-    "signature 3.0.0-rc.6",
-    "ssh-cipher 0.2.0",
-    "ssh-encoding 0.2.0",
-    "subtle",
-    "zeroize",
+ "argon2 0.5.3",
+ "bcrypt-pbkdf",
+ "digest 0.11.0-rc.5",
+ "ecdsa 0.16.9",
+ "ed25519-dalek 2.2.0",
+ "hex",
+ "hmac 0.12.1",
+ "num-bigint-dig",
+ "p256 0.13.2",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1 0.7.3",
+ "sha1 0.10.6",
+ "sha1 0.11.0-rc.3",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "signature 3.0.0-rc.6",
+ "ssh-cipher 0.2.0",
+ "ssh-encoding 0.2.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4898,7 +4898,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -4907,8 +4907,8 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
-    "memchr",
-    "serde",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -4917,9 +4917,9 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
-    "hermit-abi",
-    "libc",
-    "windows-sys 0.61.2",
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4940,7 +4940,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
-    "either",
+ "either",
 ]
 
 [[package]]
@@ -4949,7 +4949,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
-    "either",
+ "either",
 ]
 
 [[package]]
@@ -4964,15 +4964,15 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74ff642505c7ce8d31c0d43ec0e235c6fd4585d9b8172d8f9dd04d36590200b5"
 dependencies = [
-    "anyhow",
-    "libc",
-    "mappings",
-    "once_cell",
-    "pprof_util",
-    "tempfile",
-    "tikv-jemalloc-ctl",
-    "tokio",
-    "tracing",
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4981,8 +4981,8 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
-    "getrandom 0.3.4",
-    "libc",
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -4991,8 +4991,8 @@ version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
-    "once_cell",
-    "wasm-bindgen",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5001,15 +5001,15 @@ version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
 dependencies = [
-    "aws-lc-rs",
-    "base64",
-    "getrandom 0.2.17",
-    "js-sys",
-    "pem",
-    "serde",
-    "serde_json",
-    "signature 2.2.0",
-    "simple_asn1",
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -5018,8 +5018,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
-    "kqueue-sys",
-    "libc",
+ "kqueue-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5028,8 +5028,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
-    "bitflags 1.3.2",
-    "libc",
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -5038,9 +5038,9 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5c13b6857ade4c8ee05c3c3dc97d2ab5415d691213825b90d3211c425c1f907"
 dependencies = [
-    "lazy-regex-proc_macros",
-    "once_cell",
-    "regex",
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -5049,10 +5049,10 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a95c68db5d41694cea563c86a4ba4dc02141c16ef64814108cb23def4d5438"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "regex",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5061,7 +5061,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
-    "spin 0.9.8",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -5070,11 +5070,11 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
 dependencies = [
-    "lexical-parse-float",
-    "lexical-parse-integer",
-    "lexical-util",
-    "lexical-write-float",
-    "lexical-write-integer",
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
 ]
 
 [[package]]
@@ -5083,8 +5083,8 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
 dependencies = [
-    "lexical-parse-integer",
-    "lexical-util",
+ "lexical-parse-integer",
+ "lexical-util",
 ]
 
 [[package]]
@@ -5093,7 +5093,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
 dependencies = [
-    "lexical-util",
+ "lexical-util",
 ]
 
 [[package]]
@@ -5108,8 +5108,8 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
 dependencies = [
-    "lexical-util",
-    "lexical-write-integer",
+ "lexical-util",
+ "lexical-write-integer",
 ]
 
 [[package]]
@@ -5118,7 +5118,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
 dependencies = [
-    "lexical-util",
+ "lexical-util",
 ]
 
 [[package]]
@@ -5139,8 +5139,8 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc9ee7ef66569dd7516454fe26de4e401c0c62073929803486b96744594b9632"
 dependencies = [
-    "core-models",
-    "hax-lib",
+ "core-models",
+ "hax-lib",
 ]
 
 [[package]]
@@ -5149,14 +5149,14 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bb6a88086bf11bd2ec90926c749c4a427f2e59841437dbdede8cde8a96334ab"
 dependencies = [
-    "hax-lib",
-    "libcrux-intrinsics",
-    "libcrux-platform",
-    "libcrux-secrets",
-    "libcrux-sha3",
-    "libcrux-traits",
-    "rand 0.9.2",
-    "tls_codec",
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.9.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -5165,7 +5165,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db82d058aa76ea315a3b2092f69dfbd67ddb0e462038a206e1dcd73f058c0778"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -5174,7 +5174,7 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4dbbf6bc9f2bc0f20dc3bea3e5c99adff3bdccf6d2a40488963da69e2ec307"
 dependencies = [
-    "hax-lib",
+ "hax-lib",
 ]
 
 [[package]]
@@ -5183,10 +5183,10 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2400bec764d1c75b8a496d5747cffe32f1fb864a12577f0aca2f55a92021c962"
 dependencies = [
-    "hax-lib",
-    "libcrux-intrinsics",
-    "libcrux-platform",
-    "libcrux-traits",
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -5195,8 +5195,8 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034"
 dependencies = [
-    "libcrux-secrets",
-    "rand 0.9.2",
+ "libcrux-secrets",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -5205,8 +5205,8 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
-    "cfg-if",
-    "windows-link 0.2.1",
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5221,8 +5221,8 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
-    "cc",
-    "libc",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5231,9 +5231,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
-    "bitflags 2.10.0",
-    "libc",
-    "redox_syscall 0.7.0",
+ "bitflags 2.10.0",
+ "libc",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -5242,16 +5242,16 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19c97a761fc86953c5b885422b22c891dbf5bcb9dcc99d0110d6ce4c052759f0"
 dependencies = [
-    "hmac 0.12.1",
-    "libc",
-    "log",
-    "nix 0.29.0",
-    "nom 8.0.0",
-    "once_cell",
-    "serde",
-    "sha2 0.10.9",
-    "thiserror 2.0.17",
-    "uuid",
+ "hmac 0.12.1",
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "nom 8.0.0",
+ "once_cell",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "uuid",
 ]
 
 [[package]]
@@ -5260,33 +5260,33 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8270fae0f77279620962f533153fa727a9cf9485dbb79d47eed3086d42b17264"
 dependencies = [
-    "async-trait",
-    "bitflags 2.10.0",
-    "bytes",
-    "chrono",
-    "dashmap",
-    "derive_more",
-    "futures-util",
-    "getrandom 0.3.4",
-    "lazy_static",
-    "libc",
-    "md-5 0.10.6",
-    "moka",
-    "nix 0.29.0",
-    "prometheus",
-    "proxy-protocol",
-    "rustls",
-    "rustls-pemfile",
-    "slog",
-    "slog-stdlog",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-rustls",
-    "tokio-util",
-    "tracing",
-    "tracing-attributes",
-    "uuid",
-    "x509-parser 0.17.0",
+ "async-trait",
+ "bitflags 2.10.0",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "derive_more",
+ "futures-util",
+ "getrandom 0.3.4",
+ "lazy_static",
+ "libc",
+ "md-5 0.10.6",
+ "moka",
+ "nix 0.29.0",
+ "prometheus",
+ "proxy-protocol",
+ "rustls",
+ "rustls-pemfile",
+ "slog",
+ "slog-stdlog",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "tracing-attributes",
+ "uuid",
+ "x509-parser 0.17.0",
 ]
 
 [[package]]
@@ -5313,9 +5313,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
 dependencies = [
-    "cc",
-    "doxygen-rs",
-    "libc",
+ "cc",
+ "doxygen-rs",
+ "libc",
 ]
 
 [[package]]
@@ -5324,10 +5324,10 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a60bf300a990b2d1ebdde4228e873e8e4da40d834adbf5265f3da1457ede652"
 dependencies = [
-    "libc",
-    "neli",
-    "thiserror 2.0.17",
-    "windows-sys 0.61.2",
+ "libc",
+ "neli",
+ "thiserror 2.0.17",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5336,7 +5336,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
-    "scopeguard",
+ "scopeguard",
 ]
 
 [[package]]
@@ -5345,8 +5345,8 @@ version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
-    "serde_core",
-    "value-bag",
+ "serde_core",
+ "value-bag",
 ]
 
 [[package]]
@@ -5355,7 +5355,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
-    "hashbrown 0.15.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5370,7 +5370,7 @@ version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
 dependencies = [
-    "lz4-sys",
+ "lz4-sys",
 ]
 
 [[package]]
@@ -5379,8 +5379,8 @@ version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
-    "cc",
-    "libc",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5389,7 +5389,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
 dependencies = [
-    "twox-hash",
+ "twox-hash",
 ]
 
 [[package]]
@@ -5398,8 +5398,8 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fa48f5024824ecd3e8282cc948bd46fbd095aed5a98939de0594601a59b4e2b"
 dependencies = [
-    "crc",
-    "sha2 0.10.9",
+ "crc",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5408,9 +5408,9 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
 dependencies = [
-    "cc",
-    "libc",
-    "pkg-config",
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5419,11 +5419,11 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4d277bb50d4508057e7bddd7fcd19ef4a4cc38051b6a5a36868d75ae2cbeb9"
 dependencies = [
-    "anyhow",
-    "libc",
-    "once_cell",
-    "pprof_util",
-    "tracing",
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
 ]
 
 [[package]]
@@ -5432,7 +5432,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
-    "regex-automata",
+ "regex-automata",
 ]
 
 [[package]]
@@ -5453,8 +5453,8 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
-    "cfg-if",
-    "digest 0.10.7",
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5463,8 +5463,8 @@ version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64dd2c9099caf8e29b629305199dddb1c6d981562b62c089afea54b0b4b5c333"
 dependencies = [
-    "cfg-if",
-    "digest 0.11.0-rc.5",
+ "cfg-if",
+ "digest 0.11.0-rc.5",
 ]
 
 [[package]]
@@ -5491,7 +5491,7 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -5500,7 +5500,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
-    "autocfg",
+ "autocfg",
 ]
 
 [[package]]
@@ -5509,8 +5509,8 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
-    "ahash",
-    "portable-atomic",
+ "ahash",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -5519,7 +5519,7 @@ version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
-    "libmimalloc-sys",
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5534,8 +5534,8 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
-    "mime",
-    "unicase",
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -5550,8 +5550,8 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
-    "adler2",
-    "simd-adler32",
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -5560,10 +5560,10 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
-    "libc",
-    "log",
-    "wasi",
-    "windows-sys 0.61.2",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5572,18 +5572,18 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
 dependencies = [
-    "async-lock",
-    "crossbeam-channel",
-    "crossbeam-epoch",
-    "crossbeam-utils",
-    "equivalent",
-    "event-listener",
-    "futures-util",
-    "parking_lot",
-    "portable-atomic",
-    "smallvec",
-    "tagptr",
-    "uuid",
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -5598,14 +5598,14 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e23bebbf3e157c402c4d5ee113233e5e0610cc27453b2f07eefce649c7365dcc"
 dependencies = [
-    "bitflags 2.10.0",
-    "byteorder",
-    "derive_builder 0.20.2",
-    "getset",
-    "libc",
-    "log",
-    "neli-proc-macros",
-    "parking_lot",
+ "bitflags 2.10.0",
+ "byteorder",
+ "derive_builder 0.20.2",
+ "getset",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "parking_lot",
 ]
 
 [[package]]
@@ -5614,11 +5614,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
 dependencies = [
-    "either",
-    "proc-macro2",
-    "quote",
-    "serde",
-    "syn 2.0.114",
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5627,8 +5627,8 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29a01b9f018d6b7b277fef6c79fdbd9bf17bb2d1e298238055cafab49baa5ee"
 dependencies = [
-    "libc",
-    "winapi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5637,9 +5637,9 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
-    "bitflags 1.3.2",
-    "cfg-if",
-    "libc",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -5648,11 +5648,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
-    "bitflags 2.10.0",
-    "cfg-if",
-    "cfg_aliases",
-    "libc",
-    "memoffset",
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -5661,10 +5661,10 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
-    "bitflags 2.10.0",
-    "cfg-if",
-    "cfg_aliases",
-    "libc",
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -5673,8 +5673,8 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
-    "memchr",
-    "minimal-lexical",
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -5683,7 +5683,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -5692,16 +5692,16 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
-    "bitflags 2.10.0",
-    "fsevent-sys",
-    "inotify",
-    "kqueue",
-    "libc",
-    "log",
-    "mio",
-    "notify-types",
-    "walkdir",
-    "windows-sys 0.60.2",
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5710,10 +5710,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
 dependencies = [
-    "log",
-    "notify",
-    "notify-types",
-    "tempfile",
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
 ]
 
 [[package]]
@@ -5728,7 +5728,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
 dependencies = [
-    "winapi",
+ "winapi",
 ]
 
 [[package]]
@@ -5737,7 +5737,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
-    "windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5746,12 +5746,12 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
-    "num-bigint",
-    "num-complex",
-    "num-integer",
-    "num-iter",
-    "num-rational",
-    "num-traits",
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -5760,9 +5760,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
-    "num-integer",
-    "num-traits",
-    "rand 0.8.5",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5771,14 +5771,14 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
-    "lazy_static",
-    "libm",
-    "num-integer",
-    "num-iter",
-    "num-traits",
-    "rand 0.8.5",
-    "serde",
-    "smallvec",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -5787,7 +5787,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
-    "num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -5802,8 +5802,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
-    "arrayvec",
-    "itoa",
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -5812,7 +5812,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
-    "num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -5821,9 +5821,9 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
-    "autocfg",
-    "num-integer",
-    "num-traits",
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -5832,9 +5832,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
-    "num-bigint",
-    "num-integer",
-    "num-traits",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -5843,8 +5843,8 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
-    "autocfg",
-    "libm",
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5853,8 +5853,8 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
-    "hermit-abi",
-    "libc",
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5863,7 +5863,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -5878,12 +5878,12 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
 dependencies = [
-    "bitflags 2.10.0",
-    "libloading",
-    "nvml-wrapper-sys",
-    "static_assertions",
-    "thiserror 1.0.69",
-    "wrapcenum-derive",
+ "bitflags 2.10.0",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
 ]
 
 [[package]]
@@ -5892,7 +5892,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
 dependencies = [
-    "libloading",
+ "libloading",
 ]
 
 [[package]]
@@ -5901,7 +5901,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
-    "bitflags 2.10.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -5910,8 +5910,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
-    "libc",
-    "objc2-core-foundation",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -5920,7 +5920,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -5929,7 +5929,7 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -5938,22 +5938,22 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
 dependencies = [
-    "async-trait",
-    "bytes",
-    "chrono",
-    "futures",
-    "http 1.4.0",
-    "humantime",
-    "itertools 0.14.0",
-    "parking_lot",
-    "percent-encoding",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "url",
-    "walkdir",
-    "wasm-bindgen-futures",
-    "web-time",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -5962,7 +5962,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
-    "asn1-rs",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -6001,12 +6001,12 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
-    "futures-core",
-    "futures-sink",
-    "js-sys",
-    "pin-project-lite",
-    "thiserror 2.0.17",
-    "tracing",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+ "tracing",
 ]
 
 [[package]]
@@ -6015,12 +6015,12 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
-    "opentelemetry",
-    "tracing",
-    "tracing-core",
-    "tracing-log",
-    "tracing-opentelemetry",
-    "tracing-subscriber",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6029,11 +6029,11 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
-    "async-trait",
-    "bytes",
-    "http 1.4.0",
-    "opentelemetry",
-    "reqwest",
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
 ]
 
 [[package]]
@@ -6042,16 +6042,16 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
-    "flate2",
-    "http 1.4.0",
-    "opentelemetry",
-    "opentelemetry-http",
-    "opentelemetry-proto",
-    "opentelemetry_sdk",
-    "prost 0.14.3",
-    "reqwest",
-    "thiserror 2.0.17",
-    "tracing",
+ "flate2",
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.3",
+ "reqwest",
+ "thiserror 2.0.17",
+ "tracing",
 ]
 
 [[package]]
@@ -6060,11 +6060,11 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
-    "opentelemetry",
-    "opentelemetry_sdk",
-    "prost 0.14.3",
-    "tonic",
-    "tonic-prost",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.3",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -6079,9 +6079,9 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
 dependencies = [
-    "chrono",
-    "opentelemetry",
-    "opentelemetry_sdk",
+ "chrono",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -6090,15 +6090,15 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
-    "futures-channel",
-    "futures-executor",
-    "futures-util",
-    "opentelemetry",
-    "percent-encoding",
-    "rand 0.9.2",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-stream",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -6113,7 +6113,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
-    "num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -6128,9 +6128,9 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
-    "ecdsa 0.14.8",
-    "elliptic-curve 0.12.3",
-    "sha2 0.10.9",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6139,10 +6139,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
-    "ecdsa 0.16.9",
-    "elliptic-curve 0.13.8",
-    "primeorder",
-    "sha2 0.10.9",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6151,10 +6151,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
-    "ecdsa 0.16.9",
-    "elliptic-curve 0.13.8",
-    "primeorder",
-    "sha2 0.10.9",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6163,12 +6163,12 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
-    "base16ct 0.2.0",
-    "ecdsa 0.16.9",
-    "elliptic-curve 0.13.8",
-    "primeorder",
-    "rand_core 0.6.4",
-    "sha2 0.10.9",
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6177,8 +6177,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
-    "libc",
-    "winapi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -6187,17 +6187,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595"
 dependencies = [
-    "byteorder",
-    "bytes",
-    "delegate",
-    "futures",
-    "log",
-    "rand 0.8.5",
-    "sha2 0.10.9",
-    "thiserror 1.0.69",
-    "tokio",
-    "windows 0.62.2",
-    "windows-strings 0.5.1",
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows 0.62.2",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6212,8 +6212,8 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
-    "lock_api",
-    "parking_lot_core",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -6222,11 +6222,11 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
-    "cfg-if",
-    "libc",
-    "redox_syscall 0.5.18",
-    "smallvec",
-    "windows-link 0.2.1",
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6235,35 +6235,35 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6a2926a30477c0b95fea6c28c3072712b139337a242c2cc64817bdc20a8854"
 dependencies = [
-    "ahash",
-    "arrow-array",
-    "arrow-buffer",
-    "arrow-cast",
-    "arrow-data",
-    "arrow-ipc",
-    "arrow-schema",
-    "arrow-select",
-    "base64",
-    "brotli 8.0.2",
-    "bytes",
-    "chrono",
-    "flate2",
-    "futures",
-    "half",
-    "hashbrown 0.16.1",
-    "lz4_flex",
-    "num-bigint",
-    "num-integer",
-    "num-traits",
-    "object_store",
-    "paste",
-    "seq-macro",
-    "simdutf8",
-    "snap",
-    "thrift",
-    "tokio",
-    "twox-hash",
-    "zstd",
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli 8.0.2",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "object_store",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -6272,9 +6272,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
-    "base64ct",
-    "rand_core 0.6.4",
-    "subtle",
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -6283,8 +6283,8 @@ version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f77af9403a6489b7b51f552693bd48d8e81a710c92d3d77648b203558578762d"
 dependencies = [
-    "getrandom 0.4.0-rc.0",
-    "phc",
+ "getrandom 0.4.0-rc.0",
+ "phc",
 ]
 
 [[package]]
@@ -6311,7 +6311,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
 dependencies = [
-    "path-dedot",
+ "path-dedot",
 ]
 
 [[package]]
@@ -6326,7 +6326,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
 dependencies = [
-    "once_cell",
+ "once_cell",
 ]
 
 [[package]]
@@ -6335,8 +6335,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
-    "digest 0.10.7",
-    "hmac 0.12.1",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -6345,8 +6345,8 @@ version = "0.13.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9b101849c3ddab38905781f5aa7ae14ea06e87befaf0e7b003e5d3186250d"
 dependencies = [
-    "digest 0.11.0-rc.5",
-    "hmac 0.13.0-rc.3",
+ "digest 0.11.0-rc.5",
+ "hmac 0.13.0-rc.3",
 ]
 
 [[package]]
@@ -6355,8 +6355,8 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
-    "base64",
-    "serde_core",
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -6365,7 +6365,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
-    "base64ct",
+ "base64ct",
 ]
 
 [[package]]
@@ -6374,7 +6374,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
-    "base64ct",
+ "base64ct",
 ]
 
 [[package]]
@@ -6389,10 +6389,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
-    "fixedbitset",
-    "hashbrown 0.15.5",
-    "indexmap 2.13.0",
-    "serde",
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "serde",
 ]
 
 [[package]]
@@ -6401,9 +6401,9 @@ version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d390c5fe8d102c2c18ff39f1e72b9ad5996de282c2d831b0312f56910f5508"
 dependencies = [
-    "base64ct",
-    "getrandom 0.4.0-rc.0",
-    "subtle",
+ "base64ct",
+ "getrandom 0.4.0-rc.0",
+ "subtle",
 ]
 
 [[package]]
@@ -6412,8 +6412,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
-    "phf_macros",
-    "phf_shared 0.11.3",
+ "phf_macros",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -6422,7 +6422,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
-    "phf_shared 0.12.1",
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -6431,8 +6431,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
-    "phf_shared 0.11.3",
-    "rand 0.8.5",
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6441,11 +6441,11 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
-    "phf_generator",
-    "phf_shared 0.11.3",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6454,7 +6454,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
-    "siphasher",
+ "siphasher",
 ]
 
 [[package]]
@@ -6463,7 +6463,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
-    "siphasher",
+ "siphasher",
 ]
 
 [[package]]
@@ -6472,7 +6472,7 @@ version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
-    "pin-project-internal",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -6481,9 +6481,9 @@ version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6504,8 +6504,8 @@ version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
-    "der 0.8.0-rc.10",
-    "spki 0.8.0-rc.4",
+ "der 0.8.0-rc.10",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -6514,13 +6514,13 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
-    "aes 0.8.4",
-    "cbc",
-    "der 0.7.10",
-    "pbkdf2 0.12.2",
-    "scrypt",
-    "sha2 0.10.9",
-    "spki 0.7.3",
+ "aes 0.8.4",
+ "cbc",
+ "der 0.7.10",
+ "pbkdf2 0.12.2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -6529,8 +6529,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
-    "der 0.6.1",
-    "spki 0.6.0",
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -6539,10 +6539,10 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
-    "der 0.7.10",
-    "pkcs5",
-    "rand_core 0.6.4",
-    "spki 0.7.3",
+ "der 0.7.10",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -6551,8 +6551,8 @@ version = "0.11.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77089aec8290d0b7bb01b671b091095cf1937670725af4fd73d47249f03b12c0"
 dependencies = [
-    "der 0.8.0-rc.10",
-    "spki 0.8.0-rc.4",
+ "der 0.8.0-rc.10",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -6567,11 +6567,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
-    "num-traits",
-    "plotters-backend",
-    "plotters-svg",
-    "wasm-bindgen",
-    "web-sys",
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -6586,7 +6586,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
-    "plotters-backend",
+ "plotters-backend",
 ]
 
 [[package]]
@@ -6601,9 +6601,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
-    "cpufeatures",
-    "opaque-debug",
-    "universal-hash 0.5.1",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -6612,9 +6612,9 @@ version = "0.9.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c0749ae91cfe6e68c77c4d48802d9720ee06aed3f7100a38975fb0962d50bc"
 dependencies = [
-    "cpufeatures",
-    "universal-hash 0.6.0-rc.4",
-    "zeroize",
+ "cpufeatures",
+ "universal-hash 0.6.0-rc.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -6623,10 +6623,10 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "opaque-debug",
-    "universal-hash 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -6635,9 +6635,9 @@ version = "0.7.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad60831c19edda4b20878a676595c357e93a9b4e6dca2ba98d75b01066b317b"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "universal-hash 0.6.0-rc.4",
+ "cfg-if",
+ "cpufeatures",
+ "universal-hash 0.6.0-rc.4",
 ]
 
 [[package]]
@@ -6652,7 +6652,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
-    "zerovec",
+ "zerovec",
 ]
 
 [[package]]
@@ -6673,22 +6673,22 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
-    "aligned-vec",
-    "backtrace",
-    "cfg-if",
-    "findshlibs",
-    "inferno 0.11.21",
-    "libc",
-    "log",
-    "nix 0.26.4",
-    "once_cell",
-    "protobuf",
-    "protobuf-codegen",
-    "smallvec",
-    "spin 0.10.0",
-    "symbolic-demangle",
-    "tempfile",
-    "thiserror 2.0.17",
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno 0.11.21",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "protobuf",
+ "protobuf-codegen",
+ "smallvec",
+ "spin 0.10.0",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -6697,13 +6697,13 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4429d44e5e2c8a69399fc0070379201eed018e3df61e04eb7432811df073c224"
 dependencies = [
-    "anyhow",
-    "backtrace",
-    "flate2",
-    "inferno 0.12.4",
-    "num",
-    "paste",
-    "prost 0.13.5",
+ "anyhow",
+ "backtrace",
+ "flate2",
+ "inferno 0.12.4",
+ "num",
+ "paste",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -6712,7 +6712,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
-    "zerocopy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6721,8 +6721,8 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
-    "diff",
-    "yansi",
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -6731,8 +6731,8 @@ version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
-    "proc-macro2",
-    "syn 2.0.114",
+ "proc-macro2",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6741,7 +6741,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
-    "elliptic-curve 0.13.8",
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -6750,7 +6750,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
-    "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -6759,8 +6759,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
-    "proc-macro2",
-    "quote",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -6769,10 +6769,10 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
-    "proc-macro-error-attr2",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6781,7 +6781,7 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
-    "unicode-ident",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -6790,12 +6790,12 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
-    "cfg-if",
-    "fnv",
-    "lazy_static",
-    "memchr",
-    "parking_lot",
-    "thiserror 2.0.17",
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -6804,8 +6804,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
-    "bytes",
-    "prost-derive 0.13.5",
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -6814,8 +6814,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
-    "bytes",
-    "prost-derive 0.14.3",
+ "bytes",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -6824,19 +6824,19 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
-    "heck",
-    "itertools 0.14.0",
-    "log",
-    "multimap",
-    "petgraph",
-    "prettyplease",
-    "prost 0.14.3",
-    "prost-types",
-    "pulldown-cmark",
-    "pulldown-cmark-to-cmark",
-    "regex",
-    "syn 2.0.114",
-    "tempfile",
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost 0.14.3",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.114",
+ "tempfile",
 ]
 
 [[package]]
@@ -6845,11 +6845,11 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
-    "anyhow",
-    "itertools 0.14.0",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6858,11 +6858,11 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
-    "anyhow",
-    "itertools 0.14.0",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6871,7 +6871,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
-    "prost 0.14.3",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -6880,9 +6880,9 @@ version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
-    "once_cell",
-    "protobuf-support",
-    "thiserror 1.0.69",
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6891,13 +6891,13 @@ version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
-    "anyhow",
-    "once_cell",
-    "protobuf",
-    "protobuf-parse",
-    "regex",
-    "tempfile",
-    "thiserror 1.0.69",
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6906,14 +6906,14 @@ version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
-    "anyhow",
-    "indexmap 2.13.0",
-    "log",
-    "protobuf",
-    "protobuf-support",
-    "tempfile",
-    "thiserror 1.0.69",
-    "which",
+ "anyhow",
+ "indexmap 2.13.0",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which",
 ]
 
 [[package]]
@@ -6922,7 +6922,7 @@ version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
-    "thiserror 1.0.69",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6931,8 +6931,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e50c72c21c738f5c5f350cc33640aee30bf7cd20f9d9da20ed41bce2671d532"
 dependencies = [
-    "bytes",
-    "snafu 0.6.10",
+ "bytes",
+ "snafu 0.6.10",
 ]
 
 [[package]]
@@ -6941,8 +6941,8 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
 dependencies = [
-    "ar_archive_writer",
-    "cc",
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -6951,9 +6951,9 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
-    "bitflags 2.10.0",
-    "memchr",
-    "unicase",
+ "bitflags 2.10.0",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -6962,7 +6962,7 @@ version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
-    "pulldown-cmark",
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -6971,7 +6971,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -6980,8 +6980,8 @@ version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
-    "memchr",
-    "serde",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -6990,7 +6990,7 @@ version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -6999,9 +6999,9 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2e3bf4aa9d243beeb01a7b3bc30b77cfe2c44e24ec02d751a7104a53c2c49a1"
 dependencies = [
-    "memchr",
-    "serde",
-    "tokio",
+ "memchr",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -7010,18 +7010,18 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
-    "bytes",
-    "cfg_aliases",
-    "pin-project-lite",
-    "quinn-proto",
-    "quinn-udp",
-    "rustc-hash",
-    "rustls",
-    "socket2",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "web-time",
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -7030,19 +7030,19 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
-    "bytes",
-    "getrandom 0.3.4",
-    "lru-slab",
-    "rand 0.9.2",
-    "ring",
-    "rustc-hash",
-    "rustls",
-    "rustls-pki-types",
-    "slab",
-    "thiserror 2.0.17",
-    "tinyvec",
-    "tracing",
-    "web-time",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -7051,12 +7051,12 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
-    "cfg_aliases",
-    "libc",
-    "once_cell",
-    "socket2",
-    "tracing",
-    "windows-sys 0.60.2",
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7065,7 +7065,7 @@ version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
-    "proc-macro2",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -7080,9 +7080,9 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
-    "libc",
-    "rand_chacha 0.3.1",
-    "rand_core 0.6.4",
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7091,8 +7091,8 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
-    "rand_chacha 0.9.0",
-    "rand_core 0.9.3",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -7101,10 +7101,10 @@ version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bccc05ac8fad6ee391f3cc6725171817eed960345e2fb42ad229d486c1ca2d98"
 dependencies = [
-    "chacha20 0.10.0-rc.6",
-    "getrandom 0.4.0-rc.0",
-    "rand_core 0.10.0-rc-3",
-    "serde",
+ "chacha20 0.10.0-rc.6",
+ "getrandom 0.4.0-rc.0",
+ "rand_core 0.10.0-rc-3",
+ "serde",
 ]
 
 [[package]]
@@ -7113,8 +7113,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
-    "ppv-lite86",
-    "rand_core 0.6.4",
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7123,8 +7123,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
-    "ppv-lite86",
-    "rand_core 0.9.3",
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -7133,7 +7133,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
-    "getrandom 0.2.17",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -7142,7 +7142,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
-    "getrandom 0.3.4",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -7157,8 +7157,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
-    "either",
-    "rayon-core",
+ "either",
+ "rayon-core",
 ]
 
 [[package]]
@@ -7167,8 +7167,8 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
-    "crossbeam-deque",
-    "crossbeam-utils",
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -7177,12 +7177,12 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec0a99f2de91c3cddc84b37e7db80e4d96b743e05607f647eb236fc0455907f"
 dependencies = [
-    "pem",
-    "ring",
-    "rustls-pki-types",
-    "time",
-    "x509-parser 0.18.0",
-    "yasna",
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.18.0",
+ "yasna",
 ]
 
 [[package]]
@@ -7197,8 +7197,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
 dependencies = [
-    "recursive-proc-macro-impl",
-    "stacker",
+ "recursive-proc-macro-impl",
+ "stacker",
 ]
 
 [[package]]
@@ -7207,8 +7207,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
-    "quote",
-    "syn 2.0.114",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7217,7 +7217,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
-    "bitflags 2.10.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -7226,7 +7226,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
-    "bitflags 2.10.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -7235,9 +7235,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
-    "getrandom 0.2.17",
-    "libredox",
-    "thiserror 2.0.17",
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7246,10 +7246,10 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
 dependencies = [
-    "cpufeatures",
-    "fixedbitset",
-    "once_cell",
-    "readme-rustdocifier",
+ "cpufeatures",
+ "fixedbitset",
+ "once_cell",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -7258,7 +7258,7 @@ version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
-    "ref-cast-impl",
+ "ref-cast-impl",
 ]
 
 [[package]]
@@ -7267,9 +7267,9 @@ version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7278,10 +7278,10 @@ version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
-    "aho-corasick",
-    "memchr",
-    "regex-automata",
-    "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -7290,9 +7290,9 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
-    "aho-corasick",
-    "memchr",
-    "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -7319,45 +7319,45 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
-    "base64",
-    "bytes",
-    "encoding_rs",
-    "futures-channel",
-    "futures-core",
-    "futures-util",
-    "h2",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "hyper",
-    "hyper-rustls",
-    "hyper-util",
-    "js-sys",
-    "log",
-    "mime",
-    "mime_guess",
-    "percent-encoding",
-    "pin-project-lite",
-    "quinn",
-    "rustls",
-    "rustls-native-certs",
-    "rustls-pki-types",
-    "serde",
-    "serde_json",
-    "serde_urlencoded",
-    "sync_wrapper",
-    "tokio",
-    "tokio-rustls",
-    "tokio-util",
-    "tower",
-    "tower-http",
-    "tower-service",
-    "url",
-    "wasm-bindgen",
-    "wasm-bindgen-futures",
-    "wasm-streams",
-    "web-sys",
-    "webpki-roots",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7366,9 +7366,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
-    "crypto-bigint 0.4.9",
-    "hmac 0.12.1",
-    "zeroize",
+ "crypto-bigint 0.4.9",
+ "hmac 0.12.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -7377,8 +7377,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
-    "hmac 0.12.1",
-    "subtle",
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -7387,7 +7387,7 @@ version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 dependencies = [
-    "bytemuck",
+ "bytemuck",
 ]
 
 [[package]]
@@ -7396,12 +7396,12 @@ version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
-    "cc",
-    "cfg-if",
-    "getrandom 0.2.17",
-    "libc",
-    "untrusted 0.9.0",
-    "windows-sys 0.52.0",
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7410,20 +7410,20 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa"
 dependencies = [
-    "async-trait",
-    "base64",
-    "chrono",
-    "futures",
-    "pastey 0.2.1",
-    "pin-project-lite",
-    "rmcp-macros",
-    "schemars 1.2.0",
-    "serde",
-    "serde_json",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-util",
-    "tracing",
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey 0.2.1",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -7432,11 +7432,11 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3f81daaa494eb8e985c9462f7d6ce1ab05e5299f48aafd76cdd3d8b060e6f59"
 dependencies = [
-    "darling 0.23.0",
-    "proc-macro2",
-    "quote",
-    "serde_json",
-    "syn 2.0.114",
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7445,7 +7445,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
 dependencies = [
-    "num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -7454,8 +7454,8 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
-    "rmp",
-    "serde",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -7464,17 +7464,17 @@ version = "0.10.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27d813937fdf8e9ad15e3e422a55da4021d29639000139ca19d99f3949060da"
 dependencies = [
-    "const-oid 0.10.2",
-    "crypto-bigint 0.7.0-rc.15",
-    "crypto-primes",
-    "digest 0.11.0-rc.5",
-    "pkcs1",
-    "pkcs8 0.11.0-rc.8",
-    "rand_core 0.10.0-rc-3",
-    "sha2 0.11.0-rc.3",
-    "signature 3.0.0-rc.6",
-    "spki 0.8.0-rc.4",
-    "zeroize",
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.0-rc.15",
+ "crypto-primes",
+ "digest 0.11.0-rc.5",
+ "pkcs1",
+ "pkcs8 0.11.0-rc.8",
+ "rand_core 0.10.0-rc-3",
+ "sha2 0.11.0-rc.3",
+ "signature 3.0.0-rc.6",
+ "spki 0.8.0-rc.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -7483,9 +7483,9 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
-    "futures-timer",
-    "futures-util",
-    "rstest_macros",
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
 ]
 
 [[package]]
@@ -7494,16 +7494,16 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
-    "cfg-if",
-    "glob",
-    "proc-macro-crate",
-    "proc-macro2",
-    "quote",
-    "regex",
-    "relative-path",
-    "rustc_version",
-    "syn 2.0.114",
-    "unicode-ident",
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.114",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -7512,19 +7512,19 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0feff8d882bff0b2fddaf99355a10336d43dd3ed44204f85ece28cf9626ab519"
 dependencies = [
-    "bytes",
-    "fixedbitset",
-    "flume",
-    "futures-util",
-    "log",
-    "rustls-native-certs",
-    "rustls-pemfile",
-    "rustls-webpki 0.102.8",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-rustls",
-    "tokio-stream",
-    "tokio-util",
+ "bytes",
+ "fixedbitset",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7533,59 +7533,59 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbb7dcdd62c17ac911307ff693f55b3ec6712004d2d66ffdb8c0fa00269fd66"
 dependencies = [
-    "aes 0.8.4",
-    "aws-lc-rs",
-    "bitflags 2.10.0",
-    "block-padding",
-    "byteorder",
-    "bytes",
-    "cbc",
-    "ctr 0.9.2",
-    "curve25519-dalek 4.1.3",
-    "data-encoding",
-    "delegate",
-    "der 0.7.10",
-    "digest 0.10.7",
-    "ecdsa 0.16.9",
-    "ed25519-dalek 2.2.0",
-    "elliptic-curve 0.13.8",
-    "enum_dispatch",
-    "futures",
-    "generic-array 1.3.5",
-    "getrandom 0.2.17",
-    "hex-literal",
-    "hmac 0.12.1",
-    "home",
-    "inout 0.1.4",
-    "internal-russh-forked-ssh-key",
-    "libcrux-ml-kem",
-    "log",
-    "md5 0.7.0",
-    "num-bigint",
-    "p256 0.13.2",
-    "p384",
-    "p521",
-    "pageant",
-    "pbkdf2 0.12.2",
-    "pkcs1",
-    "pkcs5",
-    "pkcs8 0.10.2",
-    "rand 0.8.5",
-    "rand_core 0.6.4",
-    "rsa",
-    "russh-cryptovec",
-    "russh-util",
-    "sec1 0.7.3",
-    "sha1 0.10.6",
-    "sha2 0.10.9",
-    "signature 2.2.0",
-    "spki 0.7.3",
-    "ssh-encoding 0.2.0",
-    "subtle",
-    "thiserror 1.0.69",
-    "tokio",
-    "typenum",
-    "zeroize",
+ "aes 0.8.4",
+ "aws-lc-rs",
+ "bitflags 2.10.0",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ctr 0.9.2",
+ "curve25519-dalek 4.1.3",
+ "data-encoding",
+ "delegate",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "ecdsa 0.16.9",
+ "ed25519-dalek 2.2.0",
+ "elliptic-curve 0.13.8",
+ "enum_dispatch",
+ "futures",
+ "generic-array 1.3.5",
+ "getrandom 0.2.17",
+ "hex-literal",
+ "hmac 0.12.1",
+ "home",
+ "inout 0.1.4",
+ "internal-russh-forked-ssh-key",
+ "libcrux-ml-kem",
+ "log",
+ "md5 0.7.0",
+ "num-bigint",
+ "p256 0.13.2",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2 0.12.2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8 0.10.2",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1 0.7.3",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "ssh-encoding 0.2.0",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -7594,11 +7594,11 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb0ed583ff0f6b4aa44c7867dd7108df01b30571ee9423e250b4cc939f8c6cf"
 dependencies = [
-    "libc",
-    "log",
-    "nix 0.29.0",
-    "ssh-encoding 0.2.0",
-    "winapi",
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "ssh-encoding 0.2.0",
+ "winapi",
 ]
 
 [[package]]
@@ -7607,15 +7607,15 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5"
 dependencies = [
-    "bitflags 2.10.0",
-    "bytes",
-    "chrono",
-    "flurry",
-    "log",
-    "serde",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-util",
+ "bitflags 2.10.0",
+ "bytes",
+ "chrono",
+ "flurry",
+ "log",
+ "serde",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7624,10 +7624,10 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
 dependencies = [
-    "chrono",
-    "tokio",
-    "wasm-bindgen",
-    "wasm-bindgen-futures",
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -7636,9 +7636,9 @@ version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
 dependencies = [
-    "rust-embed-impl",
-    "rust-embed-utils",
-    "walkdir",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
 ]
 
 [[package]]
@@ -7647,12 +7647,12 @@ version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "rust-embed-utils",
-    "shellexpand",
-    "syn 2.0.114",
-    "walkdir",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "shellexpand",
+ "syn 2.0.114",
+ "walkdir",
 ]
 
 [[package]]
@@ -7661,8 +7661,8 @@ version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
-    "sha2 0.10.9",
-    "walkdir",
+ "sha2 0.10.9",
+ "walkdir",
 ]
 
 [[package]]
@@ -7683,712 +7683,712 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
-    "semver",
+ "semver",
 ]
 
 [[package]]
 name = "rustfs"
 version = "0.0.5"
 dependencies = [
-    "astral-tokio-tar",
-    "async-trait",
-    "atoi",
-    "atomic_enum",
-    "axum",
-    "axum-server",
-    "base64",
-    "base64-simd",
-    "bytes",
-    "chrono",
-    "clap",
-    "const-str",
-    "datafusion",
-    "flatbuffers",
-    "futures",
-    "futures-util",
-    "hex-simd",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "hyper",
-    "hyper-util",
-    "jemalloc_pprof",
-    "libc",
-    "libsystemd",
-    "libunftp",
-    "matchit 0.9.1",
-    "md5 0.8.0",
-    "metrics",
-    "mimalloc",
-    "mime_guess",
-    "moka",
-    "pin-project-lite",
-    "pprof",
-    "reqwest",
-    "rmp-serde",
-    "russh",
-    "russh-sftp",
-    "rust-embed",
-    "rustfs-ahm",
-    "rustfs-appauth",
-    "rustfs-audit",
-    "rustfs-common",
-    "rustfs-config",
-    "rustfs-credentials",
-    "rustfs-ecstore",
-    "rustfs-filemeta",
-    "rustfs-iam",
-    "rustfs-kms",
-    "rustfs-lock",
-    "rustfs-madmin",
-    "rustfs-notify",
-    "rustfs-obs",
-    "rustfs-policy",
-    "rustfs-protos",
-    "rustfs-rio",
-    "rustfs-s3select-api",
-    "rustfs-s3select-query",
-    "rustfs-targets",
-    "rustfs-utils",
-    "rustfs-zip",
-    "rustls",
-    "rustls-pemfile",
-    "s3s",
-    "serde",
-    "serde_json",
-    "serde_urlencoded",
-    "serial_test",
-    "shadow-rs",
-    "socket2",
-    "ssh-key",
-    "subtle",
-    "sysinfo",
-    "thiserror 2.0.17",
-    "tikv-jemalloc-ctl",
-    "tikv-jemallocator",
-    "time",
-    "tokio",
-    "tokio-rustls",
-    "tokio-stream",
-    "tokio-util",
-    "tonic",
-    "tower",
-    "tower-http",
-    "tracing",
-    "url",
-    "urlencoding",
-    "uuid",
-    "zip",
+ "astral-tokio-tar",
+ "async-trait",
+ "atoi",
+ "atomic_enum",
+ "axum",
+ "axum-server",
+ "base64",
+ "base64-simd",
+ "bytes",
+ "chrono",
+ "clap",
+ "const-str",
+ "datafusion",
+ "flatbuffers",
+ "futures",
+ "futures-util",
+ "hex-simd",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "jemalloc_pprof",
+ "libc",
+ "libsystemd",
+ "libunftp",
+ "matchit 0.9.1",
+ "md5 0.8.0",
+ "metrics",
+ "mimalloc",
+ "mime_guess",
+ "moka",
+ "pin-project-lite",
+ "pprof",
+ "reqwest",
+ "rmp-serde",
+ "russh",
+ "russh-sftp",
+ "rust-embed",
+ "rustfs-ahm",
+ "rustfs-appauth",
+ "rustfs-audit",
+ "rustfs-common",
+ "rustfs-config",
+ "rustfs-credentials",
+ "rustfs-ecstore",
+ "rustfs-filemeta",
+ "rustfs-iam",
+ "rustfs-kms",
+ "rustfs-lock",
+ "rustfs-madmin",
+ "rustfs-notify",
+ "rustfs-obs",
+ "rustfs-policy",
+ "rustfs-protos",
+ "rustfs-rio",
+ "rustfs-s3select-api",
+ "rustfs-s3select-query",
+ "rustfs-targets",
+ "rustfs-utils",
+ "rustfs-zip",
+ "rustls",
+ "rustls-pemfile",
+ "s3s",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "serial_test",
+ "shadow-rs",
+ "socket2",
+ "ssh-key",
+ "subtle",
+ "sysinfo",
+ "thiserror 2.0.17",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uuid",
+ "zip",
 ]
 
 [[package]]
 name = "rustfs-ahm"
 version = "0.0.5"
 dependencies = [
-    "anyhow",
-    "async-trait",
-    "chrono",
-    "futures",
-    "heed",
-    "rand 0.10.0-rc.6",
-    "reqwest",
-    "rustfs-common",
-    "rustfs-config",
-    "rustfs-ecstore",
-    "rustfs-filemeta",
-    "rustfs-madmin",
-    "rustfs-utils",
-    "s3s",
-    "serde",
-    "serde_json",
-    "serial_test",
-    "tempfile",
-    "thiserror 2.0.17",
-    "time",
-    "tokio",
-    "tokio-util",
-    "tracing",
-    "tracing-subscriber",
-    "uuid",
-    "walkdir",
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "heed",
+ "rand 0.10.0-rc.6",
+ "reqwest",
+ "rustfs-common",
+ "rustfs-config",
+ "rustfs-ecstore",
+ "rustfs-filemeta",
+ "rustfs-madmin",
+ "rustfs-utils",
+ "s3s",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]
 name = "rustfs-appauth"
 version = "0.0.5"
 dependencies = [
-    "base64-simd",
-    "rand 0.10.0-rc.6",
-    "rsa",
-    "serde",
-    "serde_json",
+ "base64-simd",
+ "rand 0.10.0-rc.6",
+ "rsa",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "rustfs-audit"
 version = "0.0.5"
 dependencies = [
-    "async-trait",
-    "chrono",
-    "const-str",
-    "futures",
-    "hashbrown 0.16.1",
-    "metrics",
-    "rumqttc",
-    "rustfs-config",
-    "rustfs-ecstore",
-    "rustfs-targets",
-    "serde",
-    "serde_json",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "url",
+ "async-trait",
+ "chrono",
+ "const-str",
+ "futures",
+ "hashbrown 0.16.1",
+ "metrics",
+ "rumqttc",
+ "rustfs-config",
+ "rustfs-ecstore",
+ "rustfs-targets",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "rustfs-checksums"
 version = "0.0.5"
 dependencies = [
-    "base64-simd",
-    "bytes",
-    "crc-fast",
-    "http 1.4.0",
-    "md-5 0.11.0-rc.3",
-    "pretty_assertions",
-    "sha1 0.11.0-rc.3",
-    "sha2 0.11.0-rc.3",
+ "base64-simd",
+ "bytes",
+ "crc-fast",
+ "http 1.4.0",
+ "md-5 0.11.0-rc.3",
+ "pretty_assertions",
+ "sha1 0.11.0-rc.3",
+ "sha2 0.11.0-rc.3",
 ]
 
 [[package]]
 name = "rustfs-common"
 version = "0.0.5"
 dependencies = [
-    "async-trait",
-    "chrono",
-    "path-clean",
-    "rmp-serde",
-    "rustfs-filemeta",
-    "rustfs-madmin",
-    "s3s",
-    "serde",
-    "tokio",
-    "tonic",
-    "tracing",
-    "uuid",
+ "async-trait",
+ "chrono",
+ "path-clean",
+ "rmp-serde",
+ "rustfs-filemeta",
+ "rustfs-madmin",
+ "s3s",
+ "serde",
+ "tokio",
+ "tonic",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rustfs-config"
 version = "0.0.5"
 dependencies = [
-    "const-str",
+ "const-str",
 ]
 
 [[package]]
 name = "rustfs-credentials"
 version = "0.0.5"
 dependencies = [
-    "base64-simd",
-    "rand 0.10.0-rc.6",
-    "serde",
-    "serde_json",
-    "time",
+ "base64-simd",
+ "rand 0.10.0-rc.6",
+ "serde",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
 name = "rustfs-crypto"
 version = "0.0.5"
 dependencies = [
-    "aes-gcm 0.11.0-rc.2",
-    "argon2 0.6.0-rc.5",
-    "cfg-if",
-    "chacha20poly1305",
-    "jsonwebtoken",
-    "pbkdf2 0.13.0-rc.6",
-    "rand 0.10.0-rc.6",
-    "serde_json",
-    "sha2 0.11.0-rc.3",
-    "test-case",
-    "thiserror 2.0.17",
-    "time",
+ "aes-gcm 0.11.0-rc.2",
+ "argon2 0.6.0-rc.5",
+ "cfg-if",
+ "chacha20poly1305",
+ "jsonwebtoken",
+ "pbkdf2 0.13.0-rc.6",
+ "rand 0.10.0-rc.6",
+ "serde_json",
+ "sha2 0.11.0-rc.3",
+ "test-case",
+ "thiserror 2.0.17",
+ "time",
 ]
 
 [[package]]
 name = "rustfs-ecstore"
 version = "0.0.5"
 dependencies = [
-    "async-channel",
-    "async-recursion",
-    "async-trait",
-    "aws-config",
-    "aws-credential-types",
-    "aws-sdk-s3",
-    "aws-smithy-types",
-    "base64",
-    "base64-simd",
-    "byteorder",
-    "bytes",
-    "bytesize",
-    "chrono",
-    "criterion",
-    "dunce",
-    "enumset",
-    "faster-hex",
-    "flatbuffers",
-    "futures",
-    "glob",
-    "google-cloud-auth",
-    "google-cloud-storage",
-    "hex-simd",
-    "hmac 0.13.0-rc.3",
-    "http 1.4.0",
-    "hyper",
-    "hyper-rustls",
-    "hyper-util",
-    "lazy_static",
-    "md-5 0.11.0-rc.3",
-    "moka",
-    "num_cpus",
-    "parking_lot",
-    "path-absolutize",
-    "pin-project-lite",
-    "quick-xml 0.39.0",
-    "rand 0.10.0-rc.6",
-    "reed-solomon-simd",
-    "regex",
-    "reqwest",
-    "rmp",
-    "rmp-serde",
-    "rustfs-checksums",
-    "rustfs-common",
-    "rustfs-config",
-    "rustfs-credentials",
-    "rustfs-filemeta",
-    "rustfs-lock",
-    "rustfs-madmin",
-    "rustfs-policy",
-    "rustfs-protos",
-    "rustfs-rio",
-    "rustfs-signer",
-    "rustfs-utils",
-    "rustfs-workers",
-    "rustls",
-    "s3s",
-    "serde",
-    "serde_json",
-    "serde_urlencoded",
-    "sha1 0.11.0-rc.3",
-    "sha2 0.11.0-rc.3",
-    "shadow-rs",
-    "smallvec",
-    "temp-env",
-    "tempfile",
-    "thiserror 2.0.17",
-    "time",
-    "tokio",
-    "tokio-util",
-    "tonic",
-    "tower",
-    "tracing",
-    "tracing-subscriber",
-    "url",
-    "urlencoding",
-    "uuid",
-    "xxhash-rust",
+ "async-channel",
+ "async-recursion",
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-s3",
+ "aws-smithy-types",
+ "base64",
+ "base64-simd",
+ "byteorder",
+ "bytes",
+ "bytesize",
+ "chrono",
+ "criterion",
+ "dunce",
+ "enumset",
+ "faster-hex",
+ "flatbuffers",
+ "futures",
+ "glob",
+ "google-cloud-auth",
+ "google-cloud-storage",
+ "hex-simd",
+ "hmac 0.13.0-rc.3",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "lazy_static",
+ "md-5 0.11.0-rc.3",
+ "moka",
+ "num_cpus",
+ "parking_lot",
+ "path-absolutize",
+ "pin-project-lite",
+ "quick-xml 0.39.0",
+ "rand 0.10.0-rc.6",
+ "reed-solomon-simd",
+ "regex",
+ "reqwest",
+ "rmp",
+ "rmp-serde",
+ "rustfs-checksums",
+ "rustfs-common",
+ "rustfs-config",
+ "rustfs-credentials",
+ "rustfs-filemeta",
+ "rustfs-lock",
+ "rustfs-madmin",
+ "rustfs-policy",
+ "rustfs-protos",
+ "rustfs-rio",
+ "rustfs-signer",
+ "rustfs-utils",
+ "rustfs-workers",
+ "rustls",
+ "s3s",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha1 0.11.0-rc.3",
+ "sha2 0.11.0-rc.3",
+ "shadow-rs",
+ "smallvec",
+ "temp-env",
+ "tempfile",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "urlencoding",
+ "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "rustfs-filemeta"
 version = "0.0.5"
 dependencies = [
-    "byteorder",
-    "bytes",
-    "crc-fast",
-    "criterion",
-    "regex",
-    "rmp",
-    "rmp-serde",
-    "rustfs-utils",
-    "s3s",
-    "serde",
-    "thiserror 2.0.17",
-    "time",
-    "tokio",
-    "tracing",
-    "uuid",
-    "xxhash-rust",
+ "byteorder",
+ "bytes",
+ "crc-fast",
+ "criterion",
+ "regex",
+ "rmp",
+ "rmp-serde",
+ "rustfs-utils",
+ "s3s",
+ "serde",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tracing",
+ "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "rustfs-iam"
 version = "0.0.5"
 dependencies = [
-    "arc-swap",
-    "async-trait",
-    "base64-simd",
-    "futures",
-    "jsonwebtoken",
-    "pollster",
-    "rand 0.10.0-rc.6",
-    "rustfs-credentials",
-    "rustfs-crypto",
-    "rustfs-ecstore",
-    "rustfs-madmin",
-    "rustfs-policy",
-    "rustfs-utils",
-    "serde",
-    "serde_json",
-    "thiserror 2.0.17",
-    "time",
-    "tokio",
-    "tokio-util",
-    "tracing",
+ "arc-swap",
+ "async-trait",
+ "base64-simd",
+ "futures",
+ "jsonwebtoken",
+ "pollster",
+ "rand 0.10.0-rc.6",
+ "rustfs-credentials",
+ "rustfs-crypto",
+ "rustfs-ecstore",
+ "rustfs-madmin",
+ "rustfs-policy",
+ "rustfs-utils",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "rustfs-kms"
 version = "0.0.5"
 dependencies = [
-    "aes-gcm 0.11.0-rc.2",
-    "async-trait",
-    "base64",
-    "chacha20poly1305",
-    "chrono",
-    "md5 0.8.0",
-    "moka",
-    "rand 0.10.0-rc.6",
-    "reqwest",
-    "serde",
-    "serde_json",
-    "sha2 0.11.0-rc.3",
-    "tempfile",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "url",
-    "uuid",
-    "vaultrs",
-    "zeroize",
+ "aes-gcm 0.11.0-rc.2",
+ "async-trait",
+ "base64",
+ "chacha20poly1305",
+ "chrono",
+ "md5 0.8.0",
+ "moka",
+ "rand 0.10.0-rc.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0-rc.3",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "vaultrs",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustfs-lock"
 version = "0.0.5"
 dependencies = [
-    "async-trait",
-    "crossbeam-queue",
-    "futures",
-    "parking_lot",
-    "serde",
-    "serde_json",
-    "smallvec",
-    "smartstring",
-    "thiserror 2.0.17",
-    "tokio",
-    "tonic",
-    "tracing",
-    "uuid",
+ "async-trait",
+ "crossbeam-queue",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "smartstring",
+ "thiserror 2.0.17",
+ "tokio",
+ "tonic",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rustfs-madmin"
 version = "0.0.5"
 dependencies = [
-    "chrono",
-    "humantime",
-    "hyper",
-    "serde",
-    "serde_json",
-    "time",
+ "chrono",
+ "humantime",
+ "hyper",
+ "serde",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
 name = "rustfs-mcp"
 version = "0.0.5"
 dependencies = [
-    "anyhow",
-    "aws-sdk-s3",
-    "clap",
-    "mime_guess",
-    "rmcp",
-    "schemars 1.2.0",
-    "serde",
-    "serde_json",
-    "tokio",
-    "tracing",
-    "tracing-subscriber",
+ "anyhow",
+ "aws-sdk-s3",
+ "clap",
+ "mime_guess",
+ "rmcp",
+ "schemars 1.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "rustfs-notify"
 version = "0.0.5"
 dependencies = [
-    "arc-swap",
-    "async-trait",
-    "axum",
-    "chrono",
-    "form_urlencoded",
-    "futures",
-    "hashbrown 0.16.1",
-    "quick-xml 0.39.0",
-    "rayon",
-    "rumqttc",
-    "rustc-hash",
-    "rustfs-config",
-    "rustfs-ecstore",
-    "rustfs-targets",
-    "rustfs-utils",
-    "serde",
-    "serde_json",
-    "starshard",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "tracing-subscriber",
-    "url",
-    "wildmatch",
+ "arc-swap",
+ "async-trait",
+ "axum",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "hashbrown 0.16.1",
+ "quick-xml 0.39.0",
+ "rayon",
+ "rumqttc",
+ "rustc-hash",
+ "rustfs-config",
+ "rustfs-ecstore",
+ "rustfs-targets",
+ "rustfs-utils",
+ "serde",
+ "serde_json",
+ "starshard",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "wildmatch",
 ]
 
 [[package]]
 name = "rustfs-obs"
 version = "0.0.5"
 dependencies = [
-    "flexi_logger",
-    "metrics",
-    "nu-ansi-term",
-    "nvml-wrapper",
-    "opentelemetry",
-    "opentelemetry-appender-tracing",
-    "opentelemetry-otlp",
-    "opentelemetry-semantic-conventions",
-    "opentelemetry-stdout",
-    "opentelemetry_sdk",
-    "rustfs-config",
-    "rustfs-utils",
-    "serde",
-    "smallvec",
-    "sysinfo",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "tracing-appender",
-    "tracing-error",
-    "tracing-opentelemetry",
-    "tracing-subscriber",
+ "flexi_logger",
+ "metrics",
+ "nu-ansi-term",
+ "nvml-wrapper",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "rustfs-config",
+ "rustfs-utils",
+ "serde",
+ "smallvec",
+ "sysinfo",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-error",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "rustfs-policy"
 version = "0.0.5"
 dependencies = [
-    "async-trait",
-    "base64-simd",
-    "chrono",
-    "futures",
-    "ipnetwork",
-    "jsonwebtoken",
-    "moka",
-    "pollster",
-    "regex",
-    "reqwest",
-    "rustfs-config",
-    "rustfs-credentials",
-    "rustfs-crypto",
-    "serde",
-    "serde_json",
-    "strum",
-    "temp-env",
-    "test-case",
-    "thiserror 2.0.17",
-    "time",
-    "tokio",
-    "tracing",
+ "async-trait",
+ "base64-simd",
+ "chrono",
+ "futures",
+ "ipnetwork",
+ "jsonwebtoken",
+ "moka",
+ "pollster",
+ "regex",
+ "reqwest",
+ "rustfs-config",
+ "rustfs-credentials",
+ "rustfs-crypto",
+ "serde",
+ "serde_json",
+ "strum",
+ "temp-env",
+ "test-case",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "rustfs-protos"
 version = "0.0.5"
 dependencies = [
-    "flatbuffers",
-    "prost 0.14.3",
-    "rustfs-common",
-    "tonic",
-    "tonic-prost",
-    "tonic-prost-build",
-    "tracing",
+ "flatbuffers",
+ "prost 0.14.3",
+ "rustfs-common",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
 ]
 
 [[package]]
 name = "rustfs-rio"
 version = "0.0.5"
 dependencies = [
-    "aes-gcm 0.11.0-rc.2",
-    "base64",
-    "bytes",
-    "crc-fast",
-    "faster-hex",
-    "futures",
-    "hex-simd",
-    "http 1.4.0",
-    "md-5 0.11.0-rc.3",
-    "pin-project-lite",
-    "rand 0.10.0-rc.6",
-    "reqwest",
-    "rustfs-config",
-    "rustfs-utils",
-    "s3s",
-    "serde",
-    "serde_json",
-    "sha1 0.11.0-rc.3",
-    "sha2 0.11.0-rc.3",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-test",
-    "tokio-util",
-    "tracing",
+ "aes-gcm 0.11.0-rc.2",
+ "base64",
+ "bytes",
+ "crc-fast",
+ "faster-hex",
+ "futures",
+ "hex-simd",
+ "http 1.4.0",
+ "md-5 0.11.0-rc.3",
+ "pin-project-lite",
+ "rand 0.10.0-rc.6",
+ "reqwest",
+ "rustfs-config",
+ "rustfs-utils",
+ "s3s",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0-rc.3",
+ "sha2 0.11.0-rc.3",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-test",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "rustfs-s3select-api"
 version = "0.0.5"
 dependencies = [
-    "async-trait",
-    "bytes",
-    "chrono",
-    "datafusion",
-    "futures",
-    "futures-core",
-    "http 1.4.0",
-    "object_store",
-    "parking_lot",
-    "pin-project-lite",
-    "rustfs-common",
-    "rustfs-ecstore",
-    "s3s",
-    "snafu 0.8.9",
-    "tokio",
-    "tokio-util",
-    "tracing",
-    "transform-stream",
-    "url",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion",
+ "futures",
+ "futures-core",
+ "http 1.4.0",
+ "object_store",
+ "parking_lot",
+ "pin-project-lite",
+ "rustfs-common",
+ "rustfs-ecstore",
+ "s3s",
+ "snafu 0.8.9",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "transform-stream",
+ "url",
 ]
 
 [[package]]
 name = "rustfs-s3select-query"
 version = "0.0.5"
 dependencies = [
-    "async-recursion",
-    "async-trait",
-    "datafusion",
-    "derive_builder 0.20.2",
-    "futures",
-    "parking_lot",
-    "rustfs-s3select-api",
-    "s3s",
-    "snafu 0.8.9",
-    "tokio",
-    "tracing",
+ "async-recursion",
+ "async-trait",
+ "datafusion",
+ "derive_builder 0.20.2",
+ "futures",
+ "parking_lot",
+ "rustfs-s3select-api",
+ "s3s",
+ "snafu 0.8.9",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "rustfs-signer"
 version = "0.0.5"
 dependencies = [
-    "base64-simd",
-    "bytes",
-    "http 1.4.0",
-    "hyper",
-    "rustfs-utils",
-    "s3s",
-    "serde_urlencoded",
-    "time",
-    "tracing",
+ "base64-simd",
+ "bytes",
+ "http 1.4.0",
+ "hyper",
+ "rustfs-utils",
+ "s3s",
+ "serde_urlencoded",
+ "time",
+ "tracing",
 ]
 
 [[package]]
 name = "rustfs-targets"
 version = "0.0.5"
 dependencies = [
-    "async-trait",
-    "reqwest",
-    "rumqttc",
-    "rustfs-config",
-    "rustfs-utils",
-    "serde",
-    "serde_json",
-    "snap",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "url",
-    "urlencoding",
-    "uuid",
+ "async-trait",
+ "reqwest",
+ "rumqttc",
+ "rustfs-config",
+ "rustfs-utils",
+ "serde",
+ "serde_json",
+ "snap",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uuid",
 ]
 
 [[package]]
 name = "rustfs-utils"
 version = "0.0.5"
 dependencies = [
-    "base64-simd",
-    "blake3",
-    "brotli 8.0.2",
-    "bytes",
-    "convert_case",
-    "crc-fast",
-    "flate2",
-    "futures",
-    "hashbrown 0.16.1",
-    "hex-simd",
-    "highway",
-    "hmac 0.13.0-rc.3",
-    "http 1.4.0",
-    "hyper",
-    "libc",
-    "local-ip-address",
-    "lz4",
-    "md-5 0.11.0-rc.3",
-    "netif",
-    "nix 0.30.1",
-    "rand 0.10.0-rc.6",
-    "regex",
-    "rustfs-config",
-    "rustls",
-    "rustls-pemfile",
-    "rustls-pki-types",
-    "s3s",
-    "serde",
-    "sha1 0.11.0-rc.3",
-    "sha2 0.11.0-rc.3",
-    "siphasher",
-    "snap",
-    "sysinfo",
-    "tempfile",
-    "thiserror 2.0.17",
-    "tokio",
-    "tracing",
-    "transform-stream",
-    "url",
-    "windows 0.62.2",
-    "zstd",
+ "base64-simd",
+ "blake3",
+ "brotli 8.0.2",
+ "bytes",
+ "convert_case",
+ "crc-fast",
+ "flate2",
+ "futures",
+ "hashbrown 0.16.1",
+ "hex-simd",
+ "highway",
+ "hmac 0.13.0-rc.3",
+ "http 1.4.0",
+ "hyper",
+ "libc",
+ "local-ip-address",
+ "lz4",
+ "md-5 0.11.0-rc.3",
+ "netif",
+ "nix 0.30.1",
+ "rand 0.10.0-rc.6",
+ "regex",
+ "rustfs-config",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "s3s",
+ "serde",
+ "sha1 0.11.0-rc.3",
+ "sha2 0.11.0-rc.3",
+ "siphasher",
+ "snap",
+ "sysinfo",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "transform-stream",
+ "url",
+ "windows 0.62.2",
+ "zstd",
 ]
 
 [[package]]
 name = "rustfs-workers"
 version = "0.0.5"
 dependencies = [
-    "tokio",
-    "tracing",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "rustfs-zip"
 version = "0.0.5"
 dependencies = [
-    "astral-tokio-tar",
-    "async-compression",
-    "tokio",
-    "tokio-stream",
+ "astral-tokio-tar",
+ "async-compression",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -8397,7 +8397,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
-    "nom 7.1.3",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8406,18 +8406,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759a090a17ce545d1adcffcc48207d5136c8984d8153bd8247b1ad4a71e49f5f"
 dependencies = [
-    "anyhow",
-    "async-trait",
-    "bytes",
-    "http 1.4.0",
-    "reqwest",
-    "rustify_derive",
-    "serde",
-    "serde_json",
-    "serde_urlencoded",
-    "thiserror 1.0.69",
-    "tracing",
-    "url",
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "reqwest",
+ "rustify_derive",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -8426,12 +8426,12 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f07d43b2dbdbd99aaed648192098f0f413b762f0f352667153934ef3955f1793"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "regex",
-    "serde_urlencoded",
-    "syn 1.0.109",
-    "synstructure 0.12.6",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_urlencoded",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -8440,11 +8440,11 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
-    "bitflags 2.10.0",
-    "errno",
-    "libc",
-    "linux-raw-sys 0.4.15",
-    "windows-sys 0.59.0",
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8453,11 +8453,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
-    "bitflags 2.10.0",
-    "errno",
-    "libc",
-    "linux-raw-sys 0.11.0",
-    "windows-sys 0.61.2",
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8466,14 +8466,14 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
-    "aws-lc-rs",
-    "log",
-    "once_cell",
-    "ring",
-    "rustls-pki-types",
-    "rustls-webpki 0.103.8",
-    "subtle",
-    "zeroize",
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8482,10 +8482,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
-    "openssl-probe",
-    "rustls-pki-types",
-    "schannel",
-    "security-framework",
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -8494,7 +8494,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
-    "rustls-pki-types",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8503,8 +8503,8 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
-    "web-time",
-    "zeroize",
+ "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -8513,9 +8513,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
-    "ring",
-    "rustls-pki-types",
-    "untrusted 0.9.0",
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8524,10 +8524,10 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
-    "aws-lc-rs",
-    "ring",
-    "rustls-pki-types",
-    "untrusted 0.9.0",
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8547,48 +8547,48 @@ name = "s3s"
 version = "0.13.0-alpha"
 source = "git+https://github.com/s3s-project/s3s.git?branch=main#18c168ae21bf1176555f8f529686ecdc2ebd6db7"
 dependencies = [
-    "arrayvec",
-    "async-trait",
-    "atoi",
-    "base64-simd",
-    "bytes",
-    "bytestring",
-    "cfg-if",
-    "chrono",
-    "const-str",
-    "crc-fast",
-    "futures",
-    "hex-simd",
-    "hmac 0.13.0-rc.3",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "httparse",
-    "hyper",
-    "itoa",
-    "md-5 0.11.0-rc.3",
-    "memchr",
-    "mime",
-    "nom 8.0.0",
-    "numeric_cast",
-    "pin-project-lite",
-    "quick-xml 0.37.5",
-    "serde",
-    "serde_urlencoded",
-    "sha1 0.11.0-rc.3",
-    "sha2 0.11.0-rc.3",
-    "smallvec",
-    "std-next",
-    "subtle",
-    "sync_wrapper",
-    "thiserror 2.0.17",
-    "time",
-    "tokio",
-    "tower",
-    "tracing",
-    "transform-stream",
-    "urlencoding",
-    "zeroize",
+ "arrayvec",
+ "async-trait",
+ "atoi",
+ "base64-simd",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "chrono",
+ "const-str",
+ "crc-fast",
+ "futures",
+ "hex-simd",
+ "hmac 0.13.0-rc.3",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "httparse",
+ "hyper",
+ "itoa",
+ "md-5 0.11.0-rc.3",
+ "memchr",
+ "mime",
+ "nom 8.0.0",
+ "numeric_cast",
+ "pin-project-lite",
+ "quick-xml 0.37.5",
+ "serde",
+ "serde_urlencoded",
+ "sha1 0.11.0-rc.3",
+ "sha2 0.11.0-rc.3",
+ "smallvec",
+ "std-next",
+ "subtle",
+ "sync_wrapper",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "transform-stream",
+ "urlencoding",
+ "zeroize",
 ]
 
 [[package]]
@@ -8597,7 +8597,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
-    "cipher 0.4.4",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -8606,7 +8606,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
-    "winapi-util",
+ "winapi-util",
 ]
 
 [[package]]
@@ -8615,7 +8615,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
-    "sdd",
+ "sdd",
 ]
 
 [[package]]
@@ -8624,7 +8624,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
-    "windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8633,10 +8633,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
-    "dyn-clone",
-    "ref-cast",
-    "serde",
-    "serde_json",
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -8645,12 +8645,12 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
-    "chrono",
-    "dyn-clone",
-    "ref-cast",
-    "schemars_derive",
-    "serde",
-    "serde_json",
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -8659,10 +8659,10 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "serde_derive_internals",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8677,9 +8677,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
-    "pbkdf2 0.12.2",
-    "salsa20",
-    "sha2 0.10.9",
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8694,12 +8694,12 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
-    "base16ct 0.1.1",
-    "der 0.6.1",
-    "generic-array 0.14.7",
-    "pkcs8 0.9.0",
-    "subtle",
-    "zeroize",
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8708,12 +8708,12 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
-    "base16ct 0.2.0",
-    "der 0.7.10",
-    "generic-array 0.14.7",
-    "pkcs8 0.10.2",
-    "subtle",
-    "zeroize",
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8722,8 +8722,8 @@ version = "0.8.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2568531a8ace88b848310caa98fb2115b151ef924d54aa523e659c21b9d32d71"
 dependencies = [
-    "base16ct 1.0.0",
-    "hybrid-array",
+ "base16ct 1.0.0",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -8732,11 +8732,11 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
-    "bitflags 2.10.0",
-    "core-foundation 0.10.1",
-    "core-foundation-sys",
-    "libc",
-    "security-framework-sys",
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -8745,8 +8745,8 @@ version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
-    "core-foundation-sys",
-    "libc",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -8761,8 +8761,8 @@ version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
-    "serde",
-    "serde_core",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -8777,8 +8777,8 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
-    "serde_core",
-    "serde_derive",
+ "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8787,7 +8787,7 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
-    "serde_derive",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8796,9 +8796,9 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8807,9 +8807,9 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8818,7 +8818,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e497af288b3b95d067a23a4f749f2861121ffcb2f6d8379310dcda040c345ed"
 dependencies = [
-    "serde_core",
+ "serde_core",
 ]
 
 [[package]]
@@ -8827,11 +8827,11 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
-    "itoa",
-    "memchr",
-    "serde",
-    "serde_core",
-    "zmij",
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -8840,9 +8840,9 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
-    "itoa",
-    "serde",
-    "serde_core",
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -8851,7 +8851,7 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -8860,10 +8860,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
-    "form_urlencoded",
-    "itoa",
-    "ryu",
-    "serde",
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -8872,17 +8872,17 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
-    "base64",
-    "chrono",
-    "hex",
-    "indexmap 1.9.3",
-    "indexmap 2.13.0",
-    "schemars 0.9.0",
-    "schemars 1.2.0",
-    "serde_core",
-    "serde_json",
-    "serde_with_macros",
-    "time",
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.0",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
 ]
 
 [[package]]
@@ -8891,10 +8891,10 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
-    "darling 0.21.3",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8903,8 +8903,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
 dependencies = [
-    "base16ct 1.0.0",
-    "serde",
+ "base16ct 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -8913,13 +8913,13 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
 dependencies = [
-    "futures-executor",
-    "futures-util",
-    "log",
-    "once_cell",
-    "parking_lot",
-    "scc",
-    "serial_test_derive",
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
 ]
 
 [[package]]
@@ -8928,9 +8928,9 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8939,9 +8939,9 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "digest 0.10.7",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8950,9 +8950,9 @@ version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "digest 0.11.0-rc.5",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-rc.5",
 ]
 
 [[package]]
@@ -8961,9 +8961,9 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "digest 0.10.7",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8972,9 +8972,9 @@ version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "digest 0.11.0-rc.5",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-rc.5",
 ]
 
 [[package]]
@@ -8983,12 +8983,12 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff351910f271e7065781b6b4f0f43cb515d474d812f31176a0246d9058e47d5d"
 dependencies = [
-    "cargo_metadata",
-    "const_format",
-    "is_debug",
-    "serde_json",
-    "time",
-    "tzdb",
+ "cargo_metadata",
+ "const_format",
+ "is_debug",
+ "serde_json",
+ "time",
+ "tzdb",
 ]
 
 [[package]]
@@ -8997,7 +8997,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
-    "lazy_static",
+ "lazy_static",
 ]
 
 [[package]]
@@ -9006,7 +9006,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
-    "dirs",
+ "dirs",
 ]
 
 [[package]]
@@ -9021,8 +9021,8 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
-    "errno",
-    "libc",
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -9031,8 +9031,8 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
-    "digest 0.10.7",
-    "rand_core 0.6.4",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9041,8 +9041,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
-    "digest 0.10.7",
-    "rand_core 0.6.4",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9051,8 +9051,8 @@ version = "3.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
 dependencies = [
-    "digest 0.11.0-rc.5",
-    "rand_core 0.10.0-rc-3",
+ "digest 0.11.0-rc.5",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -9073,10 +9073,10 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
-    "num-bigint",
-    "num-traits",
-    "thiserror 2.0.17",
-    "time",
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
 ]
 
 [[package]]
@@ -9097,10 +9097,10 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
 dependencies = [
-    "anyhow",
-    "erased-serde 0.3.31",
-    "rustversion",
-    "serde_core",
+ "anyhow",
+ "erased-serde 0.3.31",
+ "rustversion",
+ "serde_core",
 ]
 
 [[package]]
@@ -9109,9 +9109,9 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
 dependencies = [
-    "arc-swap",
-    "lazy_static",
-    "slog",
+ "arc-swap",
+ "lazy_static",
+ "slog",
 ]
 
 [[package]]
@@ -9120,9 +9120,9 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
 dependencies = [
-    "log",
-    "slog",
-    "slog-scope",
+ "log",
+ "slog",
+ "slog-scope",
 ]
 
 [[package]]
@@ -9131,7 +9131,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -9140,9 +9140,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
-    "autocfg",
-    "static_assertions",
-    "version_check",
+ "autocfg",
+ "static_assertions",
+ "version_check",
 ]
 
 [[package]]
@@ -9151,8 +9151,8 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
-    "doc-comment",
-    "snafu-derive 0.6.10",
+ "doc-comment",
+ "snafu-derive 0.6.10",
 ]
 
 [[package]]
@@ -9161,8 +9161,8 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
 dependencies = [
-    "backtrace",
-    "snafu-derive 0.8.9",
+ "backtrace",
+ "snafu-derive 0.8.9",
 ]
 
 [[package]]
@@ -9171,9 +9171,9 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9182,10 +9182,10 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
-    "heck",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9200,8 +9200,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
-    "libc",
-    "windows-sys 0.60.2",
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9210,7 +9210,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
-    "lock_api",
+ "lock_api",
 ]
 
 [[package]]
@@ -9219,7 +9219,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
-    "lock_api",
+ "lock_api",
 ]
 
 [[package]]
@@ -9228,8 +9228,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
-    "base64ct",
-    "der 0.6.1",
+ "base64ct",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -9238,8 +9238,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
-    "base64ct",
-    "der 0.7.10",
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -9248,8 +9248,8 @@ version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
-    "base64ct",
-    "der 0.8.0-rc.10",
+ "base64ct",
+ "der 0.8.0-rc.10",
 ]
 
 [[package]]
@@ -9258,9 +9258,9 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
-    "log",
-    "recursive",
-    "sqlparser_derive",
+ "log",
+ "recursive",
+ "sqlparser_derive",
 ]
 
 [[package]]
@@ -9269,9 +9269,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9280,15 +9280,15 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
 dependencies = [
-    "aes 0.8.4",
-    "aes-gcm 0.10.3",
-    "cbc",
-    "chacha20 0.9.1",
-    "cipher 0.4.4",
-    "ctr 0.9.2",
-    "poly1305 0.8.0",
-    "ssh-encoding 0.2.0",
-    "subtle",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
+ "cbc",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "poly1305 0.8.0",
+ "ssh-encoding 0.2.0",
+ "subtle",
 ]
 
 [[package]]
@@ -9297,14 +9297,14 @@ version = "0.3.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361de425e489d5fe3f1ecfd91531c8fe91ededbbc567e24b77a560d503309bf9"
 dependencies = [
-    "aes 0.9.0-rc.2",
-    "aes-gcm 0.11.0-rc.2",
-    "chacha20 0.10.0-rc.6",
-    "cipher 0.5.0-rc.3",
-    "des",
-    "poly1305 0.9.0-rc.3",
-    "ssh-encoding 0.3.0-rc.3",
-    "zeroize",
+ "aes 0.9.0-rc.2",
+ "aes-gcm 0.11.0-rc.2",
+ "chacha20 0.10.0-rc.6",
+ "cipher 0.5.0-rc.3",
+ "des",
+ "poly1305 0.9.0-rc.3",
+ "ssh-encoding 0.3.0-rc.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -9313,10 +9313,10 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
-    "base64ct",
-    "bytes",
-    "pem-rfc7468 0.7.0",
-    "sha2 0.10.9",
+ "base64ct",
+ "bytes",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -9325,12 +9325,12 @@ version = "0.3.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ad6a09263583e83e934fcd436b7e3bb9d69602e2feef3787adb615c1fe3a343"
 dependencies = [
-    "base64ct",
-    "crypto-bigint 0.7.0-rc.15",
-    "digest 0.11.0-rc.5",
-    "pem-rfc7468 1.0.0",
-    "subtle",
-    "zeroize",
+ "base64ct",
+ "crypto-bigint 0.7.0-rc.15",
+ "digest 0.11.0-rc.5",
+ "pem-rfc7468 1.0.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -9339,16 +9339,16 @@ version = "0.7.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7faefb89d4a5304e31238913d1f7f164e22494276ed58cd84d5058ba7b04911f"
 dependencies = [
-    "ed25519-dalek 3.0.0-pre.2",
-    "rand_core 0.10.0-rc-3",
-    "rsa",
-    "sec1 0.8.0-rc.11",
-    "sha2 0.11.0-rc.3",
-    "signature 3.0.0-rc.6",
-    "ssh-cipher 0.3.0-rc.4",
-    "ssh-encoding 0.3.0-rc.3",
-    "subtle",
-    "zeroize",
+ "ed25519-dalek 3.0.0-pre.2",
+ "rand_core 0.10.0-rc-3",
+ "rsa",
+ "sec1 0.8.0-rc.11",
+ "sha2 0.11.0-rc.3",
+ "signature 3.0.0-rc.6",
+ "ssh-cipher 0.3.0-rc.4",
+ "ssh-encoding 0.3.0-rc.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -9363,11 +9363,11 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
 dependencies = [
-    "cc",
-    "cfg-if",
-    "libc",
-    "psm",
-    "windows-sys 0.59.0",
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9376,11 +9376,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88b6e011736aa3523f5962c02ba2d6c4cff35d97a0a9a3999afa6111d704a76"
 dependencies = [
-    "hashbrown 0.16.1",
-    "rayon",
-    "rustc-hash",
-    "serde",
-    "tokio",
+ "hashbrown 0.16.1",
+ "rayon",
+ "rustc-hash",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -9395,8 +9395,8 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04082e93ed1a06debd9148c928234b46d2cf260bc65f44e1d1d3fa594c5beebc"
 dependencies = [
-    "simdutf8",
-    "thiserror 2.0.17",
+ "simdutf8",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -9423,7 +9423,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
-    "strum_macros",
+ "strum_macros",
 ]
 
 [[package]]
@@ -9432,10 +9432,10 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
-    "heck",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9450,17 +9450,17 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69a15b325bbe0a1f85de3dbf988a3a14e9cd321537dffcbf6641381dd6d7586f"
 dependencies = [
-    "async-trait",
-    "chrono",
-    "futures-lite",
-    "lazy-regex",
-    "log",
-    "pin-project",
-    "rustls",
-    "rustls-pki-types",
-    "thiserror 2.0.17",
-    "tokio",
-    "tokio-rustls",
+ "async-trait",
+ "chrono",
+ "futures-lite",
+ "lazy-regex",
+ "log",
+ "pin-project",
+ "rustls",
+ "rustls-pki-types",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -9475,8 +9475,8 @@ version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4b854348b15b6c441bdd27ce9053569b016a0723eab2d015b1fd8e6abe4f708"
 dependencies = [
-    "sval",
-    "sval_ref",
+ "sval",
+ "sval_ref",
 ]
 
 [[package]]
@@ -9485,7 +9485,7 @@ version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bd9e8b74410ddad37c6962587c5f9801a2caadba9e11f3f916ee3f31ae4a1f"
 dependencies = [
-    "sval",
+ "sval",
 ]
 
 [[package]]
@@ -9494,9 +9494,9 @@ version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe17b8deb33a9441280b4266c2d257e166bafbaea6e66b4b34ca139c91766d9"
 dependencies = [
-    "itoa",
-    "ryu",
-    "sval",
+ "itoa",
+ "ryu",
+ "sval",
 ]
 
 [[package]]
@@ -9505,9 +9505,9 @@ version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854addb048a5bafb1f496c98e0ab5b9b581c3843f03ca07c034ae110d3b7c623"
 dependencies = [
-    "itoa",
-    "ryu",
-    "sval",
+ "itoa",
+ "ryu",
+ "sval",
 ]
 
 [[package]]
@@ -9516,9 +9516,9 @@ version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96cf068f482108ff44ae8013477cb047a1665d5f1a635ad7cf79582c1845dce9"
 dependencies = [
-    "sval",
-    "sval_buffer",
-    "sval_ref",
+ "sval",
+ "sval_buffer",
+ "sval_ref",
 ]
 
 [[package]]
@@ -9527,7 +9527,7 @@ version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed02126365ffe5ab8faa0abd9be54fbe68d03d607cd623725b0a71541f8aaa6f"
 dependencies = [
-    "sval",
+ "sval",
 ]
 
 [[package]]
@@ -9536,9 +9536,9 @@ version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a263383c6aa2076c4ef6011d3bae1b356edf6ea2613e3d8e8ebaa7b57dd707d5"
 dependencies = [
-    "serde_core",
-    "sval",
-    "sval_nested",
+ "serde_core",
+ "sval",
+ "sval_nested",
 ]
 
 [[package]]
@@ -9547,10 +9547,10 @@ version = "12.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d8046c5674ab857104bc4559d505f4809b8060d57806e45d49737c97afeb60"
 dependencies = [
-    "debugid",
-    "memmap2",
-    "stable_deref_trait",
-    "uuid",
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
 ]
 
 [[package]]
@@ -9559,9 +9559,9 @@ version = "12.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1accb6e5c4b0f682de907623912e616b44be1c9e725775155546669dbff720ec"
 dependencies = [
-    "cpp_demangle",
-    "rustc-demangle",
-    "symbolic-common",
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]
@@ -9570,9 +9570,9 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "unicode-ident",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -9581,9 +9581,9 @@ version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "unicode-ident",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -9592,7 +9592,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
-    "futures-core",
+ "futures-core",
 ]
 
 [[package]]
@@ -9601,7 +9601,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
 dependencies = [
-    "crossbeam-queue",
+ "crossbeam-queue",
 ]
 
 [[package]]
@@ -9610,10 +9610,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
-    "unicode-xid",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -9622,9 +9622,9 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9633,13 +9633,13 @@ version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
-    "libc",
-    "memchr",
-    "ntapi",
-    "objc2-core-foundation",
-    "objc2-io-kit",
-    "rayon",
-    "windows 0.61.3",
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "rayon",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9648,9 +9648,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
-    "bitflags 2.10.0",
-    "core-foundation 0.9.4",
-    "system-configuration-sys",
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -9659,8 +9659,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
-    "core-foundation-sys",
-    "libc",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -9675,7 +9675,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
-    "parking_lot",
+ "parking_lot",
 ]
 
 [[package]]
@@ -9684,11 +9684,11 @@ version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
-    "fastrand",
-    "getrandom 0.3.4",
-    "once_cell",
-    "rustix 1.1.3",
-    "windows-sys 0.61.2",
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9697,7 +9697,7 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
 dependencies = [
-    "test-case-macros",
+ "test-case-macros",
 ]
 
 [[package]]
@@ -9706,10 +9706,10 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
-    "cfg-if",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9718,10 +9718,10 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
-    "test-case-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "test-case-core",
 ]
 
 [[package]]
@@ -9730,7 +9730,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
-    "thiserror-impl 1.0.69",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -9739,7 +9739,7 @@ version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
-    "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -9748,9 +9748,9 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9759,9 +9759,9 @@ version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9770,7 +9770,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
-    "cfg-if",
+ "cfg-if",
 ]
 
 [[package]]
@@ -9779,9 +9779,9 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
-    "byteorder",
-    "integer-encoding",
-    "ordered-float",
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -9790,9 +9790,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
-    "libc",
-    "paste",
-    "tikv-jemalloc-sys",
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -9801,8 +9801,8 @@ version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
-    "cc",
-    "libc",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -9811,8 +9811,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
-    "libc",
-    "tikv-jemalloc-sys",
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -9821,15 +9821,15 @@ version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
-    "deranged",
-    "itoa",
-    "libc",
-    "num-conv",
-    "num_threads",
-    "powerfmt",
-    "serde",
-    "time-core",
-    "time-macros",
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -9844,8 +9844,8 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
-    "num-conv",
-    "time-core",
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -9854,7 +9854,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
-    "crunchy",
+ "crunchy",
 ]
 
 [[package]]
@@ -9863,8 +9863,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
-    "displaydoc",
-    "zerovec",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -9873,8 +9873,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
-    "serde",
-    "serde_json",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -9883,7 +9883,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
-    "tinyvec_macros",
+ "tinyvec_macros",
 ]
 
 [[package]]
@@ -9898,8 +9898,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
 dependencies = [
-    "tls_codec_derive",
-    "zeroize",
+ "tls_codec_derive",
+ "zeroize",
 ]
 
 [[package]]
@@ -9908,9 +9908,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9919,15 +9919,15 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
-    "bytes",
-    "libc",
-    "mio",
-    "parking_lot",
-    "pin-project-lite",
-    "signal-hook-registry",
-    "socket2",
-    "tokio-macros",
-    "windows-sys 0.61.2",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9936,9 +9936,9 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -9947,8 +9947,8 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
-    "rustls",
-    "tokio",
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -9957,9 +9957,9 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
-    "futures-core",
-    "pin-project-lite",
-    "tokio",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -9968,9 +9968,9 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
 dependencies = [
-    "futures-core",
-    "tokio",
-    "tokio-stream",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -9979,12 +9979,12 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
-    "bytes",
-    "futures-core",
-    "futures-io",
-    "futures-sink",
-    "pin-project-lite",
-    "tokio",
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -9993,10 +9993,10 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
-    "serde",
-    "serde_spanned",
-    "toml_datetime 0.6.11",
-    "toml_edit 0.22.27",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -10005,7 +10005,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -10014,7 +10014,7 @@ version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
-    "serde_core",
+ "serde_core",
 ]
 
 [[package]]
@@ -10023,12 +10023,12 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
-    "indexmap 2.13.0",
-    "serde",
-    "serde_spanned",
-    "toml_datetime 0.6.11",
-    "toml_write",
-    "winnow",
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
 ]
 
 [[package]]
@@ -10037,10 +10037,10 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
-    "indexmap 2.13.0",
-    "toml_datetime 0.7.5+spec-1.1.0",
-    "toml_parser",
-    "winnow",
+ "indexmap 2.13.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -10049,7 +10049,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
-    "winnow",
+ "winnow",
 ]
 
 [[package]]
@@ -10064,30 +10064,30 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
-    "async-trait",
-    "axum",
-    "base64",
-    "bytes",
-    "flate2",
-    "h2",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "hyper",
-    "hyper-timeout",
-    "hyper-util",
-    "percent-encoding",
-    "pin-project",
-    "rustls-native-certs",
-    "socket2",
-    "sync_wrapper",
-    "tokio",
-    "tokio-rustls",
-    "tokio-stream",
-    "tower",
-    "tower-layer",
-    "tower-service",
-    "tracing",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "flate2",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10096,10 +10096,10 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
 dependencies = [
-    "prettyplease",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10108,9 +10108,9 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
-    "bytes",
-    "prost 0.14.3",
-    "tonic",
+ "bytes",
+ "prost 0.14.3",
+ "tonic",
 ]
 
 [[package]]
@@ -10119,14 +10119,14 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
 dependencies = [
-    "prettyplease",
-    "proc-macro2",
-    "prost-build",
-    "prost-types",
-    "quote",
-    "syn 2.0.114",
-    "tempfile",
-    "tonic-build",
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.114",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -10135,17 +10135,17 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
-    "futures-core",
-    "futures-util",
-    "indexmap 2.13.0",
-    "pin-project-lite",
-    "slab",
-    "sync_wrapper",
-    "tokio",
-    "tokio-util",
-    "tower-layer",
-    "tower-service",
-    "tracing",
+ "futures-core",
+ "futures-util",
+ "indexmap 2.13.0",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10154,23 +10154,23 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
-    "async-compression",
-    "bitflags 2.10.0",
-    "bytes",
-    "futures-core",
-    "futures-util",
-    "http 1.4.0",
-    "http-body 1.0.1",
-    "http-body-util",
-    "iri-string",
-    "pin-project-lite",
-    "tokio",
-    "tokio-util",
-    "tower",
-    "tower-layer",
-    "tower-service",
-    "tracing",
-    "uuid",
+ "async-compression",
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -10191,10 +10191,10 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
-    "log",
-    "pin-project-lite",
-    "tracing-attributes",
-    "tracing-core",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
 ]
 
 [[package]]
@@ -10203,10 +10203,10 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
-    "crossbeam-channel",
-    "thiserror 2.0.17",
-    "time",
-    "tracing-subscriber",
+ "crossbeam-channel",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -10215,9 +10215,9 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10226,8 +10226,8 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
-    "once_cell",
-    "valuable",
+ "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -10236,8 +10236,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
-    "tracing",
-    "tracing-subscriber",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -10246,9 +10246,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
-    "log",
-    "once_cell",
-    "tracing-core",
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -10257,14 +10257,14 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
-    "js-sys",
-    "opentelemetry",
-    "smallvec",
-    "tracing",
-    "tracing-core",
-    "tracing-log",
-    "tracing-subscriber",
-    "web-time",
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -10273,8 +10273,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
-    "serde",
-    "tracing-core",
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -10283,20 +10283,20 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
-    "matchers",
-    "nu-ansi-term",
-    "once_cell",
-    "regex-automata",
-    "serde",
-    "serde_json",
-    "sharded-slab",
-    "smallvec",
-    "thread_local",
-    "time",
-    "tracing",
-    "tracing-core",
-    "tracing-log",
-    "tracing-serde",
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -10305,7 +10305,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a814d25437963577f6221d33a2aaa60bfb44acc3330cdc7c334644e9832022"
 dependencies = [
-    "futures-core",
+ "futures-core",
 ]
 
 [[package]]
@@ -10344,9 +10344,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d4e985b6dda743ae7fd4140c28105316ffd75bc58258ee6cc12934e3eb7a0c"
 dependencies = [
-    "iana-time-zone",
-    "tz-rs",
-    "tzdb_data",
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
 ]
 
 [[package]]
@@ -10355,7 +10355,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42302a846dea7ab786f42dc5f519387069045acff793e1178d9368414168fe95"
 dependencies = [
-    "tz-rs",
+ "tz-rs",
 ]
 
 [[package]]
@@ -10394,8 +10394,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
-    "crypto-common 0.1.7",
-    "subtle",
+ "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -10404,8 +10404,8 @@ version = "0.6.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0386f227888b17b65d3e38219a7d41185035471300855c285667811907bb1677"
 dependencies = [
-    "crypto-common 0.2.0-rc.9",
-    "subtle",
+ "crypto-common 0.2.0-rc.9",
+ "subtle",
 ]
 
 [[package]]
@@ -10426,10 +10426,10 @@ version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
-    "form_urlencoded",
-    "idna",
-    "percent-encoding",
-    "serde",
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -10456,12 +10456,12 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
-    "getrandom 0.3.4",
-    "js-sys",
-    "rand 0.9.2",
-    "serde_core",
-    "uuid-macro-internal",
-    "wasm-bindgen",
+ "getrandom 0.3.4",
+ "js-sys",
+ "rand 0.9.2",
+ "serde_core",
+ "uuid-macro-internal",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -10470,9 +10470,9 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39d11901c36b3650df7acb0f9ebe624f35b5ac4e1922ecd3c57f444648429594"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10487,8 +10487,8 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 dependencies = [
-    "value-bag-serde1",
-    "value-bag-sval2",
+ "value-bag-serde1",
+ "value-bag-sval2",
 ]
 
 [[package]]
@@ -10497,9 +10497,9 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16530907bfe2999a1773ca5900a65101e092c70f642f25cc23ca0c43573262c5"
 dependencies = [
-    "erased-serde 0.4.9",
-    "serde_core",
-    "serde_fmt",
+ "erased-serde 0.4.9",
+ "serde_core",
+ "serde_fmt",
 ]
 
 [[package]]
@@ -10508,13 +10508,13 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00ae130edd690eaa877e4f40605d534790d1cf1d651e7685bd6a144521b251f"
 dependencies = [
-    "sval",
-    "sval_buffer",
-    "sval_dynamic",
-    "sval_fmt",
-    "sval_json",
-    "sval_ref",
-    "sval_serde",
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
 ]
 
 [[package]]
@@ -10523,18 +10523,18 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81eb4d9221ca29bad43d4b6871b6d2e7656e1af2cfca624a87e5d17880d831d"
 dependencies = [
-    "async-trait",
-    "bytes",
-    "derive_builder 0.12.0",
-    "http 1.4.0",
-    "reqwest",
-    "rustify",
-    "rustify_derive",
-    "serde",
-    "serde_json",
-    "thiserror 1.0.69",
-    "tracing",
-    "url",
+ "async-trait",
+ "bytes",
+ "derive_builder 0.12.0",
+ "http 1.4.0",
+ "reqwest",
+ "rustify",
+ "rustify_derive",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -10555,8 +10555,8 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
-    "same-file",
-    "winapi-util",
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -10565,7 +10565,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
-    "try-lock",
+ "try-lock",
 ]
 
 [[package]]
@@ -10580,7 +10580,7 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
-    "wit-bindgen",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -10589,11 +10589,11 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
-    "cfg-if",
-    "once_cell",
-    "rustversion",
-    "wasm-bindgen-macro",
-    "wasm-bindgen-shared",
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -10602,11 +10602,11 @@ version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
-    "cfg-if",
-    "js-sys",
-    "once_cell",
-    "wasm-bindgen",
-    "web-sys",
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -10615,8 +10615,8 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
-    "quote",
-    "wasm-bindgen-macro-support",
+ "quote",
+ "wasm-bindgen-macro-support",
 ]
 
 [[package]]
@@ -10625,11 +10625,11 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
-    "bumpalo",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
-    "wasm-bindgen-shared",
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -10638,7 +10638,7 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
-    "unicode-ident",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -10647,11 +10647,11 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
-    "futures-util",
-    "js-sys",
-    "wasm-bindgen",
-    "wasm-bindgen-futures",
-    "web-sys",
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -10660,8 +10660,8 @@ version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
-    "js-sys",
-    "wasm-bindgen",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -10670,8 +10670,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
-    "js-sys",
-    "wasm-bindgen",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -10680,7 +10680,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
-    "rustls-pki-types",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -10689,10 +10689,10 @@ version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
-    "either",
-    "home",
-    "once_cell",
-    "rustix 0.38.44",
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -10701,7 +10701,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -10710,8 +10710,8 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
-    "winapi-i686-pc-windows-gnu",
-    "winapi-x86_64-pc-windows-gnu",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
@@ -10726,7 +10726,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
-    "windows-sys 0.61.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10741,11 +10741,11 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
-    "windows-collections 0.2.0",
-    "windows-core 0.61.2",
-    "windows-future 0.2.1",
-    "windows-link 0.1.3",
-    "windows-numerics 0.2.0",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
 ]
 
 [[package]]
@@ -10754,10 +10754,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
-    "windows-collections 0.3.2",
-    "windows-core 0.62.2",
-    "windows-future 0.3.2",
-    "windows-numerics 0.3.1",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -10766,7 +10766,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
-    "windows-core 0.61.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -10775,7 +10775,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
-    "windows-core 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -10784,11 +10784,11 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
-    "windows-implement",
-    "windows-interface",
-    "windows-link 0.1.3",
-    "windows-result 0.3.4",
-    "windows-strings 0.4.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -10797,11 +10797,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
-    "windows-implement",
-    "windows-interface",
-    "windows-link 0.2.1",
-    "windows-result 0.4.1",
-    "windows-strings 0.5.1",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -10810,9 +10810,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
-    "windows-core 0.61.2",
-    "windows-link 0.1.3",
-    "windows-threading 0.1.0",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -10821,9 +10821,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
-    "windows-core 0.62.2",
-    "windows-link 0.2.1",
-    "windows-threading 0.2.1",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -10832,9 +10832,9 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10843,9 +10843,9 @@ version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10866,8 +10866,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
-    "windows-core 0.61.2",
-    "windows-link 0.1.3",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -10876,8 +10876,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
-    "windows-core 0.62.2",
-    "windows-link 0.2.1",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10886,9 +10886,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
-    "windows-link 0.2.1",
-    "windows-result 0.4.1",
-    "windows-strings 0.5.1",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -10897,7 +10897,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
-    "windows-link 0.1.3",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -10906,7 +10906,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
-    "windows-link 0.2.1",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10915,7 +10915,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
-    "windows-link 0.1.3",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -10924,7 +10924,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
-    "windows-link 0.2.1",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10933,7 +10933,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10942,7 +10942,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10951,7 +10951,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
-    "windows-targets 0.53.5",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -10960,7 +10960,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
-    "windows-link 0.2.1",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10969,14 +10969,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
-    "windows_aarch64_gnullvm 0.52.6",
-    "windows_aarch64_msvc 0.52.6",
-    "windows_i686_gnu 0.52.6",
-    "windows_i686_gnullvm 0.52.6",
-    "windows_i686_msvc 0.52.6",
-    "windows_x86_64_gnu 0.52.6",
-    "windows_x86_64_gnullvm 0.52.6",
-    "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -10985,15 +10985,15 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
-    "windows-link 0.2.1",
-    "windows_aarch64_gnullvm 0.53.1",
-    "windows_aarch64_msvc 0.53.1",
-    "windows_i686_gnu 0.53.1",
-    "windows_i686_gnullvm 0.53.1",
-    "windows_i686_msvc 0.53.1",
-    "windows_x86_64_gnu 0.53.1",
-    "windows_x86_64_gnullvm 0.53.1",
-    "windows_x86_64_msvc 0.53.1",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -11002,7 +11002,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
-    "windows-link 0.1.3",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -11011,7 +11011,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
-    "windows-link 0.2.1",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -11116,7 +11116,7 @@ version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -11131,10 +11131,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
-    "darling 0.20.11",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -11149,15 +11149,15 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
-    "asn1-rs",
-    "data-encoding",
-    "der-parser",
-    "lazy_static",
-    "nom 7.1.3",
-    "oid-registry",
-    "rusticata-macros",
-    "thiserror 2.0.17",
-    "time",
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
 ]
 
 [[package]]
@@ -11166,16 +11166,16 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
 dependencies = [
-    "asn1-rs",
-    "data-encoding",
-    "der-parser",
-    "lazy_static",
-    "nom 7.1.3",
-    "oid-registry",
-    "ring",
-    "rusticata-macros",
-    "thiserror 2.0.17",
-    "time",
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.17",
+ "time",
 ]
 
 [[package]]
@@ -11184,8 +11184,8 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
-    "libc",
-    "rustix 1.1.3",
+ "libc",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -11206,7 +11206,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
-    "lzma-sys",
+ "lzma-sys",
 ]
 
 [[package]]
@@ -11221,7 +11221,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
-    "time",
+ "time",
 ]
 
 [[package]]
@@ -11230,9 +11230,9 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
-    "stable_deref_trait",
-    "yoke-derive",
-    "zerofrom",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
 ]
 
 [[package]]
@@ -11241,10 +11241,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
-    "synstructure 0.13.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -11253,7 +11253,7 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
-    "zerocopy-derive",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -11262,9 +11262,9 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -11273,7 +11273,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
-    "zerofrom-derive",
+ "zerofrom-derive",
 ]
 
 [[package]]
@@ -11282,10 +11282,10 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
-    "synstructure 0.13.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -11294,7 +11294,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
-    "zeroize_derive",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -11303,9 +11303,9 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -11314,9 +11314,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
-    "displaydoc",
-    "yoke",
-    "zerofrom",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
@@ -11325,9 +11325,9 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
-    "yoke",
-    "zerofrom",
-    "zerovec-derive",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
 ]
 
 [[package]]
@@ -11336,9 +11336,9 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.114",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -11347,26 +11347,26 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd8a47718a4ee5fe78e07667cd36f3de80e7c2bfe727c7074245ffc7303c037"
 dependencies = [
-    "aes 0.8.4",
-    "arbitrary",
-    "bzip2 0.6.1",
-    "constant_time_eq 0.3.1",
-    "crc32fast",
-    "deflate64",
-    "flate2",
-    "generic-array 0.14.7",
-    "getrandom 0.3.4",
-    "hmac 0.12.1",
-    "indexmap 2.13.0",
-    "lzma-rust2",
-    "memchr",
-    "pbkdf2 0.12.2",
-    "ppmd-rust",
-    "sha1 0.10.6",
-    "time",
-    "zeroize",
-    "zopfli",
-    "zstd",
+ "aes 0.8.4",
+ "arbitrary",
+ "bzip2 0.6.1",
+ "constant_time_eq 0.3.1",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "generic-array 0.14.7",
+ "getrandom 0.3.4",
+ "hmac 0.12.1",
+ "indexmap 2.13.0",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2 0.12.2",
+ "ppmd-rust",
+ "sha1 0.10.6",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -11387,10 +11387,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
-    "bumpalo",
-    "crc32fast",
-    "log",
-    "simd-adler32",
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -11399,7 +11399,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
-    "zstd-safe",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -11408,7 +11408,7 @@ version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
-    "zstd-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -11417,6 +11417,6 @@ version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
-    "cc",
-    "pkg-config",
+ "cc",
+ "pkg-config",
 ]


### PR DESCRIPTION
This PR addresses issue #1415 where object tagging was not working properly - tags set via PutObjectTagging were not being saved or retrievable via GetObjectTagging.

**Problem:**  
Users reported that object tags were not persisting after setting them, and boto3 operations failed to retrieve tags. This affected object management workflows relying on tagging for compliance and automation.

**Root Cause:**  
- Lack of version support for tagging operations in versioned buckets  
- Missing cache invalidation after tag modifications  
- Insufficient input validation for tag keys/values  
- Limited error handling and debugging capabilities  

**Solution:**  
- Enhanced `put_object_tagging`, `get_object_tagging`, and `delete_object_tagging` methods with full version support  
- Added robust validation for tag constraints (key/value length, uniqueness)  
- Implemented cache invalidation using the concurrency manager to prevent stale reads  
- Improved error handling with detailed logging and proper S3 error codes  
- Added Prometheus metrics for monitoring tagging operation success and performance  


**Changes:**  
- `rustfs/src/storage/ecfs.rs`: Updated tagging methods with version handling, validation, caching, and metrics  
 

**Testing:**  
- Unit tests for validation logic  
- E2e tests simulate full HTTP workflows  
- Manual testing with boto3 confirmed tag persistence and retrieval  

**Impact:**  
- Fully compatible with AWS S3 API for object tagging  
- Improves performance and reliability of tagging operations  
- No breaking changes to existing functionality  

Closes #1415.  