### PR TITLE
optimize:replace size magic number -1 with SIZE_TRANSFORMED constant

### DIFF
--- a/crates/rio/src/hash_reader.rs
+++ b/crates/rio/src/hash_reader.rs
@@ -161,6 +161,8 @@ pin_project! {
 }
 
 impl HashReader {
+    /// Used for transformation layers (compression/encryption)
+    pub const SIZE_PRESERVE_LAYER: i64 = -1;
     pub fn new(
         mut inner: Box<dyn Reader>,
         size: i64,
@@ -169,7 +171,8 @@ impl HashReader {
         sha256hex: Option<String>,
         diskable_md5: bool,
     ) -> std::io::Result<Self> {
-        if size >= 0
+        // Get the innermost HashReader
+        if size != Self::SIZE_PRESERVE_LAYER
             && let Some(existing_hash_reader) = inner.as_hash_reader_mut()
         {
             if existing_hash_reader.bytes_read() > 0 {

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -670,7 +670,7 @@ impl FS {
                     let hrd = HashReader::new(reader, size, actual_size, None, None, false).map_err(ApiError::from)?;
 
                     reader = Box::new(CompressReader::new(hrd, CompressionAlgorithm::default()));
-                    size = -1;
+                    size = HashReader::SIZE_PRESERVE_LAYER;
                 }
 
                 let hrd = HashReader::new(reader, size, actual_size, None, None, false).map_err(ApiError::from)?;
@@ -1222,7 +1222,7 @@ impl S3 for FS {
             // let hrd = HashReader::new(reader, length, actual_size, None, false).map_err(ApiError::from)?;
 
             reader = Box::new(CompressReader::new(hrd, CompressionAlgorithm::default()));
-            length = -1;
+            length = HashReader::SIZE_PRESERVE_LAYER;
         } else {
             src_info
                 .user_defined
@@ -3699,7 +3699,7 @@ impl S3 for FS {
             opts.want_checksum = hrd.checksum();
 
             reader = Box::new(CompressReader::new(hrd, CompressionAlgorithm::default()));
-            size = -1;
+            size = HashReader::SIZE_PRESERVE_LAYER;
             md5hex = None;
             sha256hex = None;
         }
@@ -4211,7 +4211,7 @@ impl S3 for FS {
 
             let compress_reader = CompressReader::new(hrd, CompressionAlgorithm::default());
             reader = Box::new(compress_reader);
-            size = -1;
+            size = HashReader::SIZE_PRESERVE_LAYER;
             md5hex = None;
             sha256hex = None;
         }
@@ -4439,7 +4439,7 @@ impl S3 for FS {
         if is_compressible {
             let hrd = HashReader::new(reader, size, actual_size, None, None, false).map_err(ApiError::from)?;
             reader = Box::new(CompressReader::new(hrd, CompressionAlgorithm::default()));
-            size = -1;
+            size = HashReader::SIZE_PRESERVE_LAYER;
         }
 
         let mut reader = HashReader::new(reader, size, actual_size, None, None, false).map_err(ApiError::from)?;


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
RELATE #1668

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->
Replace hardcoded -1 values used to indicate transformed data size (compression/encryption) with HashReader::SIZE_TRANSFORMED constant.
This improves code readability and maintainability by:
- Eliminating magic numbers in compression/encryption paths
- Making the intent clear through a named constant

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)
