### PR TITLE
test(ci): cover Helm Recreate strategy rendering

### DIFF
--- a/.github/workflows/helm-package.yml
+++ b/.github/workflows/helm-package.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4.3.0
 
+      - name: Test Helm Chart Templates
+        run: ./scripts/test_helm_templates.sh
+
       - name: Package Helm Chart
         run: |
           set -eux

--- a/scripts/test_helm_templates.sh
+++ b/scripts/test_helm_templates.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CHART_DIR="$ROOT_DIR/helm/rustfs"
+
+render_standalone_deployment() {
+  helm template rustfs "$CHART_DIR" \
+    --namespace rustfs \
+    --set mode.distributed.enabled=false \
+    --set mode.standalone.enabled=true \
+    "$@" |
+    awk '
+      /^# Source: rustfs\/templates\/deployment.yaml$/ { in_deployment = 1 }
+      in_deployment && /^---$/ { exit }
+      in_deployment { print }
+    '
+}
+
+recreate_output=$(render_standalone_deployment --set mode.standalone.strategy.type=Recreate)
+grep -q "type: Recreate" <<<"$recreate_output"
+if grep -q "rollingUpdate:" <<<"$recreate_output"; then
+  echo "Recreate strategy must not render rollingUpdate fields" >&2
+  exit 1
+fi
+
+rolling_output=$(render_standalone_deployment)
+grep -q "type: RollingUpdate" <<<"$rolling_output"
+grep -q "rollingUpdate:" <<<"$rolling_output"


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Recent Helm changes fixed standalone Deployment strategy rendering so `rollingUpdate` is only emitted for `RollingUpdate`. This PR adds a focused Helm template regression test for that behavior and wires it into the Helm chart publishing workflow before packaging.

The test renders the standalone Deployment twice: once with the default rolling strategy and once with `mode.standalone.strategy.type=Recreate`. It asserts the default path still includes `rollingUpdate`, while the `Recreate` path keeps `type: Recreate` without invalid `rollingUpdate` fields.

## Verification
- `./scripts/test_helm_templates.sh`
- `make pre-commit`

## Impact
No runtime behavior change. Helm chart publishing now fails earlier if standalone Deployment strategy rendering regresses.

## Additional Notes
N/A
