### PR TITLE
test: add regression coverage for access action mapping

### DIFF
--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -421,6 +421,22 @@ pub fn has_bypass_governance_header(headers: &http::HeaderMap) -> bool {
         .unwrap_or(false)
 }
 
+fn get_bucket_policy_authorize_action() -> Action {
+    Action::S3Action(S3Action::GetBucketPolicyAction)
+}
+
+fn get_object_acl_authorize_action() -> Action {
+    Action::S3Action(S3Action::GetObjectAclAction)
+}
+
+fn put_bucket_policy_authorize_action() -> Action {
+    Action::S3Action(S3Action::PutBucketPolicyAction)
+}
+
+fn put_object_acl_authorize_action() -> Action {
+    Action::S3Action(S3Action::PutObjectAclAction)
+}
+
 #[async_trait::async_trait]
 impl S3Access for FS {
     // /// Checks whether the current request has accesses to the resources.
@@ -865,7 +881,7 @@ impl S3Access for FS {
         let req_info = req.extensions.get_mut::<ReqInfo>().expect("ReqInfo not found");
         req_info.bucket = Some(req.input.bucket.clone());
 
-        authorize_request(req, Action::S3Action(S3Action::GetBucketPolicyAction)).await
+        authorize_request(req, get_bucket_policy_authorize_action()).await
     }
 
     /// Checks whether the GetBucketPolicyStatus request has accesses to the resources.
@@ -943,7 +959,7 @@ impl S3Access for FS {
         req_info.object = Some(req.input.key.clone());
         req_info.version_id = req.input.version_id.clone();
 
-        authorize_request(req, Action::S3Action(S3Action::GetObjectAclAction)).await
+        authorize_request(req, get_object_acl_authorize_action()).await
     }
 
     /// Checks whether the GetObjectAttributes request has accesses to the resources.
@@ -1270,7 +1286,7 @@ impl S3Access for FS {
         let req_info = req.extensions.get_mut::<ReqInfo>().expect("ReqInfo not found");
         req_info.bucket = Some(req.input.bucket.clone());
 
-        authorize_request(req, Action::S3Action(S3Action::PutBucketPolicyAction)).await
+        authorize_request(req, put_bucket_policy_authorize_action()).await
     }
 
     /// Checks whether the PutBucketReplication request has accesses to the resources.
@@ -1340,7 +1356,7 @@ impl S3Access for FS {
         req_info.object = Some(req.input.key.clone());
         req_info.version_id = req.input.version_id.clone();
 
-        authorize_request(req, Action::S3Action(S3Action::PutObjectAclAction)).await
+        authorize_request(req, put_object_acl_authorize_action()).await
     }
 
     /// Checks whether the PutObjectLegalHold request has accesses to the resources.
@@ -1450,5 +1466,30 @@ impl S3Access for FS {
     /// This method returns `Ok(())` by default.
     async fn write_get_object_response(&self, _req: &mut S3Request<WriteGetObjectResponseInput>) -> S3Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_bucket_policy_uses_get_bucket_policy_action() {
+        assert_eq!(get_bucket_policy_authorize_action(), Action::S3Action(S3Action::GetBucketPolicyAction));
+    }
+
+    #[test]
+    fn get_object_acl_uses_get_object_acl_action() {
+        assert_eq!(get_object_acl_authorize_action(), Action::S3Action(S3Action::GetObjectAclAction));
+    }
+
+    #[test]
+    fn put_bucket_policy_uses_put_bucket_policy_action() {
+        assert_eq!(put_bucket_policy_authorize_action(), Action::S3Action(S3Action::PutBucketPolicyAction));
+    }
+
+    #[test]
+    fn put_object_acl_uses_put_object_acl_action() {
+        assert_eq!(put_object_acl_authorize_action(), Action::S3Action(S3Action::PutObjectAclAction));
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- Follow-up of PR #1927

## Summary of Changes
- Add regression coverage for the action mapping fixed in #1927 (`GetBucketPolicy`, `GetObjectAcl`, `PutBucketPolicy`, `PutObjectAcl`).
- Introduce dedicated authorization-action helper functions in `rustfs/src/storage/access.rs` for these four operations.
- Update the four access handlers to use those helpers, and add unit tests that lock each mapping to the expected `S3Action` variant.
- This prevents accidental action swap regressions like the issue corrected by #1927.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Adds regression tests only; no runtime behavior change intended beyond preserving the mapping introduced in #1927.

## Additional Notes
- Local verification completed:
  - `/opt/homebrew/bin/cargo fmt --all --check`
  - `/opt/homebrew/bin/cargo clippy --all-targets --all-features -- -D warnings`
  - `/opt/homebrew/bin/cargo test -p rustfs storage::access::tests:: -- --test-threads=1` (4/4 passed)
- `cargo test --workspace --exclude e2e_test` currently fails on an existing baseline issue unrelated to this patch: the `rustfs` test binary exits due to clap conflict between `--access-key` and `--access-key-file`.
