### PR TITLE
test(admin): cover list service account authorization

### DIFF
--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -1444,6 +1444,26 @@ mod tests {
     }
 
     #[test]
+    fn list_service_account_cross_user_uses_list_service_accounts_action() {
+        let src = include_str!("service_account.rs");
+        let list_block =
+            extract_block_between_markers(src, "impl Operation for ListServiceAccount", "struct ListAccessKeysQuery");
+
+        assert!(
+            list_block.contains("query.user.as_ref().is_some_and(|v| v != &cred.access_key)"),
+            "cross-user ListServiceAccount path should stay explicitly guarded"
+        );
+        assert!(
+            list_block.contains("Action::AdminAction(AdminAction::ListServiceAccountsAdminAction)"),
+            "cross-user ListServiceAccount should authorize with ListServiceAccountsAdminAction"
+        );
+        assert!(
+            !list_block.contains("Action::AdminAction(AdminAction::UpdateServiceAccountAdminAction)"),
+            "cross-user ListServiceAccount must not require UpdateServiceAccountAdminAction"
+        );
+    }
+
+    #[test]
     fn delete_service_account_uses_external_success_status() {
         assert_eq!(
             delete_service_account_success_status("/minio/admin/v3/delete-service-account"),
@@ -1525,5 +1545,12 @@ mod tests {
         assert!(is_service_account_owner_of(&parent_owner, "owner-user"));
         assert!(is_service_account_owner_of(&derived_owner, "owner-user"));
         assert!(!is_service_account_owner_of(&foreign_user, "owner-user"));
+    }
+
+    fn extract_block_between_markers<'a>(src: &'a str, start_marker: &str, end_marker: &str) -> &'a str {
+        let start = src.find(start_marker).expect("start marker should exist");
+        let rest = &src[start..];
+        let end = rest.find(end_marker).expect("end marker should exist");
+        &rest[..end]
     }
 }

--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -1446,19 +1446,25 @@ mod tests {
     #[test]
     fn list_service_account_cross_user_uses_list_service_accounts_action() {
         let src = include_str!("service_account.rs");
-        let list_block =
-            extract_block_between_markers(src, "impl Operation for ListServiceAccount", "struct ListAccessKeysQuery");
+        let list_start = src
+            .find("impl Operation for ListServiceAccount")
+            .expect("ListServiceAccount operation should exist");
+        let list_block = &src[list_start..];
+        let list_end = list_block
+            .find("struct ListAccessKeysQuery")
+            .expect("ListAccessKeysQuery marker should exist");
+        let list_block = &list_block[..list_end];
 
         assert!(
-            list_block.contains("query.user.as_ref().is_some_and(|v| v != &cred.access_key)"),
+            list_block.contains("query.user.as_ref().is_some_and(") && list_block.contains("v != &cred.access_key"),
             "cross-user ListServiceAccount path should stay explicitly guarded"
         );
         assert!(
-            list_block.contains("Action::AdminAction(AdminAction::ListServiceAccountsAdminAction)"),
+            list_block.contains("ListServiceAccountsAdminAction"),
             "cross-user ListServiceAccount should authorize with ListServiceAccountsAdminAction"
         );
         assert!(
-            !list_block.contains("Action::AdminAction(AdminAction::UpdateServiceAccountAdminAction)"),
+            !list_block.contains("UpdateServiceAccountAdminAction"),
             "cross-user ListServiceAccount must not require UpdateServiceAccountAdminAction"
         );
     }
@@ -1545,12 +1551,5 @@ mod tests {
         assert!(is_service_account_owner_of(&parent_owner, "owner-user"));
         assert!(is_service_account_owner_of(&derived_owner, "owner-user"));
         assert!(!is_service_account_owner_of(&foreign_user, "owner-user"));
-    }
-
-    fn extract_block_between_markers<'a>(src: &'a str, start_marker: &str, end_marker: &str) -> &'a str {
-        let start = src.find(start_marker).expect("start marker should exist");
-        let rest = &src[start..];
-        let end = rest.find(end_marker).expect("end marker should exist");
-        &rest[..end]
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This adds focused regression coverage for the recent `ListServiceAccount` authorization fix. Cross-user service account listing should be authorized by `admin:ListServiceAccounts`, matching the sibling service-account read paths, and must not regress to requiring `admin:UpdateServiceAccount`.

The test inspects the `ListServiceAccount` handler block and asserts that the cross-user branch stays explicit, uses `ListServiceAccountsAdminAction`, and does not use `UpdateServiceAccountAdminAction`. This keeps the coverage narrow to the changed admin handler behavior without introducing a broad or fragile IAM integration fixture.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: test-only change, no runtime behavior change

## Additional Notes
Verification:

- `cargo test -p rustfs list_service_account_cross_user_uses_list_service_accounts_action`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`
