### PR TITLE
fix: return error instead of silently ignoring invalid ARNs in notification config

### DIFF
--- a/crates/targets/src/arn.rs
+++ b/crates/targets/src/arn.rs
@@ -129,6 +129,8 @@ impl ARN {
     }
 
     /// Parsing ARN from string
+    /// Only accepts ARNs with the RustFS prefix: "arn:rustfs:sqs:"
+    /// Format: arn:rustfs:sqs:{region}:{id}:{name}
     pub fn parse(s: &str) -> Result<Self, TargetError> {
         if !s.starts_with(ARN_PREFIX) {
             return Err(TargetError::InvalidARN(s.to_string()));


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Purpose
This PR fixes a bug where invalid ARNs in `PutBucketNotificationConfiguration` were silently ignored instead of returning an error.

**Before**: Users could configure bucket notifications with an invalid ARN (e.g., `arn:minio:sqs::1:webhook` instead of `arn:rustfs:sqs::1:webhook`). The API would return success, but notifications would never work because the ARN was quietly discarded.

**After**: Invalid ARNs return an `InvalidArgument` error, matching S3 API behavior where "if validation fails, the entire PUT action will fail."

The bug existed because `process_topic_configurations` and `process_lambda_configurations` used `.ok()` to silently convert parsing errors to `None`, while `process_queue_configurations` correctly propagated errors. This inconsistency has been fixed.

## Summary
- Fixed silent failure when invalid ARNs are provided in `PutBucketNotificationConfiguration`
- `process_topic_configurations` and `process_lambda_configurations` now return `Result` and propagate errors
- Invalid ARNs now return `InvalidArgument` S3 error instead of being silently ignored
- Startup code in `init.rs` now logs errors instead of silently ignoring them

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)
