### PR TITLE
test(ecstore): cover fresh tmp cleanup path

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -2839,6 +2839,32 @@ mod test {
     }
 
     #[tokio::test]
+    async fn cleanup_stale_tmp_objects_keeps_fresh_dirs_and_regular_files() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let tmp = LocalDisk::meta_path(dir.path(), RUSTFS_META_TMP_BUCKET);
+        let fresh_dir = tmp.join("fresh").join("data");
+        let regular_file = tmp.join("note.txt");
+        let trash = LocalDisk::meta_path(dir.path(), RUSTFS_META_TMP_DELETED_BUCKET);
+
+        fs::create_dir_all(fresh_dir.parent().unwrap()).await.unwrap();
+        fs::create_dir_all(&trash).await.unwrap();
+        fs::write(&fresh_dir, b"temporary").await.unwrap();
+        fs::write(&regular_file, b"keep").await.unwrap();
+
+        LocalDisk::cleanup_stale_tmp_objects_with_expiry(dir.path().to_path_buf(), Duration::from_secs(60))
+            .await
+            .unwrap();
+
+        assert!(tmp.join("fresh").exists());
+        assert!(regular_file.exists());
+
+        let mut entries = fs::read_dir(&trash).await.unwrap();
+        assert!(entries.next_entry().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn test_scan_dir_includes_nested_object_dirs() {
         use rustfs_filemeta::MetacacheReader;
         use tempfile::tempdir;


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- N/A

## Summary of Changes
This PR adds focused regression coverage for the recent ECStore temporary-data cleanup changes.

The recent cleanup work added logic that moves expired temporary object directories into the deleted-temp area, but the fresh-directory and non-directory branches in that logic were still untested. Without explicit coverage, a future cleanup change could accidentally start moving active temporary directories or ordinary files out of `.rustfs.sys/tmp`, which would turn a background cleanup task into a source of write-path regressions.

This change adds a single unit test in `crates/ecstore/src/disk/local.rs` that creates a fresh temporary directory and a regular file under the tmp bucket, runs `cleanup_stale_tmp_objects_with_expiry`, and verifies that both entries remain in place while the trash directory stays empty. That keeps the scope tight to the changed area and validates the intended guard rails around the cleanup behavior.

Validation used for this change:
- `cargo test -p rustfs-ecstore cleanup_stale_tmp_objects_keeps_fresh_dirs_and_regular_files -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
Adds regression coverage for ECStore tmp cleanup skip paths.

## Additional Notes
- N/A
