### PR TITLE
fix(storage): keep storage info RPC map encoded

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -422,7 +422,7 @@ impl LocalDisk {
                             total: info.total,
                             free: info.free,
                             used: info.used,
-                            used_inodes: info.files - info.ffree,
+                            used_inodes: info.files.saturating_sub(info.ffree),
                             free_inodes: info.ffree,
                             major: info.major,
                             minor: info.minor,

--- a/rustfs/src/storage/rpc/health.rs
+++ b/rustfs/src/storage/rpc/health.rs
@@ -236,3 +236,30 @@ impl NodeService {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_storage_info_rpc_payload_uses_msgpack_map_encoding() {
+        let info = rustfs_madmin::StorageInfo {
+            disks: Vec::new(),
+            backend: rustfs_madmin::BackendInfo {
+                backend_type: rustfs_madmin::BackendByte::Erasure,
+                standard_sc_data: vec![2, 2],
+                total_sets: vec![1, 1],
+                drives_per_set: vec![4, 4],
+                ..Default::default()
+            },
+        };
+
+        let encoded = encode_msgpack_map(&info).expect("storage info should serialize");
+        assert_eq!(encoded.first().copied(), Some(0x82));
+
+        let mut decoder = Deserializer::new(Cursor::new(encoded));
+        let decoded: rustfs_madmin::StorageInfo = Deserialize::deserialize(&mut decoder).expect("storage info should decode");
+        assert_eq!(decoded.backend.drives_per_set, vec![4, 4]);
+        assert_eq!(decoded.backend.total_sets, vec![1, 1]);
+    }
+}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other: N/A

## Related Issues
#2780

## Summary of Changes
- Add regression coverage for `LocalStorageInfo` RPC msgpack map encoding with multi-pool backend vectors.
- Preserve storage info peer decoding compatibility by relying on the shared map-encoding RPC helper from the current base branch.
- Clamp derived local disk `used_inodes` at zero to avoid an underflow panic when filesystem stats report free inodes greater than total files.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Improves internode RPC compatibility for storage info responses and hardens local disk info collection.

## Additional Notes
Verification performed:
- `cargo fmt --all --check`
- `cargo test -p rustfs local_storage_info_rpc_payload_uses_msgpack_map_encoding --lib`
- `cargo test -p rustfs-ecstore cleanup_removes_empty_multipart_sha_dirs --lib -- --nocapture`
- `make pre-commit`

Live multi-pool cluster validation was not run locally.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
