### PR TITLE
feat(ci): allow selecting build platforms in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           ]}'
 
           if [[ "${selected}" == "all" ]]; then
-            matrix="${all}"
+            matrix="$(jq -c . <<<"${all}")"
           else
             unknown="$(jq -rn --arg selected "${selected}" --argjson all "${all}" '
               ($selected | split(",") | map(select(length > 0))) as $req


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Added a new `platforms` input for `workflow_dispatch` in `.github/workflows/build.yml`.
- Supports selecting one or multiple build targets with comma-separated platform IDs.
- Keeps default behavior as `all` so existing dispatch behavior remains unchanged.
- Added a `prepare-platform-matrix` job to validate and resolve selected IDs into a dynamic matrix.
- Updated `build-rustfs` to consume the dynamic matrix via `fromJson(...)`.
- Fixed matrix output formatting to always write compact single-line JSON to `$GITHUB_OUTPUT`.

Supported platform IDs:
- `linux-x86_64-musl`
- `linux-aarch64-musl`
- `linux-x86_64-gnu`
- `linux-aarch64-gnu`
- `macos-aarch64`
- `macos-x86_64`
- `windows-x86_64`

Examples:
- `all`
- `linux-x86_64-musl`
- `linux-x86_64-musl,macos-aarch64`

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
- This PR only changes CI workflow behavior for manual dispatch input handling.
- Existing push/tag/schedule behavior is preserved when `platforms=all`.
