### PR TITLE
fix(webdav): decode URL-encoded filenames in path parsing

### DIFF
--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -53,7 +53,7 @@ swift = [
     "dep:base64",
     "dep:async-compression",
 ]
-webdav = ["dep:dav-server", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tokio-rustls", "dep:base64", "dep:rustls"]
+webdav = ["dep:dav-server", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tokio-rustls", "dep:base64", "dep:rustls", "dep:percent-encoding"]
 
 [dependencies]
 # Core RustFS dependencies

--- a/crates/protocols/src/webdav/driver.rs
+++ b/crates/protocols/src/webdav/driver.rs
@@ -21,6 +21,7 @@ use dav_server::fs::{
     DavDirEntry, DavFile, DavFileSystem, DavMetaData, FsError, FsFuture, FsResult, FsStream, OpenOptions, ReadDirMeta,
 };
 use futures_util::{FutureExt, StreamExt, stream};
+use percent_encoding::percent_decode_str;
 use rustfs_utils::path;
 use s3s::dto::*;
 use std::fmt::Debug;
@@ -432,6 +433,9 @@ where
     /// Parse WebDAV path to bucket and object key
     fn parse_path(&self, path: &DavPath) -> Result<(String, Option<String>), FsError> {
         let path_str = path.as_url_string();
+        let decoded_path = percent_decode_str(&path_str)
+            .decode_utf8()
+            .map_err(|_| FsError::GeneralFailure)?;
         let cleaned_path = path::clean(&path_str);
         let (bucket, object) = path::path_to_bucket_object(&cleaned_path);
 

--- a/crates/protocols/src/webdav/driver.rs
+++ b/crates/protocols/src/webdav/driver.rs
@@ -436,7 +436,7 @@ where
         let decoded_path = percent_decode_str(&path_str)
             .decode_utf8()
             .map_err(|_| FsError::GeneralFailure)?;
-        let cleaned_path = path::clean(&path_str);
+        let cleaned_path = path::clean(&decoded_path);
         let (bucket, object) = path::path_to_bucket_object(&cleaned_path);
 
         if bucket.is_empty() {


### PR DESCRIPTION
## 🐛 Problem

When uploading files via WebDAV with special characters in filenames (e.g., spaces, Chinese characters), the filenames were stored with URL encoding preserved.

## ✅ Solution

Added URL decoding in `parse_path` using `percent_encoding::percent_decode_str`.

### Changes
- **Cargo.toml**: Added `percent-encoding` to webdav feature dependencies
- **driver.rs**: Decode URL-encoded path strings before processing

### Before
```
Client request: /bucket/hello%20world.txt
Stored key:     hello%20world.txt  ❌
```

### After
```
Client request: /bucket/hello%20world.txt
Stored key:     hello world.txt    ✅