### PR TITLE
test(protocols): cover TLS reload fingerprint ordering

### DIFF
--- a/crates/protocols/src/tls_hot_reload.rs
+++ b/crates/protocols/src/tls_hot_reload.rs
@@ -311,6 +311,7 @@ mod tests {
         let second_state = ResolverState::from_cert_key_pairs(second).unwrap();
 
         assert_eq!(first_state.cert_count, 3);
+        assert_eq!(second_state.cert_count, 3);
         assert_eq!(first_state.fingerprint, second_state.fingerprint);
     }
 }

--- a/crates/protocols/src/tls_hot_reload.rs
+++ b/crates/protocols/src/tls_hot_reload.rs
@@ -237,6 +237,20 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    fn cert_key_pair(san: &str) -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+        let cert = generate_simple_self_signed(vec![san.to_string()]).unwrap();
+        (
+            vec![cert.cert.der().clone()],
+            PrivateKeyDer::try_from(cert.signing_key.serialize_der()).unwrap(),
+        )
+    }
+
+    fn clone_cert_key_pair(
+        cert_key_pair: &(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>),
+    ) -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+        (cert_key_pair.0.clone(), cert_key_pair.1.clone_key())
+    }
+
     fn write_default_cert(dir: &std::path::Path, san: &str) {
         let cert = generate_simple_self_signed(vec![san.to_string()]).unwrap();
         fs::write(dir.join(RUSTFS_TLS_CERT), cert.cert.pem()).unwrap();
@@ -275,5 +289,28 @@ mod tests {
         let resolver = ReloadableCertResolver::load_from_directory(temp_dir.path().to_str().unwrap()).unwrap();
         let outcome = resolver.reload_from_directory(temp_dir.path().to_str().unwrap()).unwrap();
         assert_eq!(outcome, None);
+    }
+
+    #[test]
+    fn resolver_state_fingerprint_is_stable_across_domain_ordering() {
+        let default_cert = cert_key_pair("localhost");
+        let api_cert = cert_key_pair("api.example.com");
+        let web_cert = cert_key_pair("web.example.com");
+
+        let mut first = HashMap::new();
+        first.insert("default".to_string(), clone_cert_key_pair(&default_cert));
+        first.insert("api.example.com".to_string(), clone_cert_key_pair(&api_cert));
+        first.insert("web.example.com".to_string(), clone_cert_key_pair(&web_cert));
+
+        let mut second = HashMap::new();
+        second.insert("web.example.com".to_string(), clone_cert_key_pair(&web_cert));
+        second.insert("default".to_string(), clone_cert_key_pair(&default_cert));
+        second.insert("api.example.com".to_string(), clone_cert_key_pair(&api_cert));
+
+        let first_state = ResolverState::from_cert_key_pairs(first).unwrap();
+        let second_state = ResolverState::from_cert_key_pairs(second).unwrap();
+
+        assert_eq!(first_state.cert_count, 3);
+        assert_eq!(first_state.fingerprint, second_state.fingerprint);
     }
 }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This adds focused unit coverage for TLS certificate hot reload fingerprinting.

The recent hot reload implementation compares fingerprints to skip reloads when certificate material is unchanged. With multiple certificate entries, the fingerprint must be stable for the same set of domain certificates regardless of map insertion order. The new test builds equivalent certificate maps with different domain insertion order and verifies that `ResolverState::from_cert_key_pairs` produces the same fingerprint while preserving the expected certificate count.

## Verification
- `RUSTC=$(rustup which --toolchain 1.95.0-aarch64-apple-darwin rustc) $(rustup which --toolchain 1.95.0-aarch64-apple-darwin cargo) test -p rustfs-protocols --features ftps --lib resolver_state_fingerprint_is_stable_across_domain_ordering -- --nocapture`
- `RUSTC=$(rustup which --toolchain 1.95.0-aarch64-apple-darwin rustc) $(rustup which --toolchain 1.95.0-aarch64-apple-darwin cargo) test -p rustfs-protocols --features webdav --lib resolver_state_fingerprint_is_stable_across_domain_ordering -- --nocapture`
- `RUSTC=$(rustup which --toolchain 1.95.0-aarch64-apple-darwin rustc) $(rustup which --toolchain 1.95.0-aarch64-apple-darwin cargo) fmt --all --check`
- `git diff --check`
- `RUST_TOOLCHAIN_BIN=$(dirname "$(rustup which --toolchain 1.95.0-aarch64-apple-darwin cargo)") RUSTC=$(rustup which --toolchain 1.95.0-aarch64-apple-darwin rustc) PATH="$RUST_TOOLCHAIN_BIN:$PATH" make pre-commit`

## Impact
No runtime behavior change. This is test-only coverage for TLS reload fingerprint stability.

## Additional Notes
The local environment has Homebrew `cargo` and `rustc` 1.93.1 earlier on PATH, while the workspace requires Rust 1.95.0. Verification commands pin the installed rustup 1.95.0 toolchain explicitly.
