### PR TITLE
chore(ci): pin RustFS setup-protoc release

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -56,7 +56,7 @@ runs:
           libssl-dev
 
     - name: Install protoc
-      uses: arduino/setup-protoc@v3
+      uses: rustfs/setup-protoc@v3
       with:
         version: "34.1"
         repo-token: ${{ inputs.github-token || github.token }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -56,7 +56,7 @@ runs:
           libssl-dev
 
     - name: Install protoc
-      uses: rustfs/setup-protoc@v3
+      uses: rustfs/setup-protoc@v3.0.1
       with:
         version: "34.1"
         repo-token: ${{ inputs.github-token || github.token }}


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Switch the shared setup action from arduino/setup-protoc@v3 to rustfs/setup-protoc@v3.0.1.
- Keep the existing protoc version and token inputs unchanged.

## Verification
- git diff --check

## Impact
CI now uses the RustFS-maintained setup-protoc release while preserving the existing setup behavior.

## Additional Notes
N/A