### PR TITLE
fix: handle empty multipart list-parts

### DIFF
--- a/crates/ecstore/src/set_disk/multipart.rs
+++ b/crates/ecstore/src/set_disk/multipart.rs
@@ -49,9 +49,24 @@ where
             Err(_) => {}
         }
 
-        if successful_responses + pending < read_quorum {
+        if successful_responses + pending < read_quorum && !errs.iter().any(|err| matches!(err, Some(DiskError::FileNotFound))) {
             return Err(DiskError::ErasureReadQuorum);
         }
+    }
+
+    if successful_responses < read_quorum {
+        let saw_file_not_found = errs.iter().any(|err| matches!(err, Some(DiskError::FileNotFound)));
+        let only_missing_or_ignored = errs.iter().all(|err| match err {
+            Some(DiskError::FileNotFound) => true,
+            Some(err) => OBJECT_OP_IGNORED_ERRS.contains(err),
+            None => false,
+        });
+
+        if successful_responses == 0 && saw_file_not_found && only_missing_or_ignored {
+            return Err(DiskError::FileNotFound);
+        }
+
+        return Err(DiskError::ErasureReadQuorum);
     }
 
     Ok((errs, object_parts))
@@ -230,6 +245,27 @@ mod tests {
             .expect("quorum should still succeed");
         assert_eq!(errs.iter().filter(|err| err.is_none()).count(), 2);
         assert_eq!(object_parts.iter().filter(|parts| !parts.is_empty()).count(), 2);
+    }
+
+    #[tokio::test]
+    async fn collect_list_parts_results_returns_file_not_found_for_empty_upload_dirs() {
+        let tasks: Vec<_> = vec![
+            (5_u64, Err(DiskError::FileNotFound)),
+            (10, Err(DiskError::DiskNotFound)),
+            (12, Err(DiskError::DiskNotFound)),
+        ]
+        .into_iter()
+        .map(|(delay_ms, outcome)| async move {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            outcome
+        })
+        .collect();
+
+        let err = collect_list_parts_results(tasks, 2)
+            .await
+            .expect_err("missing multipart directories should be treated as empty uploads");
+
+        assert_eq!(err, DiskError::FileNotFound);
     }
 
     #[test]

--- a/crates/ecstore/src/set_disk/multipart.rs
+++ b/crates/ecstore/src/set_disk/multipart.rs
@@ -17,6 +17,16 @@ use std::future::Future;
 use std::time::Duration;
 use tokio::task::JoinSet;
 
+fn empty_upload_fallback_possible(successful_responses: usize, errs: &[Option<DiskError>]) -> bool {
+    successful_responses == 0
+        && errs.iter().any(|err| matches!(err, Some(DiskError::FileNotFound)))
+        && errs.iter().all(|err| match err {
+            Some(DiskError::FileNotFound) => true,
+            Some(err) => OBJECT_OP_IGNORED_ERRS.contains(err),
+            None => false,
+        })
+}
+
 async fn collect_list_parts_results<F>(
     tasks: Vec<F>,
     read_quorum: usize,
@@ -49,20 +59,13 @@ where
             Err(_) => {}
         }
 
-        if successful_responses + pending < read_quorum && !errs.iter().any(|err| matches!(err, Some(DiskError::FileNotFound))) {
+        if successful_responses + pending < read_quorum && !empty_upload_fallback_possible(successful_responses, &errs) {
             return Err(DiskError::ErasureReadQuorum);
         }
     }
 
     if successful_responses < read_quorum {
-        let saw_file_not_found = errs.iter().any(|err| matches!(err, Some(DiskError::FileNotFound)));
-        let only_missing_or_ignored = errs.iter().all(|err| match err {
-            Some(DiskError::FileNotFound) => true,
-            Some(err) => OBJECT_OP_IGNORED_ERRS.contains(err),
-            None => false,
-        });
-
-        if successful_responses == 0 && saw_file_not_found && only_missing_or_ignored {
+        if empty_upload_fallback_possible(successful_responses, &errs) {
             return Err(DiskError::FileNotFound);
         }
 
@@ -266,6 +269,29 @@ mod tests {
             .expect_err("missing multipart directories should be treated as empty uploads");
 
         assert_eq!(err, DiskError::FileNotFound);
+    }
+
+    #[tokio::test]
+    async fn collect_list_parts_results_fails_early_when_file_not_found_fallback_is_impossible() {
+        let started = std::time::Instant::now();
+        let tasks: Vec<_> = vec![
+            (5_u64, Err(DiskError::FileNotFound)),
+            (10, Err(DiskError::FileCorrupt)),
+            (250, Err(DiskError::DiskNotFound)),
+        ]
+        .into_iter()
+        .map(|(delay_ms, outcome)| async move {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            outcome
+        })
+        .collect();
+
+        let err = collect_list_parts_results(tasks, 2)
+            .await
+            .expect_err("non-ignored errors should preserve early quorum failure");
+
+        assert_eq!(err, DiskError::ErasureReadQuorum);
+        assert!(started.elapsed() < Duration::from_millis(120));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Fixes #2760.

## Summary of Changes
- treat missing multipart part directories as an empty upload state when no parts have been uploaded yet
- avoid collapsing the fresh-upload `ListParts` path into a read-quorum failure when the only observed result is `FileNotFound` plus ignored offline-disk errors
- add regression coverage for the empty-upload directory case in `set_disk::multipart`

## Verification
- `cargo test -p rustfs-ecstore collect_list_parts_results_ -- --nocapture`
- `cargo test -p rustfs-ecstore`
- `cargo build -p rustfs --bin rustfs`
- reproduced locally before the fix with a fresh multipart upload followed by `ListParts` returning HTTP 500 / `InternalError`
- reproduced locally after the fix with the rebuilt server returning HTTP 200 and an empty parts list for the same flow
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
`ListParts` now matches S3/MinIO behavior for freshly-created multipart uploads that have no uploaded parts yet, which unblocks clients like Harbor / Docker Distribution that probe empty uploads during resume.

## Additional Notes
The fix is intentionally narrow to the multipart part-directory collection path. Existing early quorum-failure behavior is preserved for cases that do not involve the empty-upload `FileNotFound` state.
