### PR TITLE
fix(ecstore): propagate walk listing errors

### DIFF
--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -67,21 +67,21 @@ fn ensure_non_empty_listing_disks(bucket: &str, path: &str, disks: &[DiskStore])
     Ok(())
 }
 
-fn walk_result_from_set_errors(errs: Vec<Option<Error>>) -> Result<()> {
-    if is_all_not_found(&errs) {
-        if is_all_volume_not_found(&errs) {
+fn walk_result_from_set_errors(errs: &[Option<Error>]) -> Result<()> {
+    if is_all_not_found(errs) {
+        if is_all_volume_not_found(errs) {
             return Err(StorageError::VolumeNotFound);
         }
 
         return Ok(());
     }
 
-    for err in errs.into_iter().flatten() {
-        if err == Error::Unexpected {
+    for err in errs.iter().flatten() {
+        if err == &Error::Unexpected || err.is_not_found() {
             continue;
         }
 
-        return Err(err);
+        return Err(err.clone());
     }
 
     Ok(())
@@ -988,23 +988,25 @@ impl ECStore {
 
         let walk_results = join_all(futures).await;
         let mut errs = Vec::new();
-        for (idx, walk_result) in walk_results.into_iter().enumerate() {
+        for walk_result in walk_results {
             match walk_result {
                 Ok(()) => errs.push(None),
-                Err(err) => {
-                    error!(
-                        bucket = %bucket,
-                        prefix = %prefix,
-                        set_task_index = idx,
-                        error = ?err,
-                        "walk_internal list_path_raw task failed"
-                    );
-                    errs.push(Some(err.into()));
-                }
+                Err(err) => errs.push(Some(err.into())),
             }
         }
 
-        walk_result_from_set_errors(errs)
+        let result = walk_result_from_set_errors(&errs);
+        if let Err(err) = &result {
+            error!(
+                bucket = %bucket,
+                prefix = %prefix,
+                error = ?err,
+                set_errors = ?errs,
+                "walk_internal list_path_raw tasks failed"
+            );
+        }
+
+        result
     }
 }
 
@@ -1555,15 +1557,27 @@ mod test {
 
     #[test]
     fn walk_result_from_set_errors_returns_non_eof_error() {
-        let err = walk_result_from_set_errors(vec![Some(StorageError::Unexpected), Some(StorageError::FileAccessDenied)])
+        let err = walk_result_from_set_errors(&[Some(StorageError::Unexpected), Some(StorageError::FileAccessDenied)])
             .expect_err("walk should fail when any set reports a real listing error");
 
         assert_eq!(err, StorageError::FileAccessDenied);
     }
 
     #[test]
+    fn walk_result_from_set_errors_prefers_real_error_over_not_found() {
+        let err = walk_result_from_set_errors(&[
+            Some(StorageError::VolumeNotFound),
+            Some(StorageError::DiskNotFound),
+            Some(StorageError::FileAccessDenied),
+        ])
+        .expect_err("walk should report the real listing error");
+
+        assert_eq!(err, StorageError::FileAccessDenied);
+    }
+
+    #[test]
     fn walk_result_from_set_errors_preserves_volume_not_found() {
-        let err = walk_result_from_set_errors(vec![Some(StorageError::VolumeNotFound), Some(StorageError::VolumeNotFound)])
+        let err = walk_result_from_set_errors(&[Some(StorageError::VolumeNotFound), Some(StorageError::VolumeNotFound)])
             .expect_err("all volume-not-found set errors should remain visible");
 
         assert_eq!(err, StorageError::VolumeNotFound);

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -67,6 +67,26 @@ fn ensure_non_empty_listing_disks(bucket: &str, path: &str, disks: &[DiskStore])
     Ok(())
 }
 
+fn walk_result_from_set_errors(errs: Vec<Option<Error>>) -> Result<()> {
+    if is_all_not_found(&errs) {
+        if is_all_volume_not_found(&errs) {
+            return Err(StorageError::VolumeNotFound);
+        }
+
+        return Ok(());
+    }
+
+    for err in errs.into_iter().flatten() {
+        if err == Error::Unexpected {
+            continue;
+        }
+
+        return Err(err);
+    }
+
+    Ok(())
+}
+
 pub fn max_keys_plus_one(max_keys: i32, add_one: bool) -> i32 {
     let mut max_keys = max_keys;
     if !(0..=MAX_OBJECT_LIST).contains(&max_keys) {
@@ -967,19 +987,24 @@ impl ECStore {
         tokio::spawn(async move { merge_entry_channels(rx, inputs, merge_tx, 1).await });
 
         let walk_results = join_all(futures).await;
+        let mut errs = Vec::new();
         for (idx, walk_result) in walk_results.into_iter().enumerate() {
-            if let Err(err) = walk_result {
-                error!(
-                    bucket = %bucket,
-                    prefix = %prefix,
-                    set_task_index = idx,
-                    error = ?err,
-                    "walk_internal list_path_raw task failed"
-                );
+            match walk_result {
+                Ok(()) => errs.push(None),
+                Err(err) => {
+                    error!(
+                        bucket = %bucket,
+                        prefix = %prefix,
+                        set_task_index = idx,
+                        error = ?err,
+                        "walk_internal list_path_raw task failed"
+                    );
+                    errs.push(Some(err.into()));
+                }
             }
         }
 
-        Ok(())
+        walk_result_from_set_errors(errs)
     }
 }
 
@@ -1416,7 +1441,8 @@ fn calc_common_counter(infos: &[DiskInfo], read_quorum: usize) -> u64 {
 
 #[cfg(test)]
 mod test {
-    use super::{ListPathOptions, MAX_OBJECT_LIST, max_keys_plus_one};
+    use super::{ListPathOptions, MAX_OBJECT_LIST, max_keys_plus_one, walk_result_from_set_errors};
+    use crate::error::StorageError;
     use uuid::Uuid;
 
     #[test]
@@ -1525,6 +1551,22 @@ mod test {
         assert_eq!(parsed.pool_idx, Some(3));
         assert_eq!(parsed.set_idx, Some(7));
         assert!(!parsed.create);
+    }
+
+    #[test]
+    fn walk_result_from_set_errors_returns_non_eof_error() {
+        let err = walk_result_from_set_errors(vec![Some(StorageError::Unexpected), Some(StorageError::FileAccessDenied)])
+            .expect_err("walk should fail when any set reports a real listing error");
+
+        assert_eq!(err, StorageError::FileAccessDenied);
+    }
+
+    #[test]
+    fn walk_result_from_set_errors_preserves_volume_not_found() {
+        let err = walk_result_from_set_errors(vec![Some(StorageError::VolumeNotFound), Some(StorageError::VolumeNotFound)])
+            .expect_err("all volume-not-found set errors should remain visible");
+
+        assert_eq!(err, StorageError::VolumeNotFound);
     }
 
     // use std::sync::Arc;


### PR DESCRIPTION
  ## Related Issues

  Fixes #2916.

  ## Summary of Changes

  - Propagate `walk_internal` listing errors from set-level `list_path_raw` tasks instead of logging them and returning success.
  - Preserve EOF-style `Unexpected` handling so completed listings keep existing behavior.
  - Preserve all-volume-not-found handling as `VolumeNotFound`.
  - Add focused regression coverage for walk error selection.

  ## Verification

  - `cargo test -p rustfs-ecstore walk_result_from_set_errors --lib`
  - `cargo test -p rustfs-ecstore list_path_raw --lib`
  - `cargo fmt --all --check`

  ## Impact

  Recursive walk-based listings now fail explicitly when underlying set listing fails, instead of returning a successful partial result. No API, configuration, migration, or deployment changes are expected.

  ## Additional Notes
