### PR TITLE
fix(deploy): auto-create rustfs log directory

### DIFF
--- a/deploy/build/rustfs.service
+++ b/deploy/build/rustfs.service
@@ -30,6 +30,7 @@ EnvironmentFile=-/etc/default/rustfs
 ExecStart=/usr/local/bin/rustfs  $RUSTFS_VOLUMES $RUSTFS_OPTS
 
 # service log configuration
+LogsDirectory=rustfs
 StandardOutput=append:/var/log/rustfs/rustfs.log
 StandardError=append:/var/log/rustfs/rustfs-err.log
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- add `LogsDirectory=rustfs` to [`deploy/build/rustfs.service`](deploy/build/rustfs.service) so systemd creates `/var/log/rustfs` before opening the configured log files
- keep the fix scoped to the unit file instead of broadening the deployment scripts or runtime code

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
Evidence:
- commit `11552eb7` changed the service log destination from `/data/deploy/rust/logs/*` to `/var/log/rustfs/*`
- the same commit updated `deploy/build/rustfs.run.md` to create `/var/log/rustfs`, which shows the new unit now depends on that directory existing first
- the unit itself did not create the directory, so a host that installs the updated service file without the manual directory-creation step can fail when systemd tries to append to `/var/log/rustfs/rustfs.log`

Why this fix is minimal and safe:
- `LogsDirectory=rustfs` is a native systemd mechanism for creating `/var/log/rustfs`
- it matches the log path already configured in the unit and avoids changing runtime behavior outside service startup

Verification:
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`
- `cargo clean`

N/A
