### PR TITLE
refactor(storage): use named params for ListObjectVersions

### DIFF
--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -3600,17 +3600,23 @@ impl S3 for FS {
             ..
         } = req.input;
 
-        let (prefix, delimiter, key_marker, version_id_marker, max_keys) =
-            parse_list_object_versions_params(prefix, delimiter, key_marker, version_id_marker, max_keys)?;
+        let parsed = parse_list_object_versions_params(prefix, delimiter, key_marker, version_id_marker, max_keys)?;
 
         let store = get_validated_store(&bucket).await?;
 
         let object_infos = store
-            .list_object_versions(&bucket, &prefix, key_marker, version_id_marker, delimiter.clone(), max_keys)
+            .list_object_versions(
+                &bucket,
+                &parsed.prefix,
+                parsed.key_marker,
+                parsed.version_id_marker,
+                parsed.delimiter.clone(),
+                parsed.max_keys,
+            )
             .await
             .map_err(ApiError::from)?;
 
-        let output = build_list_object_versions_output(object_infos, bucket, prefix, delimiter, max_keys);
+        let output = build_list_object_versions_output(object_infos, bucket, parsed.prefix, parsed.delimiter, parsed.max_keys);
 
         Ok(s3_response(output))
     }

--- a/rustfs/src/storage/s3_api/bucket.rs
+++ b/rustfs/src/storage/s3_api/bucket.rs
@@ -22,7 +22,14 @@ use s3s::{S3Error, S3ErrorCode};
 use tracing::debug;
 use urlencoding::encode;
 
-pub(crate) type ListObjectVersionsParams = (String, Option<String>, Option<String>, Option<String>, i32);
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ListObjectVersionsParams {
+    pub prefix: String,
+    pub delimiter: Option<String>,
+    pub key_marker: Option<String>,
+    pub version_id_marker: Option<String>,
+    pub max_keys: i32,
+}
 #[derive(Debug)]
 pub(crate) struct ListObjectsV2Params {
     pub prefix: String,
@@ -72,7 +79,13 @@ pub(crate) fn parse_list_object_versions_params(
         return Err(S3Error::with_message(S3ErrorCode::InvalidArgument, "Invalid max keys".to_string()));
     }
 
-    Ok((prefix, delimiter, key_marker, version_id_marker, max_keys))
+    Ok(ListObjectVersionsParams {
+        prefix,
+        delimiter,
+        key_marker,
+        version_id_marker,
+        max_keys,
+    })
 }
 
 pub(crate) fn parse_list_objects_v2_params(
@@ -455,15 +468,14 @@ mod tests {
 
     #[test]
     fn test_parse_list_object_versions_params_defaults_and_filters_empty_values() {
-        let (prefix, delimiter, key_marker, version_id_marker, max_keys) =
-            parse_list_object_versions_params(None, Some(String::new()), Some(String::new()), None, None)
-                .expect("parse should succeed");
+        let parsed = parse_list_object_versions_params(None, Some(String::new()), Some(String::new()), None, None)
+            .expect("parse should succeed");
 
-        assert_eq!(prefix, String::new());
-        assert_eq!(delimiter, None);
-        assert_eq!(key_marker, None);
-        assert_eq!(version_id_marker, None);
-        assert_eq!(max_keys, 1000);
+        assert_eq!(parsed.prefix, String::new());
+        assert_eq!(parsed.delimiter, None);
+        assert_eq!(parsed.key_marker, None);
+        assert_eq!(parsed.version_id_marker, None);
+        assert_eq!(parsed.max_keys, 1000);
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- https://github.com/rustfs/issues/issues/573

## Summary of Changes
- Replaced tuple-based `ListObjectVersionsParams` with a named struct in `rustfs/src/storage/s3_api/bucket.rs`.
- Updated `parse_list_object_versions_params(...)` to return the named struct while preserving all parsing and validation behavior.
- Updated `rustfs/src/storage/ecfs.rs` call site to use named fields when invoking `list_object_versions` and response builder.
- Updated existing unit test assertions to validate named fields instead of tuple positions.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Internal refactor only, no behavior change.

## Additional Notes
Verification run locally:
- `cargo fmt --all --check`
- `cargo check -p rustfs`
- `cargo clippy -p rustfs -- -D warnings`
- `cargo test -p rustfs storage::s3_api::bucket::tests -- --nocapture`
- `make pre-commit`

