### PR TITLE
fix(helm): only render rollingUpdate when strategy type is RollingUpdate

### DIFF
--- a/helm/rustfs/templates/deployment.yaml
+++ b/helm/rustfs/templates/deployment.yaml
@@ -15,7 +15,11 @@ spec:
   replicas: 1
   {{- with .Values.mode.standalone.strategy }}
   strategy:
-    {{- toYaml . | nindent 4 }}
+    type: {{ .type }}
+    {{- if and (eq .type "RollingUpdate") .rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml .rollingUpdate | nindent 6 }}
+    {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/helm/rustfs/templates/deployment.yaml
+++ b/helm/rustfs/templates/deployment.yaml
@@ -14,9 +14,10 @@ metadata:
 spec:
   replicas: 1
   {{- with .Values.mode.standalone.strategy }}
+  {{- $type := default "RollingUpdate" .type }}
   strategy:
-    type: {{ .type }}
-    {{- if and (eq .type "RollingUpdate") .rollingUpdate }}
+    type: {{ $type }}
+    {{- if and (eq $type "RollingUpdate") .rollingUpdate }}
     rollingUpdate:
       {{- toYaml .rollingUpdate | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
Fixes #2727.

The chart was always emitting `spec.strategy.rollingUpdate`, even when users set `mode.standalone.strategy.type=Recreate`. Kubernetes rejects that combination, so `helm install` fails.

Now `rollingUpdate` is only rendered when `type` is `RollingUpdate`. Default behavior is unchanged.

### Verified with `helm template`

`type=Recreate`:
```yaml
strategy:
  type: Recreate
```

Default (`RollingUpdate`):
```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 1
```

Custom `rollingUpdate` values:
```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 2
    maxUnavailable: 0
```

`helm lint` passes.
