### PR TITLE
fix(targets): handle postgres dsn redaction scheme case

### DIFF
--- a/crates/targets/src/config/loader.rs
+++ b/crates/targets/src/config/loader.rs
@@ -45,12 +45,15 @@ fn redact_target_field_value(field_name: &str, value: &str) -> String {
     if value.is_empty() {
         return value.to_string();
     }
-    // MySQL DSN fields need partial redaction instead of full masking so the
-    // remaining connection details (host, port, database) remain visible in
-    // debug logs while the password is hidden.
+    // Shared DSN fields need target-specific partial redaction so connection
+    // details stay visible in debug logs while passwords remain hidden.
     if field_name == rustfs_config::BASE_DSN_STRING {
         let trimmed = value.trim_start();
-        if trimmed.starts_with("postgres://") || trimmed.starts_with("postgresql://") {
+        if ["postgres://", "postgresql://"].iter().any(|prefix| {
+            trimmed
+                .get(..prefix.len())
+                .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
+        }) {
             return crate::target::postgres::redact_postgres_dsn(value);
         }
         return crate::target::mysql::redact_mysql_dsn(value);
@@ -344,6 +347,14 @@ mod tests {
         let redacted = redact_target_field_value(rustfs_config::POSTGRES_DSN_STRING, dsn);
         assert_eq!(redacted, "postgres://rustfs:***@pg.example.com:5432/rustfs_events?search_path=public");
         assert_eq!(redact_target_field_value(rustfs_config::POSTGRES_DSN_STRING, ""), "");
+    }
+
+    #[test]
+    fn redact_postgres_dsn_string_handles_case_insensitive_scheme() {
+        let dsn = "POSTGRES://rustfs:secret123@pg.example.com:5432/rustfs_events?search_path=public";
+        let redacted = redact_target_field_value(rustfs_config::POSTGRES_DSN_STRING, dsn);
+
+        assert_eq!(redacted, "postgres://rustfs:***@pg.example.com:5432/rustfs_events?search_path=public");
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This PR closes a focused test gap in the recent targets DSN redaction path. The shared `dsn_string` redaction dispatcher recognized PostgreSQL DSNs only when the scheme was lowercase, even though URL schemes are case-insensitive and the PostgreSQL parser/redactor already accepts uppercase schemes.

The change adds a regression test for an uppercase `POSTGRES://` DSN and makes the dispatcher compare the PostgreSQL scheme prefixes case-insensitively before selecting the PostgreSQL redactor. This preserves useful non-secret connection details while keeping the password masked.

## Verification
- `PATH=/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH cargo test -p rustfs-targets redact_postgres_dsn_string_handles_case_insensitive_scheme --lib` (fails before the fix, passes after)
- `PATH=/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH cargo test -p rustfs-targets config::loader::tests --lib`
- `PATH=/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH cargo fmt --all --check`
- `PATH=/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH cargo test -p rustfs-targets --lib`
- `PATH=/Users/overtrue/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH make pre-commit`

## Impact
No API, storage, or runtime behavior changes beyond diagnostic redaction formatting for uppercase PostgreSQL DSN schemes. Secrets remain masked.

## Additional Notes
N/A
