### PR TITLE
refactor(rpc): use node name accessor in health handlers

### DIFF
--- a/crates/common/src/globals.rs
+++ b/crates/common/src/globals.rs
@@ -38,6 +38,14 @@ pub async fn set_global_local_node_name(name: &str) {
     *GLOBAL_LOCAL_NODE_NAME.write().await = name.to_string();
 }
 
+/// Get the global local node name.
+///
+/// # Returns
+/// * `String` - The local node name.
+pub async fn get_global_local_node_name() -> String {
+    GLOBAL_LOCAL_NODE_NAME.read().await.clone()
+}
+
 /// Set the global RustFS initialization time to the current UTC time.
 pub async fn set_global_init_time_now() {
     let now = Utc::now();

--- a/rustfs/src/storage/rpc/health.rs
+++ b/rustfs/src/storage/rpc/health.rs
@@ -19,7 +19,7 @@ impl NodeService {
         &self,
         _request: Request<GetProcInfoRequest>,
     ) -> Result<Response<GetProcInfoResponse>, Status> {
-        let addr = GLOBAL_LOCAL_NODE_NAME.read().await.clone();
+        let addr = get_global_local_node_name().await;
         let info = get_proc_info(&addr);
         let mut buf = Vec::new();
         if let Err(err) = info.serialize(&mut Serializer::new(&mut buf)) {
@@ -40,7 +40,7 @@ impl NodeService {
         &self,
         _request: Request<GetMemInfoRequest>,
     ) -> Result<Response<GetMemInfoResponse>, Status> {
-        let addr = GLOBAL_LOCAL_NODE_NAME.read().await.clone();
+        let addr = get_global_local_node_name().await;
         let info = get_mem_info(&addr);
         let mut buf = Vec::new();
         if let Err(err) = info.serialize(&mut Serializer::new(&mut buf)) {
@@ -61,7 +61,7 @@ impl NodeService {
         &self,
         _request: Request<GetSysErrorsRequest>,
     ) -> Result<Response<GetSysErrorsResponse>, Status> {
-        let addr = GLOBAL_LOCAL_NODE_NAME.read().await.clone();
+        let addr = get_global_local_node_name().await;
         let info = get_sys_errors(&addr);
         let mut buf = Vec::new();
         if let Err(err) = info.serialize(&mut Serializer::new(&mut buf)) {
@@ -82,7 +82,7 @@ impl NodeService {
         &self,
         _request: Request<GetSysConfigRequest>,
     ) -> Result<Response<GetSysConfigResponse>, Status> {
-        let addr = GLOBAL_LOCAL_NODE_NAME.read().await.clone();
+        let addr = get_global_local_node_name().await;
         let info = get_sys_config(&addr);
         let mut buf = Vec::new();
         if let Err(err) = info.serialize(&mut Serializer::new(&mut buf)) {
@@ -103,7 +103,7 @@ impl NodeService {
         &self,
         _request: Request<GetSeLinuxInfoRequest>,
     ) -> Result<Response<GetSeLinuxInfoResponse>, Status> {
-        let addr = GLOBAL_LOCAL_NODE_NAME.read().await.clone();
+        let addr = get_global_local_node_name().await;
         let info = get_sys_services(&addr);
         let mut buf = Vec::new();
         if let Err(err) = info.serialize(&mut Serializer::new(&mut buf)) {
@@ -164,7 +164,7 @@ impl NodeService {
         &self,
         _request: Request<GetNetInfoRequest>,
     ) -> Result<Response<GetNetInfoResponse>, Status> {
-        let addr = GLOBAL_LOCAL_NODE_NAME.read().await.clone();
+        let addr = get_global_local_node_name().await;
         let info = get_net_info(&addr, "");
         let mut buf = Vec::new();
         if let Err(err) = info.serialize(&mut Serializer::new(&mut buf)) {

--- a/rustfs/src/storage/rpc/node_service.rs
+++ b/rustfs/src/storage/rpc/node_service.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use futures::Stream;
 use futures_util::future::join_all;
 use rmp_serde::{Deserializer, Serializer};
-use rustfs_common::{GLOBAL_LOCAL_NODE_NAME, heal_channel::HealOpts};
+use rustfs_common::{get_global_local_node_name, heal_channel::HealOpts};
 use rustfs_ecstore::{
     admin_server_info::get_local_server_property,
     bucket::{metadata::load_bucket_metadata, metadata_sys},


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- #573

## Summary of Changes
- Add `get_global_local_node_name()` accessor in `rustfs-common` global module.
- Replace direct `GLOBAL_LOCAL_NODE_NAME` reads in RPC health handlers with the accessor.
- Keep behavior unchanged while reducing direct global-state coupling in the interface path.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: internal refactor only, no external behavior change.

## Additional Notes
- This is a small P5-02 incremental step focused on one RPC module to keep review scope tight.
