### PR TITLE
fix(utils): map common Linux filesystem magic values

### DIFF
--- a/crates/utils/src/os/fs_type.rs
+++ b/crates/utils/src/os/fs_type.rs
@@ -1,0 +1,53 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Returns the filesystem type of the underlying mounted filesystem.
+///
+/// TODO: Verify these less common magic values against stable Linux headers or
+/// filesystem documentation before adding them:
+///
+/// "137d" => "EXT",
+/// "4244" => "HFS",
+/// "5346544e" => "NTFS",
+/// "61756673" => "AUFS",
+/// "ef51" => "EXT2OLD",
+/// "2fc12fc1" => "zfs",
+/// "ff534d42" => "cifs",
+/// "53464846" => "wslfs",
+pub(crate) fn get_fs_type(fs_type: u64) -> &'static str {
+    // Magic numbers for various filesystems.
+    match fs_type {
+        0x01021994 => "TMPFS",
+        0x4d44 => "MSDOS",
+        0x6969 => "NFS",
+        0xEF53 => "EXT4",
+        0xf15f => "ecryptfs",
+        0x794c7630 => "overlayfs",
+        0x52654973 => "REISERFS",
+        0x58465342 => "XFS",
+        0x9123683E => "BTRFS",
+        _ => "UNKNOWN",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_common_linux_filesystem_magic_numbers() {
+        assert_eq!(get_fs_type(0x58465342), "XFS");
+        assert_eq!(get_fs_type(0x9123683E), "BTRFS");
+    }
+}

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::os::{DiskInfo, IOStats};
+use super::{DiskInfo, IOStats, fs_type::get_fs_type};
 use rustix::fs::statfs;
 use std::collections::BTreeSet;
 use std::fs;
@@ -84,35 +84,6 @@ pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
         minor: rustix::fs::minor(st.st_dev) as u64,
         ..Default::default()
     })
-}
-
-/// Returns the filesystem type of the underlying mounted filesystem
-///
-/// TODO The following mapping could not find the corresponding constant in `nix`:
-///
-/// "137d" => "EXT",
-/// "4244" => "HFS",
-/// "5346544e" => "NTFS",
-/// "61756673" => "AUFS",
-/// "ef51" => "EXT2OLD",
-/// "2fc12fc1" => "zfs",
-/// "ff534d42" => "cifs",
-/// "53464846" => "wslfs",
-fn get_fs_type(fs_type: u64) -> &'static str {
-    // Magic numbers for various filesystems
-    match fs_type {
-        0x01021994 => "TMPFS",
-        0x4d44 => "MSDOS",
-        0x6969 => "NFS",
-        0xEF53 => "EXT4",
-        0xf15f => "ecryptfs",
-        0x794c7630 => "overlayfs",
-        0x52654973 => "REISERFS",
-        // Additional common ones can be added here:
-        // 0x58465342 => "XFS",
-        // 0x9123683E => "BTRFS",
-        _ => "UNKNOWN",
-    }
 }
 
 pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {

--- a/crates/utils/src/os/mod.rs
+++ b/crates/utils/src/os/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod fs_type;
+
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(all(unix, not(target_os = "linux")))]


### PR DESCRIPTION
## Summary
- Add tested Linux filesystem magic mappings for XFS and BTRFS.
- Move the filesystem magic mapping helper into a small shared module so the mapping can be unit-tested on non-Linux hosts.
- Preserve the unverified, less common magic values as TODOs instead of guessing mappings.

Backlog: rustfs/backlog#646

## Validation
- RED: `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-utils --features os map_common_linux_filesystem_magic_numbers -- --nocapture` failed with `UNKNOWN` for XFS before adding the mappings.
- GREEN: `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-utils --features os map_common_linux_filesystem_magic_numbers -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-utils --features os os:: -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p rustfs-utils --features os --tests -- -D warnings`

## Performance
- The runtime work remains a single match on the filesystem magic number. The refactor only moves the helper for testability and adds two constant arms.
