### PR TITLE
Ensure CreationDate is always present in ListBuckets response

### DIFF
--- a/rustfs/src/storage/s3_api/bucket.rs
+++ b/rustfs/src/storage/s3_api/bucket.rs
@@ -68,7 +68,7 @@ pub(crate) fn build_list_buckets_output(bucket_infos: &[BucketInfo]) -> ListBuck
     let buckets: Vec<Bucket> = bucket_infos
         .iter()
         .map(|bucket_info| Bucket {
-            creation_date: bucket_info.created.map(Timestamp::from),
+            creation_date: Some(Timestamp::from(bucket_info.created.unwrap_or(time::OffsetDateTime::UNIX_EPOCH))),
             name: Some(bucket_info.name.clone()),
             ..Default::default()
         })
@@ -380,7 +380,7 @@ mod tests {
         assert_eq!(buckets[0].name.as_deref(), Some("bucket-a"));
         assert_eq!(buckets[0].creation_date, Some(s3s::dto::Timestamp::from(OffsetDateTime::UNIX_EPOCH)));
         assert_eq!(buckets[1].name.as_deref(), Some("bucket-b"));
-        assert_eq!(buckets[1].creation_date, None);
+        assert_eq!(buckets[1].creation_date, Some(s3s::dto::Timestamp::from(OffsetDateTime::UNIX_EPOCH)));
 
         let expected_owner = rustfs_owner();
         assert_eq!(owner.display_name, expected_owner.display_name);


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/rustfs/rustfs/issues/2782

## Summary of Changes

`build_list_buckets_output` now falls back to the UNIX epoch (`1970-01-01T00:00:00Z`) when a bucket's stored creation timestamp is `None`, so `CreationDate` is always present in the ListBuckets response. Updated the corresponding unit test to expect the fallback value.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p rustfs --all-targets -- -D warnings`
- `cargo test -p rustfs --lib storage::s3_api::bucket::tests` (16 passed)
- Tested against local bucket with missing creation date

<img width="447" height="88" alt="image" src="https://github.com/user-attachments/assets/a5bf340d-3ba7-4d45-b36e-27cc01e33865" />

## Impact

Fixes `aws s3 ls` and other S3 clients that depend on `CreationDate` being present for every bucket in the ListBuckets response.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
