### PR TITLE
refactor(admin): route kms handlers through app context

### DIFF
--- a/rustfs/src/admin/handlers/kms.rs
+++ b/rustfs/src/admin/handlers/kms.rs
@@ -31,7 +31,13 @@ use serde_json;
 use tracing::{error, info, warn};
 
 async fn kms_encryption_service_from_context() -> Option<std::sync::Arc<rustfs_kms::ObjectEncryptionService>> {
-    let manager = resolve_kms_runtime_service_manager().unwrap_or_else(init_global_kms_service_manager);
+    let manager = match resolve_kms_runtime_service_manager() {
+        Some(manager) => manager,
+        None => {
+            warn!("KMS service manager not initialized, initializing now as fallback");
+            init_global_kms_service_manager()
+        }
+    };
     manager.get_encryption_service().await
 }
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- #573

## Summary of Changes
- Replace direct `get_global_encryption_service()` calls in `admin/handlers/kms.rs`.
- Add `kms_encryption_service_from_context()` helper that resolves KMS runtime via `resolve_kms_runtime_service_manager()`.
- Keep existing runtime fallback by initializing KMS service manager when context runtime is unavailable.
- Preserve external admin API behavior for KMS status/config/cache endpoints.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Internal dependency-direction convergence only; no external API contract changes.

## Additional Notes
- This PR is a P5-02 incremental sub-step focused only on `admin/handlers/kms.rs` to keep review scope small.
