### PR TITLE
test(admin): cover pool used-size saturation

### DIFF
--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -648,6 +648,27 @@ mod tests {
     }
 
     #[test]
+    fn admin_pool_list_item_saturates_used_size_when_current_exceeds_total() {
+        let pool = PoolStatus {
+            id: 0,
+            cmd_line: "pool-0".to_string(),
+            last_update: OffsetDateTime::UNIX_EPOCH,
+            decommission: Some(PoolDecommissionInfo {
+                total_size: 100,
+                current_size: 150,
+                ..Default::default()
+            }),
+        };
+
+        let item = DefaultAdminUsecase::pool_list_item_from_status(pool);
+
+        assert_eq!(item.total_size, 100);
+        assert_eq!(item.current_size, 150);
+        assert_eq!(item.used_size, 0);
+        assert_eq!(item.used, 0.0);
+    }
+
+    #[test]
     fn admin_pool_list_item_maps_running_decommission_status() {
         let pool = PoolStatus {
             id: 0,


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds a focused unit test for the admin pool list capacity mapping introduced by the recent pools list response change.

The test covers the edge case where backend decommission data reports `current_size` greater than `total_size`. In that case the public `usedSize` and `used` fields should stay saturated at zero instead of underflowing or producing an invalid ratio.

This is separate from the existing pools list serialization coverage in PR #2862.

## Verification
- `RUSTC="$(rustup which --toolchain 1.95.0 rustc)" rustup run 1.95.0 cargo test -p rustfs admin_pool_list_item_saturates_used_size_when_current_exceeds_total --lib`
- `rustup run 1.95.0 cargo fmt --all --check`
- `TOOLCHAIN_BIN="$(dirname "$(rustup which --toolchain 1.95.0 cargo)")" RUSTC="$(rustup which --toolchain 1.95.0 rustc)" PATH="$(dirname "$(rustup which --toolchain 1.95.0 cargo)"):$PATH" make pre-commit`

## Impact
Test-only change. No runtime behavior, API, deployment, or configuration impact.

## Additional Notes
N/A
