### PR TITLE
refactor(storage): extract list object versions helpers

### DIFF
--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -24,8 +24,7 @@ use crate::storage::helper::OperationHelper;
 use crate::storage::options::{filter_object_metadata, get_content_sha256};
 use crate::storage::readers::InMemoryAsyncReader;
 use crate::storage::s3_api::bucket::{
-    build_list_object_versions_output, build_list_objects_output, build_list_objects_v2_output,
-    normalize_list_object_versions_params,
+    build_list_object_versions_output, build_list_objects_output, build_list_objects_v2_output, parse_list_object_versions_params,
 };
 use crate::storage::s3_api::common::rustfs_owner;
 use crate::storage::s3_api::multipart::{
@@ -3601,7 +3600,7 @@ impl S3 for FS {
         } = req.input;
 
         let (prefix, delimiter, key_marker, version_id_marker, max_keys) =
-            normalize_list_object_versions_params(prefix, delimiter, key_marker, version_id_marker, max_keys);
+            parse_list_object_versions_params(prefix, delimiter, key_marker, version_id_marker, max_keys)?;
 
         let store = get_validated_store(&bucket).await?;
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- rustfs/issues#573

## Summary of Changes
- Extracted `ListObjectVersions` request normalization into `normalize_list_object_versions_params` in `rustfs/src/storage/s3_api/bucket.rs`.
- Extracted `ListObjectVersions` response assembly into `build_list_object_versions_output` in `rustfs/src/storage/s3_api/bucket.rs`.
- Updated `list_object_versions` in `rustfs/src/storage/ecfs.rs` to keep orchestration flow (`parse -> store call -> response`).
- Added focused unit tests for normalization defaults/filtering and output mapping semantics.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Internal refactor only, no external API behavior change intended.

## Additional Notes
- This step preserves existing empty-marker filtering and `"null"` fallback for missing version IDs.
- Validation commands:
  - `cargo fmt --all --check`
  - `cargo check -p rustfs`
  - `cargo clippy -p rustfs -- -D warnings`
  - `cargo test -p rustfs storage::s3_api::bucket::tests -- --nocapture`
  - `make pre-commit`
