### PR TITLE
fix(admin): authorize cross-user ListServiceAccount with ListServiceAccount

### DIFF
--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -925,11 +925,13 @@ impl Operation for ListServiceAccount {
         };
 
         let target_account = if query.user.as_ref().is_some_and(|v| v != &cred.access_key) {
+            // Cross-user listing must be authorized by ListServiceAccounts, matching the
+            // sibling InfoServiceAccount/InfoAccessKey/ListAccessKeysBulk handlers.
             if !iam_store
                 .is_allowed(&Args {
                     account: &cred.access_key,
                     groups: &cred.groups,
-                    action: Action::AdminAction(AdminAction::UpdateServiceAccountAdminAction),
+                    action: Action::AdminAction(AdminAction::ListServiceAccountsAdminAction),
                     bucket: "",
                     conditions: &get_condition_values(
                         &req.headers,


### PR DESCRIPTION

<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other: N/A

## Related Issues
N/A

## Summary of Changes
This PR fixes an authorization mismatch in the cross-user branch of the list-service-accounts admin handler.

Before this change, ListServiceAccount authorization for requests like GET /rustfs/admin/v3/list-service-accounts?user=<other_user> was checked against admin:UpdateServiceAccount, which is incorrect for a list operation. This caused permission inversion:
- Principals with admin:UpdateServiceAccount could list cross-user service accounts.
- Principals with admin:ListServiceAccounts could be denied.

This PR updates the action check to admin:ListServiceAccounts in ListServiceAccount::call, aligning behavior with sibling handlers that already use ListServiceAccountsAdminAction.

Changed file:
- service_account.rs

Scope note:
- This PR only fixes the wrong action constant in the list handler.
- It does not change UpdateServiceAccount ownership validation logic.

## Checklist
- [x] I have read and followed the CONTRIBUTING.md guidelines
- [x] Passed make pre-commit
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Restores expected IAM semantics for cross-user service-account listing by enforcing admin:ListServiceAccounts instead of admin:UpdateServiceAccount.

## Additional Notes
Verification performed locally:
- make pre-commit
- cargo fmt --all --check
- cargo clippy --all-targets --workspace -- -D warnings
- cargo test -p rustfs --lib admin::handlers::service_account::

Branch and commit:
- Branch: fix/list-service-accounts-action
- Commit: 37bbc3686c4661bd366876d15bbb082757b6f829

---

Thank you for your contribution! Please ensure your PR follows the community standards (CODE_OF_CONDUCT.md). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting I have read and agree to the CLA.