### PR TITLE
docs(readme): fix inconsistent startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Similarly, you can run the command with podman
 podman compose --profile observability up -d
 ```
 
-**NOTE**: We recommend reviewing the `docker-compose.yaml` file before running. It defines several services including Grafana, Prometheus, and Jaeger, which are helpful for RustFS observability. If you wish to start Redis or Nginx containers, you can specify the corresponding profiles.
+**NOTE**: We recommend reviewing the `docker-compose.yml` file before running. It defines several services including Grafana, Prometheus, and Jaeger, which are helpful for RustFS observability. If you wish to start Redis or Nginx containers, you can specify the corresponding profiles.
 
 ### 3\. Build from Source (Option 3) - Advanced Users
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -122,7 +122,7 @@ RustFS 容器以非 root 用户 `rustfs` (UID `10001`) 运行。如果您使用 
 docker compose --profile observability up -d
 ```
 
-**注意**: 我们建议您在运行前查看 `docker-compose.yaml` 文件。该文件定义了包括 Grafana、Prometheus 和 Jaeger 在内的多个服务，有助于 RustFS 的可观测性监控。如果您还想启动 Redis 或 Nginx 容器，可以指定相应的 profile。
+**注意**: 我们建议您在运行前查看 `docker-compose.yml` 文件。该文件定义了包括 Grafana、Prometheus 和 Jaeger 在内的多个服务，有助于 RustFS 的可观测性监控。如果您还想启动 Redis 或 Nginx 容器，可以指定相应的 profile。
 
 ### 3\. 源码编译 (选项 3) - 进阶用户
 
@@ -228,7 +228,7 @@ rustfs --help
 - **商务合作**: [hello@rustfs.com](mailto:hello@rustfs.com)
 - **工作机会**: [jobs@rustfs.com](mailto:jobs@rustfs.com)
 - **一般讨论**: [GitHub Discussions](https://github.com/rustfs/rustfs/discussions)
-- **贡献指南**: [CONTRIBUTING.md](https://www.google.com/search?q=CONTRIBUTING.md)
+- **贡献指南**: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## 贡献者
 

--- a/rustfs/README.md
+++ b/rustfs/README.md
@@ -81,7 +81,7 @@ To get started with RustFS, follow these steps:
    podman run -d -p 9000:9000 -v /data:/data rustfs/rustfs:latest
    ```
 
-3. **Access the Console**: Open your web browser and navigate to `http://localhost:9000` to access the RustFS console,
+3. **Access the Console**: Open your web browser and navigate to `http://localhost:9001` to access the RustFS console,
    default username and password is `rustfsadmin` .
 4. **Create a Bucket**: Use the console to create a new bucket for your objects.
 5. **Upload Objects**: You can upload files directly through the console or use S3-compatible APIs to interact with your


### PR DESCRIPTION
  ## Summary

  - align the Docker Compose filename in `README.md` and `README_ZH.md` with the actual root file name
  (`docker-compose.yml`)
  - fix the broken contributing guide link in `README_ZH.md`
  - correct the console URL in `rustfs/README.md` from `http://localhost:9000` to `http://localhost:9001`

  ## Why

  These README files contained a few inconsistencies with the current repository layout and startup setup:

  - the docs referenced both `docker-compose.yml` and `docker-compose.yaml`
  - the Chinese contributing guide link pointed to a Google search instead of the repository file
  - `rustfs/README.md` documented the console on port `9000`, while the current setup uses `9001` for the console

  This PR keeps the documentation aligned with the current project state and reduces confusion for new users.

  ## Test plan

  - [x] reviewed the changed README entries against the current repository files
  - [x] verified the root compose file is `docker-compose.yml`
  - [x] verified the current compose setup exposes the console on port `9001`