### PR TITLE
fix(notify): improve webhook target diagnostics for env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ Similarly, you can run the command with podman
 podman compose --profile observability up -d
 ```
 
+Webhook notification quick start (Docker):
+
+```bash
+docker run -d --name rustfs -p 9000:9000 \
+  -e RUSTFS_NOTIFY_ENABLE=true \
+  -e RUSTFS_NOTIFY_WEBHOOK_ENABLE_PRIMARY=on \
+  -e RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY=http://<host-ip>:3020/webhook \
+  -e RUSTFS_NOTIFY_WEBHOOK_QUEUE_DIR_PRIMARY=/tmp/rustfs-events \
+  rustfs/rustfs:latest
+```
+
+Notes:
+- `RUSTFS_NOTIFY_ENABLE=true` enables the global notify module switch.
+- For ARN `arn:rustfs:sqs::primary:webhook`, use instance-scoped env vars with `_PRIMARY`.
+- If queue dir is omitted, default is `/opt/rustfs/events`; ensure it is writable by the container runtime user.
+
 **NOTE**: We recommend reviewing the `docker-compose.yml` file before running. It defines several services including Grafana, Prometheus, and Jaeger, which are helpful for RustFS observability. If you wish to start Redis or Nginx containers, you can specify the corresponding profiles.
 
 ### 3\. Build from Source (Option 3) - Advanced Users

--- a/crates/notify/src/integration.rs
+++ b/crates/notify/src/integration.rs
@@ -41,6 +41,7 @@ use tokio::sync::{RwLock, Semaphore, broadcast, mpsc};
 use tracing::{debug, info, warn};
 
 const MAX_RECENT_LIVE_EVENTS: usize = 1024;
+const NOTIFY_CONFIGURATION_HINT: &str = "No notify targets configured. Check RUSTFS_NOTIFY_ENABLE=true and instance-scoped target env vars (for example RUSTFS_NOTIFY_WEBHOOK_ENABLE_PRIMARY + RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY for arn:rustfs:sqs::primary:webhook). If using default queue_dir, ensure /opt/rustfs/events is writable.";
 
 fn subsystem_target_type(target_type: &str) -> &str {
     match target_type {
@@ -325,6 +326,9 @@ impl NotificationSystem {
         let targets: Vec<Box<dyn Target<Event> + Send + Sync>> = self.registry.create_targets_from_config(&config).await?;
 
         info!("{} notification targets were created", targets.len());
+        if targets.is_empty() {
+            warn!("{NOTIFY_CONFIGURATION_HINT}");
+        }
 
         // Initialize targets and start event streams
         let cancellers = self.init_targets_and_start_streams(&targets).await;
@@ -607,7 +611,7 @@ impl NotificationSystem {
     ) -> Result<(), NotificationError> {
         let arn_list = self.notifier.get_arn_list(&cfg.region).await;
         if arn_list.is_empty() {
-            return Err(NotificationError::Configuration("No targets configured".to_string()));
+            return Err(NotificationError::Configuration(NOTIFY_CONFIGURATION_HINT.to_string()));
         }
         info!("Available ARNs: {:?}", arn_list);
         // Validate the configuration against the available ARNs

--- a/crates/notify/src/integration.rs
+++ b/crates/notify/src/integration.rs
@@ -27,6 +27,7 @@ use rustfs_config::notify::{
     DEFAULT_NOTIFY_TARGET_STREAM_CONCURRENCY, ENV_NOTIFY_TARGET_STREAM_CONCURRENCY, NOTIFY_KAFKA_SUB_SYS, NOTIFY_MQTT_SUB_SYS,
     NOTIFY_NATS_SUB_SYS, NOTIFY_PULSAR_SUB_SYS, NOTIFY_WEBHOOK_SUB_SYS,
 };
+use rustfs_config::{ENV_NOTIFY_ENABLE, EVENT_DEFAULT_DIR};
 use rustfs_ecstore::config::{Config, KVS};
 use rustfs_s3_common::EventName;
 use rustfs_targets::arn::TargetID;
@@ -41,7 +42,12 @@ use tokio::sync::{RwLock, Semaphore, broadcast, mpsc};
 use tracing::{debug, info, warn};
 
 const MAX_RECENT_LIVE_EVENTS: usize = 1024;
-const NOTIFY_CONFIGURATION_HINT: &str = "No notify targets configured. Check RUSTFS_NOTIFY_ENABLE=true and instance-scoped target env vars (for example RUSTFS_NOTIFY_WEBHOOK_ENABLE_PRIMARY + RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY for arn:rustfs:sqs::primary:webhook). If using default queue_dir, ensure /opt/rustfs/events is writable.";
+
+fn notify_configuration_hint() -> String {
+    format!(
+        "No notify targets configured. Check {ENV_NOTIFY_ENABLE}=true and instance-scoped target env vars (for example RUSTFS_NOTIFY_WEBHOOK_ENABLE_PRIMARY + RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY for arn:rustfs:sqs::primary:webhook). If using default queue_dir, ensure {EVENT_DEFAULT_DIR} is writable."
+    )
+}
 
 fn subsystem_target_type(target_type: &str) -> &str {
     match target_type {
@@ -327,7 +333,7 @@ impl NotificationSystem {
 
         info!("{} notification targets were created", targets.len());
         if targets.is_empty() {
-            warn!("{NOTIFY_CONFIGURATION_HINT}");
+            warn!("{}", notify_configuration_hint());
         }
 
         // Initialize targets and start event streams
@@ -590,6 +596,9 @@ impl NotificationSystem {
             .map_err(NotificationError::Target)?;
 
         info!("{} notification targets were created from the new configuration", targets.len());
+        if targets.is_empty() {
+            warn!("{}", notify_configuration_hint());
+        }
 
         // Initialize targets and start event streams using shared helper
         let new_cancellers = self.init_targets_and_start_streams(&targets).await;
@@ -611,7 +620,7 @@ impl NotificationSystem {
     ) -> Result<(), NotificationError> {
         let arn_list = self.notifier.get_arn_list(&cfg.region).await;
         if arn_list.is_empty() {
-            return Err(NotificationError::Configuration(NOTIFY_CONFIGURATION_HINT.to_string()));
+            return Err(NotificationError::Configuration(notify_configuration_hint()));
         }
         info!("Available ARNs: {:?}", arn_list);
         // Validate the configuration against the available ARNs

--- a/crates/notify/src/integration.rs
+++ b/crates/notify/src/integration.rs
@@ -24,8 +24,9 @@ use crate::{
 };
 use hashbrown::HashMap;
 use rustfs_config::notify::{
-    DEFAULT_NOTIFY_TARGET_STREAM_CONCURRENCY, ENV_NOTIFY_TARGET_STREAM_CONCURRENCY, NOTIFY_KAFKA_SUB_SYS, NOTIFY_MQTT_SUB_SYS,
-    NOTIFY_NATS_SUB_SYS, NOTIFY_PULSAR_SUB_SYS, NOTIFY_WEBHOOK_SUB_SYS,
+    DEFAULT_NOTIFY_TARGET_STREAM_CONCURRENCY, ENV_NOTIFY_TARGET_STREAM_CONCURRENCY, ENV_NOTIFY_WEBHOOK_ENABLE,
+    ENV_NOTIFY_WEBHOOK_ENDPOINT, NOTIFY_KAFKA_SUB_SYS, NOTIFY_MQTT_SUB_SYS, NOTIFY_NATS_SUB_SYS, NOTIFY_PULSAR_SUB_SYS,
+    NOTIFY_WEBHOOK_SUB_SYS,
 };
 use rustfs_config::{ENV_NOTIFY_ENABLE, EVENT_DEFAULT_DIR};
 use rustfs_ecstore::config::{Config, KVS};
@@ -44,8 +45,10 @@ use tracing::{debug, info, warn};
 const MAX_RECENT_LIVE_EVENTS: usize = 1024;
 
 fn notify_configuration_hint() -> String {
+    let webhook_enable_primary = format!("{ENV_NOTIFY_WEBHOOK_ENABLE}_PRIMARY");
+    let webhook_endpoint_primary = format!("{ENV_NOTIFY_WEBHOOK_ENDPOINT}_PRIMARY");
     format!(
-        "No notify targets configured. Check {ENV_NOTIFY_ENABLE}=true and instance-scoped target env vars (for example RUSTFS_NOTIFY_WEBHOOK_ENABLE_PRIMARY + RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY for arn:rustfs:sqs::primary:webhook). If using default queue_dir, ensure {EVENT_DEFAULT_DIR} is writable."
+        "No notify targets configured. Check {ENV_NOTIFY_ENABLE}=true and instance-scoped target env vars (for example {webhook_enable_primary} + {webhook_endpoint_primary} for arn:rustfs:sqs::primary:webhook). If using default queue_dir, ensure {EVENT_DEFAULT_DIR} is writable."
     )
 }
 

--- a/rustfs/src/server/event.rs
+++ b/rustfs/src/server/event.rs
@@ -107,7 +107,8 @@ pub async fn init_event_notifier() {
     if !enabled {
         info!(
             target: "rustfs::main::init_event_notifier",
-            "Notify module is disabled, event notifier initialization is skipped. Set RUSTFS_NOTIFY_ENABLE=true to enable notify initialization."
+            "Notify module is disabled, event notifier initialization is skipped. Set {}=true to enable notify initialization.",
+            rustfs_config::ENV_NOTIFY_ENABLE
         );
         return;
     }

--- a/rustfs/src/server/event.rs
+++ b/rustfs/src/server/event.rs
@@ -107,7 +107,7 @@ pub async fn init_event_notifier() {
     if !enabled {
         info!(
             target: "rustfs::main::init_event_notifier",
-            "Notify module is disabled, event notifier initialization is skipped. Enable the notify module first."
+            "Notify module is disabled, event notifier initialization is skipped. Set RUSTFS_NOTIFY_ENABLE=true to enable notify initialization."
         );
         return;
     }


### PR DESCRIPTION
## Related Issues
Fixes #2756.

## Summary of Changes
- Improve notify diagnostics when no targets are available by returning a detailed configuration hint instead of a generic `No targets configured` message.
- Add a startup guidance log when notify initialization is skipped due to the global module switch being disabled, explicitly pointing to `RUSTFS_NOTIFY_ENABLE=true`.
- Add README webhook Docker quick-start that uses instance-scoped `_PRIMARY` variables and an explicit writable queue dir.

## Verification
- `make pre-commit`

## Impact
- Improves operator troubleshooting for webhook notification setup failures.
- No behavior-breaking API changes; this is primarily diagnostics and documentation improvement.

## Additional Notes
- This PR intentionally keeps runtime behavior unchanged and focuses on low-risk observability/UX improvements for configuration errors.
