### PR TITLE
fix(heal): ignore missing response subscribers

### DIFF
--- a/crates/common/src/heal_channel.rs
+++ b/crates/common/src/heal_channel.rs
@@ -379,7 +379,12 @@ fn heal_response_sender() -> &'static HealResponseSender {
 
 /// Publish a heal response to subscribers.
 pub fn publish_heal_response(response: HealChannelResponse) -> Result<(), broadcast::error::SendError<HealChannelResponse>> {
-    heal_response_sender().send(response).map(|_| ())
+    let sender = heal_response_sender();
+    if sender.receiver_count() == 0 {
+        return Ok(());
+    }
+
+    sender.send(response).map(|_| ())
 }
 
 /// Subscribe to heal responses.
@@ -626,5 +631,12 @@ mod tests {
         let received = receiver.recv().await.expect("should receive heal response");
         assert_eq!(received.request_id, response.request_id);
         assert!(received.success);
+    }
+
+    #[tokio::test]
+    async fn heal_response_broadcast_without_subscribers_is_ignored() {
+        let response = create_heal_response("req-no-subscriber".to_string(), true, None, None);
+
+        publish_heal_response(response).expect("publish without subscribers should be ignored");
     }
 }

--- a/crates/common/src/heal_channel.rs
+++ b/crates/common/src/heal_channel.rs
@@ -380,11 +380,8 @@ fn heal_response_sender() -> &'static HealResponseSender {
 /// Publish a heal response to subscribers.
 pub fn publish_heal_response(response: HealChannelResponse) -> Result<(), broadcast::error::SendError<HealChannelResponse>> {
     let sender = heal_response_sender();
-    if sender.receiver_count() == 0 {
-        return Ok(());
-    }
-
-    sender.send(response).map(|_| ())
+    let _ = sender.send(response);
+    Ok(())
 }
 
 /// Subscribe to heal responses.
@@ -631,10 +628,8 @@ mod tests {
         let received = receiver.recv().await.expect("should receive heal response");
         assert_eq!(received.request_id, response.request_id);
         assert!(received.success);
-    }
 
-    #[tokio::test]
-    async fn heal_response_broadcast_without_subscribers_is_ignored() {
+        drop(receiver);
         let response = create_heal_response("req-no-subscriber".to_string(), true, None, None);
 
         publish_heal_response(response).expect("publish without subscribers should be ignored");


### PR DESCRIPTION
## Related Issues
Fixes #3002.

## Summary of Changes
- Treat the heal response broadcast no-subscriber case as non-fatal before calling `broadcast::Sender::send`.
- Preserve delivery to active heal response subscribers.
- Add regression coverage for publishing a heal response when there are no subscribers.

## Verification
- `cargo test -p rustfs-common heal_response_broadcast -- --nocapture`
- `cargo test -p rustfs-common`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit` was started and completed the compilation check, but the command timed out during clippy after 10 minutes in the local environment.

## Impact
Prevents repeated `Failed to broadcast heal response: channel closed` error logs when heal responses are produced without an active broadcast subscriber. No API or configuration changes.

## Additional Notes
The reported data-corruption concern should be investigated separately with disk/layout/object-specific diagnostics; this change only addresses the heal response broadcast log spam.
