### PR TITLE
fix(ecstore): guard transition worker max

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -2303,7 +2303,7 @@ mod tests {
         assert!(opts.skip_decommissioned);
     }
 
-    // SAFETY: these serial tests restore process environment variables before returning.
+    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
     #[allow(unsafe_code)]
     fn with_transition_worker_env<F>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
     where
@@ -2353,7 +2353,7 @@ mod tests {
         }
     }
 
-    // SAFETY: these serial tests restore process environment variables before returning.
+    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
     #[allow(unsafe_code)]
     async fn with_transition_worker_env_async<F, Fut>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
     where
@@ -2404,7 +2404,7 @@ mod tests {
         }
     }
 
-    // SAFETY: these serial tests restore process environment variables before returning.
+    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
     #[allow(unsafe_code)]
     fn with_transition_queue_env<F>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
     where
@@ -2454,7 +2454,7 @@ mod tests {
         }
     }
 
-    // SAFETY: these serial tests restore process environment variables before returning.
+    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
     #[allow(unsafe_code)]
     async fn with_transition_queue_env_async<F, Fut>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
     where

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -112,9 +112,18 @@ fn resolve_transition_worker_count() -> (i64, i64, i64) {
         .filter(|value| *value > 0)
         .unwrap_or(fallback);
     let mut effective = configured;
-    let absolute_max = get_env_i64(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+    let absolute_max = resolve_transition_workers_absolute_max();
     effective = std::cmp::min(effective, absolute_max);
     (configured, absolute_max, effective)
+}
+
+fn resolve_transition_workers_absolute_max() -> i64 {
+    let absolute_max = get_env_i64(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+    if absolute_max > 0 {
+        absolute_max
+    } else {
+        DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX
+    }
 }
 
 fn resolve_transition_queue_capacity() -> usize {
@@ -942,7 +951,7 @@ impl TransitionState {
             n = effective;
         }
         // Allow environment override of maximum workers
-        let absolute_max = get_env_i64(ENV_TRANSITION_WORKERS_ABSOLUTE_MAX, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+        let absolute_max = resolve_transition_workers_absolute_max();
         n = std::cmp::min(n, absolute_max);
 
         let previous_num_workers = GLOBAL_TransitionState.num_workers.load(Ordering::SeqCst);
@@ -2294,6 +2303,7 @@ mod tests {
         assert!(opts.skip_decommissioned);
     }
 
+    // SAFETY: these serial tests restore process environment variables before returning.
     #[allow(unsafe_code)]
     fn with_transition_worker_env<F>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
     where
@@ -2343,6 +2353,7 @@ mod tests {
         }
     }
 
+    // SAFETY: these serial tests restore process environment variables before returning.
     #[allow(unsafe_code)]
     async fn with_transition_worker_env_async<F, Fut>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
     where
@@ -2393,6 +2404,7 @@ mod tests {
         }
     }
 
+    // SAFETY: these serial tests restore process environment variables before returning.
     #[allow(unsafe_code)]
     fn with_transition_queue_env<F>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
     where
@@ -2442,6 +2454,7 @@ mod tests {
         }
     }
 
+    // SAFETY: these serial tests restore process environment variables before returning.
     #[allow(unsafe_code)]
     async fn with_transition_queue_env_async<F, Fut>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
     where
@@ -2551,6 +2564,26 @@ mod tests {
             assert_eq!(configured, 64);
             assert_eq!(absolute_max, 16);
             assert_eq!(effective, 16);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_transition_worker_count_ignores_non_positive_absolute_max() {
+        with_transition_worker_env(Some("4"), Some("0"), || {
+            let (configured, absolute_max, effective) = resolve_transition_worker_count();
+
+            assert_eq!(configured, 4);
+            assert_eq!(absolute_max, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+            assert_eq!(effective, 4);
+        });
+
+        with_transition_worker_env(Some("4"), Some("-1"), || {
+            let (configured, absolute_max, effective) = resolve_transition_worker_count();
+
+            assert_eq!(configured, 4);
+            assert_eq!(absolute_max, DEFAULT_TRANSITION_WORKERS_ABSOLUTE_MAX);
+            assert_eq!(effective, 4);
         });
     }
 

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -2303,7 +2303,9 @@ mod tests {
         assert!(opts.skip_decommissioned);
     }
 
-    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
+    // SAFETY: this helper is only used from `#[serial]` tests and those tests run under a
+    // single-thread runtime (`worker_threads = 1`), so no concurrent reader/writer can access
+    // process environment while `env::set_var`/`env::remove_var` is active.
     #[allow(unsafe_code)]
     fn with_transition_worker_env<F>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
     where
@@ -2353,7 +2355,9 @@ mod tests {
         }
     }
 
-    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
+    // SAFETY: this helper is only used from `#[serial]` tests and those tests run under a
+    // single-thread runtime (`worker_threads = 1`), so no concurrent reader/writer can access
+    // process environment while `env::set_var`/`env::remove_var` is active.
     #[allow(unsafe_code)]
     async fn with_transition_worker_env_async<F, Fut>(transition: Option<&str>, absolute: Option<&str>, test_fn: F)
     where
@@ -2404,7 +2408,9 @@ mod tests {
         }
     }
 
-    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
+    // SAFETY: this helper is only used from `#[serial]` tests and those tests run under a
+    // single-thread runtime (`worker_threads = 1`), so no concurrent reader/writer can access
+    // process environment while `env::set_var`/`env::remove_var` is active.
     #[allow(unsafe_code)]
     fn with_transition_queue_env<F>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
     where
@@ -2454,7 +2460,9 @@ mod tests {
         }
     }
 
-    // SAFETY: only `#[serial]` tests call this helper, so env mutations are serialized here.
+    // SAFETY: this helper is only used from `#[serial]` tests and those tests run under a
+    // single-thread runtime (`worker_threads = 1`), so no concurrent reader/writer can access
+    // process environment while `env::set_var`/`env::remove_var` is active.
     #[allow(unsafe_code)]
     async fn with_transition_queue_env_async<F, Fut>(capacity: Option<&str>, timeout_ms: Option<&str>, test_fn: F)
     where

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -807,7 +807,9 @@ async fn wait_for_transition(
     }
 }
 
-// SAFETY: these serial tests restore the process environment variable before returning.
+// SAFETY: this helper is used only by `#[serial]` tests and runs under the single-threaded Tokio
+// runtime (`worker_threads = 1`), so no concurrent test can mutate process environment during the
+// `env::set_var` / `env::remove_var` window.
 #[allow(unsafe_code)]
 async fn with_forced_immediate_enqueue_timeout<F, Fut>(test_fn: F)
 where

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -807,6 +807,7 @@ async fn wait_for_transition(
     }
 }
 
+// SAFETY: these serial tests restore the process environment variable before returning.
 #[allow(unsafe_code)]
 async fn with_forced_immediate_enqueue_timeout<F, Fut>(test_fn: F)
 where

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -327,7 +327,9 @@ async fn wait_for_transition(
     }
 }
 
-// SAFETY: these serial tests restore the process environment variable before returning.
+// SAFETY: this helper is used only by `#[serial]` tests and runs under the single-threaded Tokio
+// runtime (`worker_threads = 1`), so no concurrent test can mutate process environment during the
+// `env::set_var` / `env::remove_var` window.
 #[allow(unsafe_code)]
 async fn with_forced_immediate_enqueue_timeout<F, Fut>(test_fn: F)
 where

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -327,6 +327,7 @@ async fn wait_for_transition(
     }
 }
 
+// SAFETY: these serial tests restore the process environment variable before returning.
 #[allow(unsafe_code)]
 async fn with_forced_immediate_enqueue_timeout<F, Fut>(test_fn: F)
 where


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Ignore non-positive `RUSTFS_ABSOLUTE_MAX_WORKERS` values and fall back to the default absolute transition worker cap.
- Reuse the same absolute-max parsing path for startup resolution and dynamic worker updates.
- Add regression coverage for `0` and negative absolute max values.
- Add required SAFETY comments for recent test-only environment mutation helpers so the local unsafe-code gate passes.

## Verification
- `cargo fmt --all --check`
- `scripts/check_unsafe_code_allowances.sh`
- `git diff --check`
- `RUSTC=$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin/rustc ~/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin/cargo test -p rustfs-ecstore resolve_transition_worker_count --lib`
- `PATH="$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" RUSTC="$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin/rustc" make pre-commit` reached `cargo nextest`: 4926 passed, 95 skipped; the command was later terminated by SIGTERM during `cargo test --all --doc` compilation.

## Impact
Misconfigured non-positive transition worker absolute caps no longer disable or deadlock transition worker updates.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
