### PR TITLE
fix(server): fail fast when configured TLS parsing fails

### DIFF
--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -225,7 +225,7 @@ async fn async_main() -> Result<()> {
     // Initialize TLS outbound material (root CAs, mTLS identity) if configured.
     // Server-side TLS acceptor is built separately inside start_http_server()
     // using the same TlsMaterialSnapshot loading logic.
-    if let Some(tls_path) = &config.tls_path {
+    if let Some(tls_path) = config.tls_path.as_deref().map(str::trim).filter(|path| !path.is_empty()) {
         match rustfs::server::tls_material::TlsMaterialSnapshot::load(tls_path).await {
             Ok(snapshot) => {
                 snapshot.apply_outbound().await;

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -223,16 +223,16 @@ pub async fn start_http_server(
         .await
         .map_err(|e| Error::other(e.to_string()))?;
 
-    let tls_acceptor = tls_snapshot
-        .build_tls_acceptor(tls_path)
-        .await
-        .map_err(|e| Error::other(e.to_string()))?;
-    if tls_path_configured && tls_acceptor.is_none() {
-        return Err(Error::other(format!(
-            "TLS is explicitly configured via RUSTFS_TLS_PATH/tls_path='{}' but no valid server certificate/private key could be loaded; refusing HTTP fallback startup",
-            tls_path
-        )));
-    }
+    let tls_acceptor = tls_snapshot.build_tls_acceptor(tls_path).await.map_err(|e| {
+        if tls_path_configured {
+            Error::other(format!(
+                "TLS is explicitly configured via RUSTFS_TLS_PATH/tls_path='{}' but TLS acceptor initialization failed: {}",
+                tls_path, e
+            ))
+        } else {
+            Error::other(e.to_string())
+        }
+    })?;
     let tls_enabled = tls_acceptor.is_some();
     let protocol = if tls_enabled { "https" } else { "http" };
 

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -216,6 +216,7 @@ pub async fn start_http_server(
     };
 
     let tls_path = config.tls_path.as_deref().unwrap_or_default();
+    let tls_path_configured = config.tls_path.as_ref().is_some_and(|path| !path.trim().is_empty());
     // Load TLS materials and build server acceptor.
     // Note: outbound material (root CAs, mTLS identity) is already applied in main.rs.
     let tls_snapshot = TlsMaterialSnapshot::load(tls_path)
@@ -226,6 +227,12 @@ pub async fn start_http_server(
         .build_tls_acceptor(tls_path)
         .await
         .map_err(|e| Error::other(e.to_string()))?;
+    if tls_path_configured && tls_acceptor.is_none() {
+        return Err(Error::other(format!(
+            "TLS is explicitly configured via RUSTFS_TLS_PATH/tls_path='{}' but no valid server certificate/private key could be loaded; refusing HTTP fallback startup",
+            tls_path
+        )));
+    }
     let tls_enabled = tls_acceptor.is_some();
     let protocol = if tls_enabled { "https" } else { "http" };
 

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -215,8 +215,8 @@ pub async fn start_http_server(
         TcpListener::from_std(socket.into())?
     };
 
-    let tls_path = config.tls_path.as_deref().unwrap_or_default();
-    let tls_path_configured = config.tls_path.as_ref().is_some_and(|path| !path.trim().is_empty());
+    let tls_path = config.tls_path.as_deref().map(str::trim).unwrap_or_default();
+    let tls_path_configured = !tls_path.is_empty();
     // Load TLS materials and build server acceptor.
     // Note: outbound material (root CAs, mTLS identity) is already applied in main.rs.
     let tls_snapshot = TlsMaterialSnapshot::load(tls_path)

--- a/rustfs/src/server/tls_material.rs
+++ b/rustfs/src/server/tls_material.rs
@@ -66,8 +66,6 @@ pub struct OutboundTlsMaterial {
 pub struct TlsMaterialSnapshot {
     /// Material for outbound client connections.
     pub outbound: OutboundTlsMaterial,
-    /// Whether any server certificates were found.
-    pub has_server_certs: bool,
 }
 
 impl TlsMaterialSnapshot {
@@ -86,13 +84,7 @@ impl TlsMaterialSnapshot {
         // Load outbound material (root CAs + mTLS identity)
         let outbound = load_outbound_material(&tls_dir).await?;
 
-        // Check if server certs exist (actual loading happens in build_tls_acceptor)
-        let has_server_certs = has_server_certificates(tls_path).await;
-
-        Ok(Self {
-            outbound,
-            has_server_certs,
-        })
+        Ok(Self { outbound })
     }
 
     /// Apply outbound material to global state (root CAs, mTLS identity).
@@ -174,7 +166,6 @@ impl TlsMaterialSnapshot {
                 root_ca_pem: Vec::new(),
                 mtls_identity: None,
             },
-            has_server_certs: false,
         }
     }
 }
@@ -287,24 +278,6 @@ async fn load_outbound_material(tls_dir: &Path) -> Result<OutboundTlsMaterial, T
         root_ca_pem,
         mtls_identity,
     })
-}
-
-/// Quick check whether server certificate files exist in the TLS directory.
-async fn has_server_certificates(tls_path: &str) -> bool {
-    if tokio::fs::metadata(tls_path).await.is_err() {
-        return false;
-    }
-    // Check for multi-cert directory structure OR single cert files
-    if rustfs_utils::load_all_certs_from_directory(
-        rustfs_utils::CertDirectoryLoadOptions::builder(tls_path, RUSTFS_TLS_CERT, RUSTFS_TLS_KEY).build(),
-    )
-    .is_ok_and(|p| !p.is_empty())
-    {
-        return true;
-    }
-    let key_path = format!("{tls_path}/{RUSTFS_TLS_KEY}");
-    let cert_path = format!("{tls_path}/{RUSTFS_TLS_CERT}");
-    tokio::try_join!(tokio::fs::metadata(&key_path), tokio::fs::metadata(&cert_path)).is_ok()
 }
 
 /// Load mTLS client identity from the TLS directory.

--- a/rustfs/src/server/tls_material.rs
+++ b/rustfs/src/server/tls_material.rs
@@ -110,7 +110,7 @@ impl TlsMaterialSnapshot {
     /// handling both multi-cert (SNI resolver) and single-cert fallback.
     /// Returns `None` if no TLS certificates are available.
     pub(crate) async fn build_tls_acceptor(&self, tls_path: &str) -> Result<Option<Arc<TlsAcceptorHolder>>, TlsMaterialError> {
-        if tls_path.is_empty() || !self.has_server_certs {
+        if tls_path.is_empty() {
             return Ok(None);
         }
 
@@ -122,6 +122,7 @@ impl TlsMaterialSnapshot {
         .map_err(|e| TlsMaterialError::Io(format!("build mTLS verifier: {e}")))?;
 
         // Try multi-cert (SNI) first
+        let mut multi_cert_error: Option<String> = None;
         match rustfs_utils::load_all_certs_from_directory(
             rustfs_utils::CertDirectoryLoadOptions::builder(tls_path, RUSTFS_TLS_CERT, RUSTFS_TLS_KEY).build(),
         ) {
@@ -132,10 +133,15 @@ impl TlsMaterialSnapshot {
                     let acceptor = Arc::new(TlsAcceptor::from(Arc::new(config)));
                     return Ok(Some(Arc::new(TlsAcceptorHolder::new(acceptor))));
                 }
-                Err(e) => warn!("Failed to build multi-cert resolver: {}, falling back to single-cert", e),
+                Err(e) => {
+                    return Err(TlsMaterialError::Parse(format!("failed to build multi-cert resolver: {e}")));
+                }
             },
             Ok(_) => debug!("No valid multi-cert directory structure found"),
-            Err(_) => debug!("load_all_certs_from_directory failed, trying single-cert fallback"),
+            Err(e) => {
+                multi_cert_error = Some(e.to_string());
+                debug!("load_all_certs_from_directory failed, trying single-cert fallback");
+            }
         }
 
         // Fallback: single cert
@@ -149,6 +155,13 @@ impl TlsMaterialSnapshot {
             info!("Created TLS acceptor with single certificate");
             let acceptor = Arc::new(TlsAcceptor::from(Arc::new(config)));
             return Ok(Some(Arc::new(TlsAcceptorHolder::new(acceptor))));
+        }
+
+        if let Some(err) = multi_cert_error {
+            return Err(TlsMaterialError::Parse(format!(
+                "failed to parse TLS certificates under '{}': {}",
+                tls_path, err
+            )));
         }
 
         debug!("No valid TLS certificates found, starting with HTTP");

--- a/rustfs/src/server/tls_material.rs
+++ b/rustfs/src/server/tls_material.rs
@@ -114,11 +114,10 @@ impl TlsMaterialSnapshot {
         .map_err(|e| TlsMaterialError::Io(format!("build mTLS verifier: {e}")))?;
 
         // Try multi-cert (SNI) first
-        let mut multi_cert_error: Option<String> = None;
-        match rustfs_utils::load_all_certs_from_directory(
+        let multi_cert_error = match rustfs_utils::load_all_certs_from_directory(
             rustfs_utils::CertDirectoryLoadOptions::builder(tls_path, RUSTFS_TLS_CERT, RUSTFS_TLS_KEY).build(),
         ) {
-            Ok(cert_key_pairs) if !cert_key_pairs.is_empty() => match rustfs_utils::create_multi_cert_resolver(cert_key_pairs) {
+            Ok(cert_key_pairs) => match rustfs_utils::create_multi_cert_resolver(cert_key_pairs) {
                 Ok(resolver) => {
                     let config = build_server_config(ServerCertSource::Resolver(Arc::new(resolver)), mtls_verifier)?;
                     info!("Created TLS acceptor with SNI resolver");
@@ -129,12 +128,11 @@ impl TlsMaterialSnapshot {
                     return Err(TlsMaterialError::Parse(format!("failed to build multi-cert resolver: {e}")));
                 }
             },
-            Ok(_) => debug!("No valid multi-cert directory structure found"),
             Err(e) => {
-                multi_cert_error = Some(e.to_string());
                 debug!("load_all_certs_from_directory failed, trying single-cert fallback");
+                Some(e.to_string())
             }
-        }
+        };
 
         // Fallback: single cert
         let key_path = format!("{tls_path}/{RUSTFS_TLS_KEY}");
@@ -150,8 +148,8 @@ impl TlsMaterialSnapshot {
         }
 
         if let Some(err) = multi_cert_error {
-            return Err(TlsMaterialError::Parse(format!(
-                "failed to parse TLS certificates under '{}': {}",
+            return Err(TlsMaterialError::Io(format!(
+                "failed to discover TLS certificates under '{}': {}",
                 tls_path, err
             )));
         }


### PR DESCRIPTION
## Related Issues
Fixes #2726

## Summary of Changes
- Make TLS startup fail fast when `RUSTFS_TLS_PATH`/`tls_path` is explicitly configured but server TLS certificates cannot be loaded.
- Stop silently falling back to HTTP startup in that configured-TLS scenario.
- Return certificate parsing/build errors from TLS acceptor initialization instead of swallowing them behind fallback behavior.

## Verification
- `cargo fmt --all`
- `cargo check -p rustfs`
- `make pre-commit`

## Impact
- Behavior change: TLS misconfiguration now fails startup with explicit errors instead of allowing HTTP fallback.
- Operator-facing diagnostics improve because certificate parsing failures are now propagated.
- No API surface change.

## Additional Notes
N/A
