### PR TITLE
test: cover S3 error XML body compatibility

### DIFF
--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -871,6 +871,30 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_fix_s3_error_message_in_xml_reports_changed_body() {
+        let body = Full::from(Bytes::from_static(b"<Error><Code>SignatureDoesNotMatch</Code></Error>"));
+
+        let (fixed, changed) = fix_s3_error_message_in_xml(body).await.unwrap();
+        let bytes = BodyExt::collect(fixed).await.unwrap().to_bytes();
+
+        assert!(changed);
+        assert!(bytes.starts_with(b"<Error><Code>SignatureDoesNotMatch</Code><Message>"));
+        assert!(bytes.ends_with(b"</Message></Error>"));
+    }
+
+    #[tokio::test]
+    async fn test_fix_s3_error_message_in_xml_reports_unchanged_body() {
+        let input = Bytes::from_static(b"<Error><Code>AccessDenied</Code></Error>");
+        let body = Full::from(input.clone());
+
+        let (fixed, changed) = fix_s3_error_message_in_xml(body).await.unwrap();
+        let bytes = BodyExt::collect(fixed).await.unwrap().to_bytes();
+
+        assert!(!changed);
+        assert_eq!(bytes, input);
+    }
+
     #[test]
     fn test_insert_missing_signature_error_message() {
         let (fixed, changed) =


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This PR adds focused regression coverage for the S3 error XML compatibility path introduced for GitLab registry interoperability.

The compatibility layer fills in a missing `<Message>` element for `SignatureDoesNotMatch` XML errors. The existing tests covered the string insertion helper, but not the body-level helper that consumes the HTTP body and reports whether the response changed. Without that coverage, regressions in body collection, unchanged-body handling, or the changed flag could slip through while the string-only test still passed.

The new tests verify that `fix_s3_error_message_in_xml` rewrites a `SignatureDoesNotMatch` XML body and reports `changed = true`, and preserves unrelated S3 XML error bodies with `changed = false`.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Test-only change for S3 error XML compatibility coverage.

## Additional Notes
Verification performed:

- `cargo test -p rustfs --lib server::layer::tests::test_fix_s3_error_message_in_xml -- --nocapture`
- `cargo fmt --all && cargo fmt --all --check`
- `make pre-commit`
