### PR TITLE
fix(storage): fix critical bug in range calculation

### DIFF
--- a/crates/e2e_test/src/range_request_test.rs
+++ b/crates/e2e_test/src/range_request_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! End-to-end regression test for invalid GET object ranges.
+//! End-to-end regression tests for invalid and suffix GET object ranges.
 
 #[cfg(test)]
 mod tests {
@@ -76,5 +76,102 @@ mod tests {
             }
             other_err => panic!("Expected S3 service error, got: {other_err:?}"),
         }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_get_object_suffix_byte_range_returns_correct_body() {
+        init_logging();
+        info!("TEST: GetObject suffix byte-range should return correct body");
+
+        let mut env = RustFSTestEnvironment::new().await.expect("Failed to create test environment");
+        env.start_rustfs_server(vec![]).await.expect("Failed to start RustFS");
+
+        let client = create_s3_client(&env);
+        let bucket = "test-suffix-range";
+        let key = "range-suffix.bin";
+
+        // ~3 MB so the object spans multiple erasure blocks (block_size = 1 MB).
+        // Suffix ranges on single-block objects never hit the bug.
+        let file_size: usize = 3_095_910;
+        let content: Vec<u8> = (0..file_size).map(|i| (i % 256) as u8).collect();
+
+        create_bucket(&client, bucket).await.expect("Failed to create bucket");
+        client
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(ByteStream::from(content.clone()))
+            .send()
+            .await
+            .expect("PutObject should succeed");
+
+        // bytes=-8  — last 8 bytes (parquet footer read)
+        let result = client
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .range("bytes=-8")
+            .send()
+            .await
+            .expect("bytes=-8 should succeed");
+        let body = result.body.collect().await.expect("bytes=-8 body").into_bytes();
+        assert_eq!(body.len(), 8, "bytes=-8 body length");
+        assert_eq!(&body[..], &content[file_size - 8..], "bytes=-8 body content");
+
+        // bytes=-96 — last 96 bytes
+        let result = client
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .range("bytes=-96")
+            .send()
+            .await
+            .expect("bytes=-96 should succeed");
+        let body = result.body.collect().await.expect("bytes=-96 body").into_bytes();
+        assert_eq!(body.len(), 96, "bytes=-96 body length");
+        assert_eq!(&body[..], &content[file_size - 96..], "bytes=-96 body content");
+
+        // bytes=-1 — last byte
+        let result = client
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .range("bytes=-1")
+            .send()
+            .await
+            .expect("bytes=-1 should succeed");
+        let body = result.body.collect().await.expect("bytes=-1 body").into_bytes();
+        assert_eq!(body.len(), 1, "bytes=-1 body length");
+        assert_eq!(body[0], content[file_size - 1], "bytes=-1 body content");
+
+        // bytes=0-7  — absolute range (regression guard)
+        let result = client
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .range("bytes=0-7")
+            .send()
+            .await
+            .expect("bytes=0-7 should succeed");
+        let body = result.body.collect().await.expect("bytes=0-7 body").into_bytes();
+        assert_eq!(body.len(), 8, "bytes=0-7 body length");
+        assert_eq!(&body[..], &content[0..8], "bytes=0-7 body content");
+
+        // Equivalent absolute range for the same last-8-bytes window
+        let start = file_size - 8;
+        let end = file_size - 1;
+        let range = format!("bytes={start}-{end}");
+        let result = client
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .range(&range)
+            .send()
+            .await
+            .expect("absolute tail range should succeed");
+        let body = result.body.collect().await.expect("absolute tail body").into_bytes();
+        assert_eq!(body.len(), 8, "absolute tail body length");
+        assert_eq!(&body[..], &content[start..], "absolute tail body content");
     }
 }

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -419,6 +419,7 @@ async fn build_reconstructed_part_stream(
     skip_verify_bitrot: bool,
     use_zero_copy: bool,
 ) -> Result<Option<BoxChunkStream>> {
+    let shard_length = till_offset - read_offset;
     let mut readers = Vec::with_capacity(disks.len());
     let mut errors = Vec::with_capacity(disks.len());
     for (idx, disk_op) in disks.iter().enumerate() {
@@ -428,7 +429,7 @@ async fn build_reconstructed_part_stream(
             bucket,
             &format!("{}/{}/part.{}", object, files[idx].data_dir.unwrap_or_default(), part_number),
             read_offset,
-            till_offset,
+            shard_length,
             erasure.shard_size(),
             checksum_algo.clone(),
             skip_verify_bitrot,
@@ -1563,6 +1564,7 @@ impl SetDisks {
 
             let mut readers = Vec::with_capacity(disks.len());
             let mut errors = Vec::with_capacity(disks.len());
+            let shard_length = till_offset - read_offset;
             for (idx, disk_op) in disks.iter().enumerate() {
                 match create_bitrot_reader(
                     files[idx].data.as_deref(),
@@ -1570,7 +1572,7 @@ impl SetDisks {
                     bucket,
                     &format!("{}/{}/part.{}", object, files[idx].data_dir.unwrap_or_default(), part_number),
                     read_offset,
-                    till_offset,
+                    shard_length,
                     erasure.shard_size(),
                     checksum_algo.clone(),
                     skip_verify_bitrot,

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -1564,7 +1564,7 @@ impl SetDisks {
 
             let mut readers = Vec::with_capacity(disks.len());
             let mut errors = Vec::with_capacity(disks.len());
-            let shard_length = till_offset - read_offset;
+            let shard_length = till_offset.saturating_sub(read_offset);
             for (idx, disk_op) in disks.iter().enumerate() {
                 match create_bitrot_reader(
                     files[idx].data.as_deref(),

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -419,7 +419,7 @@ async fn build_reconstructed_part_stream(
     skip_verify_bitrot: bool,
     use_zero_copy: bool,
 ) -> Result<Option<BoxChunkStream>> {
-    let shard_length = till_offset - read_offset;
+    let shard_length = till_offset.saturating_sub(read_offset);
     let mut readers = Vec::with_capacity(disks.len());
     let mut errors = Vec::with_capacity(disks.len());
     for (idx, disk_op) in disks.iter().enumerate() {


### PR DESCRIPTION
Hi,

While using rustfs locally as an s3 storage for my iceberg warehouse, I noticed that sometimes my requests using duckdb failed. Duckdb and other tools read the last 8 bytes of parquet files, as this format stores a metadata footer (end of the file). 

While debugging the issue, I noticed that doing a Range: -8 http returns no data; a 206 Partial Content response with correct headers but still an empty body.

For example, requesting the last 8 bytes of a 3,095,910-byte file:
```
  Request:  Range: bytes=-8

  Response: HTTP/1.1 206 Partial Content
            content-length: 8
            content-range: bytes 3095902-3095909/3095910
            accept-ranges: bytes

            <empty — 0 bytes transferred>
```

The Content-Range and Content-Length headers were computed correctly (the start offset math was right), but the response body was never written. Absolute ranges worked fine for the same file:

```
  Request:  Range: bytes=0-7    → 206, 8 bytes body 
  Request:  Range: bytes=-8     → 206, 0 bytes body 
```

The file size has to be larger than 3MB (at least with smaller files i was unable to reproduce).
 
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
None

## Summary of Changes

The bug was when calling `create_bitrot_reader`, the caller passed the absolute end offset `till_offset` rather than the length as expected by the function. 

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [-] Documentation updated (if needed)
- [-] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
None

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
