### PR TITLE
test(notify): cover encoded key target union

### DIFF
--- a/crates/notify/src/notifier.rs
+++ b/crates/notify/src/notifier.rs
@@ -457,6 +457,21 @@ mod tests {
     }
 
     #[test]
+    fn encoded_event_key_matches_raw_and_decoded_rule_targets() {
+        let raw_target = TargetID::new("raw".to_string(), "webhook".to_string());
+        let decoded_target = TargetID::new("decoded".to_string(), "webhook".to_string());
+        let mut rules_map = RulesMap::new();
+        rules_map.add_rule_config(&[EventName::ObjectCreatedPut], "uploads%2F*.csv".to_string(), raw_target.clone());
+        rules_map.add_rule_config(&[EventName::ObjectCreatedPut], "uploads/*.csv".to_string(), decoded_target.clone());
+
+        let targets = match_event_targets(&rules_map, EventName::ObjectCreatedPut, "uploads%2Freport.csv");
+
+        assert_eq!(targets.len(), 2);
+        assert!(targets.contains(&raw_target));
+        assert!(targets.contains(&decoded_target));
+    }
+
+    #[test]
     fn encoded_event_key_does_not_bypass_suffix_filter() {
         let target_id = TargetID::new("primary".to_string(), "webhook".to_string());
         let mut rules_map = RulesMap::new();


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds a focused regression test for notification event matching when a percent-encoded object key matches both raw and decoded rule patterns.

The test asserts that `match_event_targets` keeps both target IDs instead of replacing the raw match with the decoded match. This covers the union behavior around the recent decoded event key filter fix.

## Verification
- `PATH="$HOME/.cargo/bin:$PATH" RUSTUP_TOOLCHAIN=1.95.0 cargo test -p rustfs-notify encoded_event_key_matches_raw_and_decoded_rule_targets --lib`
- `PATH="$HOME/.cargo/bin:$PATH" RUSTUP_TOOLCHAIN=1.95.0 cargo fmt --all --check`
- `PATH="$HOME/.cargo/bin:$PATH" RUSTUP_TOOLCHAIN=1.95.0 make pre-commit`

## Impact
Test-only change. No runtime, API, deployment, or configuration impact.

## Additional Notes
N/A
