### PR TITLE
fix(iam): propagate cache miss load failures

### DIFF
--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -255,18 +255,30 @@ where
         let mut sts_policy_map = HashMap::new();
         let mut policy_docs_map = HashMap::new();
 
-        let _ = self.api.load_user(access_key, UserType::Svc, &mut users_map).await;
+        match self.api.load_user(access_key, UserType::Svc, &mut users_map).await {
+            Ok(()) => {}
+            Err(err) if is_err_no_such_user(&err) => {}
+            Err(err) => return Err(err),
+        }
 
         let parent_user = users_map.get(access_key).map(|svc| svc.credentials.parent_user.clone());
 
         if let Some(parent_user) = parent_user {
-            let _ = self.api.load_user(&parent_user, UserType::Reg, &mut users_map).await;
+            match self.api.load_user(&parent_user, UserType::Reg, &mut users_map).await {
+                Ok(()) => {}
+                Err(err) if is_err_no_such_user(&err) => {}
+                Err(err) => return Err(err),
+            }
             let _ = self
                 .api
                 .load_mapped_policy(&parent_user, UserType::Reg, false, &mut user_policy_map)
                 .await;
         } else {
-            let _ = self.api.load_user(access_key, UserType::Reg, &mut users_map).await;
+            match self.api.load_user(access_key, UserType::Reg, &mut users_map).await {
+                Ok(()) => {}
+                Err(err) if is_err_no_such_user(&err) => {}
+                Err(err) => return Err(err),
+            }
             if users_map.contains_key(access_key) {
                 let _ = self
                     .api
@@ -274,7 +286,11 @@ where
                     .await;
             }
 
-            let _ = self.api.load_user(access_key, UserType::Sts, &mut sts_users_map).await;
+            match self.api.load_user(access_key, UserType::Sts, &mut sts_users_map).await {
+                Ok(()) => {}
+                Err(err) if is_err_no_such_user(&err) => {}
+                Err(err) => return Err(err),
+            }
 
             let has_sts_user = sts_users_map.get(access_key);
 

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -15,6 +15,7 @@
 use crate::error::Error as IamError;
 use crate::error::is_err_no_such_account;
 use crate::error::is_err_no_such_temp_account;
+use crate::error::is_err_no_such_user;
 use crate::error::{Error, Result};
 use crate::manager::extract_jwt_claims;
 use crate::manager::get_default_policyes;
@@ -755,7 +756,11 @@ impl<T: Store> IamSys<T> {
                 Ok((Some(res), ok))
             }
             None => {
-                let _ = self.store.load_user(access_key).await;
+                match self.store.load_user(access_key).await {
+                    Ok(()) => {}
+                    Err(err) if is_err_no_such_user(&err) => {}
+                    Err(err) => return Err(err),
+                }
 
                 if let Some(res) = self.store.get_user(access_key).await {
                     let ok = res.credentials.is_valid();
@@ -1372,6 +1377,10 @@ mod tests {
         }
 
         async fn load_user(&self, name: &str, user_type: UserType, m: &mut HashMap<String, UserIdentity>) -> Result<()> {
+            if user_type == UserType::Reg && name == "load-failure-user" {
+                return Err(Error::Io(std::io::Error::other("load user failed")));
+            }
+
             if user_type == UserType::Reg && name == "notify-user" {
                 let user = UserIdentity::from(Credentials {
                     access_key: name.to_string(),
@@ -1811,6 +1820,17 @@ mod tests {
             bucket_users.contains_key("notify-user"),
             "regular user mapped policy must be written to user_policies for bucket user listing"
         );
+    }
+
+    #[tokio::test]
+    async fn test_check_key_propagates_cache_miss_load_failure() {
+        let store = StsTestMockStore { empty_policies: false };
+        let cache_manager = IamCache::new(store).await;
+        let iam_sys = IamSys::new(cache_manager);
+
+        let result = iam_sys.check_key("load-failure-user").await;
+
+        assert!(matches!(result, Err(Error::Io(_))));
     }
 
     #[tokio::test]

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -15,7 +15,6 @@
 use crate::error::Error as IamError;
 use crate::error::is_err_no_such_account;
 use crate::error::is_err_no_such_temp_account;
-use crate::error::is_err_no_such_user;
 use crate::error::{Error, Result};
 use crate::manager::extract_jwt_claims;
 use crate::manager::get_default_policyes;
@@ -756,11 +755,7 @@ impl<T: Store> IamSys<T> {
                 Ok((Some(res), ok))
             }
             None => {
-                match self.store.load_user(access_key).await {
-                    Ok(()) => {}
-                    Err(err) if is_err_no_such_user(&err) => {}
-                    Err(err) => return Err(err),
-                }
+                self.store.load_user(access_key).await?;
 
                 if let Some(res) = self.store.get_user(access_key).await {
                     let ok = res.credentials.is_valid();

--- a/rustfs/src/auth.rs
+++ b/rustfs/src/auth.rs
@@ -175,7 +175,7 @@ impl S3Auth for IAMAuth {
                 }
                 Err(e) => {
                     warn!("get_secret_key failed: check_key error, access_key: {access_key}, error: {e:?}");
-                    return Err(s3_error!(InternalError, "IAM user lookup failed"));
+                    return Err(iam_lookup_error_to_s3_error(&e));
                 }
             }
         } else {
@@ -187,6 +187,10 @@ impl S3Auth for IAMAuth {
             "The Access Key Id you provided does not exist in our records."
         ))
     }
+}
+
+fn iam_lookup_error_to_s3_error(_err: &IamError) -> S3Error {
+    s3_error!(InternalError, "IAM user lookup failed")
 }
 
 // check_key_valid checks the key is valid or not. return the user's credentials and if the user is the owner.
@@ -967,6 +971,14 @@ mod tests {
         let error = result.unwrap_err();
         assert_eq!(error.code(), &S3ErrorCode::UnauthorizedAccess);
         assert!(error.message().unwrap_or("").contains("Your account is not signed up"));
+    }
+
+    #[test]
+    fn test_iam_lookup_error_maps_to_internal_error() {
+        let result = iam_lookup_error_to_s3_error(&IamError::Io(std::io::Error::other("load user failed")));
+
+        assert_eq!(result.code(), &S3ErrorCode::InternalError);
+        assert_eq!(result.message(), Some("IAM user lookup failed"));
     }
 
     #[test]

--- a/rustfs/src/auth.rs
+++ b/rustfs/src/auth.rs
@@ -175,6 +175,7 @@ impl S3Auth for IAMAuth {
                 }
                 Err(e) => {
                     warn!("get_secret_key failed: check_key error, access_key: {access_key}, error: {e:?}");
+                    return Err(s3_error!(InternalError, "IAM user lookup failed"));
                 }
             }
         } else {


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This PR fixes IAM authentication cache-miss handling so storage load failures are not reported as missing access keys.

When `check_key` misses the IAM cache, it now treats `NoSuchUser` as a valid not-found outcome but propagates other user-load failures. The auth layer maps propagated IAM lookup failures to `InternalError` instead of falling through to `InvalidAccessKeyId`.

A regression test covers the cache-miss path and verifies load failures are returned to the caller.

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: IAM storage/load failures now surface as server errors instead of invalid access key responses.

## Additional Notes
Verification run:

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-iam test_check_key_propagates_cache_miss_load_failure`
- `cargo test -p rustfs test_iam_auth_get_secret_key_empty_access_key`

`make pre-commit` was intentionally not completed per maintainer request.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
