### PR TITLE
fix(admin): accept trailing slash listen notification paths

### DIFF
--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -271,7 +271,6 @@ fn is_valid_filter_rule_value(value: &str) -> bool {
 
 fn extract_bucket_for_bucket_level_path(path: &str) -> Option<String> {
     let bucket = path.strip_prefix('/')?;
-    let bucket = bucket.strip_suffix('/').unwrap_or(bucket);
     if bucket.is_empty() || bucket.contains('/') {
         return None;
     }
@@ -344,7 +343,8 @@ fn parse_misc_extension_request(method: &Method, uri: &Uri) -> Option<MiscExtRou
         if uri.path() == "/" {
             return Some(MiscExtRoute::ListenNotification { bucket: None });
         }
-        if let Some(bucket) = extract_bucket_for_bucket_level_path(uri.path()) {
+        let path = uri.path().strip_suffix('/').unwrap_or(uri.path());
+        if let Some(bucket) = extract_bucket_for_bucket_level_path(path) {
             return Some(MiscExtRoute::ListenNotification { bucket: Some(bucket) });
         }
     }
@@ -2493,12 +2493,14 @@ mod tests {
         let object_level: Uri = "/demo-bucket/path/file?replication-metrics"
             .parse()
             .expect("uri should parse");
+        let bucket_trailing_slash: Uri = "/demo-bucket/?replication-metrics".parse().expect("uri should parse");
         let invalid_value: Uri = "/demo-bucket?replication-metrics=1".parse().expect("uri should parse");
         let wrong_method: Uri = "/demo-bucket?replication-check".parse().expect("uri should parse");
         let wrong_method_reset: Uri = "/demo-bucket?replication-reset".parse().expect("uri should parse");
         let wrong_method_status: Uri = "/demo-bucket?replication-reset-status".parse().expect("uri should parse");
 
         assert!(parse_replication_extension_request(&Method::GET, &object_level).is_none());
+        assert!(parse_replication_extension_request(&Method::GET, &bucket_trailing_slash).is_none());
         assert!(parse_replication_extension_request(&Method::GET, &invalid_value).is_none());
         assert!(parse_replication_extension_request(&Method::PUT, &wrong_method).is_none());
         assert!(parse_replication_extension_request(&Method::GET, &wrong_method_reset).is_none());

--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -271,6 +271,7 @@ fn is_valid_filter_rule_value(value: &str) -> bool {
 
 fn extract_bucket_for_bucket_level_path(path: &str) -> Option<String> {
     let bucket = path.strip_prefix('/')?;
+    let bucket = bucket.strip_suffix('/').unwrap_or(bucket);
     if bucket.is_empty() || bucket.contains('/') {
         return None;
     }
@@ -3099,6 +3100,7 @@ mod tests {
             .parse()
             .expect("uri should parse");
         let listen_bucket: Uri = "/demo-bucket?events=s3:ObjectCreated:*".parse().expect("uri should parse");
+        let listen_bucket_trailing_slash: Uri = "/demo-bucket/?events=s3:ObjectCreated:*".parse().expect("uri should parse");
         let listen_root: Uri = "/?events=s3:ObjectRemoved:*".parse().expect("uri should parse");
 
         let object_route = parse_misc_extension_request(&Method::GET, &object_lambda).expect("object lambda route should parse");
@@ -3114,6 +3116,15 @@ mod tests {
             parse_misc_extension_request(&Method::GET, &listen_bucket).expect("bucket listen route should parse");
         assert_eq!(
             listen_bucket_route,
+            MiscExtRoute::ListenNotification {
+                bucket: Some("demo-bucket".to_string())
+            }
+        );
+
+        let listen_bucket_trailing_slash_route = parse_misc_extension_request(&Method::GET, &listen_bucket_trailing_slash)
+            .expect("bucket listen route with trailing slash should parse");
+        assert_eq!(
+            listen_bucket_trailing_slash_route,
             MiscExtRoute::ListenNotification {
                 bucket: Some("demo-bucket".to_string())
             }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Closes #2559

## Summary of Changes
This fixes path-style bucket watch requests used by MinIO clients. minio-go sends ListenBucketNotification requests for a bucket root as `/{bucket}/?events=...`; RustFS only recognized `/{bucket}?events=...`, so the request fell through to the regular S3 ListObjects path and surfaced `NotImplemented`.

- Normalize a trailing slash only for bucket-level misc extension routes.
- Keep object-level paths such as `/bucket/object?...` out of this extension route.
- Add route coverage for `/{bucket}/?events=...`.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

Validation:
- `make pre-commit`
- `cargo build --bin rustfs`
- Real `mc mirror --watch` against a local RustFS build with a path-style alias; a new object synced without `NotImplemented` or watch errors.

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Restores compatibility for bucket-level `mc mirror --watch` requests that include a trailing slash before the `events` query.

## Additional Notes
No S3 object path routing is changed; the normalization is only applied before rejecting paths that still contain a slash after the bucket segment.
