### PR TITLE
chore(release): prepare 1.0.0-beta.3

### DIFF
--- a/.agents/skills/rustfs-release-version-bump/SKILL.md
+++ b/.agents/skills/rustfs-release-version-bump/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: rustfs-release-version-bump
+description: Prepare a RustFS release branch like PR #2957 by bumping versioned files, aligning release assets, running required verification, and finishing with commit, push, and gh PR creation. Use when publishing a new RustFS alpha, beta, or stable release.
+---
+
+# RustFS Release Version Bump
+
+Use this skill when the task is to prepare a new RustFS version release branch following the pattern validated in PR `#2957`.
+
+## Read first
+
+- Read `AGENTS.md`.
+- Read `.github/pull_request_template.md`.
+- Inspect the current branch diff against `origin/main`.
+- Do not assume every release file should change in the same way every time.
+
+## Scope validated by PR #2957
+
+The `1.0.0-beta.3` release branch updated these files:
+
+- `Cargo.toml`
+- `Cargo.lock`
+- `README.md`
+- `README_ZH.md`
+- `flake.nix`
+- `helm/rustfs/Chart.yaml`
+- `rustfs.spec`
+
+Treat this file list as the default checklist for future release bumps. Only drop a file if the repository's current release pattern clearly says it is no longer part of the publish flow.
+
+## Workflow
+
+1. Confirm release intent
+- Identify the target version string exactly, for example `1.0.0-beta.4`.
+- Check whether the user wants only local commit preparation or the full `commit + push + PR` flow.
+- Compare the branch against `origin/main` and isolate only release-related edits.
+- If the target version is not explicit, stop and ask for it before editing.
+
+2. Update core Rust workspace versions
+- Bump the workspace version in `Cargo.toml`.
+- Bump all internal workspace crate versions in `Cargo.toml`.
+- Ensure `Cargo.lock` reflects the same release version for workspace packages.
+- Re-read the diff and verify there are no partial version leftovers.
+
+3. Align release assets
+- Update versioned Docker examples in `README.md` and `README_ZH.md` using the `<version>` tag form, for example `rustfs/rustfs:1.0.0-beta.4`.
+- Update `flake.nix` package version.
+- Update `helm/rustfs/Chart.yaml` `appVersion`.
+- Update `helm/rustfs/Chart.yaml` `version` using the release-chart rule:
+- `1.0.0-beta.3` -> `0.3.0`
+- `1.0.0-beta.4` -> `0.4.0`
+- Follow the same pattern for later beta releases unless the repository rule changes.
+- Update `rustfs.spec` release metadata and changelog entry.
+- Keep `rustfs.spec` `Release` aligned with the app version string.
+- Keep the release asset changes in a separate commit from the core Rust workspace version bump when the branch contains both.
+
+4. Stop and discuss before changing release policy
+- Ask before changing the established Docker tag style away from `<version>`.
+- Ask before changing the established Helm chart version mapping away from `beta.N -> 0.N.0`.
+- Ask before changing the established `rustfs.spec` `Release` rule away from the app version string.
+- Ask before widening the release scope beyond the files already validated in PR `#2957`.
+
+5. Verify before shipping
+- Run `make pre-commit`.
+- If verification succeeds, run `cargo clean` to remove generated build artifacts before wrapping up.
+- If `make pre-commit` fails, stop and return `BLOCKED`.
+
+6. Commit structure
+- Prefer two commits when the change naturally splits:
+- `chore(release): prepare <version>` for `Cargo.toml` and `Cargo.lock`
+- `chore(release): align release assets for <version>` for docs and packaging metadata
+- If the user asks for a single commit, follow that request.
+
+7. Push and PR
+- Push the release branch with `git push -u origin <branch>` or `git push` if upstream already exists.
+- Create the PR with `gh pr create --base main --head <branch> --title ... --body-file ...`.
+- Keep the PR title and body in English.
+- Keep the `.github/pull_request_template.md` headings exactly.
+
+## Ready-to-check commands
+
+- `git diff --name-only origin/main...HEAD`
+- `git diff --stat origin/main...HEAD`
+- `make pre-commit`
+- `cargo clean`
+- `git status --short --branch`
+
+## Output expectations
+
+When using this skill, return:
+
+- The files changed for the release bump
+- Any uncertainty that needs user confirmation before editing
+- Verification status
+- Commit messages used
+- Push status and PR URL when the GitHub flow was requested
+
+## Established release policy
+
+- Docs use Docker tags in `<version>` form, not `v<version>`.
+- `helm/rustfs/Chart.yaml` `version` follows `beta.N -> 0.N.0` based on the current release policy.
+- `rustfs.spec` `Release` follows the app version string.
+- If any of these rules need to change in the future, pause and confirm before editing.

--- a/.agents/skills/rustfs-release-version-bump/SKILL.md
+++ b/.agents/skills/rustfs-release-version-bump/SKILL.md
@@ -51,13 +51,13 @@ Treat this file list as the default checklist for future release bumps. Only dro
 - `1.0.0-beta.4` -> `0.4.0`
 - Follow the same pattern for later beta releases unless the repository rule changes.
 - Update `rustfs.spec` release metadata and changelog entry.
-- Keep `rustfs.spec` `Release` aligned with the app version string.
+- Set `rustfs.spec` `Release` to the prerelease suffix without the base version, for example `beta.3` for `1.0.0-beta.3`.
 - Keep the release asset changes in a separate commit from the core Rust workspace version bump when the branch contains both.
 
 4. Stop and discuss before changing release policy
 - Ask before changing the established Docker tag style away from `<version>`.
 - Ask before changing the established Helm chart version mapping away from `beta.N -> 0.N.0`.
-- Ask before changing the established `rustfs.spec` `Release` rule away from the app version string.
+- Ask before changing the established `rustfs.spec` `Release` rule away from the release suffix form such as `beta.N`.
 - Ask before widening the release scope beyond the files already validated in PR `#2957`.
 
 5. Verify before shipping
@@ -99,5 +99,5 @@ When using this skill, return:
 
 - Docs use Docker tags in `<version>` form, not `v<version>`.
 - `helm/rustfs/Chart.yaml` `version` follows `beta.N -> 0.N.0` based on the current release policy.
-- `rustfs.spec` `Release` follows the app version string.
+- `rustfs.spec` `Release` follows the release suffix form, for example `beta.3`.
 - If any of these rules need to change in the future, pause and confirm before editing.

--- a/.agents/skills/rustfs-release-version-bump/agents/openai.yaml
+++ b/.agents/skills/rustfs-release-version-bump/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RustFS Release Bump"
+  short_description: "Prepare RustFS release branches like PR #2957."
+  default_prompt: "Use $rustfs-release-version-bump to prepare a RustFS release version, ask about any unclear version policy, and finish the commit/push/PR flow."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,7 +3654,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9251,7 +9251,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "anyhow",
@@ -9368,7 +9368,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-appauth"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "base64-simd",
  "rand 0.10.1",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "chrono",
  "const-str",
@@ -9401,7 +9401,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9415,7 +9415,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "rustfs-io-core",
  "rustfs-io-metrics",
@@ -9446,14 +9446,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "const-str",
 ]
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "base64-simd",
  "rand 0.10.1",
@@ -9464,7 +9464,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "argon2 0.6.0-rc.8",
@@ -9481,7 +9481,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "async-channel",
@@ -9581,7 +9581,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9605,7 +9605,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9633,7 +9633,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9668,7 +9668,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "bytes",
  "memmap2 0.9.10",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "criterion",
  "metrics",
@@ -9740,7 +9740,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "bytes",
  "futures",
@@ -9765,7 +9765,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "arc-swap",
@@ -9794,7 +9794,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9815,7 +9815,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "chrono",
  "humantime",
@@ -9828,7 +9828,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9859,7 +9859,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "criterion",
  "futures",
@@ -9878,7 +9878,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9924,7 +9924,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9952,7 +9952,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -10010,7 +10010,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "flatbuffers",
  "prost 0.14.3",
@@ -10025,7 +10025,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "axum",
@@ -10058,7 +10058,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-common"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "metrics",
  "serde",
@@ -10067,7 +10067,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10094,7 +10094,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10142,7 +10142,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10158,7 +10158,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -10199,7 +10199,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -10223,7 +10223,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "base64-simd",
  "blake2 0.11.0-rc.6",
@@ -10268,7 +10268,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-workers"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "tokio",
  "tracing",
@@ -10276,7 +10276,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.95.0"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -76,42 +76,42 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.2" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.2" }
-rustfs-appauth = { path = "crates/appauth", version = "1.0.0-beta.2" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.2" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.2" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.2" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.2" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.2" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.2" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.2" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.2" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.2" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.2" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.2" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.2" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.2" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.2" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.2" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.2" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.2" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.2" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.2" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.2" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.2" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.2" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.2" }
-rustfs-s3-common = { path = "crates/s3-common", version = "1.0.0-beta.2" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.2" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.2" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.2" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.2" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.2" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.2" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.2" }
-rustfs-workers = { path = "crates/workers", version = "1.0.0-beta.2" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.2" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.3" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.3" }
+rustfs-appauth = { path = "crates/appauth", version = "1.0.0-beta.3" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.3" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.3" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.3" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.3" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.3" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.3" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.3" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.3" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.3" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.3" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.3" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.3" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.3" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.3" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.3" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.3" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.3" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.3" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.3" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.3" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.3" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.3" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.3" }
+rustfs-s3-common = { path = "crates/s3-common", version = "1.0.0-beta.3" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.3" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.3" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.3" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.3" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.3" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.3" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.3" }
+rustfs-workers = { path = "crates/workers", version = "1.0.0-beta.3" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.3" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:v1.0.0-beta.1
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.3
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ RustFS 容器以非 root 用户 `rustfs` (UID `10001`) 运行。如果您使用 
  docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
  # 使用指定版本运行
- docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:v1.0.0-beta.1
+ docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.3
 ```
 
 您也可以使用 Docker Compose。使用根目录下的 `docker-compose.yml` 文件：

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "0.0.5";
+            version = "1.0.0-beta.3";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.1.0"
-appVersion: "1.0.0-beta.1"
+version: "0.3.0"
+appVersion: "1.0.0-beta.3"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -2,7 +2,7 @@
 %global _empty_manifest_terminate_build 0
 Name:           rustfs
 Version:        1.0.0
-Release:        1.0.0-beta.3
+Release:        beta.3
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,7 +58,7 @@ install %_builddir/%{name}-%{version}-%{release}/target/%_arch/%_arch-unknown-li
 
 %changelog
 * Thu May 14 2026 houseme <housemecn@gmail.com>
-- Initial RPM package for RustFS 1.0.0-beta.3
+- Update RPM package to RustFS 1.0.0-beta.3
 
 * Thu Jan 28 2026 houseme <housemecn@gmail.com>
 - Initial RPM package for RustFS 1.0.0-alpha.81

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -2,7 +2,7 @@
 %global _empty_manifest_terminate_build 0
 Name:           rustfs
 Version:        1.0.0
-Release:        alpha.81
+Release:        1.0.0-beta.3
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -57,6 +57,9 @@ install %_builddir/%{name}-%{version}-%{release}/target/%_arch/%_arch-unknown-li
 %_bindir/rustfs
 
 %changelog
+* Thu May 14 2026 houseme <housemecn@gmail.com>
+- Initial RPM package for RustFS 1.0.0-beta.3
+
 * Thu Jan 28 2026 houseme <housemecn@gmail.com>
 - Initial RPM package for RustFS 1.0.0-alpha.81
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Bump workspace release version from `1.0.0-beta.2` to `1.0.0-beta.3`.
- Update internal workspace crate version references in `Cargo.toml`.
- Regenerate `Cargo.lock` package version entries for the beta.3 release.
- Align release-facing assets, including docs, Nix packaging, Helm metadata, and RPM metadata, with `1.0.0-beta.3`.
- Add a reusable RustFS release bump skill under `.agents/skills` based on the workflow validated in this PR.

## Verification
- `make pre-commit`

## Impact
- Prepares RustFS workspace metadata and release assets for the `1.0.0-beta.3` release.
- Adds an internal skill to streamline future RustFS release version bump workflows.
- No runtime behavior changes.

## Additional Notes
N/A
