### PR TITLE
docs(targets): sync AGENTS.md and test doc comments with code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,5 +113,6 @@ Do not open a PR with code changes when the required checks fail.
 - `crates/iam/AGENTS.md`
 - `crates/kms/AGENTS.md`
 - `crates/policy/AGENTS.md`
+- `crates/targets/AGENTS.md`
 - `rustfs/src/admin/AGENTS.md`
 - `rustfs/src/storage/AGENTS.md`

--- a/crates/targets/AGENTS.md
+++ b/crates/targets/AGENTS.md
@@ -4,9 +4,9 @@ Applies to `crates/targets/`.
 
 `rustfs-targets` provides the notification target abstraction layer:
 the `Target<E>` trait, built-in implementations (Webhook, Kafka, MQTT,
-NATS, Pulsar, MySQL), persistent queue store, DSN/configuration
-builders, and the `ChannelTargetType` registry that maps target types
-to their runtime factories.
+NATS, Pulsar, MySQL, Postgres, Redis), persistent queue store,
+DSN/configuration builders, and the `ChannelTargetType` registry that
+maps target types to their runtime factories.
 
 ## Library Design
 
@@ -27,34 +27,12 @@ to their runtime factories.
 
 ## Integration Tests
 
-### MySQL Integration Tests
+Integration tests under `tests/` are `#[ignore]` by default so CI never runs
+them. See the module-level doc comment in each test file for prerequisites
+and run commands:
 
-Integration tests in `tests/mysql_integration.rs` require a running MySQL 8.0+
-or TiDB 8.5+ instance. They are `#[ignore]` by default so CI never runs them.
-
-Start a test MySQL instance with Podman:
-
-```bash
-podman run -d --name rustfs-mysql-test \
-  -e MYSQL_ROOT_PASSWORD=testpass \
-  -e MYSQL_DATABASE=testdb \
-  -p 3306:3306 \
-  docker.io/library/mysql:8.0.36
-```
-
-Wait for MySQL to be ready (look for `ready for connections` in logs),
-then run the integration tests:
-
-```bash
-RUSTFS_MYSQL_TEST_DSN="root:testpass@tcp(127.0.0.1:3306)/testdb" \
-  cargo test -p rustfs-targets -- --ignored
-```
-
-Clean up:
-
-```bash
-podman rm -f rustfs-mysql-test
-```
+- `tests/mysql_integration.rs` — MySQL 8.0+ / TiDB 8.5+
+- `tests/postgres_integration.rs` — PostgreSQL
 
 ## Suggested Validation
 

--- a/crates/targets/src/target/mod.rs
+++ b/crates/targets/src/target/mod.rs
@@ -268,16 +268,21 @@ impl QueuedPayload {
 /// used in the notification system.
 ///
 /// It includes:
-/// - `Webhook`: Represents a webhook target for sending notifications via HTTP requests.
-/// - `Kafka`: Represents a Kafka target for sending notifications to a Kafka topic.
-/// - `Mqtt`: Represents an MQTT target for sending notifications via MQTT protocol.
+/// - `Webhook`: Sends notifications via HTTP POST requests.
+/// - `Kafka`: Publishes notifications to a Kafka topic.
+/// - `Mqtt`: Publishes notifications via MQTT protocol.
+/// - `MySql`: Writes notifications to a MySQL/TiDB table.
+/// - `Nats`: Publishes notifications to a NATS subject.
+/// - `Postgres`: Writes notifications to a PostgreSQL table (namespace or access format).
+/// - `Pulsar`: Publishes notifications to a Pulsar topic.
+/// - `Redis`: Publishes notifications to a Redis channel (pub/sub).
 ///
 /// Each variant has an associated string representation that can be used for serialization
 /// or logging purposes.
 /// The `as_str` method returns the string representation of the target type,
 /// and the `Display` implementation allows for easy formatting of the target type as a string.
 ///
-/// example usage:
+/// Example usage:
 /// ```rust
 /// use rustfs_targets::target::ChannelTargetType;
 ///
@@ -285,9 +290,6 @@ impl QueuedPayload {
 /// assert_eq!(target_type.as_str(), "webhook");
 /// println!("Target type: {}", target_type);
 /// ```
-///
-/// example output:
-/// Target type: webhook
 pub enum ChannelTargetType {
     Webhook,
     Kafka,

--- a/crates/targets/tests/mysql_integration.rs
+++ b/crates/targets/tests/mysql_integration.rs
@@ -15,11 +15,26 @@
 //! MySQL notification target integration tests.
 //!
 //! These tests require a running MySQL 8.0+ or TiDB 8.5+ instance.
-//! Set `RUSTFS_MYSQL_TEST_DSN` to enable them:
+//! They are `#[ignore]` by default so CI never runs them. To run locally:
 //!
 //! ```bash
-//! RUSTFS_MYSQL_TEST_DSN="user:pass@tcp(127.0.0.1:3306)/testdb" \
-//!   cargo test -p rustfs-targets -- --ignored
+//! podman run -d --name rustfs-mysql-test -p 3306:3306 \
+//!     -e MYSQL_ROOT_PASSWORD=testpass -e MYSQL_DATABASE=testdb \
+//!     docker.io/library/mysql:8.0.36
+//! ```
+//!
+//! Wait for MySQL to be ready (look for `ready for connections` in logs),
+//! then set `RUSTFS_TEST_MYSQL_DSN` and run:
+//!
+//! ```bash
+//! export RUSTFS_TEST_MYSQL_DSN="root:testpass@tcp(127.0.0.1:3306)/testdb"
+//! cargo test -p rustfs-targets --test mysql_integration -- --ignored
+//! ```
+//!
+//! Clean up:
+//!
+//! ```bash
+//! podman rm -f rustfs-mysql-test
 //! ```
 
 use mysql_async::{Opts, OptsBuilder, Pool, SslOpts, prelude::Queryable};
@@ -30,7 +45,7 @@ use tempfile::TempDir;
 use uuid::Uuid;
 
 fn test_dsn() -> String {
-    env::var("RUSTFS_MYSQL_TEST_DSN").expect("RUSTFS_MYSQL_TEST_DSN must be set")
+    env::var("RUSTFS_TEST_MYSQL_DSN").expect("RUSTFS_TEST_MYSQL_DSN must be set")
 }
 
 fn table_name(prefix: &str) -> String {

--- a/crates/targets/tests/mysql_integration.rs
+++ b/crates/targets/tests/mysql_integration.rs
@@ -15,7 +15,8 @@
 //! MySQL notification target integration tests.
 //!
 //! These tests require a running MySQL 8.0+ or TiDB 8.5+ instance.
-//! They are `#[ignore]` by default so CI never runs them. To run locally:
+//! They are `#[ignore]` by default so CI never runs them. To run locally
+//! (podman recommended; docker works too):
 //!
 //! ```bash
 //! podman run -d --name rustfs-mysql-test -p 3306:3306 \

--- a/crates/targets/tests/postgres_integration.rs
+++ b/crates/targets/tests/postgres_integration.rs
@@ -15,7 +15,8 @@
 //! PostgreSQL notification target integration tests.
 //!
 //! These tests require a running PostgreSQL server. They are `#[ignore]` by
-//! default so CI never runs them. To run locally:
+//! default so CI never runs them. To run locally
+//! (podman recommended; docker works too):
 //!
 //! ```bash
 //! podman run -d --name rustfs-pg-test -p 5432:5432 \

--- a/crates/targets/tests/postgres_integration.rs
+++ b/crates/targets/tests/postgres_integration.rs
@@ -55,10 +55,7 @@ fn env_or(key: &str, default: &str) -> String {
 }
 
 fn test_args(table: &str, format: PostgresFormat) -> PostgresArgs {
-    let dsn = env_or(
-        "RUSTFS_TEST_PG_DSN",
-        "postgres://postgres:rustfs@localhost:5432/rustfs_events",
-    );
+    let dsn = env_or("RUSTFS_TEST_PG_DSN", "postgres://postgres:rustfs@localhost:5432/rustfs_events");
     let schema = PostgresDsn::parse(&dsn)
         .expect("RUSTFS_TEST_PG_DSN must be a valid PostgreSQL DSN")
         .schema;

--- a/crates/targets/tests/postgres_integration.rs
+++ b/crates/targets/tests/postgres_integration.rs
@@ -12,20 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Integration tests for the PostgreSQL notification target.
+//! PostgreSQL notification target integration tests.
 //!
-//! All tests in this file are `#[ignore]` because they require a running
-//! PostgreSQL server. CI does not run them by default. To run locally:
+//! These tests require a running PostgreSQL server. They are `#[ignore]` by
+//! default so CI never runs them. To run locally:
 //!
 //! ```bash
-//! docker run -d --name rustfs-pg -p 5432:5432 \
-//!     -e POSTGRES_PASSWORD=rustfs -e POSTGRES_DB=rustfs_events postgres:16
+//! podman run -d --name rustfs-pg-test -p 5432:5432 \
+//!     -e POSTGRES_PASSWORD=rustfs -e POSTGRES_DB=rustfs_events \
+//!     docker.io/library/postgres:16
+//! ```
+//!
+//! Wait for PostgreSQL to be ready (look for `database system is ready` in logs),
+//! then set `RUSTFS_TEST_PG_DSN` and run:
+//!
+//! ```bash
 //! export RUSTFS_TEST_PG_DSN="postgres://postgres:rustfs@localhost:5432/rustfs_events?search_path=public"
 //! cargo test -p rustfs-targets --test postgres_integration -- --ignored
 //! ```
 //!
-//! Connection parameters can be overridden via environment variable:
-//! `RUSTFS_TEST_PG_DSN`.
+//! Clean up:
+//!
+//! ```bash
+//! podman rm -f rustfs-pg-test
+//! ```
 
 use rustfs_s3_common::EventName;
 use rustfs_targets::Target;

--- a/crates/targets/tests/postgres_integration.rs
+++ b/crates/targets/tests/postgres_integration.rs
@@ -27,7 +27,7 @@
 //! then set `RUSTFS_TEST_PG_DSN` and run:
 //!
 //! ```bash
-//! export RUSTFS_TEST_PG_DSN="postgres://postgres:rustfs@localhost:5432/rustfs_events?search_path=public"
+//! export RUSTFS_TEST_PG_DSN="postgres://postgres:rustfs@localhost:5432/rustfs_events"
 //! cargo test -p rustfs-targets --test postgres_integration -- --ignored
 //! ```
 //!
@@ -56,7 +56,7 @@ fn env_or(key: &str, default: &str) -> String {
 fn test_args(table: &str, format: PostgresFormat) -> PostgresArgs {
     let dsn = env_or(
         "RUSTFS_TEST_PG_DSN",
-        "postgres://postgres:rustfs@localhost:5432/rustfs_events?search_path=public",
+        "postgres://postgres:rustfs@localhost:5432/rustfs_events",
     );
     let schema = PostgresDsn::parse(&dsn)
         .expect("RUSTFS_TEST_PG_DSN must be a valid PostgreSQL DSN")


### PR DESCRIPTION
## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->
* https://github.com/rustfs/rustfs/issues/2747
* #2608

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->
- AGENTS.md: added missing Postgres/Redis to targets list, replaced duplicated integration test instructions with pointers to test file doc comments
- `target/mod.rs`: documented all 8 `ChannelTargetType` variants in enum doc comment
- `mysql_integration.rs`: added full podman startup/run/cleanup guide, renamed env var to `RUSTFS_TEST_MYSQL_DSN` for consistency, added `--test` filter to cargo command
- `postgres_integration.rs`: aligned doc comment structure with MySQL test, removed redundant `?search_path=public` from DSN (PostgresDsn::parse defaults to `public` schema)
- Both test files: clarified both podman and docker are supported

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->
- `cargo fmt --all --check`
- `cargo test -p rustfs-targets --test mysql_integration -- --ignored` — 5 passed
- `cargo test -p rustfs-targets --test postgres_integration -- --ignored` — 6 passed

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->
Documentation only. The env var rename from `RUSTFS_MYSQL_TEST_DSN` to `RUSTFS_TEST_MYSQL_DSN` affects local test runners only (integration tests are `#[ignore]` and never run in CI).

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->
N/A
