### PR TITLE
fix:correctly handle compress object when put object

### DIFF
--- a/crates/rio/src/hash_reader.rs
+++ b/crates/rio/src/hash_reader.rs
@@ -169,8 +169,9 @@ impl HashReader {
         sha256hex: Option<String>,
         diskable_md5: bool,
     ) -> std::io::Result<Self> {
-        // Check if it's already a HashReader and update its parameters
-        if let Some(existing_hash_reader) = inner.as_hash_reader_mut() {
+        if size >= 0
+            && let Some(existing_hash_reader) = inner.as_hash_reader_mut()
+        {
             if existing_hash_reader.bytes_read() > 0 {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -212,7 +213,8 @@ impl HashReader {
             let content_sha256 = existing_hash_reader.content_sha256().clone();
             let content_sha256_hasher = existing_hash_reader.content_sha256().clone().map(|_| Sha256Hasher::new());
             let inner = existing_hash_reader.take_inner();
-            return Ok(Self {
+
+            Ok(Self {
                 inner,
                 size,
                 checksum: md5hex.clone(),
@@ -225,34 +227,36 @@ impl HashReader {
                 content_hasher,
                 checksum_on_finish: false,
                 trailer_s3s: existing_hash_reader.get_trailer().cloned(),
-            });
-        }
+            })
+        } else {
+            if size > 0 {
+                let hr = HardLimitReader::new(inner, size);
+                inner = Box::new(hr);
 
-        if size > 0 {
-            let hr = HardLimitReader::new(inner, size);
-            inner = Box::new(hr);
-            if !diskable_md5 && !inner.is_hash_reader() {
+                if !diskable_md5 && !inner.is_hash_reader() {
+                    let er = EtagReader::new(inner, md5hex.clone());
+                    inner = Box::new(er);
+                }
+            } else if !diskable_md5 {
                 let er = EtagReader::new(inner, md5hex.clone());
                 inner = Box::new(er);
             }
-        } else if !diskable_md5 {
-            let er = EtagReader::new(inner, md5hex.clone());
-            inner = Box::new(er);
+
+            Ok(Self {
+                inner,
+                size,
+                checksum: md5hex,
+                actual_size,
+                diskable_md5,
+                bytes_read: 0,
+                content_hash: None,
+                content_hasher: None,
+                content_sha256: sha256hex.clone(),
+                content_sha256_hasher: sha256hex.map(|_| Sha256Hasher::new()),
+                checksum_on_finish: false,
+                trailer_s3s: None,
+            })
         }
-        Ok(Self {
-            inner,
-            size,
-            checksum: md5hex,
-            actual_size,
-            diskable_md5,
-            bytes_read: 0,
-            content_hash: None,
-            content_hasher: None,
-            content_sha256: sha256hex.clone(),
-            content_sha256_hasher: sha256hex.clone().map(|_| Sha256Hasher::new()),
-            checksum_on_finish: false,
-            trailer_s3s: None,
-        })
     }
 
     pub fn into_inner(self) -> Box<dyn Reader> {


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
FIX #1419 
RELATE #1668
## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->
Skip unwrapping inner HashReader when size < 0 to preserve transformation layers (compression). This fixes compression not being applied during put_object operations.
## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)
