### PR TITLE
refactor(app): route admin/object globals through AppContext

### DIFF
--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -98,10 +98,7 @@ impl DefaultAdminUsecase {
     }
 
     fn endpoints(&self) -> Option<EndpointServerPools> {
-        self.context
-            .as_ref()
-            .and_then(|context| context.endpoints().handle())
-            .or_else(|| rustfs_ecstore::GLOBAL_Endpoints.get().cloned())
+        self.context.as_ref().and_then(|context| context.endpoints().handle())
     }
 
     fn app_error(code: S3ErrorCode, message: impl Into<String>) -> ApiError {

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -201,10 +201,7 @@ impl DefaultObjectUsecase {
     }
 
     fn bucket_metadata_sys(&self) -> Option<Arc<RwLock<metadata_sys::BucketMetadataSys>>> {
-        self.context
-            .as_ref()
-            .and_then(|context| context.bucket_metadata().handle())
-            .or_else(|| rustfs_ecstore::bucket::metadata_sys::GLOBAL_BucketMetadataSys.get().cloned())
+        self.context.as_ref().and_then(|context| context.bucket_metadata().handle())
     }
 
     #[instrument(level = "debug", skip(self, fs, req))]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- #573

## Summary of Changes
This PR advances the refactor plan by tightening dependency direction in the application layer for admin/object critical paths. Specifically, it removes direct `GLOBAL_*` fallback reads from `DefaultAdminUsecase` and `DefaultObjectUsecase`, and keeps dependency access on the `AppContext` interface path only.

Behavior is preserved for runtime code paths because handlers already construct usecases via `from_global()`, and `AppContext::with_default_interfaces(...)` is initialized during startup.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: reduces direct global-state coupling in app usecases and aligns with Phase 5 dependency-convergence goals.

## Additional Notes
Validation executed locally:
- `make pre-commit`
