### PR TITLE
test(object-lock): cover validation gaps

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -1670,6 +1670,28 @@ mod tests {
     }
 
     #[test]
+    fn versioning_configuration_has_object_lock_incompatible_settings_rejects_exclude_folders() {
+        let config = VersioningConfiguration {
+            exclude_folders: Some(true),
+            ..Default::default()
+        };
+
+        assert!(versioning_configuration_has_object_lock_incompatible_settings(&config));
+    }
+
+    #[test]
+    fn versioning_configuration_has_object_lock_incompatible_settings_rejects_excluded_prefixes() {
+        let config = VersioningConfiguration {
+            excluded_prefixes: Some(vec![ExcludedPrefix {
+                prefix: Some("archive/".to_string()),
+            }]),
+            ..Default::default()
+        };
+
+        assert!(versioning_configuration_has_object_lock_incompatible_settings(&config));
+    }
+
+    #[test]
     fn resolve_notification_region_prefers_global_region() {
         let binding = resolve_notification_region(Some("us-east-1".parse().unwrap()), Some("ap-southeast-1".parse().unwrap()));
         assert_eq!(binding, "us-east-1");

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -5135,6 +5135,51 @@ mod tests {
         assert_eq!(err.code(), &S3ErrorCode::MalformedXML);
     }
 
+    #[test]
+    fn validate_object_lock_configuration_rejects_missing_default_retention() {
+        let cfg = ObjectLockConfiguration {
+            object_lock_enabled: Some(ObjectLockEnabled::from_static(ObjectLockEnabled::ENABLED)),
+            rule: Some(ObjectLockRule { default_retention: None }),
+        };
+
+        let err = validate_object_lock_configuration_input(&cfg).unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::MalformedXML);
+    }
+
+    #[test]
+    fn validate_object_lock_configuration_rejects_zero_days() {
+        let cfg = ObjectLockConfiguration {
+            object_lock_enabled: Some(ObjectLockEnabled::from_static(ObjectLockEnabled::ENABLED)),
+            rule: Some(ObjectLockRule {
+                default_retention: Some(DefaultRetention {
+                    mode: Some(ObjectLockRetentionMode::from_static(ObjectLockRetentionMode::GOVERNANCE)),
+                    days: Some(0),
+                    years: None,
+                }),
+            }),
+        };
+
+        let err = validate_object_lock_configuration_input(&cfg).unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::Custom("InvalidRetentionPeriod".into()));
+    }
+
+    #[test]
+    fn validate_object_lock_configuration_rejects_too_many_years() {
+        let cfg = ObjectLockConfiguration {
+            object_lock_enabled: Some(ObjectLockEnabled::from_static(ObjectLockEnabled::ENABLED)),
+            rule: Some(ObjectLockRule {
+                default_retention: Some(DefaultRetention {
+                    mode: Some(ObjectLockRetentionMode::from_static(ObjectLockRetentionMode::COMPLIANCE)),
+                    days: None,
+                    years: Some(MAXIMUM_RETENTION_YEARS + 1),
+                }),
+            }),
+        };
+
+        let err = validate_object_lock_configuration_input(&cfg).unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::Custom("InvalidRetentionPeriod".into()));
+    }
+
     #[tokio::test]
     async fn execute_put_object_retention_returns_internal_error_when_store_uninitialized() {
         let input = PutObjectRetentionInput::builder()


### PR DESCRIPTION
## Summary
This change adds focused regression coverage for recent object-lock validation logic that landed without direct tests for every new branch.

The first gap was in bucket versioning compatibility checks. The recent object-lock change began rejecting versioning updates that use `exclude_folders` or `excluded_prefixes`, but only the suspended-status branch had a unit test. Without direct coverage, those compatibility guards could regress silently.

The second gap was in object-lock configuration validation. The new validation code rejects malformed default-retention payloads such as missing `DefaultRetention`, zero `Days`, and retention periods that exceed the allowed maximum. Those branches were exercised by the implementation but not by tests.

This PR adds small unit tests for those missing paths only. It does not change production behavior.

## Root Cause
Recent object-lock fixes added new validation branches faster than direct regression tests were added for each branch.

## Validation
- `cargo test -p rustfs versioning_configuration_has_object_lock_incompatible_settings -- --nocapture`
- `cargo test -p rustfs validate_object_lock_configuration_ -- --nocapture`
- `make pre-commit`

## Risks
N/A
