### PR TITLE
refactor(storage): drop ecfs test-only helper

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -3094,6 +3094,14 @@ mod tests {
         assert_eq!(raw.as_deref(), Some("null"));
         assert_eq!(uuid, Some(Uuid::nil()));
 
+        let (raw, uuid) = normalize_delete_objects_version_id(Some(String::new())).unwrap();
+        assert!(raw.is_none());
+        assert!(uuid.is_none());
+
+        let (raw, uuid) = normalize_delete_objects_version_id(Some("   ".to_string())).unwrap();
+        assert!(raw.is_none());
+        assert!(uuid.is_none());
+
         let valid = "550e8400-e29b-41d4-a716-446655440000".to_string();
         let (raw, uuid) = normalize_delete_objects_version_id(Some(valid.clone())).unwrap();
         assert_eq!(raw.as_deref(), Some(valid.as_str()));

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -3088,6 +3088,25 @@ mod tests {
         assert_eq!(err.code(), &S3ErrorCode::InvalidStorageClass);
     }
 
+    #[test]
+    fn normalize_delete_objects_version_id_handles_null_uuid_and_empty_values() {
+        let (raw, uuid) = normalize_delete_objects_version_id(Some("null".to_string())).unwrap();
+        assert_eq!(raw.as_deref(), Some("null"));
+        assert_eq!(uuid, Some(Uuid::nil()));
+
+        let valid = "550e8400-e29b-41d4-a716-446655440000".to_string();
+        let (raw, uuid) = normalize_delete_objects_version_id(Some(valid.clone())).unwrap();
+        assert_eq!(raw.as_deref(), Some(valid.as_str()));
+        assert_eq!(uuid, Some(Uuid::parse_str(&valid).unwrap()));
+
+        let err = normalize_delete_objects_version_id(Some("not-a-uuid".to_string())).unwrap_err();
+        assert!(!err.is_empty());
+
+        let (raw, uuid) = normalize_delete_objects_version_id(None).unwrap();
+        assert!(raw.is_none());
+        assert!(uuid.is_none());
+    }
+
     #[tokio::test]
     async fn execute_put_object_tagging_rejects_too_many_tags() {
         let tag_set = (0..11)

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -103,25 +103,6 @@ impl FS {
         }
         Ok(out)
     }
-
-    #[cfg(test)]
-    pub(crate) fn normalize_delete_objects_version_id(
-        &self,
-        version_id: Option<String>,
-    ) -> std::result::Result<(Option<String>, Option<Uuid>), String> {
-        let version_id = version_id.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
-        match version_id {
-            Some(id) => {
-                if id.eq_ignore_ascii_case("null") {
-                    Ok((Some("null".to_string()), Some(Uuid::nil())))
-                } else {
-                    let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
-                    Ok((Some(id), Some(uuid)))
-                }
-            }
-            None => Ok((None, None)),
-        }
-    }
 }
 
 pub(crate) fn parse_object_version_id(version_id: Option<String>) -> S3Result<Option<Uuid>> {

--- a/rustfs/src/storage/ecfs_test.rs
+++ b/rustfs/src/storage/ecfs_test.rs
@@ -856,31 +856,6 @@ mod tests {
         assert_eq!(formatted, "550e8400-e29b-41d4-a716-446655440000");
     }
 
-    #[test]
-    fn test_delete_objects_version_id_normalization() {
-        use uuid::Uuid;
-
-        let fs = FS::new();
-
-        let (raw, uuid) = fs.normalize_delete_objects_version_id(Some("null".to_string())).unwrap();
-        assert_eq!(raw.as_deref(), Some("null"));
-        assert_eq!(uuid, Some(Uuid::nil()));
-
-        let valid = "550e8400-e29b-41d4-a716-446655440000".to_string();
-        let (raw, uuid) = fs.normalize_delete_objects_version_id(Some(valid.clone())).unwrap();
-        assert_eq!(raw.as_deref(), Some(valid.as_str()));
-        assert_eq!(uuid, Some(Uuid::parse_str(&valid).unwrap()));
-
-        let err = fs
-            .normalize_delete_objects_version_id(Some("not-a-uuid".to_string()))
-            .unwrap_err();
-        assert!(!err.is_empty());
-
-        let (raw, uuid) = fs.normalize_delete_objects_version_id(None).unwrap();
-        assert!(raw.is_none());
-        assert!(uuid.is_none());
-    }
-
     /// Test that ListObjectVersionsOutput markers are correctly set
     /// This verifies the fix for boto3 ParamValidationError
     #[test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Refactor
- [ ] Test/CI
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- remove the `FS::normalize_delete_objects_version_id` test-only helper from `rustfs/src/storage/ecfs.rs`
- move the version-id normalization assertions next to the real `normalize_delete_objects_version_id` implementation in `rustfs/src/app/object_usecase.rs`
- drop the duplicate helper-focused test from `rustfs/src/storage/ecfs_test.rs`

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
- Verification: `cargo test -p rustfs --lib normalize_delete_objects_version_id_handles_null_uuid_and_empty_values -- --nocapture`
- Verification: `make pre-commit`
- N/A
