### PR TITLE
 fix(replication): handle TLS CA trust and force-delete replication edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7345,6 +7345,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-smithy-http-client",
  "aws-smithy-types",
  "base64 0.22.1",
  "base64-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ atomic_enum = "0.3.0"
 aws-config = { version = "1.8.14" }
 aws-credential-types = { version = "1.2.13" }
 aws-sdk-s3 = { version = "1.124.0", default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
+aws-smithy-http-client = { version = "1.1.11", default-features = false, features = ["default-client", "rustls-aws-lc"] }
 aws-smithy-types = { version = "1.4.5" }
 backtrace = "0.3.76"
 base64 = "0.22.1"

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -112,6 +112,7 @@ google-cloud-auth = { workspace = true }
 aws-config = { workspace = true }
 faster-hex = { workspace = true }
 ratelimit = { workspace = true }
+aws-smithy-http-client.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -2051,6 +2051,10 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                         warn!("replication head_object failed bucket:{} arn:{} error:{}", bucket, tgt_client.arn, e);
                         return rinfo;
                     }
+                } else if e.raw_response().is_some_and(|resp| resp.status().as_u16() == 404) {
+                    // Some HEAD Object 404 responses are surfaced by the AWS SDK as `response error`
+                    // instead of `service error (NotFound)`. Treat raw HTTP 404 as object-not-found
+                    // so replication can proceed with PUT.
                 } else {
                     rinfo.error = Some(e.to_string());
                     warn!("replication head_object failed bucket:{} arn:{} error:{}", bucket, tgt_client.arn, e);

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -2518,6 +2518,7 @@ impl DefaultObjectUsecase {
         let mut opts: ObjectOptions = del_opts(&bucket, &key, version_id, &req.headers, metadata)
             .await
             .map_err(ApiError::from)?;
+        let force_delete = opts.delete_prefix;
 
         let lock_cfg = BucketObjectLockSys::get(&bucket).await;
         if lock_cfg.is_some() && opts.delete_prefix {
@@ -2540,6 +2541,17 @@ impl DefaultObjectUsecase {
         let Some(store) = new_object_layer_fn() else {
             return Err(S3Error::with_message(S3ErrorCode::InternalError, "Not init".to_string()));
         };
+
+        let replicate_force_delete = force_delete
+            && !replica
+            && has_replication_rules(
+                &bucket,
+                &[ObjectToDelete {
+                    object_name: key.clone(),
+                    ..Default::default()
+                }],
+            )
+            .await;
 
         // Check Object Lock retention before deletion
         // TODO: Future optimization (separate PR) - If performance becomes critical under high delete load:
@@ -2602,6 +2614,19 @@ impl DefaultObjectUsecase {
         });
 
         if obj_info.name.is_empty() {
+            if replicate_force_delete {
+                schedule_replication_delete(DeletedObjectReplicationInfo {
+                    delete_object: rustfs_ecstore::store_api::DeletedObject {
+                        object_name: key.clone(),
+                        force_delete: true,
+                        ..Default::default()
+                    },
+                    bucket: bucket.clone(),
+                    event_type: REPLICATE_INCOMING_DELETE.to_string(),
+                    ..Default::default()
+                })
+                .await;
+            }
             return Ok(S3Response::with_status(DeleteObjectOutput::default(), StatusCode::NO_CONTENT));
         }
 


### PR DESCRIPTION

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
FIX #1865 
RELATE #1989
## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->
  - Use path-style addressing for remote replication targets by default (especially for custom S3-compatible endpoints), while honoring explicit target path mode values.
  - Configure the replication AWS SDK S3 client to trust certificates from `RUSTFS_TLS_PATH` (`ca.crt`, and optionally `rustfs_cert.pem` when `RUSTFS_TRUST_LEAF_CERT_AS_CA=1`) to avoid `UnknownIssuer` errors.
  - Treat `HEAD Object` raw HTTP 404 `response error` results as "object not found" so replication can proceed instead of failing early.
  - Ensure delete replication is scheduled for force-delete (`RUSTFS_FORCE_DELETE=true` / `delete_prefix`) in the single-object delete path, where storage returns an empty `ObjectInfo`.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

