### PR TITLE
Fix/x86 64 compat drop target cpu native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
             target: x86_64-apple-darwin
             cross: false
             platform: macos
-            rustflags: '-C target-cpu=native'
+            rustflags: '-C target-cpu=x86-64-v2'
           # Windows builds (temporarily disabled)
           - os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Fixes #1838

## Summary of Changes

Released x86_64 binaries crash with **SIGILL (exit code 132)** on CPUs without AVX/AVX2 support (e.g. Intel Celeron J4125 on Synology DS920+). The root cause is the CI build flag `-C target-cpu=native`, which bakes the CI runner's CPU instruction set (AVX/AVX2) into all distributed binaries.

**Changes made to `.github/workflows/build.yml`:**

- Replaced the single global `RUSTFLAGS: ${{ matrix.cross == 'false' && '-C target-cpu=native' || '' }}` expression with a per-target `rustflags` matrix field.
- Linux (`x86_64-unknown-linux-musl`, `x86_64-unknown-linux-gnu`) and Windows (`x86_64-pc-windows-msvc`) release builds now use `-C target-cpu=x86-64-v2` (SSE4.2 baseline, compatible with all x86_64 CPUs since ~2009).
- macOS `x86_64-apple-darwin` retains `-C target-cpu=native` as it targets developer hardware, not Docker distribution.
- aarch64 targets remain unchanged (`''`).

**SIMD performance is not degraded:** all performance-critical paths (`reed-solomon-simd`, `blake3`, `crc-fast`, `base64-simd`, `hex-simd`) use runtime CPU dispatch via the `cpufeatures` crate and will continue to use AVX2 code paths transparently on capable hardware.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: fixes SIGILL crash on older/low-power x86_64 CPUs (Celeron, Atom, Synology NAS, etc.)

## Additional Notes

`x86-64-v2` requires SSE4.2 + POPCNT + SSSE3, supported by all mainstream x86_64 CPUs since Intel Westmere (2010) and AMD Bulldozer (2011). The affected J4125 (Gemini Lake, 2019) fully supports this level.

Related issues with the same root cause: #1348 (Raspberry Pi 4 aarch64), #1142 (crc-fast SIGILL, partially fixed via #1513).

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.