### PR TITLE
test(ecstore): cover system path failure classifier

### DIFF
--- a/crates/ecstore/src/error.rs
+++ b/crates/ecstore/src/error.rs
@@ -1037,6 +1037,28 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_system_path_failure_reason() {
+        assert_eq!(classify_system_path_failure_reason(&StorageError::ConfigNotFound), "config_not_found");
+        assert_eq!(classify_system_path_failure_reason(&StorageError::ErasureReadQuorum), "read_quorum");
+        assert_eq!(
+            classify_system_path_failure_reason(&StorageError::InsufficientReadQuorum(
+                "bucket".to_string(),
+                "object".to_string()
+            )),
+            "read_quorum"
+        );
+        assert_eq!(
+            classify_system_path_failure_reason(&StorageError::Io(IoError::new(ErrorKind::TimedOut, "probe"))),
+            "timeout"
+        );
+        assert_eq!(
+            classify_system_path_failure_reason(&StorageError::Io(IoError::new(ErrorKind::PermissionDenied, "probe"))),
+            "io"
+        );
+        assert_eq!(classify_system_path_failure_reason(&StorageError::DiskFull), "other");
+    }
+
+    #[test]
     fn test_storage_error_from_disk_error() {
         // Test conversion from DiskError
         let disk_io = DiskError::Io(IoError::other("disk io error"));


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds focused unit coverage for the system path failure reason classifier introduced in the recent ecstore runtime read-path hardening work.

The new test covers config-not-found, read-quorum, timeout, generic I/O, and fallback error classifications so IAM and data-usage telemetry paths keep stable failure reason labels.

## Verification
- `cargo test -p rustfs-ecstore test_classify_system_path_failure_reason --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
Test-only change. No runtime, API, configuration, or compatibility impact.

## Additional Notes
Used Rust 1.95.0 explicitly for local verification because the default Homebrew rustc on this machine is older than the workspace MSRV.
