### PR TITLE
fix: exclude matching key from ListObjects results when using marker/startAfter

### DIFF
--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -410,13 +410,13 @@ impl ECStore {
             ..Default::default()
         };
 
-        let mut list_result = match self.list_path(&opts).await {
-            Ok(res) => res,
-            Err(err) => MetaCacheEntriesSortedResult {
+        let mut list_result = self
+            .list_path(&opts)
+            .await
+            .unwrap_or_else(|err| MetaCacheEntriesSortedResult {
                 err: Some(err.into()),
                 ..Default::default()
-            },
-        };
+            });
 
         if let Some(err) = list_result.err.clone()
             && err != rustfs_filemeta::Error::Unexpected
@@ -988,7 +988,7 @@ async fn gather_results(
         }
 
         if let Some(marker) = &opts.marker
-            && &entry.name < marker
+            && &entry.name <= marker
         {
             continue;
         }
@@ -1476,7 +1476,6 @@ mod test {
     // use crate::error::Error;
     // use crate::metacache::writer::MetacacheReader;
     // use crate::set_disk::SetDisks;
-    // use crate::store::ECStore;
     // use crate::store_list_objects::ListPathOptions;
     // use crate::store_list_objects::WalkOptions;
     // use crate::store_list_objects::WalkVersionsSortOrder;


### PR DESCRIPTION

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 --> #1165

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

This PR fixes a bug where `ListObjects` and `ListObjectsV2` incorrectly included the object matching the `marker` or `startAfter` parameter in the results. According to the S3 API specification, these parameters should be exclusive.

## Changes
- Modified `crates/ecstore/src/store_list_objects.rs`:
    - Updated the filtering logic in `gather_results` to skip entries where `entry.name <= marker`.
    - Changed the comparison operator from `<` to `<=` to ensure the starting key is excluded.

## Impact
- **API Compliance**: Aligns RustFS listing behavior with AWS S3 standards.
- **Bug Fix**: Resolves infinite loops in client pagination logic where the last returned key is used as the `startAfter` value for the next page.

## Verification Results
- Verified that calling `ListObjectsV2` with `startAfter="b.txt"` on a bucket containing `[a.txt, b.txt, c.txt]` now returns only `[c.txt]`.
- Confirmed that pagination loops now terminate correctly when reaching the end of the object list.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
