### PR TITLE
fix(ecstore): remove stale bucket metadata parse TODO

### DIFF
--- a/crates/ecstore/src/bucket/metadata.rs
+++ b/crates/ecstore/src/bucket/metadata.rs
@@ -724,7 +724,7 @@ impl BucketMetadata {
             return Err(Error::other("errServerNotInitialized"));
         };
 
-        self.parse_all_configs(store.clone())?;
+        self.parse_all_configs()?;
 
         let mut buf: Vec<u8> = vec![0; 4];
 
@@ -752,7 +752,7 @@ impl BucketMetadata {
         Ok(())
     }
 
-    fn parse_all_configs(&mut self, _api: Arc<ECStore>) -> Result<()> {
+    fn parse_all_configs(&mut self) -> Result<()> {
         if let Err(e) = self.parse_policy_config() {
             tracing::warn!(bucket = %self.name, config = "policy", error = %e, "parse_all_configs: failed to parse");
         }
@@ -881,10 +881,8 @@ pub async fn load_bucket_metadata_parse(api: Arc<ECStore>, bucket: &str, parse: 
     bm.default_timestamps();
 
     if parse {
-        bm.parse_all_configs(api)?;
+        bm.parse_all_configs()?;
     }
-
-    // TODO: parse_all_configs
 
     Ok(bm)
 }
@@ -937,6 +935,18 @@ mod test {
         let new = BucketMetadata::unmarshal(&buf).unwrap();
 
         assert_eq!(bm.name, new.name);
+    }
+
+    #[test]
+    fn parse_all_configs_parses_stored_configs_without_store_dependency() {
+        let mut bm = BucketMetadata::new("test-bucket");
+        bm.policy_config_json = br#"{"Version":"2012-10-17","Statement":[]}"#.to_vec();
+        bm.bucket_targets_config_json = Vec::new();
+
+        bm.parse_all_configs().unwrap();
+
+        assert!(bm.policy_config.is_some());
+        assert!(bm.bucket_target_config.is_some());
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/bucket/metadata.rs
+++ b/crates/ecstore/src/bucket/metadata.rs
@@ -941,12 +941,17 @@ mod test {
     fn parse_all_configs_parses_stored_configs_without_store_dependency() {
         let mut bm = BucketMetadata::new("test-bucket");
         bm.policy_config_json = br#"{"Version":"2012-10-17","Statement":[]}"#.to_vec();
-        bm.bucket_targets_config_json = Vec::new();
+        bm.bucket_targets_config_json =
+            br#"{"targets":[{"endpoint":"s3.amazonaws.com","targetbucket":"target-bucket","arn":"arn:aws:s3:::target-bucket"}]}"#
+                .to_vec();
 
         bm.parse_all_configs().unwrap();
 
         assert!(bm.policy_config.is_some());
-        assert!(bm.bucket_target_config.is_some());
+        let bucket_targets = bm.bucket_target_config.unwrap();
+        assert_eq!(bucket_targets.targets.len(), 1);
+        assert_eq!(bucket_targets.targets[0].endpoint, "s3.amazonaws.com");
+        assert_eq!(bucket_targets.targets[0].target_bucket, "target-bucket");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Remove the stale `parse_all_configs` TODO in bucket metadata loading.
- Drop the unused `Arc<ECStore>` argument from the private `parse_all_configs` helper.
- Add a regression test proving stored configs are parsed without any store dependency.

Backlog: rustfs/backlog#646

## Validation
- RED: `cargo test -p rustfs-ecstore parse_all_configs_parses_stored_configs_without_store_dependency -- --nocapture` failed before the helper signature cleanup because `parse_all_configs` still required an unused store argument.
- GREEN: `cargo test -p rustfs-ecstore parse_all_configs_parses_stored_configs_without_store_dependency -- --nocapture`
- `cargo test -p rustfs-ecstore bucket::metadata -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs-ecstore --all-targets --all-features -- -D warnings`

## Performance
- No new runtime work is added. This removes an unused parameter and avoids an unnecessary `Arc<ECStore>` clone at the call sites.
