### PR TITLE
fix: make help color not right

### DIFF
--- a/.config/make/help.mak
+++ b/.config/make/help.mak
@@ -4,7 +4,7 @@
 .PHONY: help
 help: ## Shows This Help Menu
 	echo -e "$$HEADER"
-	grep -E '(^[a-zA-Z0-9_-]+:.*?## .*$$)|(^## )' $(MAKEFILE_LIST) | sed 's/^[^:]*://g' | awk 'BEGIN {FS = ":.*?## | #"} ; {printf "${cyan}%-30s${reset} ${white}%s${reset} ${green}%s${reset}\n", $$1, $$2, $$3}' | sed -e 's/\[36m##/\n[32m##/'
+	grep -E '(^[a-zA-Z0-9_-]+:.*?## .*$$)|(^## )' $(MAKEFILE_LIST) | sed 's/^[^:]*://g' | awk 'BEGIN {FS = ":.*?## | #"} /^## / {printf "\n${green}%s${reset}\n", $$0; next} {printf "${cyan}%-30s${reset} ${white}%s${reset} ${green}%s${reset}\n", $$1, $$2, $$3}'
 
 .PHONY: help-build
 help-build: ## Shows RustFS build help


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.


the old make help color is not right 

befroe this patch

<img width="989" height="365" alt="image" src="https://github.com/user-attachments/assets/93ba068e-7f27-4d44-98e9-2e087411a7e0" />

after this patch

<img width="1282" height="423" alt="image" src="https://github.com/user-attachments/assets/2edca4ac-aeff-469f-b6f2-d17b1864dbdc" />

