### PR TITLE
refactor(app): reuse put object request context

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -636,8 +636,6 @@ impl DefaultObjectUsecase {
         } else {
             (EventName::ObjectCreatedPut, QuotaOperation::PutObject)
         };
-        let helper = OperationHelper::new(&req, event_name, S3Operation::PutObject);
-
         if request_context.is_post_object && is_post_object_sse_kms_requested(&req.input, &request_context.headers) {
             return Err(s3_error!(NotImplemented, "SSE-KMS is not supported for POST object uploads"));
         }
@@ -649,6 +647,8 @@ impl DefaultObjectUsecase {
         if is_put_object_extract_requested(&request_context.headers) {
             return self.execute_put_object_extract(req, request_context).await;
         }
+
+        let helper = OperationHelper::new(&req, event_name, S3Operation::PutObject);
 
         let resolved_size = resolve_put_body_size(req.input.content_length, &request_context.headers)?;
         self.check_bucket_quota(&req.input.bucket, quota_operation, resolved_size as u64)

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -647,7 +647,7 @@ impl DefaultObjectUsecase {
             return Err(s3_error!(InvalidStorageClass));
         }
         if is_put_object_extract_requested(&request_context.headers) {
-            return self.execute_put_object_extract(req).await;
+            return self.execute_put_object_extract(req, request_context).await;
         }
 
         let resolved_size = resolve_put_body_size(req.input.content_length, &request_context.headers)?;
@@ -3075,20 +3075,12 @@ impl DefaultObjectUsecase {
         )))
     }
 
-    #[instrument(level = "debug", skip(self, req))]
-    pub async fn execute_put_object_extract(&self, req: S3Request<PutObjectInput>) -> S3Result<S3Response<PutObjectOutput>> {
-        let request_context = PutObjectRequestContext {
-            headers: req.headers.clone(),
-            trailing_headers: req.trailing_headers.clone(),
-            uri_query: req.uri.query().map(str::to_string),
-            is_post_object: req.extensions.get::<PostObjectRequestMarker>().is_some(),
-            method: req.method.clone(),
-            uri: req.uri.clone(),
-            extensions: req.extensions.clone(),
-            credentials: req.credentials.clone(),
-            region: req.region.clone(),
-            service: req.service.clone(),
-        };
+    #[instrument(level = "debug", skip(self, req, request_context))]
+    async fn execute_put_object_extract(
+        &self,
+        req: S3Request<PutObjectInput>,
+        request_context: PutObjectRequestContext,
+    ) -> S3Result<S3Response<PutObjectOutput>> {
         let helper = OperationHelper::new(&req, EventName::ObjectCreatedPut, S3Operation::PutObject).suppress_event();
         if is_sse_kms_requested(&req.input, &request_context.headers) {
             return Err(s3_error!(NotImplemented, "SSE-KMS is not supported for extract uploads"));


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- reuse the existing `PutObjectRequestContext` when the PUT handler dispatches into the extract path
- remove the duplicate request-context reconstruction from `execute_put_object_extract`
- keep the extract flow and PUT behavior unchanged while trimming one repeated parameter-clone block

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  - Reduces one repeated request-context construction in the PUT/extract path without changing S3 behavior.

## Additional Notes
### Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs execute_put_object_`
- `make pre-commit`

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.