### PR TITLE
test(admin): cover site replication scheme normalization

### DIFF
--- a/rustfs/src/admin/site_replication_identity.rs
+++ b/rustfs/src/admin/site_replication_identity.rs
@@ -17,9 +17,16 @@ use std::collections::{BTreeMap, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 use url::Url;
 
+fn has_http_scheme(endpoint: &str) -> bool {
+    endpoint.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("http://"))
+        || endpoint
+            .get(..8)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("https://"))
+}
+
 pub fn canonical_endpoint(endpoint: &str) -> String {
     let trimmed = endpoint.trim().trim_end_matches('/');
-    let candidate = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+    let candidate = if has_http_scheme(trimmed) {
         trimmed.to_string()
     } else {
         format!("http://{trimmed}")
@@ -41,7 +48,7 @@ pub fn canonical_endpoint(endpoint: &str) -> String {
 
 pub fn site_identity_key(endpoint: &str) -> String {
     let trimmed = endpoint.trim().trim_end_matches('/');
-    let candidate = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+    let candidate = if has_http_scheme(trimmed) {
         trimmed.to_string()
     } else {
         format!("http://{trimmed}")
@@ -137,4 +144,26 @@ where
     }
 
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_endpoint_accepts_case_insensitive_scheme() {
+        assert_eq!(
+            canonical_endpoint(" HTTPS://Node-A.Example.Com:9000/ "),
+            "https://node-a.example.com:9000"
+        );
+    }
+
+    #[test]
+    fn site_identity_key_accepts_case_insensitive_scheme() {
+        assert_eq!(site_identity_key("HTTPS://Node-A.Example.Com:9000/"), "node-a.example.com:9000");
+        assert!(same_identity_endpoint(
+            "HTTPS://Node-A.Example.Com:9000/",
+            "http://node-a.example.com:9000"
+        ));
+    }
 }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Recent site-replication identity handling introduced shared endpoint normalization for persisted peer state and admin peer comparisons. The code accepted lower-case `http://` and `https://` schemes, but a legal endpoint with an upper-case scheme such as `HTTPS://Node-A.Example.Com:9000/` was treated as missing a scheme and normalized through the fallback `http://` path.

This PR adds focused unit coverage for the identity helper and fixes the scheme check to be case-insensitive before URL parsing. The result keeps canonical endpoints and identity keys stable for mixed-case scheme input while preserving the existing default scheme behavior for host-only endpoints.

## Verification
- `cargo test -p rustfs site_replication_identity --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
Improves compatibility for site-replication peer endpoints whose URL scheme is provided with mixed or upper case letters. No API shape or persisted state format changes.

## Additional Notes
The new tests fail on `origin/main` before the fix with `http://https:80` and `https:80` normalization results, then pass after the case-insensitive scheme check.
