### PR TITLE
test(admin): cover orphan resync status cleanup

### DIFF
--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -3383,6 +3383,57 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_sites_prunes_orphan_resync_status_without_matching_site() {
+        let mut state = SiteReplicationState {
+            name: "local".to_string(),
+            ..Default::default()
+        };
+        state.peers.insert(
+            "remote-a-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "remote-a-deployment".to_string(),
+                ..peer("remote-a", "https://remote-a.example.com")
+            },
+        );
+        state.peers.insert(
+            "remote-b-deployment".to_string(),
+            PeerInfo {
+                deployment_id: "remote-b-deployment".to_string(),
+                ..peer("remote-b", "https://remote-b.example.com")
+            },
+        );
+        state.resync_status.insert(
+            "remote-a-deployment".to_string(),
+            SRResyncOpStatus {
+                resync_id: "active-a".to_string(),
+                status: "success".to_string(),
+                ..Default::default()
+            },
+        );
+        state.resync_status.insert(
+            "removed-deployment".to_string(),
+            SRResyncOpStatus {
+                resync_id: "orphaned".to_string(),
+                status: "success".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let state = remove_sites(
+            state,
+            SRRemoveReq {
+                site_names: vec!["missing-site".to_string()],
+                ..Default::default()
+            },
+        );
+
+        assert!(state.peers.contains_key("remote-a-deployment"));
+        assert!(state.peers.contains_key("remote-b-deployment"));
+        assert!(state.resync_status.contains_key("remote-a-deployment"));
+        assert!(!state.resync_status.contains_key("removed-deployment"));
+    }
+
+    #[test]
     fn test_remove_sites_clears_state_when_local_site_is_removed() {
         let mut state = SiteReplicationState {
             name: "local".to_string(),


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This adds focused regression coverage for site replication remove state cleanup.

Recent remove-site logic now prunes `resync_status` entries whose deployment IDs no longer exist in `peers`, even when the requested site name does not match any current peer. Without a dedicated test, that orphan-status cleanup path could regress while the removed-peer and local-site removal tests still pass.

The new unit test builds a state with two active peers plus one orphaned resync status, calls `remove_sites` with a missing site name, and verifies active peer state remains intact while the orphaned resync status is removed.

## Verification
- `cargo test -p rustfs test_remove_sites_prunes_orphan_resync_status_without_matching_site`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
No user-facing behavior change. This is test-only coverage for existing site replication cleanup behavior.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
