### PR TITLE
Helm: Add ability to enable Virtual Hosting paths

### DIFF
--- a/helm/rustfs/templates/configmap.yaml
+++ b/helm/rustfs/templates/configmap.yaml
@@ -19,3 +19,6 @@ data:
   {{- else }}
   RUSTFS_VOLUMES: "/data"
   {{- end }}
+  {{- if .Values.config.rustfs.domains }}
+  RUSTFS_SERVER_DOMAINS: {{ .Values.config.rustfs.domains | quote }}
+  {{- end }}

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -58,6 +58,9 @@ config:
     region: "us-east-1"
     obs_log_directory: "/logs"
     obs_environment: "develop"
+    # Optionally enable support for virtual-hosted-style requests.
+    # See more information: https://docs.rustfs.com/integration/virtual.html
+    domains: "" # e.g. "example.com"
 
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [X] Other: Helm Chart: Providing additional environment variable.

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
N/A

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

This adds a new `domains` field to the `config.rustfs` object in the Helm values. If set, will provide `RUSTFS_SERVER_DOMAINS` to the ConfigMap to enable Virtual Hosting as per https://docs.rustfs.com/integration/virtual.html.

The Helm Chart has no other mechanism to supply additional environment variables to the running pods within the Deployment.

## Checklist
- [X] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [X] Passed `make pre-commit`
- [X] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [X] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
