### PR TITLE
feat(obs): expose key S3 usecase spans at info

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -1908,7 +1908,7 @@ impl DefaultBucketUsecase {
         Ok(S3Response::new(PutBucketVersioningOutput {}))
     }
 
-    #[instrument(level = "debug", skip(self, req))]
+    #[instrument(level = "info", skip(self, req))]
     pub async fn execute_list_objects_v2(&self, req: S3Request<ListObjectsV2Input>) -> S3Result<S3Response<ListObjectsV2Output>> {
         // warn!("list_objects_v2 req {:?}", &req.input);
         let ListObjectsV2Input {

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -1631,7 +1631,7 @@ impl DefaultObjectUsecase {
         }
     }
 
-    #[instrument(level = "debug", skip(self, _fs, req))]
+    #[instrument(level = "info", skip(self, _fs, req))]
     pub async fn execute_put_object(&self, _fs: &FS, req: S3Request<PutObjectInput>) -> S3Result<S3Response<PutObjectOutput>> {
         let start_time = std::time::Instant::now();
         let mut req = req;
@@ -2182,7 +2182,7 @@ impl DefaultObjectUsecase {
     }
 
     #[instrument(
-        level = "debug",
+        level = "info",
         skip(self, req),
         fields(start_time=?time::OffsetDateTime::now_utc())
     )]
@@ -3175,7 +3175,7 @@ impl DefaultObjectUsecase {
         result
     }
 
-    #[instrument(level = "debug", skip(self, req))]
+    #[instrument(level = "info", skip(self, req))]
     pub async fn execute_delete_object(&self, mut req: S3Request<DeleteObjectInput>) -> S3Result<S3Response<DeleteObjectOutput>> {
         if let Some(context) = &self.context {
             let _ = context.object_store();


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Raise selected high-traffic S3 usecase spans from `debug` to `info` so default observability settings (`RUSTFS_OBS_LOGGER_LEVEL=info`) retain request-chain trace visibility.
- Updated 4 request-path handlers:
  - `execute_put_object`
  - `execute_get_object`
  - `execute_delete_object`
  - `execute_list_objects_v2`
- Scope is intentionally minimal: no logic changes, no payload changes, no ecstore-wide instrumentation widening.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
- Improves default Tempo/Jaeger trace visibility for common S3 request paths at `info` level.
- Reduces the chance of seeing only HTTP entry spans while missing core usecase spans under default logging.
- No API/behavior/config compatibility changes expected.

## Additional Notes
- This PR intentionally leaves deeper storage-layer debug spans unchanged to avoid broad trace-volume increases.
