### PR TITLE
docs: remind agents to clean build artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ make pre-commit
 
 If `make` is unavailable, run the equivalent checks defined under `.config/make/`.
 Documentation-only or instruction-only changes are exempt from the verification commands above (including the `.config/make/` equivalents), though any installed git pre-commit hooks (for example, from `make setup-hooks`) may still run on commit unless explicitly skipped.
+After build-based verification completes, clean generated build artifacts before wrapping up to avoid unnecessary disk usage.
 Do not open a PR with code changes when the required checks fail.
 
 ## Git and PR Baseline


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Add a repository-wide reminder in `AGENTS.md` to clean generated build artifacts after build-based verification to avoid unnecessary disk usage.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

N/A

## Additional Notes
- Verification: Not run. `make pre-commit` was not run because this is a documentation-only change, and `AGENTS.md` exempts documentation-only changes from the baseline verification commands.
- Branch was cut from the latest `upstream/main`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
