### PR TITLE
build(obs): restrict pyroscope dependency to unix targets

### DIFF
--- a/crates/obs/Cargo.toml
+++ b/crates/obs/Cargo.toml
@@ -56,8 +56,10 @@ tracing-subscriber = { workspace = true, features = ["registry", "std", "fmt", "
 tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "rt", "time", "macros"] }
 sysinfo = { workspace = true }
 thiserror = { workspace = true }
-pyroscope = { workspace = true, features= ["backend-pprof-rs"]}
 walkdir = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+pyroscope = { workspace = true, features = ["backend-pprof-rs"] }
 
 
 [dev-dependencies]

--- a/crates/obs/src/telemetry/otel.rs
+++ b/crates/obs/src/telemetry/otel.rs
@@ -49,10 +49,6 @@ use opentelemetry_sdk::{
     metrics::{PeriodicReader, SdkMeterProvider},
     trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
 };
-#[cfg(unix)]
-use pyroscope::PyroscopeAgent;
-#[cfg(unix)]
-use pyroscope::pyroscope::PyroscopeAgentRunning;
 use rustfs_config::{
     APP_NAME, DEFAULT_OBS_LOG_STDOUT_ENABLED, DEFAULT_OBS_LOGS_EXPORT_ENABLED, DEFAULT_OBS_METRICS_EXPORT_ENABLED,
     DEFAULT_OBS_PROFILING_EXPORT_ENABLED, DEFAULT_OBS_TRACES_EXPORT_ENABLED, METER_INTERVAL, SAMPLE_RATIO,
@@ -321,7 +317,7 @@ fn build_logger_provider(
 /// Starts the Pyroscope continuous profiling agent if `ENV_OBS_PROFILING_ENDPOINT` is set.
 /// No-op and returns None on non-unix platforms.
 #[cfg(unix)]
-fn init_profiler(config: &OtelConfig) -> Option<PyroscopeAgent<PyroscopeAgentRunning>> {
+fn init_profiler(config: &OtelConfig) -> Option<pyroscope::PyroscopeAgent<pyroscope::pyroscope::PyroscopeAgentRunning>> {
     use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
     use pyroscope::pyroscope::PyroscopeAgentBuilder;
     use rustfs_config::VERSION;


### PR DESCRIPTION

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->
https://github.com/rustfs/rustfs/actions/runs/22612834051/job/65518743403

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

build(obs): restrict pyroscope dependency to unix targets

Move `pyroscope` dependency under `[target.'cfg(unix)'.dependencies]` to ensure it is only included for Unix-like systems. This prevents build issues on non-Unix platforms where the pprof backend may not be supported.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
