### PR TITLE
refactor(admin): extract user policy binding route registration

### DIFF
--- a/rustfs/src/admin/handlers/mod.rs
+++ b/rustfs/src/admin/handlers/mod.rs
@@ -38,6 +38,7 @@ pub mod trace;
 pub mod user;
 pub mod user_iam;
 pub mod user_lifecycle;
+pub mod user_policy_binding;
 
 #[cfg(test)]
 mod tests {

--- a/rustfs/src/admin/handlers/user.rs
+++ b/rustfs/src/admin/handlers/user.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{account_info, event, group, policies, service_account, user_iam, user_lifecycle};
+use super::{account_info, group, service_account, user_iam, user_lifecycle, user_policy_binding};
 use crate::{
     admin::{
         auth::validate_admin_request,
@@ -61,8 +61,7 @@ pub fn register_user_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<
     group::register_group_management_route(r)?;
     service_account::register_service_account_route(r)?;
     user_iam::register_user_iam_route(r)?;
-    policies::register_iam_policy_route(r)?;
-    event::register_notification_target_route(r)?;
+    user_policy_binding::register_user_policy_binding_route(r)?;
 
     Ok(())
 }

--- a/rustfs/src/admin/handlers/user_policy_binding.rs
+++ b/rustfs/src/admin/handlers/user_policy_binding.rs
@@ -1,0 +1,22 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{event, policies};
+use crate::admin::router::{AdminOperation, S3Router};
+
+pub fn register_user_policy_binding_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
+    policies::register_iam_policy_route(r)?;
+    event::register_notification_target_route(r)?;
+    Ok(())
+}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- rustfs/issues#573

## Summary of Changes
- Extracted user policy-binding route registration from `rustfs/src/admin/handlers/user.rs` into a dedicated module:
  - Added `rustfs/src/admin/handlers/user_policy_binding.rs`
  - Added `register_user_policy_binding_route`
- Updated `register_user_route` to delegate policy/event route registration through the new module.
- Exported the new module in `rustfs/src/admin/handlers/mod.rs`.
- Kept route paths, methods, auth checks, and handler logic unchanged.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - No behavior change; only route registration ownership moved for better module boundaries.

## Additional Notes
- This is the final P1-06 sub-step in the refactor plan (user lifecycle / IAM import-export / policy-binding entry split).
- Verification run locally:
  - `cargo fmt --all --check`
  - `cargo check -p rustfs`
  - `cargo clippy -p rustfs -- -D warnings`
  - `make pre-commit`
