### PR TITLE
test(s3): cover signed equals object reads

### DIFF
--- a/crates/e2e_test/src/special_chars_test.rs
+++ b/crates/e2e_test/src/special_chars_test.rs
@@ -333,6 +333,44 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn test_signed_get_existing_object_with_trailing_equals_returns_content() -> Result<(), Box<dyn Error + Send + Sync>> {
+        init_logging();
+
+        let mut env = RustFSTestEnvironment::new().await?;
+        env.start_rustfs_server(vec![]).await?;
+
+        let client = create_s3_client(&env);
+        let bucket = "test-existing-equals-key";
+        create_bucket(&client, bucket).await?;
+
+        let key = "path/sitemap.xmlage=";
+        let content = b"object content for raw signed URL with trailing equals";
+        client
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(ByteStream::from_static(content))
+            .send()
+            .await?;
+
+        let url = format!("{}/{}/{}", env.url, bucket, key);
+        let response = signed_get(&url, &env.access_key, &env.secret_key).await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "existing object key ending with '=' should pass signature validation and return content"
+        );
+
+        let body = response.bytes().await?;
+        assert_eq!(body.as_ref(), content);
+
+        env.stop_server();
+        Ok(())
+    }
+
     /// Test DELETE operation with special characters
     #[tokio::test]
     #[serial]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This PR adds focused end-to-end coverage for a recently fixed SigV4/raw URI edge case involving object keys that end with `=`.

The existing regression coverage verifies that a signed raw GET for a missing trailing-`=` key reaches object lookup and returns `NoSuchKey`. This adds the complementary success path: create an object whose key ends with `=`, sign a raw GET request manually, and assert that RustFS returns `200 OK` with the original object bytes.

The user-facing effect covered by this test is that clients using raw signed URLs for object names containing trailing equals signs can retrieve existing objects without the request being rejected during signature validation.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Adds regression coverage only; no production behavior changes.

## Additional Notes
Verification:

- `cargo test -p e2e_test test_signed_get_existing_object_with_trailing_equals_returns_content -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
