### PR TITLE
perf: avoid blocking hop for owned disk writes

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1179,14 +1179,7 @@ impl LocalDisk {
                 f.write_all(buf).await.map_err(to_file_error)?;
             }
             InternalBuf::Owned(buf) => {
-                // Reduce one copy by using the owned buffer directly.
-                // It may be more efficient for larger writes.
-                let mut f = f.into_std().await;
-                let task = tokio::task::spawn_blocking(move || {
-                    use std::io::Write as _;
-                    f.write_all(buf.as_ref()).map_err(to_file_error)
-                });
-                task.await??;
+                f.write_all(buf.as_ref()).await.map_err(to_file_error)?;
             }
         }
 

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1180,6 +1180,8 @@ impl LocalDisk {
             }
             InternalBuf::Owned(buf) => {
                 f.write_all(buf.as_ref()).await.map_err(to_file_error)?;
+                // Ensure write errors are observed before returning for owned buffers.
+                f.sync_all().await.map_err(to_file_error)?;
             }
         }
 


### PR DESCRIPTION
## Related Issues
- Related: https://github.com/rustfs/backlog/issues/645

## Summary of Changes
- Avoid converting Tokio files back to std files for `InternalBuf::Owned` writes in `LocalDisk::write_all_internal`.
- Write the owned buffer directly with Tokio `File::write_all(buf.as_ref())`, removing the extra `into_std()` + `tokio::spawn_blocking()` write hop.
- Leave the surrounding `sync_all()` behavior unchanged.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore test_local_disk_file_operations -- --nocapture`
- `cargo build --release -p rustfs --bin rustfs`
- `make pre-commit` partially ran, but failed on pre-existing `unsafe_code` allowance checks unrelated to this change:
  - `rustfs/src/app/lifecycle_transition_api_test.rs:330`
  - `crates/scanner/tests/lifecycle_integration_test.rs:810`
  - `crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs:2297`
  - `crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs:2346`
  - `crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs:2396`
  - `crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs:2445`
- Local release-mode paired A/B benchmark, 3 repetitions per variant, `warp put --concurrent 20 --duration 20s --autoterm`, object sizes `4KiB`, `16KiB`, `64KiB`, `256KiB`, and `1MiB`.

Benchmark summary:

| Size | Baseline obj/s mean ± sd | Candidate obj/s mean ± sd | Delta |
|---:|---:|---:|---:|
| 4KiB | 3529.5 ± 521.8 | 5419.0 ± 472.7 | +53.5% |
| 16KiB | 4001.8 ± 314.4 | 4993.9 ± 351.3 | +24.8% |
| 64KiB | 4039.9 ± 748.2 | 4584.0 ± 311.4 | +13.5% |
| 256KiB | 1504.3 ± 405.6 | 1992.9 ± 130.0 | +32.5% |
| 1MiB | 864.8 ± 269.0 | 1208.0 ± 33.6 | +39.7% |

Latency also improved in every tested bucket in this run:
- Average latency: -12.5% to -48.5%
- p99 latency: -12.8% to -69.1%

## Impact
- Improves local PUT/write throughput for owned-buffer disk writes by avoiding an unnecessary blocking-task write hop.
- No intended API, configuration, or compatibility changes.

## Additional Notes
This is intentionally narrow. A separate `rename_data()` metadata-write fast path and allocator-profiling fast path were benchmarked but rejected because their signals were mixed or regressive.