### PR TITLE
fix(scanner): preserve totals for compacted folder scans

### DIFF
--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -858,21 +858,22 @@ impl FolderScanner {
 
                 (self.update_current_path)(&folder_item.name).await;
 
-                let mut dst = if !into.compacted {
-                    DataUsageEntry::default()
+                if into.compacted {
+                    // In compacted mode child totals are accumulated directly into the parent entry.
+                    let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), into));
+                    fut.await.map_err(|e| ScannerError::Other(e.to_string()))?;
+                    tokio::task::yield_now().await;
                 } else {
-                    into.clone()
-                };
+                    let mut dst = DataUsageEntry::default();
 
-                // Use Box::pin for recursive async call
-                let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), &mut dst));
-                if let Err(e) = fut.await {
-                    warn!("scan_folder: failed to scan child folder {}: {}", folder_item.name, e);
-                    continue;
-                }
-                tokio::task::yield_now().await;
+                    // Use Box::pin for recursive async call
+                    let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), &mut dst));
+                    if let Err(e) = fut.await {
+                        warn!("scan_folder: failed to scan child folder {}: {}", folder_item.name, e);
+                        continue;
+                    }
+                    tokio::task::yield_now().await;
 
-                if !into.compacted {
                     let h = DataUsageHash(folder_item.name.clone());
                     into.add_child(&h);
                     // We scanned a folder, optionally send update.
@@ -910,21 +911,22 @@ impl FolderScanner {
 
                 (self.update_current_path)(&folder_item.name).await;
 
-                let mut dst = if !into.compacted {
-                    DataUsageEntry::default()
+                if into.compacted {
+                    // In compacted mode child totals are accumulated directly into the parent entry.
+                    let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), into));
+                    fut.await.map_err(|e| ScannerError::Other(e.to_string()))?;
+                    tokio::task::yield_now().await;
                 } else {
-                    into.clone()
-                };
+                    let mut dst = DataUsageEntry::default();
 
-                // Use Box::pin for recursive async call
-                let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), &mut dst));
-                if let Err(e) = fut.await {
-                    warn!("scan_folder: failed to scan child folder {}: {}", folder_item.name, e);
-                    continue;
-                }
-                tokio::task::yield_now().await;
+                    // Use Box::pin for recursive async call
+                    let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), &mut dst));
+                    if let Err(e) = fut.await {
+                        warn!("scan_folder: failed to scan child folder {}: {}", folder_item.name, e);
+                        continue;
+                    }
+                    tokio::task::yield_now().await;
 
-                if !into.compacted {
                     let h = DataUsageHash(folder_item.name.clone());
                     into.add_child(&h);
                     // We scanned a folder, optionally send update.
@@ -1124,21 +1126,22 @@ impl FolderScanner {
                         object_heal_prob_div: 1,
                     };
 
-                    let mut dst = if !into.compacted {
-                        DataUsageEntry::default()
+                    if into.compacted {
+                        // In compacted mode child totals are accumulated directly into the parent entry.
+                        let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), into));
+                        fut.await.map_err(|e| ScannerError::Other(e.to_string()))?;
+                        tokio::task::yield_now().await;
                     } else {
-                        into.clone()
-                    };
+                        let mut dst = DataUsageEntry::default();
 
-                    // Use Box::pin for recursive async call
-                    let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), &mut dst));
-                    if let Err(e) = fut.await {
-                        warn!("scan_folder: failed to scan child folder {}: {}", folder_item.name, e);
-                        continue;
-                    }
-                    tokio::task::yield_now().await;
+                        // Use Box::pin for recursive async call
+                        let fut = Box::pin(self.scan_folder(ctx.clone(), folder_item.clone(), &mut dst));
+                        if let Err(e) = fut.await {
+                            warn!("scan_folder: failed to scan child folder {}: {}", folder_item.name, e);
+                            continue;
+                        }
+                        tokio::task::yield_now().await;
 
-                    if !into.compacted {
                         let h = DataUsageHash(folder_item.name.clone());
                         into.add_child(&h);
                         // We scanned a folder, optionally send update.


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Fixes #1596
#2381 

## Summary of Changes
This PR fixes scanner accounting for high fan-out prefixes that enter compacted mode.

When a folder is already compacted, recursive child scans now accumulate totals directly into the parent entry instead of scanning into a cloned entry that is later discarded. This prevents data usage overview counts and sizes from staying at zero or becoming incomplete for buckets with large GUID-style prefix fan-out.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Corrects scanner/data usage aggregation for compacted folder scans.

## Additional Notes
Verification performed:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p rustfs-scanner -- --nocapture`
- `make pre-commit`

Manual validation was also performed with a local bucket containing 160,000 objects across three GUID-style prefixes. ListObjects returned 160,000 objects, and admin data usage reported `objects_total_count=160000` with non-zero bucket size.

No new automated test was added because the scanner unit harness does not initialize the global object layer required by the metadata sizing path. The existing scanner package tests and full pre-commit suite pass.

No documentation, configuration, or deployment changes are required.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
