### PR TITLE
test(ecstore): cover inline bitrot offset reads

### DIFF
--- a/crates/ecstore/src/bitrot.rs
+++ b/crates/ecstore/src/bitrot.rs
@@ -227,6 +227,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_bitrot_reader_with_inline_offset_starts_at_requested_shard() {
+        let shard_size = 4;
+        let checksum_algo = HashAlgorithm::HighwayHash256S;
+        let payload = b"abcdefghijkl";
+
+        let mut writer = create_bitrot_writer(
+            true,
+            None,
+            "test-volume",
+            "test-path",
+            payload.len() as i64,
+            shard_size,
+            checksum_algo.clone(),
+        )
+        .await
+        .expect("inline bitrot writer");
+
+        for chunk in payload.chunks(shard_size) {
+            writer.write(chunk).await.expect("write chunk");
+        }
+
+        let inline_data = writer.into_inline_data().expect("inline buffer");
+        let mut reader = create_bitrot_reader(
+            Some(&inline_data),
+            None,
+            "test-bucket",
+            "test-path",
+            shard_size,
+            shard_size,
+            shard_size,
+            checksum_algo,
+            false,
+            false,
+        )
+        .await
+        .expect("create reader")
+        .expect("reader");
+
+        let mut out = [0u8; 4];
+        let n = reader.read(&mut out).await.expect("read second shard");
+
+        assert_eq!(n, shard_size);
+        assert_eq!(&out[..n], b"efgh");
+    }
+
+    #[tokio::test]
     async fn test_create_bitrot_reader_without_data_or_disk() {
         let shard_size = 16;
         let checksum_algo = HashAlgorithm::HighwayHash256S;


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- N/A

## Summary of Changes
This PR adds a focused regression test for `create_bitrot_reader` when it reads inline bitrot-encoded data from a non-zero shard-aligned offset. The recent fix in `crates/ecstore/src/bitrot.rs` started applying the computed inline offset before constructing the `BitrotReader`, but the existing tests only covered reader creation with offset `0` and did not prove that the requested shard was actually selected.

The new test builds a real inline bitrot payload with `create_bitrot_writer`, reopens it through `create_bitrot_reader` starting at the second shard, and asserts that the first read returns `efgh` instead of the first shard. In user terms, this protects inline-object reads from silently starting at the wrong shard after offset-based reads, which would otherwise surface as incorrect data or hash mismatches on resumed or ranged reads.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
This is a test-only change that tightens coverage around a recently fixed inline bitrot read path.

## Additional Notes
Verification used:
- `cargo test -p rustfs-ecstore bitrot::tests -- --nocapture`
- `make pre-commit`

