### PR TITLE
test(ci): cover Helm chart version mapping

### DIFF
--- a/.github/workflows/helm-package.yml
+++ b/.github/workflows/helm-package.yml
@@ -69,24 +69,7 @@ jobs:
               ;;
           esac
 
-          VERSION="$RAW_TAG"
-          case "$VERSION" in
-            v*)
-              VERSION="${VERSION#v}"
-              ;;
-          esac
-          
-          APP_VERSION="${RAW_TAG#v}"
-          BETA_NUM=$(echo "$APP_VERSION" | sed -n -E 's/^.*-beta\.([0-9]+)$/\1/p')
-          if [ -n "$BETA_NUM" ]; then
-            CHART_VERSION="0.${BETA_NUM}.0"
-          else
-            CHART_VERSION="$APP_VERSION"
-          fi
-
-          echo "raw_tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
-          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
-          echo "chart_version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+          ./scripts/helm_chart_version.sh "$RAW_TAG"
 
       - name: Replace chart version and app version
         run: |

--- a/scripts/helm_chart_version.sh
+++ b/scripts/helm_chart_version.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <tag-or-ref>" >&2
+  exit 2
+fi
+
+RAW="$1"
+case "$RAW" in
+  refs/tags/*)
+    RAW_TAG="${RAW#refs/tags/}"
+    ;;
+  *)
+    RAW_TAG="$RAW"
+    ;;
+esac
+
+APP_VERSION="${RAW_TAG#v}"
+BETA_NUM=$(printf '%s\n' "$APP_VERSION" | sed -n -E 's/^.*-beta\.([0-9]+)$/\1/p')
+if [ -n "$BETA_NUM" ]; then
+  CHART_VERSION="0.${BETA_NUM}.0"
+else
+  CHART_VERSION="$APP_VERSION"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "raw_tag=$RAW_TAG"
+    echo "app_version=$APP_VERSION"
+    echo "chart_version=$CHART_VERSION"
+  } >>"$GITHUB_OUTPUT"
+else
+  printf 'raw_tag=%s\n' "$RAW_TAG"
+  printf 'app_version=%s\n' "$APP_VERSION"
+  printf 'chart_version=%s\n' "$CHART_VERSION"
+fi

--- a/scripts/test_helm_chart_version.sh
+++ b/scripts/test_helm_chart_version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/helm_chart_version.sh"
+
+assert_version() {
+  local raw="$1"
+  local expected_raw_tag="$2"
+  local expected_app_version="$3"
+  local expected_chart_version="$4"
+  local output
+
+  output=$(mktemp)
+  GITHUB_OUTPUT="$output" "$SCRIPT" "$raw"
+
+  grep -qx "raw_tag=$expected_raw_tag" "$output"
+  grep -qx "app_version=$expected_app_version" "$output"
+  grep -qx "chart_version=$expected_chart_version" "$output"
+
+  rm -f "$output"
+}
+
+assert_version "refs/tags/v1.0.0-beta.12" "v1.0.0-beta.12" "1.0.0-beta.12" "0.12.0"
+assert_version "v1.0.0" "v1.0.0" "1.0.0" "1.0.0"
+assert_version "refs/tags/1.0.0" "1.0.0" "1.0.0" "1.0.0"


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This PR adds focused coverage for the Helm chart version mapping used by the helm package workflow.

The recent workflow fix made non-beta release tags use the app version as the chart version instead of producing an invalid `0.<full-version>.0` value. To keep that behavior testable, the version mapping now lives in `scripts/helm_chart_version.sh`, and the workflow calls that helper from the existing version step.

`scripts/test_helm_chart_version.sh` covers beta tags, non-beta tags with a leading `v`, and plain SemVer tags so future workflow edits cannot regress the chart version output silently.

## Verification
- `./scripts/test_helm_chart_version.sh`
- `bash -n scripts/helm_chart_version.sh scripts/test_helm_chart_version.sh`
- `git diff --check`
- `make pre-commit`

## Impact
Helm chart package version generation is unchanged for beta tags and now has direct script-level regression coverage for non-beta release tags. No runtime RustFS behavior changes.

## Additional Notes
N/A
