### PR TITLE
fix(console): block disabled health probes from SPA fallback

### DIFF
--- a/rustfs/src/admin/console.rs
+++ b/rustfs/src/admin/console.rs
@@ -470,6 +470,17 @@ fn setup_console_middleware_stack(
         app = app
             .route(&format!("{CONSOLE_PREFIX}{HEALTH_PREFIX}"), get(health_check).head(health_check))
             .route(&format!("{CONSOLE_PREFIX}{HEALTH_READY_PATH}"), get(health_check).head(health_check));
+    } else {
+        // Keep disabled health probes from falling through to the SPA fallback.
+        app = app
+            .route(
+                &format!("{CONSOLE_PREFIX}{HEALTH_PREFIX}"),
+                get(health_route_disabled).head(health_route_disabled),
+            )
+            .route(
+                &format!("{CONSOLE_PREFIX}{HEALTH_READY_PATH}"),
+                get(health_route_disabled).head(health_route_disabled),
+            );
     }
 
     // Add comprehensive middleware layers using tower-http features
@@ -590,6 +601,10 @@ async fn health_check(method: Method, uri: Uri) -> Response {
     }
 }
 
+async fn health_route_disabled() -> StatusCode {
+    StatusCode::NOT_FOUND
+}
+
 /// Parse CORS allowed origins from configuration
 ///
 /// # Arguments:
@@ -664,6 +679,7 @@ mod tests {
     use axum::body::Body;
     use http::{Request, StatusCode};
     use std::net::{IpAddr, Ipv4Addr};
+    use temp_env::async_with_vars;
     use tower::ServiceExt;
 
     #[test]
@@ -709,5 +725,36 @@ mod tests {
             response.headers().contains_key("x-request-id"),
             "console response should include propagated x-request-id header"
         );
+    }
+
+    #[tokio::test]
+    async fn console_middleware_stack_hides_health_routes_when_disabled() {
+        async_with_vars([(rustfs_config::ENV_HEALTH_ENDPOINT_ENABLE, Some("false"))], async {
+            let app = setup_console_middleware_stack(parse_cors_origins(None), false, 0, 30);
+
+            let health_response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(format!("{CONSOLE_PREFIX}{HEALTH_PREFIX}"))
+                        .body(Body::empty())
+                        .expect("failed to build health request"),
+                )
+                .await
+                .expect("health request should complete");
+            assert_eq!(health_response.status(), StatusCode::NOT_FOUND);
+
+            let readiness_response = app
+                .oneshot(
+                    Request::builder()
+                        .uri(format!("{CONSOLE_PREFIX}{HEALTH_READY_PATH}"))
+                        .body(Body::empty())
+                        .expect("failed to build readiness request"),
+                )
+                .await
+                .expect("readiness request should complete");
+            assert_eq!(readiness_response.status(), StatusCode::NOT_FOUND);
+        })
+        .await;
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
- N/A

## Summary of Changes
This PR fixes a console routing gap introduced by the health endpoint toggle in #2662. When `RUSTFS_HEALTH_ENDPOINT_ENABLE=false`, the admin router already stopped registering `/health` and `/health/ready`, but the console router still let those paths fall through to the SPA fallback and return a `200` response instead of a disabled probe response.

The fix adds explicit `404 Not Found` handlers for the console health probe paths when the toggle is disabled, so the console surface now matches the documented behavior of the config flag. A focused regression test covers both `/rustfs/console/health` and `/rustfs/console/health/ready` under the disabled setting.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
  Console health probes now return `404` when explicitly disabled instead of falling back to the SPA shell.

## Additional Notes
Validation used:
- `cargo test -p rustfs console_middleware_stack_hides_health_routes_when_disabled -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`
