### PR TITLE
fix(io-metrics): remove dead GET chunk fast path metrics

### DIFF
--- a/crates/io-metrics/src/lib.rs
+++ b/crates/io-metrics/src/lib.rs
@@ -349,59 +349,6 @@ pub fn record_io_fallback(stage: IoStage, reason: FallbackReason) {
     .increment(1);
 }
 
-/// Record a selected GET chunk fast path.
-#[inline(always)]
-pub fn record_get_object_fast_path_selected(path: &'static str, copy_mode: CopyMode, promised_bytes: i64) {
-    counter!(
-        metric_names::data_plane::GET_FAST_PATH_SELECTED_TOTAL,
-        "path" => path.to_string(),
-        "copy_mode" => copy_mode.as_str().to_string()
-    )
-    .increment(1);
-
-    if promised_bytes >= 0 {
-        histogram!(metric_names::data_plane::GET_FAST_PATH_PROMISED_BYTES).record(promised_bytes as f64);
-    }
-}
-
-/// Record a failed GET chunk fast path probe before the response is committed.
-#[inline(always)]
-pub fn record_get_object_fast_path_probe_failed(path: &'static str, copy_mode: CopyMode, promised_bytes: i64) {
-    counter!(
-        metric_names::data_plane::GET_FAST_PATH_PROBE_FAILED_TOTAL,
-        "path" => path.to_string(),
-        "copy_mode" => copy_mode.as_str().to_string()
-    )
-    .increment(1);
-
-    if promised_bytes >= 0 {
-        histogram!(metric_names::data_plane::GET_FAST_PATH_PROMISED_BYTES).record(promised_bytes as f64);
-    }
-}
-
-/// Record a GET chunk fast path mid-stream error after headers have already been committed.
-#[inline(always)]
-pub fn record_get_object_fast_path_midstream_error(
-    path: &'static str,
-    copy_mode: CopyMode,
-    error_kind: &'static str,
-    sent_bytes: usize,
-    promised_bytes: i64,
-) {
-    counter!(
-        metric_names::data_plane::GET_FAST_PATH_MIDSTREAM_ERROR_TOTAL,
-        "path" => path.to_string(),
-        "copy_mode" => copy_mode.as_str().to_string(),
-        "error_kind" => error_kind.to_string()
-    )
-    .increment(1);
-
-    histogram!(metric_names::data_plane::GET_FAST_PATH_MIDSTREAM_SENT_BYTES).record(sent_bytes as f64);
-    if promised_bytes >= 0 {
-        histogram!(metric_names::data_plane::GET_FAST_PATH_PROMISED_BYTES).record(promised_bytes as f64);
-    }
-}
-
 /// Record the currently active mmap bytes held by LocalDisk chunk streams.
 #[inline(always)]
 pub fn record_local_disk_active_mmap_bytes(active_bytes: usize) {
@@ -982,13 +929,6 @@ mod tests {
     #[test]
     fn test_record_local_disk_compat_collect() {
         record_local_disk_compat_collect(3, 16384);
-    }
-
-    #[test]
-    fn test_record_get_object_fast_path_metrics() {
-        record_get_object_fast_path_selected("direct", CopyMode::TrueZeroCopy, 8192);
-        record_get_object_fast_path_probe_failed("bridge", CopyMode::SingleCopy, 4096);
-        record_get_object_fast_path_midstream_error("direct", CopyMode::Reconstructed, "unexpected_eof", 2048, 8192);
     }
 
     #[test]

--- a/crates/io-metrics/src/metric_names.rs
+++ b/crates/io-metrics/src/metric_names.rs
@@ -54,19 +54,4 @@ pub mod data_plane {
 
     /// Size distribution for transformed PUT selections.
     pub const PUT_TRANSFORM_SIZE_BYTES: &str = "rustfs.io.put.transform.size.bytes";
-
-    /// Total number of selected GET chunk fast paths.
-    pub const GET_FAST_PATH_SELECTED_TOTAL: &str = "rustfs.io.get.fast_path.selected_total";
-
-    /// Total number of GET chunk fast path probe failures before response commit.
-    pub const GET_FAST_PATH_PROBE_FAILED_TOTAL: &str = "rustfs.io.get.fast_path.probe_failed_total";
-
-    /// Total number of GET chunk fast path mid-stream errors after response commit.
-    pub const GET_FAST_PATH_MIDSTREAM_ERROR_TOTAL: &str = "rustfs.io.get.fast_path.midstream_error_total";
-
-    /// Byte distribution promised by GET chunk fast path selections or failures.
-    pub const GET_FAST_PATH_PROMISED_BYTES: &str = "rustfs.io.get.fast_path.promised.bytes";
-
-    /// Byte distribution already sent when a GET chunk fast path fails mid-stream.
-    pub const GET_FAST_PATH_MIDSTREAM_SENT_BYTES: &str = "rustfs.io.get.fast_path.midstream_sent.bytes";
 }


### PR DESCRIPTION
## Summary

Remove dead GET chunk fast path metric constants and recording functions from `rustfs-io-metrics`.

These were introduced by PR #2351 and left behind when PR #2507 reverted the GET code path but forgot to clean up the corresponding metric definitions.

## Motivation

Part of the effort to fully revert #2351's chunk fast path infrastructure (tracked in rustfs/backlog#636).

These 5 constants and 3 functions had zero callers after #2507 removed the GET chunk fast path code.

## Changes

### Removed metric constants (`metric_names::data_plane`)
- `GET_FAST_PATH_SELECTED_TOTAL`
- `GET_FAST_PATH_PROBE_FAILED_TOTAL`
- `GET_FAST_PATH_MIDSTREAM_ERROR_TOTAL`
- `GET_FAST_PATH_PROMISED_BYTES`
- `GET_FAST_PATH_MIDSTREAM_SENT_BYTES`

### Removed functions
- `record_get_object_fast_path_selected()`
- `record_get_object_fast_path_probe_failed()`
- `record_get_object_fast_path_midstream_error()`

### Removed tests
- `test_record_get_object_fast_path_metrics`

## Verification

```
cargo check -p rustfs-io-metrics  # OK
cargo test -p rustfs-io-metrics   # OK
cargo check                       # Full workspace OK
```

## N/A

- No migration needed
- No configuration changes
- No breaking API changes (removed functions had zero external callers)
