### PR TITLE
test(server): cover default module switch source

### DIFF
--- a/rustfs/src/server/module_switch.rs
+++ b/rustfs/src/server/module_switch.rs
@@ -260,6 +260,35 @@ mod tests {
 
     #[test]
     #[serial]
+    fn current_module_switch_snapshot_uses_defaults_when_persisted_file_is_absent() {
+        set_persisted_module_switches(
+            PersistedModuleSwitches {
+                notify_enabled: false,
+                audit_enabled: false,
+            },
+            false,
+        );
+
+        with_vars(
+            [
+                (rustfs_config::ENV_NOTIFY_ENABLE, None::<&str>),
+                (rustfs_config::ENV_AUDIT_ENABLE, None::<&str>),
+            ],
+            || {
+                let snapshot = current_module_switch_snapshot();
+
+                assert_eq!(snapshot.notify_enabled, rustfs_config::DEFAULT_NOTIFY_ENABLE);
+                assert_eq!(snapshot.audit_enabled, rustfs_config::DEFAULT_AUDIT_ENABLE);
+                assert!(!snapshot.persisted_notify_enabled);
+                assert!(!snapshot.persisted_audit_enabled);
+                assert_eq!(snapshot.notify_source, ModuleSwitchSource::Default);
+                assert_eq!(snapshot.audit_source, ModuleSwitchSource::Default);
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
     fn validate_module_switch_update_rejects_env_conflict() {
         with_var(rustfs_config::ENV_NOTIFY_ENABLE, Some("true"), || {
             let err = validate_module_switch_update(PersistedModuleSwitches {


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This PR adds focused regression coverage for the module switch snapshot path introduced by the recent console-managed notify/audit switch work. The new test exercises the case where no persisted module switch file exists, ensuring the effective notify/audit state falls back to the configured defaults and reports `Default` as the source instead of incorrectly treating stale in-memory values as console-managed state.

Without this check, the recent module-switch changes had coverage for env overrides and persisted console values, but not for the unconfigured startup path. That left the default-source branch unverified even though it directly affects what the admin API reports before operators save any module switch configuration.

The test keeps scope tight by touching only `rustfs/src/server/module_switch.rs` and asserting the effective booleans, persisted snapshot values, and source metadata for the absent-config case.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Additional Notes
- Verification: `cargo test -p rustfs current_module_switch_snapshot_uses_defaults_when_persisted_file_is_absent --lib`
- Verification: `cargo fmt --all --check`
- Verification: `make pre-commit`
