### PR TITLE
fix(admin): normalize empty admin POST content length

### DIFF
--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -259,19 +259,31 @@ where
 }
 
 fn should_force_zero_content_length_for_admin_empty_body<B>(req: &HttpRequest<B>) -> bool {
-    req.method() == Method::PUT
-        && is_empty_body_admin_put_path(req.uri().path())
-        && !req.headers().contains_key(http::header::CONTENT_LENGTH)
+    is_empty_body_admin_path(req.method(), req.uri().path()) && !req.headers().contains_key(http::header::CONTENT_LENGTH)
 }
 
-fn is_empty_body_admin_put_path(path: &str) -> bool {
-    matches!(
-        path,
-        "/minio/admin/v3/set-user-status"
-            | "/minio/admin/v3/set-group-status"
-            | "/rustfs/admin/v3/set-user-status"
-            | "/rustfs/admin/v3/set-group-status"
-    )
+fn is_empty_body_admin_path(method: &Method, path: &str) -> bool {
+    match *method {
+        Method::PUT => matches!(
+            path,
+            "/minio/admin/v3/set-user-status"
+                | "/minio/admin/v3/set-group-status"
+                | "/rustfs/admin/v3/set-user-status"
+                | "/rustfs/admin/v3/set-group-status"
+        ),
+        Method::POST => matches!(
+            path,
+            "/minio/admin/v3/rebalance/start"
+                | "/minio/admin/v3/rebalance/stop"
+                | "/minio/admin/v3/pools/decommission"
+                | "/minio/admin/v3/pools/cancel"
+                | "/rustfs/admin/v3/rebalance/start"
+                | "/rustfs/admin/v3/rebalance/stop"
+                | "/rustfs/admin/v3/pools/decommission"
+                | "/rustfs/admin/v3/pools/cancel"
+        ),
+        _ => false,
+    }
 }
 
 #[derive(Clone)]
@@ -952,6 +964,29 @@ mod tests {
     }
 
     #[test]
+    fn admin_empty_body_post_without_content_length_is_normalized() {
+        let paths = [
+            "/minio/admin/v3/rebalance/start",
+            "/minio/admin/v3/rebalance/stop",
+            "/minio/admin/v3/pools/decommission?pool=http%3A%2F%2Fminio-%7B1...4%7D%3A9000%2Fdata%7B1...2%7D",
+            "/minio/admin/v3/pools/cancel?pool=http%3A%2F%2Fminio-%7B1...4%7D%3A9000%2Fdata%7B1...2%7D",
+            "/rustfs/admin/v3/rebalance/start",
+            "/rustfs/admin/v3/rebalance/stop",
+            "/rustfs/admin/v3/pools/decommission?pool=http%3A%2F%2Fminio-%7B1...4%7D%3A9000%2Fdata%7B1...2%7D",
+            "/rustfs/admin/v3/pools/cancel?pool=http%3A%2F%2Fminio-%7B1...4%7D%3A9000%2Fdata%7B1...2%7D",
+        ];
+
+        for path in paths {
+            let request = Request::builder().method(Method::POST).uri(path).body(()).expect("request");
+
+            assert!(
+                should_force_zero_content_length_for_admin_empty_body(&request),
+                "{path} should force Content-Length: 0"
+            );
+        }
+    }
+
+    #[test]
     fn admin_request_with_explicit_content_length_is_left_unchanged() {
         let request = Request::builder()
             .method(Method::PUT)
@@ -968,6 +1003,17 @@ mod tests {
         let request = Request::builder()
             .method(Method::PUT)
             .uri("/bucket/object")
+            .body(())
+            .expect("request");
+
+        assert!(!should_force_zero_content_length_for_admin_empty_body(&request));
+    }
+
+    #[test]
+    fn non_empty_body_admin_post_path_is_not_normalized() {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/minio/admin/v3/update-service-account")
             .body(())
             .expect("request");
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Normalize known empty-body admin POST endpoints by adding `Content-Length: 0` when the header is missing.
- Keep the existing empty-body admin PUT compatibility behavior.
- Add regression coverage for rebalance and pool decommission/cancel endpoints, including both MinIO-compatible and RustFS admin prefixes.
- Add a negative test to keep body-bearing admin POST endpoints unchanged.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs server::layer::tests`
- `make pre-commit`

## Impact
Fixes compatibility for clients that send empty-body admin rebalance/decommission requests without an explicit `Content-Length` header. No configuration, API, or storage format changes.

## Additional Notes
N/A
