### PR TITLE
fix(ecstore): remove stale disk TODOs

### DIFF
--- a/crates/ecstore/src/disk/disk_store.rs
+++ b/crates/ecstore/src/disk/disk_store.rs
@@ -557,8 +557,6 @@ impl LocalDiskWrapper {
 
     /// Monitor disk writability periodically
     async fn monitor_disk_writable(disk: Arc<LocalDisk>, health: Arc<DiskHealthTracker>, cancel_token: CancellationToken) {
-        // TODO: config interval
-
         let mut interval = time::interval(get_drive_active_check_interval());
 
         loop {

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3051,7 +3051,6 @@ impl DiskAPI for LocalDisk {
     #[tracing::instrument(skip(self))]
     async fn disk_info(&self, _: &DiskInfoOptions) -> Result<DiskInfo> {
         let mut info = Cache::get(self.disk_info_cache.clone()).await?;
-        // TODO: nr_requests, rotational
         info.nr_requests = self.nrrequests;
         info.rotational = self.rotational;
         info.mount_path = self.path().to_str().unwrap().to_string();
@@ -3719,6 +3718,8 @@ mod test {
         assert!(!disk_info.fs_type.is_empty(), "fs_type should not be empty on this platform");
         assert!(disk_info.total > 0);
         assert!(disk_info.free <= disk_info.total);
+        assert_eq!(disk_info.nr_requests, disk.nrrequests);
+        assert_eq!(disk_info.rotational, disk.rotational);
         assert!(!disk_info.mount_path.is_empty());
         assert!(!disk_info.endpoint.is_empty());
 


### PR DESCRIPTION
## Summary
- Remove stale disk TODOs whose behavior is already implemented.
- Keep drive writable monitoring on the existing configured active-check interval path.
- Add assertions that `disk_info()` reports cached `nr_requests` and `rotational` values.

Backlog: rustfs/backlog#646

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-ecstore test_local_disk_disk_info -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-ecstore drive_active_check_interval -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p rustfs-ecstore --tests -- -D warnings`

## Performance
- No runtime behavior changes. The interval path and disk info assignments already existed; this only removes stale comments and adds test coverage.
