### PR TITLE
fix(admin): clear removed site resync status

### DIFF
--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -1594,8 +1594,27 @@ fn remove_sites(mut state: SiteReplicationState, req: SRRemoveReq) -> SiteReplic
         return state;
     }
 
-    let names: Vec<String> = req.site_names.into_iter().collect();
-    state.peers.retain(|_, peer| !names.iter().any(|name| name == &peer.name));
+    let names: HashSet<String> = req.site_names.into_iter().collect();
+    if names.contains(&state.name) {
+        state.peers.clear();
+        state.resync_status.clear();
+        state.updated_at = Some(OffsetDateTime::now_utc());
+        return state;
+    }
+
+    let removed_deployment_ids: Vec<String> = state
+        .peers
+        .iter()
+        .filter(|(_, peer)| names.contains(&peer.name))
+        .map(|(deployment_id, _)| deployment_id.clone())
+        .collect();
+    for deployment_id in removed_deployment_ids {
+        state.peers.remove(&deployment_id);
+        state.resync_status.remove(&deployment_id);
+    }
+    state
+        .resync_status
+        .retain(|deployment_id, _| state.peers.contains_key(deployment_id));
     state.updated_at = Some(OffsetDateTime::now_utc());
     state
 }
@@ -3293,6 +3312,122 @@ mod tests {
         assert_eq!(status.status, SITE_REPL_REMOVE_SUCCESS);
         assert!(status.err_detail.contains("failed to notify 1 peer"));
         assert!(status.err_detail.contains("403 Forbidden"));
+    }
+
+    #[test]
+    fn test_remove_sites_drops_resync_status_for_removed_peer() {
+        let mut state = SiteReplicationState {
+            name: "local".to_string(),
+            ..Default::default()
+        };
+        state.peers.insert(
+            "local-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "local-deployment".to_string(),
+                ..peer("local", "https://local.example.com")
+            },
+        );
+        state.peers.insert(
+            "remote-a-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "remote-a-deployment".to_string(),
+                ..peer("remote-a", "https://remote-a.example.com")
+            },
+        );
+        state.peers.insert(
+            "remote-b-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "remote-b-deployment".to_string(),
+                ..peer("remote-b", "https://remote-b.example.com")
+            },
+        );
+        state.resync_status.insert(
+            "remote-a-deployment".to_string(),
+            SRResyncOpStatus {
+                resync_id: "stale-a".to_string(),
+                status: "success".to_string(),
+                ..Default::default()
+            },
+        );
+        state.resync_status.insert(
+            "remote-a-legacy-key".to_string(),
+            SRResyncOpStatus {
+                resync_id: "stale-a-legacy".to_string(),
+                status: "success".to_string(),
+                ..Default::default()
+            },
+        );
+        state.resync_status.insert(
+            "remote-b-deployment".to_string(),
+            SRResyncOpStatus {
+                resync_id: "active-b".to_string(),
+                status: "success".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let state = remove_sites(
+            state,
+            SRRemoveReq {
+                site_names: vec!["remote-a".to_string()],
+                ..Default::default()
+            },
+        );
+
+        assert!(state.peers.contains_key("local-deployment"));
+        assert!(!state.peers.contains_key("remote-a-deployment"));
+        assert!(state.peers.contains_key("remote-b-deployment"));
+        assert!(!state.resync_status.contains_key("remote-a-deployment"));
+        assert!(!state.resync_status.contains_key("remote-a-legacy-key"));
+        assert!(state.resync_status.contains_key("remote-b-deployment"));
+    }
+
+    #[test]
+    fn test_remove_sites_clears_state_when_local_site_is_removed() {
+        let mut state = SiteReplicationState {
+            name: "local".to_string(),
+            ..Default::default()
+        };
+        state.peers.insert(
+            "local-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "local-deployment".to_string(),
+                ..peer("local", "https://local.example.com")
+            },
+        );
+        state.peers.insert(
+            "remote-a-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "remote-a-deployment".to_string(),
+                ..peer("remote-a", "https://remote-a.example.com")
+            },
+        );
+        state.peers.insert(
+            "remote-b-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "remote-b-deployment".to_string(),
+                ..peer("remote-b", "https://remote-b.example.com")
+            },
+        );
+        state.resync_status.insert(
+            "remote-a-deployment".to_string(),
+            SRResyncOpStatus {
+                resync_id: "active-a".to_string(),
+                status: "success".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let state = remove_sites(
+            state,
+            SRRemoveReq {
+                site_names: vec!["local".to_string()],
+                ..Default::default()
+            },
+        );
+
+        assert!(state.peers.is_empty());
+        assert!(state.resync_status.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Partial site replication removal now clears stored resync status for removed peer deployment IDs and prunes stale resync entries that no longer match remaining peers. If the local site receives its own removal request, it now clears the local replication peer state so the node detaches cleanly.

Added focused regression coverage for partial removal with distinct peer names and deployment IDs, stale resync keys, and local-site removal.

## Verification
- `cargo test -p rustfs test_remove_sites_ --lib`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs --lib -- -D warnings`
- `make pre-commit`

## Impact
No API or configuration changes. The change only keeps persisted site replication state consistent after site removal.

## Additional Notes
The partial-remove test failed before the fix because `resync_status` retained removed peer state.
