### PR TITLE
fix(ecstore): preserve list marker set index

### DIFF
--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1488,7 +1488,11 @@ mod test {
         };
 
         let marker = opts.encode_marker("photos/2026/image.jpg");
-        assert_eq!(marker, "photos/2026/image.jpg[rustfs_cache:v1,id:list-cache-id,p:3,s:7]");
+        let expected_marker = format!(
+            "photos/2026/image.jpg[rustfs_cache:{},id:list-cache-id,p:3,s:7]",
+            super::MARKER_TAG_VERSION
+        );
+        assert_eq!(marker, expected_marker);
 
         let mut parsed = ListPathOptions {
             marker: Some(marker),

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -213,7 +213,7 @@ impl ListPathOptions {
                 MARKER_TAG_VERSION,
                 id.to_owned(),
                 self.pool_idx.unwrap_or_default(),
-                self.pool_idx.unwrap_or_default(),
+                self.set_idx.unwrap_or_default(),
             )
         } else {
             format!("{marker}[rustfs_cache:{MARKER_TAG_VERSION},return:]")
@@ -1405,6 +1405,7 @@ fn calc_common_counter(infos: &[DiskInfo], read_quorum: usize) -> u64 {
 
 #[cfg(test)]
 mod test {
+    use super::ListPathOptions;
     use uuid::Uuid;
 
     /// Test that "null" version marker is handled correctly
@@ -1475,6 +1476,31 @@ mod test {
         };
         assert!(parsed.is_some());
         assert_eq!(parsed.unwrap().to_string(), uuid_str);
+    }
+
+    #[test]
+    fn list_path_marker_round_trip_preserves_set_index() {
+        let mut opts = ListPathOptions {
+            id: Some("list-cache-id".to_string()),
+            pool_idx: Some(3),
+            set_idx: Some(7),
+            ..Default::default()
+        };
+
+        let marker = opts.encode_marker("photos/2026/image.jpg");
+        assert_eq!(marker, "photos/2026/image.jpg[rustfs_cache:v1,id:list-cache-id,p:3,s:7]");
+
+        let mut parsed = ListPathOptions {
+            marker: Some(marker),
+            ..Default::default()
+        };
+        parsed.parse_marker();
+
+        assert_eq!(parsed.marker.as_deref(), Some("photos/2026/image.jpg"));
+        assert_eq!(parsed.id.as_deref(), Some("list-cache-id"));
+        assert_eq!(parsed.pool_idx, Some(3));
+        assert_eq!(parsed.set_idx, Some(7));
+        assert!(!parsed.create);
     }
 
     // use std::sync::Arc;


### PR DESCRIPTION
  ## Related Issues

  Related to #2916 and #2775.

  ## Summary of Changes

  Fixes list continuation marker encoding so the `s` marker tag preserves `set_idx` instead of incorrectly reusing `pool_idx`.

  Adds a regression test that round-trips a marker with different pool and set indexes to ensure pagination resumes with the original set index.

  ## Verification

  - `cargo fmt --all` - passed
  - `cargo fmt --all --check` - passed
  - `cargo test -p rustfs-ecstore list_path_marker_round_trip_preserves_set_index` - passed
  - `cargo test -p rustfs-ecstore` - failed on existing Windows path/local disk tests unrelated to this marker change

  ## Impact

  No API, configuration, migration, or deployment changes.

  The change improves continuation marker correctness for listing pagination when pool and set indexes differ.

  ## Additional Notes

  `make pre-commit` has not been run yet, so this PR should remain draft or blocked until the full required gate passes.