### PR TITLE
fix: missing object.key in S3 event notifications for multipart uploads

### DIFF
--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -699,6 +699,7 @@ impl S3 for FS {
         let mpu_key = key.clone();
         let mpu_version = obj_info.version_id.map(|v| v.to_string());
         let mpu_version_clone = mpu_version.clone();
+        let mpu_version_for_event = mpu_version.clone();
         tokio::spawn(async move {
             manager
                 .invalidate_cache_versioned(&mpu_bucket, &mpu_key, mpu_version_clone.as_deref())
@@ -792,7 +793,7 @@ impl S3 for FS {
 
         // Set object info for event notification
         helper = helper.object(obj_info.clone());
-        if let Some(version_id) = &mpu_version {
+        if let Some(version_id) = &mpu_version_for_event {
             helper = helper.version_id(version_id.clone());
         }
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
https://github.com/rustfs/rustfs/issues/1609
Issue: 
![img_v3_02ub_c7906ec1-006f-46fa-af36-f4e0001fdadg](https://github.com/user-attachments/assets/1f3fa601-484b-4feb-bb4e-b65669d5d46c)

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->
In the complete_multipart_upload method, although the obj_info was correctly retrieved (containing proper object name and size), it was not passed to the event notification system.

Fixed: 
<img width="716" height="436" alt="image" src="https://github.com/user-attachments/assets/bcc5afe8-613b-48a7-883b-216cc37476e1" />
