### PR TITLE
refactor(app): inline remaining tagging outputs

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -23,12 +23,12 @@ use crate::error::ApiError;
 use crate::server::RemoteAddr;
 use crate::storage::access::{ReqInfo, authorize_request, req_info_ref};
 use crate::storage::helper::{OperationHelper, spawn_background_with_context};
+use crate::storage::s3_api::acl;
 use crate::storage::s3_api::bucket::{
     ListObjectVersionsParams, ListObjectsV2Params, build_list_buckets_output, build_list_object_versions_output,
     build_list_objects_v2_output, parse_list_object_versions_params, parse_list_objects_v2_params,
 };
 use crate::storage::s3_api::common::rustfs_owner;
-use crate::storage::s3_api::{acl, tagging};
 use crate::storage::*;
 use futures::StreamExt;
 use http::StatusCode;
@@ -1333,7 +1333,7 @@ impl DefaultBucketUsecase {
             }
         };
 
-        Ok(S3Response::new(tagging::build_get_bucket_tagging_output(tag_set)))
+        Ok(S3Response::new(GetBucketTaggingOutput { tag_set }))
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -2394,6 +2394,20 @@ mod tests {
         let usecase = DefaultBucketUsecase::without_context();
 
         let err = usecase.execute_get_public_access_block(req).await.unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::InternalError);
+    }
+
+    #[tokio::test]
+    async fn execute_get_bucket_tagging_returns_internal_error_when_store_uninitialized() {
+        let input = GetBucketTaggingInput::builder()
+            .bucket("test-bucket".to_string())
+            .build()
+            .unwrap();
+
+        let req = build_request(input, Method::GET);
+        let usecase = DefaultBucketUsecase::without_context();
+
+        let err = usecase.execute_get_bucket_tagging(req).await.unwrap_err();
         assert_eq!(err.code(), &S3ErrorCode::InternalError);
     }
 

--- a/rustfs/src/storage/s3_api/tagging.rs
+++ b/rustfs/src/storage/s3_api/tagging.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use s3s::dto::{DeleteObjectTaggingOutput, GetBucketTaggingOutput, GetObjectTaggingOutput, PutObjectTaggingOutput, Tag};
+use s3s::dto::Tag;
 use s3s::{S3Error, S3ErrorCode, S3Result};
 use std::collections::HashSet;
 
@@ -54,28 +54,9 @@ pub(crate) fn validate_object_tag_set(tag_set: &[Tag]) -> S3Result<()> {
     Ok(())
 }
 
-pub(crate) fn build_get_bucket_tagging_output(tag_set: Vec<Tag>) -> GetBucketTaggingOutput {
-    GetBucketTaggingOutput { tag_set }
-}
-
-pub(crate) fn build_get_object_tagging_output(tag_set: Vec<Tag>, version_id: Option<String>) -> GetObjectTaggingOutput {
-    GetObjectTaggingOutput { tag_set, version_id }
-}
-
-pub(crate) fn build_put_object_tagging_output(version_id: Option<String>) -> PutObjectTaggingOutput {
-    PutObjectTaggingOutput { version_id }
-}
-
-pub(crate) fn build_delete_object_tagging_output(version_id: Option<String>) -> DeleteObjectTaggingOutput {
-    DeleteObjectTaggingOutput { version_id }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        build_delete_object_tagging_output, build_get_bucket_tagging_output, build_get_object_tagging_output,
-        build_put_object_tagging_output, validate_object_tag_set,
-    };
+    use super::validate_object_tag_set;
     use s3s::S3ErrorCode;
     use s3s::dto::Tag;
 
@@ -145,22 +126,5 @@ mod tests {
             .expect_err("duplicate tag key must be rejected");
         assert_eq!(*err.code(), S3ErrorCode::InvalidTag);
         assert!(err.to_string().contains("Cannot provide multiple Tags with the same key"));
-    }
-
-    #[test]
-    fn test_build_tagging_outputs_preserve_fields() {
-        let tag_set = vec![tag(Some("k1"), Some("v1"))];
-        let version_id = Some("vid-1".to_string());
-
-        let bucket_output = build_get_bucket_tagging_output(tag_set.clone());
-        let get_object_output = build_get_object_tagging_output(tag_set.clone(), version_id.clone());
-        let put_object_output = build_put_object_tagging_output(version_id.clone());
-        let delete_object_output = build_delete_object_tagging_output(version_id.clone());
-
-        assert_eq!(bucket_output.tag_set, tag_set);
-        assert_eq!(get_object_output.tag_set, vec![tag(Some("k1"), Some("v1"))]);
-        assert_eq!(get_object_output.version_id, version_id);
-        assert_eq!(put_object_output.version_id, Some("vid-1".to_string()));
-        assert_eq!(delete_object_output.version_id, Some("vid-1".to_string()));
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
- N/A

## Summary of Changes
- inline `GetBucketTaggingOutput` in `execute_get_bucket_tagging` and keep `PutBucketTagging`/`DeleteBucketTagging` output construction local to the handler layer
- remove the now-unused tagging output builders from `rustfs/src/storage/s3_api/tagging.rs` so the module only keeps the shared object-tag validation rules
- add an application use-case regression test for `execute_get_bucket_tagging` and keep the existing bucket/object tagging behavior tests in place

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
Refactor only. No behavior or API contract changes intended.

## Additional Notes
Verification:
- `cargo fmt --all`
- `cargo test -p rustfs execute_get_bucket_tagging_returns_internal_error_when_store_uninitialized`
- `cargo test -p rustfs execute_put_bucket_tagging_returns_internal_error_when_store_uninitialized`
- `cargo test -p rustfs validate_object_tag_set`
- `cargo fmt --all --check`
- `make pre-commit`

Risk is low because the removed helpers only mirrored DTO fields and the real shared boundary in this module remains `validate_object_tag_set`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
