### PR TITLE
ci: update CLA workflow for corrected comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -42,7 +42,7 @@ jobs:
           permission-contents: write
 
       - name: Run CLA Bot
-        uses: overtrue/cla-bot@v0.0.7
+        uses: overtrue/cla-bot@v0.0.8
         with:
           github-token: ${{ github.token }}
           registry-token: ${{ steps.registry-token.outputs.token }}


### PR DESCRIPTION
## Summary
- update `.github/workflows/cla.yml` to use `overtrue/cla-bot@v0.0.8`
- listen to `issue_comment` `edited` events as well as `created`

## Why
Two CLA-miss cases showed up on active PRs:

- PR #2382: the contributor edited an existing comment to the expected phrase after creation
- PR #2383: the contributor used a GitHub quote-reply, so the comment body contained the quoted CLA instructions above the signature phrase

The relevant timelines were:
- PR #2382 comment created on April 3, 2026 at 11:07:30 UTC and edited on April 3, 2026 at 11:08:17 UTC
- PR #2383 signature comment created on April 3, 2026 at 12:41:42 UTC with quoted bot text plus the signature phrase

`overtrue/cla-bot@v0.0.8` fixes this by:
- handling edited signature comments directly
- backfilling matching PR signature comments during later `pull_request_target` runs, so missed comment events can self-heal
- ignoring quoted reply lines and blank lines before matching, while still requiring the remaining body to match the CLA phrase exactly

## Validation
- published [overtrue/cla-bot v0.0.8](https://github.com/overtrue/cla-bot/releases/tag/v0.0.8)
- verified the workflow diff only changes `.github/workflows/cla.yml`
