### PR TITLE
fix(deploy): use standard rustfs log directory

### DIFF
--- a/deploy/build/rustfs.run.md
+++ b/deploy/build/rustfs.run.md
@@ -21,9 +21,12 @@ sudo mkdir -p /data/rustfs/{vol1,vol2}
 # Create configuration directory
 sudo mkdir -p /etc/rustfs
 
+# Create log directory
+sudo mkdir -p /var/log/rustfs
+
 # Set directory permissions
-sudo chown -R rustfs:rustfs /opt/rustfs /data/rustfs
-sudo chmod 755 /opt/rustfs /data/rustfs
+sudo chown -R rustfs:rustfs /opt/rustfs /data/rustfs /var/log/rustfs
+sudo chmod 755 /opt/rustfs /data/rustfs /var/log/rustfs
 ```
 
 ## 2. Install RustFS

--- a/deploy/build/rustfs.service
+++ b/deploy/build/rustfs.service
@@ -30,8 +30,8 @@ EnvironmentFile=-/etc/default/rustfs
 ExecStart=/usr/local/bin/rustfs  $RUSTFS_VOLUMES $RUSTFS_OPTS
 
 # service log configuration
-StandardOutput=append:/data/deploy/rust/logs/rustfs.log
-StandardError=append:/data/deploy/rust/logs/rustfs-err.log
+StandardOutput=append:/var/log/rustfs/rustfs.log
+StandardError=append:/var/log/rustfs/rustfs-err.log
 
 # resource constraints
 LimitNOFILE=1048576
@@ -58,7 +58,7 @@ ProtectKernelModules=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 RestrictRealtime=true
-ReadWritePaths=/data/rustfs
+ReadWritePaths=/data/rustfs /var/log/rustfs
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/dev_rustfs.sh
+++ b/scripts/dev_rustfs.sh
@@ -147,8 +147,8 @@ add_ssh_key() {
 
 monitor_logs() {
     for SERVER in "${SERVER_LIST[@]}"; do
-        echo "Monitoring $SERVER:/var/logs/rustfs/rustfs.log ..."
-        ssh "$SERVER" "tail -F /var/logs/rustfs/rustfs.log" |
+        echo "Monitoring $SERVER:/var/log/rustfs/rustfs.log ..."
+        ssh "$SERVER" "tail -F /var/log/rustfs/rustfs.log" |
             sed "s/^/[$SERVER] /" &
     done
     wait


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other: N/A

## Related Issues
- Fixes #2291

## Summary of Changes
- update the sample systemd unit to write logs to `/var/log/rustfs` instead of a non-standard path
- allow the service to write to `/var/log/rustfs` via `ReadWritePaths`
- update the deployment guide to create and permission the log directory
- align `scripts/dev_rustfs.sh` log monitoring with the same path

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact: N/A

## Additional Notes
Verification commands:
- `cargo fmt --all --check`
- `bash -n scripts/dev_rustfs.sh`
- `make pre-commit` (still running locally when this PR was opened due to first-time full dependency compilation)

Test updates:
- N/A. This change only updates deployment examples and log path references.

Notes:
- `cargo fmt --all --check` passed locally.
- `bash -n scripts/dev_rustfs.sh` passed locally.
- `make pre-commit` had not completed at PR creation time.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.