### PR TITLE
refactor(app): remove remaining global access in main init

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -977,6 +977,10 @@ pub async fn init_background_replication<S: StorageAPI>(storage: Arc<S>) {
     assert!(GLOBAL_REPLICATION_POOL.get().is_some());
 }
 
+pub fn get_global_replication_pool() -> Option<Arc<DynReplicationPool>> {
+    GLOBAL_REPLICATION_POOL.get().cloned()
+}
+
 pub async fn schedule_replication<S: StorageAPI>(oi: ObjectInfo, o: Arc<S>, dsc: ReplicateDecision, op_type: ReplicationType) {
     let tgt_statuses = replication_statuses_map(&oi.replication_status_internal.clone().unwrap_or_default());
     let purge_statuses = version_purge_statuses_map(&oi.version_purge_status_internal.clone().unwrap_or_default());

--- a/crates/ecstore/src/config/mod.rs
+++ b/crates/ecstore/src/config/mod.rs
@@ -71,6 +71,10 @@ pub fn get_global_server_config() -> Option<Config> {
     GLOBAL_SERVER_CONFIG.get().cloned()
 }
 
+pub async fn init_global_config_sys(api: Arc<ECStore>) -> Result<()> {
+    GLOBAL_CONFIG_SYS.init(api).await
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct KV {
     pub key: String,


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- #573

## Summary of Changes
- Added `ecconfig::init_global_config_sys(...)` in `crates/ecstore/src/config/mod.rs`.
- Added `get_global_replication_pool()` in `crates/ecstore/src/bucket/replication/replication_pool.rs`.
- Updated `rustfs/src/main.rs` to stop directly referencing `GLOBAL_CONFIG_SYS` and `GLOBAL_REPLICATION_POOL`.
- Main init path now uses the new encapsulated APIs, keeping behavior unchanged.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  Reduced direct `GLOBAL_*` access in lower-priority module (`main.rs`) for P5-02 convergence.

## Additional Notes
- Verification commands:
  - `cargo fmt --all --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test --workspace --exclude e2e_test`
  - `RUST_TEST_THREADS=1 cargo test --workspace --exclude e2e_test`
- In this environment, the default parallel test run still shows known flaky argument-conflict noise for the `rustfs` bin test process; serial rerun passes.
