### PR TITLE
test(protocols): cover SFTP host key reload failure

### DIFF
--- a/crates/protocols/src/sftp/server.rs
+++ b/crates/protocols/src/sftp/server.rs
@@ -600,6 +600,26 @@ mod hot_reload_tests {
     }
 
     #[tokio::test]
+    async fn ssh_config_holder_reload_failure_keeps_current_host_keys() {
+        let dir = TempDir::new().expect("tempdir");
+        write_file_with_mode(&dir.path().join("ssh_host_ed25519_key"), &test_ed25519_pem(), 0o600);
+
+        let config = test_config(dir.path());
+        let initial_keys = SftpConfig::load_host_keys(dir.path()).await.expect("initial key load");
+        let holder = SshConfigHolder::new(build_ssh_config(initial_keys, config.idle_timeout_secs, &config.banner));
+        assert!(matches!(holder.get().keys[0].algorithm(), russh::keys::Algorithm::Ed25519));
+
+        std::fs::remove_file(dir.path().join("ssh_host_ed25519_key")).expect("remove old key");
+
+        let err = holder
+            .reload_from_config(&config)
+            .await
+            .expect_err("empty host key directory must fail reload");
+        assert!(matches!(err, SftpInitError::NoHostKeysFound { .. }));
+        assert!(matches!(holder.get().keys[0].algorithm(), russh::keys::Algorithm::Ed25519));
+    }
+
+    #[tokio::test]
     async fn fingerprint_host_keys_is_order_independent() {
         let dir = TempDir::new().expect("tempdir");
         write_file_with_mode(&dir.path().join("ssh_host_ed25519_key"), &test_ed25519_pem(), 0o600);


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds a focused SFTP host-key hot reload regression test for the failure path introduced by recent protocol reload work.

The test starts with a valid Ed25519 host key, removes the key from disk, verifies reload fails with `NoHostKeysFound`, and asserts the active SSH config still serves the previous host key instead of replacing it with invalid state.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-protocols --features sftp ssh_config_holder_reload_failure_keeps_current_host_keys`
- `make pre-commit`

## Impact
Test-only change. No runtime behavior, API, configuration, or compatibility impact.

## Additional Notes
Local validation used Rust 1.95.0 because the workspace now requires `rust-version = "1.95.0"`.
