### PR TITLE
test(metrics): cover Prometheus descriptor names

### DIFF
--- a/crates/metrics/src/format.rs
+++ b/crates/metrics/src/format.rs
@@ -182,3 +182,39 @@ impl PrometheusMetric {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MetricDescriptor, MetricName, MetricNamespace, MetricSubsystem};
+
+    #[test]
+    fn from_descriptor_uses_prometheus_metric_names_for_all_types() {
+        let cases = [
+            (MetricType::Counter, "rustfs_api_requests_total"),
+            (MetricType::Gauge, "rustfs_system_memory_used_bytes"),
+            (MetricType::Histogram, "rustfs_custom_path_latency_seconds"),
+        ];
+
+        for (metric_type, expected_name) in cases {
+            let subsystem = match metric_type {
+                MetricType::Counter => MetricSubsystem::ApiRequests,
+                MetricType::Gauge => MetricSubsystem::SystemMemory,
+                MetricType::Histogram => MetricSubsystem::new("/custom/path"),
+            };
+            let name = match metric_type {
+                MetricType::Counter => MetricName::ApiRequestsTotal,
+                MetricType::Gauge => MetricName::Custom("used_bytes".to_string()),
+                MetricType::Histogram => MetricName::Custom("latency_seconds".to_string()),
+            };
+
+            let metric = PrometheusMetric::from_descriptor(
+                &MetricDescriptor::new(name, metric_type, "test help".to_string(), vec![], MetricNamespace::RustFS, subsystem),
+                1.0,
+            );
+
+            assert_eq!(metric.name, expected_name);
+            assert_eq!(metric.metric_type, metric_type);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a focused regression test for the recent Prometheus metric naming fix in the metrics crate.

The recent metrics change removed the legacy `counter.`, `gauge.`, and `histogram.` prefixes from descriptor-derived metric names so exported names stay Prometheus-compatible. Existing coverage already checks several descriptor and collector call sites, but the formatter boundary still lacked a direct regression test. That left room for a future change to reintroduce type-prefixed names when `PrometheusMetric::from_descriptor` builds the emitted metric metadata.

This change adds a single unit test in `crates/metrics/src/format.rs` that exercises `PrometheusMetric::from_descriptor` for counter, gauge, and histogram descriptors. The test verifies that all three metric types produce Prometheus-style names without the old type prefix while preserving the metric type itself.

## Validation
- `cargo test -p rustfs-metrics`
- `make pre-commit`
