### PR TITLE
fix(admin): enforce owner check for service account update

### DIFF
--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -79,6 +79,16 @@ fn delete_service_account_success_status(path: &str) -> StatusCode {
     }
 }
 
+fn is_service_account_owner_of(caller: &StoredCredentials, target_parent_user: &str) -> bool {
+    let caller_parent = if caller.parent_user.is_empty() {
+        caller.access_key.as_str()
+    } else {
+        caller.parent_user.as_str()
+    };
+
+    caller_parent == target_parent_user
+}
+
 fn map_service_account_lookup_error(err: rustfs_iam::error::Error, action: &str) -> S3Error {
     debug!("{action}, e: {:?}", err);
     if is_err_no_such_service_account(&err) {
@@ -551,6 +561,15 @@ impl Operation for UpdateServiceAccount {
             })
             .await
         {
+            return Err(s3_error!(AccessDenied, "access denied"));
+        }
+
+        let (svc_account, _) = iam_store
+            .get_service_account(&access_key)
+            .await
+            .map_err(|e| map_service_account_lookup_error(e, "get service account failed"))?;
+
+        if !is_service_account_owner_of(&cred, &svc_account.parent_user) {
             return Err(s3_error!(AccessDenied, "access denied"));
         }
 
@@ -1483,5 +1502,28 @@ mod tests {
         let policy = policy.unwrap();
         assert!(policy.version.is_empty());
         assert!(policy.statements.is_empty());
+    }
+
+    #[test]
+    fn update_service_account_requires_requester_parent_match() {
+        let parent_owner = StoredCredentials {
+            access_key: "owner-user".to_string(),
+            parent_user: String::new(),
+            ..Default::default()
+        };
+        let derived_owner = StoredCredentials {
+            access_key: "sa-user".to_string(),
+            parent_user: "owner-user".to_string(),
+            ..Default::default()
+        };
+        let foreign_user = StoredCredentials {
+            access_key: "other".to_string(),
+            parent_user: String::new(),
+            ..Default::default()
+        };
+
+        assert!(is_service_account_owner_of(&parent_owner, "owner-user"));
+        assert!(is_service_account_owner_of(&derived_owner, "owner-user"));
+        assert!(!is_service_account_owner_of(&foreign_user, "owner-user"));
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- Security report: wrong action handling and unauthorized service account secret update path in `UpdateServiceAccount`.

## Summary of Changes
- Add ownership verification to `UpdateServiceAccount::call` so updates are limited to service accounts owned by the caller (or caller parent account).
- Reuse helper `is_service_account_owner_of` for parent-account matching logic.
- Add unit test `update_service_account_requires_requester_parent_match` covering parent user and derived-user authorization.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:
  - Closes a privilege-escalation primitive: a principal with `admin:UpdateServiceAccount` can no longer change secrets for arbitrary service accounts outside its ownership scope.

## Additional Notes
- This addresses the ownership-check gap described in the vulnerability report and complements the cross-account list authorization fix path.