### PR TITLE
fix(ecstore): map missing metadata to not found

### DIFF
--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -5560,6 +5560,36 @@ mod tests {
     }
 
     #[test]
+    fn test_object_quorum_from_meta_returns_not_found_when_all_metadata_is_missing() {
+        let errs = vec![
+            Some(DiskError::FileNotFound),
+            Some(DiskError::VolumeNotFound),
+            Some(DiskError::DiskNotFound),
+            Some(DiskError::FileNotFound),
+        ];
+
+        let err = SetDisks::object_quorum_from_meta(&vec![FileInfo::default(); errs.len()], &errs, 2)
+            .expect_err("missing metadata should map to FileNotFound");
+
+        assert_eq!(err, DiskError::FileNotFound);
+    }
+
+    #[test]
+    fn test_object_quorum_from_meta_preserves_read_quorum_for_mixed_failures() {
+        let errs = vec![
+            Some(DiskError::FileNotFound),
+            Some(DiskError::VolumeNotFound),
+            Some(DiskError::FileCorrupt),
+            Some(DiskError::DiskNotFound),
+        ];
+
+        let err = SetDisks::object_quorum_from_meta(&vec![FileInfo::default(); errs.len()], &errs, 2)
+            .expect_err("mixed metadata failures should keep quorum semantics");
+
+        assert_eq!(err, DiskError::ErasureReadQuorum);
+    }
+
+    #[test]
     fn test_shuffle_parts_metadata() {
         // Test metadata shuffling
         let metadata = vec![

--- a/crates/ecstore/src/set_disk/metadata.rs
+++ b/crates/ecstore/src/set_disk/metadata.rs
@@ -15,6 +15,28 @@
 use super::*;
 
 impl SetDisks {
+    pub(super) fn all_not_found_metadata(errs: &[Option<DiskError>]) -> bool {
+        !errs.is_empty()
+            && errs.iter().all(|err| match err {
+                Some(err) => {
+                    matches!(
+                        err,
+                        DiskError::FileNotFound
+                            | DiskError::FileVersionNotFound
+                            | DiskError::VolumeNotFound
+                            | DiskError::DiskNotFound
+                    ) || OBJECT_OP_IGNORED_ERRS.contains(err)
+                }
+                None => false,
+            })
+            && errs.iter().any(|err| {
+                matches!(
+                    err,
+                    Some(DiskError::FileNotFound | DiskError::FileVersionNotFound | DiskError::VolumeNotFound)
+                )
+            })
+    }
+
     pub(super) fn reduce_common_data_dir(data_dirs: &Vec<Option<Uuid>>, write_quorum: usize) -> Option<Uuid> {
         let mut data_dirs_count = HashMap::new();
 
@@ -237,6 +259,10 @@ impl SetDisks {
         errs: &[Option<DiskError>],
         default_parity_count: usize,
     ) -> disk::error::Result<(i32, i32)> {
+        if Self::all_not_found_metadata(errs) {
+            return Err(DiskError::FileNotFound);
+        }
+
         let expected_rquorum = if default_parity_count == 0 {
             parts_metadata.len()
         } else {


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Treat metadata reads where every shard reports missing object metadata as `FileNotFound` before quorum reduction.
- Keep mixed metadata failures, such as corrupt metadata alongside missing metadata, on the existing read quorum error path.
- Add regression coverage for both missing-only and mixed-failure metadata quorum behavior.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2 make pre-commit`

## Impact
Missing rebalance/object metadata is surfaced as a not-found condition instead of a read quorum failure. Mixed metadata failures still surface as read quorum errors, preserving the existing integrity signal for non-not-found failures. No API, configuration, deployment, or migration changes are expected.

## Additional Notes
The first `make pre-commit` run failed because the local disk filled while writing build artifacts. After cleaning generated `target` artifacts and rerunning with lower disk usage settings, the full pre-commit gate passed.
