### PR TITLE
ci(build): pin macOS x86 release runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
             {"target_id":"linux-x86_64-gnu","os":"ubicloud-standard-2","target":"x86_64-unknown-linux-gnu","cross":false,"platform":"linux","rustflags":""},
             {"target_id":"linux-aarch64-gnu","os":"ubicloud-standard-2","target":"aarch64-unknown-linux-gnu","cross":true,"platform":"linux","rustflags":""},
             {"target_id":"macos-aarch64","os":"macos-latest","target":"aarch64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
-            {"target_id":"macos-x86_64","os":"macos-latest","target":"x86_64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
+            {"target_id":"macos-x86_64","os":"macos-15-intel","target":"x86_64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
             {"target_id":"windows-x86_64","os":"windows-latest","target":"x86_64-pc-windows-msvc","cross":false,"platform":"windows","rustflags":""}
           ]}'
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Pin the macOS x86_64 release build job to the Intel-hosted `macos-15-intel` runner.
- Keep the existing Apple Silicon macOS build on `macos-latest`.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "yaml ok"'`
- `git diff --check`

## Impact
- Fixes the `Build and Release` macOS x86_64 job after `macos-latest` resolved to an arm64 runner and restored an incompatible Cargo cache.
- Workflow-only change; Rust code behavior is unchanged.

## Additional Notes
- `make pre-commit` was not run because this only changes GitHub Actions runner selection.
