### PR TITLE
refactor(admin): move kms dynamic route registration

### DIFF
--- a/rustfs/src/admin/handlers/kms.rs
+++ b/rustfs/src/admin/handlers/kms.rs
@@ -112,7 +112,7 @@ fn extract_query_params(uri: &hyper::Uri) -> HashMap<String, String> {
 
 pub fn register_kms_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
     register_kms_management_route(r)?;
-    register_kms_dynamic_route(r)?;
+    kms_dynamic::register_kms_dynamic_route(r)?;
     register_kms_key_route(r)?;
 
     Ok(())
@@ -159,40 +159,6 @@ fn register_kms_management_route(r: &mut S3Router<AdminOperation>) -> std::io::R
         Method::POST,
         format!("{}{}", ADMIN_PREFIX, "/v3/kms/clear-cache").as_str(),
         AdminOperation(&KmsClearCacheHandler {}),
-    )?;
-
-    Ok(())
-}
-
-fn register_kms_dynamic_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
-    r.insert(
-        Method::POST,
-        format!("{}{}", ADMIN_PREFIX, "/v3/kms/configure").as_str(),
-        AdminOperation(&kms_dynamic::ConfigureKmsHandler {}),
-    )?;
-
-    r.insert(
-        Method::POST,
-        format!("{}{}", ADMIN_PREFIX, "/v3/kms/start").as_str(),
-        AdminOperation(&kms_dynamic::StartKmsHandler {}),
-    )?;
-
-    r.insert(
-        Method::POST,
-        format!("{}{}", ADMIN_PREFIX, "/v3/kms/stop").as_str(),
-        AdminOperation(&kms_dynamic::StopKmsHandler {}),
-    )?;
-
-    r.insert(
-        Method::GET,
-        format!("{}{}", ADMIN_PREFIX, "/v3/kms/service-status").as_str(),
-        AdminOperation(&kms_dynamic::GetKmsStatusHandler {}),
-    )?;
-
-    r.insert(
-        Method::POST,
-        format!("{}{}", ADMIN_PREFIX, "/v3/kms/reconfigure").as_str(),
-        AdminOperation(&kms_dynamic::ReconfigureKmsHandler {}),
     )?;
 
     Ok(())

--- a/rustfs/src/admin/handlers/kms_dynamic.rs
+++ b/rustfs/src/admin/handlers/kms_dynamic.rs
@@ -15,10 +15,10 @@
 //! KMS dynamic configuration admin API handlers
 
 use crate::admin::auth::validate_admin_request;
-use crate::admin::router::Operation;
+use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::auth::{check_key_valid, get_session_token};
-use crate::server::RemoteAddr;
-use hyper::StatusCode;
+use crate::server::{ADMIN_PREFIX, RemoteAddr};
+use hyper::{Method, StatusCode};
 use matchit::Params;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
 use rustfs_ecstore::config::com::{read_config, save_config};
@@ -78,6 +78,40 @@ pub async fn load_kms_config() -> Option<KmsConfig> {
             None
         }
     }
+}
+
+pub fn register_kms_dynamic_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
+    r.insert(
+        Method::POST,
+        format!("{}{}", ADMIN_PREFIX, "/v3/kms/configure").as_str(),
+        AdminOperation(&ConfigureKmsHandler {}),
+    )?;
+
+    r.insert(
+        Method::POST,
+        format!("{}{}", ADMIN_PREFIX, "/v3/kms/start").as_str(),
+        AdminOperation(&StartKmsHandler {}),
+    )?;
+
+    r.insert(
+        Method::POST,
+        format!("{}{}", ADMIN_PREFIX, "/v3/kms/stop").as_str(),
+        AdminOperation(&StopKmsHandler {}),
+    )?;
+
+    r.insert(
+        Method::GET,
+        format!("{}{}", ADMIN_PREFIX, "/v3/kms/service-status").as_str(),
+        AdminOperation(&GetKmsStatusHandler {}),
+    )?;
+
+    r.insert(
+        Method::POST,
+        format!("{}{}", ADMIN_PREFIX, "/v3/kms/reconfigure").as_str(),
+        AdminOperation(&ReconfigureKmsHandler {}),
+    )?;
+
+    Ok(())
 }
 
 /// Configure KMS service handler


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- rustfs/issues#573

## Summary of Changes
- Moved dynamic KMS route registration ownership from `rustfs/src/admin/handlers/kms.rs` to `rustfs/src/admin/handlers/kms_dynamic.rs`.
- Added `register_kms_dynamic_route` in `kms_dynamic.rs`.
- Updated `register_kms_route` in `kms.rs` to delegate to `kms_dynamic::register_kms_dynamic_route`.
- Kept all route paths, HTTP methods, and handlers unchanged.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - No behavior change; this is a registration ownership refactor only.

## Additional Notes
- This is a minimal P1-07 sub-step to further slim `admin/handlers/kms.rs`.
- Validation run locally:
  - `cargo fmt --all --check`
  - `cargo check -p rustfs`
  - `cargo clippy -p rustfs -- -D warnings`
  - `make pre-commit`
