### PR TITLE
fix(audit): remove unwrap from target shutdown path

### DIFF
--- a/crates/audit/src/registry.rs
+++ b/crates/audit/src/registry.rs
@@ -200,8 +200,8 @@ impl AuditRegistry {
             }
         }
 
-        if !errors.is_empty() {
-            return Err(AuditError::Target(errors.into_iter().next().unwrap()));
+        if let Some(error) = errors.into_iter().next() {
+            return Err(AuditError::Target(error));
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- replace the unwrap in AuditRegistry::close_all with an if let Some(error) branch so the shutdown path stays within the crate panic policy