### PR TITLE
feat(ecstore): enforce local disk topology guardrails and expose device ids

### DIFF
--- a/crates/config/src/constants/app.rs
+++ b/crates/config/src/constants/app.rs
@@ -131,6 +131,12 @@ pub const ENV_RUSTFS_ADDRESS: &str = "RUSTFS_ADDRESS";
 /// Environment variable for server volumes.
 pub const ENV_RUSTFS_VOLUMES: &str = "RUSTFS_VOLUMES";
 
+/// Environment variable to explicitly bypass local physical disk independence checks.
+pub const ENV_UNSAFE_BYPASS_DISK_CHECK: &str = "RUSTFS_UNSAFE_BYPASS_DISK_CHECK";
+
+/// Default flag value for bypassing local physical disk independence checks.
+pub const DEFAULT_UNSAFE_BYPASS_DISK_CHECK: bool = false;
+
 /// Environment variable for server access key.
 pub const ENV_RUSTFS_ACCESS_KEY: &str = "RUSTFS_ACCESS_KEY";
 

--- a/crates/config/src/constants/app.rs
+++ b/crates/config/src/constants/app.rs
@@ -134,6 +134,12 @@ pub const ENV_RUSTFS_VOLUMES: &str = "RUSTFS_VOLUMES";
 /// Environment variable to explicitly bypass local physical disk independence checks.
 pub const ENV_UNSAFE_BYPASS_DISK_CHECK: &str = "RUSTFS_UNSAFE_BYPASS_DISK_CHECK";
 
+/// Compatibility alias used by legacy MinIO CI pipelines.
+///
+/// RustFS keeps this alias for backward compatibility only. Prefer
+/// `ENV_UNSAFE_BYPASS_DISK_CHECK` for explicit bypass control.
+pub const ENV_MINIO_CI: &str = "MINIO_CI";
+
 /// Default flag value for bypassing local physical disk independence checks.
 pub const DEFAULT_UNSAFE_BYPASS_DISK_CHECK: bool = false;
 

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -126,7 +126,7 @@ metrics = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 criterion = { workspace = true, features = ["html_reports"] }
-temp-env = { workspace = true }
+temp-env = { workspace = true, features = ["async_closure"] }
 tracing-subscriber = { workspace = true }
 serial_test = { workspace = true }
 opentelemetry_sdk = { workspace = true }

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -170,22 +170,21 @@ impl LocalDisk {
             file_info: format_meta,
             last_check: format_last_check,
         };
-        let physical_device_ids = match rustfs_utils::os::get_physical_device_ids(root.to_string_lossy().as_ref()) {
-            Ok(ids) => ids,
-            Err(err) => {
-                warn!(root = ?root, error = ?err, "failed to resolve physical device ids for disk root");
-                Vec::new()
-            }
-        };
         let root_clone = root.clone();
-        let physical_device_ids_clone = physical_device_ids.clone();
         let update_fn: UpdateFn<DiskInfo> = Box::new(move || {
             let disk_id = id;
             let root = root_clone.clone();
-            let physical_device_ids = physical_device_ids_clone.clone();
             Box::pin(async move {
                 match get_disk_info(root.clone()).await {
                     Ok((info, root_disk)) => {
+                        let physical_device_ids = match rustfs_utils::os::get_physical_device_ids(root.to_string_lossy().as_ref())
+                        {
+                            Ok(ids) => ids,
+                            Err(err) => {
+                                warn!(root = ?root, error = ?err, "failed to resolve physical device ids for disk root");
+                                Vec::new()
+                            }
+                        };
                         let disk_info = DiskInfo {
                             total: info.total,
                             free: info.free,

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -170,13 +170,16 @@ impl LocalDisk {
             file_info: format_meta,
             last_check: format_last_check,
         };
+        let physical_device_ids = rustfs_utils::os::get_physical_device_ids(root.to_string_lossy().as_ref()).unwrap_or_default();
         let root_clone = root.clone();
+        let physical_device_ids_clone = physical_device_ids.clone();
         let update_fn: UpdateFn<DiskInfo> = Box::new(move || {
             let disk_id = id;
             let root = root_clone.clone();
+            let physical_device_ids = physical_device_ids_clone.clone();
             Box::pin(async move {
                 match get_disk_info(root.clone()).await {
-                    Ok((info, root)) => {
+                    Ok((info, root_disk)) => {
                         let disk_info = DiskInfo {
                             total: info.total,
                             free: info.free,
@@ -186,7 +189,8 @@ impl LocalDisk {
                             major: info.major,
                             minor: info.minor,
                             fs_type: info.fstype,
-                            root_disk: root,
+                            root_disk,
+                            physical_device_ids,
                             id: disk_id,
                             ..Default::default()
                         };

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -170,7 +170,13 @@ impl LocalDisk {
             file_info: format_meta,
             last_check: format_last_check,
         };
-        let physical_device_ids = rustfs_utils::os::get_physical_device_ids(root.to_string_lossy().as_ref()).unwrap_or_default();
+        let physical_device_ids = match rustfs_utils::os::get_physical_device_ids(root.to_string_lossy().as_ref()) {
+            Ok(ids) => ids,
+            Err(err) => {
+                warn!(root = ?root, error = ?err, "failed to resolve physical device ids for disk root");
+                Vec::new()
+            }
+        };
         let root_clone = root.clone();
         let physical_device_ids_clone = physical_device_ids.clone();
         let update_fn: UpdateFn<DiskInfo> = Box::new(move || {

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -596,6 +596,8 @@ pub struct DiskInfo {
     pub scanning: bool,
     pub endpoint: String,
     pub mount_path: String,
+    /// Leaf physical block devices backing this mount path when available.
+    pub physical_device_ids: Vec<String>,
     pub id: Option<Uuid>,
     pub rotational: bool,
     pub metrics: DiskMetrics,

--- a/crates/ecstore/src/endpoints.rs
+++ b/crates/ecstore/src/endpoints.rs
@@ -658,12 +658,16 @@ fn validate_local_physical_disk_independence(pools: &[Endpoints]) -> Result<()> 
         }
     }
 
-    if local_paths.len() <= 1 {
+    if local_paths.is_empty() {
         return Ok(());
     }
 
     let local_paths = local_paths.into_iter().collect::<Vec<_>>();
     validate_local_cross_device_mounts(&local_paths)?;
+
+    if local_paths.len() <= 1 {
+        return Ok(());
+    }
 
     if rustfs_utils::get_env_bool(ENV_UNSAFE_BYPASS_DISK_CHECK, DEFAULT_UNSAFE_BYPASS_DISK_CHECK) {
         warn!(

--- a/crates/ecstore/src/endpoints.rs
+++ b/crates/ecstore/src/endpoints.rs
@@ -1515,7 +1515,7 @@ mod test {
     #[serial]
     #[tokio::test]
     async fn reject_shared_local_physical_disks_by_default() {
-        async_with_vars([(ENV_UNSAFE_BYPASS_DISK_CHECK, None), (ENV_MINIO_CI, None)], async {
+        async_with_vars([(ENV_UNSAFE_BYPASS_DISK_CHECK, None::<&str>), (ENV_MINIO_CI, None::<&str>)], async {
             let dir = tempdir().unwrap();
             let disk1 = dir.path().join("disk1");
             let disk2 = dir.path().join("disk2");
@@ -1560,7 +1560,7 @@ mod test {
     #[serial]
     #[tokio::test]
     async fn allow_shared_local_physical_disks_with_minio_ci_alias() {
-        async_with_vars([(ENV_UNSAFE_BYPASS_DISK_CHECK, None), (ENV_MINIO_CI, Some("1"))], async {
+        async_with_vars([(ENV_UNSAFE_BYPASS_DISK_CHECK, None::<&str>), (ENV_MINIO_CI, Some("1"))], async {
             let dir = tempdir().unwrap();
             let disk1 = dir.path().join("disk1");
             let disk2 = dir.path().join("disk2");

--- a/crates/ecstore/src/endpoints.rs
+++ b/crates/ecstore/src/endpoints.rs
@@ -17,10 +17,11 @@ use crate::{
     disks_layout::DisksLayout,
     global::global_rustfs_port,
 };
+use rustfs_config::{DEFAULT_UNSAFE_BYPASS_DISK_CHECK, ENV_UNSAFE_BYPASS_DISK_CHECK};
 use rustfs_utils::{XHost, check_local_server_addr, get_host_ip, is_local_host};
 use std::{
-    collections::{HashMap, HashSet, hash_map::Entry},
-    io::{Error, Result},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, hash_map::Entry},
+    io::{Error, ErrorKind, Result},
     net::IpAddr,
 };
 use tracing::{error, info, instrument, warn};
@@ -348,6 +349,8 @@ impl PoolEndpointList {
             }
         }
 
+        validate_local_physical_disk_independence(pool_endpoint_list.as_ref())?;
+
         let setup_type = match pool_endpoint_list.as_ref()[0].as_ref()[0].get_type() {
             EndpointType::Path => SetupType::Erasure,
             EndpointType::Url => match unique_args.len() {
@@ -645,12 +648,99 @@ impl EndpointServerPools {
     }
 }
 
+fn validate_local_physical_disk_independence(pools: &[Endpoints]) -> Result<()> {
+    let mut local_paths = BTreeSet::new();
+    for endpoints in pools {
+        for endpoint in endpoints.as_ref() {
+            if endpoint.is_local {
+                local_paths.insert(endpoint.get_file_path());
+            }
+        }
+    }
+
+    if local_paths.len() <= 1 {
+        return Ok(());
+    }
+
+    let local_paths = local_paths.into_iter().collect::<Vec<_>>();
+    validate_local_cross_device_mounts(&local_paths)?;
+
+    if rustfs_utils::get_env_bool(ENV_UNSAFE_BYPASS_DISK_CHECK, DEFAULT_UNSAFE_BYPASS_DISK_CHECK) {
+        warn!(
+            env = ENV_UNSAFE_BYPASS_DISK_CHECK,
+            local_paths = ?local_paths,
+            "Skipping local physical disk independence validation due to explicit environment override",
+        );
+        return Ok(());
+    }
+
+    let mut device_paths = BTreeMap::<String, BTreeSet<String>>::new();
+
+    for path in &local_paths {
+        let canonical = match rustfs_utils::canonicalize(path) {
+            Ok(path) => path,
+            Err(err) if err.kind() == ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(Error::other(format!(
+                    "failed to resolve local endpoint path '{path}' for disk validation: {err}"
+                )));
+            }
+        };
+        let canonical_path = canonical.to_string_lossy().into_owned();
+        let device_ids = rustfs_utils::os::get_physical_device_ids(&canonical_path).map_err(|err| {
+            Error::other(format!("failed to inspect physical disk for local endpoint '{canonical_path}': {err}"))
+        })?;
+
+        for device_id in device_ids {
+            device_paths.entry(device_id).or_default().insert(canonical_path.clone());
+        }
+    }
+
+    let shared_devices = device_paths
+        .into_iter()
+        .filter_map(|(device_id, paths)| {
+            if paths.len() <= 1 {
+                return None;
+            }
+
+            Some((device_id, paths.into_iter().collect::<Vec<_>>()))
+        })
+        .collect::<Vec<_>>();
+
+    if shared_devices.is_empty() {
+        return Ok(());
+    }
+
+    let details = shared_devices
+        .into_iter()
+        .map(|(device_id, paths)| format!("{device_id} => {}", paths.join(", ")))
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    Err(Error::other(format!(
+        "local erasure endpoints must use distinct physical disks; detected shared devices [{details}]. \
+Set {ENV_UNSAFE_BYPASS_DISK_CHECK}=true only for local testing or CI to bypass this safety check"
+    )))
+}
+
+fn validate_local_cross_device_mounts(local_paths: &[String]) -> Result<()> {
+    rustfs_utils::os::check_cross_device_mounts(local_paths)
+        .map_err(|err| Error::other(format!("local endpoint cross-device mount validation failed: {err}")))
+}
+
 #[cfg(test)]
 mod test {
     use rustfs_utils::must_get_local_ips;
 
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    use serial_test::serial;
     use std::path::Path;
+    #[cfg(target_os = "linux")]
+    use temp_env::async_with_vars;
+    #[cfg(target_os = "linux")]
+    use tempfile::tempdir;
 
     #[test]
     fn test_new_endpoints() {
@@ -1411,5 +1501,46 @@ mod test {
                 panic!("Test {}: expected failure but passed instead", i + 1);
             }
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn reject_shared_local_physical_disks_by_default() {
+        let dir = tempdir().unwrap();
+        let disk1 = dir.path().join("disk1");
+        let disk2 = dir.path().join("disk2");
+        std::fs::create_dir_all(&disk1).unwrap();
+        std::fs::create_dir_all(&disk2).unwrap();
+
+        let args = vec![disk1.to_string_lossy().into_owned(), disk2.to_string_lossy().into_owned()];
+        let layout = DisksLayout::from_volumes(args.as_slice()).unwrap();
+
+        let err = EndpointServerPools::create_server_endpoints("0.0.0.0:9000", &layout)
+            .await
+            .unwrap_err();
+
+        let err_text = err.to_string();
+        assert!(err_text.contains("distinct physical disks"), "unexpected error: {err_text}");
+        assert!(err_text.contains(ENV_UNSAFE_BYPASS_DISK_CHECK), "unexpected error: {err_text}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[serial]
+    #[tokio::test]
+    async fn allow_shared_local_physical_disks_with_explicit_env_bypass() {
+        async_with_vars([(ENV_UNSAFE_BYPASS_DISK_CHECK, Some("true"))], async {
+            let dir = tempdir().unwrap();
+            let disk1 = dir.path().join("disk1");
+            let disk2 = dir.path().join("disk2");
+            std::fs::create_dir_all(&disk1).unwrap();
+            std::fs::create_dir_all(&disk2).unwrap();
+
+            let args = vec![disk1.to_string_lossy().into_owned(), disk2.to_string_lossy().into_owned()];
+            let layout = DisksLayout::from_volumes(args.as_slice()).unwrap();
+
+            let ret = EndpointServerPools::create_server_endpoints("0.0.0.0:9000", &layout).await;
+            assert!(ret.is_ok(), "expected bypassed disk validation to succeed, got {ret:?}");
+        })
+        .await;
     }
 }

--- a/crates/ecstore/src/endpoints.rs
+++ b/crates/ecstore/src/endpoints.rs
@@ -1512,24 +1512,28 @@ mod test {
     }
 
     #[cfg(target_os = "linux")]
+    #[serial]
     #[tokio::test]
     async fn reject_shared_local_physical_disks_by_default() {
-        let dir = tempdir().unwrap();
-        let disk1 = dir.path().join("disk1");
-        let disk2 = dir.path().join("disk2");
-        std::fs::create_dir_all(&disk1).unwrap();
-        std::fs::create_dir_all(&disk2).unwrap();
+        async_with_vars([(ENV_UNSAFE_BYPASS_DISK_CHECK, None), (ENV_MINIO_CI, None)], async {
+            let dir = tempdir().unwrap();
+            let disk1 = dir.path().join("disk1");
+            let disk2 = dir.path().join("disk2");
+            std::fs::create_dir_all(&disk1).unwrap();
+            std::fs::create_dir_all(&disk2).unwrap();
 
-        let args = vec![disk1.to_string_lossy().into_owned(), disk2.to_string_lossy().into_owned()];
-        let layout = DisksLayout::from_volumes(args.as_slice()).unwrap();
+            let args = vec![disk1.to_string_lossy().into_owned(), disk2.to_string_lossy().into_owned()];
+            let layout = DisksLayout::from_volumes(args.as_slice()).unwrap();
 
-        let err = EndpointServerPools::create_server_endpoints("0.0.0.0:9000", &layout)
-            .await
-            .unwrap_err();
+            let err = EndpointServerPools::create_server_endpoints("0.0.0.0:9000", &layout)
+                .await
+                .unwrap_err();
 
-        let err_text = err.to_string();
-        assert!(err_text.contains("distinct physical disks"), "unexpected error: {err_text}");
-        assert!(err_text.contains(ENV_UNSAFE_BYPASS_DISK_CHECK), "unexpected error: {err_text}");
+            let err_text = err.to_string();
+            assert!(err_text.contains("distinct physical disks"), "unexpected error: {err_text}");
+            assert!(err_text.contains(ENV_UNSAFE_BYPASS_DISK_CHECK), "unexpected error: {err_text}");
+        })
+        .await;
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/ecstore/src/endpoints.rs
+++ b/crates/ecstore/src/endpoints.rs
@@ -17,7 +17,7 @@ use crate::{
     disks_layout::DisksLayout,
     global::global_rustfs_port,
 };
-use rustfs_config::{DEFAULT_UNSAFE_BYPASS_DISK_CHECK, ENV_UNSAFE_BYPASS_DISK_CHECK};
+use rustfs_config::{DEFAULT_UNSAFE_BYPASS_DISK_CHECK, ENV_MINIO_CI, ENV_UNSAFE_BYPASS_DISK_CHECK};
 use rustfs_utils::{XHost, check_local_server_addr, get_host_ip, is_local_host};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, hash_map::Entry},
@@ -669,7 +669,11 @@ fn validate_local_physical_disk_independence(pools: &[Endpoints]) -> Result<()> 
         return Ok(());
     }
 
-    if rustfs_utils::get_env_bool(ENV_UNSAFE_BYPASS_DISK_CHECK, DEFAULT_UNSAFE_BYPASS_DISK_CHECK) {
+    // Compatibility behavior:
+    // - canonical key: RUSTFS_UNSAFE_BYPASS_DISK_CHECK
+    // - legacy CI alias: MINIO_CI
+    // If both are set, `get_env_bool_with_aliases` keeps canonical key precedence.
+    if rustfs_utils::get_env_bool_with_aliases(ENV_UNSAFE_BYPASS_DISK_CHECK, &[ENV_MINIO_CI], DEFAULT_UNSAFE_BYPASS_DISK_CHECK) {
         warn!(
             env = ENV_UNSAFE_BYPASS_DISK_CHECK,
             local_paths = ?local_paths,
@@ -1544,6 +1548,26 @@ mod test {
 
             let ret = EndpointServerPools::create_server_endpoints("0.0.0.0:9000", &layout).await;
             assert!(ret.is_ok(), "expected bypassed disk validation to succeed, got {ret:?}");
+        })
+        .await;
+    }
+
+    #[cfg(target_os = "linux")]
+    #[serial]
+    #[tokio::test]
+    async fn allow_shared_local_physical_disks_with_minio_ci_alias() {
+        async_with_vars([(ENV_UNSAFE_BYPASS_DISK_CHECK, None), (ENV_MINIO_CI, Some("1"))], async {
+            let dir = tempdir().unwrap();
+            let disk1 = dir.path().join("disk1");
+            let disk2 = dir.path().join("disk2");
+            std::fs::create_dir_all(&disk1).unwrap();
+            std::fs::create_dir_all(&disk2).unwrap();
+
+            let args = vec![disk1.to_string_lossy().into_owned(), disk2.to_string_lossy().into_owned()];
+            let layout = DisksLayout::from_volumes(args.as_slice()).unwrap();
+
+            let ret = EndpointServerPools::create_server_endpoints("0.0.0.0:9000", &layout).await;
+            assert!(ret.is_ok(), "expected MINIO_CI alias to bypass disk validation, got {ret:?}");
         })
         .await;
     }

--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -4148,6 +4148,7 @@ async fn get_disks_info(disks: &[Option<DiskStore>], eps: &[Endpoint]) -> Vec<ru
                         total_space: res.total,
                         used_space: res.used,
                         available_space: res.free,
+                        physical_device_ids: (!res.physical_device_ids.is_empty()).then_some(res.physical_device_ids.clone()),
                         utilization: {
                             if res.total > 0 {
                                 res.used as f64 / res.total as f64 * 100_f64

--- a/crates/madmin/src/info_commands.rs
+++ b/crates/madmin/src/info_commands.rs
@@ -97,6 +97,9 @@ pub struct Disk {
     pub runtime_state: Option<String>,
     #[serde(rename = "offlineDurationSeconds", default, skip_serializing_if = "Option::is_none")]
     pub offline_duration_seconds: Option<u64>,
+    /// Leaf physical block devices backing this disk path when the platform can resolve them.
+    #[serde(rename = "physicalDeviceIds", default, skip_serializing_if = "Option::is_none")]
+    pub physical_device_ids: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -481,6 +484,7 @@ mod tests {
         assert!(disk.heal_info.is_none());
         assert_eq!(disk.used_inodes, 0);
         assert_eq!(disk.free_inodes, 0);
+        assert!(disk.physical_device_ids.is_none());
         assert!(!disk.local);
         assert_eq!(disk.pool_index, 0);
         assert_eq!(disk.set_index, 0);
@@ -514,6 +518,7 @@ mod tests {
             heal_info: None,
             used_inodes: 1000000,
             free_inodes: 9000000,
+            physical_device_ids: Some(vec!["nvme0n1".to_string()]),
             local: true,
             pool_index: 0,
             set_index: 1,
@@ -533,6 +538,7 @@ mod tests {
         assert!(disk.metrics.is_some());
         assert_eq!(disk.runtime_state.as_deref(), Some("online"));
         assert_eq!(disk.offline_duration_seconds, Some(0));
+        assert_eq!(disk.physical_device_ids, Some(vec!["nvme0n1".to_string()]));
         assert!(disk.local);
     }
 
@@ -575,6 +581,7 @@ mod tests {
         assert_eq!(decoded.used_inodes, 11_125);
         assert_eq!(decoded.runtime_state, None);
         assert_eq!(decoded.offline_duration_seconds, None);
+        assert_eq!(decoded.physical_device_ids, None);
     }
 
     #[test]
@@ -606,6 +613,7 @@ mod tests {
             pool_index: 1,
             set_index: 2,
             disk_index: 3,
+            physical_device_ids: Some(vec!["nvme0n1".to_string(), "nvme1n1".to_string()]),
             runtime_state: Some("online".to_string()),
             offline_duration_seconds: Some(0),
         };
@@ -620,6 +628,19 @@ mod tests {
         assert_eq!(decoded.used_inodes, 22_250);
         assert_eq!(decoded.disk_index, 3);
         assert_eq!(decoded.endpoint, "http://current-node:9000");
+    }
+
+    #[test]
+    fn test_disk_serializes_physical_device_ids_when_present() {
+        let disk = Disk {
+            physical_device_ids: Some(vec!["nvme0n1".to_string(), "nvme1n1".to_string()]),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&disk).unwrap();
+        assert!(json.contains("physicalDeviceIds"));
+        assert!(json.contains("nvme0n1"));
+        assert!(json.contains("nvme1n1"));
     }
 
     #[test]

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -240,6 +240,12 @@ fn ensure_no_sub_mounts(path: &str, mount_paths: &[String]) -> std::io::Result<(
             format!("Invalid argument, path ({path}) is expected to be absolute"),
         ));
     }
+    if path == "/" {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Invalid argument, path (/) cannot be the filesystem root for export validation",
+        ));
+    }
 
     let base = normalize_mount_path(path);
     let mut cross_mounts = Vec::new();
@@ -414,6 +420,13 @@ mod tests {
         let err = ensure_no_sub_mounts("relative/path", &[]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidInput);
         assert!(err.to_string().contains("expected to be absolute"));
+    }
+
+    #[test]
+    fn reject_root_path_for_cross_device_validation() {
+        let err = ensure_no_sub_mounts("/", &[]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("cannot be the filesystem root"));
     }
 
     #[test]

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -259,7 +259,7 @@ fn ensure_no_sub_mounts(path: &str, mount_paths: &[String]) -> std::io::Result<(
     cross_mounts.dedup();
 
     Err(Error::other(format!(
-        "Cross-device mounts detected on path ({path}) at following locations {}. Export path should not have any sub-mounts, refusing to start.",
+        "Nested mount points detected under path ({path}) at the following locations: {}. Export path should not have any sub-mounts, refusing to start.",
         cross_mounts.join(", ")
     )))
 }
@@ -387,7 +387,7 @@ mod tests {
 ";
 
         let err = check_cross_device_mounts_with_reader(&["/data/disk1".to_string()], mounts.as_bytes()).unwrap_err();
-        assert!(err.to_string().contains("Cross-device mounts detected"));
+        assert!(err.to_string().contains("Nested mount points detected under path"));
         assert!(err.to_string().contains("/data/disk1/sub"));
     }
 

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -14,9 +14,11 @@
 
 use crate::os::{DiskInfo, IOStats};
 use rustix::fs::statfs;
+use std::collections::BTreeSet;
+use std::fs;
 use std::fs::File;
-use std::io::{self, BufRead, Error, ErrorKind};
-use std::path::Path;
+use std::io::{self, BufRead, Error, ErrorKind, Read};
+use std::path::{Path, PathBuf};
 
 /// Returns total and free bytes available in a directory, e.g. `/`.
 pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
@@ -120,6 +122,158 @@ pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {
     Ok(stat1.st_dev == stat2.st_dev)
 }
 
+/// Resolve the leaf physical device identities backing a local filesystem path.
+///
+/// Linux block stacks such as partitions, `dm-*`, or software RAID can all
+/// expose a filesystem through an intermediate device node. This helper walks
+/// sysfs until it reaches the leaf backing devices so the caller can compare
+/// physical failure domains instead of only filesystem device numbers.
+pub fn get_physical_device_ids(disk: &str) -> std::io::Result<Vec<String>> {
+    let stat = rustix::fs::stat(disk)?;
+    let major = rustix::fs::major(stat.st_dev) as u64;
+    let minor = rustix::fs::minor(stat.st_dev) as u64;
+    let devices = resolve_block_device_ids(major, minor)?;
+
+    Ok(devices.into_iter().collect())
+}
+
+fn resolve_block_device_ids(major: u64, minor: u64) -> std::io::Result<BTreeSet<String>> {
+    let sysfs_path = PathBuf::from(format!("/sys/dev/block/{major}:{minor}"));
+    let resolved = match fs::canonicalize(&sysfs_path) {
+        Ok(path) => path,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            return Ok(BTreeSet::from([format!("{major}:{minor}")]));
+        }
+        Err(err) => return Err(err),
+    };
+    let devices = collect_block_device_ids(&resolved)?;
+
+    if devices.is_empty() {
+        Ok(BTreeSet::from([format!("{major}:{minor}")]))
+    } else {
+        Ok(devices)
+    }
+}
+
+fn collect_block_device_ids(device_path: &Path) -> std::io::Result<BTreeSet<String>> {
+    let mut ids = BTreeSet::new();
+    let slaves_dir = device_path.join("slaves");
+
+    match fs::read_dir(&slaves_dir) {
+        Ok(entries) => {
+            let mut found_slave = false;
+            for entry in entries {
+                let entry = entry?;
+                found_slave = true;
+                let resolved = fs::canonicalize(entry.path())?;
+                ids.extend(collect_block_device_ids(&resolved)?);
+            }
+
+            if found_slave {
+                return Ok(ids);
+            }
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
+
+    ids.insert(normalize_block_device_name(device_path));
+
+    Ok(ids)
+}
+
+fn normalize_block_device_name(device_path: &Path) -> String {
+    if device_path.join("partition").exists()
+        && let Some(parent_name) = device_path.parent().and_then(|parent| parent.file_name())
+    {
+        return parent_name.to_string_lossy().into_owned();
+    }
+
+    device_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| device_path.display().to_string())
+}
+
+/// Check whether any configured export path contains nested mount points.
+///
+/// This mirrors the intent of MinIO's cross-device mount guardrail: once an
+/// export path is selected, RustFS should not silently traverse into child
+/// mount points hosted by other devices.
+pub fn check_cross_device_mounts(paths: &[String]) -> std::io::Result<()> {
+    check_cross_device_mounts_with_reader(paths, File::open("/proc/mounts")?)
+}
+
+/// Parse `/proc/mounts`-style content and validate each export path against it.
+fn check_cross_device_mounts_with_reader(paths: &[String], mut reader: impl Read) -> std::io::Result<()> {
+    let mut content = String::new();
+    reader.read_to_string(&mut content)?;
+    let mount_paths = parse_mount_paths(&content);
+
+    for path in paths {
+        ensure_no_sub_mounts(path, &mount_paths)?;
+    }
+
+    Ok(())
+}
+
+/// Extract mount paths from `/proc/mounts` content, decoding escaped spaces.
+fn parse_mount_paths(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            if fields.len() != 6 {
+                return None;
+            }
+
+            Some(fields[1].replace("\\040", " "))
+        })
+        .collect()
+}
+
+/// Validate that `path` does not contain nested child mount points.
+fn ensure_no_sub_mounts(path: &str, mount_paths: &[String]) -> std::io::Result<()> {
+    if !Path::new(path).is_absolute() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("Invalid argument, path ({path}) is expected to be absolute"),
+        ));
+    }
+
+    let base = normalize_mount_path(path);
+    let mut cross_mounts = Vec::new();
+
+    for mount_path in mount_paths {
+        let mount_base = normalize_mount_path(mount_path);
+        if mount_base.starts_with(&base) && mount_base != base {
+            cross_mounts.push(mount_path.clone());
+        }
+    }
+
+    if cross_mounts.is_empty() {
+        return Ok(());
+    }
+
+    cross_mounts.sort();
+    cross_mounts.dedup();
+
+    Err(Error::other(format!(
+        "Cross-device mounts detected on path ({path}) at following locations {}. Export path should not have any sub-mounts, refusing to start.",
+        cross_mounts.join(", ")
+    )))
+}
+
+/// Normalize mount paths so prefix checks treat `/a/b` and `/a/b/` identically.
+fn normalize_mount_path(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        format!("{trimmed}/")
+    }
+}
+
 pub fn get_drive_stats(major: u32, minor: u32) -> std::io::Result<IOStats> {
     read_drive_stats(&format!("/sys/dev/block/{major}:{minor}/stat"))
 }
@@ -179,4 +333,94 @@ fn read_stat(file_name: &str) -> std::io::Result<Vec<u64>> {
     }
 
     Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn normalize_partition_device_to_parent_disk() {
+        let dir = tempdir().unwrap();
+        let block = dir.path().join("block");
+        let disk = block.join("nvme0n1");
+        let partition = disk.join("nvme0n1p1");
+        let slaves = partition.join("slaves");
+
+        fs::create_dir_all(&slaves).unwrap();
+        fs::write(partition.join("partition"), "1").unwrap();
+
+        let ids = collect_block_device_ids(&partition).unwrap();
+        assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec!["nvme0n1".to_string()]);
+    }
+
+    #[test]
+    fn flatten_device_mapper_slaves_to_leaf_devices() {
+        let dir = tempdir().unwrap();
+        let block = dir.path().join("block");
+        let dm = block.join("dm-0");
+        let dm_slaves = dm.join("slaves");
+        let nvme0 = block.join("nvme0n1");
+        let nvme1 = block.join("nvme1n1");
+
+        fs::create_dir_all(&dm_slaves).unwrap();
+        fs::create_dir_all(&nvme0).unwrap();
+        fs::create_dir_all(&nvme1).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&nvme0, dm_slaves.join("nvme0n1")).unwrap();
+            std::os::unix::fs::symlink(&nvme1, dm_slaves.join("nvme1n1")).unwrap();
+        }
+
+        let ids = collect_block_device_ids(&dm).unwrap();
+        assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec!["nvme0n1".to_string(), "nvme1n1".to_string()]);
+    }
+
+    #[test]
+    fn detect_cross_device_sub_mounts() {
+        let mounts = "\
+/dev/root / ext4 rw 0 0
+/dev/sdb1 /data ext4 rw 0 0
+/dev/sdc1 /data/disk1/sub ext4 rw 0 0
+";
+
+        let err = check_cross_device_mounts_with_reader(&["/data/disk1".to_string()], mounts.as_bytes()).unwrap_err();
+        assert!(err.to_string().contains("Cross-device mounts detected"));
+        assert!(err.to_string().contains("/data/disk1/sub"));
+    }
+
+    #[test]
+    fn allow_mount_path_without_sub_mounts() {
+        let mounts = "\
+/dev/root / ext4 rw 0 0
+/dev/sdb1 /data/disk1 ext4 rw 0 0
+";
+
+        check_cross_device_mounts_with_reader(&["/data/disk1".to_string()], mounts.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn parse_mount_paths_decodes_escaped_spaces() {
+        let mounts = "/dev/sdb1 /data/my\\040disk ext4 rw 0 0\n";
+
+        let paths = parse_mount_paths(mounts);
+        assert_eq!(paths, vec!["/data/my disk".to_string()]);
+    }
+
+    #[test]
+    fn reject_relative_path_for_cross_device_validation() {
+        let err = ensure_no_sub_mounts("relative/path", &[]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("expected to be absolute"));
+    }
+
+    #[test]
+    fn fallback_to_major_minor_when_sysfs_link_missing() {
+        let major = u64::MAX;
+        let minor = u64::MAX;
+        let ids = resolve_block_device_ids(major, minor).unwrap();
+        assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec![format!("{major}:{minor}")]);
+    }
 }

--- a/crates/utils/src/os/mod.rs
+++ b/crates/utils/src/os/mod.rs
@@ -21,13 +21,13 @@ mod unix;
 mod windows;
 
 #[cfg(target_os = "linux")]
-pub use linux::{get_drive_stats, get_info, same_disk};
+pub use linux::{check_cross_device_mounts, get_drive_stats, get_info, get_physical_device_ids, same_disk};
 
 #[cfg(all(unix, not(target_os = "linux")))]
-pub use unix::{get_drive_stats, get_info, same_disk};
+pub use unix::{check_cross_device_mounts, get_drive_stats, get_info, get_physical_device_ids, same_disk};
 
 #[cfg(target_os = "windows")]
-pub use windows::{get_drive_stats, get_info, same_disk};
+pub use windows::{check_cross_device_mounts, get_drive_stats, get_info, get_physical_device_ids, same_disk};
 
 #[derive(Debug, Default, PartialEq)]
 pub struct IOStats {

--- a/crates/utils/src/os/unix.rs
+++ b/crates/utils/src/os/unix.rs
@@ -93,6 +93,18 @@ pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {
     Ok(stat1.st_dev == stat2.st_dev)
 }
 
+pub fn get_physical_device_ids(disk: &str) -> std::io::Result<Vec<String>> {
+    let stat = rustix::fs::stat(disk)?;
+    let major = rustix::fs::major(stat.st_dev);
+    let minor = rustix::fs::minor(stat.st_dev);
+
+    Ok(vec![format!("{major}:{minor}")])
+}
+
+pub fn check_cross_device_mounts(_paths: &[String]) -> std::io::Result<()> {
+    Ok(())
+}
+
 #[cfg(not(target_os = "linux"))]
 pub fn get_drive_stats(_major: u32, _minor: u32) -> std::io::Result<IOStats> {
     Ok(IOStats::default())

--- a/crates/utils/src/os/windows.rs
+++ b/crates/utils/src/os/windows.rs
@@ -151,6 +151,17 @@ pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {
     Ok(volume1 == volume2)
 }
 
+pub fn get_physical_device_ids(disk: &str) -> std::io::Result<Vec<String>> {
+    let path_wide = to_wide_path(Path::new(disk));
+    let volume = get_volume_name(&path_wide)?;
+
+    Ok(vec![String::from_utf16_lossy(&volume)])
+}
+
+pub fn check_cross_device_mounts(_paths: &[String]) -> std::io::Result<()> {
+    Ok(())
+}
+
 pub fn get_drive_stats(_major: u32, _minor: u32) -> std::io::Result<IOStats> {
     Ok(IOStats::default())
 }

--- a/scripts/s3-tests/run.sh
+++ b/scripts/s3-tests/run.sh
@@ -40,9 +40,11 @@ XDIST="${XDIST:-0}"
 
 # Compatibility default for the s3-tests harness:
 # this script provisions multiple local export directories on the same physical disk.
-# Enable legacy CI alias by default so topology guardrails do not block the harness.
-# Canonical key `RUSTFS_UNSAFE_BYPASS_DISK_CHECK` still takes precedence when explicitly set.
-export MINIO_CI="${MINIO_CI:-1}"
+# Prefer the canonical bypass knob by default, and only honor the legacy CI alias
+# when it is already provided by the environment.
+if [ -z "${RUSTFS_UNSAFE_BYPASS_DISK_CHECK+x}" ] && [ -z "${MINIO_CI+x}" ]; then
+    export RUSTFS_UNSAFE_BYPASS_DISK_CHECK="true"
+fi
 
 # Directories (define early for use in test list loading)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/s3-tests/run.sh
+++ b/scripts/s3-tests/run.sh
@@ -38,6 +38,12 @@ TEST_MODE="${TEST_MODE:-single}"
 MAXFAIL="${MAXFAIL:-1}"
 XDIST="${XDIST:-0}"
 
+# Compatibility default for the s3-tests harness:
+# this script provisions multiple local export directories on the same physical disk.
+# Enable legacy CI alias by default so topology guardrails do not block the harness.
+# Canonical key `RUSTFS_UNSAFE_BYPASS_DISK_CHECK` still takes precedence when explicitly set.
+export MINIO_CI="${MINIO_CI:-1}"
+
 # Directories (define early for use in test list loading)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
#2678

## Summary of Changes
This PR hardens local erasure endpoint topology validation and improves disk diagnostics.

### Commit 1: `feat(ecstore): validate local disk topology for erasure endpoints`
- Enforce local erasure endpoints to map to distinct physical devices.
- Add Linux physical-device resolution that walks block-device relationships (including partitions and dm/slaves).
- Add MinIO-aligned cross-device sub-mount guardrails for local export paths.
- Add explicit environment bypass support via `RUSTFS_UNSAFE_BYPASS_DISK_CHECK`, with constants centralized in `rustfs-config`.
- Improve deterministic validation output and robustness fallbacks for missing sysfs mappings.
- Add/adjust Linux-focused unit coverage for mount parsing and device resolution edge cases.

### Commit 2: `feat(admin): expose physical device ids in disk diagnostics`
- Extend EC disk info with resolved `physical_device_ids`.
- Surface `physicalDeviceIds` in madmin disk info response model.
- Wire values through disk info aggregation path and add serde/behavior tests.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
- New env knob: `RUSTFS_UNSAFE_BYPASS_DISK_CHECK` (default: `false`).
- Intended usage of bypass is limited to controlled testing/CI scenarios.
- This branch was rebased/reorganized into review-friendly commits; push with `--force-with-lease`.


---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
