### PR TITLE
refactor(admin): route kms handlers via app context

### DIFF
--- a/rustfs/src/admin/handlers/kms_keys.rs
+++ b/rustfs/src/admin/handlers/kms_keys.rs
@@ -16,7 +16,7 @@
 
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::app::context::{default_kms_runtime_interface, get_global_app_context};
+use crate::app::context::resolve_kms_runtime_service_manager;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use base64::Engine;
@@ -103,9 +103,7 @@ fn extract_query_params(uri: &hyper::Uri) -> HashMap<String, String> {
 }
 
 fn kms_service_manager_from_context() -> Option<std::sync::Arc<rustfs_kms::KmsServiceManager>> {
-    get_global_app_context()
-        .and_then(|context| context.kms_runtime().service_manager())
-        .or_else(|| default_kms_runtime_interface().service_manager())
+    resolve_kms_runtime_service_manager()
 }
 
 async fn kms_encryption_service_from_context() -> Option<std::sync::Arc<rustfs_kms::ObjectEncryptionService>> {

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -320,6 +320,13 @@ pub fn default_kms_runtime_interface() -> Arc<dyn KmsRuntimeInterface> {
     Arc::new(KmsRuntimeHandle)
 }
 
+/// Resolve KMS runtime service manager using AppContext-first precedence.
+pub fn resolve_kms_runtime_service_manager() -> Option<Arc<KmsServiceManager>> {
+    get_global_app_context()
+        .and_then(|context| context.kms_runtime().service_manager())
+        .or_else(|| default_kms_runtime_interface().service_manager())
+}
+
 pub fn default_bucket_metadata_interface() -> Arc<dyn BucketMetadataInterface> {
     Arc::new(BucketMetadataHandle)
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- #573

## Summary of Changes
This PR continues Phase 5 (`P5-02`) global-state convergence by routing KMS admin handlers through `AppContext` interfaces instead of direct global function access.

Main changes:
- Added `KmsRuntimeInterface` and `KmsRuntimeHandle` in `rustfs/src/app/context.rs`.
- Extended `AppContext` with `kms_runtime()` accessor and default runtime interface wiring.
- Refactored `rustfs/src/admin/handlers/kms_dynamic.rs` to use `kms_service_manager_from_context()` with AppContext-first resolution and existing fallback initialization behavior preserved.
- Refactored `rustfs/src/admin/handlers/kms_keys.rs` to use context-driven helpers for both encryption service and service manager paths, while preserving current HTTP/status semantics.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Internal dependency-direction cleanup only; external Admin API behavior remains unchanged.

## Additional Notes
- Validation executed locally:
  - `cargo fmt --all --check`
  - `cargo clippy -p rustfs -- -D warnings`
  - `cargo check -p rustfs`
  - `make pre-commit`
