### PR TITLE
ci: bump cla-bot to v0.0.6

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -42,7 +42,7 @@ jobs:
           permission-contents: write
 
       - name: Run CLA Bot
-        uses: overtrue/cla-bot@3fc26b411bf72abef1251ac11bd90420ebc708a2
+        uses: overtrue/cla-bot@v0.0.5
         with:
           github-token: ${{ github.token }}
           registry-token: ${{ steps.registry-token.outputs.token }}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- update `.github/workflows/cla.yml` to use `overtrue/cla-bot@v0.0.6`
- pick up the CLA bot fix that ignores merge commits used only to sync the base branch into a PR branch when resolving required signers
- include the metadata fix required for GitHub to load the action correctly when referenced by release tag

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - updates the CLA bot release used by CI

## Additional Notes
- Verification for the released action version:

```bash
cd /Users/overtrue/www/cla-bot
npm test
```

- No RustFS source files or runtime behavior are changed in this PR; this is a workflow-only update.
- Release: https://github.com/overtrue/cla-bot/releases/tag/v0.0.6

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
