### PR TITLE
ci: bump cla-bot to v0.0.9

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -42,7 +42,7 @@ jobs:
           permission-contents: write
 
       - name: Run CLA Bot
-        uses: overtrue/cla-bot@v0.0.8
+        uses: overtrue/cla-bot@v0.0.9
         with:
           github-token: ${{ github.token }}
           registry-token: ${{ steps.registry-token.outputs.token }}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Performance Improvement
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Bump `overtrue/cla-bot` from `v0.0.8` to `v0.0.9` in `.github/workflows/cla.yml`.
- Pick up the upstream fix that honors GitHub-reported bot accounts even when the login does not end with `[bot]`.
- Avoid false CLA failures for accounts such as `@copilot`, which is the case we hit in recent PR checks.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
Verification performed locally:
- `git diff --check`
- `rg -n 'overtrue/cla-bot@' .github/workflows .github`

Notes:
- This is a workflow-only version bump.
- `actionlint` is not installed in the local environment, so no additional workflow linter run was available.
- The upstream release is available at https://github.com/overtrue/cla-bot/releases/tag/v0.0.9.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
