### PR TITLE
refactor(app): inline bucket tagging outputs

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -973,7 +973,7 @@ impl DefaultBucketUsecase {
             warn!(bucket = %bucket, error = ?err, "site replication bucket tagging delete hook failed");
         }
 
-        Ok(S3Response::new(tagging::build_delete_bucket_tagging_output()))
+        Ok(S3Response::new(DeleteBucketTaggingOutput {}))
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -1788,7 +1788,7 @@ impl DefaultBucketUsecase {
             warn!(bucket = %bucket, error = ?err, "site replication bucket tagging hook failed");
         }
 
-        Ok(S3Response::new(tagging::build_put_bucket_tagging_output()))
+        Ok(S3Response::new(PutBucketTaggingOutput::default()))
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -2853,6 +2853,26 @@ mod tests {
         let usecase = DefaultBucketUsecase::without_context();
 
         let err = usecase.execute_put_bucket_encryption(req).await.unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::InternalError);
+    }
+
+    #[tokio::test]
+    async fn execute_put_bucket_tagging_returns_internal_error_when_store_uninitialized() {
+        let input = PutBucketTaggingInput::builder()
+            .bucket("test-bucket".to_string())
+            .tagging(Tagging {
+                tag_set: vec![Tag {
+                    key: Some("env".to_string()),
+                    value: Some("prod".to_string()),
+                }],
+            })
+            .build()
+            .unwrap();
+
+        let req = build_request(input, Method::PUT);
+        let usecase = DefaultBucketUsecase::without_context();
+
+        let err = usecase.execute_put_bucket_tagging(req).await.unwrap_err();
         assert_eq!(err.code(), &S3ErrorCode::InternalError);
     }
 

--- a/rustfs/src/storage/s3_api/tagging.rs
+++ b/rustfs/src/storage/s3_api/tagging.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use s3s::dto::{
-    DeleteBucketTaggingOutput, DeleteObjectTaggingOutput, GetBucketTaggingOutput, GetObjectTaggingOutput, PutBucketTaggingOutput,
-    PutObjectTaggingOutput, Tag,
-};
+use s3s::dto::{DeleteObjectTaggingOutput, GetBucketTaggingOutput, GetObjectTaggingOutput, PutObjectTaggingOutput, Tag};
 use s3s::{S3Error, S3ErrorCode, S3Result};
 use std::collections::HashSet;
 
@@ -73,23 +70,14 @@ pub(crate) fn build_delete_object_tagging_output(version_id: Option<String>) -> 
     DeleteObjectTaggingOutput { version_id }
 }
 
-pub(crate) fn build_put_bucket_tagging_output() -> PutBucketTaggingOutput {
-    PutBucketTaggingOutput::default()
-}
-
-pub(crate) fn build_delete_bucket_tagging_output() -> DeleteBucketTaggingOutput {
-    DeleteBucketTaggingOutput {}
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        build_delete_bucket_tagging_output, build_delete_object_tagging_output, build_get_bucket_tagging_output,
-        build_get_object_tagging_output, build_put_bucket_tagging_output, build_put_object_tagging_output,
-        validate_object_tag_set,
+        build_delete_object_tagging_output, build_get_bucket_tagging_output, build_get_object_tagging_output,
+        build_put_object_tagging_output, validate_object_tag_set,
     };
     use s3s::S3ErrorCode;
-    use s3s::dto::{DeleteBucketTaggingOutput, Tag};
+    use s3s::dto::Tag;
 
     fn tag(key: Option<&str>, value: Option<&str>) -> Tag {
         Tag {
@@ -174,14 +162,5 @@ mod tests {
         assert_eq!(get_object_output.version_id, version_id);
         assert_eq!(put_object_output.version_id, Some("vid-1".to_string()));
         assert_eq!(delete_object_output.version_id, Some("vid-1".to_string()));
-    }
-
-    #[test]
-    fn test_build_bucket_tagging_outputs_are_default_shape() {
-        let put_output = build_put_bucket_tagging_output();
-        let delete_output = build_delete_bucket_tagging_output();
-
-        assert_eq!(put_output, Default::default());
-        assert_eq!(delete_output, DeleteBucketTaggingOutput {});
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- inline the single-use `PutBucketTaggingOutput` and `DeleteBucketTaggingOutput` wrappers in `rustfs/src/app/bucket_usecase.rs`
- remove the now-unused default-output helpers from `rustfs/src/storage/s3_api/tagging.rs`
- add a handler-level regression test for `execute_put_bucket_tagging`

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Reduces one-off bucket tagging output wrappers without changing S3 behavior.

## Additional Notes
### Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs execute_put_bucket_tagging_returns_internal_error_when_store_uninitialized`
- `cargo test -p rustfs test_build_tagging_outputs_preserve_fields`
- `make pre-commit`

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.