### PR TITLE
fix: map unversioned destination replication error correctly

### DIFF
--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -431,13 +431,15 @@ impl BucketTargetSys {
             let versioning = target_client
                 .get_bucket_versioning(&target.target_bucket)
                 .await
-                .map_err(|_e| BucketTargetError::BucketReplicationSourceNotVersioned {
-                    bucket: bucket.to_string(),
+                .map_err(|e| BucketTargetError::RemoteTargetConnectionErr {
+                    bucket: target.target_bucket.clone(),
+                    access_key: target.credentials.as_ref().map(|c| c.access_key.clone()).unwrap_or_default(),
+                    error: e.to_string(),
                 })?;
 
             if versioning.is_none() {
-                return Err(BucketTargetError::BucketReplicationSourceNotVersioned {
-                    bucket: bucket.to_string(),
+                return Err(BucketTargetError::BucketRemoteTargetNotVersioned {
+                    bucket: target.target_bucket.to_string(),
                 });
             }
         }


### PR DESCRIPTION
Correctly map error when configuring replication from versioned source to unversioned destination

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
#1644 

## Summary of Changes
Correctly map error when configuring replication from versioned source to unversioned destination. Previously returned incorrect error that source bucket must be versioned, when in actuality the destination bucket must be versioned. 

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
