### PR TITLE
test(get): reject range with part number

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -4796,6 +4796,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_get_object_rejects_range_with_part_number() {
+        let input = GetObjectInput::builder()
+            .bucket("test-bucket".to_string())
+            .key("test-key".to_string())
+            .part_number(Some(1))
+            .range(Some(Range::Int { first: 0, last: Some(1) }))
+            .build()
+            .unwrap();
+
+        let req = build_request(input, Method::GET);
+        let usecase = DefaultObjectUsecase::without_context();
+
+        let err = Box::pin(usecase.execute_get_object(req)).await.unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::InvalidArgument);
+    }
+
+    #[tokio::test]
     async fn execute_copy_object_rejects_self_copy_without_replace_directive() {
         let input = CopyObjectInput::builder()
             .copy_source(CopySource::Bucket {


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
None.

## Summary of Changes
- Added a regression test for `GetObject` requests that include both `Range` and `partNumber`.
- Verifies the request is rejected with `InvalidArgument` before object-store context is required.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: test-only change; no runtime behavior change.

## Additional Notes
Verification run locally:
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs execute_get_object_rejects_range_with_part_number`
- `make pre-commit`

Note: `cargo-nextest` was installed locally so `make pre-commit` used the repository's intended nextest path. The nextest run reported `4214 passed, 33 skipped`; doctests emitted repeated jobserver warnings but completed successfully.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
