### PR TITLE
test(helm): cover standalone scale-to-zero rendering

### DIFF
--- a/scripts/test_helm_templates.sh
+++ b/scripts/test_helm_templates.sh
@@ -33,6 +33,10 @@ fi
 rolling_output=$(render_standalone_deployment)
 grep -q "type: RollingUpdate" <<<"$rolling_output"
 grep -q "rollingUpdate:" <<<"$rolling_output"
+grep -Eq '^[[:space:]]*replicas:[[:space:]]*1[[:space:]]*$' <<<"$rolling_output"
+
+scaled_to_zero_output=$(render_standalone_deployment --set replicaCount=0)
+grep -Eq '^[[:space:]]*replicas:[[:space:]]*0[[:space:]]*$' <<<"$scaled_to_zero_output"
 
 # Fail-closed credential checks. Rendering must fail when no credentials,
 # existingSecret, or allowInsecureDefaults override is supplied.


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds focused Helm chart regression coverage for standalone deployments using `replicaCount=0`.

The recent standalone chart change allows operators to scale a standalone Deployment down to zero replicas. The template test previously only checked the default strategy rendering, so a regression back to a hardcoded replica count would not be caught.

This PR extends `scripts/test_helm_templates.sh` to assert the default standalone render still emits `replicas: 1` while `--set replicaCount=0` emits `replicas: 0`.

## Verification
- `./scripts/test_helm_templates.sh`
- `make pre-commit`
- `make pre-commit` after rebasing onto latest `origin/main`

## Impact
Test-only change. No runtime behavior, API, deployment, or configuration behavior changes.

## Additional Notes
N/A
