### PR TITLE
test(get): cover reader-backed output context

### DIFF
--- a/rustfs/src/app/object_usecase/get_object_flow.rs
+++ b/rustfs/src/app/object_usecase/get_object_flow.rs
@@ -408,7 +408,7 @@ mod tests {
             permit_wait_duration: Duration::ZERO,
             queue_status: crate::storage::concurrency::IoQueueStatus {
                 total_permits: 1,
-                permits_in_use: 0,
+                permits_in_use: 1,
                 high_priority_waiting: 0,
                 normal_priority_waiting: 0,
                 low_priority_waiting: 0,
@@ -417,7 +417,7 @@ mod tests {
                 low_priority_processed: 0,
                 starvation_events: 0,
             },
-            queue_utilization: 0.0,
+            queue_utilization: 100.0,
         };
         let manager = ConcurrencyManager::new();
 

--- a/rustfs/src/app/object_usecase/get_object_flow.rs
+++ b/rustfs/src/app/object_usecase/get_object_flow.rs
@@ -409,13 +409,7 @@ mod tests {
             queue_status: crate::storage::concurrency::IoQueueStatus {
                 total_permits: 1,
                 permits_in_use: 1,
-                high_priority_waiting: 0,
-                normal_priority_waiting: 0,
-                low_priority_waiting: 0,
-                high_priority_processed: 0,
-                normal_priority_processed: 0,
-                low_priority_processed: 0,
-                starvation_events: 0,
+                ..Default::default()
             },
             queue_utilization: 100.0,
         };

--- a/rustfs/src/app/object_usecase/get_object_flow.rs
+++ b/rustfs/src/app/object_usecase/get_object_flow.rs
@@ -355,8 +355,13 @@ pub(super) async fn run_get_object_flow(
 mod tests {
     use super::get_object_strategy_range;
     use super::*;
+    use futures_util::StreamExt;
     use http::HeaderMap;
     use rustfs_ecstore::store_api::ObjectOptions;
+    use rustfs_object_io::get::{GetObjectEncryptionState, LegacyReadPlan, build_reader_read_setup};
+    use rustfs_rio::{Reader, WarpReader};
+    use std::{io::Cursor, sync::Arc, time::Duration};
+    use tokio::sync::Semaphore;
 
     fn sample_range(start: i64, end: i64) -> HTTPRangeSpec {
         HTTPRangeSpec {
@@ -377,6 +382,61 @@ mod tests {
             sse_customer_key: None,
             sse_customer_key_md5: None,
         }
+    }
+
+    #[tokio::test]
+    async fn build_get_object_output_context_materializes_reader_payload_with_legacy_metrics() {
+        let payload = b"hello from legacy reader".to_vec();
+        let reader = Box::new(WarpReader::new(Cursor::new(payload.clone()))) as Box<dyn Reader>;
+        let read_setup = build_reader_read_setup(
+            ObjectInfo::default(),
+            ObjectInfo::default(),
+            reader,
+            LegacyReadPlan {
+                rs: None,
+                content_type: None,
+                last_modified: None,
+                response_content_length: payload.len() as i64,
+                content_range: None,
+            },
+            GetObjectEncryptionState::default(),
+        );
+        let semaphore = Arc::new(Semaphore::new(1));
+        let permit = semaphore.acquire().await.expect("disk permit");
+        let io_planning = GetObjectIoPlanning {
+            _disk_permit: permit,
+            permit_wait_duration: Duration::ZERO,
+            queue_status: crate::storage::concurrency::IoQueueStatus {
+                total_permits: 1,
+                permits_in_use: 0,
+                high_priority_waiting: 0,
+                normal_priority_waiting: 0,
+                low_priority_waiting: 0,
+                high_priority_processed: 0,
+                normal_priority_processed: 0,
+                low_priority_processed: 0,
+                starvation_events: 0,
+            },
+            queue_utilization: 0.0,
+        };
+        let manager = ConcurrencyManager::new();
+
+        let (output_context, metric_contract) =
+            build_get_object_output_context(&sample_request_context(), &manager, read_setup, &io_planning, 8 * 1024, false)
+                .await
+                .expect("reader-backed output context");
+
+        assert_eq!(metric_contract.io_path, rustfs_io_metrics::IoPath::Legacy);
+        assert_eq!(metric_contract.copy_mode, rustfs_io_metrics::CopyMode::SingleCopy);
+        assert_eq!(output_context.output.content_length, Some(payload.len() as i64));
+        assert_eq!(output_context.copy_mode_override, Some(rustfs_io_metrics::CopyMode::SingleCopy));
+
+        let mut body = output_context.output.body.expect("streaming body");
+        let mut collected = Vec::new();
+        while let Some(chunk) = body.next().await {
+            collected.extend_from_slice(&chunk.expect("body chunk"));
+        }
+        assert_eq!(collected, payload);
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
The recent GET fast-path removal left `build_get_object_output_context` without direct coverage for the reader-backed path that now handles every successful GET response. This PR adds a focused unit test that builds a reader-backed `GetObjectReadSetup`, runs it through `build_get_object_output_context`, and verifies the payload is materialized correctly while the legacy data-plane metric contract remains `Legacy` plus `SingleCopy`.

Without this test, a regression in the post-removal reader path could break response-body materialization or metric wiring without any targeted failure in the changed area. The new test stays narrow to the changed flow and avoids reintroducing the deleted zero-copy suite.

Verification used:
- `cargo test -p rustfs build_get_object_output_context_materializes_reader_payload_with_legacy_metrics -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
