### PR TITLE
fix: revert #2351 readers.rs behavioral changes (phase 6)

### DIFF
--- a/crates/ecstore/src/store_api/readers.rs
+++ b/crates/ecstore/src/store_api/readers.rs
@@ -63,34 +63,31 @@ impl GetObjectReader {
             rs = HTTPRangeSpec::from_object_info(oi, part_number);
         }
 
-        let logical_size = oi.get_actual_size()?;
-        let encrypted_object = oi.user_defined.contains_key("x-rustfs-encryption-key")
-            || oi
-                .user_defined
-                .contains_key("x-amz-server-side-encryption-customer-algorithm");
+        // TODO:Encrypted
 
         let (algo, is_compressed) = oi.is_compressed_ok()?;
 
         // TODO: check TRANSITION
 
         if is_compressed {
+            let actual_size = oi.get_actual_size()?;
             let (off, length, dec_off, dec_length) = if let Some(rs) = rs {
                 // Support range requests for compressed objects
-                let (dec_off, dec_length) = rs.get_offset_length(logical_size)?;
+                let (dec_off, dec_length) = rs.get_offset_length(actual_size)?;
                 (0, oi.size, dec_off, dec_length)
             } else {
-                (0, oi.size, 0, logical_size)
+                (0, oi.size, 0, actual_size)
             };
 
             let dec_reader = DecompressReader::new(reader, algo);
 
-            let actual_size_usize = if logical_size > 0 {
-                logical_size as usize
+            let actual_size_usize = if actual_size > 0 {
+                actual_size as usize
             } else {
-                return Err(Error::other(format!("invalid decompressed size {logical_size}")));
+                return Err(Error::other(format!("invalid decompressed size {actual_size}")));
             };
 
-            let final_reader: Box<dyn AsyncRead + Unpin + Send + Sync> = if dec_off > 0 || dec_length != logical_size {
+            let final_reader: Box<dyn AsyncRead + Unpin + Send + Sync> = if dec_off > 0 || dec_length != actual_size {
                 // Use RangedDecompressReader for streaming range processing
                 // The new implementation supports any offset size by streaming and skipping data
                 match RangedDecompressReader::new(dec_reader, dec_off, dec_length, actual_size_usize) {
@@ -125,19 +122,8 @@ impl GetObjectReader {
             ));
         }
 
-        if encrypted_object && rs.is_none() {
-            return Ok((
-                GetObjectReader {
-                    stream: reader,
-                    object_info: oi.clone(),
-                },
-                0,
-                oi.size,
-            ));
-        }
-
         if let Some(rs) = rs {
-            let (off, length) = rs.get_offset_length(logical_size)?;
+            let (off, length) = rs.get_offset_length(oi.size)?;
 
             Ok((
                 GetObjectReader {
@@ -154,7 +140,7 @@ impl GetObjectReader {
                     object_info: oi.clone(),
                 },
                 0,
-                logical_size,
+                oi.size,
             ))
         }
     }


### PR DESCRIPTION
## Description

Revert #2351 behavioral changes in `GetObjectReader` (phase 6 of the #2351 revert effort).

### What changed

The `GetObjectReader::new()` function in `crates/ecstore/src/store_api/readers.rs` had three #2351 behavioral modifications that are now reverted:

| Change | #2351 Behavior | Baseline Behavior (restored) |
|--------|---------------|------|
| `get_actual_size()` call | Called unconditionally at function entry for all objects | Called only inside `is_compressed` branch where it's needed |
| Encrypted object bypass | Early return skipping range calculation for encrypted objects without range spec | No special encrypted path (uses standard flow) |
| Non-compressed range calc | Used `logical_size` (decompressed size) for range offset calculation | Uses `oi.size` (on-disk size), correct for non-compressed objects |

### Why this matters

1. **Unnecessary overhead**: `get_actual_size()` does decompression metadata lookup — calling it for every GET including non-compressed objects adds latency.
2. **Incorrect encrypted bypass**: The early return for encrypted objects without ranges bypassed range calculation entirely, which could mask bugs in downstream range handling.
3. **Wrong size for ranges**: Using `logical_size` instead of `oi.size` for non-compressed objects is semantically wrong — for non-compressed data, on-disk size IS the actual size.

## Motivation

Continued cleanup of PR #2351 artifacts. This is a standalone behavioral revert with no cross-dependencies.

Tracking issue: https://github.com/rustfs/backlog/issues/636
Prior phases: #2531, #2532, #2533, #2535

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

```
cargo check -p rustfs-ecstore  # ✅ pass
cargo fmt --all --check         # ✅ pass
```

## N/A

- Test Plan: Internal logic revert; function signature unchanged. Existing tests cover range/compressed paths.
- Documentation: N/A
- Breaking Change: N/A
