### PR TITLE
test(ecstore): cover offline capacity snapshots

### DIFF
--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -5407,6 +5407,27 @@ mod tests {
         assert!(info[2].drive_path.is_empty(), "offline disk should use runtime snapshot fallback");
     }
 
+    #[tokio::test]
+    async fn test_get_disks_info_uses_capacity_snapshot_for_offline_disk() {
+        let format = FormatV3::new(1, 1);
+        let (temp_dir, endpoint, disk) = make_formatted_local_disk_for_info_test(0, &format).await;
+        disk.record_capacity_probe(100, 40, 60);
+        disk.force_runtime_state_for_test(RuntimeDriveHealthState::Offline);
+
+        let info = get_disks_info(&[Some(disk)], &[endpoint]).await;
+        assert_eq!(info.len(), 1);
+        assert_eq!(info[0].state, "offline");
+        assert_eq!(info[0].runtime_state.as_deref(), Some("offline"));
+        assert_eq!(info[0].capacity_observation_source.as_deref(), Some("snapshot"));
+        assert!(info[0].capacity_observation_age_seconds.unwrap_or(u64::MAX) <= 60);
+        assert_eq!(info[0].total_space, 100);
+        assert_eq!(info[0].used_space, 40);
+        assert_eq!(info[0].available_space, 60);
+        assert_eq!(info[0].utilization, 40.0);
+
+        drop(temp_dir);
+    }
+
     #[test]
     fn test_dangling_meta_errs_count() {
         // Test counting dangling metadata errors


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This PR adds focused regression coverage for the recent ECStore admin disk-info capacity snapshot fallback. The new test records a capacity probe on a local disk, forces the disk offline, then verifies `get_disks_info` reports the offline runtime state while preserving cached total, used, free, utilization, observation source, and observation age fields.

The path matters because the recent read-path quorum hardening keeps admin capacity reporting useful when a disk cannot be live-probed. Without this coverage, the offline snapshot fallback could regress while existing tests only checked the runtime state and empty drive path.

## Verification
- `PATH="$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" cargo test -p rustfs-ecstore test_get_disks_info_uses_capacity_snapshot_for_offline_disk --lib`
- `PATH="$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" cargo fmt --all --check`
- `PATH="$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" make pre-commit`

## Impact
Test-only change. No runtime behavior, API, configuration, or deployment impact.

## Additional Notes
The local shell resolves the repository `stable` toolchain to Homebrew Rust 1.93.1, while the workspace requires Rust 1.95.0. Verification was run by temporarily prepending the installed Rust 1.95.0 toolchain to `PATH`.
