### PR TITLE
refactor(app): add iam and notify interface boundaries

### DIFF
--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -271,14 +271,18 @@ impl DefaultAdminUsecase {
     }
 
     pub fn execute_collect_dependency_readiness(&self) -> DependencyReadiness {
-        if let Some(context) = &self.context {
-            let _ = context.object_store();
-            let _ = context.iam();
-        }
+        let iam_ready = self
+            .context
+            .as_ref()
+            .map(|context| {
+                let _ = context.object_store();
+                context.iam().is_ready()
+            })
+            .unwrap_or(false);
 
         DependencyReadiness {
             storage_ready: new_object_layer_fn().is_some(),
-            iam_ready: rustfs_iam::get().is_ok(),
+            iam_ready,
         }
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- #573

## Summary of Changes
This PR advances `P4D-02` by introducing interface-first boundaries for IAM/Notify access in the application layer and removing direct infra-global calls from app usecases.

Main changes:
- Extended `AppContext` interfaces:
  - Added `IamInterface::is_ready()`.
  - Added `NotifyInterface` with default `NotifyHandle` adapter.
  - Added `AppContext::notify()` and default notify wiring.
- Replaced direct infra-global usage in app usecases:
  - `admin_usecase`: replaced direct `rustfs_iam::get()` readiness probing with `context.iam().is_ready()`.
  - `bucket_usecase`: replaced direct `notifier_global` calls with `context.notify()` clear/add rule calls.
  - `object_usecase`: replaced direct `notifier_global::notify` in async delete events with `context.notify().notify(...)`.

This keeps external S3/Admin API behavior unchanged and narrows infra detail usage behind app-layer interfaces.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Internal layering cleanup only.

## Additional Notes
Validation performed:
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude e2e_test`
- `make pre-commit`
