### PR TITLE
bump workspace versions and replace cfg-if in crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,7 +3191,17 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -3225,7 +3235,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3470,7 +3480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4741,7 +4751,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4818,7 +4828,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5794,7 +5804,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5980,12 +5990,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -5996,6 +6033,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -7827,7 +7875,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7944,7 +7992,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-appauth"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "base64-simd",
  "rand 0.10.1",
@@ -7955,7 +8003,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7978,7 +8026,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -7992,7 +8040,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8011,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "rustfs-io-core",
  "rustfs-io-metrics",
@@ -8023,14 +8071,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "const-str",
 ]
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "base64-simd",
  "rand 0.10.1",
@@ -8041,7 +8089,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -8059,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-channel",
  "async-recursion",
@@ -8157,7 +8205,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -8181,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8209,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8243,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "bytes",
  "memmap2 0.9.10",
@@ -8254,7 +8302,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "criterion",
  "metrics",
@@ -8315,7 +8363,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "bytes",
  "futures",
@@ -8340,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -8369,7 +8417,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -8390,7 +8438,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "chrono",
  "humantime",
@@ -8403,7 +8451,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8434,7 +8482,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "criterion",
  "futures",
@@ -8453,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -8499,7 +8547,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -8527,7 +8575,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -8577,7 +8625,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "flatbuffers",
  "prost 0.14.3",
@@ -8592,7 +8640,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -8625,7 +8673,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-common"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "metrics",
  "serde",
@@ -8634,7 +8682,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8661,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -8678,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8709,7 +8757,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -8725,7 +8773,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -8754,7 +8802,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -8778,7 +8826,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "base64-simd",
  "blake2 0.11.0-rc.6",
@@ -8822,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-workers"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "tokio",
  "tracing",
@@ -8830,7 +8878,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -8904,7 +8952,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8963,7 +9011,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9920,15 +9968,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "rayon",
  "windows",
 ]
@@ -9980,7 +10029,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10970,7 +11019,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8093,7 +8093,6 @@ version = "1.0.0-beta.2"
 dependencies = [
  "aes-gcm",
  "argon2",
- "cfg-if",
  "chacha20poly1305",
  "jsonwebtoken",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ resolver = "3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
-rust-version = "1.93.0"
-version = "1.0.0-beta.1"
+rust-version = "1.95.0"
+version = "1.0.0-beta.2"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -76,42 +76,42 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.1" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.1" }
-rustfs-appauth = { path = "crates/appauth", version = "1.0.0-beta.1" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.1" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.1" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.1" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.1" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.1" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.1" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.1" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.1" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.1" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.1" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.1" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.1" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.1" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.1" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.1" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.1" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.1" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.1" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.1" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.1" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.1" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.1" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.1" }
-rustfs-s3-common = { path = "crates/s3-common", version = "1.0.0-beta.1" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.1" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.1" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.1" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.1" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.1" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.1" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.1" }
-rustfs-workers = { path = "crates/workers", version = "1.0.0-beta.1" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.1" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.2" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.2" }
+rustfs-appauth = { path = "crates/appauth", version = "1.0.0-beta.2" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.2" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.2" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.2" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.2" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.2" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.2" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.2" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.2" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.2" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.2" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.2" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.2" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.2" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.2" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.2" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.2" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.2" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.2" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.2" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.2" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.2" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.2" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.2" }
+rustfs-s3-common = { path = "crates/s3-common", version = "1.0.0-beta.2" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.2" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.2" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.2" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.2" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.2" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.2" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.2" }
+rustfs-workers = { path = "crates/workers", version = "1.0.0-beta.2" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.2" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"
@@ -261,7 +261,7 @@ snafu = "0.9.0"
 snap = "1.1.1"
 starshard = { version = "1.1.0", features = ["rayon", "async", "serde"] }
 strum = { version = "0.28.0", features = ["derive"] }
-sysinfo = "0.38.4"
+sysinfo = "0.39.0"
 temp-env = "0.3.6"
 tempfile = "3.27.0"
 test-case = "3.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,6 @@ backtrace = "0.3.76"
 base64 = "0.22.1"
 base64-simd = "0.8.0"
 brotli = "8.0.2"
-cfg-if = "1.0.4"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 const-str = { version = "1.1.0", features = ["std", "proc"] }
 convert_case = "0.11.0"

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -31,7 +31,6 @@ workspace = true
 [dependencies]
 aes-gcm = { workspace = true, optional = true }
 argon2 = { workspace = true, optional = true }
-cfg-if = { workspace = true }
 chacha20poly1305 = { workspace = true, optional = true }
 jsonwebtoken = { workspace = true }
 pbkdf2 = { workspace = true, optional = true }

--- a/crates/crypto/src/encdec/aes.rs
+++ b/crates/crypto/src/encdec/aes.rs
@@ -13,19 +13,23 @@
 // limitations under the License.
 
 pub fn native_aes() -> bool {
-    cfg_if::cfg_if! {
-        if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+    cfg_select! {
+        any(target_arch = "x86", target_arch = "x86_64") => {
             std::is_x86_feature_detected!("aes") && std::is_x86_feature_detected!("pclmulqdq")
-        } else if #[cfg(target_arch = "aarch64")] {
+        }
+        target_arch = "aarch64" => {
             std::arch::is_aarch64_feature_detected!("aes")
-        } else if #[cfg(target_arch = "powerpc64")] {
+        }
+        target_arch = "powerpc64" => {
             false
-        } else if #[cfg(target_arch = "s390x")] {
+        }
+        target_arch = "s390x" => {
             std::is_s390x_feature_detected!("aes")
                 && std::is_s390x_feature_detected!("aescbc")
                 && std::is_s390x_feature_detected!("aesctr")
                 && (std::is_s390x_feature_detected!("aesgcm") || std::is_s390x_feature_detected!("ghash"))
-        } else {
+        }
+        _ => {
             false
         }
     }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This PR updates the RustFS workspace metadata and modernizes the AES capability check in `rustfs-crypto`.

Changes include:
- Bump the workspace minimum Rust version from `1.93.0` to `1.95.0`
- Bump the workspace version from `1.0.0-beta.1` to `1.0.0-beta.2`
- Update all workspace crate version references from `1.0.0-beta.1` to `1.0.0-beta.2`
- Upgrade `sysinfo` from `0.38.4` to `0.39.0`
- Replace `cfg_if::cfg_if!` with `std::cfg_select!` in `rustfs-crypto::encdec::aes::native_aes`
- Remove the now-unused `cfg-if` dependency from `rustfs-crypto`

## Verification
- `cargo check --workspace --offline --quiet`
- `cargo check -p rustfs-crypto --offline --quiet`

## Impact
This is a dependency and metadata update with one internal implementation cleanup.

User-facing impact:
- Requires Rust 1.95.0 or newer
- Updates the published crate/workspace version labels to `1.0.0-beta.2`

Behavioral impact:
- AES feature detection logic remains the same
- `rustfs-crypto` now relies on the standard library's `cfg_select!` instead of the external `cfg-if` crate

## Additional Notes
N/A
