### PR TITLE
fix(iam): preserve trailing slash in OIDC issuer URL

### DIFF
--- a/crates/iam/src/oidc.rs
+++ b/crates/iam/src/oidc.rs
@@ -761,13 +761,20 @@ fn normalize_config_url(config_url: &str) -> Result<String, String> {
         return Err(format!("invalid config_url scheme: {}", url.scheme()));
     }
     let host = url.host_str().ok_or_else(|| "config_url missing host".to_string())?;
-    let path = url.path().trim_end_matches('/');
+    let path = url.path();
 
-    if path.contains("/.well-known/") && !path.ends_with("/.well-known/openid-configuration") {
+    // Strip `/.well-known/openid-configuration` (with optional trailing slash) if present.
+    // Everything else is preserved exactly so the issuer URL matches the provider's discovery
+    // document (e.g. Authentik includes a trailing slash, Keycloak does not).
+    let normalized_path = path
+        .strip_suffix('/')
+        .unwrap_or(path)
+        .strip_suffix("/.well-known/openid-configuration")
+        .unwrap_or(if path == "/" { "" } else { path });
+
+    if normalized_path.contains("/.well-known/") {
         return Err("config_url uses an unsupported .well-known discovery URL".into());
     }
-
-    let normalized_path = path.strip_suffix("/.well-known/openid-configuration").unwrap_or(path);
 
     let mut issuer = format!("{}://{host}", url.scheme());
     if let Some(port) = url.port() {
@@ -886,20 +893,57 @@ mod tests {
 
     #[test]
     fn test_normalize_config_url() {
+        // --- Well-known suffix stripping ---
+        // Bare well-known URL → stripped to just the host
         assert_eq!(
             normalize_config_url("https://idp.example.com/.well-known/openid-configuration").unwrap(),
             "https://idp.example.com"
         );
+        // Trailing slash after well-known suffix is also stripped
         assert_eq!(
             normalize_config_url("https://idp.example.com/.well-known/openid-configuration/").unwrap(),
             "https://idp.example.com"
+        );
+        // Well-known under a sub-path (Keycloak realms)
+        assert_eq!(
+            normalize_config_url("https://keycloak.example.com/realms/myrealm/.well-known/openid-configuration").unwrap(),
+            "https://keycloak.example.com/realms/myrealm"
+        );
+
+        // --- Providers WITHOUT trailing slash (Keycloak, Auth0, Okta, Google) ---
+        assert_eq!(
+            normalize_config_url("https://keycloak.example.com/realms/myrealm").unwrap(),
+            "https://keycloak.example.com/realms/myrealm"
         );
         assert_eq!(
             normalize_config_url("https://idp.example.com/custom/realm").unwrap(),
             "https://idp.example.com/custom/realm"
         );
+
+        // --- Providers WITH trailing slash (Authentik) ---
+        assert_eq!(
+            normalize_config_url("https://auth.example.com/application/o/myapp/").unwrap(),
+            "https://auth.example.com/application/o/myapp/"
+        );
+
+        // --- Root-level issuer (bare host) ---
+        assert_eq!(normalize_config_url("https://idp.example.com").unwrap(), "https://idp.example.com");
+        assert_eq!(normalize_config_url("https://idp.example.com/").unwrap(), "https://idp.example.com");
+
+        // --- Custom port ---
+        assert_eq!(
+            normalize_config_url("https://idp.example.com:8443/auth/realms/test").unwrap(),
+            "https://idp.example.com:8443/auth/realms/test"
+        );
+        assert_eq!(
+            normalize_config_url("http://localhost:8080/application/o/app/").unwrap(),
+            "http://localhost:8080/application/o/app/"
+        );
+
+        // --- Error cases ---
         assert!(normalize_config_url("https://idp.example.com/.well-known/invalid").is_err());
         assert!(normalize_config_url("gopher://idp.example.com").is_err());
+        assert!(normalize_config_url("not-a-url").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues

#2049

## Summary of Changes

PR #2050 fixed an issue where `normalize_config_url()` was *adding* a trailing slash to OIDC issuer URLs, which broke Keycloak (whose discovery document does not include one). However, the fix introduced `trim_end_matches('/')` which now *strips* trailing slashes — breaking providers like **Authentik** whose discovery document always includes a trailing slash in the `issuer` claim (e.g. `https://auth.example.com/application/o/myapp/`).

The OIDC spec ([RFC 8414 §2](https://www.rfc-editor.org/rfc/rfc8414#section-2)) requires the `issuer` value in the discovery document to exactly match the issuer URL used during token validation. When RustFS strips the trailing slash but the provider returns one, token validation fails with:

```
unexpected issuer URI 'https://auth.example.com/application/o/myapp/'
  (expected 'https://auth.example.com/application/o/myapp')
```

### Fix

The change replaces the `trim_end_matches('/')` approach with a targeted `strip_suffix` chain that only removes `/.well-known/openid-configuration` (with an optional trailing slash). Everything else — including any trailing slash in the issuer path — is preserved exactly as given:

```rust
let normalized_path = path
    .strip_suffix('/')
    .unwrap_or(path)
    .strip_suffix("/.well-known/openid-configuration")
    .unwrap_or(if path == "/" { "" } else { path });
```

This way:
- **Keycloak** (`/realms/myrealm` — no trailing slash) continues to work
- **Authentik** (`/application/o/myapp/` — trailing slash) now works
- Any other provider works regardless of trailing-slash convention

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes

### Known limitation

When a user provides the full `.well-known/openid-configuration` URL instead of the base issuer URL, the trailing slash is lost during suffix stripping — there's no way to distinguish `…/myapp/.well-known/openid-configuration` originating from issuer `…/myapp` vs `…/myapp/`. This is a pre-existing limitation (present before #2050 as well) and only affects providers like Authentik that include a trailing slash in their issuer claim. The recommended configuration is to provide the issuer URL directly (e.g. `https://auth.example.com/application/o/myapp/`), which preserves the trailing slash exactly as given.

### Test coverage

The `test_normalize_config_url` test has been expanded from 4 to 14 assertions:

| Scenario | Input | Expected Output |
|---|---|---|
| Well-known stripping (bare) | `https://idp.example.com/.well-known/openid-configuration` | `https://idp.example.com` |
| Well-known stripping (trailing slash) | `…/.well-known/openid-configuration/` | `https://idp.example.com` |
| Well-known under sub-path (Keycloak) | `…/realms/myrealm/.well-known/openid-configuration` | `…/realms/myrealm` |
| Provider without trailing slash | `…/realms/myrealm` | `…/realms/myrealm` |
| Provider without trailing slash (custom) | `…/custom/realm` | `…/custom/realm` |
| Provider with trailing slash (Authentik) | `…/application/o/myapp/` | `…/application/o/myapp/` |
| Root-level issuer (no slash) | `https://idp.example.com` | `https://idp.example.com` |
| Root-level issuer (trailing slash) | `https://idp.example.com/` | `https://idp.example.com` |
| Custom port (no trailing slash) | `https://idp.example.com:8443/auth/realms/test` | preserved |
| Custom port (trailing slash) | `http://localhost:8080/application/o/app/` | preserved |
| Invalid well-known suffix | `…/.well-known/invalid` | error |
| Bad scheme | `gopher://…` | error |
| Invalid URL | `not-a-url` | error |
