### PR TITLE
test(credentials): cover URL-safe secret keys

### DIFF
--- a/crates/credentials/src/credentials.rs
+++ b/crates/credentials/src/credentials.rs
@@ -475,6 +475,16 @@ mod tests {
     }
 
     #[test]
+    fn test_gen_secret_key_uses_url_safe_base64_without_padding() {
+        let key = gen_secret_key(32).expect("secret key should generate");
+
+        assert_eq!(key.len(), 32);
+        assert!(!key.contains('/'));
+        assert!(!key.contains('+'));
+        assert!(!key.contains('='));
+    }
+
+    #[test]
     fn test_masked_debug() {
         // Test None
         assert_eq!(format!("{:?}", Masked(None)), "");


### PR DESCRIPTION
## Summary
This PR adds a focused regression test for `rustfs_credentials::gen_secret_key`.
The recent fix in `credentials.rs` removed a dead `.replace("/", "+")` call because URL-safe base64 output never contains `/`, but the crate did not have a direct test that locked in that contract. Without a regression test, the implementation could drift again without any signal from the test suite.

The new test exercises `gen_secret_key(32)` and verifies the generated secret key stays URL-safe and unpadded by asserting the output length remains `32` and the string never contains `/`, `+`, or `=`. This keeps the scope tight to the changed behavior and gives a small, reliable guard around the exact path that was recently fixed.

## Verification
- `cargo test -p rustfs-credentials test_gen_secret_key_uses_url_safe_base64_without_padding`
- `cargo test -p rustfs-credentials`
- `cargo fmt --all --check`
- `make pre-commit`
