### PR TITLE
fix(metrics): use Prometheus-compatible metric names (#2312)

### DIFF
--- a/.docker/observability/grafana/dashboards/rustfs.json
+++ b/.docker/observability/grafana/dashboards/rustfs.json
@@ -91,7 +91,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "gauge_rustfs_process_uptime_seconds{job=~\"$job\"}",
+          "expr": "rustfs_system_process_uptime_seconds{job=~\"$job\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -223,7 +223,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(gauge_rustfs_cluster_buckets_total{job=~\"$job\"})",
+          "expr": "sum(rustfs_cluster_buckets_total{job=~\"$job\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -289,7 +289,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(gauge_rustfs_cluster_objects_total{job=~\"$job\"})",
+          "expr": "sum(rustfs_cluster_objects_total{job=~\"$job\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -427,7 +427,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(gauge_rustfs_cluster_capacity_used_bytes{job=~\"$job\"})",
+          "expr": "sum(rustfs_cluster_capacity_used_bytes{job=~\"$job\"})",
           "legendFormat": "Used",
           "range": true,
           "refId": "A"
@@ -438,7 +438,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(gauge_rustfs_cluster_capacity_raw_total_bytes{job=~\"$job\"})",
+          "expr": "sum(rustfs_cluster_capacity_raw_total_bytes{job=~\"$job\"})",
           "hide": false,
           "legendFormat": "Total",
           "range": true,
@@ -450,7 +450,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(gauge_rustfs_cluster_capacity_used_bytes{job=~\"$job\"}) / sum(gauge_rustfs_cluster_capacity_raw_total_bytes{job=~\"$job\"})",
+          "expr": "sum(rustfs_cluster_capacity_used_bytes{job=~\"$job\"}) / sum(rustfs_cluster_capacity_raw_total_bytes{job=~\"$job\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "Percent",
@@ -1971,7 +1971,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (drive) (gauge_rustfs_node_disk_used_bytes{job=~\"$job\", drive=~\"$drive\"})",
+          "expr": "sum by (drive) (rustfs_node_disk_used_bytes{job=~\"$job\", drive=~\"$drive\"})",
           "legendFormat": "{{drive}} (bytes)",
           "range": true,
           "refId": "A"
@@ -1982,7 +1982,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (drive) (gauge_rustfs_node_disk_used_bytes{job=~\"$job\", drive=~\"$drive\"}) / sum by (drive)(gauge_rustfs_node_disk_total_bytes{job=~\"$job\", drive=~\"$drive\"})",
+          "expr": "sum by (drive) (rustfs_node_disk_used_bytes{job=~\"$job\", drive=~\"$drive\"}) / sum by (drive)(rustfs_node_disk_total_bytes{job=~\"$job\", drive=~\"$drive\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "{{drive}} (percent)",
@@ -2473,7 +2473,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (job) (gauge_rustfs_process_cpu_usage{job=~\"$job\"})",
+          "expr": "sum by (job) (rustfs_system_process_cpu_usage{job=~\"$job\"})",
           "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
@@ -2572,7 +2572,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (job) (gauge_rustfs_process_resident_memory_bytes{job=~\"$job\"})",
+          "expr": "sum by (job) (rustfs_system_process_resident_memory_bytes{job=~\"$job\"})",
           "legendFormat": "{{job}}",
           "range": true,
           "refId": "B"
@@ -2670,7 +2670,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (job) (rate(gauge_rustfs_process_network_io{job=~\"$job\", direction=\"received\"}[5m]))",
+          "expr": "sum by (job) (rate(rustfs_system_process_network_io{job=~\"$job\", direction=\"received\"}[5m]))",
           "legendFormat": "RX - {{job}}",
           "range": true,
           "refId": "C"
@@ -2681,7 +2681,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (job) (rate(gauge_rustfs_process_network_io{job=~\"$job\", direction=\"transmitted\"}[5m]))",
+          "expr": "sum by (job) (rate(rustfs_system_process_network_io{job=~\"$job\", direction=\"transmitted\"}[5m]))",
           "legendFormat": "TX - {{job}}",
           "range": true,
           "refId": "D"

--- a/crates/metrics/src/collectors/system_cpu.rs
+++ b/crates/metrics/src/collectors/system_cpu.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(metrics.len(), 8);
 
         // Verify that metric names are properly generated from descriptors
-        assert!(metrics.iter().all(|m| m.name.starts_with("gauge.rustfs_system_cpu_")));
+        assert!(metrics.iter().all(|m| m.name.starts_with("rustfs_system_cpu_")));
     }
 
     #[test]

--- a/crates/metrics/src/collectors/system_memory.rs
+++ b/crates/metrics/src/collectors/system_memory.rs
@@ -122,7 +122,7 @@ mod tests {
         report_metrics(&metrics);
 
         assert_eq!(metrics.len(), 8);
-        assert!(metrics.iter().all(|m| m.name.starts_with("gauge.rustfs_system_memory_")));
+        assert!(metrics.iter().all(|m| m.name.starts_with("rustfs_system_memory_")));
     }
 
     #[test]

--- a/crates/metrics/src/metrics_type/entry/descriptor.rs
+++ b/crates/metrics/src/metrics_type/entry/descriptor.rs
@@ -51,14 +51,13 @@ impl MetricDescriptor {
         }
     }
 
-    /// Get the full metric name, including the prefix and formatting path
+    /// Get the full metric name in Prometheus style: <namespace>_<subsystem>_<name>
     #[allow(dead_code)]
     pub fn get_full_metric_name(&self) -> String {
-        let prefix = self.metric_type.as_prom();
         let namespace = self.namespace.as_str();
         let formatted_subsystem = self.subsystem.as_str();
 
-        format!("{}{}_{}_{}", prefix, namespace, formatted_subsystem, self.name.as_str())
+        format!("{}_{}_{}", namespace, formatted_subsystem, self.name.as_str())
     }
 
     /// check whether the label is in the label set
@@ -77,5 +76,38 @@ impl MetricDescriptor {
             self.label_set = Some(set);
         }
         self.label_set.as_ref().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_metric_name_uses_prometheus_convention_without_type_prefix() {
+        let descriptor = MetricDescriptor::new(
+            MetricName::ApiRequestsTotal,
+            MetricType::Counter,
+            "test help".to_string(),
+            vec![],
+            MetricNamespace::RustFS,
+            MetricSubsystem::ApiRequests,
+        );
+
+        assert_eq!(descriptor.get_full_metric_name(), "rustfs_api_requests_total");
+    }
+
+    #[test]
+    fn full_metric_name_formats_custom_subsystems_without_type_prefix() {
+        let descriptor = MetricDescriptor::new(
+            MetricName::Custom("latency_seconds".to_string()),
+            MetricType::Histogram,
+            "test help".to_string(),
+            vec![],
+            MetricNamespace::RustFS,
+            MetricSubsystem::new("/custom/path-metrics"),
+        );
+
+        assert_eq!(descriptor.get_full_metric_name(), "rustfs_custom_path_metrics_latency_seconds");
     }
 }

--- a/crates/metrics/src/metrics_type/entry/mod.rs
+++ b/crates/metrics/src/metrics_type/entry/mod.rs
@@ -110,7 +110,7 @@ mod tests {
         assert_eq!(histogram_md.subsystem, MetricSubsystem::ApiRequests);
 
         // Verify that the full metric name generated is formatted correctly
-        assert_eq!(histogram_md.get_full_metric_name(), "histogram.rustfs_api_requests_seconds_distribution");
+        assert_eq!(histogram_md.get_full_metric_name(), "rustfs_api_requests_seconds_distribution");
 
         // Tests use custom subsystems
         let custom_histogram_md = new_histogram_md(
@@ -123,7 +123,7 @@ mod tests {
         // Verify the custom name and subsystem
         assert_eq!(
             custom_histogram_md.get_full_metric_name(),
-            "histogram.rustfs_custom_path_metrics_custom_latency_distribution"
+            "rustfs_custom_path_metrics_custom_latency_distribution"
         );
     }
 }

--- a/crates/metrics/src/metrics_type/entry/subsystem.rs
+++ b/crates/metrics/src/metrics_type/entry/subsystem.rs
@@ -233,7 +233,7 @@ mod tests {
             MetricSubsystem::ApiRequests,
         );
 
-        assert_eq!(md.get_full_metric_name(), "counter.rustfs_api_requests_total");
+        assert_eq!(md.get_full_metric_name(), "rustfs_api_requests_total");
 
         let custom_md = MetricDescriptor::new(
             MetricName::Custom("test_metric".to_string()),
@@ -244,6 +244,6 @@ mod tests {
             MetricSubsystem::new("/custom/path-with-dash"),
         );
 
-        assert_eq!(custom_md.get_full_metric_name(), "gauge.rustfs_custom_path_with_dash_test_metric");
+        assert_eq!(custom_md.get_full_metric_name(), "rustfs_custom_path_with_dash_test_metric");
     }
 }


### PR DESCRIPTION
  ## Type of Change
  - [ ] New Feature
  - [x] Bug Fix
  - [ ] Documentation
  - [ ] Performance Improvement
  - [ ] Test/CI
  - [ ] Refactor
  - [ ] Other:

  ## Related Issues
  - #2312

  ## Summary of Changes
  - Remove the metric type prefixes from generated metric names so exported series use standard Prometheus-style names such as `rustfs_api_requests_total`.
  - Align the exported metric names with the bundled Grafana dashboard queries that already expect `rustfs_*` names.
  - Add regression coverage for metric descriptor name generation without type prefixes.
  - Update collector tests that previously asserted the old `gauge.`-prefixed names.

  ## Checklist
  - [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
  - [x] Passed `make pre-commit`
  - [x] Added/updated necessary tests
  - [ ] Documentation updated (if needed)
  - [ ] CI/CD passed (if applicable)

  ## Impact
  - [ ] Breaking change (compatibility)
  - [ ] Requires doc/config/deployment update
  - [x] Other impact: Restores compatibility between exported RustFS metrics and the bundled Grafana dashboard queries.

  ## Additional Notes
  - Verification commands:
    - `cargo test -p rustfs-metrics --lib -- --nocapture`
    - `cargo fmt --all --check`
    - `make pre-commit`
    - End-to-end validation was also performed by:
    - starting the observability stack with `docker compose --profile observability up -d prometheus grafana loki tempo jaeger otel-collector`
    - starting the local RustFS binary with `target/debug/rustfs`
    - generating HTTP traffic with `curl`
    - confirming that `rustfs_api_requests_total` appeared on the OTEL application metrics endpoint and in Prometheus query results
    - confirming that the old `counter.rustfs_api_requests_total` name no longer appeared
  - This change is intentionally limited to metric naming. Metric values, labels, and collection flow remain unchanged.
  - No documentation, config, or deployment changes are required.

  ---

  Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.