### PR TITLE
refactor(admin): extract user IAM route registration

### DIFF
--- a/rustfs/src/admin/handlers/mod.rs
+++ b/rustfs/src/admin/handlers/mod.rs
@@ -36,6 +36,7 @@ pub mod system;
 pub mod tier;
 pub mod trace;
 pub mod user;
+pub mod user_iam;
 
 #[cfg(test)]
 mod tests {

--- a/rustfs/src/admin/handlers/user.rs
+++ b/rustfs/src/admin/handlers/user.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{account_info, event, group, policies, service_account};
+use super::{account_info, event, group, policies, service_account, user_iam};
 use crate::{
     admin::{
         auth::validate_admin_request,
@@ -61,7 +61,7 @@ pub fn register_user_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<
     register_user_management_route(r)?;
     group::register_group_management_route(r)?;
     service_account::register_service_account_route(r)?;
-    register_user_iam_route(r)?;
+    user_iam::register_user_iam_route(r)?;
     policies::register_iam_policy_route(r)?;
     event::register_notification_target_route(r)?;
 
@@ -97,22 +97,6 @@ fn register_user_management_route(r: &mut S3Router<AdminOperation>) -> std::io::
         Method::PUT,
         format!("{}{}", ADMIN_PREFIX, "/v3/set-user-status").as_str(),
         AdminOperation(&SetUserStatus {}),
-    )?;
-
-    Ok(())
-}
-
-fn register_user_iam_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
-    r.insert(
-        Method::GET,
-        format!("{}{}", ADMIN_PREFIX, "/v3/export-iam").as_str(),
-        AdminOperation(&ExportIam {}),
-    )?;
-
-    r.insert(
-        Method::PUT,
-        format!("{}{}", ADMIN_PREFIX, "/v3/import-iam").as_str(),
-        AdminOperation(&ImportIam {}),
     )?;
 
     Ok(())

--- a/rustfs/src/admin/handlers/user_iam.rs
+++ b/rustfs/src/admin/handlers/user_iam.rs
@@ -1,0 +1,36 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::user::{ExportIam, ImportIam};
+use crate::{
+    admin::router::{AdminOperation, S3Router},
+    server::ADMIN_PREFIX,
+};
+use hyper::Method;
+
+pub fn register_user_iam_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
+    r.insert(
+        Method::GET,
+        format!("{}{}", ADMIN_PREFIX, "/v3/export-iam").as_str(),
+        AdminOperation(&ExportIam {}),
+    )?;
+
+    r.insert(
+        Method::PUT,
+        format!("{}{}", ADMIN_PREFIX, "/v3/import-iam").as_str(),
+        AdminOperation(&ImportIam {}),
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- rustfs/issues#573

## Summary of Changes
- Extract IAM import/export route registration from `rustfs/src/admin/handlers/user.rs` into a dedicated module `rustfs/src/admin/handlers/user_iam.rs`.
- Keep `register_user_route` in `user.rs` as the facade entry and delegate IAM route registration to `user_iam::register_user_iam_route`.
- Keep IAM handler implementations (`ExportIam`, `ImportIam`) and route semantics unchanged.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Internal route-registration ownership cleanup only; no external API behavior change.

## Additional Notes
- This is a small incremental step under the admin refactor plan to keep review scope minimal.
