### PR TITLE
fix: address security review follow-ups

### DIFF
--- a/crates/ecstore/src/rpc/http_auth.rs
+++ b/crates/ecstore/src/rpc/http_auth.rs
@@ -58,19 +58,35 @@ fn get_shared_secret() -> std::io::Result<String> {
     })
 }
 
-/// Generate HMAC-SHA256 signature for the given data
-fn generate_signature(secret: &str, url: &str, method: &Method, timestamp: i64) -> String {
+/// Build the canonical payload covered by the RPC HMAC.
+fn signature_payload(url: &str, method: &Method, timestamp: i64) -> String {
     let uri: Uri = url.parse().expect("Invalid URL");
 
     let path_and_query = uri.path_and_query().unwrap();
 
     let url = path_and_query.to_string();
 
-    let data = format!("{url}|{method}|{timestamp}");
+    format!("{url}|{method}|{timestamp}")
+}
+
+/// Generate HMAC-SHA256 signature for the given data
+fn generate_signature(secret: &str, url: &str, method: &Method, timestamp: i64) -> String {
+    let data = signature_payload(url, method, timestamp);
     let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
     mac.update(data.as_bytes());
     let result = mac.finalize();
     general_purpose::STANDARD.encode(result.into_bytes())
+}
+
+fn verify_signature(secret: &str, url: &str, method: &Method, timestamp: i64, signature: &str) -> bool {
+    let Ok(signature) = general_purpose::STANDARD.decode(signature) else {
+        return false;
+    };
+
+    let data = signature_payload(url, method, timestamp);
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+    mac.update(data.as_bytes());
+    mac.verify_slice(&signature).is_ok()
 }
 
 /// Build headers with authentication signature
@@ -126,12 +142,10 @@ pub fn verify_rpc_signature(url: &str, method: &Method, headers: &HeaderMap) -> 
         return Err(std::io::Error::other("Request timestamp expired"));
     }
 
-    // Generate expected signature
+    // Verify signature with constant-time HMAC comparison.
     let secret = get_shared_secret()?;
-    let expected_signature = generate_signature(&secret, url, method, timestamp);
 
-    // Compare signatures
-    if signature != expected_signature {
+    if !verify_signature(&secret, url, method, timestamp, signature) {
         error!(
             "verify_rpc_signature: Invalid signature: url {}, method {}, timestamp {}, signature_len {}",
             url,
@@ -353,6 +367,22 @@ mod tests {
 
         let error = result.unwrap_err();
         assert_eq!(error.to_string(), "Invalid signature");
+    }
+
+    #[test]
+    fn test_verify_signature_uses_hmac_verification() {
+        let secret = "test-secret";
+        let url = "http://example.com/api/test";
+        let method = Method::GET;
+        let timestamp = 1640995200;
+        let signature = generate_signature(secret, url, &method, timestamp);
+        let mut tampered = general_purpose::STANDARD.decode(&signature).unwrap();
+        tampered[0] ^= 1;
+        let tampered_signature = general_purpose::STANDARD.encode(tampered);
+
+        assert!(verify_signature(secret, url, &method, timestamp, &signature));
+        assert!(!verify_signature(secret, url, &method, timestamp, &tampered_signature));
+        assert!(!verify_signature(secret, url, &method, timestamp, "invalid-signature"));
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/user.rs
+++ b/rustfs/src/admin/handlers/user.rs
@@ -140,6 +140,7 @@ fn imported_service_account_status(status: &str) -> Option<String> {
 }
 
 const SERVICE_ACCOUNT_PARENT_SCOPE_ERROR: &str = "service account parent is outside requester scope";
+const SERVICE_ACCOUNT_ACCESS_KEY_MISMATCH_ERROR: &str = "service account access key does not match import entry";
 
 fn imported_service_account_parent_allowed(parent: &str, requester: &Credentials, owner: bool) -> bool {
     if parent.is_empty() {
@@ -166,6 +167,13 @@ fn imported_service_account_parent_scope_failure(
     (!imported_service_account_parent_allowed(parent, requester, owner)).then(|| IAMErrEntity {
         name: access_key.to_string(),
         error: SERVICE_ACCOUNT_PARENT_SCOPE_ERROR.to_string(),
+    })
+}
+
+fn imported_service_account_access_key_failure(entry_access_key: &str, payload_access_key: &str) -> Option<IAMErrEntity> {
+    (entry_access_key != payload_access_key).then(|| IAMErrEntity {
+        name: entry_access_key.to_string(),
+        error: SERVICE_ACCOUNT_ACCESS_KEY_MISMATCH_ERROR.to_string(),
     })
 }
 
@@ -1014,6 +1022,11 @@ impl Operation for ImportIam {
                         return Err(s3_error!(InvalidArgument, "has space be {ak}"));
                     }
 
+                    if let Some(err) = imported_service_account_access_key_failure(&ak, &req.access_key) {
+                        failed.service_accounts.push(err);
+                        continue;
+                    }
+
                     if let Some(err) = imported_service_account_parent_scope_failure(&ak, &req.parent, &cred, owner) {
                         failed.service_accounts.push(err);
                         continue;
@@ -1021,7 +1034,7 @@ impl Operation for ImportIam {
 
                     let mut update = true;
 
-                    if let Err(e) = iam_store.get_service_account(&req.access_key).await {
+                    if let Err(e) = iam_store.get_service_account(&ak).await {
                         if !matches!(e, rustfs_iam::error::Error::NoSuchServiceAccount(_)) {
                             return Err(s3_error!(InvalidArgument, "failed to get service account {ak} {e}"));
                         }
@@ -1029,7 +1042,7 @@ impl Operation for ImportIam {
                     }
 
                     if update {
-                        iam_store.delete_service_account(&req.access_key, true).await.map_err(|e| {
+                        iam_store.delete_service_account(&ak, true).await.map_err(|e| {
                             S3Error::with_message(
                                 S3ErrorCode::InternalError,
                                 format!("failed to delete service account {ak} {e}"),
@@ -1251,7 +1264,8 @@ impl Operation for ImportIam {
 #[cfg(test)]
 mod tests {
     use super::{
-        GROUP_POLICY_MAPPING_USER_TYPE, SERVICE_ACCOUNT_PARENT_SCOPE_ERROR, imported_service_account_parent_allowed,
+        GROUP_POLICY_MAPPING_USER_TYPE, SERVICE_ACCOUNT_ACCESS_KEY_MISMATCH_ERROR, SERVICE_ACCOUNT_PARENT_SCOPE_ERROR,
+        imported_service_account_access_key_failure, imported_service_account_parent_allowed,
         imported_service_account_parent_scope_failure, imported_service_account_status, should_check_deny_only,
         should_reject_group_import_name, should_restore_group_as_disabled,
     };
@@ -1397,6 +1411,33 @@ mod tests {
         assert!(
             imported_service_account_parent_scope_failure("svc-access-key", "delegated-importer", &requester, false).is_none()
         );
+    }
+
+    #[test]
+    fn test_service_account_import_rejects_payload_access_key_mismatch() {
+        let payload = r#"{
+            "svcalpha": {
+                "parent": "useralpha",
+                "accessKey": "svcbeta",
+                "secretKey": "svcAlphaSecret123",
+                "groups": [],
+                "claims": {},
+                "sessionPolicy": null,
+                "status": "on",
+                "name": "uploaderKey",
+                "description": "alpha upload key",
+                "expiration": "1970-01-01T00:00:00Z"
+            }
+        }"#;
+
+        let svc_accts: HashMap<String, SRSvcAccCreate> = serde_json::from_str(payload).unwrap();
+        let req = svc_accts.get("svcalpha").unwrap();
+        let err = imported_service_account_access_key_failure("svcalpha", &req.access_key)
+            .expect("mismatched service account access keys must be rejected");
+
+        assert_eq!(err.name, "svcalpha");
+        assert_eq!(err.error, SERVICE_ACCOUNT_ACCESS_KEY_MISMATCH_ERROR);
+        assert!(imported_service_account_access_key_failure("svcalpha", "svcalpha").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Follow-up to #2773 after it was merged.

Security advisories / reports covered by the original #2773 fix and tightened by this follow-up:

| Advisory / report ID | Follow-up coverage in this PR | Fix area |
| --- | --- | --- |
| GHSA-566f-q62r-wcr8 | Tightened | Reject ImportIam service-account entries when the import map key does not match the payload `accessKey`, before IAM lookup/delete/create side effects. |
| GHSA-r5qv-rc46-hv8q | Tightened | Verify RPC HMAC signatures with decoded signature bytes through HMAC verification instead of comparing generated signature strings. |

## Summary of Changes
- Reject service-account import entries whose map key and payload `accessKey` differ.
- Keep service-account import lookup/delete/create side effects keyed by the validated import entry key.
- Verify RPC signatures by decoding the supplied signature and using HMAC `verify_slice`.
- Add regression tests for mismatched service-account imports and RPC HMAC verification behavior.

## Verification
- `cargo test -p rustfs test_service_account_import_rejects_payload_access_key_mismatch -- --nocapture`
- `cargo test -p rustfs-ecstore test_verify_signature_uses_hmac_verification -- --nocapture`
- `cargo test -p rustfs-ecstore rpc::http_auth::tests -- --nocapture`
- `cargo test -p rustfs admin::handlers::user::tests -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

Note: `make pre-commit` fell back to `cargo test` because `cargo-nextest` is not installed.

## Impact
- ImportIam now records a failed service-account entry when the import map key and payload `accessKey` differ.
- RPC signature verification now uses HMAC verification over decoded signature bytes.
- No public API changes.

## Additional Notes
#2773 was merged before these two remaining review follow-ups could be included, so this PR carries only the remaining review hardening on top of latest `main`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
