### PR TITLE
test(ecstore): cover walk listing error success paths

### DIFF
--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1583,6 +1583,18 @@ mod test {
         assert_eq!(err, StorageError::VolumeNotFound);
     }
 
+    #[test]
+    fn walk_result_from_set_errors_allows_missing_entries() {
+        walk_result_from_set_errors(&[Some(StorageError::FileNotFound), Some(StorageError::VolumeNotFound)])
+            .expect("missing objects under an existing listing path should not fail the walk");
+    }
+
+    #[test]
+    fn walk_result_from_set_errors_ignores_only_unexpected_and_successes() {
+        walk_result_from_set_errors(&[None, Some(StorageError::Unexpected)])
+            .expect("successful sets and unexpected EOF-style markers should not fail the walk");
+    }
+
     // use std::sync::Arc;
 
     // use crate::cache_value::metacache_set::list_path_raw;


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds focused unit coverage for the recent ECStore walk-listing error aggregation path.

The new tests cover two success branches that were not asserted by the existing regression tests: mixed missing-entry errors should be tolerated as an empty listing result, and a successful set combined with an `Unexpected` EOF-style marker should not fail the walk.

## Verification
- `RUSTC="$(rustup which --toolchain 1.95.0 rustc)" rustup run 1.95.0 cargo test -p rustfs-ecstore walk_result_from_set_errors --lib`
- `rustup run 1.95.0 cargo fmt --all`
- `rustup run 1.95.0 cargo fmt --all --check`
- `PATH="$(dirname "$(rustup which --toolchain 1.95.0 rustc)"):$PATH" RUSTC="$(rustup which --toolchain 1.95.0 rustc)" make pre-commit`

## Impact
No runtime behavior change. This only increases regression coverage for ECStore list-walk error handling.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
