### PR TITLE
test: cover license verifier success path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7871,6 +7871,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.3",
  "rmp-serde",
+ "rsa 0.10.0-rc.18",
  "rust-embed",
  "rustfs-appauth",
  "rustfs-audit",

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -198,6 +198,7 @@ tokio = { workspace = true, features = ["test-util"] }
 temp-env = { workspace = true, features = ["async_closure"] }
 tracing-subscriber = { workspace = true }
 opentelemetry_sdk = { workspace = true }
+rsa = { workspace = true }
 
 [build-dependencies]
 http.workspace = true

--- a/rustfs/src/license.rs
+++ b/rustfs/src/license.rs
@@ -324,6 +324,11 @@ pub fn license_check() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rsa::{
+        RsaPrivateKey, RsaPublicKey,
+        pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding},
+    };
+    use rustfs_appauth::token::sign_license_token;
     use serial_test::serial;
 
     #[test]
@@ -352,6 +357,32 @@ mod tests {
         temp_env::with_var(rustfs_config::ENV_RUSTFS_LICENSE_PUBLIC_KEY, Some("  \t\n  "), || {
             assert_license_public_key_error(AppAuthLicenseVerifier.validate("signed-license", 0));
         });
+    }
+
+    #[test]
+    #[serial]
+    fn appauth_verifier_accepts_signed_license_with_trimmed_public_key() {
+        let mut rng = rand::rng();
+        let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("private key should be generated");
+        let public_key = RsaPublicKey::from(&private_key);
+        let private_key_pem = private_key.to_pkcs8_pem(LineEnding::LF).expect("private key should encode");
+        let public_key_pem = public_key
+            .to_public_key_pem(LineEnding::LF)
+            .expect("public key should encode");
+        let expected = Token {
+            name: "test_app".to_string(),
+            expired: 100,
+        };
+        let signed_license = sign_license_token(&expected, &private_key_pem).expect("license should sign");
+        let public_key_env = format!(" \n{public_key_pem}\t ");
+
+        let actual = temp_env::with_var(rustfs_config::ENV_RUSTFS_LICENSE_PUBLIC_KEY, Some(public_key_env), || {
+            AppAuthLicenseVerifier.validate(&signed_license, 0)
+        })
+        .expect("signed license should validate with env public key");
+
+        assert_eq!(expected.name, actual.name);
+        assert_eq!(expected.expired, actual.expired);
     }
 
     fn assert_license_public_key_error(result: LicenseResult<Token>) {


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds focused coverage for the AppAuth license verifier success path. Recent coverage asserted that missing or blank `RUSTFS_LICENSE_PUBLIC_KEY` values are rejected; this adds the complementary case that a signed license validates when the public key comes from the environment with surrounding whitespace.

The test generates a temporary RSA keypair, signs a license token through the existing appauth helper, pads the public-key environment value, and verifies the decoded token matches the signed payload.

## Verification
- `cargo test -p rustfs license::tests --lib`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
No runtime behavior change. This only adds unit coverage and a test-only RSA dependency for key generation.

## Additional Notes
N/A
