### PR TITLE
chore(lint): clippy rules needless_collect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ unsafe_code = "deny"
 
 [workspace.lints.clippy]
 all = "warn"
+needless_collect = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates

--- a/crates/e2e_test/src/reliant/sql.rs
+++ b/crates/e2e_test/src/reliant/sql.rs
@@ -281,8 +281,11 @@ async fn test_select_object_content_csv_limit() -> Result<(), Box<dyn Error>> {
     println!("CSV Limit result: {result_str}");
 
     // Verify only first 2 records are returned
-    let lines: Vec<&str> = result_str.lines().filter(|line| !line.trim().is_empty()).collect();
-    assert_eq!(lines.len(), 2, "Should return exactly 2 records");
+    assert_eq!(
+        result_str.lines().filter(|line| !line.trim().is_empty()).count(),
+        2,
+        "Should return exactly 2 records"
+    );
 
     Ok(())
 }
@@ -321,8 +324,10 @@ async fn test_select_object_content_csv_order_by() -> Result<(), Box<dyn Error>>
     println!("CSV Order By result: {result_str}");
 
     // Verify ordered by age descending
-    let lines: Vec<&str> = result_str.lines().filter(|line| !line.trim().is_empty()).collect();
-    assert!(lines.len() >= 2, "Should return at least 2 records");
+    assert!(
+        result_str.lines().filter(|line| !line.trim().is_empty()).count() >= 2,
+        "Should return at least 2 records"
+    );
 
     // Check if contains highest age records
     assert!(result_str.contains("Charlie,35"));

--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -1493,7 +1493,7 @@ mod test {
         let sorted_order: Vec<_> = fm.versions.iter().map(|v| v.header.version_id).collect();
 
         // Sorting should remain stable for identical timestamps
-        assert_eq!(original_order.len(), sorted_order.len());
+        assert_eq!(original_order, sorted_order);
     }
 
     #[test]

--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -1488,9 +1488,9 @@ mod test {
         }
 
         // Verify stable ordering
-        let original_order: Vec<_> = fm.versions.iter().map(|v| v.header.version_id).collect();
+        let original_order = fm.versions.iter().map(|v| v.header.version_id).len();
         fm.sort_by_mod_time();
-        let sorted_order: Vec<_> = fm.versions.iter().map(|v| v.header.version_id).collect();
+        let sorted_order = fm.versions.iter().map(|v| v.header.version_id).len();
 
         // Sorting should remain stable for identical timestamps
         assert_eq!(original_order, sorted_order);

--- a/crates/targets/src/target/webhook.rs
+++ b/crates/targets/src/target/webhook.rs
@@ -293,8 +293,7 @@ where
 
         if !self.args.auth_token.is_empty() {
             // Split auth_token string to check if the authentication type is included
-            let tokens: Vec<&str> = self.args.auth_token.split_whitespace().collect();
-            match tokens.len() {
+            match self.args.auth_token.split_whitespace().count() {
                 2 => {
                     // Already include authentication type and token, such as "Bearer token123"
                     req_builder = req_builder.header("Authorization", &self.args.auth_token);

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -454,8 +454,11 @@ impl ConditionalCorsLayer {
         let allowed_origin = match (origin, &self.cors_origins) {
             (Some(orig), Some(config)) if config == "*" => Some(orig),
             (Some(orig), Some(config)) => {
-                let origins: Vec<&str> = config.split(',').map(|s| s.trim()).collect();
-                if origins.contains(&orig.as_str()) { Some(orig) } else { None }
+                if config.split(',').map(|s| s.trim()).any(|x| x == orig.as_str()) {
+                    Some(orig)
+                } else {
+                    None
+                }
             }
             (Some(orig), None) => Some(orig), // Default: allow all if not configured
             _ => None,


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [x] Other: Clippy Rules

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

Add `needless_collect` lint to avoid unnecessary performance overhead by removing redundant collection calls.


## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
