### PR TITLE
ci: integrate CLA bot checks

### DIFF
--- a/.github/cla.yml
+++ b/.github/cla.yml
@@ -1,0 +1,17 @@
+enabled: true
+
+document:
+  version: v1
+  url: https://github.com/rustfs/cla/blob/main/cla/v1.md
+
+signing:
+  mode: comment
+  comment_pattern: I have read and agree to the CLA.
+
+registry:
+  type: json-repo
+  repository: rustfs/cla
+  path_prefix: signatures
+
+status:
+  check_name: CLA Check

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,4 +34,4 @@ Pull Request Template for RustFS
 
 ---
 
-Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
+Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,37 @@
+# Copyright 2026 RustFS Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CLA Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+  checks: write
+
+jobs:
+  cla:
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run CLA Bot
+        uses: overtrue/cla-bot@v0.0.1
+        with:
+          github-token: ${{ github.token }}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Add `cla-bot` repository configuration for RustFS CLA v1.
- Add a dedicated `CLA Check` workflow for `pull_request_target` and PR comment signing events.
- Use GitHub App installation tokens for both the target repository and the `rustfs/cla` registry repository.
- Update the PR template with the exact CLA signing instructions for first-time contributors.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
- Configure `CLA_BOT_APP_ID` as a repository Actions variable.
- Configure `CLA_BOT_APP_PRIVATE_KEY` as a repository Actions secret.
- Install the GitHub App on both `rustfs/rustfs` and `rustfs/cla`.
- Signatures are stored in the `rustfs/cla` repository via the `json-repo` backend.
- Verification:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cla.yml")'`
  - Review the workflow diff against the current `cla-bot` and `actions/create-github-app-token` interfaces.
