### PR TITLE
test(admin): cover pools list response serialization

### DIFF
--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -673,7 +673,7 @@ mod tests {
             })
         );
     }
-  
+
     #[test]
     fn admin_pool_list_item_saturates_used_size_when_current_exceeds_total() {
         let pool = PoolStatus {

--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -648,6 +648,33 @@ mod tests {
     }
 
     #[test]
+    fn admin_pool_list_item_serializes_admin_api_fields() {
+        let item = DefaultAdminUsecase::pool_list_item_from_status(PoolStatus {
+            id: 1,
+            cmd_line: "pool-1".to_string(),
+            last_update: OffsetDateTime::UNIX_EPOCH,
+            decommission: None,
+        });
+
+        let value = serde_json::to_value(item).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "id": 1,
+                "cmdline": "pool-1",
+                "lastUpdate": "1970-01-01T00:00:00Z",
+                "totalSize": 0,
+                "currentSize": 0,
+                "usedSize": 0,
+                "used": 0.0,
+                "status": "active",
+                "decommissionInfo": null
+            })
+        );
+    }
+
+    #[test]
     fn admin_pool_list_item_maps_running_decommission_status() {
         let pool = PoolStatus {
             id: 0,


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds focused regression coverage for the enriched admin pools list response introduced by #2853.

The new test serializes an `AdminPoolListItem` and verifies the external JSON contract, including `cmdline`, `lastUpdate`, capacity fields, `used`, `status`, and `decommissionInfo`.

## Verification
- `PATH="/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" cargo test -p rustfs admin_pool_list_item --lib`
- `PATH="/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" cargo fmt --all`
- `PATH="/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" cargo fmt --all --check`
- `PATH="/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" make pre-commit`

## Impact
No production behavior change. This only locks the admin pools list JSON response shape with a unit test.

## Additional Notes
The local default Homebrew Rust toolchain is 1.93.1, while this workspace requires Rust 1.95.0, so verification used the installed rustup 1.95.0 toolchain explicitly.
