### PR TITLE
[codex] fix scanner first cycle startup delay

### DIFF
--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -258,6 +258,11 @@ pub async fn run_data_scanner(ctx: CancellationToken, storeapi: Arc<ECStore>) ->
         }
     }
 
+    if !ctx.is_cancelled() {
+        // Preserve previous behavior: run one cycle immediately after lock acquisition.
+        run_data_scanner_cycle(&ctx, &storeapi, &mut cycle_info).await;
+    }
+
     loop {
         if ctx.is_cancelled() {
             break;


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This PR fixes a scanner scheduling regression introduced by dynamic throttling changes.

After acquiring the leader lock, `run_data_scanner()` now executes one scanner cycle immediately before entering the randomized inter-cycle sleep loop. This restores the previous behavior where the first cycle started right away, instead of being delayed by a sleep interval.

User impact before this fix: first scan execution could be delayed significantly (up to the configured long cycle interval, e.g. around 30 minutes on the slowest preset), which postpones data-usage updates and background healing progress right after scanner start.

Root cause: the scheduling logic switched from an interval-based loop to a sleep-before-run loop, unintentionally adding delay before cycle #1.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Restores immediate scanner startup cycle behavior.

## Additional Notes
Verification commands run locally:
- `make pre-commit`
- `cargo test -p rustfs-scanner --lib --tests`

