### PR TITLE
fix(ecstore): list_object_v2 error when scanning multipart folder

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3347,6 +3347,119 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_scan_dir_ignore_multipart_dirs() {
+        use rustfs_filemeta::MetacacheReader;
+        use tempfile::tempdir;
+
+        const UUID_MULTIPART_1: &str = "8b262d24-fcf9-473d-a4cd-f9b27f24f60e";
+        const UUID_MULTIPART_2: &str = "fbf3183c-63be-45cc-b3bf-424ddb7f95f8";
+        const UUID_OBJ: &str = "db8b9b74-9016-4f9e-83e9-82a772947d28";
+        const VER_ID_1: &str = "c683f9f8-c0a1-4bc5-8a67-0faafa839a1a";
+        const VER_ID_2: &str = "a4b84f6e-c8ba-461b-8f9d-43feb0893efb";
+        const BASE_DIR: &str = "dir1/obj/";
+        const MULTIPART_DIR: &str = "multipart-file";
+        const EMPTY_STR: &str = "";
+
+        let parse_uuid = |s: &str| Uuid::parse_str(s).unwrap();
+        let create_file_info = |version_id: &str, data_dir: &str| FileInfo {
+            version_id: Some(parse_uuid(version_id)),
+            data_dir: Some(parse_uuid(data_dir)),
+            mod_time: Some(OffsetDateTime::now_utc()),
+            ..Default::default()
+        };
+
+        let dir = tempdir().unwrap();
+        let obj_base = dir.path().join("test-bucket").join(BASE_DIR);
+        let multipart_base = obj_base.join(MULTIPART_DIR);
+
+        fs::create_dir_all(&multipart_base).await.unwrap();
+        for uuid in &[UUID_MULTIPART_1, UUID_MULTIPART_2] {
+            fs::create_dir_all(multipart_base.join(uuid)).await.unwrap();
+            fs::write(multipart_base.join(uuid).join("part.1"), b"part").await.unwrap();
+        }
+        fs::create_dir_all(obj_base.join(UUID_OBJ)).await.unwrap();
+        fs::write(obj_base.join(UUID_OBJ).join("part.1"), b"part").await.unwrap();
+
+        let mut fm = FileMeta::default();
+        fm.add_version(create_file_info(VER_ID_1, UUID_MULTIPART_1)).unwrap();
+        fm.add_version(create_file_info(VER_ID_2, UUID_MULTIPART_2)).unwrap();
+        fs::write(multipart_base.join(STORAGE_FORMAT_FILE), fm.marshal_msg().unwrap())
+            .await
+            .unwrap();
+
+        let mut fm = FileMeta::default();
+        fm.add_version(create_file_info(VER_ID_1, UUID_OBJ)).unwrap();
+        fs::write(obj_base.join(STORAGE_FORMAT_FILE), fm.marshal_msg().unwrap())
+            .await
+            .unwrap();
+
+        let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+        let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+
+        let (reader, mut writer) = tokio::io::duplex(4096);
+        let mut out = MetacacheWriter::new(&mut writer);
+        let mut objs_returned = 0;
+
+        disk.scan_dir(
+            BASE_DIR.to_string(),
+            EMPTY_STR.to_string(),
+            &WalkDirOptions {
+                bucket: "test-bucket".to_string(),
+                base_dir: BASE_DIR.to_string(),
+                recursive: true,
+                filter_prefix: Some(EMPTY_STR.to_string()),
+                ..Default::default()
+            },
+            &mut out,
+            &mut objs_returned,
+            true,
+        )
+        .await
+        .unwrap();
+        out.close().await.unwrap();
+
+        let mut reader = MetacacheReader::new(reader);
+        let entries = reader.read_all().await.unwrap();
+        let names: Vec<String> = entries.into_iter().map(|entry| entry.name).collect();
+
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}", BASE_DIR, MULTIPART_DIR))
+                .count(),
+            1
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/", BASE_DIR, MULTIPART_DIR))
+                .count(),
+            1
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/{}", BASE_DIR, MULTIPART_DIR, UUID_MULTIPART_1))
+                .count(),
+            0
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/{}", BASE_DIR, MULTIPART_DIR, UUID_MULTIPART_2))
+                .count(),
+            0
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}", BASE_DIR, UUID_OBJ))
+                .count(),
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn test_make_volume() {
         let p = "./testv0";
         fs::create_dir_all(&p).await.unwrap();

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3356,8 +3356,10 @@ mod test {
         const UUID_OBJ: &str = "db8b9b74-9016-4f9e-83e9-82a772947d28";
         const VER_ID_1: &str = "c683f9f8-c0a1-4bc5-8a67-0faafa839a1a";
         const VER_ID_2: &str = "a4b84f6e-c8ba-461b-8f9d-43feb0893efb";
+        const VER_ID_3: &str = "892c9ae7-2bb3-44ee-9a71-bc7ddf08d765";
         const BASE_DIR: &str = "dir1/obj/";
         const MULTIPART_DIR: &str = "multipart-file";
+        const DIR_IN_MULTIPART_DIR: &str = "dir-in-multipart";
         const EMPTY_STR: &str = "";
 
         let parse_uuid = |s: &str| Uuid::parse_str(s).unwrap();
@@ -3371,6 +3373,7 @@ mod test {
         let dir = tempdir().unwrap();
         let obj_base = dir.path().join("test-bucket").join(BASE_DIR);
         let multipart_base = obj_base.join(MULTIPART_DIR);
+        let dir_in_multipart_base = multipart_base.join(DIR_IN_MULTIPART_DIR);
 
         fs::create_dir_all(&multipart_base).await.unwrap();
         for uuid in &[UUID_MULTIPART_1, UUID_MULTIPART_2] {
@@ -3380,6 +3383,11 @@ mod test {
         fs::create_dir_all(obj_base.join(UUID_OBJ)).await.unwrap();
         fs::write(obj_base.join(UUID_OBJ).join("part.1"), b"part").await.unwrap();
 
+        fs::create_dir_all(&dir_in_multipart_base).await.unwrap();
+        fs::write(dir_in_multipart_base.join(STORAGE_FORMAT_FILE), b"meta")
+            .await
+            .unwrap();
+
         let mut fm = FileMeta::default();
         fm.add_version(create_file_info(VER_ID_1, UUID_MULTIPART_1)).unwrap();
         fm.add_version(create_file_info(VER_ID_2, UUID_MULTIPART_2)).unwrap();
@@ -3388,7 +3396,7 @@ mod test {
             .unwrap();
 
         let mut fm = FileMeta::default();
-        fm.add_version(create_file_info(VER_ID_1, UUID_OBJ)).unwrap();
+        fm.add_version(create_file_info(VER_ID_3, UUID_OBJ)).unwrap();
         fs::write(obj_base.join(STORAGE_FORMAT_FILE), fm.marshal_msg().unwrap())
             .await
             .unwrap();
@@ -3421,7 +3429,6 @@ mod test {
         let mut reader = MetacacheReader::new(reader);
         let entries = reader.read_all().await.unwrap();
         let names: Vec<String> = entries.into_iter().map(|entry| entry.name).collect();
-
         assert_eq!(
             names
                 .iter()
@@ -3433,6 +3440,20 @@ mod test {
             names
                 .iter()
                 .filter(|name| *name == &format!("{}{}/", BASE_DIR, MULTIPART_DIR))
+                .count(),
+            1
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/{}", BASE_DIR, MULTIPART_DIR, DIR_IN_MULTIPART_DIR))
+                .count(),
+            1
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/{}/", BASE_DIR, MULTIPART_DIR, DIR_IN_MULTIPART_DIR))
                 .count(),
             1
         );
@@ -3454,6 +3475,27 @@ mod test {
             names
                 .iter()
                 .filter(|name| *name == &format!("{}{}", BASE_DIR, UUID_OBJ))
+                .count(),
+            0
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/{}/", BASE_DIR, MULTIPART_DIR, UUID_MULTIPART_1))
+                .count(),
+            0
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/{}/", BASE_DIR, MULTIPART_DIR, UUID_MULTIPART_2))
+                .count(),
+            0
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == &format!("{}{}/", BASE_DIR, UUID_OBJ))
                 .count(),
             0
         );

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1291,12 +1291,31 @@ impl LocalDisk {
 
         let mut dir_objes = HashSet::new();
 
+        // need to skip multipart dirs
+        let mut multipart_dir_to_skip = HashSet::new();
+        if skip_current_dir_object
+            && let Ok(meta) = self
+                .read_metadata(bucket, format!("{}/{}", &current, STORAGE_FORMAT_FILE).as_str())
+                .await
+            && let Ok(file_meta) = FileMeta::load(&meta)
+            && let Ok(data_dirs) = file_meta.get_data_dirs()
+        {
+            for data_dir in data_dirs.iter().flatten() {
+                multipart_dir_to_skip.insert(data_dir.to_string());
+            }
+        }
+
         // First-level filtering
         for item in entries.iter_mut() {
             let entry = item.clone();
             // check limit
             if opts.limit > 0 && *objs_returned >= opts.limit {
                 return Ok(());
+            }
+            // check multipart dir
+            if skip_current_dir_object && multipart_dir_to_skip.contains(entry.trim_end_matches(SLASH_SEPARATOR)) {
+                *item = "".to_owned();
+                continue;
             }
             // check prefix
             if !prefix.is_empty() && !entry.starts_with(prefix.as_str()) {

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3382,7 +3382,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_scan_dir_ignore_multipart_dirs() {
+    async fn test_walk_dir_ignore_multipart_dirs() {
         use rustfs_filemeta::MetacacheReader;
         use tempfile::tempdir;
 
@@ -3440,28 +3440,19 @@ mod test {
         let disk = LocalDisk::new(&endpoint, false).await.unwrap();
 
         let (reader, mut writer) = tokio::io::duplex(4096);
-        let mut out = MetacacheWriter::new(&mut writer);
-        let mut objs_returned = 0;
-
-        let multipart_dir_to_skip = HashSet::from([UUID_OBJ.to_string()]);
-        disk.scan_dir(
-            BASE_DIR.to_string(),
-            EMPTY_STR.to_string(),
-            &WalkDirOptions {
+        disk.walk_dir(
+            WalkDirOptions {
                 bucket: "test-bucket".to_string(),
                 base_dir: BASE_DIR.to_string(),
                 recursive: true,
                 filter_prefix: Some(EMPTY_STR.to_string()),
                 ..Default::default()
             },
-            &mut out,
-            &mut objs_returned,
-            true,
-            Some(multipart_dir_to_skip),
+            &mut writer,
         )
         .await
         .unwrap();
-        out.close().await.unwrap();
+        MetacacheWriter::new(&mut writer).close().await.unwrap();
 
         let mut reader = MetacacheReader::new(reader);
         let entries = reader.read_all().await.unwrap();

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1234,6 +1234,7 @@ impl LocalDisk {
     }
 
     #[async_recursion::async_recursion]
+    #[allow(clippy::too_many_arguments)]
     async fn scan_dir<W>(
         &self,
         mut current: String,
@@ -1242,6 +1243,7 @@ impl LocalDisk {
         out: &mut MetacacheWriter<W>,
         objs_returned: &mut i32,
         skip_current_dir_object: bool,
+        multipart_dir_to_skip: Option<HashSet<String>>,
     ) -> Result<()>
     where
         W: AsyncWrite + Unpin + Send,
@@ -1291,20 +1293,6 @@ impl LocalDisk {
 
         let mut dir_objes = HashSet::new();
 
-        // need to skip multipart dirs
-        let mut multipart_dir_to_skip = HashSet::new();
-        if skip_current_dir_object
-            && let Ok(meta) = self
-                .read_metadata(bucket, format!("{}/{}", &current, STORAGE_FORMAT_FILE).as_str())
-                .await
-            && let Ok(file_meta) = FileMeta::load(&meta)
-            && let Ok(data_dirs) = file_meta.get_data_dirs()
-        {
-            for data_dir in data_dirs.iter().flatten() {
-                multipart_dir_to_skip.insert(data_dir.to_string());
-            }
-        }
-
         // First-level filtering
         for item in entries.iter_mut() {
             let entry = item.clone();
@@ -1313,7 +1301,10 @@ impl LocalDisk {
                 return Ok(());
             }
             // check multipart dir
-            if skip_current_dir_object && multipart_dir_to_skip.contains(entry.trim_end_matches(SLASH_SEPARATOR)) {
+            if skip_current_dir_object
+                && let Some(ref dir_to_skip) = multipart_dir_to_skip
+                && dir_to_skip.contains(entry.trim_end_matches(SLASH_SEPARATOR))
+            {
                 *item = "".to_owned();
                 continue;
             }
@@ -1386,15 +1377,25 @@ impl LocalDisk {
             }
         }
 
-        let mut dir_stack: Vec<(String, bool)> = Vec::with_capacity(5);
+        let mut dir_stack: Vec<(String, bool, Option<HashSet<String>>)> = Vec::with_capacity(5);
         // Explicit directory markers and real directories can resolve to the same logical path.
-        let schedule_dir = |dir_stack: &mut Vec<(String, bool)>, dir_name: String, skip_object: bool| {
-            if let Some((last_dir_name, existing_skip_object)) = dir_stack.last_mut()
+        let schedule_dir = |dir_stack: &mut Vec<(String, bool, Option<HashSet<String>>)>,
+                            dir_name: String,
+                            skip_object: bool,
+                            dir_to_skip: Option<HashSet<String>>| {
+            if let Some((last_dir_name, existing_skip_object, existing_dir_to_skip)) = dir_stack.last_mut()
                 && *last_dir_name == dir_name
             {
                 *existing_skip_object |= skip_object;
+                if let Some(existing_dir_to_skip) = existing_dir_to_skip {
+                    if let Some(new_dir_to_skip) = &dir_to_skip {
+                        existing_dir_to_skip.extend(new_dir_to_skip.iter().cloned());
+                    }
+                } else {
+                    *existing_dir_to_skip = dir_to_skip;
+                }
             } else {
-                dir_stack.push((dir_name, skip_object));
+                dir_stack.push((dir_name, skip_object, dir_to_skip));
             }
         };
         prefix = "".to_owned();
@@ -1410,7 +1411,7 @@ impl LocalDisk {
 
             let name = path_join_buf(&[current.as_str(), entry.as_str()]);
 
-            while let Some((pop, skip_object)) = dir_stack.last().cloned()
+            while let Some((pop, skip_object, dir_to_skip)) = dir_stack.last().cloned()
                 && pop < name
             {
                 out.write_obj(&MetaCacheEntry {
@@ -1420,7 +1421,8 @@ impl LocalDisk {
                 .await?;
 
                 if opts.recursive
-                    && let Err(er) = Box::pin(self.scan_dir(pop, prefix.clone(), opts, out, objs_returned, skip_object)).await
+                    && let Err(er) =
+                        Box::pin(self.scan_dir(pop, prefix.clone(), opts, out, objs_returned, skip_object, dir_to_skip)).await
                 {
                     error!("scan_dir err {:?}", er);
                 }
@@ -1461,11 +1463,24 @@ impl LocalDisk {
                     // }
 
                     if opts.recursive {
+                        let mut dir_to_skip = HashSet::new();
+                        if let Ok(file_meta) = FileMeta::load(&res)
+                            && let Ok(data_dirs) = file_meta.get_data_dirs()
+                        {
+                            for data_dir in data_dirs.iter().flatten() {
+                                dir_to_skip.insert(data_dir.to_string());
+                            }
+                        }
                         let mut dir_name = meta.name.clone();
                         if !dir_name.ends_with(SLASH_SEPARATOR) {
                             dir_name.push_str(SLASH_SEPARATOR);
                         }
-                        schedule_dir(&mut dir_stack, dir_name, true);
+                        schedule_dir(
+                            &mut dir_stack,
+                            dir_name,
+                            true,
+                            if dir_to_skip.is_empty() { None } else { Some(dir_to_skip) },
+                        );
                     }
                 }
                 Err(err) => {
@@ -1474,7 +1489,7 @@ impl LocalDisk {
                         // If dirObject, but no metadata (which is unexpected) we skip it.
                         if !is_dir_obj && !is_empty_dir(self.get_object_path(&opts.bucket, &meta.name)?).await {
                             meta.name.push_str(SLASH_SEPARATOR);
-                            schedule_dir(&mut dir_stack, meta.name, false);
+                            schedule_dir(&mut dir_stack, meta.name, false, None);
                         }
                     }
 
@@ -1483,7 +1498,7 @@ impl LocalDisk {
             };
         }
 
-        while let Some((dir, skip_object)) = dir_stack.pop() {
+        while let Some((dir, skip_object, dir_to_skip)) = dir_stack.pop() {
             if opts.limit > 0 && *objs_returned >= opts.limit {
                 return Ok(());
             }
@@ -1495,7 +1510,8 @@ impl LocalDisk {
             .await?;
 
             if opts.recursive
-                && let Err(er) = Box::pin(self.scan_dir(dir, prefix.clone(), opts, out, objs_returned, skip_object)).await
+                && let Err(er) =
+                    Box::pin(self.scan_dir(dir, prefix.clone(), opts, out, objs_returned, skip_object, dir_to_skip)).await
             {
                 warn!("scan_dir err {:?}", &er);
             }
@@ -2347,6 +2363,7 @@ impl DiskAPI for LocalDisk {
         let mut objs_returned = 0;
 
         let mut skip_current_dir_object = false;
+        let mut multipart_dir_to_skip: HashSet<String> = HashSet::new();
         if opts.base_dir.ends_with(SLASH_SEPARATOR) {
             if let Ok(data) = self
                 .read_metadata(
@@ -2370,10 +2387,23 @@ impl DiskAPI for LocalDisk {
                 let fpath =
                     self.get_object_path(&opts.bucket, path_join_buf(&[opts.base_dir.as_str(), STORAGE_FORMAT_FILE]).as_str())?;
 
-                if let Ok(meta) = tokio::fs::metadata(fpath).await
+                if let Ok(meta) = tokio::fs::metadata(&fpath).await
                     && meta.is_file()
                 {
                     skip_current_dir_object = true;
+                    if let Ok(meta_bytes) = self
+                        .read_metadata(
+                            opts.bucket.as_str(),
+                            path_join_buf(&[opts.base_dir.as_str(), STORAGE_FORMAT_FILE]).as_str(),
+                        )
+                        .await
+                        && let Ok(file_meta) = FileMeta::load(&meta_bytes)
+                        && let Ok(data_dirs) = file_meta.get_data_dirs()
+                    {
+                        for data_dir in data_dirs.iter().flatten() {
+                            multipart_dir_to_skip.insert(data_dir.to_string());
+                        }
+                    }
                 }
             }
         }
@@ -2385,6 +2415,11 @@ impl DiskAPI for LocalDisk {
             &mut out,
             &mut objs_returned,
             skip_current_dir_object,
+            if multipart_dir_to_skip.is_empty() {
+                None
+            } else {
+                Some(multipart_dir_to_skip.clone())
+            },
         )
         .await?;
 
@@ -3170,7 +3205,7 @@ mod test {
         };
         let mut objs_returned = 0;
 
-        disk.scan_dir("".to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false)
+        disk.scan_dir("".to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false, None)
             .await
             .unwrap();
         out.close().await.unwrap();
@@ -3225,7 +3260,7 @@ mod test {
         };
         let mut objs_returned = 0;
 
-        disk.scan_dir("marker/".to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false)
+        disk.scan_dir("marker/".to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false, None)
             .await
             .unwrap();
         out.close().await.unwrap();
@@ -3285,7 +3320,7 @@ mod test {
             };
             let mut objs_returned = 0;
 
-            disk.scan_dir(base_dir.to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false)
+            disk.scan_dir(base_dir.to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false, None)
                 .await
                 .unwrap();
             out.close().await.unwrap();
@@ -3408,6 +3443,7 @@ mod test {
         let mut out = MetacacheWriter::new(&mut writer);
         let mut objs_returned = 0;
 
+        let multipart_dir_to_skip = HashSet::from([UUID_OBJ.to_string()]);
         disk.scan_dir(
             BASE_DIR.to_string(),
             EMPTY_STR.to_string(),
@@ -3421,6 +3457,7 @@ mod test {
             &mut out,
             &mut objs_returned,
             true,
+            Some(multipart_dir_to_skip),
         )
         .await
         .unwrap();
@@ -3429,6 +3466,7 @@ mod test {
         let mut reader = MetacacheReader::new(reader);
         let entries = reader.read_all().await.unwrap();
         let names: Vec<String> = entries.into_iter().map(|entry| entry.name).collect();
+
         assert_eq!(
             names
                 .iter()

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1411,9 +1411,10 @@ impl LocalDisk {
 
             let name = path_join_buf(&[current.as_str(), entry.as_str()]);
 
-            while let Some((pop, skip_object, dir_to_skip)) = dir_stack.last().cloned()
-                && pop < name
+            while let Some((last_name, _, _)) = dir_stack.last()
+                && *last_name < name
             {
+                let (pop, skip_object, dir_to_skip) = dir_stack.pop().unwrap();
                 out.write_obj(&MetaCacheEntry {
                     name: pop.clone(),
                     ..Default::default()
@@ -1426,7 +1427,6 @@ impl LocalDisk {
                 {
                     error!("scan_dir err {:?}", er);
                 }
-                dir_stack.pop();
             }
 
             let mut meta = MetaCacheEntry {
@@ -2418,7 +2418,7 @@ impl DiskAPI for LocalDisk {
             if multipart_dir_to_skip.is_empty() {
                 None
             } else {
-                Some(multipart_dir_to_skip.clone())
+                Some(multipart_dir_to_skip)
             },
         )
         .await?;


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->

Fixes #2759 

When scanning folders and objects on disk, the `scan_dir` function incorrectly treats the multipart folder as a normal folder, resulting in the `list_object_v2` api response error.

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->

When the `scan_dir` function is called, the `skip_current_dir_object` flag indicates whether the current path corresponds to an object. If `skip_current_dir_object` is true, attempt to extract the multipart folder name from xl.meta. If found, remove it from the list. If the object is versioned, extract all its multipart folders and remove them as well.

- Multipart folders (formatted as UUID) will not be included in the response. Folders that do not match the UUID format will remain unchanged.
- Multipart folders of a versioned object will not be included in the response.

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets`
- `make test`
- `make pre-commit`

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->

N/A

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->

N/A