### PR TITLE
fix: persist replication status and timestamp after replicate_object

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -1899,8 +1899,8 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
             rinfo.replication_status = ReplicationStatusType::Failed;
             rinfo.error = Some(err.to_string());
             warn!(
-                "replication put_object failed bucket={} object={} err={:?}",
-                tgt_client.bucket, object, err
+                "replication put_object failed src_bucket={} dest_bucket={} object={} err={:?}",
+                bucket, tgt_client.bucket, object, err
             );
 
             // TODO: check offline


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
FIX #1742 
RELATE #1764

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->
After a successful replication, the code now updates the object’s metadata with the new replication status and timestamp via put_object_metadata and eval_metadata. Previously, put_object_metadata was either not called or called without eval_metadata, so the replication status was never written. As a result, objects stayed in PENDING, the scanner kept re-queuing them, and replication never showed as COMPLETED. With this fix, the completed status and timestamp are persisted so the scanner no longer re-replicates the same object.
## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)
