### PR TITLE
fix(admin): surface access key policy errors

### DIFF
--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -124,7 +124,8 @@ fn parse_service_account_policy(policy: &serde_json::Value) -> S3Result<Policy> 
     let policy_bytes = serde_json::to_vec(policy).map_err(|e| s3_error!(InvalidArgument, "marshal policy failed: {:?}", e))?;
     Policy::parse_config(&policy_bytes).map_err(|e| {
         debug!("parse service account policy failed, e: {:?}", e);
-        s3_error!(InvalidArgument, "invalid service account policy: {}", e)
+        let message = e.to_string().replace('\'', "");
+        s3_error!(InvalidArgument, "invalid service account policy: {}", message)
     })
 }
 
@@ -1547,7 +1548,7 @@ mod tests {
         .expect_err("policy without Resource should be rejected");
 
         assert_eq!(*err.code(), S3ErrorCode::InvalidArgument);
-        assert_eq!(err.message(), Some("invalid service account policy: 'Resource' is empty"));
+        assert_eq!(err.message(), Some("invalid service account policy: Resource is empty"));
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -120,18 +120,20 @@ fn map_temp_account_lookup_error(err: rustfs_iam::error::Error, action: &str) ->
     }
 }
 
+fn parse_service_account_policy(policy: &serde_json::Value) -> S3Result<Policy> {
+    let policy_bytes = serde_json::to_vec(policy).map_err(|e| s3_error!(InvalidArgument, "marshal policy failed: {:?}", e))?;
+    Policy::parse_config(&policy_bytes).map_err(|e| {
+        debug!("parse service account policy failed, e: {:?}", e);
+        s3_error!(InvalidArgument, "invalid service account policy: {}", e)
+    })
+}
+
 fn parse_update_service_account_policy(new_policy: Option<serde_json::Value>) -> S3Result<Option<Policy>> {
     let Some(policy) = new_policy else {
         return Ok(None);
     };
 
-    let policy_bytes = serde_json::to_vec(&policy).map_err(|e| s3_error!(InvalidArgument, "marshal policy failed: {:?}", e))?;
-    let sp = Policy::parse_config(&policy_bytes).map_err(|e| {
-        debug!("parse policy failed, e: {:?}", e);
-        s3_error!(InvalidArgument, "parse policy failed")
-    })?;
-
-    Ok(Some(sp))
+    Ok(Some(parse_service_account_policy(&policy)?))
 }
 
 pub fn register_service_account_route(r: &mut S3Router<AdminOperation>) -> std::io::Result<()> {
@@ -219,13 +221,7 @@ impl Operation for AddServiceAccount {
         create_req.validate().map_err(|e| S3Error::with_message(InvalidRequest, e))?;
 
         let session_policy = if let Some(policy) = &create_req.policy {
-            let policy_bytes =
-                serde_json::to_vec(policy).map_err(|e| s3_error!(InvalidArgument, "marshal policy failed: {:?}", e))?;
-            let p = Policy::parse_config(&policy_bytes).map_err(|e| {
-                debug!("parse policy failed, e: {:?}", e);
-                s3_error!(InvalidArgument, "parse policy failed")
-            })?;
-            Some(p)
+            Some(parse_service_account_policy(policy)?)
         } else {
             None
         };
@@ -1535,6 +1531,23 @@ mod tests {
         let policy = policy.unwrap();
         assert!(policy.version.is_empty());
         assert!(policy.statements.is_empty());
+    }
+
+    #[test]
+    fn parse_service_account_policy_reports_missing_resource() {
+        let err = parse_service_account_policy(&json!({
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject"]
+                }
+            ]
+        }))
+        .expect_err("policy without Resource should be rejected");
+
+        assert_eq!(*err.code(), S3ErrorCode::InvalidArgument);
+        assert_eq!(err.message(), Some("invalid service account policy: 'Resource' is empty"));
     }
 
     #[test]


### PR DESCRIPTION
  ## Related Issues

  Partially addresses #2969.

  ## Summary of Changes

  - Reused a single service account policy parsing helper for create and update flows.
  - Return the concrete policy validation error as `InvalidArgument` when an embedded access-key policy is invalid.
  - Added regression coverage for the missing `Resource` case reported in the access key policy flow.

  ## Verification

  - `cargo fmt --all --check`
  - `cargo test -p rustfs parse_service_account_policy_reports_missing_resource --lib`
  - `cargo test -p rustfs admin::handlers::service_account::tests --lib`
  - `git diff --check`
  - `make pre-commit` failed locally due unrelated existing Windows/main failures:
    - `crates/io-core/src/io_profile.rs` dead-code under `-D warnings`
    - existing Windows path expectation and Rustls provider test failures

  ## Impact

  Invalid embedded service-account policies now return actionable admin API errors. No policy semantics are relaxed.

  ## Additional Notes

  The frontend default sample policy appears to live outside this repository, so this PR fixes the backend error reporting path for the invalid policy.