### PR TITLE
refactor(app): converge lower-priority global reads via AppContext

### DIFF
--- a/rustfs/src/admin/handlers/trace.rs
+++ b/rustfs/src/admin/handlers/trace.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use crate::admin::router::Operation;
+use crate::app::context::get_global_app_context;
 use http::StatusCode;
 use hyper::Uri;
 use matchit::Params;
-use rustfs_ecstore::{GLOBAL_Endpoints, rpc::PeerRestClient};
+use rustfs_ecstore::rpc::PeerRestClient;
 use rustfs_madmin::service_commands::ServiceTraceOpts;
 use s3s::{Body, S3Request, S3Response, S3Result, s3_error};
 use tracing::warn;
@@ -42,7 +43,7 @@ impl Operation for Trace {
         let _trace_opts = extract_trace_options(&req.uri)?;
 
         // let (tx, rx) = mpsc::channel(10000);
-        let _peers = match GLOBAL_Endpoints.get() {
+        let _peers = match get_global_app_context().and_then(|context| context.endpoints().handle()) {
             Some(ep) => PeerRestClient::new_clients(ep.clone()).await,
             None => (Vec::new(), Vec::new()),
         };

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -165,6 +165,10 @@ impl DefaultBucketUsecase {
         self.context.clone()
     }
 
+    fn global_region(&self) -> Option<String> {
+        self.context.as_ref().and_then(|context| context.region().get())
+    }
+
     #[instrument(
         level = "debug",
         skip(self, req),
@@ -425,7 +429,7 @@ impl DefaultBucketUsecase {
             .await
             .map_err(ApiError::from)?;
 
-        if let Some(region) = rustfs_ecstore::global::get_global_region() {
+        if let Some(region) = self.global_region() {
             return Ok(S3Response::new(GetBucketLocationOutput {
                 location_constraint: Some(BucketLocationConstraint::from(region)),
             }));
@@ -1187,7 +1191,7 @@ impl DefaultBucketUsecase {
             .await
             .map_err(ApiError::from)?;
 
-        let region = resolve_notification_region(rustfs_ecstore::global::get_global_region(), request_region);
+        let region = resolve_notification_region(self.global_region(), request_region);
         let notify = self
             .context
             .as_ref()

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -164,6 +164,10 @@ impl DefaultMultipartUsecase {
         self.context.as_ref().and_then(|context| context.bucket_metadata().handle())
     }
 
+    fn global_region(&self) -> Option<String> {
+        self.context.as_ref().and_then(|context| context.region().get())
+    }
+
     #[instrument(level = "debug", skip(self))]
     pub async fn execute_abort_multipart_upload(
         &self,
@@ -418,7 +422,7 @@ impl DefaultMultipartUsecase {
             }
         }
 
-        let region = rustfs_ecstore::global::get_global_region().unwrap_or_else(|| "us-east-1".to_string());
+        let region = self.global_region().unwrap_or_else(|| "us-east-1".to_string());
         let output = CompleteMultipartUploadOutput {
             bucket: Some(bucket.clone()),
             key: Some(key.clone()),


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- #573

## Summary of Changes
- Add `RegionInterface` to `AppContext` and route region reads in app usecases through context.
- Replace direct global region access in `bucket_usecase` and `multipart_usecase` with AppContext interface calls.
- Replace direct `GLOBAL_Endpoints` reads in admin `pools` and `trace` handlers with AppContext endpoint interface access.
- Replace direct `GLOBAL_BucketMetadataSys` and `GLOBAL_OBJECT_API` reads in admin quota handlers with AppContext-backed accessors.
- Keep external S3/Admin API behavior unchanged; this is dependency-direction cleanup for `P5-02`.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
- Internal refactor only; no external API changes expected.

## Additional Notes
- Validation executed locally via `make pre-commit` (fmt/clippy/check/test).
- This step intentionally increases migration granularity while keeping scope within `P5-02` global-state convergence.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
