### PR TITLE
docs(io-metrics): fix misleading metrics links

### DIFF
--- a/crates/io-metrics/README.md
+++ b/crates/io-metrics/README.md
@@ -4,9 +4,6 @@
   <a href="https://github.com/rustfs/rustfs/actions/workflows/ci.yml">
     <img src="https://github.com/rustfs/rustfs/actions/workflows/ci.yml/badge.svg" alt="CI Status" />
   </a>
-  <a href="https://docs.rs/rustfs-io-metrics">
-    <img src="https://docs.rs/rustfs-io-metrics/badge.svg" alt="Documentation" />
-  </a>
   <a href="https://crates.io/crates/rustfs-io-metrics">
     <img src="https://img.shields.io/crates/v/rustfs-io-metrics.svg" alt="Crates.io" />
   </a>
@@ -14,7 +11,7 @@
 
 <p align="center">
   · <a href="https://github.com/rustfs/rustfs">Home</a>
-  · <a href="https://docs.rs/rustfs-io-metrics">Docs</a>
+  · <a href="#documentation">Docs</a>
   · <a href="https://github.com/rustfs/rustfs/issues">Issues</a>
   · <a href="https://github.com/rustfs/rustfs/discussions">Discussions</a>
 </p>
@@ -205,10 +202,23 @@ cargo bench --package rustfs-io-metrics --bench metrics_pipeline
 
 ## Documentation
 
-- [API Documentation](https://docs.rs/rustfs-io-metrics)
-- [Adaptive TTL Design](./docs/adaptive-ttl-design.md)
-- [Metrics Guide](./docs/metrics-guide.md)
-- [Configuration Reference](./docs/config-reference.md)
+This crate records metrics through the Rust `metrics` crate and leaves
+exporting to `rustfs-obs` or the application-level observability pipeline. It
+does not expose Prometheus-compatible HTTP endpoints such as
+`/rustfs/v2/metrics/cluster` or `/rustfs/v2/metrics/node`.
+
+API documentation can be generated locally:
+
+```bash
+cargo doc --package rustfs-io-metrics --no-deps --open
+```
+
+Useful source references:
+
+- [Crate API overview](./src/lib.rs)
+- [Metrics example](./examples/metrics_example.rs)
+- [Configuration module](./src/config.rs)
+- [Adaptive TTL module](./src/adaptive_ttl.rs)
 
 ## Related Modules
 

--- a/crates/io-metrics/README_zh.md
+++ b/crates/io-metrics/README_zh.md
@@ -4,9 +4,6 @@
   <a href="https://github.com/rustfs/rustfs/actions/workflows/ci.yml">
     <img src="https://github.com/rustfs/rustfs/actions/workflows/ci.yml/badge.svg" alt="CI Status" />
   </a>
-  <a href="https://docs.rs/rustfs-io-metrics">
-    <img src="https://docs.rs/rustfs-io-metrics/badge.svg" alt="Documentation" />
-  </a>
   <a href="https://crates.io/crates/rustfs-io-metrics">
     <img src="https://img.shields.io/crates/v/rustfs-io-metrics.svg" alt="Crates.io" />
   </a>
@@ -14,7 +11,7 @@
 
 <p align="center">
   · <a href="https://github.com/rustfs/rustfs">🏠 主页</a>
-  · <a href="https://docs.rs/rustfs-io-metrics">📚 文档</a>
+  · <a href="#-文档">📚 文档</a>
   · <a href="https://github.com/rustfs/rustfs/issues">🐛 问题</a>
   · <a href="https://github.com/rustfs/rustfs/discussions">💬 讨论</a>
 </p>
@@ -286,10 +283,22 @@ cargo bench --package rustfs-io-metrics --bench metrics_pipeline
 
 ## 📚 文档
 
-- [API 文档](https://docs.rs/rustfs-io-metrics)
-- [自适应 TTL 设计](./docs/adaptive-ttl-design.md)
-- [指标收集指南](./docs/metrics-guide.md)
-- [配置参考](./docs/config-reference.md)
+此 crate 通过 Rust `metrics` crate 记录指标，并由 `rustfs-obs` 或应用层可观测性管线负责导出。
+它本身不提供 Prometheus 兼容的 HTTP 端点，例如 `/rustfs/v2/metrics/cluster`
+或 `/rustfs/v2/metrics/node`。
+
+可以在本地生成 API 文档：
+
+```bash
+cargo doc --package rustfs-io-metrics --no-deps --open
+```
+
+相关源码入口：
+
+- [Crate API 概览](./src/lib.rs)
+- [指标示例](./examples/metrics_example.rs)
+- [配置模块](./src/config.rs)
+- [自适应 TTL 模块](./src/adaptive_ttl.rs)
 
 ## 🔗 相关模块
 


### PR DESCRIPTION
## Related Issues

Fixes #2808

## Summary of Changes

Update the `rustfs-io-metrics` README files to remove stale documentation links and clarify the metrics export boundary.

The README now states that `rustfs-io-metrics` records through the Rust `metrics` crate and does not expose Prometheus-compatible HTTP endpoints such as `/rustfs/v2/metrics/cluster` or `/rustfs/v2/metrics/node`. The removed links pointed to missing local documentation files or unavailable API docs; they were replaced with local `cargo doc` guidance and source references.

## Verification

- `rg -n "docs\\.rs/rustfs-io-metrics|\\.\\/docs\\/" crates\\io-metrics\\README.md crates\\io-metrics\\README_zh.md`
- `git diff --check`

## Impact

Documentation only. No runtime, API, configuration, or deployment behavior changes.

## Additional Notes

`make pre-commit` was not run because this is a documentation-only change, which is exempt under the repository instructions.