### PR TITLE
fix(ci): keep Helm chart versions valid for non-beta releases

### DIFF
--- a/.github/workflows/helm-package.yml
+++ b/.github/workflows/helm-package.yml
@@ -77,8 +77,12 @@ jobs:
           esac
           
           APP_VERSION="${RAW_TAG#v}"
-          BETA_NUM=$(echo "$APP_VERSION" | sed -E 's/.*-beta\.([0-9]+).*/\1/')
-          CHART_VERSION="0.${BETA_NUM}.0"
+          BETA_NUM=$(echo "$APP_VERSION" | sed -n -E 's/^.*-beta\.([0-9]+)$/\1/p')
+          if [ -n "$BETA_NUM" ]; then
+            CHART_VERSION="0.${BETA_NUM}.0"
+          else
+            CHART_VERSION="$APP_VERSION"
+          fi
 
           echo "raw_tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
           echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Keep the existing `*-beta.N` Helm chart mapping to `0.N.0`.
- Fall back to the release app version for alpha, rc, stable, and other non-beta SemVer releases.
- Fix the recent workflow regression where non-beta versions generated invalid chart versions such as `0.1.0.0-alpha.99.0`.

## Verification
- Reproduced the current failure with `helm package` using generated chart version `0.1.0.0-alpha.99.0`; Helm rejected it as invalid.
- Validated patched normalization with `helm package` for `v1.0.0-beta.1`, `1.0.0-beta.12`, `v1.0.0-alpha.99`, `v1.0.0-rc.1`, `v1.0.0`, and `1.2.3`.
- `git diff --check`
- Not run: `actionlint .github/workflows/helm-package.yml` because `actionlint` is not installed locally.

## Impact
Helm publishing keeps beta chart numbering unchanged and no longer fails for non-beta release channels due to an invalid chart version.

## Additional Notes
Daily bug scan found no open `codex-automation` PR overlapping this Helm workflow fix lane.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
