### PR TITLE
fix: harden lifecycle transition compensation and regression coverage

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -58,13 +58,13 @@ runs:
     - name: Install protoc
       uses: arduino/setup-protoc@v3
       with:
-        version: "33.1"
+        version: "34.1"
         repo-token: ${{ inputs.github-token }}
 
     - name: Install flatc
-      uses: Nugine/setup-flatc@v1.2.4
+      uses: Nugine/setup-flatc@v1
       with:
-        version: "25.9.23"
+        version: "25.12.19"
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable

--- a/crates/config/src/constants/runtime.rs
+++ b/crates/config/src/constants/runtime.rs
@@ -59,6 +59,25 @@ pub const DEFAULT_RUNTIME_DIAL9_ROTATION_COUNT: usize = 10;
 pub const DEFAULT_RUNTIME_DIAL9_SAMPLING_RATE: f64 = 1.0; // 100% sampling
 // Note: S3 bucket/prefix have no default; absence means upload is disabled (modeled as Option<String>)
 
+/// Maximum transition workers used as a local fallback when runtime env is unset.
+pub const DEFAULT_TRANSITION_WORKERS_CAP: i64 = 16;
+/// Absolute upper bound for transition workers accepted from runtime env.
+pub const DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX: i64 = 32;
+/// Default capacity for the transition queue.
+pub const DEFAULT_TRANSITION_QUEUE_CAPACITY: usize = 1000;
+/// Default send timeout for transition queue enqueue attempts, in milliseconds.
+pub const DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS: usize = 100;
+/// Test-only fault injection env var that forces the immediate transition enqueue timeout path.
+pub const ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT: &str = "RUSTFS_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT";
+/// Runtime env var controlling the transition worker count.
+pub const ENV_TRANSITION_WORKERS: &str = "RUSTFS_MAX_TRANSITION_WORKERS";
+/// Runtime env var controlling the absolute maximum transition workers.
+pub const ENV_TRANSITION_WORKERS_ABSOLUTE_MAX: &str = "RUSTFS_ABSOLUTE_MAX_WORKERS";
+/// Runtime env var controlling the transition queue capacity.
+pub const ENV_TRANSITION_QUEUE_CAPACITY: &str = "RUSTFS_TRANSITION_QUEUE_CAPACITY";
+/// Runtime env var controlling the transition queue send timeout in milliseconds.
+pub const ENV_TRANSITION_QUEUE_SEND_TIMEOUT_MS: &str = "RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS";
+
 // Allocator reclaim configuration
 pub const ENV_ALLOCATOR_RECLAIM_ENABLED: &str = "RUSTFS_ALLOCATOR_RECLAIM_ENABLED";
 pub const ENV_ALLOCATOR_RECLAIM_INTERVAL_SECS: &str = "RUSTFS_ALLOCATOR_RECLAIM_INTERVAL_SECS";

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -607,10 +607,10 @@ impl TransitionState {
         })
     }
 
-    fn schedule_bucket_compensation(&self, bucket: &str) {
+    fn schedule_bucket_compensation(&self, bucket: &str) -> bool {
         let mut scheduled = self.compensation_buckets.lock().unwrap();
         if !scheduled.insert(bucket.to_string()) {
-            return;
+            return false;
         }
         self.compensation_scheduled_tasks.fetch_add(1, Ordering::SeqCst);
         let bucket = bucket.to_string();
@@ -634,6 +634,7 @@ impl TransitionState {
             scheduled.lock().unwrap().remove(&bucket);
             state.compensation_running_tasks.fetch_add(-1, Ordering::SeqCst);
         });
+        true
     }
 
     pub async fn queue_transition_task(&self, oi: &ObjectInfo, event: &lifecycle::Event, src: &LcEventSrc) {
@@ -649,24 +650,26 @@ impl TransitionState {
                 Ok(Err(_)) => {
                     self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
                     self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
-                    self.schedule_bucket_compensation(&oi.bucket);
+                    let scheduled = self.schedule_bucket_compensation(&oi.bucket);
                     warn!(
                         bucket = %oi.bucket,
                         object = %oi.name,
                         source = ?src,
                         timeout_ms = send_timeout.as_millis() as u64,
+                        compensation_scheduled = scheduled,
                         "transition enqueue failed because the queue is closed"
                     );
                 }
                 Err(_) => {
                     self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
                     self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
-                    self.schedule_bucket_compensation(&oi.bucket);
+                    let scheduled = self.schedule_bucket_compensation(&oi.bucket);
                     warn!(
                         bucket = %oi.bucket,
                         object = %oi.name,
                         source = ?src,
                         timeout_ms = send_timeout.as_millis() as u64,
+                        compensation_scheduled = scheduled,
                         "transition enqueue timed out under backpressure"
                     );
                 }

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -95,6 +95,8 @@ const DEFAULT_STALE_UPLOADS_CLEANUP_INTERVAL: StdDuration = StdDuration::from_se
 const DATE_EXPIRY_EXISTING_OBJECTS_GRACE_SECS: i64 = 5;
 const DEFAULT_TRANSITION_WORKERS_CAP: i64 = 16;
 const DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX: i64 = 32;
+const DEFAULT_TRANSITION_QUEUE_CAPACITY: usize = 1000;
+const DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS: usize = 100;
 
 lazy_static! {
     pub static ref GLOBAL_ExpiryState: Arc<RwLock<ExpiryState>> = ExpiryState::new();
@@ -112,6 +114,23 @@ fn resolve_transition_worker_count() -> (i64, i64, i64) {
     let absolute_max = get_env_i64("RUSTFS_ABSOLUTE_MAX_WORKERS", DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
     effective = std::cmp::min(effective, absolute_max);
     (configured, absolute_max, effective)
+}
+
+fn resolve_transition_queue_capacity() -> usize {
+    get_env_usize("RUSTFS_TRANSITION_QUEUE_CAPACITY", DEFAULT_TRANSITION_QUEUE_CAPACITY).max(1)
+}
+
+fn resolve_transition_queue_send_timeout() -> StdDuration {
+    StdDuration::from_millis(
+        get_env_usize("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS", DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS).max(1) as u64,
+    )
+}
+
+fn is_immediate_transition_source(src: &LcEventSrc) -> bool {
+    matches!(
+        src,
+        LcEventSrc::S3PutObject | LcEventSrc::S3CopyObject | LcEventSrc::S3CompleteMultipartUpload
+    )
 }
 
 pub struct LifecycleSys;
@@ -554,13 +573,19 @@ pub struct TransitionState {
     kill_rx: A_Receiver<()>,
     active_tasks: AtomicI64,
     missed_immediate_tasks: AtomicI64,
+    queue_full_tasks: AtomicI64,
+    queue_send_timeout_tasks: AtomicI64,
     last_day_stats: Arc<Mutex<HashMap<String, LastDayTierStats>>>,
 }
 
 impl TransitionState {
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Arc<Self> {
-        let (tx1, rx1) = bounded(1000);
+        Self::new_with_capacity(resolve_transition_queue_capacity())
+    }
+
+    fn new_with_capacity(capacity: usize) -> Arc<Self> {
+        let (tx1, rx1) = bounded(capacity);
         let (tx2, rx2) = bounded(1);
         Arc::new(Self {
             transition_tx: tx1,
@@ -570,6 +595,8 @@ impl TransitionState {
             kill_rx: rx2,
             active_tasks: AtomicI64::new(0),
             missed_immediate_tasks: AtomicI64::new(0),
+            queue_full_tasks: AtomicI64::new(0),
+            queue_send_timeout_tasks: AtomicI64::new(0),
             last_day_stats: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -580,26 +607,68 @@ impl TransitionState {
             src: src.clone(),
             event: event.clone(),
         };
-        select! {
-            //_ -> t.ctx.Done() => (),
-            _ = self.transition_tx.send(Some(task)) => (),
-            else => {
-                match src {
-                    LcEventSrc::S3PutObject | LcEventSrc::S3CopyObject | LcEventSrc::S3CompleteMultipartUpload => {
-                        self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                    }
-                    _ => ()
+        if is_immediate_transition_source(src) {
+            let send_timeout = resolve_transition_queue_send_timeout();
+            match tokio::time::timeout(send_timeout, self.transition_tx.send(Some(task))).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
+                    self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
+                    warn!(
+                        bucket = %oi.bucket,
+                        object = %oi.name,
+                        source = ?src,
+                        timeout_ms = send_timeout.as_millis() as u64,
+                        "transition enqueue failed because the queue is closed"
+                    );
                 }
-            },
+                Err(_) => {
+                    self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
+                    self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
+                    warn!(
+                        bucket = %oi.bucket,
+                        object = %oi.name,
+                        source = ?src,
+                        timeout_ms = send_timeout.as_millis() as u64,
+                        "transition enqueue timed out under backpressure"
+                    );
+                }
+            }
+            return;
+        }
+
+        if let Err(err) = self.transition_tx.try_send(Some(task)) {
+            match err {
+                async_channel::TrySendError::Full(_) => {
+                    debug!(
+                        bucket = %oi.bucket,
+                        object = %oi.name,
+                        source = ?src,
+                        "transition queue is full; deferring to scanner/backfill"
+                    );
+                }
+                async_channel::TrySendError::Closed(_) => {
+                    warn!(
+                        bucket = %oi.bucket,
+                        object = %oi.name,
+                        source = ?src,
+                        "transition enqueue failed because the queue is closed"
+                    );
+                }
+            }
         }
     }
 
     pub async fn init(api: Arc<ECStore>) {
         let (configured, absolute_max, n) = resolve_transition_worker_count();
+        let queue_capacity = resolve_transition_queue_capacity();
+        let queue_send_timeout = resolve_transition_queue_send_timeout();
         info!(
             configured_transition_workers = configured,
             absolute_max_workers = absolute_max,
             effective_transition_workers = n,
+            transition_queue_capacity = queue_capacity,
+            transition_queue_send_timeout_ms = queue_send_timeout.as_millis() as u64,
             "transition worker count resolved"
         );
 
@@ -620,6 +689,14 @@ impl TransitionState {
 
     pub fn missed_immediate_tasks(&self) -> i64 {
         self.missed_immediate_tasks.load(Ordering::SeqCst)
+    }
+
+    pub fn queue_full_tasks(&self) -> i64 {
+        self.queue_full_tasks.load(Ordering::SeqCst)
+    }
+
+    pub fn queue_send_timeout_tasks(&self) -> i64 {
+        self.queue_send_timeout_tasks.load(Ordering::SeqCst)
     }
 
     pub async fn worker(api: Arc<ECStore>) {
@@ -2031,11 +2108,12 @@ pub async fn apply_lifecycle_action(event: &lifecycle::Event, src: &LcEventSrc, 
 #[cfg(test)]
 mod tests {
     use super::{
-        DATE_EXPIRY_EXISTING_OBJECTS_GRACE_SECS, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX, DEFAULT_TRANSITION_WORKERS_CAP,
-        GLOBAL_TransitionState, StaleMultipartUploadCandidate, TransitionState, cleanup_empty_multipart_sha_dirs_on_local_disks,
-        cleanup_stale_multipart_uploads_once_at, lifecycle_deleted_object, lifecycle_rule_has_date_expiration,
-        lifecycle_version_purge_state_from_completed_targets, mark_delete_opts_skip_decommissioned_on_remote_success,
-        merge_stale_multipart_candidate, replication_state_for_delete, resolve_transition_worker_count,
+        DATE_EXPIRY_EXISTING_OBJECTS_GRACE_SECS, DEFAULT_TRANSITION_QUEUE_CAPACITY, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX,
+        DEFAULT_TRANSITION_WORKERS_CAP, GLOBAL_TransitionState, StaleMultipartUploadCandidate, TransitionState,
+        cleanup_empty_multipart_sha_dirs_on_local_disks, cleanup_stale_multipart_uploads_once_at, lifecycle_deleted_object,
+        lifecycle_rule_has_date_expiration, lifecycle_version_purge_state_from_completed_targets,
+        mark_delete_opts_skip_decommissioned_on_remote_success, merge_stale_multipart_candidate, replication_state_for_delete,
+        resolve_transition_queue_capacity, resolve_transition_queue_send_timeout, resolve_transition_worker_count,
         should_defer_date_expiry_for_recent_config_update, should_reuse_lifecycle_delete_replication_state,
     };
     use crate::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
@@ -2173,6 +2251,105 @@ mod tests {
         }
     }
 
+    #[allow(unsafe_code)]
+    fn with_transition_queue_env<F>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
+    where
+        F: FnOnce(),
+    {
+        let original_capacity = env::var_os("RUSTFS_TRANSITION_QUEUE_CAPACITY");
+        let original_timeout = env::var_os("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS");
+
+        match capacity {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_CAPACITY", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_CAPACITY");
+            },
+        }
+        match timeout_ms {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS");
+            },
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test_fn));
+
+        match original_capacity {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_CAPACITY", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_CAPACITY");
+            },
+        }
+        match original_timeout {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS");
+            },
+        }
+
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
+    }
+
+    #[allow(unsafe_code)]
+    async fn with_transition_queue_env_async<F, Fut>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let original_capacity = env::var_os("RUSTFS_TRANSITION_QUEUE_CAPACITY");
+        let original_timeout = env::var_os("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS");
+
+        match capacity {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_CAPACITY", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_CAPACITY");
+            },
+        }
+        match timeout_ms {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS");
+            },
+        }
+
+        let result = std::panic::AssertUnwindSafe(test_fn()).catch_unwind().await;
+
+        match original_capacity {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_CAPACITY", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_CAPACITY");
+            },
+        }
+        match original_timeout {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS");
+            },
+        }
+
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
+    }
+
     #[test]
     fn lifecycle_rule_has_date_expiration_detects_enabled_date_rule() {
         let lc = BucketLifecycleConfiguration {
@@ -2248,6 +2425,30 @@ mod tests {
         });
     }
 
+    #[test]
+    #[serial]
+    fn resolve_transition_queue_capacity_uses_default_when_env_missing() {
+        with_transition_queue_env(None, None, || {
+            assert_eq!(resolve_transition_queue_capacity(), DEFAULT_TRANSITION_QUEUE_CAPACITY);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_transition_queue_capacity_honors_positive_env_value() {
+        with_transition_queue_env(Some("128"), None, || {
+            assert_eq!(resolve_transition_queue_capacity(), 128);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_transition_queue_send_timeout_honors_positive_env_value() {
+        with_transition_queue_env(None, Some("250"), || {
+            assert_eq!(resolve_transition_queue_send_timeout(), StdDuration::from_millis(250));
+        });
+    }
+
     #[tokio::test]
     #[serial]
     async fn transition_state_init_honors_runtime_configured_worker_count() {
@@ -2259,7 +2460,15 @@ mod tests {
         })
         .await;
 
-        TransitionState::update_workers(ecstore, original_workers).await;
+        let current_workers = GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst);
+        if original_workers > 0 {
+            TransitionState::update_workers(ecstore, original_workers).await;
+        } else {
+            for _ in 0..current_workers {
+                let _ = GLOBAL_TransitionState.kill_tx.send(()).await;
+                GLOBAL_TransitionState.num_workers.fetch_add(-1, Ordering::SeqCst);
+            }
+        }
     }
 
     #[test]

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -942,7 +942,7 @@ impl TransitionState {
             n = effective;
         }
         // Allow environment override of maximum workers
-        let absolute_max = get_env_i64("RUSTFS_ABSOLUTE_MAX_WORKERS", DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+        let absolute_max = get_env_i64(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
         n = std::cmp::min(n, absolute_max);
 
         let previous_num_workers = GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst);
@@ -2269,6 +2269,7 @@ mod tests {
         BucketOperations, BucketOptions, MakeBucketOptions, MultipartOperations, ObjectInfo, ObjectOptions, PutObjReader,
     };
     use futures::FutureExt;
+    use rustfs_config::ENV_TRANSITION_WORKERS_ABSOLUTE_MAX;
     use rustfs_filemeta::{ReplicateDecision, VersionPurgeStatusType};
     use s3s::dto::{BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule, Timestamp};
     use serial_test::serial;
@@ -2299,7 +2300,7 @@ mod tests {
         F: FnOnce(),
     {
         let original_transition = env::var_os("RUSTFS_MAX_TRANSITION_WORKERS");
-        let original_absolute = env::var_os("RUSTFS_ABSOLUTE_MAX_WORKERS");
+        let original_absolute = env::var_os(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX);
 
         match transition {
             Some(value) => unsafe {
@@ -2311,10 +2312,10 @@ mod tests {
         }
         match absolute {
             Some(value) => unsafe {
-                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+                env::set_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, value);
             },
             None => unsafe {
-                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+                env::remove_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX);
             },
         }
 
@@ -2330,10 +2331,10 @@ mod tests {
         }
         match original_absolute {
             Some(value) => unsafe {
-                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+                env::set_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, value);
             },
             None => unsafe {
-                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+                env::remove_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX);
             },
         }
 
@@ -2349,7 +2350,7 @@ mod tests {
         Fut: std::future::Future<Output = ()>,
     {
         let original_transition = env::var_os("RUSTFS_MAX_TRANSITION_WORKERS");
-        let original_absolute = env::var_os("RUSTFS_ABSOLUTE_MAX_WORKERS");
+        let original_absolute = env::var_os(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX);
 
         match transition {
             Some(value) => unsafe {
@@ -2361,10 +2362,10 @@ mod tests {
         }
         match absolute {
             Some(value) => unsafe {
-                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+                env::set_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, value);
             },
             None => unsafe {
-                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+                env::remove_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX);
             },
         }
 
@@ -2380,10 +2381,10 @@ mod tests {
         }
         match original_absolute {
             Some(value) => unsafe {
-                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+                env::set_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, value);
             },
             None => unsafe {
-                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+                env::remove_var(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX);
             },
         }
 

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -47,6 +47,11 @@ use lazy_static::lazy_static;
 use rustfs_common::data_usage::TierStats;
 use rustfs_common::heal_channel::rep_has_active_rules;
 use rustfs_common::metrics::{IlmAction, Metrics};
+use rustfs_config::{
+    DEFAULT_TRANSITION_QUEUE_CAPACITY, DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX,
+    DEFAULT_TRANSITION_WORKERS_CAP, ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT, ENV_TRANSITION_QUEUE_CAPACITY,
+    ENV_TRANSITION_QUEUE_SEND_TIMEOUT_MS, ENV_TRANSITION_WORKERS, ENV_TRANSITION_WORKERS_ABSOLUTE_MAX,
+};
 use rustfs_filemeta::{
     FileInfo, FileInfoOpts, NULL_VERSION_ID, REPLICATE_INCOMING_DELETE, ReplicateDecision, ReplicationState, RestoreStatusOps,
     VersionPurgeStatusType, get_file_info, is_restored_object_on_disk,
@@ -93,11 +98,6 @@ const ENV_STALE_UPLOADS_CLEANUP_INTERVAL: &str = "RUSTFS_API_STALE_UPLOADS_CLEAN
 const DEFAULT_STALE_UPLOADS_EXPIRY: StdDuration = StdDuration::from_secs(24 * 60 * 60);
 const DEFAULT_STALE_UPLOADS_CLEANUP_INTERVAL: StdDuration = StdDuration::from_secs(6 * 60 * 60);
 const DATE_EXPIRY_EXISTING_OBJECTS_GRACE_SECS: i64 = 5;
-const DEFAULT_TRANSITION_WORKERS_CAP: i64 = 16;
-const DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX: i64 = 32;
-const DEFAULT_TRANSITION_QUEUE_CAPACITY: usize = 1000;
-const DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS: usize = 100;
-const ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT: &str = "RUSTFS_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT";
 
 lazy_static! {
     pub static ref GLOBAL_ExpiryState: Arc<RwLock<ExpiryState>> = ExpiryState::new();
@@ -106,25 +106,23 @@ lazy_static! {
 
 fn resolve_transition_worker_count() -> (i64, i64, i64) {
     let fallback = std::cmp::min(num_cpus::get() as i64, DEFAULT_TRANSITION_WORKERS_CAP);
-    let configured = env::var("RUSTFS_MAX_TRANSITION_WORKERS")
+    let configured = env::var(ENV_TRANSITION_WORKERS)
         .ok()
         .and_then(|value| value.parse::<i64>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(fallback);
     let mut effective = configured;
-    let absolute_max = get_env_i64("RUSTFS_ABSOLUTE_MAX_WORKERS", DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+    let absolute_max = get_env_i64(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
     effective = std::cmp::min(effective, absolute_max);
     (configured, absolute_max, effective)
 }
 
 fn resolve_transition_queue_capacity() -> usize {
-    get_env_usize("RUSTFS_TRANSITION_QUEUE_CAPACITY", DEFAULT_TRANSITION_QUEUE_CAPACITY).max(1)
+    get_env_usize(ENV_TRANSITION_QUEUE_CAPACITY, DEFAULT_TRANSITION_QUEUE_CAPACITY).max(1)
 }
 
 fn resolve_transition_queue_send_timeout() -> StdDuration {
-    StdDuration::from_millis(
-        get_env_usize("RUSTFS_TRANSITION_QUEUE_SEND_TIMEOUT_MS", DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS).max(1) as u64,
-    )
+    StdDuration::from_millis(get_env_usize(ENV_TRANSITION_QUEUE_SEND_TIMEOUT_MS, DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS).max(1) as u64)
 }
 
 fn is_immediate_transition_source(src: &LcEventSrc) -> bool {
@@ -134,10 +132,16 @@ fn is_immediate_transition_source(src: &LcEventSrc) -> bool {
     )
 }
 
+#[cfg(any(test, debug_assertions))]
 fn should_force_immediate_transition_enqueue_timeout() -> bool {
     env::var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT)
         .ok()
         .is_some_and(|value| value == "1")
+}
+
+#[cfg(not(any(test, debug_assertions)))]
+fn should_force_immediate_transition_enqueue_timeout() -> bool {
+    false
 }
 
 pub struct LifecycleSys;
@@ -620,7 +624,7 @@ impl TransitionState {
         })
     }
 
-    fn schedule_bucket_compensation(&self, bucket: &str) -> bool {
+    fn schedule_bucket_compensation(self: &Arc<Self>, bucket: &str) -> bool {
         let mut scheduled = self.compensation_buckets.lock().unwrap();
         if !scheduled.insert(bucket.to_string()) {
             return false;
@@ -628,7 +632,7 @@ impl TransitionState {
         self.compensation_scheduled_tasks.fetch_add(1, Ordering::SeqCst);
         let bucket = bucket.to_string();
         let scheduled = Arc::clone(&self.compensation_buckets);
-        let state = Arc::clone(&GLOBAL_TransitionState);
+        let state = Arc::clone(self);
         tokio::spawn(async move {
             state.compensation_running_tasks.fetch_add(1, Ordering::SeqCst);
             let Some(api) = crate::new_object_layer_fn() else {
@@ -650,7 +654,7 @@ impl TransitionState {
         true
     }
 
-    pub async fn queue_transition_task(&self, oi: &ObjectInfo, event: &lifecycle::Event, src: &LcEventSrc) {
+    pub async fn queue_transition_task(self: &Arc<Self>, oi: &ObjectInfo, event: &lifecycle::Event, src: &LcEventSrc) {
         let task = TransitionTask {
             obj_info: oi.clone(),
             src: src.clone(),
@@ -2542,11 +2546,12 @@ mod tests {
     async fn schedule_bucket_compensation_deduplicates_same_bucket() {
         let state = TransitionState::new_with_capacity(1);
 
-        state.schedule_bucket_compensation("bucket-a");
-        state.schedule_bucket_compensation("bucket-a");
+        let first = state.schedule_bucket_compensation("bucket-a");
+        let second = state.schedule_bucket_compensation("bucket-a");
 
+        assert!(first);
+        assert!(!second);
         assert_eq!(state.compensation_scheduled_tasks(), 1);
-        assert!(state.compensation_buckets.lock().unwrap().contains("bucket-a"));
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -97,6 +97,7 @@ const DEFAULT_TRANSITION_WORKERS_CAP: i64 = 16;
 const DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX: i64 = 32;
 const DEFAULT_TRANSITION_QUEUE_CAPACITY: usize = 1000;
 const DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS: usize = 100;
+const ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT: &str = "RUSTFS_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT";
 
 lazy_static! {
     pub static ref GLOBAL_ExpiryState: Arc<RwLock<ExpiryState>> = ExpiryState::new();
@@ -131,6 +132,12 @@ fn is_immediate_transition_source(src: &LcEventSrc) -> bool {
         src,
         LcEventSrc::S3PutObject | LcEventSrc::S3CopyObject | LcEventSrc::S3CompleteMultipartUpload
     )
+}
+
+fn should_force_immediate_transition_enqueue_timeout() -> bool {
+    env::var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT)
+        .ok()
+        .is_some_and(|value| value == "1")
 }
 
 pub struct LifecycleSys;
@@ -644,6 +651,19 @@ impl TransitionState {
             event: event.clone(),
         };
         if is_immediate_transition_source(src) {
+            if should_force_immediate_transition_enqueue_timeout() {
+                self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
+                self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
+                let scheduled = self.schedule_bucket_compensation(&oi.bucket);
+                warn!(
+                    bucket = %oi.bucket,
+                    object = %oi.name,
+                    source = ?src,
+                    compensation_scheduled = scheduled,
+                    "transition enqueue forced into timeout path for test fault injection"
+                );
+                return;
+            }
             let send_timeout = resolve_transition_queue_send_timeout();
             match tokio::time::timeout(send_timeout, self.transition_tx.send(Some(task))).await {
                 Ok(Ok(())) => {}

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -578,6 +578,8 @@ pub struct TransitionState {
     pub num_workers: AtomicI64,
     kill_tx: A_Sender<()>,
     kill_rx: A_Receiver<()>,
+    transition_queue_capacity: usize,
+    transition_queue_send_timeout: StdDuration,
     active_tasks: AtomicI64,
     missed_immediate_tasks: AtomicI64,
     queue_full_tasks: AtomicI64,
@@ -595,6 +597,8 @@ impl TransitionState {
     }
 
     fn new_with_capacity(capacity: usize) -> Arc<Self> {
+        let capacity = capacity.max(1);
+        let queue_send_timeout = resolve_transition_queue_send_timeout();
         let (tx1, rx1) = bounded(capacity);
         let (tx2, rx2) = bounded(1);
         Arc::new(Self {
@@ -603,6 +607,8 @@ impl TransitionState {
             num_workers: AtomicI64::new(0),
             kill_tx: tx2,
             kill_rx: rx2,
+            transition_queue_capacity: capacity,
+            transition_queue_send_timeout: queue_send_timeout,
             active_tasks: AtomicI64::new(0),
             missed_immediate_tasks: AtomicI64::new(0),
             queue_full_tasks: AtomicI64::new(0),
@@ -664,10 +670,41 @@ impl TransitionState {
                 );
                 return;
             }
-            let send_timeout = resolve_transition_queue_send_timeout();
-            match tokio::time::timeout(send_timeout, self.transition_tx.send(Some(task))).await {
-                Ok(Ok(())) => {}
-                Ok(Err(_)) => {
+            match self.transition_tx.try_send(Some(task)) {
+                Ok(()) => {}
+                Err(async_channel::TrySendError::Full(task)) => {
+                    let send_timeout = self.transition_queue_send_timeout;
+                    match tokio::time::timeout(send_timeout, self.transition_tx.send(task)).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(_)) => {
+                            self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
+                            self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
+                            let scheduled = self.schedule_bucket_compensation(&oi.bucket);
+                            warn!(
+                                bucket = %oi.bucket,
+                                object = %oi.name,
+                                source = ?src,
+                                timeout_ms = send_timeout.as_millis() as u64,
+                                compensation_scheduled = scheduled,
+                                "transition enqueue failed because the queue is closed"
+                            );
+                        }
+                        Err(_) => {
+                            self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
+                            self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
+                            let scheduled = self.schedule_bucket_compensation(&oi.bucket);
+                            warn!(
+                                bucket = %oi.bucket,
+                                object = %oi.name,
+                                source = ?src,
+                                timeout_ms = send_timeout.as_millis() as u64,
+                                compensation_scheduled = scheduled,
+                                "transition enqueue timed out under backpressure"
+                            );
+                        }
+                    }
+                }
+                Err(async_channel::TrySendError::Closed(_task)) => {
                     self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
                     self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
                     let scheduled = self.schedule_bucket_compensation(&oi.bucket);
@@ -675,22 +712,8 @@ impl TransitionState {
                         bucket = %oi.bucket,
                         object = %oi.name,
                         source = ?src,
-                        timeout_ms = send_timeout.as_millis() as u64,
                         compensation_scheduled = scheduled,
                         "transition enqueue failed because the queue is closed"
-                    );
-                }
-                Err(_) => {
-                    self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                    self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
-                    let scheduled = self.schedule_bucket_compensation(&oi.bucket);
-                    warn!(
-                        bucket = %oi.bucket,
-                        object = %oi.name,
-                        source = ?src,
-                        timeout_ms = send_timeout.as_millis() as u64,
-                        compensation_scheduled = scheduled,
-                        "transition enqueue timed out under backpressure"
                     );
                 }
             }
@@ -721,14 +744,12 @@ impl TransitionState {
 
     pub async fn init(api: Arc<ECStore>) {
         let (configured, absolute_max, n) = resolve_transition_worker_count();
-        let queue_capacity = resolve_transition_queue_capacity();
-        let queue_send_timeout = resolve_transition_queue_send_timeout();
         info!(
             configured_transition_workers = configured,
             absolute_max_workers = absolute_max,
             effective_transition_workers = n,
-            transition_queue_capacity = queue_capacity,
-            transition_queue_send_timeout_ms = queue_send_timeout.as_millis() as u64,
+            transition_queue_capacity = GLOBAL_TransitionState.transition_queue_capacity,
+            transition_queue_send_timeout_ms = GLOBAL_TransitionState.transition_queue_send_timeout.as_millis() as u64,
             "transition worker count resolved"
         );
 

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -122,7 +122,9 @@ fn resolve_transition_queue_capacity() -> usize {
 }
 
 fn resolve_transition_queue_send_timeout() -> StdDuration {
-    StdDuration::from_millis(get_env_usize(ENV_TRANSITION_QUEUE_SEND_TIMEOUT_MS, DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS).max(1) as u64)
+    StdDuration::from_millis(
+        get_env_usize(ENV_TRANSITION_QUEUE_SEND_TIMEOUT_MS, DEFAULT_TRANSITION_QUEUE_SEND_TIMEOUT_MS).max(1) as u64,
+    )
 }
 
 fn is_immediate_transition_source(src: &LcEventSrc) -> bool {

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -596,6 +596,12 @@ pub struct TransitionState {
     last_day_stats: Arc<Mutex<HashMap<String, LastDayTierStats>>>,
 }
 
+enum ImmediateEnqueueFailure {
+    ForcedTimeout,
+    QueueClosed { timeout_ms: Option<u64> },
+    QueueSendTimedOut { timeout_ms: u64 },
+}
+
 impl TransitionState {
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Arc<Self> {
@@ -631,15 +637,15 @@ impl TransitionState {
         if !scheduled.insert(bucket.to_string()) {
             return false;
         }
-        self.compensation_scheduled_tasks.fetch_add(1, Ordering::SeqCst);
+        Self::inc_counter(&self.compensation_scheduled_tasks);
         let bucket = bucket.to_string();
         let scheduled = Arc::clone(&self.compensation_buckets);
         let state = Arc::clone(self);
         tokio::spawn(async move {
-            state.compensation_running_tasks.fetch_add(1, Ordering::SeqCst);
+            Self::inc_counter(&state.compensation_running_tasks);
             let Some(api) = crate::new_object_layer_fn() else {
                 scheduled.lock().unwrap().remove(&bucket);
-                state.compensation_running_tasks.fetch_add(-1, Ordering::SeqCst);
+                Self::add_counter(&state.compensation_running_tasks, -1);
                 warn!(bucket = %bucket, "transition compensation skipped because object layer is unavailable");
                 return;
             };
@@ -651,22 +657,32 @@ impl TransitionState {
             }
 
             scheduled.lock().unwrap().remove(&bucket);
-            state.compensation_running_tasks.fetch_add(-1, Ordering::SeqCst);
+            Self::add_counter(&state.compensation_running_tasks, -1);
         });
         true
     }
 
-    pub async fn queue_transition_task(self: &Arc<Self>, oi: &ObjectInfo, event: &lifecycle::Event, src: &LcEventSrc) {
-        let task = TransitionTask {
-            obj_info: oi.clone(),
-            src: src.clone(),
-            event: event.clone(),
-        };
-        if is_immediate_transition_source(src) {
-            if should_force_immediate_transition_enqueue_timeout() {
-                self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
-                let scheduled = self.schedule_bucket_compensation(&oi.bucket);
+    #[inline]
+    fn inc_counter(counter: &AtomicI64) {
+        Self::add_counter(counter, 1);
+    }
+
+    #[inline]
+    fn add_counter(counter: &AtomicI64, delta: i64) {
+        counter.fetch_add(delta, Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn counter_value(counter: &AtomicI64) -> i64 {
+        counter.load(Ordering::Relaxed)
+    }
+
+    fn handle_immediate_enqueue_failure(self: &Arc<Self>, oi: &ObjectInfo, src: &LcEventSrc, failure: ImmediateEnqueueFailure) {
+        Self::inc_counter(&self.missed_immediate_tasks);
+        let scheduled = self.schedule_bucket_compensation(&oi.bucket);
+        match failure {
+            ImmediateEnqueueFailure::ForcedTimeout => {
+                Self::inc_counter(&self.queue_send_timeout_tasks);
                 warn!(
                     bucket = %oi.bucket,
                     object = %oi.name,
@@ -674,45 +690,19 @@ impl TransitionState {
                     compensation_scheduled = scheduled,
                     "transition enqueue forced into timeout path for test fault injection"
                 );
-                return;
             }
-            match self.transition_tx.try_send(Some(task)) {
-                Ok(()) => {}
-                Err(async_channel::TrySendError::Full(task)) => {
-                    self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
-                    let send_timeout = self.transition_queue_send_timeout;
-                    match tokio::time::timeout(send_timeout, self.transition_tx.send(task)).await {
-                        Ok(Ok(())) => {}
-                        Ok(Err(_)) => {
-                            self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                            let scheduled = self.schedule_bucket_compensation(&oi.bucket);
-                            warn!(
-                                bucket = %oi.bucket,
-                                object = %oi.name,
-                                source = ?src,
-                                timeout_ms = send_timeout.as_millis() as u64,
-                                compensation_scheduled = scheduled,
-                                "transition enqueue failed because the queue is closed"
-                            );
-                        }
-                        Err(_) => {
-                            self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                            self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
-                            let scheduled = self.schedule_bucket_compensation(&oi.bucket);
-                            warn!(
-                                bucket = %oi.bucket,
-                                object = %oi.name,
-                                source = ?src,
-                                timeout_ms = send_timeout.as_millis() as u64,
-                                compensation_scheduled = scheduled,
-                                "transition enqueue timed out under backpressure"
-                            );
-                        }
-                    }
+            ImmediateEnqueueFailure::QueueClosed { timeout_ms } => match timeout_ms {
+                Some(timeout_ms) => {
+                    warn!(
+                        bucket = %oi.bucket,
+                        object = %oi.name,
+                        source = ?src,
+                        timeout_ms,
+                        compensation_scheduled = scheduled,
+                        "transition enqueue failed because the queue is closed"
+                    );
                 }
-                Err(async_channel::TrySendError::Closed(_task)) => {
-                    self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                    let scheduled = self.schedule_bucket_compensation(&oi.bucket);
+                None => {
                     warn!(
                         bucket = %oi.bucket,
                         object = %oi.name,
@@ -720,6 +710,63 @@ impl TransitionState {
                         compensation_scheduled = scheduled,
                         "transition enqueue failed because the queue is closed"
                     );
+                }
+            },
+            ImmediateEnqueueFailure::QueueSendTimedOut { timeout_ms } => {
+                Self::inc_counter(&self.queue_send_timeout_tasks);
+                warn!(
+                    bucket = %oi.bucket,
+                    object = %oi.name,
+                    source = ?src,
+                    timeout_ms,
+                    compensation_scheduled = scheduled,
+                    "transition enqueue timed out under backpressure"
+                );
+            }
+        }
+    }
+
+    pub async fn queue_transition_task(self: &Arc<Self>, oi: &ObjectInfo, event: &lifecycle::Event, src: &LcEventSrc) {
+        if is_immediate_transition_source(src) && should_force_immediate_transition_enqueue_timeout() {
+            self.handle_immediate_enqueue_failure(oi, src, ImmediateEnqueueFailure::ForcedTimeout);
+            return;
+        }
+
+        let task = TransitionTask {
+            obj_info: oi.clone(),
+            src: src.clone(),
+            event: event.clone(),
+        };
+        if is_immediate_transition_source(src) {
+            match self.transition_tx.try_send(Some(task)) {
+                Ok(()) => {}
+                Err(async_channel::TrySendError::Full(task)) => {
+                    Self::inc_counter(&self.queue_full_tasks);
+                    let send_timeout = self.transition_queue_send_timeout;
+                    match tokio::time::timeout(send_timeout, self.transition_tx.send(task)).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(_)) => {
+                            self.handle_immediate_enqueue_failure(
+                                oi,
+                                src,
+                                ImmediateEnqueueFailure::QueueClosed {
+                                    timeout_ms: Some(send_timeout.as_millis() as u64),
+                                },
+                            );
+                        }
+                        Err(_) => {
+                            self.handle_immediate_enqueue_failure(
+                                oi,
+                                src,
+                                ImmediateEnqueueFailure::QueueSendTimedOut {
+                                    timeout_ms: send_timeout.as_millis() as u64,
+                                },
+                            );
+                        }
+                    }
+                }
+                Err(async_channel::TrySendError::Closed(_task)) => {
+                    self.handle_immediate_enqueue_failure(oi, src, ImmediateEnqueueFailure::QueueClosed { timeout_ms: None });
                 }
             }
             return;
@@ -770,27 +817,27 @@ impl TransitionState {
     }
 
     pub fn active_tasks(&self) -> i64 {
-        self.active_tasks.load(Ordering::SeqCst)
+        Self::counter_value(&self.active_tasks)
     }
 
     pub fn missed_immediate_tasks(&self) -> i64 {
-        self.missed_immediate_tasks.load(Ordering::SeqCst)
+        Self::counter_value(&self.missed_immediate_tasks)
     }
 
     pub fn queue_full_tasks(&self) -> i64 {
-        self.queue_full_tasks.load(Ordering::SeqCst)
+        Self::counter_value(&self.queue_full_tasks)
     }
 
     pub fn queue_send_timeout_tasks(&self) -> i64 {
-        self.queue_send_timeout_tasks.load(Ordering::SeqCst)
+        Self::counter_value(&self.queue_send_timeout_tasks)
     }
 
     pub fn compensation_scheduled_tasks(&self) -> i64 {
-        self.compensation_scheduled_tasks.load(Ordering::SeqCst)
+        Self::counter_value(&self.compensation_scheduled_tasks)
     }
 
     pub fn compensation_running_tasks(&self) -> i64 {
-        self.compensation_running_tasks.load(Ordering::SeqCst)
+        Self::counter_value(&self.compensation_running_tasks)
     }
 
     pub async fn worker(api: Arc<ECStore>) {
@@ -813,7 +860,7 @@ impl TransitionState {
                     if task.as_any().is::<TransitionTask>() {
                         let task = task.as_any().downcast_ref::<TransitionTask>().expect("TransitionTask downcast failed");
 
-                        GLOBAL_TransitionState.active_tasks.fetch_add(1, Ordering::SeqCst);
+                        TransitionState::inc_counter(&GLOBAL_TransitionState.active_tasks);
 
                         let obj_info_for_event = ObjectInfo {
                             bucket: task.obj_info.bucket.clone(),
@@ -858,7 +905,7 @@ impl TransitionState {
                                 ..Default::default()
                             });
                         }
-                        GLOBAL_TransitionState.active_tasks.fetch_add(-1, Ordering::SeqCst);
+                        TransitionState::add_counter(&GLOBAL_TransitionState.active_tasks, -1);
                     }
                 }
                 else => ()

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -679,12 +679,12 @@ impl TransitionState {
             match self.transition_tx.try_send(Some(task)) {
                 Ok(()) => {}
                 Err(async_channel::TrySendError::Full(task)) => {
+                    self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
                     let send_timeout = self.transition_queue_send_timeout;
                     match tokio::time::timeout(send_timeout, self.transition_tx.send(task)).await {
                         Ok(Ok(())) => {}
                         Ok(Err(_)) => {
                             self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                            self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
                             let scheduled = self.schedule_bucket_compensation(&oi.bucket);
                             warn!(
                                 bucket = %oi.bucket,
@@ -712,7 +712,6 @@ impl TransitionState {
                 }
                 Err(async_channel::TrySendError::Closed(_task)) => {
                     self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
-                    self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
                     let scheduled = self.schedule_bucket_compensation(&oi.bucket);
                     warn!(
                         bucket = %oi.bucket,
@@ -2544,7 +2543,7 @@ mod tests {
         });
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn schedule_bucket_compensation_deduplicates_same_bucket() {
         let state = TransitionState::new_with_capacity(1);
 

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -93,10 +93,25 @@ const ENV_STALE_UPLOADS_CLEANUP_INTERVAL: &str = "RUSTFS_API_STALE_UPLOADS_CLEAN
 const DEFAULT_STALE_UPLOADS_EXPIRY: StdDuration = StdDuration::from_secs(24 * 60 * 60);
 const DEFAULT_STALE_UPLOADS_CLEANUP_INTERVAL: StdDuration = StdDuration::from_secs(6 * 60 * 60);
 const DATE_EXPIRY_EXISTING_OBJECTS_GRACE_SECS: i64 = 5;
+const DEFAULT_TRANSITION_WORKERS_CAP: i64 = 16;
+const DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX: i64 = 32;
 
 lazy_static! {
     pub static ref GLOBAL_ExpiryState: Arc<RwLock<ExpiryState>> = ExpiryState::new();
     pub static ref GLOBAL_TransitionState: Arc<TransitionState> = TransitionState::new();
+}
+
+fn resolve_transition_worker_count() -> (i64, i64, i64) {
+    let fallback = std::cmp::min(num_cpus::get() as i64, DEFAULT_TRANSITION_WORKERS_CAP);
+    let configured = env::var("RUSTFS_MAX_TRANSITION_WORKERS")
+        .ok()
+        .and_then(|value| value.parse::<i64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(fallback);
+    let mut effective = configured;
+    let absolute_max = get_env_i64("RUSTFS_ABSOLUTE_MAX_WORKERS", DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+    effective = std::cmp::min(effective, absolute_max);
+    (configured, absolute_max, effective)
 }
 
 pub struct LifecycleSys;
@@ -580,12 +595,13 @@ impl TransitionState {
     }
 
     pub async fn init(api: Arc<ECStore>) {
-        let max_workers = get_env_i64("RUSTFS_MAX_TRANSITION_WORKERS", std::cmp::min(num_cpus::get() as i64, 16));
-        let mut n = max_workers;
-        let tw = 8; //globalILMConfig.getTransitionWorkers();
-        if tw > 0 {
-            n = tw;
-        }
+        let (configured, absolute_max, n) = resolve_transition_worker_count();
+        info!(
+            configured_transition_workers = configured,
+            absolute_max_workers = absolute_max,
+            effective_transition_workers = n,
+            "transition worker count resolved"
+        );
 
         //let mut transition_state = GLOBAL_TransitionState.write().await;
         //self.objAPI = objAPI
@@ -702,15 +718,17 @@ impl TransitionState {
 
     pub async fn update_workers_inner(api: Arc<ECStore>, n: i64) {
         let mut n = n;
+        let requested = n;
         if n == 0 {
-            let max_workers = get_env_i64("RUSTFS_MAX_TRANSITION_WORKERS", std::cmp::min(num_cpus::get() as i64, 16));
-            n = max_workers;
+            let (_, _, effective) = resolve_transition_worker_count();
+            n = effective;
         }
         // Allow environment override of maximum workers
-        let absolute_max = get_env_i64("RUSTFS_ABSOLUTE_MAX_WORKERS", 32);
+        let absolute_max = get_env_i64("RUSTFS_ABSOLUTE_MAX_WORKERS", DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
         n = std::cmp::min(n, absolute_max);
 
-        let mut num_workers = GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst);
+        let previous_num_workers = GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst);
+        let mut num_workers = previous_num_workers;
         while num_workers < n {
             let clone_api = api.clone();
             tokio::spawn(async move {
@@ -727,6 +745,15 @@ impl TransitionState {
             num_workers -= 1;
             GLOBAL_TransitionState.num_workers.fetch_add(-1, Ordering::SeqCst);
         }
+
+        info!(
+            requested_transition_workers = requested,
+            effective_transition_workers = n,
+            absolute_max_workers = absolute_max,
+            previous_transition_workers = previous_num_workers,
+            current_transition_workers = GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst),
+            "transition workers updated"
+        );
     }
 }
 
@@ -2004,11 +2031,12 @@ pub async fn apply_lifecycle_action(event: &lifecycle::Event, src: &LcEventSrc, 
 #[cfg(test)]
 mod tests {
     use super::{
-        DATE_EXPIRY_EXISTING_OBJECTS_GRACE_SECS, StaleMultipartUploadCandidate, cleanup_empty_multipart_sha_dirs_on_local_disks,
+        DATE_EXPIRY_EXISTING_OBJECTS_GRACE_SECS, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX, DEFAULT_TRANSITION_WORKERS_CAP,
+        GLOBAL_TransitionState, StaleMultipartUploadCandidate, TransitionState, cleanup_empty_multipart_sha_dirs_on_local_disks,
         cleanup_stale_multipart_uploads_once_at, lifecycle_deleted_object, lifecycle_rule_has_date_expiration,
         lifecycle_version_purge_state_from_completed_targets, mark_delete_opts_skip_decommissioned_on_remote_success,
-        merge_stale_multipart_candidate, replication_state_for_delete, should_defer_date_expiry_for_recent_config_update,
-        should_reuse_lifecycle_delete_replication_state,
+        merge_stale_multipart_candidate, replication_state_for_delete, resolve_transition_worker_count,
+        should_defer_date_expiry_for_recent_config_update, should_reuse_lifecycle_delete_replication_state,
     };
     use crate::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
     use crate::bucket::metadata_sys;
@@ -2021,12 +2049,15 @@ mod tests {
     use crate::store_api::{
         BucketOperations, BucketOptions, MakeBucketOptions, MultipartOperations, ObjectInfo, ObjectOptions, PutObjReader,
     };
+    use futures::FutureExt;
     use rustfs_filemeta::{ReplicateDecision, VersionPurgeStatusType};
     use s3s::dto::{BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule, Timestamp};
     use serial_test::serial;
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
+    use std::env;
     use std::path::PathBuf;
+    use std::sync::atomic::Ordering;
     use std::sync::{Arc, OnceLock};
     use std::time::Duration as StdDuration;
     use time::OffsetDateTime;
@@ -2041,6 +2072,105 @@ mod tests {
         mark_delete_opts_skip_decommissioned_on_remote_success(&mut opts, true);
 
         assert!(opts.skip_decommissioned);
+    }
+
+    #[allow(unsafe_code)]
+    fn with_transition_worker_env<F>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
+    where
+        F: FnOnce(),
+    {
+        let original_transition = env::var_os("RUSTFS_MAX_TRANSITION_WORKERS");
+        let original_absolute = env::var_os("RUSTFS_ABSOLUTE_MAX_WORKERS");
+
+        match transition {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_MAX_TRANSITION_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_MAX_TRANSITION_WORKERS");
+            },
+        }
+        match absolute {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+            },
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test_fn));
+
+        match original_transition {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_MAX_TRANSITION_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_MAX_TRANSITION_WORKERS");
+            },
+        }
+        match original_absolute {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+            },
+        }
+
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
+    }
+
+    #[allow(unsafe_code)]
+    async fn with_transition_worker_env_async<F, Fut>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let original_transition = env::var_os("RUSTFS_MAX_TRANSITION_WORKERS");
+        let original_absolute = env::var_os("RUSTFS_ABSOLUTE_MAX_WORKERS");
+
+        match transition {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_MAX_TRANSITION_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_MAX_TRANSITION_WORKERS");
+            },
+        }
+        match absolute {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+            },
+        }
+
+        let result = std::panic::AssertUnwindSafe(test_fn()).catch_unwind().await;
+
+        match original_transition {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_MAX_TRANSITION_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_MAX_TRANSITION_WORKERS");
+            },
+        }
+        match original_absolute {
+            Some(value) => unsafe {
+                env::set_var("RUSTFS_ABSOLUTE_MAX_WORKERS", value);
+            },
+            None => unsafe {
+                env::remove_var("RUSTFS_ABSOLUTE_MAX_WORKERS");
+            },
+        }
+
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
     }
 
     #[test]
@@ -2066,6 +2196,70 @@ mod tests {
 
         assert!(lifecycle_rule_has_date_expiration(&lc, "rule-date"));
         assert!(!lifecycle_rule_has_date_expiration(&lc, "missing-rule"));
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_transition_worker_count_uses_fallback_when_env_missing() {
+        with_transition_worker_env(None, None, || {
+            let (configured, absolute_max, effective) = resolve_transition_worker_count();
+
+            let fallback = std::cmp::min(num_cpus::get() as i64, DEFAULT_TRANSITION_WORKERS_CAP);
+            assert_eq!(configured, fallback);
+            assert_eq!(absolute_max, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+            assert_eq!(effective, fallback);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_transition_worker_count_honors_positive_env_value() {
+        with_transition_worker_env(Some("4"), Some("32"), || {
+            let (configured, absolute_max, effective) = resolve_transition_worker_count();
+
+            assert_eq!(configured, 4);
+            assert_eq!(absolute_max, 32);
+            assert_eq!(effective, 4);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_transition_worker_count_clamps_to_absolute_max() {
+        with_transition_worker_env(Some("64"), Some("16"), || {
+            let (configured, absolute_max, effective) = resolve_transition_worker_count();
+
+            assert_eq!(configured, 64);
+            assert_eq!(absolute_max, 16);
+            assert_eq!(effective, 16);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_transition_worker_count_falls_back_for_zero_value() {
+        with_transition_worker_env(Some("0"), Some("32"), || {
+            let (configured, absolute_max, effective) = resolve_transition_worker_count();
+
+            let fallback = std::cmp::min(num_cpus::get() as i64, DEFAULT_TRANSITION_WORKERS_CAP);
+            assert_eq!(configured, fallback);
+            assert_eq!(absolute_max, 32);
+            assert_eq!(effective, fallback);
+        });
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn transition_state_init_honors_runtime_configured_worker_count() {
+        let (_paths, ecstore) = setup_test_env().await;
+        let original_workers = GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst);
+        with_transition_worker_env_async(Some("3"), Some("8"), || async {
+            TransitionState::update_workers(ecstore.clone(), 0).await;
+            assert_eq!(GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst), 3);
+        })
+        .await;
+
+        TransitionState::update_workers(ecstore, original_workers).await;
     }
 
     #[test]

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -60,7 +60,7 @@ use s3s::dto::{
 use s3s::header::{X_AMZ_RESTORE, X_AMZ_SERVER_SIDE_ENCRYPTION};
 use sha2::{Digest, Sha256};
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -575,6 +575,9 @@ pub struct TransitionState {
     missed_immediate_tasks: AtomicI64,
     queue_full_tasks: AtomicI64,
     queue_send_timeout_tasks: AtomicI64,
+    compensation_scheduled_tasks: AtomicI64,
+    compensation_running_tasks: AtomicI64,
+    compensation_buckets: Arc<Mutex<HashSet<String>>>,
     last_day_stats: Arc<Mutex<HashMap<String, LastDayTierStats>>>,
 }
 
@@ -597,8 +600,40 @@ impl TransitionState {
             missed_immediate_tasks: AtomicI64::new(0),
             queue_full_tasks: AtomicI64::new(0),
             queue_send_timeout_tasks: AtomicI64::new(0),
+            compensation_scheduled_tasks: AtomicI64::new(0),
+            compensation_running_tasks: AtomicI64::new(0),
+            compensation_buckets: Arc::new(Mutex::new(HashSet::new())),
             last_day_stats: Arc::new(Mutex::new(HashMap::new())),
         })
+    }
+
+    fn schedule_bucket_compensation(&self, bucket: &str) {
+        let mut scheduled = self.compensation_buckets.lock().unwrap();
+        if !scheduled.insert(bucket.to_string()) {
+            return;
+        }
+        self.compensation_scheduled_tasks.fetch_add(1, Ordering::SeqCst);
+        let bucket = bucket.to_string();
+        let scheduled = Arc::clone(&self.compensation_buckets);
+        let state = Arc::clone(&GLOBAL_TransitionState);
+        tokio::spawn(async move {
+            state.compensation_running_tasks.fetch_add(1, Ordering::SeqCst);
+            let Some(api) = crate::new_object_layer_fn() else {
+                scheduled.lock().unwrap().remove(&bucket);
+                state.compensation_running_tasks.fetch_add(-1, Ordering::SeqCst);
+                warn!(bucket = %bucket, "transition compensation skipped because object layer is unavailable");
+                return;
+            };
+
+            if let Err(err) = enqueue_transition_for_existing_objects(api, &bucket).await {
+                warn!(bucket = %bucket, error = ?err, "transition compensation backfill failed");
+            } else {
+                info!(bucket = %bucket, "transition compensation backfill completed");
+            }
+
+            scheduled.lock().unwrap().remove(&bucket);
+            state.compensation_running_tasks.fetch_add(-1, Ordering::SeqCst);
+        });
     }
 
     pub async fn queue_transition_task(&self, oi: &ObjectInfo, event: &lifecycle::Event, src: &LcEventSrc) {
@@ -614,6 +649,7 @@ impl TransitionState {
                 Ok(Err(_)) => {
                     self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
                     self.queue_full_tasks.fetch_add(1, Ordering::SeqCst);
+                    self.schedule_bucket_compensation(&oi.bucket);
                     warn!(
                         bucket = %oi.bucket,
                         object = %oi.name,
@@ -625,6 +661,7 @@ impl TransitionState {
                 Err(_) => {
                     self.missed_immediate_tasks.fetch_add(1, Ordering::SeqCst);
                     self.queue_send_timeout_tasks.fetch_add(1, Ordering::SeqCst);
+                    self.schedule_bucket_compensation(&oi.bucket);
                     warn!(
                         bucket = %oi.bucket,
                         object = %oi.name,
@@ -697,6 +734,14 @@ impl TransitionState {
 
     pub fn queue_send_timeout_tasks(&self) -> i64 {
         self.queue_send_timeout_tasks.load(Ordering::SeqCst)
+    }
+
+    pub fn compensation_scheduled_tasks(&self) -> i64 {
+        self.compensation_scheduled_tasks.load(Ordering::SeqCst)
+    }
+
+    pub fn compensation_running_tasks(&self) -> i64 {
+        self.compensation_running_tasks.load(Ordering::SeqCst)
     }
 
     pub async fn worker(api: Arc<ECStore>) {
@@ -2447,6 +2492,17 @@ mod tests {
         with_transition_queue_env(None, Some("250"), || {
             assert_eq!(resolve_transition_queue_send_timeout(), StdDuration::from_millis(250));
         });
+    }
+
+    #[tokio::test]
+    async fn schedule_bucket_compensation_deduplicates_same_bucket() {
+        let state = TransitionState::new_with_capacity(1);
+
+        state.schedule_bucket_compensation("bucket-a");
+        state.schedule_bucket_compensation("bucket-a");
+
+        assert_eq!(state.compensation_scheduled_tasks(), 1);
+        assert!(state.compensation_buckets.lock().unwrap().contains("bucket-a"));
     }
 
     #[tokio::test]

--- a/crates/obs/src/metrics/collectors/ilm.rs
+++ b/crates/obs/src/metrics/collectors/ilm.rs
@@ -36,7 +36,7 @@ pub struct IlmStats {
     pub transition_pending_tasks: u64,
     /// Number of missed immediate ILM transition tasks
     pub transition_missed_immediate_tasks: u64,
-    /// Number of ILM transition tasks rejected because the queue was full/closed
+    /// Number of ILM transition tasks that initially hit full queue backpressure
     pub transition_queue_full_tasks: u64,
     /// Number of ILM transition tasks that timed out waiting for queue capacity
     pub transition_queue_send_timeout_tasks: u64,

--- a/crates/obs/src/metrics/collectors/ilm.rs
+++ b/crates/obs/src/metrics/collectors/ilm.rs
@@ -40,6 +40,10 @@ pub struct IlmStats {
     pub transition_queue_full_tasks: u64,
     /// Number of ILM transition tasks that timed out waiting for queue capacity
     pub transition_queue_send_timeout_tasks: u64,
+    /// Number of bucket-level compensation tasks scheduled after immediate enqueue failure
+    pub transition_compensation_scheduled_tasks: u64,
+    /// Number of bucket-level compensation tasks currently running
+    pub transition_compensation_running_tasks: u64,
     /// Total number of object versions scanned for ILM
     pub versions_scanned: u64,
 }
@@ -62,6 +66,14 @@ pub fn collect_ilm_metrics(stats: &IlmStats) -> Vec<PrometheusMetric> {
             &ILM_TRANSITION_QUEUE_SEND_TIMEOUT_TASKS_MD,
             stats.transition_queue_send_timeout_tasks as f64,
         ),
+        PrometheusMetric::from_descriptor(
+            &ILM_TRANSITION_COMPENSATION_SCHEDULED_TASKS_MD,
+            stats.transition_compensation_scheduled_tasks as f64,
+        ),
+        PrometheusMetric::from_descriptor(
+            &ILM_TRANSITION_COMPENSATION_RUNNING_TASKS_MD,
+            stats.transition_compensation_running_tasks as f64,
+        ),
         PrometheusMetric::from_descriptor(&ILM_VERSIONS_SCANNED_MD, stats.versions_scanned as f64),
     ]
 }
@@ -79,12 +91,14 @@ mod tests {
             transition_missed_immediate_tasks: 10,
             transition_queue_full_tasks: 2,
             transition_queue_send_timeout_tasks: 3,
+            transition_compensation_scheduled_tasks: 4,
+            transition_compensation_running_tasks: 1,
             versions_scanned: 1000000,
         };
 
         let metrics = collect_ilm_metrics(&stats);
 
-        assert_eq!(metrics.len(), 7);
+        assert_eq!(metrics.len(), 9);
 
         let pending = metrics.iter().find(|m| m.value == 100.0);
         assert!(pending.is_some());
@@ -98,7 +112,7 @@ mod tests {
         let stats = IlmStats::default();
         let metrics = collect_ilm_metrics(&stats);
 
-        assert_eq!(metrics.len(), 7);
+        assert_eq!(metrics.len(), 9);
         for metric in &metrics {
             assert_eq!(metric.value, 0.0);
             assert!(metric.labels.is_empty());

--- a/crates/obs/src/metrics/collectors/ilm.rs
+++ b/crates/obs/src/metrics/collectors/ilm.rs
@@ -36,6 +36,10 @@ pub struct IlmStats {
     pub transition_pending_tasks: u64,
     /// Number of missed immediate ILM transition tasks
     pub transition_missed_immediate_tasks: u64,
+    /// Number of ILM transition tasks rejected because the queue was full/closed
+    pub transition_queue_full_tasks: u64,
+    /// Number of ILM transition tasks that timed out waiting for queue capacity
+    pub transition_queue_send_timeout_tasks: u64,
     /// Total number of object versions scanned for ILM
     pub versions_scanned: u64,
 }
@@ -53,6 +57,11 @@ pub fn collect_ilm_metrics(stats: &IlmStats) -> Vec<PrometheusMetric> {
             &ILM_TRANSITION_MISSED_IMMEDIATE_TASKS_MD,
             stats.transition_missed_immediate_tasks as f64,
         ),
+        PrometheusMetric::from_descriptor(&ILM_TRANSITION_QUEUE_FULL_TASKS_MD, stats.transition_queue_full_tasks as f64),
+        PrometheusMetric::from_descriptor(
+            &ILM_TRANSITION_QUEUE_SEND_TIMEOUT_TASKS_MD,
+            stats.transition_queue_send_timeout_tasks as f64,
+        ),
         PrometheusMetric::from_descriptor(&ILM_VERSIONS_SCANNED_MD, stats.versions_scanned as f64),
     ]
 }
@@ -68,12 +77,14 @@ mod tests {
             transition_active_tasks: 5,
             transition_pending_tasks: 50,
             transition_missed_immediate_tasks: 10,
+            transition_queue_full_tasks: 2,
+            transition_queue_send_timeout_tasks: 3,
             versions_scanned: 1000000,
         };
 
         let metrics = collect_ilm_metrics(&stats);
 
-        assert_eq!(metrics.len(), 5);
+        assert_eq!(metrics.len(), 7);
 
         let pending = metrics.iter().find(|m| m.value == 100.0);
         assert!(pending.is_some());
@@ -87,7 +98,7 @@ mod tests {
         let stats = IlmStats::default();
         let metrics = collect_ilm_metrics(&stats);
 
-        assert_eq!(metrics.len(), 5);
+        assert_eq!(metrics.len(), 7);
         for metric in &metrics {
             assert_eq!(metric.value, 0.0);
             assert!(metric.labels.is_empty());

--- a/crates/obs/src/metrics/schema/entry/metric_name.rs
+++ b/crates/obs/src/metrics/schema/entry/metric_name.rs
@@ -250,6 +250,8 @@ pub enum MetricName {
     IlmTransitionMissedImmediateTasks,
     IlmTransitionQueueFullTasks,
     IlmTransitionQueueSendTimeoutTasks,
+    IlmTransitionCompensationScheduledTasks,
+    IlmTransitionCompensationRunningTasks,
     IlmVersionsScanned,
 
     // Copy the relevant metrics
@@ -588,6 +590,8 @@ impl MetricName {
             Self::IlmTransitionMissedImmediateTasks => "transition_missed_immediate_tasks".to_string(),
             Self::IlmTransitionQueueFullTasks => "transition_queue_full_tasks".to_string(),
             Self::IlmTransitionQueueSendTimeoutTasks => "transition_queue_send_timeout_tasks".to_string(),
+            Self::IlmTransitionCompensationScheduledTasks => "transition_compensation_scheduled_tasks".to_string(),
+            Self::IlmTransitionCompensationRunningTasks => "transition_compensation_running_tasks".to_string(),
             Self::IlmVersionsScanned => "versions_scanned".to_string(),
 
             // Copy the relevant metrics

--- a/crates/obs/src/metrics/schema/entry/metric_name.rs
+++ b/crates/obs/src/metrics/schema/entry/metric_name.rs
@@ -248,6 +248,8 @@ pub enum MetricName {
     IlmTransitionActiveTasks,
     IlmTransitionPendingTasks,
     IlmTransitionMissedImmediateTasks,
+    IlmTransitionQueueFullTasks,
+    IlmTransitionQueueSendTimeoutTasks,
     IlmVersionsScanned,
 
     // Copy the relevant metrics
@@ -584,6 +586,8 @@ impl MetricName {
             Self::IlmTransitionActiveTasks => "transition_active_tasks".to_string(),
             Self::IlmTransitionPendingTasks => "transition_pending_tasks".to_string(),
             Self::IlmTransitionMissedImmediateTasks => "transition_missed_immediate_tasks".to_string(),
+            Self::IlmTransitionQueueFullTasks => "transition_queue_full_tasks".to_string(),
+            Self::IlmTransitionQueueSendTimeoutTasks => "transition_queue_send_timeout_tasks".to_string(),
             Self::IlmVersionsScanned => "versions_scanned".to_string(),
 
             // Copy the relevant metrics

--- a/crates/obs/src/metrics/schema/ilm.rs
+++ b/crates/obs/src/metrics/schema/ilm.rs
@@ -53,6 +53,24 @@ pub static ILM_TRANSITION_MISSED_IMMEDIATE_TASKS_MD: LazyLock<MetricDescriptor> 
     )
 });
 
+pub static ILM_TRANSITION_QUEUE_FULL_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::IlmTransitionQueueFullTasks,
+        "Number of ILM transition tasks that could not enqueue because the queue was full or closed",
+        &[],
+        subsystems::ILM,
+    )
+});
+
+pub static ILM_TRANSITION_QUEUE_SEND_TIMEOUT_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::IlmTransitionQueueSendTimeoutTasks,
+        "Number of ILM transition tasks that timed out waiting for queue capacity",
+        &[],
+        subsystems::ILM,
+    )
+});
+
 pub static ILM_VERSIONS_SCANNED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::IlmVersionsScanned,

--- a/crates/obs/src/metrics/schema/ilm.rs
+++ b/crates/obs/src/metrics/schema/ilm.rs
@@ -56,7 +56,7 @@ pub static ILM_TRANSITION_MISSED_IMMEDIATE_TASKS_MD: LazyLock<MetricDescriptor> 
 pub static ILM_TRANSITION_QUEUE_FULL_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::IlmTransitionQueueFullTasks,
-        "Number of ILM transition tasks that could not enqueue because the queue was full or closed",
+        "Number of ILM transition tasks that could not enqueue because the transition queue was closed",
         &[],
         subsystems::ILM,
     )

--- a/crates/obs/src/metrics/schema/ilm.rs
+++ b/crates/obs/src/metrics/schema/ilm.rs
@@ -56,7 +56,7 @@ pub static ILM_TRANSITION_MISSED_IMMEDIATE_TASKS_MD: LazyLock<MetricDescriptor> 
 pub static ILM_TRANSITION_QUEUE_FULL_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::IlmTransitionQueueFullTasks,
-        "Number of ILM transition tasks that could not enqueue because the transition queue was closed",
+        "Number of ILM transition tasks that initially hit full transition queue backpressure",
         &[],
         subsystems::ILM,
     )

--- a/crates/obs/src/metrics/schema/ilm.rs
+++ b/crates/obs/src/metrics/schema/ilm.rs
@@ -71,6 +71,24 @@ pub static ILM_TRANSITION_QUEUE_SEND_TIMEOUT_TASKS_MD: LazyLock<MetricDescriptor
     )
 });
 
+pub static ILM_TRANSITION_COMPENSATION_SCHEDULED_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_counter_md(
+        MetricName::IlmTransitionCompensationScheduledTasks,
+        "Number of bucket-level ILM transition compensation tasks scheduled after enqueue failure",
+        &[],
+        subsystems::ILM,
+    )
+});
+
+pub static ILM_TRANSITION_COMPENSATION_RUNNING_TASKS_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::IlmTransitionCompensationRunningTasks,
+        "Number of bucket-level ILM transition compensation tasks currently running",
+        &[],
+        subsystems::ILM,
+    )
+});
+
 pub static ILM_VERSIONS_SCANNED_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::IlmVersionsScanned,

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -840,6 +840,8 @@ pub async fn collect_ilm_metric_stats() -> Option<IlmStats> {
     let transition_active_tasks = GLOBAL_TransitionState.active_tasks().max(0) as u64;
     let transition_pending_tasks = GLOBAL_TransitionState.pending_tasks() as u64;
     let transition_missed_immediate_tasks = GLOBAL_TransitionState.missed_immediate_tasks().max(0) as u64;
+    let transition_queue_full_tasks = GLOBAL_TransitionState.queue_full_tasks().max(0) as u64;
+    let transition_queue_send_timeout_tasks = GLOBAL_TransitionState.queue_send_timeout_tasks().max(0) as u64;
     let metrics = global_metrics().report().await;
     let versions_scanned = metrics.life_time_ilm.values().copied().sum();
 
@@ -848,6 +850,8 @@ pub async fn collect_ilm_metric_stats() -> Option<IlmStats> {
         transition_active_tasks,
         transition_pending_tasks,
         transition_missed_immediate_tasks,
+        transition_queue_full_tasks,
+        transition_queue_send_timeout_tasks,
         versions_scanned,
     })
 }

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -842,6 +842,8 @@ pub async fn collect_ilm_metric_stats() -> Option<IlmStats> {
     let transition_missed_immediate_tasks = GLOBAL_TransitionState.missed_immediate_tasks().max(0) as u64;
     let transition_queue_full_tasks = GLOBAL_TransitionState.queue_full_tasks().max(0) as u64;
     let transition_queue_send_timeout_tasks = GLOBAL_TransitionState.queue_send_timeout_tasks().max(0) as u64;
+    let transition_compensation_scheduled_tasks = GLOBAL_TransitionState.compensation_scheduled_tasks().max(0) as u64;
+    let transition_compensation_running_tasks = GLOBAL_TransitionState.compensation_running_tasks().max(0) as u64;
     let metrics = global_metrics().report().await;
     let versions_scanned = metrics.life_time_ilm.values().copied().sum();
 
@@ -852,6 +854,8 @@ pub async fn collect_ilm_metric_stats() -> Option<IlmStats> {
         transition_missed_immediate_tasks,
         transition_queue_full_tasks,
         transition_queue_send_timeout_tasks,
+        transition_compensation_scheduled_tasks,
+        transition_compensation_running_tasks,
         versions_scanned,
     })
 }

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -1304,6 +1304,49 @@ mod serial_tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial]
     #[ignore = "requires isolated global object layer state"]
+    async fn test_existing_object_backfill_is_idempotent_after_immediate_compensation_transition() {
+        let (_disk_paths, ecstore) = setup_isolated_test_env(false).await;
+
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&tier_name).await;
+
+        let bucket_name = format!("test-backfill-after-compensation-{}", &Uuid::new_v4().simple().to_string()[..8]);
+        let object_name = "test/object.txt";
+        let payload = b"existing-object backfill should be idempotent after compensation transition";
+
+        create_test_bucket(&ecstore, bucket_name.as_str()).await;
+        set_bucket_lifecycle_transition_with_tier(bucket_name.as_str(), &tier_name)
+            .await
+            .expect("Failed to set lifecycle configuration");
+
+        with_forced_immediate_enqueue_timeout(|| async {
+            upload_test_object(&ecstore, bucket_name.as_str(), object_name, payload).await;
+        })
+        .await;
+
+        let transitioned = wait_for_transition(&ecstore, bucket_name.as_str(), object_name, TRANSITION_WAIT_TIMEOUT)
+            .await
+            .expect("object should transition after immediate compensation backfill");
+        let remote_object = transitioned.transitioned_object.name.clone();
+        assert!(backend.objects.lock().await.contains_key(&remote_object));
+
+        enqueue_transition_for_existing_objects(ecstore.clone(), bucket_name.as_str())
+            .await
+            .expect("existing-object backfill should succeed after compensation transition");
+
+        let info = wait_for_transition(&ecstore, bucket_name.as_str(), object_name, TRANSITION_WAIT_TIMEOUT)
+            .await
+            .expect("object should remain transitioned after existing-object backfill rerun");
+
+        assert_eq!(info.transitioned_object.status, "complete");
+        assert_eq!(info.transitioned_object.tier, tier_name);
+        assert_eq!(info.transitioned_object.name, remote_object);
+        assert!(backend.objects.lock().await.contains_key(&remote_object));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[serial]
+    #[ignore = "requires isolated global object layer state"]
     async fn test_scanner_expires_zero_day_current_version() {
         let (disk_paths, ecstore) = setup_isolated_test_env(false).await;
 

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -532,6 +532,22 @@ async fn wait_for_version_count(ecstore: &Arc<ECStore>, bucket: &str, object: &s
     }
 }
 
+async fn wait_for_remote_object_count(backend: &MockWarmBackend, expected: usize, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if backend.objects.lock().await.len() == expected {
+            return true;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
 async fn scan_object_with_lifecycle(disk_path: &Path, bucket: &str, object: &str) {
     let mut endpoint = Endpoint::try_from(disk_path.to_str().unwrap()).unwrap();
     endpoint.set_pool_index(0);
@@ -1425,6 +1441,89 @@ mod serial_tests {
         assert!(
             wait_for_version_count(&ecstore, bucket_name.as_str(), object_name, 1, Duration::from_secs(3)).await,
             "noncurrent expiry should still remove the previous version after compensation transition"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[serial]
+    #[ignore = "requires isolated global object layer state"]
+    async fn test_noncurrent_transition_still_works_after_immediate_compensation_transition() {
+        let (disk_paths, ecstore) = setup_isolated_test_env(true).await;
+
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&tier_name).await;
+
+        let bucket_name = format!("test-noncurrent-transition-comp-{}", &Uuid::new_v4().simple().to_string()[..8]);
+        let object_name = "test/object.txt";
+
+        create_test_lock_bucket(&ecstore, bucket_name.as_str()).await;
+
+        let lifecycle_xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<LifecycleConfiguration>
+    <Rule>
+        <ID>test-rule</ID>
+        <Status>Enabled</Status>
+        <Filter>
+            <Prefix>test/</Prefix>
+        </Filter>
+        <Transition>
+          <Days>0</Days>
+          <StorageClass>{tier_name}</StorageClass>
+        </Transition>
+        <NoncurrentVersionTransition>
+            <NoncurrentDays>0</NoncurrentDays>
+            <StorageClass>{tier_name}</StorageClass>
+        </NoncurrentVersionTransition>
+    </Rule>
+</LifecycleConfiguration>"#
+        );
+        metadata_sys::update(bucket_name.as_str(), BUCKET_LIFECYCLE_CONFIG, lifecycle_xml.into_bytes())
+            .await
+            .expect("Failed to set lifecycle configuration");
+
+        let mut reader = PutObjReader::from_vec(b"v1".to_vec());
+        ecstore
+            .put_object(
+                bucket_name.as_str(),
+                object_name,
+                &mut reader,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("failed to upload v1");
+
+        with_forced_immediate_enqueue_timeout(|| async {
+            let mut reader = PutObjReader::from_vec(b"v2".to_vec());
+            ecstore
+                .put_object(
+                    bucket_name.as_str(),
+                    object_name,
+                    &mut reader,
+                    &ObjectOptions {
+                        versioned: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("failed to upload v2");
+        })
+        .await;
+
+        let info = wait_for_transition(&ecstore, bucket_name.as_str(), object_name, TRANSITION_WAIT_TIMEOUT)
+            .await
+            .expect("current version should transition after compensation backfill");
+        assert_eq!(info.transitioned_object.status, "complete");
+        assert_eq!(info.transitioned_object.tier, tier_name);
+
+        scan_object_with_lifecycle(&disk_paths[0], bucket_name.as_str(), object_name).await;
+
+        assert!(
+            wait_for_remote_object_count(&backend, 2, TRANSITION_WAIT_TIMEOUT).await,
+            "noncurrent transition should still move the previous version into the remote tier"
         );
     }
 

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use futures::FutureExt;
+use rustfs_config::ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT;
 use rustfs_ecstore::{
     bucket::lifecycle::lifecycle::TransitionOptions,
     bucket::metadata::BUCKET_LIFECYCLE_CONFIG,
@@ -61,7 +62,6 @@ use uuid::Uuid;
 static GLOBAL_ENV: OnceLock<(Vec<PathBuf>, Arc<ECStore>)> = OnceLock::new();
 static INIT: Once = Once::new();
 const TRANSITION_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
-const FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV: &str = "RUSTFS_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT";
 
 fn init_tracing() {
     INIT.call_once(|| {
@@ -813,17 +813,17 @@ where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
-    let original = env::var_os(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+    let original = env::var_os(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT);
     unsafe {
-        env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, "1");
+        env::set_var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT, "1");
     }
     let result = std::panic::AssertUnwindSafe(test_fn()).catch_unwind().await;
     match original {
         Some(value) => unsafe {
-            env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, value);
+            env::set_var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT, value);
         },
         None => unsafe {
-            env::remove_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+            env::remove_var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT);
         },
     }
     if let Err(err) = result {

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use futures::FutureExt;
 use rustfs_ecstore::{
     bucket::lifecycle::lifecycle::TransitionOptions,
     bucket::metadata::BUCKET_LIFECYCLE_CONFIG,
@@ -41,6 +42,7 @@ use s3s::dto::RestoreRequest;
 use serial_test::serial;
 use std::{
     collections::HashMap,
+    env,
     io::Cursor,
     path::{Path, PathBuf},
     sync::{Arc, Once, OnceLock},
@@ -56,6 +58,7 @@ use uuid::Uuid;
 static GLOBAL_ENV: OnceLock<(Vec<PathBuf>, Arc<ECStore>)> = OnceLock::new();
 static INIT: Once = Once::new();
 const TRANSITION_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+const FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV: &str = "RUSTFS_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT";
 
 fn init_tracing() {
     INIT.call_once(|| {
@@ -754,6 +757,30 @@ async fn wait_for_transition(
     }
 }
 
+#[allow(unsafe_code)]
+async fn with_forced_immediate_enqueue_timeout<F, Fut>(test_fn: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let original = env::var_os(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+    unsafe {
+        env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, "1");
+    }
+    let result = std::panic::AssertUnwindSafe(test_fn()).catch_unwind().await;
+    match original {
+        Some(value) => unsafe {
+            env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, value);
+        },
+        None => unsafe {
+            env::remove_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+        },
+    }
+    if let Err(err) = result {
+        std::panic::resume_unwind(err);
+    }
+}
+
 mod serial_tests {
     use super::*;
 
@@ -1214,6 +1241,63 @@ mod serial_tests {
         assert!(
             wait_for_object_absence(&ecstore, bucket_name.as_str(), object_name, Duration::from_secs(1)).await,
             "deleted object should remain absent after scanner cleanup"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[serial]
+    #[ignore = "requires isolated global object layer state"]
+    async fn test_scanner_cleanup_still_works_after_immediate_compensation_transition() {
+        let (disk_paths, ecstore) = setup_isolated_test_env(false).await;
+
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&tier_name).await;
+
+        let bucket_name = format!("test-scanner-after-compensation-{}", &Uuid::new_v4().simple().to_string()[..8]);
+        let object_name = "test/object.txt";
+        let payload = b"scanner cleanup should still work after immediate compensation";
+
+        create_test_bucket(&ecstore, bucket_name.as_str()).await;
+        set_bucket_lifecycle_transition_with_tier(bucket_name.as_str(), &tier_name)
+            .await
+            .expect("Failed to set lifecycle configuration");
+
+        with_forced_immediate_enqueue_timeout(|| async {
+            upload_test_object(&ecstore, bucket_name.as_str(), object_name, payload).await;
+        })
+        .await;
+
+        let transitioned = wait_for_transition(&ecstore, bucket_name.as_str(), object_name, TRANSITION_WAIT_TIMEOUT)
+            .await
+            .expect("object should transition after compensation backfill");
+        let stale_remote_object = transitioned.transitioned_object.name.clone();
+        assert!(backend.objects.lock().await.contains_key(&stale_remote_object));
+
+        ecstore
+            .delete_object(bucket_name.as_str(), object_name, ObjectOptions::default())
+            .await
+            .expect("Failed to delete transitioned object after compensation-driven transition");
+
+        assert!(
+            free_version_count(&disk_paths[0], bucket_name.as_str(), object_name).await > 0,
+            "deleting a compensation-transitioned null version should leave a free version for async cleanup"
+        );
+        assert!(
+            backend.objects.lock().await.contains_key(&stale_remote_object),
+            "stale transitioned remote object should still exist before scanner cleanup runs"
+        );
+
+        rustfs_ecstore::bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(ecstore.clone()).await;
+        scan_object_metadata(&disk_paths[0], bucket_name.as_str(), object_name).await;
+
+        assert!(
+            wait_for_remote_absence(&backend, &stale_remote_object, TRANSITION_WAIT_TIMEOUT).await,
+            "scanner should clean stale remote object even after immediate compensation transitioned it"
+        );
+        assert_eq!(
+            free_version_count(&disk_paths[0], bucket_name.as_str(), object_name).await,
+            0,
+            "free-version metadata should be removed after scanner cleanup"
         );
     }
 

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -16,7 +16,10 @@ use futures::FutureExt;
 use rustfs_ecstore::{
     bucket::lifecycle::lifecycle::TransitionOptions,
     bucket::metadata::BUCKET_LIFECYCLE_CONFIG,
-    bucket::{lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects, metadata_sys},
+    bucket::{
+        lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects, metadata_sys,
+        versioning_sys::BucketVersioningSys,
+    },
     client::transition_api::{ReadCloser, ReaderImpl},
     disk::endpoint::Endpoint,
     disk::{DiskAPI, DiskOption, STORAGE_FORMAT_FILE, new_disk},
@@ -246,6 +249,14 @@ async fn upload_test_object(ecstore: &Arc<ECStore>, bucket: &str, object: &str, 
         .expect("Failed to upload test object");
 
     info!("Uploaded test object: {}/{} ({} bytes)", bucket, object, object_info.size);
+}
+
+async fn versioned_delete_opts(bucket: &str, object: &str) -> ObjectOptions {
+    ObjectOptions {
+        versioned: BucketVersioningSys::prefix_enabled(bucket, object).await,
+        version_suspended: BucketVersioningSys::prefix_suspended(bucket, object).await,
+        ..Default::default()
+    }
 }
 
 /// Test helper: Set bucket lifecycle configuration
@@ -1524,6 +1535,54 @@ mod serial_tests {
         assert!(
             wait_for_remote_object_count(&backend, 2, TRANSITION_WAIT_TIMEOUT).await,
             "noncurrent transition should still move the previous version into the remote tier"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[serial]
+    #[ignore = "requires isolated global object layer state"]
+    async fn test_modeled_versioned_delete_creates_delete_marker_after_immediate_compensation_transition() {
+        let (_disk_paths, ecstore) = setup_isolated_test_env(true).await;
+
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&tier_name).await;
+
+        let bucket_name = format!("test-modeled-versioned-delete-{}", &Uuid::new_v4().simple().to_string()[..8]);
+        let object_name = "test/object.txt";
+        let payload = b"modeled versioned delete should create delete marker after compensation";
+
+        create_test_lock_bucket(&ecstore, bucket_name.as_str()).await;
+        set_bucket_lifecycle_transition_with_tier(bucket_name.as_str(), &tier_name)
+            .await
+            .expect("Failed to set transition lifecycle configuration");
+
+        with_forced_immediate_enqueue_timeout(|| async {
+            upload_test_object(&ecstore, bucket_name.as_str(), object_name, payload).await;
+        })
+        .await;
+
+        let transitioned = wait_for_transition(&ecstore, bucket_name.as_str(), object_name, TRANSITION_WAIT_TIMEOUT)
+            .await
+            .expect("current version should transition after compensation backfill");
+        let remote_object = transitioned.transitioned_object.name.clone();
+        assert!(backend.objects.lock().await.contains_key(&remote_object));
+
+        ecstore
+            .delete_object(
+                bucket_name.as_str(),
+                object_name,
+                versioned_delete_opts(bucket_name.as_str(), object_name).await,
+            )
+            .await
+            .expect("modeled versioned delete should succeed");
+
+        assert!(
+            object_is_delete_marker(&ecstore, bucket_name.as_str(), object_name).await,
+            "versioned delete modeled with versioned flags should create a delete marker"
+        );
+        assert!(
+            backend.objects.lock().await.contains_key(&remote_object),
+            "creating a delete marker should not remove the transitioned remote object version"
         );
     }
 

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -251,7 +251,7 @@ async fn upload_test_object(ecstore: &Arc<ECStore>, bucket: &str, object: &str, 
     info!("Uploaded test object: {}/{} ({} bytes)", bucket, object, object_info.size);
 }
 
-async fn versioned_delete_opts(bucket: &str, object: &str) -> ObjectOptions {
+async fn modeled_versioned_delete_opts(bucket: &str, object: &str) -> ObjectOptions {
     ObjectOptions {
         versioned: BucketVersioningSys::prefix_enabled(bucket, object).await,
         version_suspended: BucketVersioningSys::prefix_suspended(bucket, object).await,
@@ -1571,7 +1571,7 @@ mod serial_tests {
             .delete_object(
                 bucket_name.as_str(),
                 object_name,
-                versioned_delete_opts(bucket_name.as_str(), object_name).await,
+                modeled_versioned_delete_opts(bucket_name.as_str(), object_name).await,
             )
             .await
             .expect("modeled versioned delete should succeed");

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -285,7 +285,8 @@ async fn set_bucket_lifecycle(bucket_name: &str) -> Result<(), Box<dyn std::erro
 /// Test helper: Set bucket lifecycle configuration
 #[allow(dead_code)]
 async fn set_bucket_lifecycle_deletemarker(bucket_name: &str) -> Result<(), Box<dyn std::error::Error>> {
-    // Create a simple lifecycle configuration XML with 0 days expiry for immediate testing
+    // Create lifecycle rule that targets delete-marker cleanup only.
+    // Keep Expiration.Days unset to avoid expiring live transitioned object versions.
     let lifecycle_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <LifecycleConfiguration>
     <Rule>
@@ -295,13 +296,35 @@ async fn set_bucket_lifecycle_deletemarker(bucket_name: &str) -> Result<(), Box<
             <Prefix>test/</Prefix>
         </Filter>
         <Expiration>
-            <Days>0</Days>
             <ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker>
         </Expiration>
     </Rule>
 </LifecycleConfiguration>"#;
 
     metadata_sys::update(bucket_name, BUCKET_LIFECYCLE_CONFIG, lifecycle_xml.as_bytes().to_vec()).await?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+async fn set_bucket_lifecycle_delmarker_expiration(bucket_name: &str, days: i64) -> Result<(), Box<dyn std::error::Error>> {
+    let lifecycle_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<LifecycleConfiguration>
+    <Rule>
+        <ID>test-rule</ID>
+        <Status>Enabled</Status>
+        <Filter>
+            <Prefix>test/</Prefix>
+        </Filter>
+        <DelMarkerExpiration>
+            <Days>{days}</Days>
+        </DelMarkerExpiration>
+    </Rule>
+</LifecycleConfiguration>"#
+    );
+
+    metadata_sys::update(bucket_name, BUCKET_LIFECYCLE_CONFIG, lifecycle_xml.into_bytes()).await?;
 
     Ok(())
 }
@@ -1583,6 +1606,83 @@ mod serial_tests {
         assert!(
             backend.objects.lock().await.contains_key(&remote_object),
             "creating a delete marker should not remove the transitioned remote object version"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[serial]
+    #[ignore = "requires isolated global object layer state"]
+    async fn test_modeled_delete_marker_cleanup_after_immediate_compensation_transition() {
+        let (disk_paths, ecstore) = setup_isolated_test_env(true).await;
+
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&tier_name).await;
+
+        let bucket_name = format!("test-modeled-del-marker-cleanup-{}", &Uuid::new_v4().simple().to_string()[..8]);
+        let object_name = "test/object.txt";
+        let payload = b"modeled delete-marker cleanup should converge after compensation transition";
+
+        create_test_lock_bucket(&ecstore, bucket_name.as_str()).await;
+        set_bucket_lifecycle_transition_with_tier(bucket_name.as_str(), &tier_name)
+            .await
+            .expect("Failed to set transition lifecycle configuration");
+
+        with_forced_immediate_enqueue_timeout(|| async {
+            upload_test_object(&ecstore, bucket_name.as_str(), object_name, payload).await;
+        })
+        .await;
+
+        let transitioned = wait_for_transition(&ecstore, bucket_name.as_str(), object_name, TRANSITION_WAIT_TIMEOUT)
+            .await
+            .expect("current version should transition after compensation backfill");
+        let remote_object = transitioned.transitioned_object.name.clone();
+        assert!(backend.objects.lock().await.contains_key(&remote_object));
+
+        ecstore
+            .delete_object(
+                bucket_name.as_str(),
+                object_name,
+                modeled_versioned_delete_opts(bucket_name.as_str(), object_name).await,
+            )
+            .await
+            .expect("modeled versioned delete should succeed");
+
+        assert!(
+            object_is_delete_marker(&ecstore, bucket_name.as_str(), object_name).await,
+            "modeled versioned delete should create delete marker before cleanup"
+        );
+        assert!(
+            backend.objects.lock().await.contains_key(&remote_object),
+            "delete marker creation should not remove transitioned remote object"
+        );
+
+        set_bucket_lifecycle_delmarker_expiration(bucket_name.as_str(), 1)
+            .await
+            .expect("Failed to set delete marker expiration lifecycle configuration");
+
+        scan_object_with_lifecycle(&disk_paths[0], bucket_name.as_str(), object_name).await;
+
+        assert!(
+            object_is_delete_marker(&ecstore, bucket_name.as_str(), object_name).await,
+            "delete marker should remain before DelMarkerExpiration due time"
+        );
+        assert!(
+            backend.objects.lock().await.contains_key(&remote_object),
+            "pre-due delete marker lifecycle scan should not remove transitioned remote object"
+        );
+
+        set_bucket_lifecycle_deletemarker(bucket_name.as_str())
+            .await
+            .expect("Failed to set expired object delete marker lifecycle configuration");
+        scan_object_with_lifecycle(&disk_paths[0], bucket_name.as_str(), object_name).await;
+
+        assert!(
+            wait_for_object_absence(&ecstore, bucket_name.as_str(), object_name, Duration::from_secs(5)).await,
+            "expired object delete marker lifecycle should eventually clean up the delete marker"
+        );
+        assert!(
+            backend.objects.lock().await.contains_key(&remote_object),
+            "delete marker lifecycle cleanup should not remove transitioned remote object"
         );
     }
 

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -1347,6 +1347,90 @@ mod serial_tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial]
     #[ignore = "requires isolated global object layer state"]
+    async fn test_noncurrent_expiry_still_works_after_immediate_compensation_transition() {
+        let (disk_paths, ecstore) = setup_isolated_test_env(true).await;
+
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&tier_name).await;
+
+        let bucket_name = format!("test-versioned-compensation-{}", &Uuid::new_v4().simple().to_string()[..8]);
+        let object_name = "test/object.txt";
+
+        create_test_lock_bucket(&ecstore, bucket_name.as_str()).await;
+
+        let lifecycle_xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<LifecycleConfiguration>
+    <Rule>
+        <ID>test-rule</ID>
+        <Status>Enabled</Status>
+        <Filter>
+            <Prefix>test/</Prefix>
+        </Filter>
+        <Transition>
+          <Days>0</Days>
+          <StorageClass>{tier_name}</StorageClass>
+        </Transition>
+        <NoncurrentVersionExpiration>
+            <NoncurrentDays>0</NoncurrentDays>
+        </NoncurrentVersionExpiration>
+    </Rule>
+</LifecycleConfiguration>"#
+        );
+        metadata_sys::update(bucket_name.as_str(), BUCKET_LIFECYCLE_CONFIG, lifecycle_xml.into_bytes())
+            .await
+            .expect("Failed to set lifecycle configuration");
+
+        let mut reader = PutObjReader::from_vec(b"v1".to_vec());
+        ecstore
+            .put_object(
+                bucket_name.as_str(),
+                object_name,
+                &mut reader,
+                &ObjectOptions {
+                    versioned: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("failed to upload v1");
+
+        with_forced_immediate_enqueue_timeout(|| async {
+            let mut reader = PutObjReader::from_vec(b"v2".to_vec());
+            ecstore
+                .put_object(
+                    bucket_name.as_str(),
+                    object_name,
+                    &mut reader,
+                    &ObjectOptions {
+                        versioned: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("failed to upload v2");
+        })
+        .await;
+
+        let info = wait_for_transition(&ecstore, bucket_name.as_str(), object_name, TRANSITION_WAIT_TIMEOUT)
+            .await
+            .expect("current version should transition after compensation backfill");
+
+        assert_eq!(info.transitioned_object.status, "complete");
+        assert_eq!(info.transitioned_object.tier, tier_name);
+        assert!(backend.objects.lock().await.contains_key(&info.transitioned_object.name));
+
+        scan_object_with_lifecycle(&disk_paths[0], bucket_name.as_str(), object_name).await;
+
+        assert!(
+            wait_for_version_count(&ecstore, bucket_name.as_str(), object_name, 1, Duration::from_secs(3)).await,
+            "noncurrent expiry should still remove the previous version after compensation transition"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[serial]
+    #[ignore = "requires isolated global object layer state"]
     async fn test_scanner_expires_zero_day_current_version() {
         let (disk_paths, ecstore) = setup_isolated_test_env(false).await;
 

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -917,6 +917,83 @@ async fn compensation_driven_versioned_delete_still_creates_delete_marker() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[serial]
 #[ignore = "requires isolated global object layer state"]
+async fn compensation_driven_delete_marker_still_honors_lifecycle_cleanup() {
+    let (_disk_paths, ecstore) = setup_test_env().await;
+    let usecase = DefaultObjectUsecase::without_context();
+    let bucket_usecase = DefaultBucketUsecase::without_context();
+
+    let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+    let backend = register_mock_tier(&tier_name).await;
+
+    let bucket = format!("test-comp-del-marker-cleanup-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    let object = "test/object.txt";
+    let payload = b"delete marker lifecycle should still clean up after compensation-driven transition";
+
+    create_test_bucket(&ecstore, bucket.as_str()).await;
+    set_bucket_lifecycle_transition_with_tier(bucket.as_str(), &tier_name)
+        .await
+        .expect("Failed to set transition lifecycle configuration");
+
+    with_forced_immediate_enqueue_timeout(|| async {
+        let _ = upload_test_object(&ecstore, bucket.as_str(), object, payload).await;
+    })
+    .await;
+
+    let transitioned = wait_for_transition(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT)
+        .await
+        .expect("object should eventually transition after compensation backfill");
+    let remote_object = transitioned.transitioned_object.name.clone();
+
+    assert!(backend.objects.lock().await.contains_key(&remote_object));
+
+    let req = build_request(
+        DeleteObjectInput::builder()
+            .bucket(bucket.clone())
+            .key(object.to_string())
+            .build()
+            .unwrap(),
+        Method::DELETE,
+    );
+
+    Box::pin(usecase.execute_delete_object(req))
+        .await
+        .expect("Failed to issue versioned delete after compensation-driven transition");
+
+    assert!(
+        wait_for_delete_marker(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT).await,
+        "versioned delete should create a delete marker before lifecycle cleanup"
+    );
+    assert!(
+        backend.objects.lock().await.contains_key(&remote_object),
+        "delete marker creation should keep the transitioned remote object version"
+    );
+
+    let req = build_request(
+        PutBucketLifecycleConfigurationInput::builder()
+            .bucket(bucket.clone())
+            .lifecycle_configuration(Some(expiration_lifecycle_configuration("test/")))
+            .build()
+            .unwrap(),
+        Method::PUT,
+    );
+    bucket_usecase
+        .execute_put_bucket_lifecycle_configuration(req)
+        .await
+        .expect("Failed to update lifecycle configuration for delete marker cleanup");
+
+    assert!(
+        wait_for_delete_marker(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT).await,
+        "delete marker should remain visible after lifecycle update until cleanup completes"
+    );
+    assert!(
+        backend.objects.lock().await.contains_key(&remote_object),
+        "delete marker lifecycle cleanup should not remove the transitioned remote object version"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[ignore = "requires isolated global object layer state"]
 async fn put_bucket_lifecycle_configuration_expires_existing_objects() {
     let (_disk_paths, ecstore) = setup_test_env().await;
     let usecase = DefaultBucketUsecase::without_context();

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -863,6 +863,60 @@ async fn compensation_driven_transition_still_cleans_remote_tier_on_delete() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[serial]
 #[ignore = "requires isolated global object layer state"]
+async fn compensation_driven_versioned_delete_still_creates_delete_marker() {
+    let (_disk_paths, ecstore) = setup_test_env().await;
+    let usecase = DefaultObjectUsecase::without_context();
+
+    let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+    let backend = register_mock_tier(&tier_name).await;
+
+    let bucket = format!("test-comp-versioned-delete-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    let object = "test/object.txt";
+    let payload = b"versioned delete should preserve transitioned remote version behind delete marker";
+
+    create_test_bucket(&ecstore, bucket.as_str()).await;
+    set_bucket_lifecycle_transition_with_tier(bucket.as_str(), &tier_name)
+        .await
+        .expect("Failed to set lifecycle configuration");
+
+    with_forced_immediate_enqueue_timeout(|| async {
+        let _ = upload_test_object(&ecstore, bucket.as_str(), object, payload).await;
+    })
+    .await;
+
+    let transitioned = wait_for_transition(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT)
+        .await
+        .expect("object should eventually transition after compensation backfill");
+    let remote_object = transitioned.transitioned_object.name.clone();
+
+    assert!(backend.objects.lock().await.contains_key(&remote_object));
+
+    let req = build_request(
+        DeleteObjectInput::builder()
+            .bucket(bucket.clone())
+            .key(object.to_string())
+            .build()
+            .unwrap(),
+        Method::DELETE,
+    );
+
+    Box::pin(usecase.execute_delete_object(req))
+        .await
+        .expect("Failed to issue versioned delete after compensation-driven transition");
+
+    assert!(
+        wait_for_delete_marker(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT).await,
+        "versioned delete should create a delete marker after compensation-driven transition"
+    );
+    assert!(
+        backend.objects.lock().await.contains_key(&remote_object),
+        "creating a delete marker should not remove the transitioned remote object version"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[ignore = "requires isolated global object layer state"]
 async fn put_bucket_lifecycle_configuration_expires_existing_objects() {
     let (_disk_paths, ecstore) = setup_test_env().await;
     let usecase = DefaultBucketUsecase::without_context();

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -697,6 +697,62 @@ async fn immediate_transition_timeout_eventually_completes_via_compensation() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[serial]
 #[ignore = "requires isolated global object layer state"]
+async fn compensation_driven_transition_still_cleans_remote_tier_on_delete() {
+    let (_disk_paths, ecstore) = setup_test_env().await;
+    let usecase = DefaultObjectUsecase::without_context();
+
+    let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+    let backend = register_mock_tier(&tier_name).await;
+
+    let bucket = format!("test-compensation-delete-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    let object = "test/object.txt";
+    let payload = b"compensation should still preserve delete cleanup";
+
+    create_test_bucket(&ecstore, bucket.as_str()).await;
+    set_bucket_lifecycle_transition_with_tier(bucket.as_str(), &tier_name)
+        .await
+        .expect("Failed to set lifecycle configuration");
+
+    with_forced_immediate_enqueue_timeout(|| async {
+        let _ = upload_test_object(&ecstore, bucket.as_str(), object, payload).await;
+    })
+    .await;
+
+    let transitioned = wait_for_transition(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT)
+        .await
+        .expect("object should eventually transition after compensation backfill");
+    let remote_object = transitioned.transitioned_object.name.clone();
+
+    assert!(backend.objects.lock().await.contains_key(&remote_object));
+
+    let mut req = build_request(
+        DeleteObjectInput::builder()
+            .bucket(bucket.clone())
+            .key(object.to_string())
+            .build()
+            .unwrap(),
+        Method::DELETE,
+    );
+    insert_header(&mut req.headers, SUFFIX_FORCE_DELETE, "true");
+
+    Box::pin(usecase.execute_delete_object(req))
+        .await
+        .expect("Failed to delete object through usecase after compensation-driven transition");
+
+    assert!(
+        wait_for_object_absence(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT).await,
+        "object should be removed from hot tier after delete usecase"
+    );
+
+    assert!(
+        wait_for_remote_absence(&backend, &remote_object, TRANSITION_WAIT_TIMEOUT).await,
+        "transitioned object should be removed from remote tier after delete usecase"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[ignore = "requires isolated global object layer state"]
 async fn put_bucket_lifecycle_configuration_expires_existing_objects() {
     let (_disk_paths, ecstore) = setup_test_env().await;
     let usecase = DefaultBucketUsecase::without_context();

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 use futures::FutureExt;
 use futures::stream;
 use http::{Extensions, HeaderMap, Method, Uri};
+use rustfs_config::ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT;
 use rustfs_ecstore::{
     bucket::metadata::BUCKET_LIFECYCLE_CONFIG,
     bucket::metadata_sys,
@@ -59,7 +60,6 @@ use uuid::Uuid;
 static GLOBAL_ENV: OnceLock<(Vec<PathBuf>, Arc<ECStore>)> = OnceLock::new();
 static INIT: Once = Once::new();
 const TRANSITION_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
-const FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV: &str = "RUSTFS_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT";
 
 fn init_tracing() {
     INIT.call_once(|| {});
@@ -333,17 +333,17 @@ where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
-    let original = env::var_os(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+    let original = env::var_os(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT);
     unsafe {
-        env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, "1");
+        env::set_var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT, "1");
     }
     let result = std::panic::AssertUnwindSafe(test_fn()).catch_unwind().await;
     match original {
         Some(value) => unsafe {
-            env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, value);
+            env::set_var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT, value);
         },
         None => unsafe {
-            env::remove_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+            env::remove_var(ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT);
         },
     }
     if let Err(err) = result {

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -697,6 +697,116 @@ async fn immediate_transition_timeout_eventually_completes_via_compensation() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[serial]
 #[ignore = "requires isolated global object layer state"]
+async fn compensation_driven_copy_still_completes_transition() {
+    let (_disk_paths, ecstore) = setup_test_env().await;
+    let usecase = DefaultObjectUsecase::without_context();
+
+    let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+    let backend = register_mock_tier(&tier_name).await;
+
+    let src_bucket = format!("test-comp-copy-src-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    let dst_bucket = format!("test-comp-copy-dst-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    let src_object = "test/source.txt";
+    let dst_object = "test/copied.txt";
+    let payload = b"copy object should still transition after compensation";
+
+    create_test_bucket(&ecstore, src_bucket.as_str()).await;
+    create_test_bucket(&ecstore, dst_bucket.as_str()).await;
+    set_bucket_lifecycle_transition_with_tier(dst_bucket.as_str(), &tier_name)
+        .await
+        .expect("Failed to set destination lifecycle configuration");
+    let _ = upload_test_object(&ecstore, src_bucket.as_str(), src_object, payload).await;
+
+    let copy_input = CopyObjectInput::builder()
+        .copy_source(CopySource::Bucket {
+            bucket: src_bucket.clone().into(),
+            key: src_object.to_string().into(),
+            version_id: None,
+        })
+        .bucket(dst_bucket.clone())
+        .key(dst_object.to_string())
+        .build()
+        .unwrap();
+
+    with_forced_immediate_enqueue_timeout(|| async {
+        Box::pin(usecase.execute_copy_object(build_request(copy_input, Method::PUT)))
+            .await
+            .expect("Failed to copy object through usecase");
+    })
+    .await;
+
+    let info = wait_for_transition(&ecstore, dst_bucket.as_str(), dst_object, TRANSITION_WAIT_TIMEOUT)
+        .await
+        .expect("copied object should eventually transition after compensation backfill");
+
+    assert_eq!(info.transitioned_object.status, "complete");
+    assert_eq!(info.transitioned_object.tier, tier_name);
+    assert!(backend.objects.lock().await.contains_key(&info.transitioned_object.name));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[ignore = "requires isolated global object layer state"]
+async fn compensation_driven_complete_multipart_upload_still_transitions() {
+    let (_disk_paths, ecstore) = setup_test_env().await;
+    let usecase = DefaultMultipartUsecase::without_context();
+
+    let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+    let backend = register_mock_tier(&tier_name).await;
+
+    let bucket = format!("test-comp-mpu-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    let object = "test/multipart.txt";
+    let payload = b"multipart should still transition after compensation";
+
+    create_test_bucket(&ecstore, bucket.as_str()).await;
+    set_bucket_lifecycle_transition_with_tier(bucket.as_str(), &tier_name)
+        .await
+        .expect("Failed to set lifecycle configuration");
+
+    let upload = ecstore
+        .new_multipart_upload(bucket.as_str(), object, &ObjectOptions::default())
+        .await
+        .expect("Failed to create multipart upload");
+
+    let mut reader = PutObjReader::from_vec(payload.to_vec());
+    let uploaded_part = ecstore
+        .put_object_part(bucket.as_str(), object, &upload.upload_id, 1, &mut reader, &ObjectOptions::default())
+        .await
+        .expect("Failed to upload multipart part");
+
+    let complete_input = CompleteMultipartUploadInput::builder()
+        .bucket(bucket.clone())
+        .key(object.to_string())
+        .upload_id(upload.upload_id.clone())
+        .multipart_upload(Some(CompletedMultipartUpload {
+            parts: Some(vec![CompletedPart {
+                part_number: Some(1),
+                e_tag: uploaded_part.etag.clone().map(|etag| to_s3s_etag(&etag)),
+                ..Default::default()
+            }]),
+        }))
+        .build()
+        .unwrap();
+
+    with_forced_immediate_enqueue_timeout(|| async {
+        Box::pin(usecase.execute_complete_multipart_upload(build_request(complete_input, Method::POST)))
+            .await
+            .expect("Failed to complete multipart upload through usecase");
+    })
+    .await;
+
+    let info = wait_for_transition(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT)
+        .await
+        .expect("multipart object should eventually transition after compensation backfill");
+
+    assert_eq!(info.transitioned_object.status, "complete");
+    assert_eq!(info.transitioned_object.tier, tier_name);
+    assert!(backend.objects.lock().await.contains_key(&info.transitioned_object.name));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[ignore = "requires isolated global object layer state"]
 async fn compensation_driven_transition_still_cleans_remote_tier_on_delete() {
     let (_disk_paths, ecstore) = setup_test_env().await;
     let usecase = DefaultObjectUsecase::without_context();

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -16,6 +16,7 @@ use super::{multipart_usecase::DefaultMultipartUsecase, object_usecase::DefaultO
 use crate::app::bucket_usecase::DefaultBucketUsecase;
 use crate::storage::ecfs::FS;
 use bytes::Bytes;
+use futures::FutureExt;
 use futures::stream;
 use http::{Extensions, HeaderMap, Method, Uri};
 use rustfs_ecstore::{
@@ -43,7 +44,7 @@ use serial_test::serial;
 use std::{
     collections::HashMap,
     convert::Infallible,
-    fs as stdfs,
+    env, fs as stdfs,
     io::Cursor,
     path::PathBuf,
     sync::{Arc, Once, OnceLock},
@@ -58,6 +59,7 @@ use uuid::Uuid;
 static GLOBAL_ENV: OnceLock<(Vec<PathBuf>, Arc<ECStore>)> = OnceLock::new();
 static INIT: Once = Once::new();
 const TRANSITION_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+const FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV: &str = "RUSTFS_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT";
 
 fn init_tracing() {
     INIT.call_once(|| {});
@@ -322,6 +324,30 @@ async fn wait_for_transition(
         }
 
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[allow(unsafe_code)]
+async fn with_forced_immediate_enqueue_timeout<F, Fut>(test_fn: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let original = env::var_os(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+    unsafe {
+        env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, "1");
+    }
+    let result = std::panic::AssertUnwindSafe(test_fn()).catch_unwind().await;
+    match original {
+        Some(value) => unsafe {
+            env::set_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV, value);
+        },
+        None => unsafe {
+            env::remove_var(FORCE_IMMEDIATE_ENQUEUE_TIMEOUT_ENV);
+        },
+    }
+    if let Err(err) = result {
+        std::panic::resume_unwind(err);
     }
 }
 
@@ -635,6 +661,37 @@ async fn lifecycle_transition_marks_dirty_disks_for_capacity_manager() {
         .map(|path| stdfs::canonicalize(path).unwrap().to_string_lossy().into_owned())
         .collect();
     assert_eq!(actual_paths, expected_paths);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[ignore = "requires isolated global object layer state"]
+async fn immediate_transition_timeout_eventually_completes_via_compensation() {
+    let (_disk_paths, ecstore) = setup_test_env().await;
+    let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+    let backend = register_mock_tier(&tier_name).await;
+
+    let bucket = format!("test-compensation-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    let object = "test/object.txt";
+    let payload = b"transition compensation should eventually complete";
+
+    create_test_bucket(&ecstore, bucket.as_str()).await;
+    set_bucket_lifecycle_transition_with_tier(bucket.as_str(), &tier_name)
+        .await
+        .expect("Failed to set lifecycle configuration");
+
+    with_forced_immediate_enqueue_timeout(|| async {
+        let _ = upload_test_object(&ecstore, bucket.as_str(), object, payload).await;
+    })
+    .await;
+
+    let info = wait_for_transition(&ecstore, bucket.as_str(), object, TRANSITION_WAIT_TIMEOUT)
+        .await
+        .expect("object should eventually transition after compensation backfill");
+
+    assert_eq!(info.transitioned_object.status, "complete");
+    assert_eq!(info.transitioned_object.tier, tier_name);
+    assert!(backend.objects.lock().await.contains_key(&info.transitioned_object.name));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This PR hardens RustFS lifecycle transition compensation and expands regression coverage around transition, delete, scanner cleanup, and versioned lifecycle interactions.

Behavior and runtime changes:
- honor configured transition worker counts instead of forcing a hardcoded value during initialization
- add transition queue backpressure controls and runtime observability for queue saturation and send timeout paths
- schedule bucket-level transition compensation after immediate enqueue pressure and expose compensation runtime metrics
- log whether compensation was actually scheduled during immediate enqueue degradation

Regression coverage added:
- immediate compensation eventually completes transition
- compensation-driven transition still cleans remote tier state on delete
- compensation-driven copy still completes transition
- compensation-driven complete multipart upload still transitions
- scanner cleanup still works after immediate compensation transition
- existing-object backfill remains idempotent after compensation
- noncurrent expiry still works after compensation transition
- versioned delete still creates a delete marker after compensation
- delete marker lifecycle semantics remain valid after compensation on the usecase path
- noncurrent transition still works after compensation transition
- scanner low-level modeled versioned delete still creates a delete marker after compensation

This PR intentionally does not include the separate scanner/ecstore delete-marker runtime gap cleanup fix; that gap has been isolated into follow-up T09 analysis work.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore resolve_transition_worker_count --lib`
- `cargo test -p rustfs-ecstore transition_state_init_honors_runtime_configured_worker_count --lib`
- `cargo test -p rustfs-ecstore bucket::lifecycle::bucket_lifecycle_ops --lib`
- `cargo test -p rustfs-obs test_collect_ilm_metrics --lib`
- `cargo test -p rustfs immediate_transition_timeout_eventually_completes_via_compensation --lib -- --ignored`
- `cargo test -p rustfs compensation_driven_transition_still_cleans_remote_tier_on_delete --lib -- --ignored`
- `cargo test -p rustfs compensation_driven_copy_still_completes_transition --lib -- --ignored`
- `cargo test -p rustfs compensation_driven_complete_multipart_upload_still_transitions --lib -- --ignored`
- `cargo test -p rustfs compensation_driven_versioned_delete_still_creates_delete_marker --lib -- --ignored`
- `cargo test -p rustfs-scanner test_scanner_cleanup_still_works_after_immediate_compensation_transition --test lifecycle_integration_test -- --ignored`
- `cargo test -p rustfs-scanner test_existing_object_backfill_is_idempotent_after_immediate_compensation_transition --test lifecycle_integration_test -- --ignored`
- `cargo test -p rustfs-scanner test_noncurrent_expiry_still_works_after_immediate_compensation_transition --test lifecycle_integration_test -- --ignored`
- `cargo test -p rustfs-scanner test_noncurrent_transition_still_works_after_immediate_compensation_transition --test lifecycle_integration_test -- --ignored`
- `cargo test -p rustfs-scanner test_modeled_versioned_delete_creates_delete_marker_after_immediate_compensation_transition --test lifecycle_integration_test -- --ignored`

## Impact
- Improves lifecycle transition resilience under immediate enqueue pressure.
- Adds new ILM metrics for queue pressure and compensation visibility.
- Expands ignored regression coverage for transition compensation and versioned lifecycle scenarios.
- No intended external API contract changes.

## Additional Notes
Follow-up T09 analysis documents the remaining delete-marker cleanup runtime gap between usecase-modeled deletes and scanner/ecstore low-level delete modeling.
