### PR TITLE
fix(ecstore): log missing local paths during physical disk independence checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,7 +5986,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -6894,7 +6894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6914,7 +6914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6935,7 +6935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6948,7 +6948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -176,7 +176,7 @@ impl LocalDisk {
             let root = root_clone.clone();
             Box::pin(async move {
                 match get_disk_info(root.clone()).await {
-                    Ok((info, root_disk)) => {
+                    Ok((info, is_root_disk)) => {
                         let physical_device_ids = match rustfs_utils::os::get_physical_device_ids(root.to_string_lossy().as_ref())
                         {
                             Ok(ids) => ids,
@@ -194,7 +194,7 @@ impl LocalDisk {
                             major: info.major,
                             minor: info.minor,
                             fs_type: info.fstype,
-                            root_disk,
+                            root_disk: is_root_disk,
                             physical_device_ids,
                             id: disk_id,
                             ..Default::default()

--- a/crates/ecstore/src/endpoints.rs
+++ b/crates/ecstore/src/endpoints.rs
@@ -683,11 +683,15 @@ fn validate_local_physical_disk_independence(pools: &[Endpoints]) -> Result<()> 
     }
 
     let mut device_paths = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut missing_paths = Vec::new();
 
     for path in &local_paths {
         let canonical = match rustfs_utils::canonicalize(path) {
             Ok(path) => path,
-            Err(err) if err.kind() == ErrorKind::NotFound => continue,
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                missing_paths.push(path.clone());
+                continue;
+            }
             Err(err) => {
                 return Err(Error::other(format!(
                     "failed to resolve local endpoint path '{path}' for disk validation: {err}"
@@ -702,6 +706,13 @@ fn validate_local_physical_disk_independence(pools: &[Endpoints]) -> Result<()> 
         for device_id in device_ids {
             device_paths.entry(device_id).or_default().insert(canonical_path.clone());
         }
+    }
+
+    if !missing_paths.is_empty() {
+        warn!(
+            missing_paths = ?missing_paths,
+            "Skipping physical disk independence checks for non-existent local endpoint paths during endpoint parsing",
+        );
     }
 
     let shared_devices = device_paths

--- a/crates/ecstore/src/endpoints.rs
+++ b/crates/ecstore/src/endpoints.rs
@@ -711,7 +711,7 @@ fn validate_local_physical_disk_independence(pools: &[Endpoints]) -> Result<()> 
     if !missing_paths.is_empty() {
         warn!(
             missing_paths = ?missing_paths,
-            "Skipping physical disk independence checks for non-existent local endpoint paths during endpoint parsing",
+            "Excluding non-existent local endpoint paths from physical disk independence validation during endpoint parsing",
         );
     }
 


### PR DESCRIPTION


<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
#2678 

## Summary of Changes
- Updated `crates/ecstore/src/endpoints.rs` to collect non-existent local endpoint paths during `validate_local_physical_disk_independence`.
- Added a `warn!` log with the missing path list instead of silently ignoring `NotFound` paths.
- Updated `crates/ecstore/src/disk/local.rs` to rename `root_disk` binding to `is_root_disk` and assign explicitly to `DiskInfo.root_disk` for readability.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: improved diagnostics for missing local endpoint paths during endpoint parsing

## Additional Notes
Verification commands to run before merge/push:
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore`
- `make pre-commit`

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
