### PR TITLE
refactor(app): inline bucket replication output

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -1718,7 +1718,7 @@ impl DefaultBucketUsecase {
             warn!(bucket = %bucket, error = ?err, "site replication bucket replication-config hook failed");
         }
 
-        Ok(S3Response::new(replication::build_put_bucket_replication_output()))
+        Ok(S3Response::new(PutBucketReplicationOutput::default()))
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/rustfs/src/storage/s3_api/replication.rs
+++ b/rustfs/src/storage/s3_api/replication.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use s3s::dto::{GetBucketReplicationOutput, PutBucketReplicationOutput, ReplicationConfiguration};
+use s3s::dto::{GetBucketReplicationOutput, ReplicationConfiguration};
 
 pub(crate) fn build_get_bucket_replication_output(
     replication_configuration: ReplicationConfiguration,
@@ -22,13 +22,9 @@ pub(crate) fn build_get_bucket_replication_output(
     }
 }
 
-pub(crate) fn build_put_bucket_replication_output() -> PutBucketReplicationOutput {
-    PutBucketReplicationOutput::default()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{build_get_bucket_replication_output, build_put_bucket_replication_output};
+    use super::build_get_bucket_replication_output;
     use s3s::dto::ReplicationConfiguration;
 
     #[test]
@@ -37,11 +33,5 @@ mod tests {
         let output = build_get_bucket_replication_output(config.clone());
 
         assert_eq!(output.replication_configuration, Some(config));
-    }
-
-    #[test]
-    fn test_build_put_bucket_replication_output_is_default() {
-        let output = build_put_bucket_replication_output();
-        assert_eq!(output, Default::default());
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Inline the single-use `PutBucketReplicationOutput` wrapper in `execute_put_bucket_replication`.
- Remove the now-unused default-output helper and its dedicated unit test from `storage/s3_api/replication.rs`.
- Keep the replication response behavior unchanged while trimming one more no-op helper layer.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
Verification:
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs execute_put_bucket_replication_returns_internal_error_when_store_uninitialized`
- `cargo test -p rustfs test_build_get_bucket_replication_output_sets_configuration`
- `make pre-commit`

No S3 behavior change is intended in this refactor.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.