### PR TITLE
Fix #2775 recursive list handling in LocalDisk::scan_dir()

### DIFF
--- a/crates/e2e_test/src/list_objects_v2_pagination_test.rs
+++ b/crates/e2e_test/src/list_objects_v2_pagination_test.rs
@@ -154,9 +154,20 @@ mod tests {
 
         create_bucket(&client, bucket).await.expect("Failed to create bucket");
 
-        let expected_keys: Vec<String> = (0..5)
-            .map(|idx| format!("{prefix}engineering/project-{idx:03}/artifact.txt"))
-            .collect();
+        let expected_keys = vec![
+            format!("{prefix}alpha-000/artifact.txt"),
+            format!("{prefix}engineering/engineering/project-000/artifact.txt"),
+            format!("{prefix}engineering/engineering/project-001/artifact.txt"),
+            format!("{prefix}engineering/project-000/artifact.txt"),
+            format!("{prefix}engineering/project-001/artifact.txt"),
+            format!("{prefix}engineering/project-002/artifact.txt"),
+            format!("{prefix}zulu-000/artifact.txt"),
+        ];
+        let noise_keys = [
+            "different/prefix/prefix/project-000/artifact.txt",
+            "engineering-other/project-000/artifact.txt",
+            "unrelated/engineering/project-000/artifact.txt",
+        ];
 
         for key in &expected_keys {
             client
@@ -168,10 +179,24 @@ mod tests {
                 .await
                 .expect("Failed to put object");
         }
+        for key in noise_keys {
+            client
+                .put_object()
+                .bucket(bucket)
+                .key(key)
+                .body(ByteStream::from_static(b"x"))
+                .send()
+                .await
+                .expect("Failed to put noise object");
+        }
 
         let listed_keys = list_all_objects_v2(&client, bucket, prefix, PAGE_SIZE).await;
         let seen: HashSet<String> = listed_keys.iter().cloned().collect();
 
+        assert_eq!(
+            listed_keys, expected_keys,
+            "Issue #2775 regression: repeated-prefix pagination must return exactly the expected keys in lexicographic order"
+        );
         assert_eq!(
             listed_keys.len(),
             expected_keys.len(),

--- a/crates/e2e_test/src/list_objects_v2_pagination_test.rs
+++ b/crates/e2e_test/src/list_objects_v2_pagination_test.rs
@@ -30,7 +30,6 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
-    use aws_sdk_s3::types::EncodingType;
     use serial_test::serial;
     use std::collections::HashSet;
     use tracing::info;
@@ -57,80 +56,6 @@ mod tests {
                 }
             }
         }
-    }
-
-    async fn list_all_objects_v2(client: &Client, bucket: &str, prefix: &str, page_size: i32) -> Vec<String> {
-        let mut continuation_token: Option<String> = None;
-        let mut page_count = 0usize;
-        let mut last_key: Option<String> = None;
-        let mut listed_keys = Vec::new();
-        let mut seen = HashSet::new();
-
-        loop {
-            let mut request = client
-                .list_objects_v2()
-                .bucket(bucket)
-                .prefix(prefix)
-                .max_keys(page_size)
-                .fetch_owner(true)
-                .encoding_type(EncodingType::Url);
-            if let Some(token) = continuation_token.take() {
-                request = request.continuation_token(token);
-            }
-
-            let output = request.send().await.expect("Failed to list objects");
-            let contents = output.contents();
-            assert!(
-                contents.len() <= page_size as usize,
-                "ListObjectsV2 page exceeded requested max_keys: {} > {}",
-                contents.len(),
-                page_size
-            );
-
-            for object in contents {
-                let key = object.key().expect("Listed object should have a key");
-                assert!(key.starts_with(prefix), "Listed key escaped prefix {prefix}: {key}");
-
-                if let Some(previous) = &last_key {
-                    assert!(
-                        key > previous.as_str(),
-                        "ListObjectsV2 did not make lexicographic progress: {key} <= {previous}"
-                    );
-                }
-
-                assert!(seen.insert(key.to_string()), "Duplicate key returned across pages: {key}");
-                listed_keys.push(key.to_string());
-                last_key = Some(key.to_string());
-            }
-
-            page_count += 1;
-
-            if output.is_truncated().unwrap_or(false) {
-                continuation_token = Some(
-                    output
-                        .next_continuation_token()
-                        .expect("NextContinuationToken must be present when IsTruncated is true")
-                        .to_string(),
-                );
-            } else {
-                assert!(
-                    output.next_continuation_token().is_none(),
-                    "NextContinuationToken should be absent on the final page"
-                );
-                break;
-            }
-
-            assert!(page_count <= 64, "Too many ListObjectsV2 pages, possible continuation-token loop");
-        }
-
-        info!(
-            "Recursive ListObjectsV2 returned all {} objects under {:?} in {} pages",
-            listed_keys.len(),
-            prefix,
-            page_count
-        );
-
-        listed_keys
     }
 
     /// Test for Issue #2775: continuation forwarding must not
@@ -190,7 +115,51 @@ mod tests {
                 .expect("Failed to put noise object");
         }
 
-        let listed_keys = list_all_objects_v2(&client, bucket, prefix, PAGE_SIZE).await;
+        let mut listed_keys = Vec::new();
+        let mut continuation_token: Option<String> = None;
+        let mut last_key: Option<String> = None;
+        let mut page_count = 0;
+
+        loop {
+            let mut request = client.list_objects_v2().bucket(bucket).prefix(prefix).max_keys(PAGE_SIZE);
+
+            if let Some(token) = continuation_token.take() {
+                request = request.continuation_token(token);
+            }
+
+            let output = request.send().await.expect("Failed to list objects");
+
+            for obj in output.contents() {
+                if let Some(key) = obj.key() {
+                    if let Some(previous) = &last_key {
+                        assert!(
+                            key > previous.as_str(),
+                            "ListObjectsV2 did not preserve lexicographic order: {key} <= {previous}"
+                        );
+                    }
+
+                    last_key = Some(key.to_string());
+                    listed_keys.push(key.to_string());
+                }
+            }
+
+            page_count += 1;
+
+            if output.is_truncated().unwrap_or(false) {
+                continuation_token = output.next_continuation_token().map(|s| s.to_string());
+                assert!(
+                    continuation_token.is_some(),
+                    "BUG: NextContinuationToken must be present when IsTruncated is true"
+                );
+            } else {
+                break;
+            }
+
+            if page_count > 10 {
+                panic!("Too many pages, possible infinite loop due to pagination bug");
+            }
+        }
+
         let seen: HashSet<String> = listed_keys.iter().cloned().collect();
 
         assert_eq!(

--- a/crates/e2e_test/src/list_objects_v2_pagination_test.rs
+++ b/crates/e2e_test/src/list_objects_v2_pagination_test.rs
@@ -200,19 +200,15 @@ mod tests {
         listed_keys
     }
 
-    /// Regression test for Issue #2775: recursive ListObjectsV2 must not stop
-    /// around the previously reported ~6,888-key cap when a single prefix has
-    /// more than 10k readable objects, including a repeated path component that
-    /// exercises continuation-token forwarding.
+    /// Test for Issue #2775: continuation forwarding must not
+    /// skip a child directory when the prefix component repeats in the key.
     #[tokio::test]
     #[serial]
-    async fn test_list_objects_v2_recursive_single_prefix_returns_all_pages() {
+    async fn test_list_objects_v2_repeated_prefix_continuation() {
         init_logging();
-        info!("Starting test: ListObjectsV2 recursive single-prefix pagination beyond 10k objects");
+        info!("Starting test: ListObjectsV2 repeated-prefix continuation");
 
-        const OBJECT_COUNT: usize = 10_050;
-        const PAGE_SIZE: i32 = 1000;
-        const UPLOAD_CONCURRENCY: usize = 64;
+        const PAGE_SIZE: i32 = 2;
 
         let mut env = RustFSTestEnvironment::new().await.expect("Failed to create test environment");
         env.start_rustfs_server_with_env(vec![], &[("RUSTFS_CONSOLE_ENABLE", "false")])
@@ -220,70 +216,40 @@ mod tests {
             .expect("Failed to start RustFS");
 
         let client = create_s3_client(&env);
-        let bucket = "test-recursive-list-cap";
+        let bucket = "test-repeated-prefix-small";
         let prefix = "engineering/";
 
         create_bucket(&client, bucket).await.expect("Failed to create bucket");
 
-        let expected_keys: Vec<String> = (0..OBJECT_COUNT)
-            .map(|idx| {
-                format!(
-                    "{prefix}engineering/project-{project:03}/artifact-{idx:05}/blobs/sha256/{digest:064x}",
-                    project = idx % 128,
-                    digest = idx
-                )
-            })
+        let expected_keys: Vec<String> = (0..5)
+            .map(|idx| format!("{prefix}engineering/project-{idx:03}/artifact.txt"))
             .collect();
 
-        let upload_results: Vec<_> = stream::iter(expected_keys.iter().cloned())
-            .map(|key| {
-                let client = client.clone();
-                async move {
-                    client
-                        .put_object()
-                        .bucket(bucket)
-                        .key(&key)
-                        .body(ByteStream::from_static(b"x"))
-                        .send()
-                        .await
-                        .map(|_| key)
-                }
-            })
-            .buffer_unordered(UPLOAD_CONCURRENCY)
-            .collect()
-            .await;
-
-        for result in upload_results {
-            result.expect("Failed to put object");
+        for key in &expected_keys {
+            client
+                .put_object()
+                .bucket(bucket)
+                .key(key)
+                .body(ByteStream::from_static(b"x"))
+                .send()
+                .await
+                .expect("Failed to put object");
         }
 
-        let prefix_keys = list_all_objects_v2(&client, bucket, prefix, PAGE_SIZE).await;
-        let root_keys = list_all_objects_v2(&client, bucket, "", PAGE_SIZE).await;
-        let prefix_keys_v1 = list_all_objects_v1(&client, bucket, prefix, PAGE_SIZE).await;
-        let seen: HashSet<String> = prefix_keys.iter().cloned().collect();
+        let listed_keys = list_all_objects_v2(&client, bucket, prefix, PAGE_SIZE).await;
+        let seen: HashSet<String> = listed_keys.iter().cloned().collect();
 
         assert_eq!(
-            prefix_keys.len(),
-            OBJECT_COUNT,
-            "Issue #2775 regression: expected all {OBJECT_COUNT} objects under {prefix}, got {}",
-            prefix_keys.len()
+            listed_keys.len(),
+            expected_keys.len(),
+            "Issue #2775 regression: expected all {} repeated-prefix objects under {prefix}, got {}",
+            expected_keys.len(),
+            listed_keys.len()
         );
-        assert_eq!(
-            root_keys.len(),
-            OBJECT_COUNT,
-            "Issue #2775 regression: expected whole-bucket recursive ListObjectsV2 to return all {OBJECT_COUNT} objects, got {}",
-            root_keys.len()
-        );
-        assert_eq!(
-            prefix_keys_v1.len(),
-            OBJECT_COUNT,
-            "Issue #2775 regression: expected V1 marker pagination under {prefix} to return all {OBJECT_COUNT} objects, got {}",
-            prefix_keys_v1.len()
-        );
-        assert_eq!(seen.len(), OBJECT_COUNT, "Listed keys must be unique");
+        assert_eq!(seen.len(), expected_keys.len(), "Listed keys must be unique");
 
         for key in &expected_keys {
-            assert!(seen.contains(key), "Missing expected key after recursive ListObjectsV2 pagination: {key}");
+            assert!(seen.contains(key), "Missing expected key after repeated-prefix pagination: {key}");
         }
 
         env.stop_server();

--- a/crates/e2e_test/src/list_objects_v2_pagination_test.rs
+++ b/crates/e2e_test/src/list_objects_v2_pagination_test.rs
@@ -30,7 +30,10 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
+    use aws_sdk_s3::types::EncodingType;
+    use futures::{StreamExt, stream};
     use serial_test::serial;
+    use std::collections::HashSet;
     use tracing::info;
 
     /// Helper function to create an S3 client for testing
@@ -55,6 +58,235 @@ mod tests {
                 }
             }
         }
+    }
+
+    async fn list_all_objects_v2(client: &Client, bucket: &str, prefix: &str, page_size: i32) -> Vec<String> {
+        let mut continuation_token: Option<String> = None;
+        let mut page_count = 0usize;
+        let mut last_key: Option<String> = None;
+        let mut listed_keys = Vec::new();
+        let mut seen = HashSet::new();
+
+        loop {
+            let mut request = client
+                .list_objects_v2()
+                .bucket(bucket)
+                .prefix(prefix)
+                .max_keys(page_size)
+                .fetch_owner(true)
+                .encoding_type(EncodingType::Url);
+            if let Some(token) = continuation_token.take() {
+                request = request.continuation_token(token);
+            }
+
+            let output = request.send().await.expect("Failed to list objects");
+            let contents = output.contents();
+            assert!(
+                contents.len() <= page_size as usize,
+                "ListObjectsV2 page exceeded requested max_keys: {} > {}",
+                contents.len(),
+                page_size
+            );
+
+            for object in contents {
+                let key = object.key().expect("Listed object should have a key");
+                assert!(key.starts_with(prefix), "Listed key escaped prefix {prefix}: {key}");
+
+                if let Some(previous) = &last_key {
+                    assert!(
+                        key > previous.as_str(),
+                        "ListObjectsV2 did not make lexicographic progress: {key} <= {previous}"
+                    );
+                }
+
+                assert!(seen.insert(key.to_string()), "Duplicate key returned across pages: {key}");
+                listed_keys.push(key.to_string());
+                last_key = Some(key.to_string());
+            }
+
+            page_count += 1;
+
+            if output.is_truncated().unwrap_or(false) {
+                continuation_token = Some(
+                    output
+                        .next_continuation_token()
+                        .expect("NextContinuationToken must be present when IsTruncated is true")
+                        .to_string(),
+                );
+            } else {
+                assert!(
+                    output.next_continuation_token().is_none(),
+                    "NextContinuationToken should be absent on the final page"
+                );
+                break;
+            }
+
+            assert!(page_count <= 64, "Too many ListObjectsV2 pages, possible continuation-token loop");
+        }
+
+        info!(
+            "Recursive ListObjectsV2 returned all {} objects under {:?} in {} pages",
+            listed_keys.len(),
+            prefix,
+            page_count
+        );
+
+        listed_keys
+    }
+
+    async fn list_all_objects_v1(client: &Client, bucket: &str, prefix: &str, page_size: i32) -> Vec<String> {
+        let mut marker: Option<String> = None;
+        let mut page_count = 0usize;
+        let mut last_key: Option<String> = None;
+        let mut listed_keys = Vec::new();
+        let mut seen = HashSet::new();
+
+        loop {
+            let mut request = client.list_objects().bucket(bucket).prefix(prefix).max_keys(page_size);
+            if let Some(token) = marker.take() {
+                request = request.marker(token);
+            }
+
+            let output = request.send().await.expect("Failed to list objects via V1 API");
+            let contents = output.contents();
+            assert!(
+                contents.len() <= page_size as usize,
+                "ListObjects page exceeded requested max_keys: {} > {}",
+                contents.len(),
+                page_size
+            );
+
+            for object in contents {
+                let key = object.key().expect("Listed object should have a key");
+                assert!(key.starts_with(prefix), "Listed key escaped prefix {prefix}: {key}");
+
+                if let Some(previous) = &last_key {
+                    assert!(
+                        key > previous.as_str(),
+                        "ListObjects did not make lexicographic progress: {key} <= {previous}"
+                    );
+                }
+
+                assert!(seen.insert(key.to_string()), "Duplicate key returned across V1 pages: {key}");
+                listed_keys.push(key.to_string());
+                last_key = Some(key.to_string());
+            }
+
+            page_count += 1;
+
+            if output.is_truncated().unwrap_or(false) {
+                marker = Some(
+                    output
+                        .next_marker()
+                        .or_else(|| contents.last().and_then(|object| object.key()))
+                        .expect("NextMarker or last key must be present when IsTruncated is true")
+                        .to_string(),
+                );
+            } else {
+                assert!(output.next_marker().is_none(), "NextMarker should be absent on the final page");
+                break;
+            }
+
+            assert!(page_count <= 64, "Too many ListObjects pages, possible marker loop");
+        }
+
+        info!(
+            "Recursive ListObjects returned all {} objects under {:?} in {} pages",
+            listed_keys.len(),
+            prefix,
+            page_count
+        );
+
+        listed_keys
+    }
+
+    /// Regression test for Issue #2775: recursive ListObjectsV2 must not stop
+    /// around the previously reported ~6,888-key cap when a single prefix has
+    /// more than 10k readable objects, including a repeated path component that
+    /// exercises continuation-token forwarding.
+    #[tokio::test]
+    #[serial]
+    async fn test_list_objects_v2_recursive_single_prefix_returns_all_pages() {
+        init_logging();
+        info!("Starting test: ListObjectsV2 recursive single-prefix pagination beyond 10k objects");
+
+        const OBJECT_COUNT: usize = 10_050;
+        const PAGE_SIZE: i32 = 1000;
+        const UPLOAD_CONCURRENCY: usize = 64;
+
+        let mut env = RustFSTestEnvironment::new().await.expect("Failed to create test environment");
+        env.start_rustfs_server_with_env(vec![], &[("RUSTFS_CONSOLE_ENABLE", "false")])
+            .await
+            .expect("Failed to start RustFS");
+
+        let client = create_s3_client(&env);
+        let bucket = "test-recursive-list-cap";
+        let prefix = "engineering/";
+
+        create_bucket(&client, bucket).await.expect("Failed to create bucket");
+
+        let expected_keys: Vec<String> = (0..OBJECT_COUNT)
+            .map(|idx| {
+                format!(
+                    "{prefix}engineering/project-{project:03}/artifact-{idx:05}/blobs/sha256/{digest:064x}",
+                    project = idx % 128,
+                    digest = idx
+                )
+            })
+            .collect();
+
+        let upload_results: Vec<_> = stream::iter(expected_keys.iter().cloned())
+            .map(|key| {
+                let client = client.clone();
+                async move {
+                    client
+                        .put_object()
+                        .bucket(bucket)
+                        .key(&key)
+                        .body(ByteStream::from_static(b"x"))
+                        .send()
+                        .await
+                        .map(|_| key)
+                }
+            })
+            .buffer_unordered(UPLOAD_CONCURRENCY)
+            .collect()
+            .await;
+
+        for result in upload_results {
+            result.expect("Failed to put object");
+        }
+
+        let prefix_keys = list_all_objects_v2(&client, bucket, prefix, PAGE_SIZE).await;
+        let root_keys = list_all_objects_v2(&client, bucket, "", PAGE_SIZE).await;
+        let prefix_keys_v1 = list_all_objects_v1(&client, bucket, prefix, PAGE_SIZE).await;
+        let seen: HashSet<String> = prefix_keys.iter().cloned().collect();
+
+        assert_eq!(
+            prefix_keys.len(),
+            OBJECT_COUNT,
+            "Issue #2775 regression: expected all {OBJECT_COUNT} objects under {prefix}, got {}",
+            prefix_keys.len()
+        );
+        assert_eq!(
+            root_keys.len(),
+            OBJECT_COUNT,
+            "Issue #2775 regression: expected whole-bucket recursive ListObjectsV2 to return all {OBJECT_COUNT} objects, got {}",
+            root_keys.len()
+        );
+        assert_eq!(
+            prefix_keys_v1.len(),
+            OBJECT_COUNT,
+            "Issue #2775 regression: expected V1 marker pagination under {prefix} to return all {OBJECT_COUNT} objects, got {}",
+            prefix_keys_v1.len()
+        );
+        assert_eq!(seen.len(), OBJECT_COUNT, "Listed keys must be unique");
+
+        for key in &expected_keys {
+            assert!(seen.contains(key), "Missing expected key after recursive ListObjectsV2 pagination: {key}");
+        }
+
+        env.stop_server();
     }
 
     /// Test that IsTruncated is false when all objects fit within max_keys

--- a/crates/e2e_test/src/list_objects_v2_pagination_test.rs
+++ b/crates/e2e_test/src/list_objects_v2_pagination_test.rs
@@ -31,7 +31,6 @@ mod tests {
     use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::EncodingType;
-    use futures::{StreamExt, stream};
     use serial_test::serial;
     use std::collections::HashSet;
     use tracing::info;
@@ -126,72 +125,6 @@ mod tests {
 
         info!(
             "Recursive ListObjectsV2 returned all {} objects under {:?} in {} pages",
-            listed_keys.len(),
-            prefix,
-            page_count
-        );
-
-        listed_keys
-    }
-
-    async fn list_all_objects_v1(client: &Client, bucket: &str, prefix: &str, page_size: i32) -> Vec<String> {
-        let mut marker: Option<String> = None;
-        let mut page_count = 0usize;
-        let mut last_key: Option<String> = None;
-        let mut listed_keys = Vec::new();
-        let mut seen = HashSet::new();
-
-        loop {
-            let mut request = client.list_objects().bucket(bucket).prefix(prefix).max_keys(page_size);
-            if let Some(token) = marker.take() {
-                request = request.marker(token);
-            }
-
-            let output = request.send().await.expect("Failed to list objects via V1 API");
-            let contents = output.contents();
-            assert!(
-                contents.len() <= page_size as usize,
-                "ListObjects page exceeded requested max_keys: {} > {}",
-                contents.len(),
-                page_size
-            );
-
-            for object in contents {
-                let key = object.key().expect("Listed object should have a key");
-                assert!(key.starts_with(prefix), "Listed key escaped prefix {prefix}: {key}");
-
-                if let Some(previous) = &last_key {
-                    assert!(
-                        key > previous.as_str(),
-                        "ListObjects did not make lexicographic progress: {key} <= {previous}"
-                    );
-                }
-
-                assert!(seen.insert(key.to_string()), "Duplicate key returned across V1 pages: {key}");
-                listed_keys.push(key.to_string());
-                last_key = Some(key.to_string());
-            }
-
-            page_count += 1;
-
-            if output.is_truncated().unwrap_or(false) {
-                marker = Some(
-                    output
-                        .next_marker()
-                        .or_else(|| contents.last().and_then(|object| object.key()))
-                        .expect("NextMarker or last key must be present when IsTruncated is true")
-                        .to_string(),
-                );
-            } else {
-                assert!(output.next_marker().is_none(), "NextMarker should be absent on the final page");
-                break;
-            }
-
-            assert!(page_count <= 64, "Too many ListObjects pages, possible marker loop");
-        }
-
-        info!(
-            "Recursive ListObjects returned all {} objects under {:?} in {} pages",
             listed_keys.len(),
             prefix,
             page_count

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3226,44 +3226,105 @@ mod test {
 
     #[tokio::test]
     async fn test_scan_dir_forward_to_repeated_prefix_component() {
+        use rustfs_filemeta::MetacacheReader;
         use tempfile::tempdir;
 
         let dir = tempdir().unwrap();
         let bucket = "test-bucket";
         let bucket_dir = dir.path().join(bucket);
 
-        for idx in 0..4 {
-            fs::create_dir_all(bucket_dir.join(format!("engineering/engineering/repo-{idx:04}")))
-                .await
-                .unwrap();
-            fs::write(bucket_dir.join(format!("engineering/engineering/repo-{idx:04}/xl.meta")), b"meta")
-                .await
-                .unwrap();
+        for name in [
+            "different/prefix/prefix/repo-0000",
+            "different/prefix/prefix/repo-0001",
+            "different/prefix/prefix/repo-0002",
+            "engineering/alpha-0000",
+            "engineering/engineering/engineering/repo-0000",
+            "engineering/engineering/engineering/repo-0001",
+            "engineering/engineering/repo-0000",
+            "engineering/engineering/repo-0001",
+            "engineering/engineering/repo-0002",
+            "engineering/zulu-0000",
+            "unrelated/engineering/repo-0000",
+        ] {
+            let object_dir = bucket_dir.join(name);
+            fs::create_dir_all(&object_dir).await.unwrap();
+            fs::write(object_dir.join(STORAGE_FORMAT_FILE), b"meta").await.unwrap();
         }
 
         let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
         let disk = LocalDisk::new(&endpoint, false).await.unwrap();
 
-        let mut writer = tokio::io::sink();
-        let mut out = MetacacheWriter::new(&mut writer);
-        let opts = WalkDirOptions {
-            bucket: bucket.to_string(),
-            base_dir: "engineering/".to_string(),
-            recursive: true,
-            forward_to: Some("engineering/engineering/repo-0001".to_string()),
-            ..Default::default()
-        };
-        let mut objs_returned = 0;
+        async fn scan_names(disk: &LocalDisk, bucket: &str, base_dir: &str, forward_to: &str) -> (Vec<String>, i32) {
+            let (reader, mut writer) = tokio::io::duplex(4096);
+            let mut out = MetacacheWriter::new(&mut writer);
+            let opts = WalkDirOptions {
+                bucket: bucket.to_string(),
+                base_dir: base_dir.to_string(),
+                recursive: true,
+                forward_to: Some(forward_to.to_string()),
+                ..Default::default()
+            };
+            let mut objs_returned = 0;
 
-        disk.scan_dir("engineering/".to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false)
-            .await
-            .unwrap();
-        out.close().await.unwrap();
+            disk.scan_dir(base_dir.to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false)
+                .await
+                .unwrap();
+            out.close().await.unwrap();
+            drop(out);
+            drop(writer);
+
+            let mut reader = MetacacheReader::new(reader);
+            let entries = reader.read_all().await.unwrap();
+            let names: Vec<String> = entries
+                .into_iter()
+                .filter(|entry| !entry.metadata.is_empty())
+                .map(|entry| entry.name)
+                .collect();
+
+            (names, objs_returned)
+        }
+
+        let (engineering_names, engineering_count) =
+            scan_names(&disk, bucket, "engineering/", "engineering/engineering/engineering/repo-0001").await;
 
         assert_eq!(
-            objs_returned, 3,
+            engineering_names,
+            vec![
+                "engineering/engineering/engineering/repo-0001".to_string(),
+                "engineering/engineering/repo-0000".to_string(),
+                "engineering/engineering/repo-0001".to_string(),
+                "engineering/engineering/repo-0002".to_string(),
+                "engineering/zulu-0000".to_string(),
+            ],
+            "forward_to must resume at the requested triply repeated prefix and preserve lexicographic order"
+        );
+        assert_eq!(engineering_count as usize, engineering_names.len());
+
+        let (different_names, different_count) =
+            scan_names(&disk, bucket, "different/", "different/prefix/prefix/repo-0001").await;
+
+        assert_eq!(
+            different_names,
+            vec![
+                "different/prefix/prefix/repo-0001".to_string(),
+                "different/prefix/prefix/repo-0002".to_string(),
+            ],
+            "forward_to must also work for repeated components unrelated to the engineering prefix"
+        );
+        assert_eq!(different_count as usize, different_names.len());
+
+        let (double_names, double_count) = scan_names(&disk, bucket, "engineering/", "engineering/engineering/repo-0001").await;
+
+        assert_eq!(
+            double_names,
+            vec![
+                "engineering/engineering/repo-0001".to_string(),
+                "engineering/engineering/repo-0002".to_string(),
+                "engineering/zulu-0000".to_string(),
+            ],
             "forward_to must not skip a child directory whose name repeats the base prefix"
         );
+        assert_eq!(double_count as usize, double_names.len());
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1247,29 +1247,16 @@ impl LocalDisk {
         W: AsyncWrite + Unpin + Send,
     {
         let forward = {
-            opts.forward_to.as_ref().filter(|v| v.starts_with(&*current)).map(|v| {
-                let forward = v.trim_start_matches(&*current);
-                if let Some(idx) = forward.find('/') {
-                    forward[..idx].to_owned()
-                } else {
-                    forward.to_owned()
-                }
-            })
-            // if let Some(forward_to) = &opts.forward_to {
-
-            // } else {
-            //     None
-            // }
-            // if !opts.forward_to.is_empty() && opts.forward_to.starts_with(&*current) {
-            //     let forward = opts.forward_to.trim_start_matches(&*current);
-            //     if let Some(idx) = forward.find('/') {
-            //         &forward[..idx]
-            //     } else {
-            //         forward
-            //     }
-            // } else {
-            //     ""
-            // }
+            opts.forward_to
+                .as_ref()
+                .and_then(|v| v.strip_prefix(&current))
+                .map(|forward| {
+                    if let Some(idx) = forward.find('/') {
+                        forward[..idx].to_owned()
+                    } else {
+                        forward.to_owned()
+                    }
+                })
         };
 
         if opts.limit > 0 && *objs_returned >= opts.limit {
@@ -3235,6 +3222,48 @@ mod test {
         assert_eq!(names.iter().filter(|name| *name == "marker/subdir/file.txt").count(), 1);
         assert_eq!(names.iter().filter(|name| *name == "marker/subdir/").count(), 1);
         assert_eq!(names.iter().filter(|name| *name == "marker/file.txt").count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_scan_dir_forward_to_repeated_prefix_component() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let bucket = "test-bucket";
+        let bucket_dir = dir.path().join(bucket);
+
+        for idx in 0..4 {
+            fs::create_dir_all(bucket_dir.join(format!("engineering/engineering/repo-{idx:04}")))
+                .await
+                .unwrap();
+            fs::write(bucket_dir.join(format!("engineering/engineering/repo-{idx:04}/xl.meta")), b"meta")
+                .await
+                .unwrap();
+        }
+
+        let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+        let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+
+        let mut writer = tokio::io::sink();
+        let mut out = MetacacheWriter::new(&mut writer);
+        let opts = WalkDirOptions {
+            bucket: bucket.to_string(),
+            base_dir: "engineering/".to_string(),
+            recursive: true,
+            forward_to: Some("engineering/engineering/repo-0001".to_string()),
+            ..Default::default()
+        };
+        let mut objs_returned = 0;
+
+        disk.scan_dir("engineering/".to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false)
+            .await
+            .unwrap();
+        out.close().await.unwrap();
+
+        assert_eq!(
+            objs_returned, 3,
+            "forward_to must not skip a child directory whose name repeats the base prefix"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
 ## Related Issues

  Fixes #2775.

  ## Summary of Changes

  Fixed recursive object listing pagination when a continuation marker points into a path whose component repeats the current prefix, for example engineering/engineering/....

  The bug was caused by deriving the forward_to child component with prefix trimming semantics that could remove repeated path components and skip the next directory during recursive LIST traversal.

  Changes include:

  - Corrected scan_dir continuation forwarding so it strips only the current directory prefix.
  - Added a focused scan_dir unit regression for repeated prefix components.
  - Added a S3 ListObjectsV2 e2e regression test.

  ## Verification

  - cargo fmt --all --check
  - cargo test -p rustfs-ecstore test_scan_dir_forward_to_repeated_prefix_component -- --nocapture
  - cargo test -p e2e_test test_list_objects_v2_repeated_prefix_continuation -- --nocapture
  - make pre-commit

  ## Impact

  Recursive ListObjectsV2 and marker-based listing now return all matching objects across continuation pages when object keys contain repeated prefix components.

  No API, configuration, or deployment changes are expected.

  ## Additional Notes

  PR #2919 fixes a separate marker round-trip issue and does not resolve #2775 by itself. The small e2e regression added here to reproduce case mentioned in issue.
