### PR TITLE
ci(nix): avoid requesting review from PR author

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -61,7 +61,7 @@ jobs:
             nix
             automated
           commit-msg: "chore(deps): update flake.lock"
-          pr-reviewers: houseme, overtrue, majinghe
+          pr-reviewers: overtrue, majinghe
           token: ${{ secrets.FLAKE_UPDATE_TOKEN }}
 
       - name: Log PR details


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Remove `houseme` from the Nix flake update PR reviewers because the workflow creates those PRs with `houseme` as the author.
- Keep the remaining reviewer requests unchanged.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nix-flake-update.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/nix-flake-update.yml` (not run: `actionlint` is not installed)

## Impact
- Prevents the scheduled `Update Nix Flake` workflow from failing after it creates the automated PR.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
