### PR TITLE
ci: use GitHub App tokens for CLA bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,16 +22,37 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  issues: write
-  checks: write
 
 jobs:
   cla:
     if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - name: Run CLA Bot
-        uses: overtrue/cla-bot@v0.0.1
+      - name: Create token for rustfs/rustfs
+        id: target-token
+        uses: actions/create-github-app-token@v3
         with:
-          github-token: ${{ github.token }}
+          app-id: ${{ vars.CLA_BOT_APP_ID }}
+          private-key: ${{ secrets.CLA_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: read
+          permission-pull-requests: read
+          permission-issues: write
+          permission-checks: write
+
+      - name: Create token for rustfs/cla
+        id: registry-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CLA_BOT_APP_ID }}
+          private-key: ${{ secrets.CLA_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: cla
+          permission-contents: write
+
+      - name: Run CLA Bot
+        uses: overtrue/cla-bot@7616514cd5d28caafcabcdd96c91466d312bb1fb
+        with:
+          github-token: ${{ steps.target-token.outputs.token }}
+          registry-token: ${{ steps.registry-token.outputs.token }}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Update the `CLA Check` workflow to mint GitHub App installation tokens for both `rustfs/rustfs` and `rustfs/cla`.
- Pass the app-scoped tokens to `cla-bot` instead of relying on the workflow `GITHUB_TOKEN`.
- Pin `cla-bot` to a commit SHA and keep the registry repository on the existing `json-repo` backend.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
- Configure `CLA_BOT_APP_ID` as a repository Actions variable.
- Configure `CLA_BOT_APP_PRIVATE_KEY` as a repository Actions secret.
- Install the GitHub App on both `rustfs/rustfs` and `rustfs/cla`.
- Verification:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cla.yml")'`
  - Review the workflow diff against the current `cla-bot` and `actions/create-github-app-token` interfaces.
