### PR TITLE
test(admin): cover site replication absolute URI endpoint

### DIFF
--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -3129,6 +3129,18 @@ mod tests {
     }
 
     #[test]
+    fn test_request_endpoint_uses_absolute_uri_without_host_header() {
+        let uri: Uri = "https://node-a.example.com:9443/rustfs/admin/v3/site-replication/status"
+            .parse()
+            .unwrap();
+        let headers = HeaderMap::new();
+
+        let endpoint = request_endpoint(&uri, &headers);
+
+        assert_eq!(endpoint, "https://node-a.example.com:9443");
+    }
+
+    #[test]
     fn test_request_endpoint_falls_back_to_https_when_tls_path_is_configured() {
         with_var(ENV_RUSTFS_TLS_PATH, Some("/tmp/tls"), || {
             let uri: Uri = "/rustfs/admin/v3/site-replication/status".parse().unwrap();


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This adds focused regression coverage for the site replication endpoint reconstruction path updated by recent site replication identity hardening.

The new test covers requests that arrive as an absolute URI without a `Host` header. In that case, `request_endpoint` should preserve the URI scheme and authority instead of falling back to a default local endpoint.

## Verification
- `cargo test -p rustfs --lib test_request_endpoint_uses_absolute_uri_without_host_header -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
Test-only change. No runtime behavior, API, deployment, or configuration impact.

## Additional Notes
The open site replication remove PR covers a different remove-notification path; this PR is limited to endpoint reconstruction coverage.
