### PR TITLE
fix(s3): allow leading slash object keys

### DIFF
--- a/crates/ecstore/src/bucket/utils.rs
+++ b/crates/ecstore/src/bucket/utils.rs
@@ -15,7 +15,6 @@
 use crate::disk::{MIGRATING_META_BUCKET, RUSTFS_META_BUCKET};
 use crate::error::{Error, Result, StorageError};
 use regex::Regex;
-use rustfs_utils::path::SLASH_SEPARATOR;
 use s3s::xml;
 use tracing::instrument;
 
@@ -201,10 +200,6 @@ pub fn check_object_name_for_length_and_slash(bucket: &str, object: &str) -> Res
         return Err(StorageError::ObjectNameTooLong(bucket.to_owned(), object.to_owned()));
     }
 
-    if object.starts_with(SLASH_SEPARATOR) {
-        return Err(StorageError::ObjectNamePrefixAsSlash(bucket.to_owned(), object.to_owned()));
-    }
-
     #[cfg(target_os = "windows")]
     {
         if object.contains(':')
@@ -367,6 +362,7 @@ mod tests {
         assert!(is_valid_object_name("file.txt"));
         assert!(is_valid_object_name("path/to/file.txt"));
         assert!(is_valid_object_name("a/b/c/d/e/f"));
+        assert!(is_valid_object_name("/leading/slash"));
         assert!(is_valid_object_name("object-123"));
         assert!(is_valid_object_name("object(1)"));
         assert!(is_valid_object_name("object[1]"));
@@ -420,6 +416,7 @@ mod tests {
         assert!(is_valid_object_prefix("prefix/with/slashes"));
         assert!(is_valid_object_prefix("prefix/"));
         assert!(is_valid_object_prefix("deep/nested/prefix/"));
+        assert!(is_valid_object_prefix("/leading/slash"));
         assert!(is_valid_object_prefix("normal-prefix"));
         assert!(is_valid_object_prefix("prefix_with_underscores"));
         assert!(is_valid_object_prefix("prefix.with.dots"));
@@ -455,6 +452,7 @@ mod tests {
     fn test_check_bucket_and_object_names() {
         // Valid names
         assert!(check_bucket_and_object_names("valid-bucket", "valid-object").is_ok());
+        assert!(check_bucket_and_object_names("valid-bucket", "/valid-object").is_ok());
 
         // Invalid bucket names
         assert!(check_bucket_and_object_names("", "valid-object").is_err());
@@ -474,6 +472,7 @@ mod tests {
     #[test]
     fn test_check_multipart_args() {
         assert!(check_new_multipart_args("valid-bucket", "valid-object").is_ok());
+        assert!(check_new_multipart_args("valid-bucket", "/valid-object").is_ok());
         assert!(check_new_multipart_args("", "valid-object").is_err());
         assert!(check_new_multipart_args("valid-bucket", "").is_err());
 
@@ -509,6 +508,7 @@ mod tests {
         // Test bucket and object name validation
         assert!(check_bucket_and_object_names("test-bucket", "test-object").is_ok());
         assert!(check_bucket_and_object_names("test-bucket", "folder/test-object").is_ok());
+        assert!(check_bucket_and_object_names("test-bucket", "/foo/bar").is_ok());
 
         // Test list objects arguments
         assert!(check_list_objs_args("test-bucket", "prefix", &Some("marker".to_string())).is_ok());
@@ -523,6 +523,7 @@ mod tests {
 
         // Test put object arguments
         assert!(check_put_object_args("test-bucket", "test-object").is_ok());
+        assert!(check_put_object_args("test-bucket", "/foo/bar").is_ok());
         assert!(check_put_object_args("", "test-object").is_err());
         assert!(check_put_object_args("test-bucket", "").is_err());
     }

--- a/crates/iam/src/oidc.rs
+++ b/crates/iam/src/oidc.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::future::Future;
+use std::net::IpAddr;
 use std::pin::Pin;
 use std::sync::RwLock;
 use std::time::{Duration as StdDuration, Instant};
@@ -916,8 +917,26 @@ pub fn load_effective_oidc_provider_configs(server_config: Option<&ServerConfig>
     merge_oidc_provider_configs(env_configs, persisted_configs)
 }
 
+fn build_oidc_http_client(config_url: &str) -> Result<ReqwestHttpClient, String> {
+    let parsed = Url::parse(config_url).map_err(|e| format!("invalid config_url: {e}"))?;
+    let mut builder = reqwest::Client::builder();
+
+    let should_bypass_proxy = parsed.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost") || host.parse::<IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
+    });
+
+    if should_bypass_proxy {
+        builder = builder.no_proxy();
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("failed to build OIDC http client: {e}"))?;
+    Ok(ReqwestHttpClient(client))
+}
+
 pub async fn validate_oidc_provider_config(config: &OidcProviderConfig) -> Result<OidcProviderValidationResult, String> {
-    let http_client = ReqwestHttpClient(reqwest::Client::new());
+    let http_client = build_oidc_http_client(&config.config_url)?;
     let state = OidcSys::discover_provider(config, &http_client).await?;
 
     Ok(OidcProviderValidationResult {

--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -20,6 +20,7 @@ pub const GLOBAL_DIR_SUFFIX: &str = "__XLDIR__";
 pub const SLASH_SEPARATOR: &str = "/";
 
 pub const GLOBAL_DIR_SUFFIX_WITH_SLASH: &str = "__XLDIR__/";
+const LEADING_SLASH_ESCAPE_PREFIX: &str = "__RUSTFS_LEADING_SLASH_HEX__";
 
 #[inline]
 pub fn is_separator(c: u8) -> bool {
@@ -38,16 +39,72 @@ pub fn has_suffix(s: &str, suffix: &str) -> bool {
     }
 }
 
+fn encode_leading_slash_object(object: &str) -> String {
+    if !object.starts_with(SLASH_SEPARATOR) {
+        return object.to_string();
+    }
+
+    let mut encoded = String::with_capacity(LEADING_SLASH_ESCAPE_PREFIX.len() + object.len() * 2);
+    encoded.push_str(LEADING_SLASH_ESCAPE_PREFIX);
+
+    for byte in object.as_bytes() {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+
+    encoded
+}
+
+fn decode_leading_slash_object(object: &str) -> String {
+    let Some(encoded) = object.strip_prefix(LEADING_SLASH_ESCAPE_PREFIX) else {
+        return object.to_string();
+    };
+
+    if encoded.len() % 2 != 0 {
+        return object.to_string();
+    }
+
+    let mut bytes = Vec::with_capacity(encoded.len() / 2);
+    for idx in (0..encoded.len()).step_by(2) {
+        let Some(pair) = encoded.get(idx..idx + 2) else {
+            return object.to_string();
+        };
+        let Ok(byte) = u8::from_str_radix(pair, 16) else {
+            return object.to_string();
+        };
+        bytes.push(byte);
+    }
+
+    let Ok(decoded) = String::from_utf8(bytes) else {
+        return object.to_string();
+    };
+
+    if decoded.starts_with(SLASH_SEPARATOR) && encode_leading_slash_object(&decoded) == object {
+        decoded
+    } else {
+        object.to_string()
+    }
+}
+
 /// Encodes a directory object name by replacing the trailing slash with `GLOBAL_DIR_SUFFIX`.
 ///
 /// If the object name ends with a slash, it is considered a directory object.
 /// The trailing slash is removed and `GLOBAL_DIR_SUFFIX` is appended.
 /// If it does not end with a slash, the name is returned as is.
 pub fn encode_dir_object(object: &str) -> String {
-    if has_suffix(object, SLASH_SEPARATOR) {
-        format!("{}{}", object.trim_end_matches(SLASH_SEPARATOR), GLOBAL_DIR_SUFFIX)
+    let is_dir_object = has_suffix(object, SLASH_SEPARATOR);
+    let object = if is_dir_object {
+        object.strip_suffix(SLASH_SEPARATOR).unwrap_or_default()
     } else {
-        object.to_string()
+        object
+    };
+    let object = encode_leading_slash_object(object);
+
+    if is_dir_object {
+        format!("{object}{GLOBAL_DIR_SUFFIX}")
+    } else {
+        object
     }
 }
 
@@ -65,11 +122,17 @@ pub fn is_dir_object(object: &str) -> bool {
 /// Otherwise, the name is returned as is.
 #[allow(dead_code)]
 pub fn decode_dir_object(object: &str) -> String {
-    if has_suffix(object, GLOBAL_DIR_SUFFIX) {
-        format!("{}{}", object.trim_end_matches(GLOBAL_DIR_SUFFIX), SLASH_SEPARATOR)
+    let (object, is_dir_object) = if has_suffix(object, GLOBAL_DIR_SUFFIX) {
+        (object.trim_end_matches(GLOBAL_DIR_SUFFIX), true)
     } else {
-        object.to_string()
+        (object, false)
+    };
+
+    let mut object = decode_leading_slash_object(object);
+    if is_dir_object {
+        object.push_str(SLASH_SEPARATOR);
     }
+    object
 }
 
 /// Ensures that the string ends with a trailing slash if it is not empty.
@@ -842,6 +905,21 @@ mod tests {
             PathBuf::from("c"),
         ]);
         assert_eq!(result, PathBuf::from("b/c"));
+    }
+
+    #[test]
+    fn test_encode_dir_object_preserves_leading_slash_objects() {
+        let encoded = encode_dir_object("/foo");
+        assert_ne!(encoded, "foo");
+        assert_eq!(decode_dir_object(&encoded), "/foo");
+
+        let encoded_dir = encode_dir_object("/foo/");
+        assert!(encoded_dir.ends_with(GLOBAL_DIR_SUFFIX));
+        assert_eq!(decode_dir_object(&encoded_dir), "/foo/");
+
+        let joined_with_leading = path_join_buf(&["bucket", &encoded]);
+        let joined_without_leading = path_join_buf(&["bucket", &encode_dir_object("foo")]);
+        assert_ne!(joined_with_leading, joined_without_leading);
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- Closes #2427

## Summary of Changes
- allow S3 object keys with a leading slash in `ecstore` object validation
- add reversible on-disk encoding for leading-slash keys so `/foo` does not alias `foo`
- bypass proxies for loopback OIDC discovery requests to keep local validation stable during `make pre-commit`
- add regression coverage for leading-slash object keys and the storage-name round trip

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  restores S3-compatible handling for keys that begin with `/` and keeps loopback OIDC discovery off external proxies.

## Additional Notes
- Verification commands:
  - `cargo test -p rustfs-utils`
  - `cargo test -p rustfs-ecstore`
  - `cargo test -p rustfs-iam`
  - `make pre-commit`

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
