### PR TITLE
test(filemeta): cover legacy nil UUID metadata

### DIFF
--- a/crates/filemeta/src/filemeta/version.rs
+++ b/crates/filemeta/src/filemeta/version.rs
@@ -2797,6 +2797,57 @@ mod tests {
         write_version: u64,
     }
 
+    #[derive(Serialize)]
+    struct LegacyDeleteMarkerNilFixture {
+        version_id: Option<Vec<u8>>,
+        mod_time: Option<OffsetDateTime>,
+        meta_sys: HashMap<String, Vec<u8>>,
+    }
+
+    #[derive(Serialize)]
+    struct LegacyDeleteVersionNilFixture {
+        version_type: LegacyDeleteVersionTypeFixture,
+        object: Option<()>,
+        delete_marker: Option<LegacyDeleteMarkerNilFixture>,
+        write_version: u64,
+    }
+
+    #[derive(Serialize)]
+    enum LegacyObjectVersionTypeFixture {
+        #[serde(rename = "Object")]
+        Object,
+    }
+
+    #[derive(Serialize)]
+    struct LegacyObjectFixture {
+        version_id: Option<Vec<u8>>,
+        data_dir: Option<Vec<u8>>,
+        erasure_algorithm: String,
+        erasure_m: usize,
+        erasure_n: usize,
+        erasure_block_size: usize,
+        erasure_index: usize,
+        erasure_dist: Vec<u8>,
+        bitrot_checksum_algo: String,
+        part_numbers: Vec<usize>,
+        part_etags: Vec<String>,
+        part_sizes: Vec<usize>,
+        part_actual_sizes: Vec<i64>,
+        part_indices: Vec<Vec<u8>>,
+        size: i64,
+        mod_time: Option<OffsetDateTime>,
+        meta_sys: HashMap<String, Vec<u8>>,
+        meta_user: HashMap<String, String>,
+    }
+
+    #[derive(Serialize)]
+    struct LegacyObjectVersionFixture {
+        version_type: LegacyObjectVersionTypeFixture,
+        object: Option<LegacyObjectFixture>,
+        delete_marker: Option<()>,
+        write_version: u64,
+    }
+
     fn sample_version_id() -> Uuid {
         Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap()
     }
@@ -3085,5 +3136,77 @@ mod tests {
         .expect_err("invalid legacy delete-marker version ids should be rejected");
 
         assert!(err.to_string().contains("legacy version_id must be 16 bytes"));
+    }
+
+    #[test]
+    fn legacy_meta_v2_object_accepts_nil_uuid_fields() {
+        let payload = LegacyObjectVersionFixture {
+            version_type: LegacyObjectVersionTypeFixture::Object,
+            object: Some(LegacyObjectFixture {
+                version_id: None,
+                data_dir: None,
+                erasure_algorithm: "ReedSolomon".to_string(),
+                erasure_m: 2,
+                erasure_n: 4,
+                erasure_block_size: 1_048_576,
+                erasure_index: 1,
+                erasure_dist: vec![1, 2, 3, 4, 5, 6],
+                bitrot_checksum_algo: "HighwayHash".to_string(),
+                part_numbers: vec![1],
+                part_etags: vec!["etag-1".to_string()],
+                part_sizes: vec![11],
+                part_actual_sizes: vec![11],
+                part_indices: vec![Vec::new()],
+                size: 11,
+                mod_time: Some(sample_mod_time()),
+                meta_sys: HashMap::new(),
+                meta_user: HashMap::from([("content-type".to_string(), "text/plain".to_string())]),
+            }),
+            delete_marker: None,
+            write_version: 3,
+        };
+        let encoded = rmp_serde::to_vec_named(&payload).unwrap();
+
+        let decoded = FileMetaVersion::try_from(encoded.as_slice()).unwrap();
+        let object = decoded.object.as_ref().expect("object should be decoded");
+
+        assert_eq!(decoded.version_type, VersionType::Object);
+        assert!(decoded.uses_legacy_checksum);
+        assert_eq!(object.version_id, None);
+        assert_eq!(object.data_dir, None);
+
+        let fi = decoded.into_fileinfo("bucket", "legacy-nil.txt", true);
+        assert_eq!(fi.version_id, None);
+        assert_eq!(fi.data_dir, None);
+        assert_eq!(fi.metadata.get("content-type").map(String::as_str), Some("text/plain"));
+    }
+
+    #[test]
+    fn legacy_meta_v2_delete_marker_accepts_nil_version_id() {
+        let payload = LegacyDeleteVersionNilFixture {
+            version_type: LegacyDeleteVersionTypeFixture::DeleteMarker,
+            object: None,
+            delete_marker: Some(LegacyDeleteMarkerNilFixture {
+                version_id: None,
+                mod_time: Some(sample_mod_time()),
+                meta_sys: HashMap::from([("x-rustfs-test".to_string(), b"gone".to_vec())]),
+            }),
+            write_version: 11,
+        };
+        let encoded = rmp_serde::to_vec_named(&payload).unwrap();
+
+        let decoded = FileMetaVersion::try_from(encoded.as_slice()).unwrap();
+        let delete_marker = decoded.delete_marker.as_ref().expect("delete marker should be decoded");
+
+        assert_eq!(decoded.version_type, VersionType::Delete);
+        assert!(decoded.uses_legacy_checksum);
+        assert_eq!(delete_marker.version_id, None);
+        assert_eq!(delete_marker.mod_time, Some(sample_mod_time()));
+
+        let fi = decoded.into_fileinfo("bucket", "deleted.txt", true);
+        assert!(fi.deleted);
+        assert_eq!(fi.version_id, None);
+        assert_eq!(fi.mod_time, Some(sample_mod_time()));
+        assert_eq!(fi.metadata.get("x-rustfs-test").map(String::as_str), Some("gone"));
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- N/A

## Summary of Changes
Recent upstream work in `crates/filemeta` taught legacy MessagePack decoding to accept `nil` UUID fields when reading legacy v2 metadata. The changed code path covered both object metadata (`version_id` and `data_dir`) and delete markers (`version_id`), but the existing regression coverage only exercised the object fixture captured from issue #2434.

This PR adds two focused regression tests in `crates/filemeta/src/filemeta/version.rs` to cover the untested legacy fallback paths directly. One test serializes a legacy object payload with `nil` UUID fields and verifies those decode to `None` all the way through `into_fileinfo`. The other serializes a legacy delete-marker payload with a `nil` version ID and verifies the decoded delete marker and resulting `FileInfo` keep that field unset while preserving the rest of the metadata.

The effect for users is tighter protection around the exact compatibility fix merged on `main`: future changes to the legacy fallback path will now fail fast if they stop accepting `nil` UUID metadata in either object or delete-marker records.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
This change is test-only and scoped to legacy filemeta compatibility coverage.

## Additional Notes
Validation used:
- `cargo test -p rustfs-filemeta legacy_meta_v2_object_accepts_nil_uuid_fields -- --nocapture`
- `cargo test -p rustfs-filemeta legacy_meta_v2_delete_marker_accepts_nil_version_id -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
