### PR TITLE
helm: add drivesPerNode to decouple drive count from replica count

### DIFF
--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -169,12 +169,14 @@ Render RUSTFS_VOLUMES
   {{- $protocol = "https" -}}
 {{- end -}}
 
-{{- if eq (int .Values.replicaCount) 4 }}
-{{- printf "%s://%s-{0...%d}.%s-headless.%s.svc.cluster.local:%d/data/rustfs{0...%d}" $protocol (include "rustfs.fullname" .) (sub (.Values.replicaCount | int) 1) (include "rustfs.fullname" . ) .Release.Namespace (.Values.service.endpoint.port | int) (sub (.Values.replicaCount | int) 1) }}
-{{- end }}
-{{- if eq (int .Values.replicaCount) 16 }}
-{{- printf "%s://%s-{0...%d}.%s-headless.%s.svc.cluster.local:%d/data" $protocol (include "rustfs.fullname" .) (sub (.Values.replicaCount | int) 1) (include "rustfs.fullname" .) .Release.Namespace (.Values.service.endpoint.port | int) }}
-{{- end }}
+{{- $replicas := int .Values.replicaCount -}}
+{{- $drives := int .Values.drivesPerNode -}}
+
+{{- if gt $drives 1 -}}
+{{- printf "%s://%s-{0...%d}.%s-headless.%s.svc.cluster.local:%d/data/rustfs{0...%d}" $protocol (include "rustfs.fullname" .) (sub $replicas 1) (include "rustfs.fullname" .) .Release.Namespace (.Values.service.endpoint.port | int) (sub $drives 1) }}
+{{- else -}}
+{{- printf "%s://%s-{0...%d}.%s-headless.%s.svc.cluster.local:%d/data" $protocol (include "rustfs.fullname" .) (sub $replicas 1) (include "rustfs.fullname" .) .Release.Namespace (.Values.service.endpoint.port | int) }}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -171,6 +171,12 @@ Render RUSTFS_VOLUMES
 
 {{- $replicas := int .Values.replicaCount -}}
 {{- $drives := int .Values.drivesPerNode -}}
+{{- if lt $replicas 1 -}}
+  {{- fail "rustfs.volumes requires .Values.replicaCount to be >= 1" -}}
+{{- end -}}
+{{- if lt $drives 1 -}}
+  {{- fail "rustfs.volumes requires .Values.drivesPerNode to be >= 1" -}}
+{{- end -}}
 
 {{- if gt $drives 1 -}}
 {{- printf "%s://%s-{0...%d}.%s-headless.%s.svc.cluster.local:%d/data/rustfs{0...%d}" $protocol (include "rustfs.fullname" .) (sub $replicas 1) (include "rustfs.fullname" .) .Release.Namespace (.Values.service.endpoint.port | int) (sub $drives 1) }}

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -69,28 +69,28 @@ spec:
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           env:
-            - name: REPLICA_COUNT
-              value: {{ .Values.replicaCount | quote }}
+            - name: DRIVES_PER_NODE
+              value: {{ .Values.drivesPerNode | quote }}
           command:
             - sh
             - -c
             - |
-              if [ "$REPLICA_COUNT" -eq 4 ]; then
-                for i in $(seq 0 $(($REPLICA_COUNT - 1))); do
+              if [ "$DRIVES_PER_NODE" -gt 1 ]; then
+                for i in $(seq 0 $(($DRIVES_PER_NODE - 1))); do
                   mkdir -p /data/rustfs$i
-                done;
-              elif [ "$REPLICA_COUNT" -eq 16 ]; then
+                done
+              else
                 mkdir -p /data
               fi
               mkdir -p /mnt/rustfs/logs
               chmod 755 /mnt/rustfs/logs
           volumeMounts:
-            {{- if eq (int .Values.replicaCount) 4 }}
-            {{- range $i := until (int .Values.replicaCount) }}
+            {{- if gt (int .Values.drivesPerNode) 1 }}
+            {{- range $i := until (int $.Values.drivesPerNode) }}
             - name: data-rustfs-{{ $i }}
               mountPath: /data/rustfs{{ $i }}
             {{- end }}
-            {{- else if eq (int .Values.replicaCount) 16 }}
+            {{- else }}
             - name: data
               mountPath: /data
             {{- end }}
@@ -144,12 +144,12 @@ spec:
             - name: logs
               mountPath: {{ $logDir }}
               subPath: logs
-            {{- if eq (int .Values.replicaCount) 4 }}
-            {{- range $i := until (int .Values.replicaCount) }}
+            {{- if gt (int .Values.drivesPerNode) 1 }}
+            {{- range $i := until (int $.Values.drivesPerNode) }}
             - name: data-rustfs-{{ $i }}
               mountPath: /data/rustfs{{ $i }}
             {{- end }}
-            {{- else if eq (int .Values.replicaCount) 16 }}
+            {{- else }}
             - name: data
               mountPath: /data
             {{- end }}
@@ -189,8 +189,8 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storageclass.logStorageSize }}
-    {{- if eq (int .Values.replicaCount) 4 }}
-    {{- range $i := until (int .Values.replicaCount) }}
+    {{- if gt (int .Values.drivesPerNode) 1 }}
+    {{- range $i := until (int .Values.drivesPerNode) }}
     - metadata:
         name: data-rustfs-{{ $i }}
         labels:
@@ -204,7 +204,7 @@ spec:
           requests:
             storage: {{ $.Values.storageclass.dataStorageSize }}
     {{- end }}
-    {{- else if eq (int .Values.replicaCount) 16 }}
+    {{- else }}
     - metadata:
         name: data
         labels:

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -2,8 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+# Number of StatefulSet pods (nodes in the distributed cluster).
 replicaCount: 4
+
+# Number of data drives (PVCs) per pod. Combined with replicaCount this
+# determines the total drive count seen by rustfs.
+# - drivesPerNode > 1: each pod gets N volumes mounted at /data/rustfs0.../data/rustfsN-1
+# - drivesPerNode = 1: each pod gets a single volume mounted at /data
+drivesPerNode: 4
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:


### PR DESCRIPTION
## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues

N/A

## Summary of Changes

The statefulset template previously only handled two hardcoded configurations:
`replicaCount=4` (four drives per pod) or `replicaCount=16` (one drive per pod).
Anything else silently produced broken output — wrong volume URLs, missing mounts,
and no PVCs generated.

This adds a `drivesPerNode` value (default `4`) that independently controls how
many data volumes each pod gets. `replicaCount` now purely controls pod count and
can be set freely alongside any drive count.

- `values.yaml`: add `drivesPerNode: 4` with inline docs
- `statefulset.yaml`: init container shell script, both `volumeMounts` blocks, and
  `volumeClaimTemplates` now branch on `drivesPerNode` instead of hardcoded
  `replicaCount` checks
- `_helpers.tpl`: `rustfs.volumes` generates the correct URL pattern for any
  combination of `replicaCount` and `drivesPerNode`

## Verification

```sh
helm lint helm/rustfs/ --set secret.allowInsecureDefaults=true
# 1 chart(s) linted, 0 chart(s) failed

# default (4 nodes, 4 drives/node — unchanged behavior)
helm template test helm/rustfs/ --set secret.allowInsecureDefaults=true

# 4 nodes, 1 drive/node
helm template test helm/rustfs/ --set secret.allowInsecureDefaults=true \
  --set replicaCount=4 --set drivesPerNode=1

# arbitrary: 8 nodes, 2 drives/node
helm template test helm/rustfs/ --set secret.allowInsecureDefaults=true \
  --set replicaCount=8 --set drivesPerNode=2
```

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (N/A — Helm chart only, no Rust code changes)
- [x] Added/updated necessary tests (N/A)
- [x] Documentation updated (if needed) — `drivesPerNode` documented inline in `values.yaml`
- [ ] CI/CD passed (if applicable)


## Impact

drivesPerNode defaults to 4, so existing deployments using replicaCount=4
are unaffected. Users previously relying on replicaCount=16 (single drive per
pod) should now set replicaCount=16, drivesPerNode=1 to get the same result.

No changes to standalone (Deployment) mode.


## Additional Notes

N/A