### PR TITLE
ci: bump cla-bot to v0.0.6

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -42,7 +42,7 @@ jobs:
           permission-contents: write
 
       - name: Run CLA Bot
-        uses: overtrue/cla-bot@v0.0.5
+        uses: overtrue/cla-bot@v0.0.6
         with:
           github-token: ${{ github.token }}
           registry-token: ${{ steps.registry-token.outputs.token }}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- update `.github/workflows/cla.yml` from `overtrue/cla-bot@v0.0.5` to `overtrue/cla-bot@v0.0.6`
- replace the broken `v0.0.5` release tag reference with the fixed `v0.0.6` release tag
- keep the previously intended CLA signer fix while restoring a loadable action version for GitHub Actions

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - updates the CLA bot release used by CI to a loadable version

## Additional Notes
- `v0.0.5` is broken when referenced by release tag in GitHub Actions due to an `action.yml` metadata issue.
- `v0.0.6` contains the metadata fix and the intended merge-commit signer fix.
- Verification for the released action version:

```bash
cd /Users/overtrue/www/cla-bot
npm test
```

- Release: https://github.com/overtrue/cla-bot/releases/tag/v0.0.6

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
