### PR TITLE
ci: force Node.js 24 for JS setup actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -62,7 +62,7 @@ runs:
         repo-token: ${{ inputs.github-token }}
 
     - name: Install flatc
-      uses: Nugine/setup-flatc@v1
+      uses: Nugine/setup-flatc@v1.2.4
       with:
         version: "25.9.23"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       # Always enable Tokio unstable features (required by dial9-tokio-telemetry).
       # The RUSTFLAGS env var takes precedence over .cargo/config.toml [build] rustflags,
       # so we must include --cfg tokio_unstable here explicitly; otherwise an empty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
     if: needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubicloud-standard-4
     timeout-minutes: 60
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -138,6 +140,8 @@ jobs:
     if: needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubicloud-standard-4
     timeout-minutes: 30
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -42,6 +42,8 @@ jobs:
     name: Performance Profiling
     runs-on: ubicloud-standard-2
     timeout-minutes: 30
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -117,6 +119,8 @@ jobs:
     name: Benchmark Tests
     runs-on: ubicloud-standard-2
     timeout-minutes: 45
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other: CI maintenance

## Related Issues
- N/A

## Summary of Changes
- Pin `Nugine/setup-flatc` to `v1.2.4` in `.github/actions/setup/action.yml`.
- Remove step-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` settings and centralize it as job-level environment variables.
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to jobs that use the composite setup action:
  - `ci.yml`: `test-and-lint`, `build-rustfs-debug-binary`
  - `build.yml`: `build-rustfs`
  - `performance.yml`: `performance-profile`, `benchmark`
- This keeps deprecated Node.js 20 action usage warning-free when these actions run.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: CI environment/runtime migration

## Additional Notes
- Date: 2026-04-07
- This PR keeps `arduino/setup-protoc@v3` in place (latest available is `v3.0.0`) and opts actions into Node.js 24 via runner flag.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
