### PR TITLE
ci(build): enable tokio_unstable flag in Build RustFS job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
-      RUSTFLAGS: ${{ matrix.rustflags }}
+      # Always enable Tokio unstable features (required by dial9-tokio-telemetry).
+      # The RUSTFLAGS env var takes precedence over .cargo/config.toml [build] rustflags,
+      # so we must include --cfg tokio_unstable here explicitly; otherwise an empty
+      # RUSTFLAGS value would shadow the config-file flag and silently break tracing.
+      RUSTFLAGS: "--cfg tokio_unstable ${{ matrix.rustflags }}"
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-platform-matrix.outputs.matrix) }}


### PR DESCRIPTION

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

ci(build): enable tokio_unstable flag in Build RustFS job

The RUSTFLAGS environment variable set at job level takes precedence over
.cargo/config.toml [build] rustflags. When matrix.rustflags is an empty
string, Cargo silently ignores the config-file flag, causing the
--cfg tokio_unstable feature to be absent in CI builds even though
.cargo/config.toml already declares it for local development.

Fix the job-level env so that --cfg tokio_unstable is always prepended
to the matrix-supplied flags:

  RUSTFLAGS: "--cfg tokio_unstable ${{ matrix.rustflags }}"

This guarantees consistent behaviour between local (config.toml) and
CI (env var) builds for all seven target platforms.

Affected jobs: build-rustfs
Affected files:
  - .github/workflows/build.yml

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
