### PR TITLE
docs: update security advisory skill lessons

### DIFF
--- a/.agents/skills/security-advisory-lessons/SKILL.md
+++ b/.agents/skills/security-advisory-lessons/SKILL.md
@@ -91,7 +91,7 @@ For the full pattern map, read [advisory-patterns.md](references/advisory-patter
 - Do not reflect arbitrary `Origin` while also allowing credentials. Default CORS should be no CORS unless explicitly configured.
 - Do not render user-controlled object content in a same-origin iframe with console credentials available to JavaScript.
 - Prefer origin separation for object preview/download, `nosniff`, CSP, strict content-type handling, and avoiding durable credentials in `localStorage`.
-- License/version-like metadata endpoints should expose only coarse public data unless authenticated.
+- Console license/version-like metadata endpoints should expose only coarse public data unless authenticated, especially subject names and expiration timestamps.
 
 ### Profiling, debug, and health endpoints
 - Profiling and debug endpoints are not health checks. They require admin auth, opt-in enablement, rate limiting, and safe responses.

--- a/.agents/skills/security-advisory-lessons/references/advisory-patterns.md
+++ b/.agents/skills/security-advisory-lessons/references/advisory-patterns.md
@@ -20,7 +20,7 @@ Update this file only when an advisory adds or changes a reusable lesson, affect
 - `GHSA-mm2q-qcmx-gw4w`: `ListServiceAccount` used `UpdateServiceAccountAdminAction`, while update lacked target ownership checks. Lesson: exact action constants and ownership checks are both required; information disclosure can chain into secret rotation and takeover.
 - `GHSA-vcwh-pff9-64cc`: `ImportIam` checked `ExportIAMAction` for an import/write operation. Lesson: every admin handler must authorize the action it actually performs.
 - `GHSA-jqmc-mg33-v45g` and `GHSA-8784-9m7f-c6p6`: `/profile/cpu` and `/profile/memory` were whitelisted from auth and allowed expensive diagnostics plus path disclosure. Lesson: profiling/debug endpoints need admin auth, opt-in, rate limits, and non-sensitive responses.
-- `GHSA-x5xv-223c-8vm7`: console license metadata endpoint was public. Lesson: public metadata endpoints should be coarse or authenticated.
+- `GHSA-xp32-gxq2-3v52`: console license metadata endpoint was public and exposed subject and expiration fields. Lesson: management metadata endpoints should require admin auth or return only coarse public status.
 
 ### IAM import, service accounts, and privilege boundaries
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Update the local security advisory lessons skill for GHSA-xp32-gxq2-3v52.
- Keep GHSA-x5xv-223c-8vm7 mapped to the CORS lesson and move the console license metadata lesson to the new advisory ID.

## Verification
- `gh api repos/rustfs/rustfs/security-advisories --paginate`
- `ruby -ryaml -e 'path=".agents/skills/security-advisory-lessons/SKILL.md"; text=File.read(path); abort("missing frontmatter") unless text.start_with?("---\\n"); fm=text.split(/^---\\s*$/,3)[1]; data=YAML.safe_load(fm); abort("wrong name") unless data["name"]=="security-advisory-lessons"; abort("missing description") if data["description"].to_s.empty?; puts "frontmatter ok"'
- `rg -n 'TODO|TBD_PLACEHOLDER|PLACEHOLDER' .agents/skills/security-advisory-lessons`
- `git diff --check -- .agents/skills/security-advisory-lessons`

## Impact
Documentation-only update to the local agent skill. No RustFS product code or tests changed.

## Additional Notes
N/A
