### PR TITLE
fix(ecstore): set expiration header for put object via lifecycle prediction

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -60,7 +60,7 @@ use s3s::dto::*;
 use s3s::region::Region;
 use s3s::xml;
 use s3s::{S3Error, S3ErrorCode, S3Request, S3Response, S3Result, s3_error};
-use std::{fmt::Display, sync::Arc};
+use std::{collections::HashSet, fmt::Display, sync::Arc};
 use tracing::{debug, error, info, instrument, warn};
 use urlencoding::encode;
 
@@ -79,6 +79,45 @@ fn default_region() -> Region {
 
 fn resolve_notification_region(global_region: Option<Region>, request_region: Option<Region>) -> Region {
     global_region.or(request_region).unwrap_or_else(default_region)
+}
+
+const ERR_LIFECYCLE_RULE_STATUS: &str = "Rule status must be either Enabled or Disabled";
+
+fn assign_lifecycle_rule_ids(rules: &mut [LifecycleRule]) {
+    let mut rule_ids: HashSet<String> = HashSet::new();
+
+    for rule in rules.iter() {
+        if let Some(id) = rule.id.as_ref() {
+            rule_ids.insert(id.to_string());
+        }
+    }
+
+    for (idx, rule) in rules.iter_mut().enumerate() {
+        if rule.id.is_none() {
+            let mut suffix = 0usize;
+            let mut generated_id = format!("rule-{}", idx);
+
+            while rule_ids.contains(&generated_id) {
+                suffix += 1;
+                generated_id = format!("rule-{idx}-{suffix}");
+            }
+
+            rule_ids.insert(generated_id.clone());
+            rule.id = Some(generated_id);
+        }
+    }
+}
+
+fn validate_lifecycle_rule_status(rules: &[LifecycleRule]) -> Result<(), &'static str> {
+    for rule in rules {
+        if rule.status != ExpirationStatus::from_static(ExpirationStatus::ENABLED)
+            && rule.status != ExpirationStatus::from_static(ExpirationStatus::DISABLED)
+        {
+            return Err(ERR_LIFECYCLE_RULE_STATUS);
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Clone, Default)]
@@ -1080,7 +1119,11 @@ impl DefaultBucketUsecase {
             ..
         } = req.input;
 
-        let Some(input_cfg) = lifecycle_configuration else { return Err(s3_error!(InvalidArgument)) };
+        let Some(mut input_cfg) = lifecycle_configuration else { return Err(s3_error!(InvalidArgument)) };
+        assign_lifecycle_rule_ids(&mut input_cfg.rules);
+        if let Err(err) = validate_lifecycle_rule_status(&input_cfg.rules) {
+            return Err(S3Error::with_message(S3ErrorCode::MalformedXML, format!("Malformed XML: {err}")));
+        }
 
         let rcfg = match metadata_sys::get_object_lock_config(&bucket).await {
             Ok((cfg, _)) => cfg,
@@ -1910,6 +1953,80 @@ mod tests {
 
         let err = usecase.execute_get_bucket_versioning(req).await.unwrap_err();
         assert_eq!(err.code(), &S3ErrorCode::InternalError);
+    }
+
+    #[test]
+    fn normalize_lifecycle_rules_generate_rule_ids_for_missing_values() {
+        let mut rules = vec![
+            LifecycleRule {
+                status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
+                expiration: Some(LifecycleExpiration {
+                    days: Some(30),
+                    ..Default::default()
+                }),
+                abort_incomplete_multipart_upload: None,
+                filter: None,
+                id: None,
+                noncurrent_version_expiration: None,
+                noncurrent_version_transitions: None,
+                prefix: None,
+                transitions: None,
+            },
+            LifecycleRule {
+                status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
+                expiration: Some(LifecycleExpiration {
+                    days: Some(60),
+                    ..Default::default()
+                }),
+                abort_incomplete_multipart_upload: None,
+                filter: None,
+                id: Some("rule-1".to_string()),
+                noncurrent_version_expiration: None,
+                noncurrent_version_transitions: None,
+                prefix: None,
+                transitions: None,
+            },
+            LifecycleRule {
+                status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
+                expiration: Some(LifecycleExpiration {
+                    days: Some(90),
+                    ..Default::default()
+                }),
+                abort_incomplete_multipart_upload: None,
+                filter: None,
+                id: None,
+                noncurrent_version_expiration: None,
+                noncurrent_version_transitions: None,
+                prefix: None,
+                transitions: None,
+            },
+        ];
+
+        assign_lifecycle_rule_ids(&mut rules);
+
+        assert_eq!(rules[0].id.as_deref(), Some("rule-0"));
+        assert_eq!(rules[1].id.as_deref(), Some("rule-1"));
+        assert_eq!(rules[2].id.as_deref(), Some("rule-2"));
+    }
+
+    #[test]
+    fn validate_lifecycle_rule_status_rejects_invalid_status() {
+        let rules = vec![LifecycleRule {
+            status: ExpirationStatus::from_static("enabled"),
+            expiration: Some(LifecycleExpiration {
+                days: Some(30),
+                ..Default::default()
+            }),
+            abort_incomplete_multipart_upload: None,
+            filter: None,
+            id: None,
+            noncurrent_version_expiration: None,
+            noncurrent_version_transitions: None,
+            prefix: None,
+            transitions: None,
+        }];
+
+        assert_eq!(validate_lifecycle_rule_status(&rules).unwrap_err(), ERR_LIFECYCLE_RULE_STATUS);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- Continued follow-up work for lifecycle `PutObject` expiration header behavior after previous PR feedback.

## Summary of Changes
- Fixed lifecycle rule validation and prediction in `crates/ecstore/src/bucket/lifecycle/lifecycle.rs`:
  - Validate rule status (`Enabled`/`Disabled`), date midnight requirement, positive expiration days, and ID length.
  - Reject duplicate rule IDs only when both IDs are present.
  - Add `Lifecycle::predict_expiration` implementation to pick the nearest future delete expiration for PUT object requests.
  - Return `NoneAction` only when no expiration applies.
- Added rule normalization in `rustfs/src/app/bucket_usecase.rs`:
  - Auto-assign rule IDs when missing.
  - Add explicit status validation before persisting lifecycle config.
- Wired lifecycle expiration output into object put response in `rustfs/src/app/object_usecase.rs`:
  - Add helpers to build `x-amz-expiration` style metadata value.
  - Populate expiration header in `ObjectPutResult` when lifecycle delete action is selected.
- Expanded unit tests covering:
  - Lifecycle validation edge cases (status/date/days/ID length).
  - Predicting closest PUT expiration.
  - Rule ID normalization and status validation in bucket lifecycle API path.
  - Expiration header serialization behavior in object usecase.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:
  - S3-compatible `PutObject` responses now include `expiration` header when lifecycle rules specify an expiry action.

## Additional Notes
- Validation failures still return existing malformed XML/validation errors; response semantics are unchanged besides adding the expected header.
