### PR TITLE
perf(ecstore): remove owned write sync regression

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1180,8 +1180,6 @@ impl LocalDisk {
             }
             InternalBuf::Owned(buf) => {
                 f.write_all(buf.as_ref()).await.map_err(to_file_error)?;
-                // Ensure write errors are observed before returning for owned buffers.
-                f.sync_all().await.map_err(to_file_error)?;
             }
         }
 


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#645.

## Summary of Changes

Remove the unconditional `File::sync_all().await` from the `InternalBuf::Owned` path in `LocalDisk::write_all_internal`.

Commit `a9e62dc2` added this sync after the async owned-buffer write path. In practice it made every owned metadata write pay an fsync-level cost, which regressed small PUT throughput by an order of magnitude. The referenced `sync` argument is not otherwise honored in this function today, and the borrowed-buffer path already returns after `write_all` without `sync_all`, so this change restores the previous effective behavior while keeping the direct async write.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore test_local_disk_file_operations -- --nocapture`
- `cargo build --release -p rustfs --bin rustfs`
- Focused localhost `warp put` A/B benchmark, `--concurrent 20 --duration 20s --autoterm`:

| size | main obj/s | main avg ms | main p99 ms | candidate obj/s | candidate avg ms | candidate p99 ms | delta obj/s |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 4KiB | 261.91 | 77.9 | 131.6 | 5403.50 | 4.3 | 19.6 | +1963.1% |
| 16KiB | 251.55 | 80.2 | 141.6 | 5407.07 | 3.7 | 13.1 | +2049.5% |
| 64KiB | 236.71 | 83.9 | 149.4 | 4534.95 | 5.1 | 18.3 | +1815.8% |
| 1MiB | 188.42 | 108.4 | 169.0 | 1196.14 | 16.7 | 42.1 | +534.8% |

Additional regression narrowing:

- `ecb67046` before `a9e62dc2`: 4KiB `6663 obj/s`, 16KiB `6091 obj/s`
- `a9e62dc2`: 4KiB `269 obj/s`, 16KiB `253 obj/s`

## Impact

Restores small-object PUT performance on local disks by removing an unintended per-owned-write sync. No API, configuration, or storage format changes.

## Additional Notes

The broader durability semantics of the unused `sync` parameter in `write_all_internal` are left unchanged for this narrow performance regression fix. If stricter metadata fsync semantics are desired, they should be implemented consistently across both `InternalBuf::Ref` and `InternalBuf::Owned` paths and benchmarked separately.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the CLA document and sign it by commenting `I have read and agree to the CLA.` on the PR.
