### PR TITLE
test(ecstore): cover store init health reset delegation

### DIFF
--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -1119,4 +1119,39 @@ mod tests {
         // Clean up the test directory
         let _ = fs::remove_dir_all(&test_dir).await;
     }
+
+    #[tokio::test]
+    async fn reset_health_for_store_init_retry_delegates_to_disk_variants() {
+        let local_dir = tempfile::tempdir().unwrap();
+        let local_endpoint = Endpoint::try_from(local_dir.path().to_str().unwrap()).unwrap();
+        let local_disk = LocalDisk::new(&local_endpoint, false).await.unwrap();
+        let local_disk = Disk::Local(Box::new(LocalDiskWrapper::new(Arc::new(local_disk), false)));
+
+        let remote_endpoint = Endpoint {
+            url: url::Url::parse("http://remote-server:9000/data").unwrap(),
+            is_local: false,
+            pool_idx: 0,
+            set_idx: 0,
+            disk_idx: 0,
+        };
+        let remote_disk = RemoteDisk::new(
+            &remote_endpoint,
+            &DiskOption {
+                cleanup: false,
+                health_check: false,
+            },
+        )
+        .await
+        .unwrap();
+        let remote_disk = Disk::Remote(Box::new(remote_disk));
+
+        for disk in [&local_disk, &remote_disk] {
+            disk.force_runtime_state_for_test(RuntimeDriveHealthState::Offline);
+            assert_eq!(disk.runtime_state(), RuntimeDriveHealthState::Offline);
+
+            disk.reset_health_for_store_init_retry();
+
+            assert_eq!(disk.runtime_state(), RuntimeDriveHealthState::Online);
+        }
+    }
 }

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -1123,17 +1123,18 @@ mod tests {
     #[tokio::test]
     async fn reset_health_for_store_init_retry_delegates_to_disk_variants() {
         let local_dir = tempfile::tempdir().unwrap();
-        let local_endpoint = Endpoint::try_from(local_dir.path().to_str().unwrap()).unwrap();
+        let local_path = local_dir.path().to_str().expect("tempdir path should be utf8");
+        let mut local_endpoint = Endpoint::try_from(local_path).expect("local endpoint should parse");
+        local_endpoint.set_pool_index(0);
+        local_endpoint.set_set_index(0);
+        local_endpoint.set_disk_index(0);
         let local_disk = LocalDisk::new(&local_endpoint, false).await.unwrap();
         let local_disk = Disk::Local(Box::new(LocalDiskWrapper::new(Arc::new(local_disk), false)));
 
-        let remote_endpoint = Endpoint {
-            url: url::Url::parse("http://remote-server:9000/data").unwrap(),
-            is_local: false,
-            pool_idx: 0,
-            set_idx: 0,
-            disk_idx: 0,
-        };
+        let mut remote_endpoint = Endpoint::try_from("http://remote-server:9000/data").expect("remote endpoint should parse");
+        remote_endpoint.set_pool_index(0);
+        remote_endpoint.set_set_index(0);
+        remote_endpoint.set_disk_index(1);
         let remote_disk = RemoteDisk::new(
             &remote_endpoint,
             &DiskOption {


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This adds focused coverage for the store init drive-health retry path introduced by PR #2848.

The existing regression coverage exercised `DiskHealthTracker` directly. The store initialization loop, however, calls through the `Disk` enum on reused `DiskStore` handles. This test creates both local and remote disk variants, forces each variant offline, calls `reset_health_for_store_init_retry`, and verifies the runtime state returns to `Online`.

## Verification
- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.95.0 test -p rustfs-ecstore reset_health_for_store_init_retry_delegates_to_disk_variants --lib`
- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.95.0 fmt --all`
- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.95.0 fmt --all --check`
- `PATH="$HOME/.cargo/bin:$PATH" RUSTUP_TOOLCHAIN=1.95.0 make pre-commit`

## Impact
No runtime behavior change. This is test-only coverage for the disk health reset delegation used during store initialization retries.

## Additional Notes
The focused test would fail before PR #2848 because `Disk::reset_health_for_store_init_retry` did not exist.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
