### PR TITLE
fix(helm): use canonical scanner start delay env

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -33,7 +33,7 @@ RustFS helm chart supports **standalone and distributed mode**. For standalone m
 | config.rustfs.metrics.enabled | bool | `false` | Toggle metrics export. |
 | config.rustfs.metrics.endpoint | string | `""` | Dedicated metrics endpoint. |
 | config.rustfs.scanner.speed | string | `""` | Scanner speed preset: `fastest`, `fast`, `default`, `slow`, `slowest` |
-| config.rustfs.scanner.start_delay_secs | string | `""` | Override scanner cycle interval in seconds with `RUSTFS_DATA_SCANNER_START_DELAY_SECS` |
+| config.rustfs.scanner.start_delay_secs | string | `""` | Override scanner cycle interval in seconds with `RUSTFS_SCANNER_START_DELAY_SECS` |
 | config.rustfs.scanner.idle_mode | string | `""` | Override scanner idle throttling flag (`RUSTFS_SCANNER_IDLE_MODE`) |
 | containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/helm/rustfs/templates/configmap.yaml
+++ b/helm/rustfs/templates/configmap.yaml
@@ -52,7 +52,7 @@ data:
   RUSTFS_SCANNER_SPEED: {{ .speed | quote }}
     {{- end }}
     {{- if .start_delay_secs }}
-  RUSTFS_DATA_SCANNER_START_DELAY_SECS: {{ .start_delay_secs | quote }}
+  RUSTFS_SCANNER_START_DELAY_SECS: {{ .start_delay_secs | quote }}
     {{- end }}
     {{- if .idle_mode }}
   RUSTFS_SCANNER_IDLE_MODE: {{ .idle_mode | quote }}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Aligned Helm ConfigMap scanner delay env var with the canonical name introduced in #2129.
- Replaced `RUSTFS_DATA_SCANNER_START_DELAY_SECS` with `RUSTFS_SCANNER_START_DELAY_SECS` in `helm/rustfs/templates/configmap.yaml`.
- Updated the corresponding parameter description in `helm/README.md`.

Motivation:
- `#2129` normalized scanner env naming to `RUSTFS_SCANNER_START_DELAY_SECS`.
- Helm chart still emitted the deprecated alias, which kept deployments on compatibility path and could trigger deprecation warnings.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
Verification commands run locally:
- `helm lint helm/rustfs`
- `make pre-commit`
- `docker pull rustfs/rustfs:latest`
- `docker run -d --rm --name rustfs-daily-bug-scan-validate -p 19000:9000 -p 19001:9001 -v /tmp/.../data:/data -v /tmp/.../logs:/logs rustfs/rustfs:latest`
- `curl -fsS http://127.0.0.1:19000/health`

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
