### PR TITLE
fix: use main user for s3tests tenant to prevent teardown failures

### DIFF
--- a/.github/s3tests/s3tests.conf
+++ b/.github/s3tests/s3tests.conf
@@ -120,7 +120,11 @@ secret_key = ${S3_ALT_SECRET_KEY}
 display_name = RustFS Tenant Tester
 
 # tenant user_id
-user_id = rustfstenant
+# Note: Using same user_id as main to avoid teardown failures.
+# RustFS does not currently support multi-tenancy, so the tenant client
+# effectively operates as the main user. This ensures nuke_prefixed_buckets()
+# in s3-tests teardown can successfully clean up resources.
+user_id = rustfsadmin
 
 # tenant AWS access key
 access_key = ${S3_ACCESS_KEY}
@@ -132,7 +136,11 @@ secret_key = ${S3_SECRET_KEY}
 email = tenant@rustfs.local
 
 # tenant name
-tenant = testx
+# Note: Empty tenant name to avoid multi-tenant path issues during teardown.
+# When s3-tests calls get_tenant_client(), it uses this tenant value in requests.
+# An empty value makes the tenant client behave like the main client, preventing
+# "bucket not found" errors when teardown tries to clean up test buckets.
+tenant =
 
 #following section needs to be added for all sts-tests
 [iam]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- Fixes s3-tests teardown failures -->

## Summary of Changes
Configure s3tests tenant user to use the same credentials as main user to prevent teardown failures.

**Problem:**
The s3-tests teardown phase (`nuke_prefixed_buckets`) was failing with "bucket not found" errors. RustFS does not currently support multi-tenancy, so the tenant client (configured with `user_id=rustfstenant`, `tenant=testx`) could not find or delete buckets created by the main client.

**Solution:**
Update `[s3 tenant]` section in `.github/s3tests/s3tests.conf`:
- Set `user_id = rustfsadmin` (same as main user)
- Set `tenant =` (empty string)

This makes the tenant client behave identically to the main client, allowing teardown to successfully clean up resources.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
This is a workaround until RustFS implements proper multi-tenancy support. Added explanatory comments in the config file for future maintainers.
