### PR TITLE
test(webdav): cover decoded path parsing

### DIFF
--- a/crates/protocols/src/webdav/driver.rs
+++ b/crates/protocols/src/webdav/driver.rs
@@ -1084,3 +1084,161 @@ where
         async move { Err(FsError::NotImplemented) }.boxed()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::WebDavDriver;
+    use crate::common::client::s3::StorageBackend as S3StorageBackend;
+    use crate::common::session::{Protocol, ProtocolPrincipal, SessionContext};
+    use async_trait::async_trait;
+    use dav_server::davpath::DavPath;
+    use dav_server::fs::FsError;
+    use rustfs_credentials::Credentials;
+    use rustfs_policy::auth::UserIdentity;
+    use s3s::dto::*;
+    use std::fmt::{Debug, Formatter};
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    struct DummyStorage;
+
+    impl Debug for DummyStorage {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.write_str("DummyStorage")
+        }
+    }
+
+    #[async_trait]
+    impl S3StorageBackend for DummyStorage {
+        type Error = std::io::Error;
+
+        async fn get_object(
+            &self,
+            _bucket: &str,
+            _key: &str,
+            _access_key: &str,
+            _secret_key: &str,
+            _start_pos: Option<u64>,
+        ) -> Result<GetObjectOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn get_object_range(
+            &self,
+            _bucket: &str,
+            _key: &str,
+            _access_key: &str,
+            _secret_key: &str,
+            _start_pos: u64,
+            _length: u64,
+        ) -> Result<GetObjectOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn put_object(
+            &self,
+            _input: PutObjectInput,
+            _access_key: &str,
+            _secret_key: &str,
+        ) -> Result<PutObjectOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn delete_object(
+            &self,
+            _bucket: &str,
+            _key: &str,
+            _access_key: &str,
+            _secret_key: &str,
+        ) -> Result<DeleteObjectOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn head_object(
+            &self,
+            _bucket: &str,
+            _key: &str,
+            _access_key: &str,
+            _secret_key: &str,
+        ) -> Result<HeadObjectOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn head_bucket(
+            &self,
+            _bucket: &str,
+            _access_key: &str,
+            _secret_key: &str,
+        ) -> Result<HeadBucketOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn list_objects_v2(
+            &self,
+            _input: ListObjectsV2Input,
+            _access_key: &str,
+            _secret_key: &str,
+        ) -> Result<ListObjectsV2Output, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn list_buckets(&self, _access_key: &str, _secret_key: &str) -> Result<ListBucketsOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn create_bucket(
+            &self,
+            _bucket: &str,
+            _access_key: &str,
+            _secret_key: &str,
+        ) -> Result<CreateBucketOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+
+        async fn delete_bucket(
+            &self,
+            _bucket: &str,
+            _access_key: &str,
+            _secret_key: &str,
+        ) -> Result<DeleteBucketOutput, Self::Error> {
+            unreachable!("parse_path tests should not hit storage")
+        }
+    }
+
+    fn driver() -> WebDavDriver<DummyStorage> {
+        let identity = UserIdentity::new(Credentials {
+            access_key: "ak".to_string(),
+            secret_key: "sk".to_string(),
+            ..Default::default()
+        });
+        let session_context = SessionContext::new(
+            ProtocolPrincipal::new(Arc::new(identity)),
+            Protocol::WebDav,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+        );
+
+        WebDavDriver::new(DummyStorage, Arc::new(session_context))
+    }
+
+    #[test]
+    fn parse_path_decodes_url_encoded_object_names() {
+        let driver = driver();
+        let path = DavPath::new("/bucket/%E6%96%87%E4%BB%B6%20name.txt").expect("path should parse");
+
+        let (bucket, key) = driver.parse_path(&path).expect("path should decode");
+
+        assert_eq!(bucket, "bucket");
+        assert_eq!(key.as_deref(), Some("文件 name.txt"));
+    }
+
+    #[test]
+    fn parse_path_rejects_invalid_utf8_percent_encoding() {
+        let driver = driver();
+        let path = DavPath::new("/bucket/%FFreport.txt").expect("path should parse");
+
+        let err = driver.parse_path(&path).expect_err("invalid utf8 should be rejected");
+
+        assert_eq!(err, FsError::GeneralFailure);
+    }
+}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
This PR adds focused regression coverage for the recent WebDAV path-decoding fix in `crates/protocols/src/webdav/driver.rs`.

The WebDAV path parser now percent-decodes request paths before splitting bucket and object names. That behavior was introduced in `#2722`, but the changed branch did not yet have direct tests. Without targeted coverage, URL-encoded object names such as Unicode filenames or names containing spaces could regress back to their encoded form without a clear signal.

This patch keeps scope tight to that changed area by adding two unit tests in the existing WebDAV driver module:

- one verifies that percent-encoded Unicode and space characters are decoded into the expected object key;
- one verifies that invalid UTF-8 percent-encoded input is rejected with `FsError::GeneralFailure`.

No runtime logic changed in this PR.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact:

Adds regression coverage for the WebDAV URL-decoding path only.

## Additional Notes
Validation used:

- `cargo test -p rustfs-protocols --features webdav parse_path_ -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

