### PR TITLE
fix: allow root to bypass bucket policy deny for policy management APIs

### DIFF
--- a/crates/ecstore/src/bucket/metadata.rs
+++ b/crates/ecstore/src/bucket/metadata.rs
@@ -372,12 +372,17 @@ impl BucketMetadata {
         Ok(())
     }
 
-    fn parse_all_configs(&mut self, _api: Arc<ECStore>) -> Result<()> {
+    fn parse_policy_config(&mut self) -> Result<()> {
         if !self.policy_config_json.is_empty() {
             self.policy_config = Some(serde_json::from_slice(&self.policy_config_json)?);
         } else {
             self.policy_config = None;
         }
+        Ok(())
+    }
+
+    fn parse_all_configs(&mut self, _api: Arc<ECStore>) -> Result<()> {
+        self.parse_policy_config()?;
         if !self.notification_config_xml.is_empty() {
             self.notification_config = Some(deserialize::<NotificationConfiguration>(&self.notification_config_xml)?);
         }
@@ -667,5 +672,22 @@ mod test {
         println!("   - Policy config size: {} bytes", deserialized_bm.policy_config_json.len());
         println!("   - Lifecycle config size: {} bytes", deserialized_bm.lifecycle_config_xml.len());
         println!("   - Serialized buffer size: {} bytes", buf.len());
+    }
+
+    /// After policy deletion (policy_config_json cleared), parse_policy_config sets policy_config to None.
+    #[test]
+    fn test_parse_policy_config_clears_cache_when_json_empty() {
+        let policy_json = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}]}"#;
+        let mut bm = BucketMetadata::new("b");
+        bm.policy_config_json = policy_json.as_bytes().to_vec();
+        bm.parse_policy_config().unwrap();
+        assert!(bm.policy_config.is_some(), "policy_config should be set when JSON non-empty");
+
+        bm.policy_config_json.clear();
+        bm.parse_policy_config().unwrap();
+        assert!(
+            bm.policy_config.is_none(),
+            "policy_config should be None after JSON cleared (e.g. policy deleted)"
+        );
     }
 }

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -93,6 +93,19 @@ impl FS {
     }
 }
 
+/// Returns true when the owner (root or parent=root credentials) may bypass bucket policy
+/// explicit Deny for this action. Per AWS S3, only GetBucketPolicy, PutBucketPolicy, and
+/// DeleteBucketPolicy have this bypass so the admin can recover from a misconfigured policy.
+pub(crate) fn owner_can_bypass_policy_deny(is_owner: bool, action: &Action) -> bool {
+    is_owner
+        && matches!(
+            action,
+            Action::S3Action(S3Action::GetBucketPolicyAction)
+                | Action::S3Action(S3Action::PutBucketPolicyAction)
+                | Action::S3Action(S3Action::DeleteBucketPolicyAction)
+        )
+}
+
 /// Authorizes the request based on the action and credentials.
 pub async fn authorize_request<T>(req: &mut S3Request<T>, action: Action) -> S3Result<()> {
     let remote_addr = req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0));
@@ -132,13 +145,8 @@ pub async fn authorize_request<T>(req: &mut S3Request<T>, action: Action) -> S3R
         // Per AWS S3: root can always perform GetBucketPolicy, PutBucketPolicy, DeleteBucketPolicy
         // even if bucket policy explicitly denies. Other actions (ListBucket, GetObject, etc.) are
         // subject to bucket policy Deny for root as well. See: repost.aws/knowledge-center/s3-accidentally-denied-access
-        let owner_can_bypass_deny = req_info.is_owner
-            && matches!(
-                action,
-                Action::S3Action(S3Action::GetBucketPolicyAction)
-                    | Action::S3Action(S3Action::PutBucketPolicyAction)
-                    | Action::S3Action(S3Action::DeleteBucketPolicyAction)
-            );
+        // Here "owner" means root or credentials whose parent_user is root (e.g. Console admin via STS).
+        let owner_can_bypass_deny = owner_can_bypass_policy_deny(req_info.is_owner, &action);
         if !bucket_name.is_empty()
             && !owner_can_bypass_deny
             && !PolicySys::is_allowed(&BucketPolicyArgs {
@@ -1485,5 +1493,25 @@ mod tests {
     async fn test_bucket_policy_uses_existing_object_tag_no_policy() {
         let result = bucket_policy_uses_existing_object_tag("test-bucket-no-policy-xyz-absent").await;
         assert!(!result, "bucket with no policy should not use ExistingObjectTag");
+    }
+
+    /// Owner can bypass bucket policy Deny only for the three policy management APIs (per AWS S3).
+    #[test]
+    fn test_owner_can_bypass_policy_deny_only_for_policy_apis() {
+        // Owner + policy management actions -> bypass allowed
+        assert!(owner_can_bypass_policy_deny(true, &Action::S3Action(S3Action::GetBucketPolicyAction)));
+        assert!(owner_can_bypass_policy_deny(true, &Action::S3Action(S3Action::PutBucketPolicyAction)));
+        assert!(owner_can_bypass_policy_deny(true, &Action::S3Action(S3Action::DeleteBucketPolicyAction)));
+
+        // Owner + other actions -> no bypass (still subject to bucket policy Deny)
+        assert!(!owner_can_bypass_policy_deny(true, &Action::S3Action(S3Action::ListBucketAction)));
+        assert!(!owner_can_bypass_policy_deny(true, &Action::S3Action(S3Action::GetObjectAction)));
+
+        // Non-owner -> no bypass for any action
+        assert!(!owner_can_bypass_policy_deny(false, &Action::S3Action(S3Action::GetBucketPolicyAction)));
+        assert!(!owner_can_bypass_policy_deny(
+            false,
+            &Action::S3Action(S3Action::DeleteBucketPolicyAction)
+        ));
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Closes #2092

## Summary of Changes
- **access.rs**: Allow the account root (owner) to bypass bucket policy deny-only check only for `GetBucketPolicy`, `PutBucketPolicy`, and `DeleteBucketPolicy`, per AWS S3 semantics. This lets the admin recover when a bucket policy with explicit Deny for all principals (e.g. Console "Private" preset) was applied. Other actions (ListBucket, GetObject, etc.) remain subject to bucket policy Deny for root.
- **metadata.rs**: In `parse_all_configs`, explicitly set `policy_config = None` when `policy_config_json` is empty so the in-memory cache stays consistent after policy deletion.

## Checklist
- [x] I have read and followed the CONTRIBUTING.md guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
Verification:
- `make pre-commit`
- Manual: set bucket policy to a Deny-all (e.g. Console Private), then as root call `DeleteBucketPolicy` — should succeed and allow recovery.
