### PR TITLE
fix(server): init event notifier when partial notify configured

### DIFF
--- a/rustfs/src/server/event.rs
+++ b/rustfs/src/server/event.rs
@@ -62,14 +62,15 @@ pub(crate) async fn init_event_notifier() {
         target: "rustfs::main::init_event_notifier",
         "Global server configuration loaded successfully"
     );
-    // 2. Check if the notify subsystem exists in the configuration, and skip initialization if it doesn't
-    if server_config
+    // 2. Check if at least one notify subsystem exists in the configuration, and skip only when neither is present.
+    let mqtt_configured = server_config
         .get_value(rustfs_config::notify::NOTIFY_MQTT_SUB_SYS, DEFAULT_DELIMITER)
-        .is_none()
-        || server_config
-            .get_value(rustfs_config::notify::NOTIFY_WEBHOOK_SUB_SYS, DEFAULT_DELIMITER)
-            .is_none()
-    {
+        .is_some();
+    let webhook_configured = server_config
+        .get_value(rustfs_config::notify::NOTIFY_WEBHOOK_SUB_SYS, DEFAULT_DELIMITER)
+        .is_some();
+
+    if !mqtt_configured && !webhook_configured {
         info!(
             target: "rustfs::main::init_event_notifier",
             "'notify' subsystem not configured, skipping event notifier initialization."


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- https://github.com/rustfs/backlog/issues/585

## Summary of Changes
- Fix event notifier bootstrap condition to initialize when either MQTT or webhook is configured.
- Avoid incorrectly skipping notifier initialization when one of the two subsystems is absent.

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact: startup behavior for partial notify configs is corrected.

## Additional Notes
- Added tests are covered in a dedicated `notify` path where this initialization condition is exercised.
