### PR TITLE
test(ecstore): cover read offset overflow

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -2926,6 +2926,40 @@ mod test {
         let _ = fs::remove_dir_all(&test_dir).await;
     }
 
+    #[tokio::test]
+    async fn test_read_file_stream_rejects_offset_length_overflow() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+        let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+
+        disk.make_volume("test-volume").await.unwrap();
+        disk.write_all("test-volume", "test-file.txt", Bytes::from_static(b"test"))
+            .await
+            .unwrap();
+
+        let result = disk.read_file_stream("test-volume", "test-file.txt", usize::MAX, 1).await;
+        assert!(matches!(result, Err(DiskError::FileCorrupt)));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_zero_copy_rejects_offset_length_overflow() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+        let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+
+        disk.make_volume("test-volume").await.unwrap();
+        disk.write_all("test-volume", "test-file.txt", Bytes::from_static(b"test"))
+            .await
+            .unwrap();
+
+        let result = disk.read_file_zero_copy("test-volume", "test-file.txt", usize::MAX, 1).await;
+        assert!(matches!(result, Err(DiskError::FileCorrupt)));
+    }
+
     #[test]
     fn test_is_valid_volname() {
         // Valid volume names (length >= 3)


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- N/A

## Summary of Changes
The recent correctness fix in `LocalDisk::read_file_stream` and `LocalDisk::read_file_zero_copy` added `checked_add` guards before validating `offset + length` against file size. That change closes an integer-overflow path that could otherwise bypass bounds validation or panic in edge cases.

This PR adds two narrow regression tests in `crates/ecstore/src/disk/local.rs` that exercise the overflow case directly. Each test creates a small local disk fixture, writes a file, then calls the read path with `offset = usize::MAX` and `length = 1`. The expected behavior is a deterministic `DiskError::FileCorrupt`, matching the fix in #2327.

For users, the effect is higher confidence that oversized read requests fail safely and consistently on both the stream-based path and the zero-copy path. The production logic is unchanged in this PR; only focused regression coverage was added.

Verification commands:
- `cargo test -p rustfs-ecstore test_read_file_stream_rejects_offset_length_overflow -- --nocapture`
- `cargo test -p rustfs-ecstore test_read_file_zero_copy_rejects_offset_length_overflow -- --nocapture`
- `make pre-commit`

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
Focused regression coverage for overflow handling in ecstore local-disk reads.

## Additional Notes
- N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
