### PR TITLE
test(notify): cover prefix suffix event dispatch

### DIFF
--- a/crates/notify/src/notifier.rs
+++ b/crates/notify/src/notifier.rs
@@ -470,4 +470,39 @@ mod tests {
         assert_eq!(enabled_target.save_calls.load(Ordering::SeqCst), 1);
         assert_eq!(disabled_target.save_calls.load(Ordering::SeqCst), 0);
     }
+
+    #[tokio::test]
+    async fn send_event_respects_prefix_suffix_filters() {
+        let rule_engine = NotifyRuleEngine::new();
+        let notifier = EventNotifier::new(Arc::new(NotificationMetrics::new()), rule_engine.clone());
+        let target = TestTarget::new("filtered-target", "webhook", true);
+        let mut rules_map = RulesMap::new();
+        rules_map.add_rule_config(&[EventName::ObjectCreatedPut], "uploads/*.csv".to_string(), target.id.clone());
+
+        rule_engine.set_bucket_rules("bucket", rules_map).await;
+        notifier.target_list().write().await.add(Arc::new(target.clone())).unwrap();
+
+        notifier
+            .send(Arc::new(Event::new_test_event("bucket", "report.csv", EventName::ObjectCreatedPut)))
+            .await;
+        notifier
+            .send(Arc::new(Event::new_test_event(
+                "bucket",
+                "uploads/report.txt",
+                EventName::ObjectCreatedPut,
+            )))
+            .await;
+
+        assert_eq!(target.save_calls.load(Ordering::SeqCst), 0);
+
+        notifier
+            .send(Arc::new(Event::new_test_event(
+                "bucket",
+                "uploads/report.csv",
+                EventName::ObjectCreatedPut,
+            )))
+            .await;
+
+        assert_eq!(target.save_calls.load(Ordering::SeqCst), 1);
+    }
 }


### PR DESCRIPTION
## Related Issues

  Fixes #2784

  ## Summary of Changes

  Adds regression coverage for bucket notification prefix/suffix filtering at the event dispatch layer.

  The test verifies that a webhook target configured for `uploads/*.csv` is not called for:
  - a matching suffix outside the configured prefix
  - a matching prefix with the wrong suffix

  Only an object key matching both prefix and suffix is dispatched to the target.

  ## Verification

  - `cargo fmt --all --check`
  - `cargo test -p rustfs-notify send_event_respects_prefix_suffix_filters --lib`
  - `cargo test -p rustfs-notify --lib`
  - `git diff --check`

  ## Impact

  No production behavior change. This adds regression coverage for notification filtering semantics.

  ## Additional Notes

  N/A