### PR TITLE
test(policy): validate default policies

### DIFF
--- a/crates/policy/src/policy/policy.rs
+++ b/crates/policy/src/policy/policy.rs
@@ -762,6 +762,15 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_default_policies_validate() {
+        for (name, policy) in default::DEFAULT_POLICIES.iter() {
+            policy
+                .validate()
+                .unwrap_or_else(|err| panic!("default policy {name} should validate: {err}"));
+        }
+    }
+
     #[tokio::test]
     async fn test_deny_only_checks_only_deny_statements() -> Result<()> {
         let data = r#"


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add focused coverage that every built-in default policy passes policy validation.
- Protect the recent action-family split from regressing back to mixed-family statements.

## Verification
- `RUSTC="$(rustup which --toolchain 1.95.0 rustc)" rustup run 1.95.0 cargo test -p rustfs-policy test_default_policies_validate --lib`
- `rustup run 1.95.0 cargo fmt --all`
- `rustup run 1.95.0 cargo fmt --all --check`
- `git diff --check`
- `PATH="$(dirname "$(rustup which --toolchain 1.95.0 rustc)"):$PATH" RUSTC="$(rustup which --toolchain 1.95.0 rustc)" make pre-commit`

## Impact
Test-only change. No runtime behavior, API, deployment, or configuration impact.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
