### PR TITLE
refactor(admin): extract user lifecycle route registration

### DIFF
--- a/rustfs/src/admin/handlers/mod.rs
+++ b/rustfs/src/admin/handlers/mod.rs
@@ -37,6 +37,7 @@ pub mod tier;
 pub mod trace;
 pub mod user;
 pub mod user_iam;
+pub mod user_lifecycle;
 
 #[cfg(test)]
 mod tests {

--- a/rustfs/src/admin/handlers/user.rs
+++ b/rustfs/src/admin/handlers/user.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{account_info, event, group, policies, service_account, user_iam};
+use super::{account_info, event, group, policies, service_account, user_iam, user_lifecycle};
 use crate::{
     admin::{
         auth::validate_admin_request,
@@ -20,10 +20,9 @@ use crate::{
         utils::has_space_be,
     },
     auth::{check_key_valid, constant_time_eq, get_session_token},
-    server::{ADMIN_PREFIX, RemoteAddr},
+    server::RemoteAddr,
 };
 use http::{HeaderMap, StatusCode};
-use hyper::Method;
 use matchit::Params;
 use rustfs_config::{MAX_ADMIN_REQUEST_BODY_SIZE, MAX_IAM_IMPORT_SIZE};
 use rustfs_credentials::get_global_action_cred;
@@ -58,46 +57,12 @@ pub struct AddUserQuery {
 
 pub fn register_user_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
     account_info::register_account_info_route(r)?;
-    register_user_management_route(r)?;
+    user_lifecycle::register_user_lifecycle_route(r)?;
     group::register_group_management_route(r)?;
     service_account::register_service_account_route(r)?;
     user_iam::register_user_iam_route(r)?;
     policies::register_iam_policy_route(r)?;
     event::register_notification_target_route(r)?;
-
-    Ok(())
-}
-
-fn register_user_management_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
-    r.insert(
-        Method::GET,
-        format!("{}{}", ADMIN_PREFIX, "/v3/list-users").as_str(),
-        AdminOperation(&ListUsers {}),
-    )?;
-
-    r.insert(
-        Method::GET,
-        format!("{}{}", ADMIN_PREFIX, "/v3/user-info").as_str(),
-        AdminOperation(&GetUserInfo {}),
-    )?;
-
-    r.insert(
-        Method::DELETE,
-        format!("{}{}", ADMIN_PREFIX, "/v3/remove-user").as_str(),
-        AdminOperation(&RemoveUser {}),
-    )?;
-
-    r.insert(
-        Method::PUT,
-        format!("{}{}", ADMIN_PREFIX, "/v3/add-user").as_str(),
-        AdminOperation(&AddUser {}),
-    )?;
-
-    r.insert(
-        Method::PUT,
-        format!("{}{}", ADMIN_PREFIX, "/v3/set-user-status").as_str(),
-        AdminOperation(&SetUserStatus {}),
-    )?;
 
     Ok(())
 }

--- a/rustfs/src/admin/handlers/user_lifecycle.rs
+++ b/rustfs/src/admin/handlers/user_lifecycle.rs
@@ -1,0 +1,54 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::user::{AddUser, GetUserInfo, ListUsers, RemoveUser, SetUserStatus};
+use crate::{
+    admin::router::{AdminOperation, S3Router},
+    server::ADMIN_PREFIX,
+};
+use hyper::Method;
+
+pub fn register_user_lifecycle_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
+    r.insert(
+        Method::GET,
+        format!("{}{}", ADMIN_PREFIX, "/v3/list-users").as_str(),
+        AdminOperation(&ListUsers {}),
+    )?;
+
+    r.insert(
+        Method::GET,
+        format!("{}{}", ADMIN_PREFIX, "/v3/user-info").as_str(),
+        AdminOperation(&GetUserInfo {}),
+    )?;
+
+    r.insert(
+        Method::DELETE,
+        format!("{}{}", ADMIN_PREFIX, "/v3/remove-user").as_str(),
+        AdminOperation(&RemoveUser {}),
+    )?;
+
+    r.insert(
+        Method::PUT,
+        format!("{}{}", ADMIN_PREFIX, "/v3/add-user").as_str(),
+        AdminOperation(&AddUser {}),
+    )?;
+
+    r.insert(
+        Method::PUT,
+        format!("{}{}", ADMIN_PREFIX, "/v3/set-user-status").as_str(),
+        AdminOperation(&SetUserStatus {}),
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- rustfs/issues#573

## Summary of Changes
- Extract user lifecycle route registration from `rustfs/src/admin/handlers/user.rs` into a dedicated module `rustfs/src/admin/handlers/user_lifecycle.rs`.
- Keep `register_user_route` in `user.rs` as the facade entry and delegate lifecycle route registration to `user_lifecycle::register_user_lifecycle_route`.
- Keep handler implementations (`AddUser`, `SetUserStatus`, `ListUsers`, `RemoveUser`, `GetUserInfo`) unchanged.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Internal route-registration ownership cleanup only; no external API behavior change.

## Additional Notes
- This is an incremental `P1-06` sub-step to keep the review scope small and isolated.
