### PR TITLE
fix(ecstore): keep bucket created time when metadata is epoch

### DIFF
--- a/crates/ecstore/src/store/bucket.rs
+++ b/crates/ecstore/src/store/bucket.rs
@@ -91,9 +91,10 @@ impl ECStore {
         if !opts.no_metadata {
             for bucket in buckets.iter_mut() {
                 if let Ok(created) = metadata_sys::created_at(&bucket.name).await
-                    && should_override_created_from_metadata(created) {
-                        bucket.created = Some(created);
-                    }
+                    && should_override_created_from_metadata(created)
+                {
+                    bucket.created = Some(created);
+                }
             }
         }
         Ok(buckets)


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
