### PR TITLE
fix(obs): disable profiling export by default and fix Helm env name

### DIFF
--- a/crates/config/src/constants/app.rs
+++ b/crates/config/src/constants/app.rs
@@ -296,9 +296,9 @@ pub const DEFAULT_OBS_LOGS_EXPORT_ENABLED: bool = true;
 
 /// Default profiling export enabled
 /// It is used to enable or disable exporting profiles
-/// Default value: true
+/// Default value: false
 /// Environment variable: RUSTFS_OBS_PROFILING_EXPORT_ENABLED
-pub const DEFAULT_OBS_PROFILING_EXPORT_ENABLED: bool = true;
+pub const DEFAULT_OBS_PROFILING_EXPORT_ENABLED: bool = false;
 
 /// Default log local logging enabled for rustfs
 /// This is the default log local logging enabled for rustfs.

--- a/crates/obs/README.md
+++ b/crates/obs/README.md
@@ -80,7 +80,9 @@ The library selects a backend automatically based on configuration:
 
 ```
 1. Any OTLP endpoint set?
-   └─ YES → Full OTLP/HTTP pipeline (traces + metrics + logs + profiling)
+   └─ YES → Full OTLP/HTTP pipeline (traces + metrics + logs)
+            + Profiling (Pyroscope) only if:
+              - RUSTFS_OBS_PROFILING_EXPORT_ENABLED=true (explicit opt-in, default: false)
 
 2. RUSTFS_OBS_LOG_DIRECTORY set to a non-empty path?
    └─ YES → Rolling-file JSON logging

--- a/crates/obs/README.md
+++ b/crates/obs/README.md
@@ -117,7 +117,7 @@ All configuration is read from environment variables at startup.
 | `RUSTFS_OBS_TRACES_EXPORT_ENABLED`    | `true`    | Toggle trace export                                        |
 | `RUSTFS_OBS_METRICS_EXPORT_ENABLED`   | `true`    | Toggle metrics export                                      |
 | `RUSTFS_OBS_LOGS_EXPORT_ENABLED`      | `true`    | Toggle OTLP log export                                     |
-| `RUSTFS_OBS_PROFILING_EXPORT_ENABLED` | `true`    | Toggle profiling export                                    |
+| `RUSTFS_OBS_PROFILING_EXPORT_ENABLED` | `false`   | Toggle profiling export                                    |
 | `RUSTFS_OBS_USE_STDOUT`               | `false`   | Mirror all signals to stdout alongside OTLP                |
 | `RUSTFS_OBS_SAMPLE_RATIO`             | `0.1`     | Trace sampling ratio `0.0`–`1.0`                           |
 | `RUSTFS_OBS_METER_INTERVAL`           | `15`      | Metrics export interval (seconds)                          |

--- a/crates/obs/src/config.rs
+++ b/crates/obs/src/config.rs
@@ -52,6 +52,20 @@ use rustfs_utils::{get_env_bool, get_env_f64, get_env_opt_str, get_env_opt_u64, 
 use serde::{Deserialize, Serialize};
 use std::env;
 
+const LEGACY_ENV_OBS_PROFILING_ENABLED: &str = "RUSTFS_OBS_PROFILING_ENABLED";
+
+fn read_profiling_export_enabled() -> bool {
+    if env::var_os(ENV_OBS_PROFILING_EXPORT_ENABLED).is_some() {
+        return get_env_bool(ENV_OBS_PROFILING_EXPORT_ENABLED, DEFAULT_OBS_PROFILING_EXPORT_ENABLED);
+    }
+
+    if env::var_os(LEGACY_ENV_OBS_PROFILING_ENABLED).is_some() {
+        return get_env_bool(LEGACY_ENV_OBS_PROFILING_ENABLED, DEFAULT_OBS_PROFILING_EXPORT_ENABLED);
+    }
+
+    DEFAULT_OBS_PROFILING_EXPORT_ENABLED
+}
+
 /// Full observability configuration used by all telemetry backends.
 ///
 /// Fields are grouped into three logical sections:
@@ -282,7 +296,7 @@ impl OtelConfig {
             traces_export_enabled: Some(get_env_bool(ENV_OBS_TRACES_EXPORT_ENABLED, DEFAULT_OBS_TRACES_EXPORT_ENABLED)),
             metrics_export_enabled: Some(get_env_bool(ENV_OBS_METRICS_EXPORT_ENABLED, DEFAULT_OBS_METRICS_EXPORT_ENABLED)),
             logs_export_enabled: Some(get_env_bool(ENV_OBS_LOGS_EXPORT_ENABLED, DEFAULT_OBS_LOGS_EXPORT_ENABLED)),
-            profiling_export_enabled: Some(get_env_bool(ENV_OBS_PROFILING_EXPORT_ENABLED, DEFAULT_OBS_PROFILING_EXPORT_ENABLED)),
+            profiling_export_enabled: Some(read_profiling_export_enabled()),
             use_stdout: Some(use_stdout),
             sample_ratio: Some(get_env_f64(ENV_OBS_SAMPLE_RATIO, SAMPLE_RATIO)),
             meter_interval: Some(get_env_u64(ENV_OBS_METER_INTERVAL, METER_INTERVAL)),
@@ -414,4 +428,39 @@ impl Default for AppConfig {
 /// case-insensitively against the string `"production"`.
 pub fn is_production_environment() -> bool {
     get_env_str(ENV_OBS_ENVIRONMENT, ENVIRONMENT).eq_ignore_ascii_case(DEFAULT_OBS_ENVIRONMENT_PRODUCTION)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profiling_export_defaults_to_disabled_when_unset() {
+        temp_env::with_var_unset(ENV_OBS_PROFILING_EXPORT_ENABLED, || {
+            temp_env::with_var_unset(LEGACY_ENV_OBS_PROFILING_ENABLED, || {
+                let config = OtelConfig::extract_otel_config_from_env(None);
+                assert_eq!(config.profiling_export_enabled, Some(false));
+            });
+        });
+    }
+
+    #[test]
+    fn profiling_export_accepts_legacy_env_alias() {
+        temp_env::with_var_unset(ENV_OBS_PROFILING_EXPORT_ENABLED, || {
+            temp_env::with_var(LEGACY_ENV_OBS_PROFILING_ENABLED, Some("true"), || {
+                let config = OtelConfig::extract_otel_config_from_env(None);
+                assert_eq!(config.profiling_export_enabled, Some(true));
+            });
+        });
+    }
+
+    #[test]
+    fn canonical_profiling_toggle_has_priority_over_legacy_alias() {
+        temp_env::with_var(LEGACY_ENV_OBS_PROFILING_ENABLED, Some("true"), || {
+            temp_env::with_var(ENV_OBS_PROFILING_EXPORT_ENABLED, Some("false"), || {
+                let config = OtelConfig::extract_otel_config_from_env(None);
+                assert_eq!(config.profiling_export_enabled, Some(false));
+            });
+        });
+    }
 }

--- a/crates/obs/src/config.rs
+++ b/crates/obs/src/config.rs
@@ -48,23 +48,14 @@ use rustfs_config::{
     DEFAULT_OBS_PROFILING_EXPORT_ENABLED, DEFAULT_OBS_TRACES_EXPORT_ENABLED, ENVIRONMENT, METER_INTERVAL, SAMPLE_RATIO,
     SERVICE_VERSION, USE_STDOUT,
 };
-use rustfs_utils::{get_env_bool, get_env_f64, get_env_opt_str, get_env_opt_u64, get_env_str, get_env_u64, get_env_usize};
+use rustfs_utils::{
+    get_env_bool, get_env_bool_with_aliases, get_env_f64, get_env_opt_str, get_env_opt_u64, get_env_str, get_env_u64,
+    get_env_usize,
+};
 use serde::{Deserialize, Serialize};
 use std::env;
 
 const LEGACY_ENV_OBS_PROFILING_ENABLED: &str = "RUSTFS_OBS_PROFILING_ENABLED";
-
-fn read_profiling_export_enabled() -> bool {
-    if env::var_os(ENV_OBS_PROFILING_EXPORT_ENABLED).is_some() {
-        return get_env_bool(ENV_OBS_PROFILING_EXPORT_ENABLED, DEFAULT_OBS_PROFILING_EXPORT_ENABLED);
-    }
-
-    if env::var_os(LEGACY_ENV_OBS_PROFILING_ENABLED).is_some() {
-        return get_env_bool(LEGACY_ENV_OBS_PROFILING_ENABLED, DEFAULT_OBS_PROFILING_EXPORT_ENABLED);
-    }
-
-    DEFAULT_OBS_PROFILING_EXPORT_ENABLED
-}
 
 /// Full observability configuration used by all telemetry backends.
 ///
@@ -148,7 +139,7 @@ pub struct OtelConfig {
     pub metrics_export_enabled: Option<bool>,
     /// Whether to export logs via OTLP (default: `true`).
     pub logs_export_enabled: Option<bool>,
-    /// Whether to export profiles via pyroscope (default: `true`).
+    /// Whether to export profiles via pyroscope (default: `false`).
     pub profiling_export_enabled: Option<bool>,
     /// **[OTLP-only]** Mirror all signals to stdout in addition to OTLP export.
     /// Only applies when an OTLP endpoint is configured.
@@ -296,7 +287,11 @@ impl OtelConfig {
             traces_export_enabled: Some(get_env_bool(ENV_OBS_TRACES_EXPORT_ENABLED, DEFAULT_OBS_TRACES_EXPORT_ENABLED)),
             metrics_export_enabled: Some(get_env_bool(ENV_OBS_METRICS_EXPORT_ENABLED, DEFAULT_OBS_METRICS_EXPORT_ENABLED)),
             logs_export_enabled: Some(get_env_bool(ENV_OBS_LOGS_EXPORT_ENABLED, DEFAULT_OBS_LOGS_EXPORT_ENABLED)),
-            profiling_export_enabled: Some(read_profiling_export_enabled()),
+            profiling_export_enabled: Some(get_env_bool_with_aliases(
+                ENV_OBS_PROFILING_EXPORT_ENABLED,
+                &[LEGACY_ENV_OBS_PROFILING_ENABLED],
+                DEFAULT_OBS_PROFILING_EXPORT_ENABLED,
+            )),
             use_stdout: Some(use_stdout),
             sample_ratio: Some(get_env_f64(ENV_OBS_SAMPLE_RATIO, SAMPLE_RATIO)),
             meter_interval: Some(get_env_u64(ENV_OBS_METER_INTERVAL, METER_INTERVAL)),

--- a/helm/rustfs/templates/configmap.yaml
+++ b/helm/rustfs/templates/configmap.yaml
@@ -67,7 +67,7 @@ data:
   RUSTFS_OBS_PROFILING_ENDPOINT: {{ .profiling.endpoint | quote }}
     {{- else }}
   RUSTFS_OBS_PROFILING_ENDPOINT: ""
-  RUSTFS_OBS_PROFILING_ENABLED: "false"
+  RUSTFS_OBS_PROFILING_EXPORT_ENABLED: "false"
     {{- end }}
   {{- end }}
   {{- end }}

--- a/helm/rustfs/templates/configmap.yaml
+++ b/helm/rustfs/templates/configmap.yaml
@@ -65,6 +65,7 @@ data:
     {{- end }}
     {{- if .profiling.enabled }}
   RUSTFS_OBS_PROFILING_ENDPOINT: {{ .profiling.endpoint | quote }}
+  RUSTFS_OBS_PROFILING_EXPORT_ENABLED: "true"
     {{- else }}
   RUSTFS_OBS_PROFILING_ENDPOINT: ""
   RUSTFS_OBS_PROFILING_EXPORT_ENABLED: "false"


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues

#2715

## Summary of Changes

**Problem**

When `RUSTFS_OBS_ENDPOINT` is set but the Pyroscope/OTel collector endpoint is
unreachable, the profiling export background task accumulates data indefinitely.
After 2-3 days of idle (no bucket traffic) this eventually triggers an extremely
large allocation request (`memory allocation of 2267059503403440 bytes failed`)
and causes the process to abort.

**Root cause**

`DEFAULT_OBS_PROFILING_EXPORT_ENABLED` was `true`, meaning any deployment that
set an OTLP root endpoint automatically activated the Pyroscope profiling export
path on Linux/macOS — even when no Pyroscope endpoint was reachable or intended.
Additionally, the Helm chart emitted `RUSTFS_OBS_PROFILING_ENABLED` (wrong name)
instead of `RUSTFS_OBS_PROFILING_EXPORT_ENABLED`, so the intended `false` value
in the chart was silently ignored and the runtime default (`true`) took effect.

**Changes**

1. `crates/config/src/constants/app.rs`
   - `DEFAULT_OBS_PROFILING_EXPORT_ENABLED`: `true` → `false`.
   - Updated constant doc comment to match.

2. `crates/obs/src/config.rs`
   - Added backward-compatible `read_profiling_export_enabled()` that recognises
     the legacy alias `RUSTFS_OBS_PROFILING_ENABLED` (as emitted by older Helm
     charts) so existing deployments with `RUSTFS_OBS_PROFILING_ENABLED=true`
     continue to work without a config change.
   - Priority: `RUSTFS_OBS_PROFILING_EXPORT_ENABLED` > `RUSTFS_OBS_PROFILING_ENABLED`
     > hardcoded default (`false`).
   - Added 3 targeted tests covering default, legacy alias, and precedence.

3. `helm/rustfs/templates/configmap.yaml`
   - Fixed env var name: `RUSTFS_OBS_PROFILING_ENABLED` → `RUSTFS_OBS_PROFILING_EXPORT_ENABLED`.

4. `crates/obs/README.md`
   - Updated `RUSTFS_OBS_PROFILING_EXPORT_ENABLED` default column from `true` → `false`.

**Migration notes**

- Deployments that relied on profiling being enabled by default must now
  explicitly set `RUSTFS_OBS_PROFILING_EXPORT_ENABLED=true` (or the legacy
  alias) and ensure a reachable `RUSTFS_OBS_PROFILING_ENDPOINT`.
- Deployments using the Helm chart: this fix makes the chart's existing
  `profiling.enabled: false` default actually take effect (previously it was
  silently ignored due to the wrong env var name).

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
  - Backward-compatible: the old alias `RUSTFS_OBS_PROFILING_ENABLED` is still
    accepted. Only the **default** changes (off instead of on).
- [x] Requires doc/config/deployment update
  - Operators who want profiling must now opt in explicitly.
- [ ] Other impact:

## Additional Notes

Verification steps used during development:

```bash
cargo test -p rustfs-obs profiling_export_
cargo test -p rustfs-obs canonical_profiling_toggle_has_priority_over_legacy_alias
```

All 3 tests pass.

