### PR TITLE
test(replication): cover ETag comparison edge cases

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -3988,6 +3988,12 @@ mod tests {
         let tgt_match = HeadObjectOutput::builder().e_tag("\"abc123\"").build();
         assert!(content_matches(&src, &tgt_match), "identical ETags must match");
 
+        let tgt_unquoted_match = HeadObjectOutput::builder().e_tag("abc123").build();
+        assert!(
+            content_matches(&src, &tgt_unquoted_match),
+            "quoted and unquoted ETags with identical values must match"
+        );
+
         // version_id on the target is intentionally ignored
         let tgt_different_version = HeadObjectOutput::builder()
             .e_tag("\"abc123\"")
@@ -4006,6 +4012,9 @@ mod tests {
             ..Default::default()
         };
         assert!(!content_matches(&src_no_etag, &tgt_match), "missing source ETag must not match");
+
+        let tgt_no_etag = HeadObjectOutput::builder().build();
+        assert!(!content_matches(&src, &tgt_no_etag), "missing target ETag must not match");
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This adds focused regression coverage around the replication version-ID mismatch fallback added in recent mainline changes.

The fallback decides whether a RustFS source object and a target S3 object contain the same content by comparing ETags only. The existing test covered matching quoted ETags, differing ETags, ignored target version IDs, and a missing source ETag. This PR also covers the common quoted/unquoted ETag normalization case and the missing target ETag case, so the fallback cannot accidentally treat incomplete target metadata as a content match.

## Verification
- `cargo test -p rustfs-ecstore test_content_matches_compares_etag_only --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
No production behavior change. This is test-only coverage for replication ETag comparison edge cases.

## Additional Notes
N/A
