### PR TITLE
test(filemeta): cover shared cache reuse

### DIFF
--- a/crates/filemeta/src/metacache.rs
+++ b/crates/filemeta/src/metacache.rs
@@ -1004,6 +1004,29 @@ mod tests {
         run_cache_workload(cache, 32, 120, 2048).await;
     }
 
+    #[tokio::test]
+    async fn test_cache_get_shared_reuses_fresh_value() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let cache = Arc::new(Cache::new(
+            Box::new({
+                let calls = Arc::clone(&calls);
+                move || {
+                    let calls = Arc::clone(&calls);
+                    Box::pin(async move { Ok(calls.fetch_add(1, Ordering::SeqCst)) })
+                }
+            }),
+            Duration::from_secs(60),
+            Opts::default(),
+        ));
+
+        let first = Arc::clone(&cache).get_shared().await.expect("prime cache should succeed");
+        let second = Arc::clone(&cache).get_shared().await.expect("fresh cache hit should succeed");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(*first, 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_cache_no_wait_returns_stale_and_refreshes_in_background() {
         let calls = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Recent filemeta cache hardening added Cache::get_shared() so callers can read the cached value through a shared Arc instead of cloning the underlying value on every hit.

This PR adds a focused regression test for the fresh-cache path. The test primes the cache with get_shared(), reads it again within a long TTL, and asserts both reads return the same Arc while the update function is called only once.

## Verification
- cargo test -p rustfs-filemeta test_cache_get_shared_reuses_fresh_value
- cargo fmt --all
- cargo fmt --all --check
- make pre-commit

## Impact
No runtime behavior change. This only adds coverage for the shared cache reuse contract introduced by the recent filemeta cache change.

## Additional Notes
N/A
