### PR TITLE
test(get): cover fast path pre-commit errors

### DIFF
--- a/rustfs/src/app/object_usecase/get_object_flow.rs
+++ b/rustfs/src/app/object_usecase/get_object_flow.rs
@@ -595,4 +595,34 @@ mod tests {
         assert_eq!(err.streamed_bytes, 5);
         assert_eq!(err.source.kind(), std::io::ErrorKind::UnexpectedEof);
     }
+
+    #[tokio::test]
+    async fn materialize_chunk_stream_before_commit_rejects_long_body() {
+        let chunk_stream: BoxChunkStream = Box::pin(futures_util::stream::iter(vec![
+            Ok(IoChunk::Shared(bytes::Bytes::from_static(b"hello "))),
+            Ok(IoChunk::Shared(bytes::Bytes::from_static(b"world!"))),
+        ]));
+
+        let err = materialize_chunk_stream_before_commit_with_threshold(chunk_stream, 11, 8 * 1024, 1024)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.streamed_bytes, 12);
+        assert_eq!(err.source.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn materialize_chunk_stream_before_commit_preserves_midstream_io_errors() {
+        let chunk_stream: BoxChunkStream = Box::pin(futures_util::stream::iter(vec![
+            Ok(IoChunk::Shared(bytes::Bytes::from_static(b"hello"))),
+            Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "writer closed")),
+        ]));
+
+        let err = materialize_chunk_stream_before_commit_with_threshold(chunk_stream, 11, 8 * 1024, 1024)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.streamed_bytes, 5);
+        assert_eq!(err.source.kind(), std::io::ErrorKind::BrokenPipe);
+    }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Performance Improvement
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
Recent `GetObject` fast-path work started buffering chunk streams before committing the response so truncated or malformed bodies can fall back safely. The change already had coverage for the success path, threshold fallback, and short reads, but two failure branches remained untested: oversized bodies that exceed the promised content length before commit, and mid-stream I/O failures after partial data has been observed.

This PR adds two focused unit tests in `rustfs/src/app/object_usecase/get_object_flow.rs` to cover those branches. The first verifies that a chunk stream producing more bytes than `response_content_length` is rejected with `InvalidData` and reports the streamed byte count. The second verifies that a transport error raised after partial progress is preserved with the original `BrokenPipe` kind and the correct partial byte count.

These tests are intentionally narrow and deterministic. They exercise only the recent fast-path validation helper and avoid broader refactors or fixture churn.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
Adds regression coverage for recent `GetObject` fast-path validation logic.

## Additional Notes
Verification used:
- `cargo test -p rustfs materialize_chunk_stream_before_commit --lib`
- `make pre-commit`
