### PR TITLE
fix(cache): wire trusted-proxy cache and remove stale cache traces

### DIFF
--- a/crates/io-metrics/README_zh.md
+++ b/crates/io-metrics/README_zh.md
@@ -237,15 +237,6 @@ println!("最大并发读: {}", config.scheduler.max_concurrent_reads);
 
 ## 🔧 配置
 
-### 环境变量
-
-| 变量名 | 描述 | 默认值 |
-|--------|------|--------|
-| `RUSTFS_CACHE_MAX_CAPACITY` | 缓存最大容量 | 10000 |
-| `RUSTFS_CACHE_TTL_SECS` | 缓存 TTL 秒数 | 300 |
-| `RUSTFS_CACHE_MAX_MEMORY` | 缓存最大内存 | 104857600 |
-| `RUSTFS_ADAPTIVE_TTL_ENABLED` | 启用自适应 TTL | true |
-
 ### 代码配置
 
 ```rust

--- a/crates/trusted-proxies/Cargo.toml
+++ b/crates/trusted-proxies/Cargo.toml
@@ -30,7 +30,7 @@ axum = { workspace = true }
 http = { workspace = true }
 ipnetwork = { workspace = true }
 metrics = { workspace = true }
-moka = { workspace = true, features = ["future"] }
+moka = { workspace = true, features = ["future", "sync"] }
 reqwest = { workspace = true }
 rustfs-config = { workspace = true }
 rustfs-utils = { workspace = true, features = ["net"] }

--- a/crates/trusted-proxies/src/global.rs
+++ b/crates/trusted-proxies/src/global.rs
@@ -64,7 +64,7 @@ pub fn init() {
         .expect("Trusted proxy metrics already initialized");
 
     // Initialize the trusted proxy layer.
-    let layer = TrustedProxyLayer::new(config.proxy.clone(), metrics, enabled);
+    let layer = TrustedProxyLayer::with_cache_config(config.proxy.clone(), config.cache.clone(), metrics, enabled);
     PROXY_LAYER.set(layer).expect("Trusted proxy layer already initialized");
 
     tracing::info!("Trusted Proxies module initialized");

--- a/crates/trusted-proxies/src/middleware/layer.rs
+++ b/crates/trusted-proxies/src/middleware/layer.rs
@@ -15,12 +15,13 @@
 //! Tower layer implementation for the trusted proxy middleware.
 
 use std::sync::Arc;
+use std::time::Duration;
 use tower::Layer;
 
-use crate::ProxyMetrics;
 use crate::ProxyValidator;
 use crate::TrustedProxyConfig;
 use crate::TrustedProxyMiddleware;
+use crate::{CacheConfig, ProxyMetrics};
 
 /// Tower Layer for the trusted proxy middleware.
 #[derive(Clone, Debug)]
@@ -34,17 +35,32 @@ pub struct TrustedProxyLayer {
 impl TrustedProxyLayer {
     /// Creates a new `TrustedProxyLayer`.
     pub fn new(config: TrustedProxyConfig, metrics: Option<ProxyMetrics>, enabled: bool) -> Self {
-        let validator = ProxyValidator::new(config, metrics);
+        Self::with_cache_config(config, CacheConfig::default(), metrics, enabled)
+    }
 
-        Self {
-            validator: Arc::new(validator),
-            enabled,
+    /// Creates a new `TrustedProxyLayer` with explicit cache configuration.
+    pub fn with_cache_config(
+        config: TrustedProxyConfig,
+        cache_config: CacheConfig,
+        metrics: Option<ProxyMetrics>,
+        enabled: bool,
+    ) -> Self {
+        let validator = Arc::new(ProxyValidator::with_cache_config(config, cache_config.clone(), metrics));
+        if enabled {
+            Self::spawn_cache_maintenance_task(validator.clone(), cache_config.cleanup_interval());
         }
+
+        Self { validator, enabled }
     }
 
     /// Creates a new `TrustedProxyLayer` that is enabled by default.
     pub fn enabled(config: TrustedProxyConfig, metrics: Option<ProxyMetrics>) -> Self {
         Self::new(config, metrics, true)
+    }
+
+    /// Creates a new `TrustedProxyLayer` that is enabled with explicit cache configuration.
+    pub fn enabled_with_cache(config: TrustedProxyConfig, cache_config: CacheConfig, metrics: Option<ProxyMetrics>) -> Self {
+        Self::with_cache_config(config, cache_config, metrics, true)
     }
 
     /// Creates a new `TrustedProxyLayer` that is disabled.
@@ -59,6 +75,26 @@ impl TrustedProxyLayer {
     /// Returns true if the middleware is enabled.
     pub fn is_enabled(&self) -> bool {
         self.enabled
+    }
+
+    fn spawn_cache_maintenance_task(validator: Arc<ProxyValidator>, cleanup_interval: Duration) {
+        if cleanup_interval.is_zero() || !validator.validation_cache().is_enabled() {
+            return;
+        }
+
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            tracing::debug!("No Tokio runtime available; trusted proxy cache maintenance is disabled");
+            return;
+        };
+
+        let cache = validator.validation_cache();
+        handle.spawn(async move {
+            let mut interval = tokio::time::interval(cleanup_interval);
+            loop {
+                interval.tick().await;
+                cache.run_maintenance().await;
+            }
+        });
     }
 }
 

--- a/crates/trusted-proxies/src/middleware/layer.rs
+++ b/crates/trusted-proxies/src/middleware/layer.rs
@@ -15,7 +15,6 @@
 //! Tower layer implementation for the trusted proxy middleware.
 
 use std::sync::Arc;
-use std::time::Duration;
 use tower::Layer;
 
 use crate::ProxyValidator;
@@ -47,7 +46,7 @@ impl TrustedProxyLayer {
     ) -> Self {
         let validator = Arc::new(ProxyValidator::with_cache_config(config, cache_config.clone(), metrics));
         if enabled {
-            Self::spawn_cache_maintenance_task(validator.clone(), cache_config.cleanup_interval());
+            validator.spawn_cache_maintenance_task(cache_config.cleanup_interval());
         }
 
         Self { validator, enabled }
@@ -56,11 +55,6 @@ impl TrustedProxyLayer {
     /// Creates a new `TrustedProxyLayer` that is enabled by default.
     pub fn enabled(config: TrustedProxyConfig, metrics: Option<ProxyMetrics>) -> Self {
         Self::new(config, metrics, true)
-    }
-
-    /// Creates a new `TrustedProxyLayer` that is enabled with explicit cache configuration.
-    pub fn enabled_with_cache(config: TrustedProxyConfig, cache_config: CacheConfig, metrics: Option<ProxyMetrics>) -> Self {
-        Self::with_cache_config(config, cache_config, metrics, true)
     }
 
     /// Creates a new `TrustedProxyLayer` that is disabled.
@@ -75,26 +69,6 @@ impl TrustedProxyLayer {
     /// Returns true if the middleware is enabled.
     pub fn is_enabled(&self) -> bool {
         self.enabled
-    }
-
-    fn spawn_cache_maintenance_task(validator: Arc<ProxyValidator>, cleanup_interval: Duration) {
-        if cleanup_interval.is_zero() || !validator.validation_cache().is_enabled() {
-            return;
-        }
-
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            tracing::debug!("No Tokio runtime available; trusted proxy cache maintenance is disabled");
-            return;
-        };
-
-        let cache = validator.validation_cache();
-        handle.spawn(async move {
-            let mut interval = tokio::time::interval(cleanup_interval);
-            loop {
-                interval.tick().await;
-                cache.run_maintenance().await;
-            }
-        });
     }
 }
 

--- a/crates/trusted-proxies/src/middleware/service.rs
+++ b/crates/trusted-proxies/src/middleware/service.rs
@@ -16,6 +16,8 @@
 
 use crate::{ClientInfo, ProxyValidator, TrustedProxyLayer};
 use http::Request;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tower::Service;
@@ -51,51 +53,60 @@ impl<S> TrustedProxyMiddleware<S> {
 impl<S, ReqBody> Service<Request<ReqBody>> for TrustedProxyMiddleware<S>
 where
     S: Service<Request<ReqBody>> + Clone + Send + 'static,
-    S::Future: Send,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    S::Response: 'static,
+    S::Error: 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = S::Future;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let validator = self.validator.clone();
+        let enabled = self.enabled;
+
         // If the middleware is disabled, pass the request through immediately.
-        if !self.enabled {
+        if !enabled {
             debug!("Trusted proxy middleware is disabled");
-            return self.inner.call(req);
+            return Box::pin(async move { inner.call(req).await });
         }
 
-        let start_time = std::time::Instant::now();
+        Box::pin(async move {
+            let start_time = std::time::Instant::now();
 
-        // Extract the direct peer address from the request extensions.
-        let peer_addr = req.extensions().get::<std::net::SocketAddr>().copied();
+            // Extract the direct peer address from the request extensions.
+            let peer_addr = req.extensions().get::<std::net::SocketAddr>().copied();
 
-        // Validate the request and extract client information.
-        match self.validator.validate_request(peer_addr, req.headers()) {
-            Ok(client_info) => {
-                // Insert the verified client info into the request extensions.
-                req.extensions_mut().insert(client_info);
-
-                let duration = start_time.elapsed();
-                debug!("Proxy validation successful in {:?}", duration);
-            }
-            Err(err) => {
-                // If the error is recoverable, fallback to a direct connection info.
-                if err.is_recoverable() {
-                    let client_info = ClientInfo::direct(
-                        peer_addr.unwrap_or_else(|| std::net::SocketAddr::new(std::net::IpAddr::from([0, 0, 0, 0]), 0)),
-                    );
+            // Validate the request and extract client information.
+            match validator.validate_request(peer_addr, req.headers()).await {
+                Ok(client_info) => {
+                    // Insert the verified client info into the request extensions.
                     req.extensions_mut().insert(client_info);
-                } else {
-                    debug!("Unrecoverable proxy validation error: {}", err);
+
+                    let duration = start_time.elapsed();
+                    debug!("Proxy validation successful in {:?}", duration);
+                }
+                Err(err) => {
+                    // If the error is recoverable, fallback to a direct connection info.
+                    if err.is_recoverable() {
+                        let client_info = ClientInfo::direct(
+                            peer_addr.unwrap_or_else(|| std::net::SocketAddr::new(std::net::IpAddr::from([0, 0, 0, 0]), 0)),
+                        );
+                        req.extensions_mut().insert(client_info);
+                    } else {
+                        debug!("Unrecoverable proxy validation error: {}", err);
+                    }
                 }
             }
-        }
 
-        // Call the inner service.
-        self.inner.call(req)
+            // Call the inner service.
+            inner.call(req).await
+        })
     }
 }

--- a/crates/trusted-proxies/src/middleware/service.rs
+++ b/crates/trusted-proxies/src/middleware/service.rs
@@ -16,8 +16,6 @@
 
 use crate::{ClientInfo, ProxyValidator, TrustedProxyLayer};
 use http::Request;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tower::Service;
@@ -53,60 +51,51 @@ impl<S> TrustedProxyMiddleware<S> {
 impl<S, ReqBody> Service<Request<ReqBody>> for TrustedProxyMiddleware<S>
 where
     S: Service<Request<ReqBody>> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    ReqBody: Send + 'static,
-    S::Response: 'static,
-    S::Error: 'static,
+    S::Future: Send,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    type Future = S::Future;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let mut inner = self.inner.clone();
-        let validator = self.validator.clone();
-        let enabled = self.enabled;
-
         // If the middleware is disabled, pass the request through immediately.
-        if !enabled {
+        if !self.enabled {
             debug!("Trusted proxy middleware is disabled");
-            return Box::pin(async move { inner.call(req).await });
+            return self.inner.call(req);
         }
 
-        Box::pin(async move {
-            let start_time = std::time::Instant::now();
+        let start_time = std::time::Instant::now();
 
-            // Extract the direct peer address from the request extensions.
-            let peer_addr = req.extensions().get::<std::net::SocketAddr>().copied();
+        // Extract the direct peer address from the request extensions.
+        let peer_addr = req.extensions().get::<std::net::SocketAddr>().copied();
 
-            // Validate the request and extract client information.
-            match validator.validate_request(peer_addr, req.headers()).await {
-                Ok(client_info) => {
-                    // Insert the verified client info into the request extensions.
+        // Validate the request and extract client information.
+        match self.validator.validate_request(peer_addr, req.headers()) {
+            Ok(client_info) => {
+                // Insert the verified client info into the request extensions.
+                req.extensions_mut().insert(client_info);
+
+                let duration = start_time.elapsed();
+                debug!("Proxy validation successful in {:?}", duration);
+            }
+            Err(err) => {
+                // If the error is recoverable, fallback to a direct connection info.
+                if err.is_recoverable() {
+                    let client_info = ClientInfo::direct(
+                        peer_addr.unwrap_or_else(|| std::net::SocketAddr::new(std::net::IpAddr::from([0, 0, 0, 0]), 0)),
+                    );
                     req.extensions_mut().insert(client_info);
-
-                    let duration = start_time.elapsed();
-                    debug!("Proxy validation successful in {:?}", duration);
-                }
-                Err(err) => {
-                    // If the error is recoverable, fallback to a direct connection info.
-                    if err.is_recoverable() {
-                        let client_info = ClientInfo::direct(
-                            peer_addr.unwrap_or_else(|| std::net::SocketAddr::new(std::net::IpAddr::from([0, 0, 0, 0]), 0)),
-                        );
-                        req.extensions_mut().insert(client_info);
-                    } else {
-                        debug!("Unrecoverable proxy validation error: {}", err);
-                    }
+                } else {
+                    debug!("Unrecoverable proxy validation error: {}", err);
                 }
             }
+        }
 
-            // Call the inner service.
-            inner.call(req).await
-        })
+        // Call the inner service.
+        self.inner.call(req)
     }
 }

--- a/crates/trusted-proxies/src/proxy/cache.rs
+++ b/crates/trusted-proxies/src/proxy/cache.rs
@@ -18,21 +18,32 @@ use moka::future::Cache;
 use std::net::IpAddr;
 use std::time::Duration;
 
+use crate::ProxyMetrics;
+
 /// Cache for storing IP validation results.
 #[derive(Debug, Clone)]
 pub struct IpValidationCache {
     /// The underlying Moka cache.
     cache: Cache<IpAddr, bool>,
+    /// Configured capacity.
+    capacity: usize,
     /// Whether the cache is enabled.
     enabled: bool,
+    /// Optional metrics collector for cache activity.
+    metrics: Option<ProxyMetrics>,
 }
 
 impl IpValidationCache {
     /// Creates a new `IpValidationCache` using Moka.
-    pub fn new(capacity: usize, ttl: Duration, enabled: bool) -> Self {
+    pub fn new(capacity: usize, ttl: Duration, enabled: bool, metrics: Option<ProxyMetrics>) -> Self {
         let cache = Cache::builder().max_capacity(capacity as u64).time_to_live(ttl).build();
 
-        Self { cache, enabled }
+        Self {
+            cache,
+            capacity,
+            enabled,
+            metrics,
+        }
     }
 
     /// Checks if an IP is trusted, using the cache if available.
@@ -43,14 +54,16 @@ impl IpValidationCache {
 
         // Attempt to get the result from cache.
         if let Some(is_trusted) = self.cache.get(ip).await {
-            metrics::counter!("rustfs_trusted_proxy_cache_hits").increment(1);
+            self.record_cache_hit();
             return is_trusted;
         }
 
         // Cache miss: perform validation and update cache.
-        metrics::counter!("rustfs_trusted_proxy_cache_misses").increment(1);
+        self.record_cache_miss();
         let is_trusted = validator(ip);
         self.cache.insert(*ip, is_trusted).await;
+        self.cache.run_pending_tasks().await;
+        self.update_cache_size_metric();
 
         is_trusted
     }
@@ -58,7 +71,18 @@ impl IpValidationCache {
     /// Clears all entries from the cache.
     pub async fn clear(&self) {
         self.cache.invalidate_all();
-        metrics::gauge!("rustfs_trusted_proxy_cache_size").set(0.0);
+        self.cache.run_pending_tasks().await;
+        self.update_cache_size_metric();
+    }
+
+    /// Runs pending cache maintenance tasks and refreshes size metrics.
+    pub async fn run_maintenance(&self) {
+        if !self.enabled {
+            return;
+        }
+
+        self.cache.run_pending_tasks().await;
+        self.update_cache_size_metric();
     }
 
     /// Returns statistics about the current state of the cache.
@@ -67,9 +91,30 @@ impl IpValidationCache {
 
         CacheStats {
             size: entry_count as usize,
-            // Moka doesn't expose max_capacity directly in a simple way after build,
-            // but we can track it if needed.
-            capacity: 0,
+            capacity: self.capacity,
+        }
+    }
+
+    /// Returns whether the cache is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn record_cache_hit(&self) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_cache_hit(self.cache.entry_count() as usize);
+        }
+    }
+
+    fn record_cache_miss(&self) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_cache_miss(self.cache.entry_count() as usize);
+        }
+    }
+
+    fn update_cache_size_metric(&self) {
+        if let Some(metrics) = &self.metrics {
+            metrics.set_cache_size(self.cache.entry_count() as usize);
         }
     }
 }

--- a/crates/trusted-proxies/src/proxy/cache.rs
+++ b/crates/trusted-proxies/src/proxy/cache.rs
@@ -14,7 +14,7 @@
 
 //! High-performance cache implementation for proxy validation results using Moka.
 
-use moka::future::Cache;
+use moka::sync::Cache;
 use std::net::IpAddr;
 use std::time::Duration;
 
@@ -37,23 +37,24 @@ impl IpValidationCache {
     /// Creates a new `IpValidationCache` using Moka.
     pub fn new(capacity: usize, ttl: Duration, enabled: bool, metrics: Option<ProxyMetrics>) -> Self {
         let cache = Cache::builder().max_capacity(capacity as u64).time_to_live(ttl).build();
-
-        Self {
+        let this = Self {
             cache,
             capacity,
             enabled,
             metrics,
-        }
+        };
+        this.update_cache_size_metric();
+        this
     }
 
     /// Checks if an IP is trusted, using the cache if available.
-    pub async fn is_trusted(&self, ip: &IpAddr, validator: impl FnOnce(&IpAddr) -> bool) -> bool {
+    pub fn is_trusted(&self, ip: &IpAddr, validator: impl FnOnce(&IpAddr) -> bool) -> bool {
         if !self.enabled {
             return validator(ip);
         }
 
         // Attempt to get the result from cache.
-        if let Some(is_trusted) = self.cache.get(ip).await {
+        if let Some(is_trusted) = self.cache.get(ip) {
             self.record_cache_hit();
             return is_trusted;
         }
@@ -61,27 +62,27 @@ impl IpValidationCache {
         // Cache miss: perform validation and update cache.
         self.record_cache_miss();
         let is_trusted = validator(ip);
-        self.cache.insert(*ip, is_trusted).await;
-        self.cache.run_pending_tasks().await;
+        self.cache.insert(*ip, is_trusted);
+        self.cache.run_pending_tasks();
         self.update_cache_size_metric();
 
         is_trusted
     }
 
     /// Clears all entries from the cache.
-    pub async fn clear(&self) {
+    pub fn clear(&self) {
         self.cache.invalidate_all();
-        self.cache.run_pending_tasks().await;
+        self.cache.run_pending_tasks();
         self.update_cache_size_metric();
     }
 
     /// Runs pending cache maintenance tasks and refreshes size metrics.
-    pub async fn run_maintenance(&self) {
+    pub fn run_maintenance(&self) {
         if !self.enabled {
             return;
         }
 
-        self.cache.run_pending_tasks().await;
+        self.cache.run_pending_tasks();
         self.update_cache_size_metric();
     }
 

--- a/crates/trusted-proxies/src/proxy/cache.rs
+++ b/crates/trusted-proxies/src/proxy/cache.rs
@@ -59,12 +59,14 @@ impl IpValidationCache {
             return is_trusted;
         }
 
-        // Cache miss: perform validation and update cache.
+        // Cache miss: perform validation. Only positive trust decisions are cached
+        // to avoid polluting the cache with one-off untrusted client IPs.
         self.record_cache_miss();
         let is_trusted = validator(ip);
-        self.cache.insert(*ip, is_trusted);
-        self.cache.run_pending_tasks();
-        self.update_cache_size_metric();
+        if is_trusted {
+            self.cache.insert(*ip, is_trusted);
+            self.update_cache_size_metric();
+        }
 
         is_trusted
     }
@@ -88,6 +90,10 @@ impl IpValidationCache {
 
     /// Returns statistics about the current state of the cache.
     pub fn stats(&self) -> CacheStats {
+        if self.enabled {
+            self.cache.run_pending_tasks();
+        }
+
         let entry_count = self.cache.entry_count();
 
         CacheStats {
@@ -103,13 +109,13 @@ impl IpValidationCache {
 
     fn record_cache_hit(&self) {
         if let Some(metrics) = &self.metrics {
-            metrics.record_cache_hit(self.cache.entry_count() as usize);
+            metrics.record_cache_hit();
         }
     }
 
     fn record_cache_miss(&self) {
         if let Some(metrics) = &self.metrics {
-            metrics.record_cache_miss(self.cache.entry_count() as usize);
+            metrics.record_cache_miss();
         }
     }
 

--- a/crates/trusted-proxies/src/proxy/chain.rs
+++ b/crates/trusted-proxies/src/proxy/chain.rs
@@ -228,7 +228,7 @@ impl ProxyChainAnalyzer {
     }
 
     /// Checks if an IP address is trusted based on the configuration.
-    fn is_ip_trusted(&self, ip: &IpAddr) -> bool {
+    pub(crate) fn is_ip_trusted(&self, ip: &IpAddr) -> bool {
         if self.trusted_ip_cache.contains(ip) {
             return true;
         }

--- a/crates/trusted-proxies/src/proxy/metrics.rs
+++ b/crates/trusted-proxies/src/proxy/metrics.rs
@@ -178,6 +178,35 @@ impl ProxyMetrics {
         });
     }
 
+    /// Records a cache hit and updates the cache size gauge.
+    pub fn record_cache_hit(&self, size: usize) {
+        if !self.enabled {
+            return;
+        }
+
+        counter!("rustfs_trusted_proxy_cache_hits_total", "app" => self.app_name.clone()).increment(1);
+        gauge!("rustfs_trusted_proxy_cache_size", "app" => self.app_name.clone()).set(size as f64);
+    }
+
+    /// Records a cache miss and updates the cache size gauge.
+    pub fn record_cache_miss(&self, size: usize) {
+        if !self.enabled {
+            return;
+        }
+
+        counter!("rustfs_trusted_proxy_cache_misses_total", "app" => self.app_name.clone()).increment(1);
+        gauge!("rustfs_trusted_proxy_cache_size", "app" => self.app_name.clone()).set(size as f64);
+    }
+
+    /// Updates only the cache size gauge.
+    pub fn set_cache_size(&self, size: usize) {
+        if !self.enabled {
+            return;
+        }
+
+        gauge!("rustfs_trusted_proxy_cache_size", "app" => self.app_name.clone()).set(size as f64);
+    }
+
     /// Records cache performance metrics.
     pub fn record_cache_metrics(&self, hits: u64, misses: u64, size: usize) {
         if !self.enabled {

--- a/crates/trusted-proxies/src/proxy/metrics.rs
+++ b/crates/trusted-proxies/src/proxy/metrics.rs
@@ -178,24 +178,22 @@ impl ProxyMetrics {
         });
     }
 
-    /// Records a cache hit and updates the cache size gauge.
-    pub fn record_cache_hit(&self, size: usize) {
+    /// Records a cache hit.
+    pub fn record_cache_hit(&self) {
         if !self.enabled {
             return;
         }
 
         counter!("rustfs_trusted_proxy_cache_hits_total", "app" => self.app_name.clone()).increment(1);
-        gauge!("rustfs_trusted_proxy_cache_size", "app" => self.app_name.clone()).set(size as f64);
     }
 
-    /// Records a cache miss and updates the cache size gauge.
-    pub fn record_cache_miss(&self, size: usize) {
+    /// Records a cache miss.
+    pub fn record_cache_miss(&self) {
         if !self.enabled {
             return;
         }
 
         counter!("rustfs_trusted_proxy_cache_misses_total", "app" => self.app_name.clone()).increment(1);
-        gauge!("rustfs_trusted_proxy_cache_size", "app" => self.app_name.clone()).set(size as f64);
     }
 
     /// Updates only the cache size gauge.

--- a/crates/trusted-proxies/src/proxy/validator.rs
+++ b/crates/trusted-proxies/src/proxy/validator.rs
@@ -19,7 +19,9 @@ use std::net::{IpAddr, SocketAddr};
 use std::time::Instant;
 use tracing::{debug, warn};
 
-use crate::{ProxyChainAnalyzer, ProxyError, ProxyMetrics, TrustedProxyConfig, ValidationMode};
+use crate::{
+    CacheConfig, CacheStats, IpValidationCache, ProxyChainAnalyzer, ProxyError, ProxyMetrics, TrustedProxyConfig, ValidationMode,
+};
 
 /// Information about the client extracted from the request and proxy headers.
 #[derive(Debug, Clone)]
@@ -95,6 +97,8 @@ pub struct ProxyValidator {
     config: TrustedProxyConfig,
     /// Analyzer for verifying the integrity of the proxy chain.
     chain_analyzer: ProxyChainAnalyzer,
+    /// Cache for repeated direct-peer trusted proxy decisions.
+    validation_cache: std::sync::Arc<IpValidationCache>,
     /// Metrics collector for observability.
     metrics: Option<ProxyMetrics>,
 }
@@ -102,24 +106,37 @@ pub struct ProxyValidator {
 impl ProxyValidator {
     /// Creates a new `ProxyValidator` with the given configuration and metrics.
     pub fn new(config: TrustedProxyConfig, metrics: Option<ProxyMetrics>) -> Self {
+        Self::with_cache_config(config, CacheConfig::default(), metrics)
+    }
+
+    /// Creates a new `ProxyValidator` with explicit cache configuration.
+    pub fn with_cache_config(config: TrustedProxyConfig, cache_config: CacheConfig, metrics: Option<ProxyMetrics>) -> Self {
         let chain_analyzer = ProxyChainAnalyzer::new(config.clone());
+        let cache_enabled = cache_config.capacity > 0 && cache_config.ttl_seconds > 0;
+        let validation_cache = std::sync::Arc::new(IpValidationCache::new(
+            cache_config.capacity,
+            cache_config.ttl_duration(),
+            cache_enabled,
+            metrics.clone(),
+        ));
 
         Self {
             config,
             chain_analyzer,
+            validation_cache,
             metrics,
         }
     }
 
     /// Validates an incoming request and extracts client information.
-    pub fn validate_request(&self, peer_addr: Option<SocketAddr>, headers: &HeaderMap) -> Result<ClientInfo, ProxyError> {
+    pub async fn validate_request(&self, peer_addr: Option<SocketAddr>, headers: &HeaderMap) -> Result<ClientInfo, ProxyError> {
         let start_time = Instant::now();
 
         // Record the start of the validation attempt.
         self.record_metric_start();
 
         // Perform the internal validation logic.
-        let result = self.validate_request_internal(peer_addr, headers);
+        let result = self.validate_request_internal(peer_addr, headers).await;
 
         // Record the result and duration.
         let duration = start_time.elapsed();
@@ -129,28 +146,46 @@ impl ProxyValidator {
     }
 
     /// Internal logic for request validation.
-    fn validate_request_internal(&self, peer_addr: Option<SocketAddr>, headers: &HeaderMap) -> Result<ClientInfo, ProxyError> {
+    async fn validate_request_internal(
+        &self,
+        peer_addr: Option<SocketAddr>,
+        headers: &HeaderMap,
+    ) -> Result<ClientInfo, ProxyError> {
         // Fallback to unspecified address if peer address is missing.
         let peer_addr = peer_addr.unwrap_or_else(|| SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 0));
+        let peer_ip = peer_addr.ip();
+        let is_trusted_proxy = self
+            .validation_cache
+            .is_trusted(&peer_ip, |ip| self.chain_analyzer.is_ip_trusted(ip))
+            .await;
 
         // Check if the direct peer is a trusted proxy.
-        if self.config.is_trusted(&peer_addr) {
-            debug!("Request received from trusted proxy: {}", peer_addr.ip());
+        if is_trusted_proxy {
+            debug!("Request received from trusted proxy: {}", peer_ip);
 
             // Parse and validate headers from the trusted proxy.
             self.validate_trusted_proxy_request(&peer_addr, headers)
         } else {
             // Log a warning if the request is from a private network but not trusted.
-            if self.config.is_private_network(&peer_addr.ip()) {
+            if self.config.is_private_network(&peer_ip) {
                 warn!(
                     "Request from private network but not trusted: {}. This might indicate a configuration issue.",
-                    peer_addr.ip()
+                    peer_ip
                 );
             }
 
             // Treat as a direct connection if the peer is not trusted.
             Ok(ClientInfo::direct(peer_addr))
         }
+    }
+
+    /// Returns cache statistics for direct-peer validation decisions.
+    pub fn cache_stats(&self) -> CacheStats {
+        self.validation_cache.stats()
+    }
+
+    pub(crate) fn validation_cache(&self) -> std::sync::Arc<IpValidationCache> {
+        self.validation_cache.clone()
     }
 
     /// Validates a request that originated from a trusted proxy.

--- a/crates/trusted-proxies/src/proxy/validator.rs
+++ b/crates/trusted-proxies/src/proxy/validator.rs
@@ -16,7 +16,8 @@
 
 use axum::http::HeaderMap;
 use std::net::{IpAddr, SocketAddr};
-use std::time::Instant;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tracing::{debug, warn};
 
 use crate::{
@@ -98,7 +99,7 @@ pub struct ProxyValidator {
     /// Analyzer for verifying the integrity of the proxy chain.
     chain_analyzer: ProxyChainAnalyzer,
     /// Cache for repeated direct-peer trusted proxy decisions.
-    validation_cache: std::sync::Arc<IpValidationCache>,
+    validation_cache: Arc<IpValidationCache>,
     /// Metrics collector for observability.
     metrics: Option<ProxyMetrics>,
 }
@@ -113,7 +114,7 @@ impl ProxyValidator {
     pub fn with_cache_config(config: TrustedProxyConfig, cache_config: CacheConfig, metrics: Option<ProxyMetrics>) -> Self {
         let chain_analyzer = ProxyChainAnalyzer::new(config.clone());
         let cache_enabled = cache_config.capacity > 0 && cache_config.ttl_seconds > 0;
-        let validation_cache = std::sync::Arc::new(IpValidationCache::new(
+        let validation_cache = Arc::new(IpValidationCache::new(
             cache_config.capacity,
             cache_config.ttl_duration(),
             cache_enabled,
@@ -129,14 +130,14 @@ impl ProxyValidator {
     }
 
     /// Validates an incoming request and extracts client information.
-    pub async fn validate_request(&self, peer_addr: Option<SocketAddr>, headers: &HeaderMap) -> Result<ClientInfo, ProxyError> {
+    pub fn validate_request(&self, peer_addr: Option<SocketAddr>, headers: &HeaderMap) -> Result<ClientInfo, ProxyError> {
         let start_time = Instant::now();
 
         // Record the start of the validation attempt.
         self.record_metric_start();
 
         // Perform the internal validation logic.
-        let result = self.validate_request_internal(peer_addr, headers).await;
+        let result = self.validate_request_internal(peer_addr, headers);
 
         // Record the result and duration.
         let duration = start_time.elapsed();
@@ -146,18 +147,13 @@ impl ProxyValidator {
     }
 
     /// Internal logic for request validation.
-    async fn validate_request_internal(
-        &self,
-        peer_addr: Option<SocketAddr>,
-        headers: &HeaderMap,
-    ) -> Result<ClientInfo, ProxyError> {
+    fn validate_request_internal(&self, peer_addr: Option<SocketAddr>, headers: &HeaderMap) -> Result<ClientInfo, ProxyError> {
         // Fallback to unspecified address if peer address is missing.
         let peer_addr = peer_addr.unwrap_or_else(|| SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 0));
         let peer_ip = peer_addr.ip();
         let is_trusted_proxy = self
             .validation_cache
-            .is_trusted(&peer_ip, |ip| self.chain_analyzer.is_ip_trusted(ip))
-            .await;
+            .is_trusted(&peer_ip, |ip| self.chain_analyzer.is_ip_trusted(ip));
 
         // Check if the direct peer is a trusted proxy.
         if is_trusted_proxy {
@@ -184,8 +180,24 @@ impl ProxyValidator {
         self.validation_cache.stats()
     }
 
-    pub(crate) fn validation_cache(&self) -> std::sync::Arc<IpValidationCache> {
-        self.validation_cache.clone()
+    pub(crate) fn spawn_cache_maintenance_task(self: &Arc<Self>, cleanup_interval: Duration) {
+        if cleanup_interval.is_zero() || !self.validation_cache.is_enabled() {
+            return;
+        }
+
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            tracing::debug!("No Tokio runtime available; trusted proxy cache maintenance is disabled");
+            return;
+        };
+
+        let cache = self.validation_cache.clone();
+        handle.spawn(async move {
+            let mut interval = tokio::time::interval(cleanup_interval);
+            loop {
+                interval.tick().await;
+                cache.run_maintenance();
+            }
+        });
     }
 
     /// Validates a request that originated from a trusted proxy.

--- a/crates/trusted-proxies/src/proxy/validator.rs
+++ b/crates/trusted-proxies/src/proxy/validator.rs
@@ -148,9 +148,17 @@ impl ProxyValidator {
 
     /// Internal logic for request validation.
     fn validate_request_internal(&self, peer_addr: Option<SocketAddr>, headers: &HeaderMap) -> Result<ClientInfo, ProxyError> {
-        // Fallback to unspecified address if peer address is missing.
-        let peer_addr = peer_addr.unwrap_or_else(|| SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 0));
+        let Some(peer_addr) = peer_addr else {
+            debug!("SocketAddr extension is missing; skipping trusted proxy evaluation");
+            return Ok(ClientInfo::direct(SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 0)));
+        };
+
         let peer_ip = peer_addr.ip();
+        if peer_ip.is_unspecified() {
+            debug!("Peer address is unspecified; skipping trusted proxy evaluation");
+            return Ok(ClientInfo::direct(peer_addr));
+        }
+
         let is_trusted_proxy = self
             .validation_cache
             .is_trusted(&peer_ip, |ip| self.chain_analyzer.is_ip_trusted(ip));

--- a/crates/trusted-proxies/tests/unit/validator_tests.rs
+++ b/crates/trusted-proxies/tests/unit/validator_tests.rs
@@ -105,9 +105,30 @@ fn test_validator_caches_untrusted_direct_peer_decision() {
 
     let first = validator.validate_request(peer_addr, &headers).unwrap();
     assert!(!first.is_from_trusted_proxy);
-    assert_eq!(validator.cache_stats().size, 1);
+    assert_eq!(validator.cache_stats().size, 0);
 
     let second = validator.validate_request(peer_addr, &headers).unwrap();
     assert!(!second.is_from_trusted_proxy);
-    assert_eq!(validator.cache_stats().size, 1);
+    assert_eq!(validator.cache_stats().size, 0);
+}
+
+#[test]
+fn test_validator_skips_cache_when_peer_addr_is_missing() {
+    let validator = ProxyValidator::with_cache_config(create_test_config(), CacheConfig::default(), None);
+    let headers = HeaderMap::new();
+
+    let client_info = validator.validate_request(None, &headers).unwrap();
+    assert!(!client_info.is_from_trusted_proxy);
+    assert_eq!(validator.cache_stats().size, 0);
+}
+
+#[test]
+fn test_validator_skips_cache_for_unspecified_peer_addr() {
+    let validator = ProxyValidator::with_cache_config(create_test_config(), CacheConfig::default(), None);
+    let peer_addr = Some(SocketAddr::new(IpAddr::from([0, 0, 0, 0]), 0));
+    let headers = HeaderMap::new();
+
+    let client_info = validator.validate_request(peer_addr, &headers).unwrap();
+    assert!(!client_info.is_from_trusted_proxy);
+    assert_eq!(validator.cache_stats().size, 0);
 }

--- a/crates/trusted-proxies/tests/unit/validator_tests.rs
+++ b/crates/trusted-proxies/tests/unit/validator_tests.rs
@@ -80,34 +80,34 @@ fn test_proxy_chain_too_long() {
     }
 }
 
-#[tokio::test]
-async fn test_validator_caches_trusted_direct_peer_decision() {
+#[test]
+fn test_validator_caches_trusted_direct_peer_decision() {
     let validator = ProxyValidator::with_cache_config(create_test_config(), CacheConfig::default(), None);
     let peer_addr = Some(SocketAddr::new(IpAddr::from_str("192.168.1.100").unwrap(), 8080));
     let headers = HeaderMap::new();
 
     assert_eq!(validator.cache_stats().size, 0);
 
-    let first = validator.validate_request(peer_addr, &headers).await.unwrap();
+    let first = validator.validate_request(peer_addr, &headers).unwrap();
     assert!(first.is_from_trusted_proxy);
     assert_eq!(validator.cache_stats().size, 1);
 
-    let second = validator.validate_request(peer_addr, &headers).await.unwrap();
+    let second = validator.validate_request(peer_addr, &headers).unwrap();
     assert!(second.is_from_trusted_proxy);
     assert_eq!(validator.cache_stats().size, 1);
 }
 
-#[tokio::test]
-async fn test_validator_caches_untrusted_direct_peer_decision() {
+#[test]
+fn test_validator_caches_untrusted_direct_peer_decision() {
     let validator = ProxyValidator::with_cache_config(create_test_config(), CacheConfig::default(), None);
     let peer_addr = Some(SocketAddr::new(IpAddr::from_str("203.0.113.8").unwrap(), 8080));
     let headers = HeaderMap::new();
 
-    let first = validator.validate_request(peer_addr, &headers).await.unwrap();
+    let first = validator.validate_request(peer_addr, &headers).unwrap();
     assert!(!first.is_from_trusted_proxy);
     assert_eq!(validator.cache_stats().size, 1);
 
-    let second = validator.validate_request(peer_addr, &headers).await.unwrap();
+    let second = validator.validate_request(peer_addr, &headers).unwrap();
     assert!(!second.is_from_trusted_proxy);
     assert_eq!(validator.cache_stats().size, 1);
 }

--- a/crates/trusted-proxies/tests/unit/validator_tests.rs
+++ b/crates/trusted-proxies/tests/unit/validator_tests.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use axum::http::HeaderMap;
-use rustfs_trusted_proxies::{ClientInfo, ProxyChainAnalyzer, ProxyValidator, TrustedProxy, TrustedProxyConfig, ValidationMode};
+use rustfs_trusted_proxies::{
+    CacheConfig, ClientInfo, ProxyChainAnalyzer, ProxyValidator, TrustedProxy, TrustedProxyConfig, ValidationMode,
+};
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
@@ -76,4 +78,36 @@ fn test_proxy_chain_too_long() {
         }
         _ => panic!("Expected ChainTooLong error"),
     }
+}
+
+#[tokio::test]
+async fn test_validator_caches_trusted_direct_peer_decision() {
+    let validator = ProxyValidator::with_cache_config(create_test_config(), CacheConfig::default(), None);
+    let peer_addr = Some(SocketAddr::new(IpAddr::from_str("192.168.1.100").unwrap(), 8080));
+    let headers = HeaderMap::new();
+
+    assert_eq!(validator.cache_stats().size, 0);
+
+    let first = validator.validate_request(peer_addr, &headers).await.unwrap();
+    assert!(first.is_from_trusted_proxy);
+    assert_eq!(validator.cache_stats().size, 1);
+
+    let second = validator.validate_request(peer_addr, &headers).await.unwrap();
+    assert!(second.is_from_trusted_proxy);
+    assert_eq!(validator.cache_stats().size, 1);
+}
+
+#[tokio::test]
+async fn test_validator_caches_untrusted_direct_peer_decision() {
+    let validator = ProxyValidator::with_cache_config(create_test_config(), CacheConfig::default(), None);
+    let peer_addr = Some(SocketAddr::new(IpAddr::from_str("203.0.113.8").unwrap(), 8080));
+    let headers = HeaderMap::new();
+
+    let first = validator.validate_request(peer_addr, &headers).await.unwrap();
+    assert!(!first.is_from_trusted_proxy);
+    assert_eq!(validator.cache_stats().size, 1);
+
+    let second = validator.validate_request(peer_addr, &headers).await.unwrap();
+    assert!(!second.is_from_trusted_proxy);
+    assert_eq!(validator.cache_stats().size, 1);
 }

--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -35,9 +35,6 @@ services:
       - RUSTFS_SECRET_KEY=rustfsadmin # CHANGEME
       - RUSTFS_OBS_LOGGER_LEVEL=info
       - RUSTFS_TLS_PATH=/opt/tls
-      # Object Cache
-      - RUSTFS_OBJECT_CACHE_ENABLE=true
-      - RUSTFS_OBJECT_CACHE_TTL_SECS=300
 
     volumes:
       - rustfs_data_0:/data/rustfs0

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -2077,7 +2077,6 @@ impl DefaultObjectUsecase {
             opts,
         } = request_context;
 
-        // Try to get from cache for small, frequently accessed objects
         let manager = get_concurrency_manager();
 
         let prepared_read = Self::prepare_get_object_read_execution(

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -159,9 +159,6 @@ $env:RUSTFS_NS_SCANNER_INTERVAL = "60"
 $env:RUSTFS_SCANNER_ENABLED = "false"
 $env:RUSTFS_HEAL_ENABLED = "false"
 
-# Object cache configuration
-$env:RUSTFS_OBJECT_CACHE_ENABLE = "true"
-
 # Profiling configuration
 $env:RUSTFS_ENABLE_PROFILING = "false"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -241,9 +241,6 @@ export RUSTFS_SCANNER_ENABLED=true
 
 export RUSTFS_HEAL_ENABLED=true
 
-# Object cache configuration
-export RUSTFS_OBJECT_CACHE_ENABLE=true
-
 # Profiling configuration
 export RUSTFS_ENABLE_PROFILING=false
 # Memory profiling periodic dump


### PR DESCRIPTION
  ## Type of Change
  - [ ] New Feature
  - [x] Bug Fix
  - [x] Documentation
  - [ ] Performance Improvement
  - [ ] Test/CI
  - [x] Refactor
  - [ ] Other:

  ## Related Issues
  N/A

  ## Summary of Changes
  This PR cleans up stale cache-related traces and wires the trusted proxy cache into the real request validation path.

  Main changes:
  - Removed stale object-cache references that no longer have any runtime implementation:
    - deleted the misleading cache comment in the GetObject path
    - removed obsolete `RUSTFS_OBJECT_CACHE_*` examples from local scripts and `docker-compose-simple.yml`
    - removed undocumented/no-op generic cache env docs from `crates/io-metrics/README_zh.md`
  - Wired `RUSTFS_TRUSTED_PROXY_CACHE_CAPACITY`, `RUSTFS_TRUSTED_PROXY_CACHE_TTL_SECONDS`, and
  `RUSTFS_TRUSTED_PROXY_CACHE_CLEANUP_INTERVAL` into the actual trusted-proxy request path
  - Added direct-peer trusted proxy decision caching in `rustfs-trusted-proxies`
  - Refactored the trusted-proxy cache integration to keep the validation hot path synchronous and lightweight:
    - switched to `moka::sync::Cache` for the hot path
    - restored synchronous validator and middleware flow
    - moved cache maintenance ownership to the validator side instead of layering extra async middleware complexity
  - Added targeted unit coverage for trusted and untrusted direct-peer cache reuse

  ## Checklist
  - [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
  - [x] Passed `make pre-commit`
  - [x] Added/updated necessary tests
  - [x] Documentation updated (if needed)
  - [ ] CI/CD passed (if applicable)

  ## Impact
  - [ ] Breaking change (compatibility)
  - [x] Requires doc/config/deployment update
  - [x] Other impact:
    - `RUSTFS_OBJECT_CACHE_ENABLE` and `RUSTFS_OBJECT_CACHE_TTL_SECS` were removed from example scripts/compose because
  they were stale no-op remnants
    - trusted proxy cache envs are now active in the real validation path instead of being parsed only

  ## Additional Notes
  Verification commands run:
  - `cargo fmt --all`
  - `cargo test -p rustfs-trusted-proxies`
  - `make pre-commit`

  Reviewer notes:
  - The trusted-proxy cache now affects real request handling by caching repeated direct-peer trust decisions before
  proxy-chain parsing.
  - The cache integration was intentionally refactored away from boxed async middleware futures to keep the request hot
  path simpler and lower overhead.
  - Operators should remove any reliance on the old `RUSTFS_OBJECT_CACHE_*` example variables; they did not correspond to
  an active runtime object cache.

  ---

  Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md]
  (CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/
  blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.