### PR TITLE
fix: allow root to bypass bucket policy deny for policy management APIs

### DIFF
--- a/crates/ecstore/src/bucket/metadata.rs
+++ b/crates/ecstore/src/bucket/metadata.rs
@@ -375,6 +375,8 @@ impl BucketMetadata {
     fn parse_all_configs(&mut self, _api: Arc<ECStore>) -> Result<()> {
         if !self.policy_config_json.is_empty() {
             self.policy_config = Some(serde_json::from_slice(&self.policy_config_json)?);
+        } else {
+            self.policy_config = None;
         }
         if !self.notification_config_xml.is_empty() {
             self.notification_config = Some(deserialize::<NotificationConfiguration>(&self.notification_config_xml)?);

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -129,7 +129,18 @@ pub async fn authorize_request<T>(req: &mut S3Request<T>, action: Action) -> S3R
         }
         let bucket_name = req_info.bucket.as_deref().unwrap_or("");
 
+        // Per AWS S3: root can always perform GetBucketPolicy, PutBucketPolicy, DeleteBucketPolicy
+        // even if bucket policy explicitly denies. Other actions (ListBucket, GetObject, etc.) are
+        // subject to bucket policy Deny for root as well. See: repost.aws/knowledge-center/s3-accidentally-denied-access
+        let owner_can_bypass_deny = req_info.is_owner
+            && matches!(
+                action,
+                Action::S3Action(S3Action::GetBucketPolicyAction)
+                    | Action::S3Action(S3Action::PutBucketPolicyAction)
+                    | Action::S3Action(S3Action::DeleteBucketPolicyAction)
+            );
         if !bucket_name.is_empty()
+            && !owner_can_bypass_deny
             && !PolicySys::is_allowed(&BucketPolicyArgs {
                 bucket: bucket_name,
                 action,


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Closes #2092

## Summary of Changes
- **access.rs**: Allow the account root (owner) to bypass bucket policy deny-only check only for `GetBucketPolicy`, `PutBucketPolicy`, and `DeleteBucketPolicy`, per AWS S3 semantics. This lets the admin recover when a bucket policy with explicit Deny for all principals (e.g. Console "Private" preset) was applied. Other actions (ListBucket, GetObject, etc.) remain subject to bucket policy Deny for root.
- **metadata.rs**: In `parse_all_configs`, explicitly set `policy_config = None` when `policy_config_json` is empty so the in-memory cache stays consistent after policy deletion.

## Checklist
- [x] I have read and followed the CONTRIBUTING.md guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
Verification:
- `make pre-commit`
- Manual: set bucket policy to a Deny-all (e.g. Console Private), then as root call `DeleteBucketPolicy` — should succeed and allow recovery.
