### PR TITLE
fix(admin): restore access key listing and guard boot-time uptime

### DIFF
--- a/crates/ecstore/src/admin_server_info.rs
+++ b/crates/ecstore/src/admin_server_info.rs
@@ -162,8 +162,9 @@ pub async fn get_local_server_property() -> ServerProperties {
 
     let mut props = ServerProperties {
         endpoint: addr,
-        uptime: SystemTime::now()
-            .duration_since(*GLOBAL_BOOT_TIME.get().unwrap())
+        uptime: GLOBAL_BOOT_TIME
+            .get()
+            .and_then(|boot_time| SystemTime::now().duration_since(*boot_time).ok())
             .unwrap_or_default()
             .as_secs(),
         network,

--- a/crates/ecstore/src/notification_sys.rs
+++ b/crates/ecstore/src/notification_sys.rs
@@ -786,8 +786,9 @@ where
 
 fn offline_server_properties(host: &str, endpoints: &EndpointServerPools) -> ServerProperties {
     ServerProperties {
-        uptime: SystemTime::now()
-            .duration_since(*GLOBAL_BOOT_TIME.get().unwrap())
+        uptime: GLOBAL_BOOT_TIME
+            .get()
+            .and_then(|boot_time| SystemTime::now().duration_since(*boot_time).ok())
             .unwrap_or_default()
             .as_secs(),
         version: get_commit_id(),

--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -1018,7 +1018,9 @@ fn parse_list_access_keys_query(query: Option<&str>) -> ListAccessKeysQuery {
 
     for (key, value) in form_urlencoded::parse(query.as_bytes()) {
         match key.as_ref() {
-            "users" => parsed.users.push(value.into_owned()),
+            "users" if !value.is_empty() => {
+                parsed.users.push(value.into_owned());
+            }
             "all" => parsed.all = parse_bool_param(value.as_ref()),
             "listType" => parsed.list_type = value.into_owned(),
             _ => {}
@@ -1124,13 +1126,9 @@ impl Operation for ListAccessKeysBulk {
             }
             users
         } else {
-            let mut checked = Vec::new();
-            for user in requested_users {
-                if iam_store.get_user(&user).await.is_some() {
-                    checked.push(user);
-                }
-            }
-            checked
+            // Keep requested identities as-is. Some valid parent users (for example external
+            // identities) may not be persisted as regular IAM users, but can still own keys.
+            requested_users
         };
 
         let (list_sts_keys, list_service_accounts) = match query.list_type.as_str() {
@@ -1397,6 +1395,25 @@ mod tests {
         assert_eq!(query.users, vec!["alice".to_string(), "bob".to_string()]);
         assert!(query.all);
         assert_eq!(query.list_type, ACCESS_KEY_LIST_SVCACC_ONLY);
+    }
+
+    #[test]
+    fn list_access_keys_query_ignores_empty_users_values() {
+        let query = parse_list_access_keys_query(Some("users=&users=alice&users=&listType=all"));
+
+        assert_eq!(query.users, vec!["alice".to_string()]);
+        assert!(!query.all);
+        assert_eq!(query.list_type, ACCESS_KEY_LIST_ALL);
+    }
+
+    #[test]
+    fn list_access_keys_query_all_with_empty_users_does_not_conflict() {
+        let query = parse_list_access_keys_query(Some("users=&all=true&listType=all"));
+
+        assert!(query.users.is_empty());
+        assert!(query.all);
+        assert_eq!(query.list_type, ACCESS_KEY_LIST_ALL);
+        assert!(!query.all || query.users.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other: N/A

## Related Issues
#2570

## Summary of Changes
- Fix `ListAccessKeysBulk` in non-`all` mode to keep requested identities instead of filtering them out via `iam_store.get_user()`, which could hide valid access keys for external parent identities.
- Ignore empty `users=` query values in `parse_list_access_keys_query` to avoid empty-user lookup paths.
- Replace `GLOBAL_BOOT_TIME.get().unwrap()` with safe optional uptime calculation in server info paths to prevent startup race panics.
- Add regression tests for empty `users` handling and `all=true` query compatibility behavior.
- Verification commands:
  - `cargo fmt --all --check`
  - `cargo test -p rustfs list_access_keys_query_`
  - `cargo check -p rustfs-ecstore`

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Fixes Access Keys empty-list regression and avoids boot-time uptime panic.

## Additional Notes
- `make pre-commit` was intentionally not run in this pass per requester instruction.
- Scope is intentionally limited to issue #2570 related fixes.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
