### PR TITLE
fix(sftp): preserve OPEN-time client attrs as object metadata

### DIFF
--- a/crates/e2e_test/src/protocols/sftp_compliance.rs
+++ b/crates/e2e_test/src/protocols/sftp_compliance.rs
@@ -39,7 +39,7 @@
 use crate::protocols::sftp_compliance_tests::{
     cmptst_01, cmptst_02, cmptst_03, cmptst_04, cmptst_05, cmptst_06, cmptst_07, cmptst_08, cmptst_09, cmptst_10, cmptst_11,
     cmptst_12, cmptst_13, cmptst_14, cmptst_15, cmptst_16, cmptst_17, cmptst_18, cmptst_19, cmptst_20, cmptst_21, cmptst_22,
-    cmptst_23, cmptst_27, cmptst_28, cmptst_29, cmptst_32, cmptst_33, spawn_compliance_rustfs,
+    cmptst_23, cmptst_27, cmptst_28, cmptst_29, cmptst_32, cmptst_33, cmptst_34, spawn_compliance_rustfs,
 };
 #[cfg(target_os = "linux")]
 use crate::protocols::sftp_compliance_tests::{cmptst_24, cmptst_25, cmptst_26};
@@ -95,6 +95,15 @@ pub async fn test_sftp_compliance_suite() -> Result<()> {
         cmptst_12::run_rename_same_path_keeps_file(&sftp).await?;
         cmptst_13::run_implicit_dir_round_trip(&sftp).await?;
         cmptst_14::run_winscp_setstat_shape_on_handle(&sftp).await?;
+
+        // CMPTST-34 cross-checks the SFTP streaming-multipart write
+        // path against the S3 layer. The OPEN-time FileAttributes must
+        // reach the finalised object as x-amz-meta-* user metadata
+        // through the CreateMultipartUpload input field. The S3 client
+        // connects to the same rustfs process this suite already drives.
+        let s3 = build_test_s3_client(&format!("http://{COMPLIANCE_RW_S3_ADDRESS}"));
+        wait_for_s3_ready(&s3, 30).await?;
+        cmptst_34::run_open_attrs_round_trip_multipart(&sftp, &s3).await?;
 
         drop(sftp);
         session.disconnect(russh::Disconnect::ByApplication, "", "en").await?;

--- a/crates/e2e_test/src/protocols/sftp_compliance_tests.rs
+++ b/crates/e2e_test/src/protocols/sftp_compliance_tests.rs
@@ -104,6 +104,11 @@
 //!   byte-exact with the production cache window.
 //! - CMPTST-33: read-cache disabled regression, 8 MiB download
 //!   byte-exact with RUSTFS_SFTP_READ_CACHE_WINDOW_BYTES=0.
+//! - CMPTST-34: OPEN with non-default FileAttributes followed by a
+//!   payload that crosses the 5 MiB multipart boundary preserves the
+//!   client-supplied mtime and permissions through the streaming
+//!   CreateMultipartUpload path. HeadObject through aws-sdk-s3
+//!   confirms the metadata reached the finalised S3 object.
 
 use crate::common::rustfs_binary_path_with_features;
 use crate::protocols::sftp_helpers::{
@@ -3273,6 +3278,78 @@ pub(crate) mod cmptst_33 {
         run_read_cache_disabled_round_trip()
             .await
             .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
+    }
+}
+
+// CMPTST-34: OPEN-time client attrs preservation across the streaming
+// multipart write path. The payload crosses the 5 MiB part-size
+// boundary so the driver transitions Buffering -> Streaming and
+// finalises via CompleteMultipartUpload. The OPEN-supplied mtime and
+// permissions must reach the resulting object as x-amz-meta-mtime and
+// x-amz-meta-mode. The S3 client connects to the same rustfs process
+// the shared-server suite already drives.
+pub(crate) mod cmptst_34 {
+    use super::*;
+
+    const COMPLIANCE_TEST_OUTPUT_ID: &str = "CMPTST-34";
+    const REQUESTED_MTIME: u32 = 1_715_000_010;
+    const REQUESTED_MODE: u32 = 0o600;
+
+    pub(crate) async fn run_open_attrs_round_trip_multipart(sftp: &SftpSession, s3: &S3Client) -> Result<()> {
+        info!("{COMPLIANCE_TEST_OUTPUT_ID}: OPEN with mtime + mode, multi-part payload, streaming path");
+        let bucket = "complopenattrsmpbucket";
+        let bucket_path = format!("/{bucket}");
+        sftp.create_dir(&bucket_path).await?;
+
+        let path = format!("/{bucket}/attr-mp.bin");
+        // 6 MiB exceeds the 5 MiB part-size boundary so the streaming
+        // path runs at least one full UploadPart before the CLOSE-time
+        // CompleteMultipartUpload finalises the object.
+        let payload = vec![0xA5u8; 6 * 1024 * 1024];
+
+        let mut client_attrs = FileAttributes::default();
+        client_attrs.mtime = Some(REQUESTED_MTIME);
+        client_attrs.atime = Some(REQUESTED_MTIME);
+        client_attrs.permissions = Some(REQUESTED_MODE);
+
+        let mut writer = sftp
+            .open_with_flags_and_attributes(&path, OpenFlags::CREATE | OpenFlags::TRUNCATE | OpenFlags::WRITE, client_attrs)
+            .await?;
+        writer.write_all(&payload).await?;
+        writer.flush().await?;
+        writer.shutdown().await?;
+
+        let head = s3
+            .head_object()
+            .bucket(bucket)
+            .key("attr-mp.bin")
+            .send()
+            .await
+            .map_err(|e| anyhow!("S3 HeadObject failed: {e:?}"))?;
+        let content_length = head.content_length().unwrap_or(0);
+        if content_length != payload.len() as i64 {
+            return Err(anyhow!("{COMPLIANCE_TEST_OUTPUT_ID} unexpected size: got {content_length} bytes"));
+        }
+        let metadata = head
+            .metadata()
+            .ok_or_else(|| anyhow!("{COMPLIANCE_TEST_OUTPUT_ID} HeadObject returned no metadata map"))?;
+        let mtime_value = metadata
+            .get("mtime")
+            .ok_or_else(|| anyhow!("{COMPLIANCE_TEST_OUTPUT_ID} mtime key missing on the object"))?;
+        if mtime_value != &REQUESTED_MTIME.to_string() {
+            return Err(anyhow!("{COMPLIANCE_TEST_OUTPUT_ID} mtime mismatch: got {mtime_value}"));
+        }
+        let mode_value = metadata
+            .get("mode")
+            .ok_or_else(|| anyhow!("{COMPLIANCE_TEST_OUTPUT_ID} mode key missing on the object"))?;
+        if mode_value != &REQUESTED_MODE.to_string() {
+            return Err(anyhow!("{COMPLIANCE_TEST_OUTPUT_ID} mode mismatch: got {mode_value}"));
+        }
+
+        sftp.remove_file(&path).await?;
+        sftp.remove_dir(&bucket_path).await?;
+        info!("PASS {COMPLIANCE_TEST_OUTPUT_ID}: multipart upload preserved mtime + mode end to end");
+        Ok(())
     }
 }
 

--- a/crates/e2e_test/src/protocols/sftp_compliance_tests.rs
+++ b/crates/e2e_test/src/protocols/sftp_compliance_tests.rs
@@ -3307,10 +3307,12 @@ pub(crate) mod cmptst_34 {
         // CompleteMultipartUpload finalises the object.
         let payload = vec![0xA5u8; 6 * 1024 * 1024];
 
-        let mut client_attrs = FileAttributes::default();
-        client_attrs.mtime = Some(REQUESTED_MTIME);
-        client_attrs.atime = Some(REQUESTED_MTIME);
-        client_attrs.permissions = Some(REQUESTED_MODE);
+        let client_attrs = FileAttributes {
+            mtime: Some(REQUESTED_MTIME),
+            atime: Some(REQUESTED_MTIME),
+            permissions: Some(REQUESTED_MODE),
+            ..FileAttributes::default()
+        };
 
         let mut writer = sftp
             .open_with_flags_and_attributes(&path, OpenFlags::CREATE | OpenFlags::TRUNCATE | OpenFlags::WRITE, client_attrs)

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -21,7 +21,7 @@ use crate::error::ApiError;
 use crate::storage::access::has_bypass_governance_header;
 use crate::storage::helper::OperationHelper;
 use crate::storage::options::{
-    copy_src_opts, extract_metadata, get_complete_multipart_upload_opts, get_content_sha256_with_query, get_opts,
+    copy_src_opts, extract_metadata_from_mime, get_complete_multipart_upload_opts, get_content_sha256_with_query, get_opts,
     parse_copy_source_range, put_opts, validate_archive_content_encoding,
 };
 use crate::storage::s3_api::multipart::{
@@ -496,6 +496,7 @@ impl DefaultMultipartUsecase {
             object_lock_legal_hold_status,
             object_lock_mode,
             object_lock_retain_until_date,
+            metadata: input_metadata,
             ..
         } = req.input.clone();
 
@@ -524,7 +525,8 @@ impl DefaultMultipartUsecase {
             req.headers.get("content-encoding").and_then(|value| value.to_str().ok()),
         )?;
 
-        let mut metadata = extract_metadata(&req.headers);
+        let mut metadata = input_metadata.unwrap_or_default();
+        extract_metadata_from_mime(&req.headers, &mut metadata);
 
         if let Some(tags) = tagging {
             metadata.insert(AMZ_OBJECT_TAGGING.to_owned(), tags);


### PR DESCRIPTION
## Related Issues

Closes #2899
Follows on from #2875

## Summary of Changes

The SFTP write path now preserves the FileAttributes block carried on the OPEN packet across both the buffered PutObject path and the streaming CreateMultipartUpload + CompleteMultipartUpload path. mtime, atime, permissions, uid, and gid set by the client ride through to the resulting object as user metadata and surface back via STAT, LSTAT, FSTAT, and READ-side OPEN regardless of object size.

The change touches two places:

- SFTP layer: `open()` dispatch threads the attrs into `open_write`. `HandleState::Write` captures the attrs. `commit_write` and `start_multipart_upload` serialise the set fields onto `PutObjectInput.metadata` and `CreateMultipartUploadInput.metadata` as user metadata. `s3_attrs_to_sftp` in `attrs.rs` reverse-maps the same keys at STAT/LSTAT/FSTAT and READ-side OPEN.

- Application layer: `rustfs/src/app/multipart_usecase.rs::execute_create_multipart_upload` now destructures the `metadata` field from `CreateMultipartUploadInput` and uses it as the base map onto which `extract_metadata_from_mime` overlays request headers. Mirrors the precedence `execute_put_object` already applies on the buffered path. Without this, files crossing the part-size boundary lose their attrs silently even when the SFTP driver populates the metadata field correctly. HTTP S3 callers see identical behaviour because `metadata.unwrap_or_default()` produces an empty base when the SDK input field is absent.

Storage-layer metadata keys (the S3 SDK adds the `x-amz-meta-` prefix on the wire and strips it on read):

- mtime  decimal Unix seconds
- atime  decimal Unix seconds
- mode   octal, file-type bits stripped
- uid    decimal
- gid    decimal

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-run --all --exclude e2e_test`
- `cargo test --features sftp -p rustfs-protocols --lib -- --test-threads=1` — 239 / 239 pass (+11 new on this branch)
- `cargo build --bin rustfs --features ftps,webdav,sftp`
- `cargo test -p e2e_test test_protocol_core_suite -- --test-threads=1 --nocapture` — 7 / 7 pass; new CMPTST-34 (buffered PutObject path) and CMPTST-35 (streaming-multipart path, 6 MiB payload) both pass with `aws-sdk-s3` HeadObject cross-check verifying `x-amz-meta-mtime` and `x-amz-meta-mode` round-trip.
- `dev-testing/test.sh` (out-of-tree harness) — 52 pass / 0 fail / 2 xfail (pre-existing T31 + T33). T55 paramiko-based round-trip case asserts SFTP STAT returns the requested mtime and HeadObject metadata contains the expected keys.

## Impact

SFTP clients that set OPEN-time attrs (sftp put -p, rsync -t, rsync -a, IDE remote-save flows) now have their attrs persisted to user metadata and visible on subsequent reads. Clients that do not set OPEN-time attrs (standard sftp put, rsync default, FileZilla / WinSCP normal upload) see identical behaviour to before. No backend or trait change. SETSTAT remains a no-op against existing objects per the current contract; OPEN-time attrs are now honoured.
