### PR TITLE
test(filemeta): cover no-wait refresh coalescing

### DIFF
--- a/crates/filemeta/src/metacache.rs
+++ b/crates/filemeta/src/metacache.rs
@@ -1102,6 +1102,7 @@ mod tests {
     async fn test_cache_no_wait_coalesces_background_refreshes() {
         let calls = Arc::new(AtomicUsize::new(0));
         let release_refresh = Arc::new(Notify::new());
+        let ttl = Duration::from_secs(60);
         let cache = Arc::new(Cache::new(
             Box::new({
                 let calls = Arc::clone(&calls);
@@ -1118,7 +1119,7 @@ mod tests {
                     })
                 }
             }),
-            Duration::from_secs(1),
+            ttl,
             Opts {
                 return_last_good: true,
                 no_wait: true,
@@ -1129,7 +1130,9 @@ mod tests {
         assert_eq!(prime, 0);
 
         let now = Cache::<usize>::current_unix_secs();
-        cache.last_update_secs.store(now.saturating_sub(1), AtomicOrdering::SeqCst);
+        cache
+            .last_update_secs
+            .store(now.saturating_sub(ttl.as_secs()), AtomicOrdering::SeqCst);
 
         let stale = Arc::clone(&cache).get().await.expect("stale get should succeed");
         assert_eq!(stale, 0);

--- a/crates/filemeta/src/metacache.rs
+++ b/crates/filemeta/src/metacache.rs
@@ -872,7 +872,7 @@ mod tests {
         Arc, Mutex as StdMutex,
         atomic::{AtomicUsize, Ordering},
     };
-    use tokio::sync::oneshot;
+    use tokio::sync::{Notify, oneshot};
     use uuid::Uuid;
 
     #[tokio::test]
@@ -1096,6 +1096,71 @@ mod tests {
         })
         .await
         .expect("background refresh should complete");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_cache_no_wait_coalesces_background_refreshes() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let release_refresh = Arc::new(Notify::new());
+        let cache = Arc::new(Cache::new(
+            Box::new({
+                let calls = Arc::clone(&calls);
+                let release_refresh = Arc::clone(&release_refresh);
+                move || {
+                    let calls = Arc::clone(&calls);
+                    let release_refresh = Arc::clone(&release_refresh);
+                    Box::pin(async move {
+                        let call = calls.fetch_add(1, Ordering::SeqCst);
+                        if call > 0 {
+                            release_refresh.notified().await;
+                        }
+                        Ok(call)
+                    })
+                }
+            }),
+            Duration::from_secs(1),
+            Opts {
+                return_last_good: true,
+                no_wait: true,
+            },
+        ));
+
+        let prime = Arc::clone(&cache).get().await.expect("prime cache should succeed");
+        assert_eq!(prime, 0);
+
+        let now = Cache::<usize>::current_unix_secs();
+        cache.last_update_secs.store(now.saturating_sub(1), AtomicOrdering::SeqCst);
+
+        let stale = Arc::clone(&cache).get().await.expect("stale get should succeed");
+        assert_eq!(stale, 0);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if calls.load(Ordering::SeqCst) == 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("background refresh should start");
+
+        let mut readers = Vec::new();
+        for _ in 0..8 {
+            let cache = Arc::clone(&cache);
+            readers.push(tokio::spawn(
+                async move { Arc::clone(&cache).get().await.expect("stale get should succeed") },
+            ));
+        }
+
+        for reader in readers {
+            assert_eq!(reader.await.expect("reader task should not panic"), 0);
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        release_refresh.notify_waiters();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This PR adds focused regression coverage for the recent metacache no-wait refresh path.

The cache already had tests proving stale values are returned without waiting and that a background refresh can update the stored value. The missing branch was the in-flight coalescing behavior: once one no-wait background refresh owns the update lock, additional stale readers should keep returning the last value without starting more refresh tasks.

The new test blocks the first background refresh, issues additional concurrent stale reads, and asserts that the update function was called only for the prime read plus the single background refresh.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-filemeta test_cache_no_wait_coalesces_background_refreshes --lib`
- `make pre-commit`

## Impact
No user-facing, API, configuration, deployment, or compatibility impact. This is test-only coverage for existing cache behavior.

## Additional Notes
N/A
