### PR TITLE
fix(ecstore): stop listing after reaching result limit

### DIFF
--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -587,13 +587,16 @@ impl ECStore {
         let store = self.clone();
         let opts = o.clone();
         let cancel_rx1 = cancel.clone();
+        let cancel_rx1_for_err = cancel_rx1.clone();
         let err_tx1 = err_tx.clone();
         let job1 = tokio::spawn(async move {
             let mut opts = opts;
             opts.stop_disk_at_limit = true;
             if let Err(err) = store.list_merged(cancel_rx1, opts, sender).await {
-                error!("list_merged err {:?}", err);
-                let _ = err_tx1.send(Arc::new(err));
+                if !cancel_rx1_for_err.is_cancelled() {
+                    error!("list_merged err {:?}", err);
+                    let _ = err_tx1.send(Arc::new(err));
+                }
             }
         });
 

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1348,10 +1348,10 @@ impl SetDisks {
                         let value = tx1.clone();
                         let cancel_token = cancel_for_send1.clone();
                         async move {
-                            if let Err(err) = value.send(entry).await {
-                                if !cancel_token.is_cancelled() {
-                                    error!("list_path send fail {:?}", err);
-                                }
+                            if let Err(err) = value.send(entry).await
+                                && !cancel_token.is_cancelled()
+                            {
+                                error!("list_path send fail {:?}", err);
                             }
                         }
                     })
@@ -1364,10 +1364,9 @@ impl SetDisks {
                         async move {
                             if let Some(entry) = entries.resolve(resolver)
                                 && let Err(err) = value.send(entry).await
+                                && !cancel_token.is_cancelled()
                             {
-                                if !cancel_token.is_cancelled() {
-                                    error!("list_path send fail {:?}", err);
-                                }
+                                error!("list_path send fail {:?}", err);
                             }
                         }
                     })

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1014,7 +1014,7 @@ impl ECStore {
 }
 
 async fn gather_results(
-    _rx: CancellationToken,
+    rx: CancellationToken,
     opts: ListPathOptions,
     recv: Receiver<MetaCacheEntry>,
     results_tx: Sender<MetaCacheEntriesSortedResult>,
@@ -1060,7 +1060,11 @@ async fn gather_results(
 
         // TODO: Lifecycle
 
+        entries.push(Some(entry));
+
         if opts.limit > 0 && entries.len() >= opts.limit as usize {
+            rx.cancel();
+
             results_tx
                 .send(MetaCacheEntriesSortedResult {
                     entries: Some(MetaCacheEntriesSorted {
@@ -1073,9 +1077,6 @@ async fn gather_results(
                 .map_err(Error::other)?;
             return Ok(());
         }
-
-        entries.push(Some(entry));
-        // entries.push(entry);
     }
 
     // finish not full, return eof
@@ -1475,7 +1476,7 @@ mod test {
             .expect("limited result should be present");
         assert_eq!(result.entries.unwrap().entries().len(), 1);
 
-        timeout(Duration::from_millis(50), handle)
+        timeout(Duration::from_secs(1), handle)
             .await
             .expect("gather_results should finish after sending a limited result")
             .expect("gather_results task should not panic")

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1064,6 +1064,7 @@ async fn gather_results(
 
         if opts.limit > 0 && entries.len() >= opts.limit as usize {
             rx.cancel();
+
             results_tx
                 .send(MetaCacheEntriesSortedResult {
                     entries: Some(MetaCacheEntriesSorted {
@@ -1075,7 +1076,6 @@ async fn gather_results(
                 .await
                 .map_err(Error::other)?;
             return Ok(());
-        // entries.push(entry);
         }
     }
 
@@ -1328,6 +1328,8 @@ impl SetDisks {
 
         let tx1 = sender.clone();
         let tx2 = sender.clone();
+        let cancel_for_send1 = rx.clone();
+        let cancel_for_send2 = rx.clone();
 
         list_path_raw(
             rx,
@@ -1344,9 +1346,12 @@ impl SetDisks {
                 agreed: Some(Box::new(move |entry: MetaCacheEntry| {
                     Box::pin({
                         let value = tx1.clone();
+                        let cancel_token = cancel_for_send1.clone();
                         async move {
                             if let Err(err) = value.send(entry).await {
-                                error!("list_path send fail {:?}", err);
+                                if !cancel_token.is_cancelled() {
+                                    error!("list_path send fail {:?}", err);
+                                }
                             }
                         }
                     })
@@ -1355,11 +1360,14 @@ impl SetDisks {
                     Box::pin({
                         let value = tx2.clone();
                         let resolver = resolver.clone();
+                        let cancel_token = cancel_for_send2.clone();
                         async move {
                             if let Some(entry) = entries.resolve(resolver)
                                 && let Err(err) = value.send(entry).await
                             {
-                                error!("list_path send fail {:?}", err);
+                                if !cancel_token.is_cancelled() {
+                                    error!("list_path send fail {:?}", err);
+                                }
                             }
                         }
                     })
@@ -1456,7 +1464,6 @@ mod test {
         let (result_tx, mut result_rx) = mpsc::channel(1);
 
         entry_tx.send(test_meta_entry("obj-a")).await.unwrap();
-        entry_tx.send(test_meta_entry("obj-b")).await.unwrap();
 
         let handle = tokio::spawn(gather_results(
             CancellationToken::new(),

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1064,7 +1064,6 @@ async fn gather_results(
 
         if opts.limit > 0 && entries.len() >= opts.limit as usize {
             rx.cancel();
-
             results_tx
                 .send(MetaCacheEntriesSortedResult {
                     entries: Some(MetaCacheEntriesSorted {
@@ -1076,6 +1075,7 @@ async fn gather_results(
                 .await
                 .map_err(Error::other)?;
             return Ok(());
+        // entries.push(entry);
         }
     }
 

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -1016,10 +1016,6 @@ async fn gather_results(
     recv: Receiver<MetaCacheEntry>,
     results_tx: Sender<MetaCacheEntriesSortedResult>,
 ) -> Result<()> {
-    let mut returned = false;
-
-    let mut sender = Some(results_tx);
-
     let mut recv = recv;
     let mut entries = Vec::new();
     while let Some(mut entry) = recv.recv().await {
@@ -1027,10 +1023,6 @@ async fn gather_results(
         {
             // normalize windows path separator
             entry.name = entry.name.replace("\\", "/");
-        }
-
-        if returned {
-            continue;
         }
 
         // TODO: rx.recv()
@@ -1066,8 +1058,8 @@ async fn gather_results(
         // TODO: Lifecycle
 
         if opts.limit > 0 && entries.len() >= opts.limit as usize {
-            if let Some(tx) = sender {
-                tx.send(MetaCacheEntriesSortedResult {
+            results_tx
+                .send(MetaCacheEntriesSortedResult {
                     entries: Some(MetaCacheEntriesSorted {
                         o: MetaCacheEntries(entries.clone()),
                         ..Default::default()
@@ -1076,11 +1068,7 @@ async fn gather_results(
                 })
                 .await
                 .map_err(Error::other)?;
-
-                returned = true;
-                sender = None;
-            }
-            continue;
+            return Ok(());
         }
 
         entries.push(Some(entry));
@@ -1088,8 +1076,8 @@ async fn gather_results(
     }
 
     // finish not full, return eof
-    if let Some(tx) = sender {
-        tx.send(MetaCacheEntriesSortedResult {
+    results_tx
+        .send(MetaCacheEntriesSortedResult {
             entries: Some(MetaCacheEntriesSorted {
                 o: MetaCacheEntries(entries.clone()),
                 ..Default::default()
@@ -1098,7 +1086,6 @@ async fn gather_results(
         })
         .await
         .map_err(Error::other)?;
-    }
 
     Ok(())
 }
@@ -1443,9 +1430,54 @@ fn calc_common_counter(infos: &[DiskInfo], read_quorum: usize) -> u64 {
 
 #[cfg(test)]
 mod test {
-    use super::{ListPathOptions, MAX_OBJECT_LIST, max_keys_plus_one, walk_result_from_set_errors};
+    use super::{ListPathOptions, MAX_OBJECT_LIST, gather_results, max_keys_plus_one, walk_result_from_set_errors};
     use crate::error::StorageError;
+    use rustfs_filemeta::MetaCacheEntry;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+    use tokio::time::timeout;
+    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
+
+    fn test_meta_entry(name: &str) -> MetaCacheEntry {
+        MetaCacheEntry {
+            name: name.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn gather_results_returns_after_limit_without_waiting_for_input_close() {
+        let (entry_tx, entry_rx) = mpsc::channel(4);
+        let (result_tx, mut result_rx) = mpsc::channel(1);
+
+        entry_tx.send(test_meta_entry("obj-a")).await.unwrap();
+        entry_tx.send(test_meta_entry("obj-b")).await.unwrap();
+
+        let handle = tokio::spawn(gather_results(
+            CancellationToken::new(),
+            ListPathOptions {
+                bucket: "bucket".to_owned(),
+                limit: 1,
+                incl_deleted: true,
+                ..Default::default()
+            },
+            entry_rx,
+            result_tx,
+        ));
+
+        let result = timeout(Duration::from_secs(1), result_rx.recv())
+            .await
+            .expect("limited result should be sent promptly")
+            .expect("limited result should be present");
+        assert_eq!(result.entries.unwrap().entries().len(), 1);
+
+        timeout(Duration::from_millis(50), handle)
+            .await
+            .expect("gather_results should finish after sending a limited result")
+            .expect("gather_results task should not panic")
+            .expect("gather_results should succeed");
+    }
 
     #[test]
     fn test_max_keys_plus_one_caps_before_lookahead() {

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -592,11 +592,11 @@ impl ECStore {
         let job1 = tokio::spawn(async move {
             let mut opts = opts;
             opts.stop_disk_at_limit = true;
-            if let Err(err) = store.list_merged(cancel_rx1, opts, sender).await {
-                if !cancel_rx1_for_err.is_cancelled() {
-                    error!("list_merged err {:?}", err);
-                    let _ = err_tx1.send(Arc::new(err));
-                }
+            if let Err(err) = store.list_merged(cancel_rx1, opts, sender).await
+                && !cancel_rx1_for_err.is_cancelled()
+            {
+                error!("list_merged err {:?}", err);
+                let _ = err_tx1.send(Arc::new(err));
             }
         });
 


### PR DESCRIPTION
## Related Issues
Fixes #2999.

## Summary of Changes
- Stop `gather_results` immediately after it sends a result that satisfies the requested listing limit.
- Avoid waiting for the upstream walk/listing channel to close after the caller already has enough entries.
- Add a regression test that keeps the input channel open and verifies the limited result path finishes promptly.

## Verification
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all --check`
- `git diff --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-ecstore store_list_objects::test::gather_results_returns_after_limit_without_waiting_for_input_close -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-ecstore store_list_objects::test:: -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" make pre-commit` *(compilation and clippy passed; stopped at the existing unsafe-code allowance check in unrelated files: `rustfs/src/app/lifecycle_transition_api_test.rs`, `crates/scanner/tests/lifecycle_integration_test.rs`, and `crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs`.)*

## Impact
ListObjects/ListObjectsV2 requests that reach their requested result limit can return promptly instead of continuing to wait for the lower-level walk/listing producer to finish or time out. No configuration, API, or metadata format changes.

## Additional Notes
The change is intentionally narrow: the EOF/not-full result path remains unchanged, and the fix only changes the limited-result path to return after the result is sent.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
