### PR TITLE
ci(build): honor console asset download fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,8 +234,7 @@ jobs:
         run: |
           mkdir -p ./rustfs/static
           if [[ "${{ matrix.platform }}" == "windows" ]]; then
-            curl.exe -L "https://dl.rustfs.com/artifacts/console/rustfs-console-latest.zip" -o console.zip --retry 3 --retry-delay 5 --max-time 300
-            if [[ $? -eq 0 ]]; then
+            if curl.exe --fail -L "https://dl.rustfs.com/artifacts/console/rustfs-console-latest.zip" -o console.zip --retry 3 --retry-delay 5 --max-time 300; then
               unzip -o console.zip -d ./rustfs/static
               rm console.zip
             else
@@ -244,9 +243,8 @@ jobs:
             fi
           else
             chmod +w ./rustfs/static/LICENSE || true
-            curl -L "https://dl.rustfs.com/artifacts/console/rustfs-console-latest.zip" \
-              -o console.zip --retry 3 --retry-delay 5 --max-time 300
-            if [[ $? -eq 0 ]]; then
+            if curl --fail -L "https://dl.rustfs.com/artifacts/console/rustfs-console-latest.zip" \
+              -o console.zip --retry 3 --retry-delay 5 --max-time 300; then
               unzip -o console.zip -d ./rustfs/static
               rm console.zip
             else


### PR DESCRIPTION
## Related issue(s)

None. Found by the daily recent-change bug scan from the main-branch Build and Release failure on commit bca8b08c2bca8360356ff10605c4b7f2c0dd7037.

## Background

The macOS x86_64 Build and Release job failed while downloading console assets because dl.rustfs.com could not be resolved. The workflow already had a fallback that should continue with empty static assets, but `bash -e -o pipefail` exited immediately on the failed `curl` command before the fallback branch could run.

## Solution

Wrap the Windows and non-Windows download commands directly in `if curl ...; then` blocks so download failures reach the existing fallback path.

## Test status

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "yaml ok"'`
- `bash -e -o pipefail -c 'tmp=$(mktemp -d); cd "$tmp"; mkdir -p ./rustfs/static; if false; then unzip -o console.zip -d ./rustfs/static; rm console.zip; else echo "Warning: Failed to download console assets, continuing without them"; echo "// Static assets not available" > ./rustfs/static/empty.txt; fi; test -s ./rustfs/static/empty.txt'`
