### PR TITLE
fix(ecstore): route new ns lock by object set and pool

### DIFF
--- a/crates/ecstore/src/sets.rs
+++ b/crates/ecstore/src/sets.rs
@@ -860,7 +860,7 @@ impl HealOperations for Sets {
 #[async_trait::async_trait]
 impl StorageAPI for Sets {
     async fn new_ns_lock(&self, bucket: &str, object: &str) -> Result<NamespaceLockWrapper> {
-        self.disk_set[0].new_ns_lock(bucket, object).await
+        self.get_disks_by_key(object).new_ns_lock(bucket, object).await
     }
     #[tracing::instrument(skip(self))]
     async fn backend_info(&self) -> rustfs_madmin::BackendInfo {

--- a/crates/ecstore/src/store/rebalance.rs
+++ b/crates/ecstore/src/store/rebalance.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use rustfs_utils::{sip_hash, DEFAULT_SIP_HASH_KEY};
 
 struct LatestObjectInfoCandidate {
     info: Option<ObjectInfo>,
@@ -599,7 +600,20 @@ impl ECStore {
 
     #[instrument(skip(self))]
     pub(super) async fn handle_new_ns_lock(&self, bucket: &str, object: &str) -> Result<NamespaceLockWrapper> {
-        self.pools[0].new_ns_lock(bucket, object).await
+        if self.pools.len() == 1 {
+            return self.pools[0].new_ns_lock(bucket, object).await;
+        }
+
+        let pool_idx = match self.get_pool_idx_existing_no_lock(bucket, object).await {
+            Ok(idx) => idx,
+            Err(err) if is_err_object_not_found(&err) => {
+                let key = format!("{}/{}", bucket, object);
+                sip_hash(&key, self.pools.len(), &DEFAULT_SIP_HASH_KEY)
+            }
+            Err(err) => return Err(err),
+        };
+
+        self.pools[pool_idx].new_ns_lock(bucket, object).await
     }
 
     #[instrument(skip(self))]


### PR DESCRIPTION
## Summary
- Route set-level namespace lock acquisition to the hashed set for the object instead of fixed `set[0]`.
- Route store-level namespace lock acquisition to the existing object pool when available, with object/hash based fallback for non-existing objects to avoid hard pinning pool 0.

## Why this change
Issue 637 reports high contention from namespace lock pipeline. The previous behavior routed `new_ns_lock` through fixed indices, creating avoidable hotspotting under multi-set/pool deployment. This change keeps lock scope same while balancing lock-routing pressure across pools/sets.

## Validation
- Not run (per request): tests and pre-commit not executed.
