### PR TITLE
test(s3): promote passing copy metadata case

### DIFF
--- a/scripts/s3-tests/implemented_tests.txt
+++ b/scripts/s3-tests/implemented_tests.txt
@@ -533,3 +533,4 @@ test_object_put_acl_mtime
 test_object_raw_authenticated_bucket_acl
 test_object_raw_authenticated_object_acl
 test_object_raw_get_object_acl
+test_object_copy_to_itself_with_metadata

--- a/scripts/s3-tests/unimplemented_tests.txt
+++ b/scripts/s3-tests/unimplemented_tests.txt
@@ -31,4 +31,3 @@ test_lifecycle_transition_encrypted
 # Tests with known issues (need further investigation)
 test_bucket_policy_different_tenant
 test_bucket_policy_tenanted_bucket
-test_object_copy_to_itself_with_metadata


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Promoted `test_object_copy_to_itself_with_metadata` from `unimplemented_tests.txt` to `implemented_tests.txt`.
- The candidate audit found this as the only passing test from the current `excluded_tests.txt` and `unimplemented_tests.txt` union.

## Verification
- `DEPLOY_MODE=build TEST_MODE=candidates MAXFAIL=500 ./scripts/s3-tests/run.sh` (expected non-zero for the full candidate batch; JUnit: 307 total, 1 passed, 216 failed, 90 skipped)
- `DEPLOY_MODE=binary TEST_MODE=promoted MAXFAIL=1 ./scripts/s3-tests/run.sh` with only `test_object_copy_to_itself_with_metadata` in the temporary implemented list (pytest: 1 passed)
- Cross-list duplicate check across `implemented_tests.txt`, `unimplemented_tests.txt`, and `excluded_tests.txt`: 0 duplicates
- `git diff --check`

## Impact
- Keeps S3 compatibility classification aligned with current passing behavior.
- No runtime code changes.

## Additional Notes
N/A
