### PR TITLE
test(license): cover public key validation

### DIFF
--- a/rustfs/src/license.rs
+++ b/rustfs/src/license.rs
@@ -324,6 +324,7 @@ pub fn license_check() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn license_token_current_requires_future_expiration() {
@@ -335,5 +336,31 @@ mod tests {
         assert!(is_license_token_current(&token, 99));
         assert!(!is_license_token_current(&token, 100));
         assert!(!is_license_token_current(&token, 101));
+    }
+
+    #[test]
+    #[serial]
+    fn appauth_verifier_rejects_missing_public_key() {
+        temp_env::with_var(rustfs_config::ENV_RUSTFS_LICENSE_PUBLIC_KEY, None::<&str>, || {
+            assert_license_public_key_error(AppAuthLicenseVerifier.validate("signed-license", 0));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn appauth_verifier_rejects_blank_public_key() {
+        temp_env::with_var(rustfs_config::ENV_RUSTFS_LICENSE_PUBLIC_KEY, Some("  \t\n  "), || {
+            assert_license_public_key_error(AppAuthLicenseVerifier.validate("signed-license", 0));
+        });
+    }
+
+    fn assert_license_public_key_error(result: LicenseResult<Token>) {
+        let err = result.expect_err("license verification should fail without a public key");
+        let LicenseError::Invalid(message) = err else {
+            panic!("expected invalid license error, got {err:?}");
+        };
+
+        assert!(message.contains(rustfs_config::ENV_RUSTFS_LICENSE_PUBLIC_KEY));
+        assert!(message.contains("RSA public key"));
     }
 }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add focused regression coverage for the default AppAuth license verifier when `RUSTFS_LICENSE_PUBLIC_KEY` is missing.
- Add matching coverage for blank public-key values after trimming, ensuring license parsing fails before token verification work begins.
- Keep the change scoped to `rustfs/src/license.rs` tests for the public-key validation branch introduced by the recent license hardening.

## Verification
- `cargo test -p rustfs license::tests --lib -- --nocapture`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
No runtime behavior changes. This is test-only coverage for license public-key configuration validation.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
