### PR TITLE
fix(obs): remove stale replication metric TODOs

### DIFF
--- a/crates/obs/src/metrics/collectors/bucket_replication.rs
+++ b/crates/obs/src/metrics/collectors/bucket_replication.rs
@@ -243,7 +243,7 @@ mod tests {
             proxied_get_tagging_requests_total: 2,
             proxied_get_tagging_requests_failures: 0,
             proxied_delete_tagging_requests_total: 1,
-            proxied_delete_tagging_requests_failures: 0,
+            proxied_delete_tagging_requests_failures: 1,
             targets: vec![BucketReplicationTargetStats {
                 target_arn: "arn:rustfs:replication:us-east-1:1:target".to_string(),
                 bandwidth_limit_bytes_per_sec: 2048,
@@ -270,6 +270,20 @@ mod tests {
                     .labels
                     .iter()
                     .any(|(key, value)| *key == TARGET_ARN_L && value == "arn:rustfs:replication:us-east-1:1:target")
+        }));
+
+        let delete_tagging_total_name = BUCKET_REPL_PROXIED_DELETE_TAGGING_REQUESTS_TOTAL_MD.get_full_metric_name();
+        assert!(metrics.iter().any(|metric| {
+            metric.name == delete_tagging_total_name
+                && metric.value == 1.0
+                && metric.labels.iter().any(|(key, value)| *key == BUCKET_L && value == "b1")
+        }));
+
+        let delete_tagging_failures_name = BUCKET_REPL_PROXIED_DELETE_TAGGING_REQUESTS_FAILURES_MD.get_full_metric_name();
+        assert!(metrics.iter().any(|metric| {
+            metric.name == delete_tagging_failures_name
+                && metric.value == 1.0
+                && metric.labels.iter().any(|(key, value)| *key == BUCKET_L && value == "b1")
         }));
     }
 

--- a/crates/obs/src/metrics/schema/bucket_replication.rs
+++ b/crates/obs/src/metrics/schema/bucket_replication.rs
@@ -98,7 +98,6 @@ pub static BUCKET_REPL_PROXIED_GET_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor>
     )
 });
 
-// TODO - add a metric for the number of PUT requests proxied to replication target
 pub static BUCKET_REPL_PROXIED_GET_TAGGING_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::ProxiedGetTaggingRequestFailures,
@@ -135,7 +134,6 @@ pub static BUCKET_REPL_PROXIED_HEAD_REQUESTS_TOTAL_MD: LazyLock<MetricDescriptor
     )
 });
 
-// TODO - add a metric for the number of PUT requests proxied to replication target
 pub static BUCKET_REPL_PROXIED_PUT_TAGGING_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::ProxiedPutTaggingRequestFailures,
@@ -208,7 +206,6 @@ pub static BUCKET_REPL_BANDWIDTH_CURRENT_MD: LazyLock<MetricDescriptor> = LazyLo
     )
 });
 
-// TODO - add a metric for the number of DELETE requests proxied to replication target
 pub static BUCKET_REPL_PROXIED_DELETE_TAGGING_REQUESTS_FAILURES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::ProxiedDeleteTaggingRequestFailures,


### PR DESCRIPTION
## Summary
- Remove stale bucket replication proxy metric TODO comments after verifying the metrics already exist.
- Add regression assertions that DELETE tagging proxied total and failure metrics are emitted by the bucket replication collector.
- Do not change runtime collection logic or request paths.

Backlog: rustfs/backlog#646

## Validation
- RED/coverage check: `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-obs test_collect_bucket_replication_metrics -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p rustfs-obs --tests -- -D warnings`

## Performance
- No runtime logic changed. The only production change removes stale comments; test-only assertions validate existing metrics emission.
