### PR TITLE
test(utils): cover disk-check env alias precedence

### DIFF
--- a/crates/utils/src/envs.rs
+++ b/crates/utils/src/envs.rs
@@ -663,7 +663,9 @@ pub fn apply_external_env_compat() -> ExternalEnvCompatReport {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_external_env_compat, build_external_env_compat_report_from_entries, get_env_str};
+    use super::{
+        apply_external_env_compat, build_external_env_compat_report_from_entries, get_env_bool_with_aliases, get_env_str,
+    };
 
     fn source_key(suffix: &str) -> String {
         let mut key = super::external_env_prefix().to_string();
@@ -746,6 +748,15 @@ mod tests {
         temp_env::with_var("MINIO_ROOT_USER", Some("compat-admin"), || {
             temp_env::with_var_unset("RUSTFS_ROOT_USER", || {
                 assert_eq!(get_env_str("RUSTFS_ROOT_USER", "default-user"), "compat-admin");
+            });
+        });
+    }
+
+    #[test]
+    fn rustfs_bool_env_takes_precedence_over_minio_alias() {
+        temp_env::with_var("RUSTFS_UNSAFE_BYPASS_DISK_CHECK", Some("false"), || {
+            temp_env::with_var("MINIO_CI", Some("1"), || {
+                assert!(!get_env_bool_with_aliases("RUSTFS_UNSAFE_BYPASS_DISK_CHECK", &["MINIO_CI"], true,));
             });
         });
     }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This PR adds focused regression coverage for the environment-variable precedence path introduced by the recent local disk topology guardrail work. The endpoint validation code now allows a canonical override through `RUSTFS_UNSAFE_BYPASS_DISK_CHECK` while still accepting the legacy `MINIO_CI` alias for compatibility. That behavior depends on `get_env_bool_with_aliases` honoring the canonical `RUSTFS_*` key when both variables are present.

The existing tests covered reading a value from the `MINIO_*` alias when the canonical variable was absent, but they did not cover the conflicting-input case where both variables are set. This PR adds a small unit test in `crates/utils/src/envs.rs` to assert that `RUSTFS_UNSAFE_BYPASS_DISK_CHECK=false` wins over `MINIO_CI=1`. That keeps the recent endpoint safety check from being accidentally bypassed if the helper's precedence logic regresses.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:
Adds regression coverage for recent env-compat behavior without changing runtime logic.

## Additional Notes
Verification used:
- `cargo test -p rustfs-utils rustfs_bool_env_takes_precedence_over_minio_alias --lib -- --nocapture`
- `cargo fmt --all --check`
- `make pre-commit`
