### PR TITLE
refactor: converge storage io hot paths

### DIFF
--- a/crates/concurrency/src/backpressure.rs
+++ b/crates/concurrency/src/backpressure.rs
@@ -116,7 +116,7 @@ impl BackpressureManager {
 
     /// Create a backpressure pipe
     pub fn create_pipe(&self) -> BackpressurePipe {
-        BackpressurePipe::new(self.config.clone(), self.monitor.clone())
+        BackpressurePipe::new(self.config, self.monitor.clone())
     }
 
     /// Get current state

--- a/crates/concurrency/src/backpressure.rs
+++ b/crates/concurrency/src/backpressure.rs
@@ -20,9 +20,9 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{DuplexStream, duplex};
 
-/// Backpressure configuration
+/// Facade policy for duplex-pipe watermark backpressure.
 #[derive(Debug, Clone)]
-pub struct BackpressureConfig {
+pub struct PipeBackpressurePolicy {
     /// Buffer size in bytes
     pub buffer_size: usize,
     /// High watermark percentage
@@ -31,7 +31,7 @@ pub struct BackpressureConfig {
     pub low_watermark: u32,
 }
 
-impl Default for BackpressureConfig {
+impl Default for PipeBackpressurePolicy {
     fn default() -> Self {
         Self {
             buffer_size: 4 * 1024 * 1024, // 4MB
@@ -41,7 +41,7 @@ impl Default for BackpressureConfig {
     }
 }
 
-impl BackpressureConfig {
+impl PipeBackpressurePolicy {
     /// Calculate high watermark threshold in bytes
     pub fn high_watermark_bytes(&self) -> usize {
         (self.buffer_size as u64 * self.high_watermark as u64 / 100) as usize
@@ -53,16 +53,19 @@ impl BackpressureConfig {
     }
 }
 
+/// Backward-compatible alias for the old backpressure facade name.
+pub type BackpressureConfig = PipeBackpressurePolicy;
+
 /// Backpressure manager
 pub struct BackpressureManager {
-    config: BackpressureConfig,
+    config: PipeBackpressurePolicy,
     monitor: Arc<CoreBackpressureMonitor>,
 }
 
 impl BackpressureManager {
     /// Create a new backpressure manager
     pub fn new(buffer_size: usize, high_watermark: u32, low_watermark: u32) -> Self {
-        let config = BackpressureConfig {
+        let config = PipeBackpressurePolicy {
             buffer_size,
             high_watermark,
             low_watermark,
@@ -83,7 +86,7 @@ impl BackpressureManager {
     }
 
     /// Get the configuration
-    pub fn config(&self) -> &BackpressureConfig {
+    pub fn config(&self) -> &PipeBackpressurePolicy {
         &self.config
     }
 
@@ -112,13 +115,13 @@ impl BackpressureManager {
 pub struct BackpressurePipe {
     reader: DuplexStream,
     writer: DuplexStream,
-    config: BackpressureConfig,
+    config: PipeBackpressurePolicy,
     monitor: Arc<CoreBackpressureMonitor>,
     created_at: Instant,
 }
 
 impl BackpressurePipe {
-    fn new(config: BackpressureConfig, monitor: Arc<CoreBackpressureMonitor>) -> Self {
+    fn new(config: PipeBackpressurePolicy, monitor: Arc<CoreBackpressureMonitor>) -> Self {
         let (reader, writer) = duplex(config.buffer_size);
 
         Self {
@@ -146,7 +149,7 @@ impl BackpressurePipe {
     }
 
     /// Get the configuration
-    pub fn config(&self) -> &BackpressureConfig {
+    pub fn config(&self) -> &PipeBackpressurePolicy {
         &self.config
     }
 
@@ -204,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_config() {
-        let config = BackpressureConfig::default();
+        let config = PipeBackpressurePolicy::default();
         assert_eq!(config.buffer_size, 4 * 1024 * 1024);
         assert!(config.high_watermark > config.low_watermark);
     }

--- a/crates/concurrency/src/backpressure.rs
+++ b/crates/concurrency/src/backpressure.rs
@@ -23,7 +23,7 @@ use std::time::Instant;
 use tokio::io::{DuplexStream, duplex};
 
 /// Facade policy for duplex-pipe watermark backpressure.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct PipeBackpressurePolicy {
     /// Buffer size in bytes
     pub buffer_size: usize,

--- a/crates/concurrency/src/backpressure.rs
+++ b/crates/concurrency/src/backpressure.rs
@@ -69,9 +69,6 @@ impl PipeBackpressurePolicy {
     }
 }
 
-/// Backward-compatible alias for the old backpressure facade name.
-pub type BackpressureConfig = PipeBackpressurePolicy;
-
 /// Backpressure manager
 pub struct BackpressureManager {
     config: PipeBackpressurePolicy,
@@ -210,34 +207,6 @@ impl BackpressurePipe {
         }
         should
     }
-}
-
-/// Backpressure event
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub struct BackpressureEvent {
-    /// Event timestamp
-    pub timestamp: Instant,
-    /// Event type
-    pub event_type: BackpressureEventType,
-    /// Buffer usage
-    pub buffer_usage: usize,
-    /// Buffer capacity
-    pub buffer_capacity: usize,
-}
-
-/// Backpressure event type
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy)]
-pub enum BackpressureEventType {
-    /// High watermark reached
-    HighWatermarkReached,
-    /// High watermark exited
-    HighWatermarkExited,
-    /// Backpressure applied
-    BackpressureApplied,
-    /// Backpressure released
-    BackpressureReleased,
 }
 
 #[cfg(test)]

--- a/crates/concurrency/src/backpressure.rs
+++ b/crates/concurrency/src/backpressure.rs
@@ -14,7 +14,7 @@
 
 //! Backpressure management
 
-use rustfs_io_core::{BackpressureMonitor as CoreBackpressureMonitor, BackpressureState};
+use rustfs_io_core::{BackpressureConfig as CoreBackpressureConfig, BackpressureMonitor as CoreBackpressureMonitor, BackpressureState};
 use rustfs_io_metrics::backpressure_metrics;
 use std::sync::Arc;
 use std::time::Instant;
@@ -51,6 +51,20 @@ impl PipeBackpressurePolicy {
     pub fn low_watermark_bytes(&self) -> usize {
         (self.buffer_size as u64 * self.low_watermark as u64 / 100) as usize
     }
+
+    /// Convert the facade policy into the reusable io-core admission-pressure config.
+    ///
+    /// The concurrency layer still owns duplex buffer sizing, but the shared
+    /// overload/admission primitive lives in `io-core`.
+    pub fn to_core_config(&self) -> CoreBackpressureConfig {
+        CoreBackpressureConfig {
+            max_concurrent: 32,
+            high_water_mark: self.high_watermark as f64 / 100.0,
+            low_water_mark: self.low_watermark as f64 / 100.0,
+            cooldown: std::time::Duration::from_millis(100),
+            enabled: true,
+        }
+    }
 }
 
 /// Backward-compatible alias for the old backpressure facade name.
@@ -59,28 +73,26 @@ pub type BackpressureConfig = PipeBackpressurePolicy;
 /// Backpressure manager
 pub struct BackpressureManager {
     config: PipeBackpressurePolicy,
+    core_config: CoreBackpressureConfig,
     monitor: Arc<CoreBackpressureMonitor>,
 }
 
 impl BackpressureManager {
     /// Create a new backpressure manager
     pub fn new(buffer_size: usize, high_watermark: u32, low_watermark: u32) -> Self {
-        let config = PipeBackpressurePolicy {
+        Self::from_policy(PipeBackpressurePolicy {
             buffer_size,
             high_watermark,
             low_watermark,
-        };
+        })
+    }
 
-        let core_config = rustfs_io_core::BackpressureConfig {
-            max_concurrent: 32,
-            high_water_mark: high_watermark as f64 / 100.0,
-            low_water_mark: low_watermark as f64 / 100.0,
-            cooldown: std::time::Duration::from_millis(100),
-            enabled: true,
-        };
-
+    /// Create a new backpressure manager from the facade policy type.
+    pub fn from_policy(config: PipeBackpressurePolicy) -> Self {
+        let core_config = config.to_core_config();
         Self {
             config,
+            core_config: core_config.clone(),
             monitor: Arc::new(CoreBackpressureMonitor::new(core_config)),
         }
     }
@@ -88,6 +100,11 @@ impl BackpressureManager {
     /// Get the configuration
     pub fn config(&self) -> &PipeBackpressurePolicy {
         &self.config
+    }
+
+    /// Get the derived io-core admission-pressure configuration.
+    pub fn core_config(&self) -> &CoreBackpressureConfig {
+        &self.core_config
     }
 
     /// Get the monitor
@@ -118,6 +135,17 @@ pub struct BackpressurePipe {
     config: PipeBackpressurePolicy,
     monitor: Arc<CoreBackpressureMonitor>,
     created_at: Instant,
+}
+
+/// Shared pipe metadata snapshot for facade-level backpressure pipes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackpressurePipeMeta {
+    /// Configured duplex buffer capacity in bytes.
+    pub buffer_capacity: usize,
+    /// Current backpressure state reported by the shared core monitor.
+    pub state: BackpressureState,
+    /// Age of the pipe since creation.
+    pub age: std::time::Duration,
 }
 
 impl BackpressurePipe {
@@ -161,6 +189,15 @@ impl BackpressurePipe {
     /// Get the age of this pipe
     pub fn age(&self) -> std::time::Duration {
         self.created_at.elapsed()
+    }
+
+    /// Get a compact metadata snapshot for the pipe.
+    pub fn meta(&self) -> BackpressurePipeMeta {
+        BackpressurePipeMeta {
+            buffer_capacity: self.config.buffer_size,
+            state: self.state(),
+            age: self.age(),
+        }
     }
 
     /// Check if should apply backpressure
@@ -213,6 +250,15 @@ mod tests {
     }
 
     #[test]
+    fn test_backpressure_policy_to_core_config() {
+        let policy = PipeBackpressurePolicy::default();
+        let core = policy.to_core_config();
+        assert_eq!(core.high_water_mark, policy.high_watermark as f64 / 100.0);
+        assert_eq!(core.low_water_mark, policy.low_watermark as f64 / 100.0);
+        assert!(core.enabled);
+    }
+
+    #[test]
     fn test_backpressure_manager() {
         let manager = BackpressureManager::new(1024, 80, 50);
         assert_eq!(manager.state(), BackpressureState::Normal);
@@ -223,5 +269,6 @@ mod tests {
         let manager = BackpressureManager::new(1024, 80, 50);
         let pipe = manager.create_pipe();
         assert_eq!(pipe.state(), BackpressureState::Normal);
+        assert_eq!(pipe.meta().buffer_capacity, 1024);
     }
 }

--- a/crates/concurrency/src/backpressure.rs
+++ b/crates/concurrency/src/backpressure.rs
@@ -14,7 +14,9 @@
 
 //! Backpressure management
 
-use rustfs_io_core::{BackpressureConfig as CoreBackpressureConfig, BackpressureMonitor as CoreBackpressureMonitor, BackpressureState};
+use rustfs_io_core::{
+    BackpressureConfig as CoreBackpressureConfig, BackpressureMonitor as CoreBackpressureMonitor, BackpressureState,
+};
 use rustfs_io_metrics::backpressure_metrics;
 use std::sync::Arc;
 use std::time::Instant;

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -76,82 +76,50 @@ impl ConcurrencyFeatures {
     }
 }
 
+/// Facade policy for lock manager behavior.
+#[derive(Debug, Clone)]
+pub struct LockManagerPolicy {
+    /// Enable lock optimization.
+    pub enabled: bool,
+    /// Lock acquisition timeout.
+    pub acquire_timeout: Duration,
+}
+
+impl Default for LockManagerPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            acquire_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
 /// Main configuration for concurrency management
 #[derive(Debug, Clone)]
 pub struct ConcurrencyConfig {
     /// Feature flags
     pub features: ConcurrencyFeatures,
-
-    // Timeout configuration
-    /// Default timeout duration
-    pub default_timeout: Duration,
-    /// Maximum timeout duration
-    pub max_timeout: Duration,
-    /// Enable dynamic timeout
-    pub enable_dynamic_timeout: bool,
-
-    // Lock configuration
-    /// Enable lock optimization
-    pub enable_lock_optimization: bool,
-    /// Lock acquisition timeout
-    pub lock_acquire_timeout: Duration,
-
-    // Deadlock configuration
-    /// Enable deadlock detection
-    pub enable_deadlock_detection: bool,
-    /// Deadlock check interval
-    pub deadlock_check_interval: Duration,
-    /// Hang threshold
-    pub hang_threshold: Duration,
-
-    // Backpressure configuration
-    /// Buffer size for backpressure
-    pub backpressure_buffer_size: usize,
-    /// High watermark percentage
-    pub high_watermark: u32,
-    /// Low watermark percentage
-    pub low_watermark: u32,
-
-    // Scheduler configuration
-    /// Base buffer size for I/O
-    pub io_buffer_size: usize,
-    /// Maximum buffer size
-    pub max_buffer_size: usize,
-    /// High priority size threshold
-    pub high_priority_threshold: usize,
-    /// Low priority size threshold
-    pub low_priority_threshold: usize,
+    /// Timeout facade policy.
+    pub timeout_policy: TimeoutManagerPolicy,
+    /// Lock facade policy.
+    pub lock_policy: LockManagerPolicy,
+    /// Deadlock facade policy.
+    pub deadlock_policy: DeadlockMonitorPolicy,
+    /// Backpressure facade policy.
+    pub backpressure_policy: PipeBackpressurePolicy,
+    /// Scheduler facade policy.
+    pub scheduler_policy: SchedulerPolicy,
 }
 
 impl Default for ConcurrencyConfig {
     fn default() -> Self {
         Self {
             features: ConcurrencyFeatures::default(),
-
-            // Timeout defaults
-            default_timeout: Duration::from_secs(30),
-            max_timeout: Duration::from_secs(300),
-            enable_dynamic_timeout: true,
-
-            // Lock defaults
-            enable_lock_optimization: true,
-            lock_acquire_timeout: Duration::from_secs(5),
-
-            // Deadlock defaults
-            enable_deadlock_detection: false,
-            deadlock_check_interval: Duration::from_secs(10),
-            hang_threshold: Duration::from_secs(60),
-
-            // Backpressure defaults
-            backpressure_buffer_size: 4 * 1024 * 1024, // 4MB
-            high_watermark: 80,
-            low_watermark: 50,
-
-            // Scheduler defaults
-            io_buffer_size: 64 * 1024,                // 64KB
-            max_buffer_size: 4 * 1024 * 1024,         // 4MB
-            high_priority_threshold: 1024 * 1024,     // 1MB
-            low_priority_threshold: 10 * 1024 * 1024, // 10MB
+            timeout_policy: TimeoutManagerPolicy::default(),
+            lock_policy: LockManagerPolicy::default(),
+            deadlock_policy: DeadlockMonitorPolicy::default(),
+            backpressure_policy: PipeBackpressurePolicy::default(),
+            scheduler_policy: SchedulerPolicy::default(),
         }
     }
 }
@@ -165,25 +133,25 @@ impl ConcurrencyConfig {
         if let Ok(val) = std::env::var("RUSTFS_TIMEOUT_DEFAULT")
             && let Ok(secs) = val.parse::<u64>()
         {
-            config.default_timeout = Duration::from_secs(secs);
+            config.timeout_policy.default_timeout = Duration::from_secs(secs);
         }
 
         if let Ok(val) = std::env::var("RUSTFS_TIMEOUT_MAX")
             && let Ok(secs) = val.parse::<u64>()
         {
-            config.max_timeout = Duration::from_secs(secs);
+            config.timeout_policy.max_timeout = Duration::from_secs(secs);
         }
 
         if let Ok(val) = std::env::var("RUSTFS_BACKPRESSURE_BUFFER_SIZE")
             && let Ok(size) = val.parse::<usize>()
         {
-            config.backpressure_buffer_size = size;
+            config.backpressure_policy.buffer_size = size;
         }
 
         if let Ok(val) = std::env::var("RUSTFS_IO_BUFFER_SIZE")
             && let Ok(size) = val.parse::<usize>()
         {
-            config.io_buffer_size = size;
+            config.scheduler_policy.base_buffer_size = size;
         }
 
         config
@@ -191,17 +159,19 @@ impl ConcurrencyConfig {
 
     /// Validate configuration
     pub fn validate(&self) -> Result<(), ConfigError> {
-        if self.default_timeout > self.max_timeout {
+        if self.timeout_policy.default_timeout > self.timeout_policy.max_timeout {
             return Err(ConfigError::InvalidTimeout("default_timeout cannot exceed max_timeout".to_string()));
         }
 
-        if self.high_watermark <= self.low_watermark || self.high_watermark > 100 {
+        if self.backpressure_policy.high_watermark <= self.backpressure_policy.low_watermark
+            || self.backpressure_policy.high_watermark > 100
+        {
             return Err(ConfigError::InvalidBackpressure(
                 "high_watermark must be > low_watermark and <= 100".to_string(),
             ));
         }
 
-        if self.io_buffer_size > self.max_buffer_size {
+        if self.scheduler_policy.base_buffer_size > self.scheduler_policy.max_buffer_size {
             return Err(ConfigError::InvalidScheduler("io_buffer_size cannot exceed max_buffer_size".to_string()));
         }
 
@@ -210,39 +180,27 @@ impl ConcurrencyConfig {
 
     /// Build the timeout facade policy from the aggregate concurrency config.
     pub fn timeout_policy(&self) -> TimeoutManagerPolicy {
-        TimeoutManagerPolicy {
-            default_timeout: self.default_timeout,
-            max_timeout: self.max_timeout,
-            enable_dynamic: self.enable_dynamic_timeout,
-        }
+        self.timeout_policy.clone()
+    }
+
+    /// Build the lock facade policy from the aggregate concurrency config.
+    pub fn lock_policy(&self) -> LockManagerPolicy {
+        self.lock_policy.clone()
     }
 
     /// Build the deadlock facade policy from the aggregate concurrency config.
     pub fn deadlock_policy(&self) -> DeadlockMonitorPolicy {
-        DeadlockMonitorPolicy {
-            enabled: self.enable_deadlock_detection,
-            check_interval: self.deadlock_check_interval,
-            hang_threshold: self.hang_threshold,
-        }
+        self.deadlock_policy.clone()
     }
 
     /// Build the backpressure facade policy from the aggregate concurrency config.
     pub fn backpressure_policy(&self) -> PipeBackpressurePolicy {
-        PipeBackpressurePolicy {
-            buffer_size: self.backpressure_buffer_size,
-            high_watermark: self.high_watermark,
-            low_watermark: self.low_watermark,
-        }
+        self.backpressure_policy.clone()
     }
 
     /// Build the scheduler facade policy from the aggregate concurrency config.
     pub fn scheduler_policy(&self) -> SchedulerPolicy {
-        SchedulerPolicy {
-            base_buffer_size: self.io_buffer_size,
-            max_buffer_size: self.max_buffer_size,
-            high_priority_threshold: self.high_priority_threshold,
-            low_priority_threshold: self.low_priority_threshold,
-        }
+        self.scheduler_policy.clone()
     }
 }
 
@@ -276,8 +234,11 @@ mod tests {
     #[test]
     fn test_invalid_timeout() {
         let config = ConcurrencyConfig {
-            default_timeout: Duration::from_secs(100),
-            max_timeout: Duration::from_secs(50),
+            timeout_policy: TimeoutManagerPolicy {
+                default_timeout: Duration::from_secs(100),
+                max_timeout: Duration::from_secs(50),
+                enable_dynamic: true,
+            },
             ..Default::default()
         };
         assert!(
@@ -299,36 +260,44 @@ mod tests {
     fn test_timeout_policy_mapping() {
         let config = ConcurrencyConfig::default();
         let policy = config.timeout_policy();
-        assert_eq!(policy.default_timeout, config.default_timeout);
-        assert_eq!(policy.max_timeout, config.max_timeout);
-        assert_eq!(policy.enable_dynamic, config.enable_dynamic_timeout);
+        assert_eq!(policy.default_timeout, config.timeout_policy.default_timeout);
+        assert_eq!(policy.max_timeout, config.timeout_policy.max_timeout);
+        assert_eq!(policy.enable_dynamic, config.timeout_policy.enable_dynamic);
+    }
+
+    #[test]
+    fn test_lock_policy_mapping() {
+        let config = ConcurrencyConfig::default();
+        let policy = config.lock_policy();
+        assert_eq!(policy.enabled, config.lock_policy.enabled);
+        assert_eq!(policy.acquire_timeout, config.lock_policy.acquire_timeout);
     }
 
     #[test]
     fn test_deadlock_policy_mapping() {
         let config = ConcurrencyConfig::default();
         let policy = config.deadlock_policy();
-        assert_eq!(policy.enabled, config.enable_deadlock_detection);
-        assert_eq!(policy.check_interval, config.deadlock_check_interval);
-        assert_eq!(policy.hang_threshold, config.hang_threshold);
+        assert_eq!(policy.enabled, config.deadlock_policy.enabled);
+        assert_eq!(policy.check_interval, config.deadlock_policy.check_interval);
+        assert_eq!(policy.hang_threshold, config.deadlock_policy.hang_threshold);
     }
 
     #[test]
     fn test_backpressure_policy_mapping() {
         let config = ConcurrencyConfig::default();
         let policy = config.backpressure_policy();
-        assert_eq!(policy.buffer_size, config.backpressure_buffer_size);
-        assert_eq!(policy.high_watermark, config.high_watermark);
-        assert_eq!(policy.low_watermark, config.low_watermark);
+        assert_eq!(policy.buffer_size, config.backpressure_policy.buffer_size);
+        assert_eq!(policy.high_watermark, config.backpressure_policy.high_watermark);
+        assert_eq!(policy.low_watermark, config.backpressure_policy.low_watermark);
     }
 
     #[test]
     fn test_scheduler_policy_mapping() {
         let config = ConcurrencyConfig::default();
         let policy = config.scheduler_policy();
-        assert_eq!(policy.base_buffer_size, config.io_buffer_size);
-        assert_eq!(policy.max_buffer_size, config.max_buffer_size);
-        assert_eq!(policy.high_priority_threshold, config.high_priority_threshold);
-        assert_eq!(policy.low_priority_threshold, config.low_priority_threshold);
+        assert_eq!(policy.base_buffer_size, config.scheduler_policy.base_buffer_size);
+        assert_eq!(policy.max_buffer_size, config.scheduler_policy.max_buffer_size);
+        assert_eq!(policy.high_priority_threshold, config.scheduler_policy.high_priority_threshold);
+        assert_eq!(policy.low_priority_threshold, config.scheduler_policy.low_priority_threshold);
     }
 }

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -14,7 +14,10 @@
 
 //! Configuration for concurrency management
 
-use crate::{backpressure::PipeBackpressurePolicy, deadlock::DeadlockMonitorPolicy, timeout::TimeoutManagerPolicy};
+use crate::{
+    backpressure::PipeBackpressurePolicy, deadlock::DeadlockMonitorPolicy, scheduler::SchedulerPolicy,
+    timeout::TimeoutManagerPolicy,
+};
 use std::time::Duration;
 
 /// Feature flags for concurrency modules
@@ -231,6 +234,16 @@ impl ConcurrencyConfig {
             low_watermark: self.low_watermark,
         }
     }
+
+    /// Build the scheduler facade policy from the aggregate concurrency config.
+    pub fn scheduler_policy(&self) -> SchedulerPolicy {
+        SchedulerPolicy {
+            base_buffer_size: self.io_buffer_size,
+            max_buffer_size: self.max_buffer_size,
+            high_priority_threshold: self.high_priority_threshold,
+            low_priority_threshold: self.low_priority_threshold,
+        }
+    }
 }
 
 /// Configuration error
@@ -307,5 +320,15 @@ mod tests {
         assert_eq!(policy.buffer_size, config.backpressure_buffer_size);
         assert_eq!(policy.high_watermark, config.high_watermark);
         assert_eq!(policy.low_watermark, config.low_watermark);
+    }
+
+    #[test]
+    fn test_scheduler_policy_mapping() {
+        let config = ConcurrencyConfig::default();
+        let policy = config.scheduler_policy();
+        assert_eq!(policy.base_buffer_size, config.io_buffer_size);
+        assert_eq!(policy.max_buffer_size, config.max_buffer_size);
+        assert_eq!(policy.high_priority_threshold, config.high_priority_threshold);
+        assert_eq!(policy.low_priority_threshold, config.low_priority_threshold);
     }
 }

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -164,31 +164,6 @@ impl ConcurrencyConfig {
 
         Ok(())
     }
-
-    /// Build the timeout facade policy from the aggregate concurrency config.
-    pub fn timeout_policy(&self) -> TimeoutManagerPolicy {
-        self.timeout_policy
-    }
-
-    /// Build the lock facade policy from the aggregate concurrency config.
-    pub fn lock_policy(&self) -> LockManagerPolicy {
-        self.lock_policy
-    }
-
-    /// Build the deadlock facade policy from the aggregate concurrency config.
-    pub fn deadlock_policy(&self) -> DeadlockMonitorPolicy {
-        self.deadlock_policy
-    }
-
-    /// Build the backpressure facade policy from the aggregate concurrency config.
-    pub fn backpressure_policy(&self) -> PipeBackpressurePolicy {
-        self.backpressure_policy
-    }
-
-    /// Build the scheduler facade policy from the aggregate concurrency config.
-    pub fn scheduler_policy(&self) -> SchedulerPolicy {
-        self.scheduler_policy
-    }
 }
 
 /// Configuration error
@@ -225,6 +200,7 @@ mod tests {
                 default_timeout: Duration::from_secs(100),
                 max_timeout: Duration::from_secs(50),
                 enable_dynamic: true,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -241,50 +217,5 @@ mod tests {
 
         let features = ConcurrencyFeatures::none();
         assert!(!features.any_enabled());
-    }
-
-    #[test]
-    fn test_timeout_policy_mapping() {
-        let config = ConcurrencyConfig::default();
-        let policy = config.timeout_policy();
-        assert_eq!(policy.default_timeout, config.timeout_policy.default_timeout);
-        assert_eq!(policy.max_timeout, config.timeout_policy.max_timeout);
-        assert_eq!(policy.enable_dynamic, config.timeout_policy.enable_dynamic);
-    }
-
-    #[test]
-    fn test_lock_policy_mapping() {
-        let config = ConcurrencyConfig::default();
-        let policy = config.lock_policy();
-        assert_eq!(policy.enabled, config.lock_policy.enabled);
-        assert_eq!(policy.acquire_timeout, config.lock_policy.acquire_timeout);
-    }
-
-    #[test]
-    fn test_deadlock_policy_mapping() {
-        let config = ConcurrencyConfig::default();
-        let policy = config.deadlock_policy();
-        assert_eq!(policy.enabled, config.deadlock_policy.enabled);
-        assert_eq!(policy.check_interval, config.deadlock_policy.check_interval);
-        assert_eq!(policy.hang_threshold, config.deadlock_policy.hang_threshold);
-    }
-
-    #[test]
-    fn test_backpressure_policy_mapping() {
-        let config = ConcurrencyConfig::default();
-        let policy = config.backpressure_policy();
-        assert_eq!(policy.buffer_size, config.backpressure_policy.buffer_size);
-        assert_eq!(policy.high_watermark, config.backpressure_policy.high_watermark);
-        assert_eq!(policy.low_watermark, config.backpressure_policy.low_watermark);
-    }
-
-    #[test]
-    fn test_scheduler_policy_mapping() {
-        let config = ConcurrencyConfig::default();
-        let policy = config.scheduler_policy();
-        assert_eq!(policy.base_buffer_size, config.scheduler_policy.base_buffer_size);
-        assert_eq!(policy.max_buffer_size, config.scheduler_policy.max_buffer_size);
-        assert_eq!(policy.high_priority_threshold, config.scheduler_policy.high_priority_threshold);
-        assert_eq!(policy.low_priority_threshold, config.scheduler_policy.low_priority_threshold);
     }
 }

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -96,6 +96,7 @@ impl Default for LockManagerPolicy {
 
 /// Main configuration for concurrency management
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct ConcurrencyConfig {
     /// Feature flags
     pub features: ConcurrencyFeatures,
@@ -111,18 +112,6 @@ pub struct ConcurrencyConfig {
     pub scheduler_policy: SchedulerPolicy,
 }
 
-impl Default for ConcurrencyConfig {
-    fn default() -> Self {
-        Self {
-            features: ConcurrencyFeatures::default(),
-            timeout_policy: TimeoutManagerPolicy::default(),
-            lock_policy: LockManagerPolicy::default(),
-            deadlock_policy: DeadlockMonitorPolicy::default(),
-            backpressure_policy: PipeBackpressurePolicy::default(),
-            scheduler_policy: SchedulerPolicy::default(),
-        }
-    }
-}
 
 impl ConcurrencyConfig {
     /// Create configuration from environment variables

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -14,6 +14,7 @@
 
 //! Configuration for concurrency management
 
+use crate::{backpressure::PipeBackpressurePolicy, deadlock::DeadlockMonitorPolicy, timeout::TimeoutManagerPolicy};
 use std::time::Duration;
 
 /// Feature flags for concurrency modules
@@ -203,6 +204,33 @@ impl ConcurrencyConfig {
 
         Ok(())
     }
+
+    /// Build the timeout facade policy from the aggregate concurrency config.
+    pub fn timeout_policy(&self) -> TimeoutManagerPolicy {
+        TimeoutManagerPolicy {
+            default_timeout: self.default_timeout,
+            max_timeout: self.max_timeout,
+            enable_dynamic: self.enable_dynamic_timeout,
+        }
+    }
+
+    /// Build the deadlock facade policy from the aggregate concurrency config.
+    pub fn deadlock_policy(&self) -> DeadlockMonitorPolicy {
+        DeadlockMonitorPolicy {
+            enabled: self.enable_deadlock_detection,
+            check_interval: self.deadlock_check_interval,
+            hang_threshold: self.hang_threshold,
+        }
+    }
+
+    /// Build the backpressure facade policy from the aggregate concurrency config.
+    pub fn backpressure_policy(&self) -> PipeBackpressurePolicy {
+        PipeBackpressurePolicy {
+            buffer_size: self.backpressure_buffer_size,
+            high_watermark: self.high_watermark,
+            low_watermark: self.low_watermark,
+        }
+    }
 }
 
 /// Configuration error
@@ -252,5 +280,32 @@ mod tests {
 
         let features = ConcurrencyFeatures::none();
         assert!(!features.any_enabled());
+    }
+
+    #[test]
+    fn test_timeout_policy_mapping() {
+        let config = ConcurrencyConfig::default();
+        let policy = config.timeout_policy();
+        assert_eq!(policy.default_timeout, config.default_timeout);
+        assert_eq!(policy.max_timeout, config.max_timeout);
+        assert_eq!(policy.enable_dynamic, config.enable_dynamic_timeout);
+    }
+
+    #[test]
+    fn test_deadlock_policy_mapping() {
+        let config = ConcurrencyConfig::default();
+        let policy = config.deadlock_policy();
+        assert_eq!(policy.enabled, config.enable_deadlock_detection);
+        assert_eq!(policy.check_interval, config.deadlock_check_interval);
+        assert_eq!(policy.hang_threshold, config.hang_threshold);
+    }
+
+    #[test]
+    fn test_backpressure_policy_mapping() {
+        let config = ConcurrencyConfig::default();
+        let policy = config.backpressure_policy();
+        assert_eq!(policy.buffer_size, config.backpressure_buffer_size);
+        assert_eq!(policy.high_watermark, config.high_watermark);
+        assert_eq!(policy.low_watermark, config.low_watermark);
     }
 }

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -77,7 +77,7 @@ impl ConcurrencyFeatures {
 }
 
 /// Facade policy for lock manager behavior.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LockManagerPolicy {
     /// Enable lock optimization.
     pub enabled: bool,
@@ -169,27 +169,27 @@ impl ConcurrencyConfig {
 
     /// Build the timeout facade policy from the aggregate concurrency config.
     pub fn timeout_policy(&self) -> TimeoutManagerPolicy {
-        self.timeout_policy.clone()
+        self.timeout_policy
     }
 
     /// Build the lock facade policy from the aggregate concurrency config.
     pub fn lock_policy(&self) -> LockManagerPolicy {
-        self.lock_policy.clone()
+        self.lock_policy
     }
 
     /// Build the deadlock facade policy from the aggregate concurrency config.
     pub fn deadlock_policy(&self) -> DeadlockMonitorPolicy {
-        self.deadlock_policy.clone()
+        self.deadlock_policy
     }
 
     /// Build the backpressure facade policy from the aggregate concurrency config.
     pub fn backpressure_policy(&self) -> PipeBackpressurePolicy {
-        self.backpressure_policy.clone()
+        self.backpressure_policy
     }
 
     /// Build the scheduler facade policy from the aggregate concurrency config.
     pub fn scheduler_policy(&self) -> SchedulerPolicy {
-        self.scheduler_policy.clone()
+        self.scheduler_policy
     }
 }
 

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -95,8 +95,7 @@ impl Default for LockManagerPolicy {
 }
 
 /// Main configuration for concurrency management
-#[derive(Debug, Clone)]
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ConcurrencyConfig {
     /// Feature flags
     pub features: ConcurrencyFeatures,
@@ -111,7 +110,6 @@ pub struct ConcurrencyConfig {
     /// Scheduler facade policy.
     pub scheduler_policy: SchedulerPolicy,
 }
-
 
 impl ConcurrencyConfig {
     /// Create configuration from environment variables

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -149,6 +149,9 @@ impl ConcurrencyConfig {
         if self.timeout_policy.default_timeout > self.timeout_policy.max_timeout {
             return Err(ConfigError::InvalidTimeout("default_timeout cannot exceed max_timeout".to_string()));
         }
+        if self.timeout_policy.min_timeout > self.timeout_policy.max_timeout {
+            return Err(ConfigError::InvalidTimeout("min_timeout cannot exceed max_timeout".to_string()));
+        }
 
         if self.backpressure_policy.high_watermark <= self.backpressure_policy.low_watermark
             || self.backpressure_policy.high_watermark > 100
@@ -159,7 +162,9 @@ impl ConcurrencyConfig {
         }
 
         if self.scheduler_policy.base_buffer_size > self.scheduler_policy.max_buffer_size {
-            return Err(ConfigError::InvalidScheduler("io_buffer_size cannot exceed max_buffer_size".to_string()));
+            return Err(ConfigError::InvalidScheduler(
+                "base_buffer_size cannot exceed max_buffer_size".to_string(),
+            ));
         }
 
         Ok(())
@@ -207,6 +212,22 @@ mod tests {
         assert!(
             config.validate().is_err(),
             "validate() should return an error when default_timeout > max_timeout"
+        );
+    }
+
+    #[test]
+    fn test_invalid_min_timeout() {
+        let config = ConcurrencyConfig {
+            timeout_policy: TimeoutManagerPolicy {
+                min_timeout: Duration::from_secs(100),
+                max_timeout: Duration::from_secs(50),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(
+            config.validate().is_err(),
+            "validate() should return an error when min_timeout > max_timeout"
         );
     }
 

--- a/crates/concurrency/src/deadlock.rs
+++ b/crates/concurrency/src/deadlock.rs
@@ -14,7 +14,7 @@
 
 //! Deadlock detection management
 
-use rustfs_io_core::{DeadlockDetector as CoreDeadlockDetector, LockType};
+use rustfs_io_core::{DeadlockDetector as CoreDeadlockDetector, DeadlockDetectorConfig as CoreDeadlockConfig, LockType};
 use rustfs_io_metrics::deadlock_metrics;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -41,6 +41,17 @@ impl Default for DeadlockMonitorPolicy {
     }
 }
 
+impl DeadlockMonitorPolicy {
+    /// Convert the facade policy into the reusable io-core deadlock config.
+    pub fn to_core_config(&self) -> CoreDeadlockConfig {
+        CoreDeadlockConfig {
+            enabled: self.enabled,
+            detection_interval: self.check_interval,
+            max_hold_time: self.hang_threshold,
+        }
+    }
+}
+
 /// Backward-compatible alias for the old deadlock facade name.
 pub type DeadlockConfig = DeadlockMonitorPolicy;
 
@@ -54,18 +65,16 @@ pub struct DeadlockManager {
 impl DeadlockManager {
     /// Create a new deadlock manager
     pub fn new(enabled: bool, check_interval: Duration, hang_threshold: Duration) -> Self {
-        let config = DeadlockMonitorPolicy {
+        Self::from_policy(DeadlockMonitorPolicy {
             enabled,
             check_interval,
             hang_threshold,
-        };
+        })
+    }
 
-        let core_config = rustfs_io_core::DeadlockDetectorConfig {
-            enabled,
-            detection_interval: check_interval,
-            max_hold_time: hang_threshold,
-        };
-
+    /// Create a new deadlock manager from the facade policy type.
+    pub fn from_policy(config: DeadlockMonitorPolicy) -> Self {
+        let core_config = config.to_core_config();
         Self {
             config,
             detector: Arc::new(CoreDeadlockDetector::new(core_config)),
@@ -132,7 +141,11 @@ impl DeadlockManager {
     }
 }
 
-/// Request tracker for tracking resources
+/// Lightweight compatibility wrapper for request-scoped deadlock bookkeeping.
+///
+/// This type intentionally stays minimal in the concurrency layer. Rich
+/// request-level lock/resource diagnostics belong to
+/// `rustfs::storage::deadlock_detector::RequestResourceTracker`.
 pub struct RequestTracker {
     request_id: String,
     description: String,
@@ -177,6 +190,11 @@ impl RequestTracker {
         deadlock_metrics::record_lock_acquisition("read");
     }
 
+    /// Return a read-only view of tracked resource names.
+    pub fn resources(&self) -> &HashMap<String, Vec<String>> {
+        &self.resources
+    }
+
     /// Record a lock release
     pub fn record_lock_release(&mut self, lock_id: u64) {
         self.detector.record_release(lock_id);
@@ -199,12 +217,24 @@ mod tests {
         assert!(!manager.config().enabled);
     }
 
+    #[test]
+    fn test_deadlock_policy_to_core_config() {
+        let policy = DeadlockMonitorPolicy::default();
+        let core = policy.to_core_config();
+        assert_eq!(core.enabled, policy.enabled);
+        assert_eq!(core.detection_interval, policy.check_interval);
+        assert_eq!(core.max_hold_time, policy.hang_threshold);
+    }
+
     #[tokio::test]
     async fn test_request_tracker() {
         let manager = DeadlockManager::new(true, Duration::from_secs(10), Duration::from_secs(60));
-        let tracker = manager.track_request("req-1".to_string(), "test request".to_string());
+        let mut tracker = manager.track_request("req-1".to_string(), "test request".to_string());
+        let lock_id = manager.register_lock(LockType::Mutex);
+        tracker.record_lock_acquire(lock_id, "bucket/key".to_string());
 
         assert_eq!(tracker.request_id(), "req-1");
         assert_eq!(tracker.description(), "test request");
+        assert_eq!(tracker.resources().get("locks").map(Vec::len), Some(1));
     }
 }

--- a/crates/concurrency/src/deadlock.rs
+++ b/crates/concurrency/src/deadlock.rs
@@ -52,9 +52,6 @@ impl DeadlockMonitorPolicy {
     }
 }
 
-/// Backward-compatible alias for the old deadlock facade name.
-pub type DeadlockConfig = DeadlockMonitorPolicy;
-
 /// Deadlock manager
 pub struct DeadlockManager {
     config: DeadlockMonitorPolicy,

--- a/crates/concurrency/src/deadlock.rs
+++ b/crates/concurrency/src/deadlock.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Facade policy for the concurrency-layer deadlock monitor.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct DeadlockMonitorPolicy {
     /// Enable deadlock detection
     pub enabled: bool,

--- a/crates/concurrency/src/deadlock.rs
+++ b/crates/concurrency/src/deadlock.rs
@@ -20,9 +20,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-/// Deadlock configuration
+/// Facade policy for the concurrency-layer deadlock monitor.
 #[derive(Debug, Clone)]
-pub struct DeadlockConfig {
+pub struct DeadlockMonitorPolicy {
     /// Enable deadlock detection
     pub enabled: bool,
     /// Check interval
@@ -31,7 +31,7 @@ pub struct DeadlockConfig {
     pub hang_threshold: Duration,
 }
 
-impl Default for DeadlockConfig {
+impl Default for DeadlockMonitorPolicy {
     fn default() -> Self {
         Self {
             enabled: false,
@@ -41,9 +41,12 @@ impl Default for DeadlockConfig {
     }
 }
 
+/// Backward-compatible alias for the old deadlock facade name.
+pub type DeadlockConfig = DeadlockMonitorPolicy;
+
 /// Deadlock manager
 pub struct DeadlockManager {
-    config: DeadlockConfig,
+    config: DeadlockMonitorPolicy,
     detector: Arc<CoreDeadlockDetector>,
     running: Arc<tokio::sync::Mutex<bool>>,
 }
@@ -51,7 +54,7 @@ pub struct DeadlockManager {
 impl DeadlockManager {
     /// Create a new deadlock manager
     pub fn new(enabled: bool, check_interval: Duration, hang_threshold: Duration) -> Self {
-        let config = DeadlockConfig {
+        let config = DeadlockMonitorPolicy {
             enabled,
             check_interval,
             hang_threshold,
@@ -71,7 +74,7 @@ impl DeadlockManager {
     }
 
     /// Get the configuration
-    pub fn config(&self) -> &DeadlockConfig {
+    pub fn config(&self) -> &DeadlockMonitorPolicy {
         &self.config
     }
 

--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -128,19 +128,19 @@ pub mod workers;
 
 // Public module exports with feature gates
 #[cfg(feature = "timeout")]
-pub use timeout::{TimeoutConfig, TimeoutGuard, TimeoutManager};
+pub use timeout::{TimeoutConfig, TimeoutGuard, TimeoutManager, TimeoutManagerPolicy};
 
 #[cfg(feature = "lock")]
 pub use lock::{LockConfig, LockManager, LockScopeGuard, OptimizedLockGuard};
 
 #[cfg(feature = "deadlock")]
-pub use deadlock::{DeadlockConfig, DeadlockManager, RequestTracker};
+pub use deadlock::{DeadlockConfig, DeadlockManager, DeadlockMonitorPolicy, RequestTracker};
 
 #[cfg(feature = "backpressure")]
-pub use backpressure::{BackpressureConfig, BackpressureManager, BackpressurePipe};
+pub use backpressure::{BackpressureConfig, BackpressureManager, BackpressurePipe, PipeBackpressurePolicy};
 
 #[cfg(feature = "scheduler")]
-pub use scheduler::{IoStrategy, SchedulerConfig, SchedulerManager};
+pub use scheduler::{IoStrategy, SchedulerConfig, SchedulerManager, SchedulerPolicy};
 
 // Configuration
 mod config;
@@ -155,19 +155,19 @@ pub mod prelude {
     //! Prelude module for convenient imports
 
     #[cfg(feature = "timeout")]
-    pub use crate::timeout::{TimeoutConfig, TimeoutGuard, TimeoutManager};
+    pub use crate::timeout::{TimeoutConfig, TimeoutGuard, TimeoutManager, TimeoutManagerPolicy};
 
     #[cfg(feature = "lock")]
     pub use crate::lock::{LockConfig, LockManager, LockScopeGuard, OptimizedLockGuard};
 
     #[cfg(feature = "deadlock")]
-    pub use crate::deadlock::{DeadlockConfig, DeadlockManager, RequestTracker};
+    pub use crate::deadlock::{DeadlockConfig, DeadlockManager, DeadlockMonitorPolicy, RequestTracker};
 
     #[cfg(feature = "backpressure")]
-    pub use crate::backpressure::{BackpressureConfig, BackpressureManager, BackpressurePipe};
+    pub use crate::backpressure::{BackpressureConfig, BackpressureManager, BackpressurePipe, PipeBackpressurePolicy};
 
     #[cfg(feature = "scheduler")]
-    pub use crate::scheduler::{IoStrategy, SchedulerConfig, SchedulerManager};
+    pub use crate::scheduler::{IoStrategy, SchedulerConfig, SchedulerManager, SchedulerPolicy};
 
     pub use crate::{ConcurrencyConfig, ConcurrencyFeatures, ConcurrencyManager};
 }

--- a/crates/concurrency/src/lib.rs
+++ b/crates/concurrency/src/lib.rs
@@ -128,19 +128,19 @@ pub mod workers;
 
 // Public module exports with feature gates
 #[cfg(feature = "timeout")]
-pub use timeout::{TimeoutConfig, TimeoutGuard, TimeoutManager, TimeoutManagerPolicy};
+pub use timeout::{TimeoutGuard, TimeoutManager, TimeoutManagerPolicy};
 
 #[cfg(feature = "lock")]
 pub use lock::{LockConfig, LockManager, LockScopeGuard, OptimizedLockGuard};
 
 #[cfg(feature = "deadlock")]
-pub use deadlock::{DeadlockConfig, DeadlockManager, DeadlockMonitorPolicy, RequestTracker};
+pub use deadlock::{DeadlockManager, DeadlockMonitorPolicy, RequestTracker};
 
 #[cfg(feature = "backpressure")]
-pub use backpressure::{BackpressureConfig, BackpressureManager, BackpressurePipe, PipeBackpressurePolicy};
+pub use backpressure::{BackpressureManager, BackpressurePipe, PipeBackpressurePolicy};
 
 #[cfg(feature = "scheduler")]
-pub use scheduler::{IoStrategy, SchedulerConfig, SchedulerManager, SchedulerPolicy};
+pub use scheduler::{IoStrategy, SchedulerManager, SchedulerPolicy};
 
 // Configuration
 mod config;
@@ -155,19 +155,19 @@ pub mod prelude {
     //! Prelude module for convenient imports
 
     #[cfg(feature = "timeout")]
-    pub use crate::timeout::{TimeoutConfig, TimeoutGuard, TimeoutManager, TimeoutManagerPolicy};
+    pub use crate::timeout::{TimeoutGuard, TimeoutManager, TimeoutManagerPolicy};
 
     #[cfg(feature = "lock")]
     pub use crate::lock::{LockConfig, LockManager, LockScopeGuard, OptimizedLockGuard};
 
     #[cfg(feature = "deadlock")]
-    pub use crate::deadlock::{DeadlockConfig, DeadlockManager, DeadlockMonitorPolicy, RequestTracker};
+    pub use crate::deadlock::{DeadlockManager, DeadlockMonitorPolicy, RequestTracker};
 
     #[cfg(feature = "backpressure")]
-    pub use crate::backpressure::{BackpressureConfig, BackpressureManager, BackpressurePipe, PipeBackpressurePolicy};
+    pub use crate::backpressure::{BackpressureManager, BackpressurePipe, PipeBackpressurePolicy};
 
     #[cfg(feature = "scheduler")]
-    pub use crate::scheduler::{IoStrategy, SchedulerConfig, SchedulerManager, SchedulerPolicy};
+    pub use crate::scheduler::{IoStrategy, SchedulerManager, SchedulerPolicy};
 
     pub use crate::{ConcurrencyConfig, ConcurrencyFeatures, ConcurrencyManager};
 }

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -88,10 +88,10 @@ impl ConcurrencyManager {
             timeout: Arc::new(crate::timeout::TimeoutManager::from_policy(config.timeout_policy())),
 
             #[cfg(feature = "lock")]
-            lock: Arc::new(crate::lock::LockManager::new(
-                config.enable_lock_optimization,
-                config.lock_acquire_timeout,
-            )),
+            lock: Arc::new({
+                let lock_policy = config.lock_policy();
+                crate::lock::LockManager::new(lock_policy.enabled, lock_policy.acquire_timeout)
+            }),
 
             #[cfg(feature = "deadlock")]
             deadlock: Arc::new(crate::deadlock::DeadlockManager::from_policy(config.deadlock_policy())),
@@ -227,7 +227,7 @@ impl ConcurrencyManager {
     pub async fn start(&self) {
         #[cfg(feature = "deadlock")]
         {
-            if self.config.enable_deadlock_detection {
+            if self.config.deadlock_policy.enabled {
                 self.deadlock.start().await;
             }
         }

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -100,12 +100,7 @@ impl ConcurrencyManager {
             backpressure: Arc::new(crate::backpressure::BackpressureManager::from_policy(config.backpressure_policy())),
 
             #[cfg(feature = "scheduler")]
-            scheduler: Arc::new(crate::scheduler::SchedulerManager::new(
-                config.io_buffer_size,
-                config.max_buffer_size,
-                config.high_priority_threshold,
-                config.low_priority_threshold,
-            )),
+            scheduler: Arc::new(crate::scheduler::SchedulerManager::from_policy(config.scheduler_policy())),
 
             config,
         }

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -85,22 +85,22 @@ impl ConcurrencyManager {
 
         Self {
             #[cfg(feature = "timeout")]
-            timeout: Arc::new(crate::timeout::TimeoutManager::from_policy(config.timeout_policy())),
+            timeout: Arc::new(crate::timeout::TimeoutManager::from_policy(config.timeout_policy)),
 
             #[cfg(feature = "lock")]
-            lock: Arc::new({
-                let lock_policy = config.lock_policy();
-                crate::lock::LockManager::new(lock_policy.enabled, lock_policy.acquire_timeout)
-            }),
+            lock: Arc::new(crate::lock::LockManager::new(
+                config.lock_policy.enabled,
+                config.lock_policy.acquire_timeout,
+            )),
 
             #[cfg(feature = "deadlock")]
-            deadlock: Arc::new(crate::deadlock::DeadlockManager::from_policy(config.deadlock_policy())),
+            deadlock: Arc::new(crate::deadlock::DeadlockManager::from_policy(config.deadlock_policy)),
 
             #[cfg(feature = "backpressure")]
-            backpressure: Arc::new(crate::backpressure::BackpressureManager::from_policy(config.backpressure_policy())),
+            backpressure: Arc::new(crate::backpressure::BackpressureManager::from_policy(config.backpressure_policy)),
 
             #[cfg(feature = "scheduler")]
-            scheduler: Arc::new(crate::scheduler::SchedulerManager::from_policy(config.scheduler_policy())),
+            scheduler: Arc::new(crate::scheduler::SchedulerManager::from_policy(config.scheduler_policy)),
 
             config,
         }

--- a/crates/concurrency/src/manager.rs
+++ b/crates/concurrency/src/manager.rs
@@ -85,11 +85,7 @@ impl ConcurrencyManager {
 
         Self {
             #[cfg(feature = "timeout")]
-            timeout: Arc::new(crate::timeout::TimeoutManager::new(
-                config.default_timeout,
-                config.max_timeout,
-                config.enable_dynamic_timeout,
-            )),
+            timeout: Arc::new(crate::timeout::TimeoutManager::from_policy(config.timeout_policy())),
 
             #[cfg(feature = "lock")]
             lock: Arc::new(crate::lock::LockManager::new(
@@ -98,18 +94,10 @@ impl ConcurrencyManager {
             )),
 
             #[cfg(feature = "deadlock")]
-            deadlock: Arc::new(crate::deadlock::DeadlockManager::new(
-                config.enable_deadlock_detection,
-                config.deadlock_check_interval,
-                config.hang_threshold,
-            )),
+            deadlock: Arc::new(crate::deadlock::DeadlockManager::from_policy(config.deadlock_policy())),
 
             #[cfg(feature = "backpressure")]
-            backpressure: Arc::new(crate::backpressure::BackpressureManager::new(
-                config.backpressure_buffer_size,
-                config.high_watermark,
-                config.low_watermark,
-            )),
+            backpressure: Arc::new(crate::backpressure::BackpressureManager::from_policy(config.backpressure_policy())),
 
             #[cfg(feature = "scheduler")]
             scheduler: Arc::new(crate::scheduler::SchedulerManager::new(

--- a/crates/concurrency/src/scheduler.rs
+++ b/crates/concurrency/src/scheduler.rs
@@ -59,9 +59,6 @@ impl SchedulerPolicy {
     }
 }
 
-/// Backward-compatible alias for the old scheduler facade name.
-pub type SchedulerConfig = SchedulerPolicy;
-
 /// Scheduler manager
 pub struct SchedulerManager {
     config: SchedulerPolicy,

--- a/crates/concurrency/src/scheduler.rs
+++ b/crates/concurrency/src/scheduler.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// Facade policy for the concurrency-layer scheduler manager.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct SchedulerPolicy {
     /// Base buffer size
     pub base_buffer_size: usize,

--- a/crates/concurrency/src/scheduler.rs
+++ b/crates/concurrency/src/scheduler.rs
@@ -46,12 +46,26 @@ impl Default for SchedulerPolicy {
     }
 }
 
+impl SchedulerPolicy {
+    /// Convert facade policy to io-core scheduler config.
+    pub fn to_core_config(&self) -> rustfs_io_core::IoSchedulerConfig {
+        rustfs_io_core::IoSchedulerConfig {
+            base_buffer_size: self.base_buffer_size,
+            max_buffer_size: self.max_buffer_size,
+            high_priority_size_threshold: self.high_priority_threshold,
+            low_priority_size_threshold: self.low_priority_threshold,
+            ..rustfs_io_core::IoSchedulerConfig::default()
+        }
+    }
+}
+
 /// Backward-compatible alias for the old scheduler facade name.
 pub type SchedulerConfig = SchedulerPolicy;
 
 /// Scheduler manager
 pub struct SchedulerManager {
     config: SchedulerPolicy,
+    core_config: rustfs_io_core::IoSchedulerConfig,
     scheduler: Arc<CoreIoScheduler>,
 }
 
@@ -63,17 +77,21 @@ impl SchedulerManager {
         high_priority_threshold: usize,
         low_priority_threshold: usize,
     ) -> Self {
-        let config = SchedulerPolicy {
+        Self::from_policy(SchedulerPolicy {
             base_buffer_size,
             max_buffer_size,
             high_priority_threshold,
             low_priority_threshold,
-        };
+        })
+    }
 
-        let core_config = rustfs_io_core::IoSchedulerConfig::default();
+    /// Create a scheduler manager from facade policy.
+    pub fn from_policy(config: SchedulerPolicy) -> Self {
+        let core_config = config.to_core_config();
 
         Self {
             config,
+            core_config: core_config.clone(),
             scheduler: Arc::new(CoreIoScheduler::new(core_config)),
         }
     }
@@ -81,6 +99,11 @@ impl SchedulerManager {
     /// Get the configuration
     pub fn config(&self) -> &SchedulerPolicy {
         &self.config
+    }
+
+    /// Get the derived io-core scheduler config.
+    pub fn core_config(&self) -> &rustfs_io_core::IoSchedulerConfig {
+        &self.core_config
     }
 
     /// Get the scheduler
@@ -207,6 +230,16 @@ mod tests {
     fn test_scheduler_config() {
         let config = SchedulerPolicy::default();
         assert!(config.base_buffer_size < config.max_buffer_size);
+    }
+
+    #[test]
+    fn test_scheduler_policy_to_core_config() {
+        let policy = SchedulerPolicy::default();
+        let core = policy.to_core_config();
+        assert_eq!(core.base_buffer_size, policy.base_buffer_size);
+        assert_eq!(core.max_buffer_size, policy.max_buffer_size);
+        assert_eq!(core.high_priority_size_threshold, policy.high_priority_threshold);
+        assert_eq!(core.low_priority_size_threshold, policy.low_priority_threshold);
     }
 
     #[test]

--- a/crates/concurrency/src/scheduler.rs
+++ b/crates/concurrency/src/scheduler.rs
@@ -22,9 +22,9 @@ use rustfs_io_metrics::io_metrics;
 use std::sync::Arc;
 use std::time::Duration;
 
-/// Scheduler configuration
+/// Facade policy for the concurrency-layer scheduler manager.
 #[derive(Debug, Clone)]
-pub struct SchedulerConfig {
+pub struct SchedulerPolicy {
     /// Base buffer size
     pub base_buffer_size: usize,
     /// Maximum buffer size
@@ -35,7 +35,7 @@ pub struct SchedulerConfig {
     pub low_priority_threshold: usize,
 }
 
-impl Default for SchedulerConfig {
+impl Default for SchedulerPolicy {
     fn default() -> Self {
         Self {
             base_buffer_size: 64 * 1024,              // 64KB
@@ -46,9 +46,12 @@ impl Default for SchedulerConfig {
     }
 }
 
+/// Backward-compatible alias for the old scheduler facade name.
+pub type SchedulerConfig = SchedulerPolicy;
+
 /// Scheduler manager
 pub struct SchedulerManager {
-    config: SchedulerConfig,
+    config: SchedulerPolicy,
     scheduler: Arc<CoreIoScheduler>,
 }
 
@@ -60,7 +63,7 @@ impl SchedulerManager {
         high_priority_threshold: usize,
         low_priority_threshold: usize,
     ) -> Self {
-        let config = SchedulerConfig {
+        let config = SchedulerPolicy {
             base_buffer_size,
             max_buffer_size,
             high_priority_threshold,
@@ -76,7 +79,7 @@ impl SchedulerManager {
     }
 
     /// Get the configuration
-    pub fn config(&self) -> &SchedulerConfig {
+    pub fn config(&self) -> &SchedulerPolicy {
         &self.config
     }
 
@@ -111,12 +114,12 @@ impl SchedulerManager {
 
 /// I/O strategy
 pub struct IoStrategy {
-    config: SchedulerConfig,
+    config: SchedulerPolicy,
     scheduler: Arc<CoreIoScheduler>,
 }
 
 impl IoStrategy {
-    fn new(config: SchedulerConfig, scheduler: Arc<CoreIoScheduler>) -> Self {
+    fn new(config: SchedulerPolicy, scheduler: Arc<CoreIoScheduler>) -> Self {
         Self { config, scheduler }
     }
 
@@ -191,7 +194,7 @@ impl IoStrategy {
     }
 
     /// Get the configuration
-    pub fn config(&self) -> &SchedulerConfig {
+    pub fn config(&self) -> &SchedulerPolicy {
         &self.config
     }
 }
@@ -202,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_scheduler_config() {
-        let config = SchedulerConfig::default();
+        let config = SchedulerPolicy::default();
         assert!(config.base_buffer_size < config.max_buffer_size);
     }
 

--- a/crates/concurrency/src/scheduler.rs
+++ b/crates/concurrency/src/scheduler.rs
@@ -113,7 +113,7 @@ impl SchedulerManager {
 
     /// Create an I/O strategy
     pub fn create_strategy(&self) -> IoStrategy {
-        IoStrategy::new(self.config.clone(), self.scheduler.clone())
+        IoStrategy::new(self.config, self.scheduler.clone())
     }
 
     /// Calculate buffer size

--- a/crates/concurrency/src/timeout.rs
+++ b/crates/concurrency/src/timeout.rs
@@ -18,9 +18,9 @@ use rustfs_io_core::{TimeoutError, calculate_adaptive_timeout};
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
-/// Timeout configuration
+/// Facade policy for the concurrency-layer timeout manager.
 #[derive(Debug, Clone)]
-pub struct TimeoutConfig {
+pub struct TimeoutManagerPolicy {
     /// Default timeout duration
     pub default_timeout: Duration,
     /// Maximum timeout duration
@@ -29,7 +29,7 @@ pub struct TimeoutConfig {
     pub enable_dynamic: bool,
 }
 
-impl Default for TimeoutConfig {
+impl Default for TimeoutManagerPolicy {
     fn default() -> Self {
         Self {
             default_timeout: Duration::from_secs(30),
@@ -39,16 +39,19 @@ impl Default for TimeoutConfig {
     }
 }
 
+/// Backward-compatible alias for the old timeout facade name.
+pub type TimeoutConfig = TimeoutManagerPolicy;
+
 /// Timeout manager
 pub struct TimeoutManager {
-    config: TimeoutConfig,
+    config: TimeoutManagerPolicy,
 }
 
 impl TimeoutManager {
     /// Create a new timeout manager
     pub fn new(default_timeout: Duration, max_timeout: Duration, enable_dynamic: bool) -> Self {
         Self {
-            config: TimeoutConfig {
+            config: TimeoutManagerPolicy {
                 default_timeout,
                 max_timeout,
                 enable_dynamic,
@@ -57,7 +60,7 @@ impl TimeoutManager {
     }
 
     /// Get the configuration
-    pub fn config(&self) -> &TimeoutConfig {
+    pub fn config(&self) -> &TimeoutManagerPolicy {
         &self.config
     }
 
@@ -134,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_timeout_config() {
-        let config = TimeoutConfig::default();
+        let config = TimeoutManagerPolicy::default();
         assert!(config.default_timeout < config.max_timeout);
     }
 

--- a/crates/concurrency/src/timeout.rs
+++ b/crates/concurrency/src/timeout.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 /// Facade policy for the concurrency-layer timeout manager.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TimeoutManagerPolicy {
     /// Default timeout duration
     pub default_timeout: Duration,

--- a/crates/concurrency/src/timeout.rs
+++ b/crates/concurrency/src/timeout.rs
@@ -14,7 +14,7 @@
 
 //! Timeout management for operations
 
-use rustfs_io_core::{TimeoutError, calculate_adaptive_timeout};
+use rustfs_io_core::{TimeoutConfig as CoreTimeoutConfig, TimeoutError, calculate_adaptive_timeout};
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
@@ -39,29 +39,58 @@ impl Default for TimeoutManagerPolicy {
     }
 }
 
+impl TimeoutManagerPolicy {
+    /// Convert the facade policy into the reusable io-core timeout configuration.
+    ///
+    /// This keeps the concurrency layer explicitly wired to the shared core
+    /// timeout primitives without changing the facade's public behavior.
+    pub fn to_core_config(&self) -> CoreTimeoutConfig {
+        CoreTimeoutConfig {
+            base_timeout: self.default_timeout,
+            timeout_per_mb: Duration::ZERO,
+            max_timeout: self.max_timeout,
+            min_timeout: Duration::from_secs(1),
+            get_object_timeout: self.default_timeout,
+            put_object_timeout: self.max_timeout,
+            list_objects_timeout: self.default_timeout,
+            enable_dynamic_timeout: self.enable_dynamic,
+        }
+    }
+}
+
 /// Backward-compatible alias for the old timeout facade name.
 pub type TimeoutConfig = TimeoutManagerPolicy;
 
 /// Timeout manager
 pub struct TimeoutManager {
     config: TimeoutManagerPolicy,
+    core_config: CoreTimeoutConfig,
 }
 
 impl TimeoutManager {
     /// Create a new timeout manager
     pub fn new(default_timeout: Duration, max_timeout: Duration, enable_dynamic: bool) -> Self {
-        Self {
-            config: TimeoutManagerPolicy {
-                default_timeout,
-                max_timeout,
-                enable_dynamic,
-            },
-        }
+        Self::from_policy(TimeoutManagerPolicy {
+            default_timeout,
+            max_timeout,
+            enable_dynamic,
+        })
+    }
+
+    /// Create a new timeout manager from the facade policy type.
+    pub fn from_policy(config: TimeoutManagerPolicy) -> Self {
+        let core_config = config.to_core_config();
+        Self { config, core_config }
     }
 
     /// Get the configuration
     pub fn config(&self) -> &TimeoutManagerPolicy {
         &self.config
+    }
+
+    /// Get the derived io-core timeout configuration.
+    pub fn core_config(&self) -> &CoreTimeoutConfig {
+        &self.core_config
     }
 
     /// Calculate timeout for a given size
@@ -70,7 +99,8 @@ impl TimeoutManager {
             return self.config.default_timeout;
         }
 
-        calculate_adaptive_timeout(self.config.default_timeout, None, 0, size).min(self.config.max_timeout)
+        calculate_adaptive_timeout(self.core_config.base_timeout, None, 0, size)
+            .clamp(self.core_config.min_timeout, self.core_config.max_timeout)
     }
 
     /// Wrap an operation with timeout control
@@ -90,7 +120,7 @@ impl TimeoutManager {
 
     /// Create a timeout guard for manual timeout control
     pub fn create_guard(&self, timeout: Option<Duration>) -> TimeoutGuard {
-        TimeoutGuard::new(timeout.unwrap_or(self.config.default_timeout))
+        TimeoutGuard::new(timeout.unwrap_or(self.core_config.base_timeout))
     }
 }
 
@@ -139,6 +169,16 @@ mod tests {
     fn test_timeout_config() {
         let config = TimeoutManagerPolicy::default();
         assert!(config.default_timeout < config.max_timeout);
+    }
+
+    #[test]
+    fn test_timeout_policy_to_core_config() {
+        let policy = TimeoutManagerPolicy::default();
+        let core = policy.to_core_config();
+        assert_eq!(core.base_timeout, policy.default_timeout);
+        assert_eq!(core.max_timeout, policy.max_timeout);
+        assert_eq!(core.get_object_timeout, policy.default_timeout);
+        assert!(core.enable_dynamic_timeout);
     }
 
     #[tokio::test]

--- a/crates/concurrency/src/timeout.rs
+++ b/crates/concurrency/src/timeout.rs
@@ -70,16 +70,23 @@ pub struct TimeoutManager {
 impl TimeoutManager {
     /// Create a new timeout manager
     pub fn new(default_timeout: Duration, max_timeout: Duration, enable_dynamic: bool) -> Self {
+        let min_timeout = default_timeout.min(max_timeout);
         Self::from_policy(TimeoutManagerPolicy {
             default_timeout,
             max_timeout,
+            min_timeout,
             enable_dynamic,
-            ..Default::default()
         })
     }
 
     /// Create a new timeout manager from the facade policy type.
     pub fn from_policy(config: TimeoutManagerPolicy) -> Self {
+        let config = TimeoutManagerPolicy {
+            // Guard clamp(min, max) from panic when callers provide an
+            // out-of-order policy (or very small max_timeout).
+            min_timeout: config.min_timeout.min(config.max_timeout),
+            ..config
+        };
         let core_config = config.to_core_config();
         Self { config, core_config }
     }
@@ -181,6 +188,26 @@ mod tests {
         assert_eq!(core.min_timeout, policy.min_timeout);
         assert_eq!(core.get_object_timeout, policy.default_timeout);
         assert!(core.enable_dynamic_timeout);
+    }
+
+    #[test]
+    fn test_timeout_manager_new_sanitizes_min_timeout_with_small_max_timeout() {
+        let manager = TimeoutManager::new(Duration::from_secs(1), Duration::from_secs(1), true);
+        let timeout = manager.calculate_timeout(1024, &[]);
+        assert_eq!(timeout, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_timeout_manager_from_policy_sanitizes_min_timeout() {
+        let manager = TimeoutManager::from_policy(TimeoutManagerPolicy {
+            default_timeout: Duration::from_secs(30),
+            max_timeout: Duration::from_secs(1),
+            min_timeout: Duration::from_secs(5),
+            enable_dynamic: true,
+        });
+
+        assert_eq!(manager.config().min_timeout, Duration::from_secs(1));
+        assert_eq!(manager.core_config().min_timeout, Duration::from_secs(1));
     }
 
     #[tokio::test]

--- a/crates/concurrency/src/timeout.rs
+++ b/crates/concurrency/src/timeout.rs
@@ -25,6 +25,8 @@ pub struct TimeoutManagerPolicy {
     pub default_timeout: Duration,
     /// Maximum timeout duration
     pub max_timeout: Duration,
+    /// Minimum timeout floor (prevents dynamic calculation from going too low).
+    pub min_timeout: Duration,
     /// Enable dynamic timeout calculation
     pub enable_dynamic: bool,
 }
@@ -34,6 +36,7 @@ impl Default for TimeoutManagerPolicy {
         Self {
             default_timeout: Duration::from_secs(30),
             max_timeout: Duration::from_secs(300),
+            min_timeout: Duration::from_secs(5),
             enable_dynamic: true,
         }
     }
@@ -49,7 +52,7 @@ impl TimeoutManagerPolicy {
             base_timeout: self.default_timeout,
             timeout_per_mb: Duration::ZERO,
             max_timeout: self.max_timeout,
-            min_timeout: Duration::from_secs(1),
+            min_timeout: self.min_timeout,
             get_object_timeout: self.default_timeout,
             put_object_timeout: self.max_timeout,
             list_objects_timeout: self.default_timeout,
@@ -57,9 +60,6 @@ impl TimeoutManagerPolicy {
         }
     }
 }
-
-/// Backward-compatible alias for the old timeout facade name.
-pub type TimeoutConfig = TimeoutManagerPolicy;
 
 /// Timeout manager
 pub struct TimeoutManager {
@@ -74,6 +74,7 @@ impl TimeoutManager {
             default_timeout,
             max_timeout,
             enable_dynamic,
+            ..Default::default()
         })
     }
 
@@ -177,6 +178,7 @@ mod tests {
         let core = policy.to_core_config();
         assert_eq!(core.base_timeout, policy.default_timeout);
         assert_eq!(core.max_timeout, policy.max_timeout);
+        assert_eq!(core.min_timeout, policy.min_timeout);
         assert_eq!(core.get_object_timeout, policy.default_timeout);
         assert!(core.enable_dynamic_timeout);
     }

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -32,7 +32,7 @@ use crate::storage::options::{
 use crate::storage::request_context::spawn_traced;
 use crate::storage::s3_api::multipart::parse_list_parts_params;
 use crate::storage::sse::{SSEType, build_ssec_read_headers, encryption_material_to_metadata, map_get_object_reader_error};
-use crate::storage::timeout_wrapper::{RequestTimeoutWrapper, TimeoutConfig};
+use crate::storage::timeout_wrapper::{GetObjectTimeoutPolicy, RequestTimeoutWrapper};
 use crate::storage::*;
 use bytes::Bytes;
 use datafusion::arrow::{
@@ -159,7 +159,7 @@ impl Drop for DeadlockRequestGuard {
 }
 
 struct GetObjectBootstrap {
-    timeout_config: TimeoutConfig,
+    timeout_config: GetObjectTimeoutPolicy,
     wrapper: RequestTimeoutWrapper,
     request_start: std::time::Instant,
     request_guard: GetObjectGuard,
@@ -443,14 +443,14 @@ fn should_buffer_get_object_in_memory_with_threshold(
 #[cfg(test)]
 mod deadlock_request_guard_tests {
     use super::DeadlockRequestGuard;
-    use crate::storage::deadlock_detector::{DeadlockDetector, DeadlockDetectorConfig};
+    use crate::storage::deadlock_detector::{DeadlockDetector, RequestHangDetectionPolicy};
     use std::sync::Arc;
 
     #[test]
     fn deadlock_request_guard_unregisters_on_drop() {
-        let detector = Arc::new(DeadlockDetector::new(DeadlockDetectorConfig {
+        let detector = Arc::new(DeadlockDetector::new(RequestHangDetectionPolicy {
             enabled: true,
-            ..DeadlockDetectorConfig::default()
+            ..RequestHangDetectionPolicy::default()
         }));
         let request_id = "test-request-id".to_string();
 
@@ -1112,7 +1112,7 @@ impl DefaultObjectUsecase {
     }
 
     fn init_get_object_bootstrap(bucket: &str, key: &str, request_id: &str) -> S3Result<GetObjectBootstrap> {
-        let timeout_config = TimeoutConfig::from_env();
+        let timeout_config = GetObjectTimeoutPolicy::from_env();
         let wrapper = RequestTimeoutWrapper::with_request_id(timeout_config.clone(), request_id.to_string());
         let request_start = std::time::Instant::now();
         let request_guard = ConcurrencyManager::track_request();
@@ -1154,7 +1154,7 @@ impl DefaultObjectUsecase {
     async fn acquire_get_object_io_planning<'a>(
         manager: &'a ConcurrencyManager,
         wrapper: &RequestTimeoutWrapper,
-        timeout_config: &TimeoutConfig,
+        timeout_config: &GetObjectTimeoutPolicy,
         bucket: &str,
         key: &str,
     ) -> S3Result<GetObjectIoPlanning<'a>> {
@@ -1274,7 +1274,7 @@ impl DefaultObjectUsecase {
         req: &S3Request<GetObjectInput>,
         manager: &'a ConcurrencyManager,
         wrapper: &RequestTimeoutWrapper,
-        timeout_config: &TimeoutConfig,
+        timeout_config: &GetObjectTimeoutPolicy,
         bucket: &str,
         key: &str,
         rs: Option<HTTPRangeSpec>,
@@ -2024,7 +2024,7 @@ impl DefaultObjectUsecase {
 
     fn finalize_get_object_completion(
         wrapper: &RequestTimeoutWrapper,
-        timeout_config: &TimeoutConfig,
+        timeout_config: &GetObjectTimeoutPolicy,
         total_duration: Duration,
         response_content_length: i64,
         optimal_buffer_size: usize,

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -1123,16 +1123,12 @@ impl DefaultObjectUsecase {
         deadlock_detector.register_request(&request_id, format!("GetObject {bucket}/{key}"));
         let deadlock_request_guard = DeadlockRequestGuard::new(deadlock_detector, request_id);
 
-        if wrapper.is_timeout() {
-            warn!(
-                bucket = %bucket,
-                key = %key,
-                timeout_secs = timeout_config.get_object_timeout.as_secs(),
-                elapsed_ms = wrapper.elapsed().as_millis(),
-                "GetObject request timed out before processing"
-            );
-            return Err(s3_error!(InternalError, "Request timeout before processing"));
-        }
+        Self::ensure_get_object_not_timed_out_before_processing(
+            &wrapper,
+            &timeout_config,
+            bucket,
+            key,
+        )?;
 
         rustfs_io_metrics::record_get_object_request_start(concurrent_requests);
 
@@ -1165,19 +1161,13 @@ impl DefaultObjectUsecase {
             .map_err(|_| s3_error!(InternalError, "disk read semaphore closed"))?;
         let permit_wait_duration = permit_wait_start.elapsed();
 
-        if wrapper.is_timeout() {
-            warn!(
-                bucket = %bucket,
-                key = %key,
-                wait_ms = permit_wait_duration.as_millis(),
-                timeout_secs = timeout_config.get_object_timeout.as_secs(),
-                elapsed_ms = wrapper.elapsed().as_millis(),
-                "GetObject request timed out while waiting for disk permit"
-            );
-
-            rustfs_io_metrics::record_get_object_timeout(Some("disk_permit"), Some(wrapper.elapsed().as_secs_f64()));
-            return Err(s3_error!(InternalError, "Request timeout while waiting for disk permit"));
-        }
+        Self::ensure_get_object_not_timed_out_while_waiting_for_disk_permit(
+            wrapper,
+            timeout_config,
+            bucket,
+            key,
+            permit_wait_duration,
+        )?;
 
         let queue_status = manager.io_queue_status();
         let queue_snapshot = GetObjectQueueSnapshot::from_available_permits(
@@ -1199,17 +1189,12 @@ impl DefaultObjectUsecase {
             rustfs_io_metrics::record_io_queue_congestion();
         }
 
-        if wrapper.is_timeout() {
-            warn!(
-                bucket = %bucket,
-                key = %key,
-                timeout_secs = timeout_config.get_object_timeout.as_secs(),
-                elapsed_ms = wrapper.elapsed().as_millis(),
-                "GetObject request timed out before reading object"
-            );
-            rustfs_io_metrics::record_get_object_timeout(Some("before_read"), Some(wrapper.elapsed().as_secs_f64()));
-            return Err(s3_error!(InternalError, "Request timeout before reading object"));
-        }
+        Self::ensure_get_object_not_timed_out_before_read(
+            wrapper,
+            timeout_config,
+            bucket,
+            key,
+        )?;
 
         Ok(GetObjectIoPlanning {
             _disk_permit: disk_permit,
@@ -2050,6 +2035,73 @@ impl DefaultObjectUsecase {
             "GetObject completed: size={} duration={:?} buffer={}",
             response_content_length, total_duration, optimal_buffer_size
         );
+    }
+
+    fn ensure_get_object_not_timed_out_before_processing(
+        wrapper: &RequestTimeoutWrapper,
+        timeout_config: &GetObjectTimeoutPolicy,
+        bucket: &str,
+        key: &str,
+    ) -> S3Result<()> {
+        if !wrapper.is_timeout() {
+            return Ok(());
+        }
+
+        warn!(
+            bucket = %bucket,
+            key = %key,
+            timeout_secs = timeout_config.get_object_timeout.as_secs(),
+            elapsed_ms = wrapper.elapsed().as_millis(),
+            "GetObject request timed out before processing"
+        );
+
+        Err(s3_error!(InternalError, "Request timeout before processing"))
+    }
+
+    fn ensure_get_object_not_timed_out_while_waiting_for_disk_permit(
+        wrapper: &RequestTimeoutWrapper,
+        timeout_config: &GetObjectTimeoutPolicy,
+        bucket: &str,
+        key: &str,
+        permit_wait_duration: Duration,
+    ) -> S3Result<()> {
+        if !wrapper.is_timeout() {
+            return Ok(());
+        }
+
+        warn!(
+            bucket = %bucket,
+            key = %key,
+            wait_ms = permit_wait_duration.as_millis(),
+            timeout_secs = timeout_config.get_object_timeout.as_secs(),
+            elapsed_ms = wrapper.elapsed().as_millis(),
+            "GetObject request timed out while waiting for disk permit"
+        );
+
+        rustfs_io_metrics::record_get_object_timeout(Some("disk_permit"), Some(wrapper.elapsed().as_secs_f64()));
+        Err(s3_error!(InternalError, "Request timeout while waiting for disk permit"))
+    }
+
+    fn ensure_get_object_not_timed_out_before_read(
+        wrapper: &RequestTimeoutWrapper,
+        timeout_config: &GetObjectTimeoutPolicy,
+        bucket: &str,
+        key: &str,
+    ) -> S3Result<()> {
+        if !wrapper.is_timeout() {
+            return Ok(());
+        }
+
+        warn!(
+            bucket = %bucket,
+            key = %key,
+            timeout_secs = timeout_config.get_object_timeout.as_secs(),
+            elapsed_ms = wrapper.elapsed().as_millis(),
+            "GetObject request timed out before reading object"
+        );
+
+        rustfs_io_metrics::record_get_object_timeout(Some("before_read"), Some(wrapper.elapsed().as_secs_f64()));
+        Err(s3_error!(InternalError, "Request timeout before reading object"))
     }
 
     async fn finalize_get_object_response(

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -1123,12 +1123,7 @@ impl DefaultObjectUsecase {
         deadlock_detector.register_request(&request_id, format!("GetObject {bucket}/{key}"));
         let deadlock_request_guard = DeadlockRequestGuard::new(deadlock_detector, request_id);
 
-        Self::ensure_get_object_not_timed_out_before_processing(
-            &wrapper,
-            &timeout_config,
-            bucket,
-            key,
-        )?;
+        Self::ensure_get_object_not_timed_out_before_processing(&wrapper, &timeout_config, bucket, key)?;
 
         rustfs_io_metrics::record_get_object_request_start(concurrent_requests);
 
@@ -1189,12 +1184,7 @@ impl DefaultObjectUsecase {
             rustfs_io_metrics::record_io_queue_congestion();
         }
 
-        Self::ensure_get_object_not_timed_out_before_read(
-            wrapper,
-            timeout_config,
-            bucket,
-            key,
-        )?;
+        Self::ensure_get_object_not_timed_out_before_read(wrapper, timeout_config, bucket, key)?;
 
         Ok(GetObjectIoPlanning {
             _disk_permit: disk_permit,

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -217,6 +217,12 @@ struct GetObjectOutputContext {
     optimal_buffer_size: usize,
 }
 
+enum GetObjectTimeoutStage {
+    BeforeProcessing,
+    DiskPermitWait { permit_wait_duration: Duration },
+    BeforeRead,
+}
+
 async fn enqueue_transitioned_delete_cleanup(bucket: &str, object: &str, opts: &ObjectOptions, existing: Option<&ObjectInfo>) {
     let Some(existing) = existing else {
         return;
@@ -1123,7 +1129,7 @@ impl DefaultObjectUsecase {
         deadlock_detector.register_request(&request_id, format!("GetObject {bucket}/{key}"));
         let deadlock_request_guard = DeadlockRequestGuard::new(deadlock_detector, request_id);
 
-        Self::ensure_get_object_not_timed_out_before_processing(&wrapper, &timeout_config, bucket, key)?;
+        Self::ensure_get_object_not_timed_out(&wrapper, &timeout_config, bucket, key, GetObjectTimeoutStage::BeforeProcessing)?;
 
         rustfs_io_metrics::record_get_object_request_start(concurrent_requests);
 
@@ -1156,12 +1162,12 @@ impl DefaultObjectUsecase {
             .map_err(|_| s3_error!(InternalError, "disk read semaphore closed"))?;
         let permit_wait_duration = permit_wait_start.elapsed();
 
-        Self::ensure_get_object_not_timed_out_while_waiting_for_disk_permit(
+        Self::ensure_get_object_not_timed_out(
             wrapper,
             timeout_config,
             bucket,
             key,
-            permit_wait_duration,
+            GetObjectTimeoutStage::DiskPermitWait { permit_wait_duration },
         )?;
 
         let queue_status = manager.io_queue_status();
@@ -1184,7 +1190,7 @@ impl DefaultObjectUsecase {
             rustfs_io_metrics::record_io_queue_congestion();
         }
 
-        Self::ensure_get_object_not_timed_out_before_read(wrapper, timeout_config, bucket, key)?;
+        Self::ensure_get_object_not_timed_out(wrapper, timeout_config, bucket, key, GetObjectTimeoutStage::BeforeRead)?;
 
         Ok(GetObjectIoPlanning {
             _disk_permit: disk_permit,
@@ -2027,71 +2033,55 @@ impl DefaultObjectUsecase {
         );
     }
 
-    fn ensure_get_object_not_timed_out_before_processing(
+    fn ensure_get_object_not_timed_out(
         wrapper: &RequestTimeoutWrapper,
         timeout_config: &GetObjectTimeoutPolicy,
         bucket: &str,
         key: &str,
+        stage: GetObjectTimeoutStage,
     ) -> S3Result<()> {
         if !wrapper.is_timeout() {
             return Ok(());
         }
 
-        warn!(
-            bucket = %bucket,
-            key = %key,
-            timeout_secs = timeout_config.get_object_timeout.as_secs(),
-            elapsed_ms = wrapper.elapsed().as_millis(),
-            "GetObject request timed out before processing"
-        );
+        let timeout_secs = timeout_config.get_object_timeout.as_secs();
+        let elapsed_ms = wrapper.elapsed().as_millis();
 
-        Err(s3_error!(InternalError, "Request timeout before processing"))
-    }
-
-    fn ensure_get_object_not_timed_out_while_waiting_for_disk_permit(
-        wrapper: &RequestTimeoutWrapper,
-        timeout_config: &GetObjectTimeoutPolicy,
-        bucket: &str,
-        key: &str,
-        permit_wait_duration: Duration,
-    ) -> S3Result<()> {
-        if !wrapper.is_timeout() {
-            return Ok(());
+        match stage {
+            GetObjectTimeoutStage::BeforeProcessing => {
+                warn!(
+                    bucket = %bucket,
+                    key = %key,
+                    timeout_secs,
+                    elapsed_ms,
+                    "GetObject request timed out before processing"
+                );
+                Err(s3_error!(InternalError, "Request timeout before processing"))
+            }
+            GetObjectTimeoutStage::DiskPermitWait { permit_wait_duration } => {
+                warn!(
+                    bucket = %bucket,
+                    key = %key,
+                    wait_ms = permit_wait_duration.as_millis(),
+                    timeout_secs,
+                    elapsed_ms,
+                    "GetObject request timed out while waiting for disk permit"
+                );
+                rustfs_io_metrics::record_get_object_timeout(Some("disk_permit"), Some(wrapper.elapsed().as_secs_f64()));
+                Err(s3_error!(InternalError, "Request timeout while waiting for disk permit"))
+            }
+            GetObjectTimeoutStage::BeforeRead => {
+                warn!(
+                    bucket = %bucket,
+                    key = %key,
+                    timeout_secs,
+                    elapsed_ms,
+                    "GetObject request timed out before reading object"
+                );
+                rustfs_io_metrics::record_get_object_timeout(Some("before_read"), Some(wrapper.elapsed().as_secs_f64()));
+                Err(s3_error!(InternalError, "Request timeout before reading object"))
+            }
         }
-
-        warn!(
-            bucket = %bucket,
-            key = %key,
-            wait_ms = permit_wait_duration.as_millis(),
-            timeout_secs = timeout_config.get_object_timeout.as_secs(),
-            elapsed_ms = wrapper.elapsed().as_millis(),
-            "GetObject request timed out while waiting for disk permit"
-        );
-
-        rustfs_io_metrics::record_get_object_timeout(Some("disk_permit"), Some(wrapper.elapsed().as_secs_f64()));
-        Err(s3_error!(InternalError, "Request timeout while waiting for disk permit"))
-    }
-
-    fn ensure_get_object_not_timed_out_before_read(
-        wrapper: &RequestTimeoutWrapper,
-        timeout_config: &GetObjectTimeoutPolicy,
-        bucket: &str,
-        key: &str,
-    ) -> S3Result<()> {
-        if !wrapper.is_timeout() {
-            return Ok(());
-        }
-
-        warn!(
-            bucket = %bucket,
-            key = %key,
-            timeout_secs = timeout_config.get_object_timeout.as_secs(),
-            elapsed_ms = wrapper.elapsed().as_millis(),
-            "GetObject request timed out before reading object"
-        );
-
-        rustfs_io_metrics::record_get_object_timeout(Some("before_read"), Some(wrapper.elapsed().as_secs_f64()));
-        Err(s3_error!(InternalError, "Request timeout before reading object"))
     }
 
     async fn finalize_get_object_response(

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -105,6 +105,7 @@ impl ObjectPipeBackpressurePolicy {
 }
 
 /// Backward-compatible alias for the old object pipe config name.
+#[deprecated(note = "use ObjectPipeBackpressurePolicy instead")]
 pub type BackpressureConfig = ObjectPipeBackpressurePolicy;
 
 /// Backpressure state.
@@ -258,7 +259,7 @@ pub struct BackpressurePipe {
 impl BackpressurePipe {
     /// Create a new backpressure-aware pipe with default configuration.
     pub fn new() -> Self {
-        Self::with_config(BackpressureConfig::from_env())
+        Self::with_config(ObjectPipeBackpressurePolicy::from_env())
     }
 
     /// Create a new backpressure-aware pipe with custom configuration.
@@ -423,7 +424,7 @@ impl Default for BackpressurePipe {
 /// wrap the streams but provides monitoring capabilities.
 pub struct BackpressureMonitor {
     /// Configuration.
-    config: BackpressureConfig,
+    config: ObjectPipeBackpressurePolicy,
     /// Current buffer usage.
     buffer_usage: Arc<AtomicUsize>,
     /// In high watermark state.
@@ -433,11 +434,11 @@ pub struct BackpressureMonitor {
 impl BackpressureMonitor {
     /// Create a new monitor with default configuration.
     pub fn new() -> Self {
-        Self::with_config(BackpressureConfig::from_env())
+        Self::with_config(ObjectPipeBackpressurePolicy::from_env())
     }
 
     /// Create a new monitor with custom configuration.
-    pub fn with_config(config: BackpressureConfig) -> Self {
+    pub fn with_config(config: ObjectPipeBackpressurePolicy) -> Self {
         Self {
             config,
             buffer_usage: Arc::new(AtomicUsize::new(0)),
@@ -527,7 +528,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_config_default() {
-        let config = BackpressureConfig::default();
+        let config = ObjectPipeBackpressurePolicy::default();
         assert_eq!(config.buffer_size, 4 * 1024 * 1024);
         assert_eq!(config.high_watermark, 80);
         assert_eq!(config.low_watermark, 50);
@@ -535,7 +536,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_config_watermarks() {
-        let config = BackpressureConfig {
+        let config = ObjectPipeBackpressurePolicy {
             buffer_size: 1000,
             high_watermark: 80,
             low_watermark: 50,
@@ -553,7 +554,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_monitor() {
-        let config = BackpressureConfig {
+        let config = ObjectPipeBackpressurePolicy {
             buffer_size: 1000,
             high_watermark: 80,
             low_watermark: 50,
@@ -587,7 +588,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_pipe_state_transitions() {
-        let config = BackpressureConfig {
+        let config = ObjectPipeBackpressurePolicy {
             buffer_size: 1000,
             high_watermark: 80,
             low_watermark: 50,

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -321,19 +321,20 @@ impl BackpressurePipe {
     pub fn record_write(&self, bytes: usize) {
         self.total_written.fetch_add(bytes, Ordering::Relaxed);
         self.buffer_usage.fetch_add(bytes, Ordering::Relaxed);
-        self.check_high_watermark();
+        self.update_watermark_state();
     }
 
     /// Record bytes read (call after successful read).
     pub fn record_read(&self, bytes: usize) {
         self.total_read.fetch_add(bytes, Ordering::Relaxed);
         self.buffer_usage.fetch_sub(bytes, Ordering::Relaxed);
-        self.check_low_watermark();
+        self.update_watermark_state();
     }
 
-    /// Check if high watermark is reached.
-    fn check_high_watermark(&self) {
+    /// Update watermark state and emit transition signals.
+    fn update_watermark_state(&self) {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
+        let usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32;
         let (next_state, changed) = apply_watermark_transition(
             &self.state,
             usage,
@@ -342,40 +343,32 @@ impl BackpressurePipe {
             self.config.low_watermark_bytes(),
         );
 
-        if changed && matches!(next_state, BackpressureState::HighWatermark) {
-            counter!("rustfs_backpressure_events_total", "state" => "high_watermark").increment(1);
+        if changed {
+            match next_state {
+                BackpressureState::HighWatermark => {
+                    counter!("rustfs_backpressure_events_total", "state" => "high_watermark").increment(1);
 
-            warn!(
-                buffer_usage = usage,
-                buffer_capacity = self.config.buffer_size,
-                usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32,
-                high_watermark = self.config.high_watermark,
-                "Backpressure: high watermark reached"
-            );
-        }
-    }
+                    warn!(
+                        buffer_usage = usage,
+                        buffer_capacity = self.config.buffer_size,
+                        usage_percent,
+                        high_watermark = self.config.high_watermark,
+                        "Backpressure: high watermark reached"
+                    );
+                }
+                BackpressureState::Normal => {
+                    counter!("rustfs_backpressure_events_total", "state" => "normal").increment(1);
 
-    /// Check if low watermark is reached (backpressure can be released).
-    fn check_low_watermark(&self) {
-        let usage = self.buffer_usage.load(Ordering::Relaxed);
-        let (next_state, changed) = apply_watermark_transition(
-            &self.state,
-            usage,
-            self.config.buffer_size,
-            self.config.high_watermark_bytes(),
-            self.config.low_watermark_bytes(),
-        );
-
-        if changed && matches!(next_state, BackpressureState::Normal) {
-            counter!("rustfs_backpressure_events_total", "state" => "normal").increment(1);
-
-            debug!(
-                buffer_usage = usage,
-                buffer_capacity = self.config.buffer_size,
-                usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32,
-                low_watermark = self.config.low_watermark,
-                "Backpressure: returned to normal"
-            );
+                    debug!(
+                        buffer_usage = usage,
+                        buffer_capacity = self.config.buffer_size,
+                        usage_percent,
+                        low_watermark = self.config.low_watermark,
+                        "Backpressure: returned to normal"
+                    );
+                }
+                BackpressureState::BackpressureApplied => {}
+            }
         }
     }
 
@@ -472,6 +465,7 @@ impl BackpressureMonitor {
     /// Update state based on current usage.
     fn update_state(&self) -> BackpressureState {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
+        let usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32;
         let (next_state, changed) = apply_watermark_transition(
             &self.in_high_watermark,
             usage,
@@ -484,14 +478,14 @@ impl BackpressureMonitor {
             if changed {
                 counter!("rustfs_backpressure_events_total", "state" => "high_watermark").increment(1);
 
-                debug!(usage_percent = self.usage_percent() as u32, "Backpressure: entered high watermark");
+                debug!(usage_percent, "Backpressure: entered high watermark");
             }
             BackpressureState::HighWatermark
         } else {
             if changed {
                 counter!("rustfs_backpressure_events_total", "state" => "normal").increment(1);
 
-                debug!(usage_percent = self.usage_percent() as u32, "Backpressure: returned to normal");
+                debug!(usage_percent, "Backpressure: returned to normal");
             }
             BackpressureState::Normal
         }

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -181,10 +181,12 @@ pub struct BackpressurePipeMeta {
 }
 
 /// Compact metadata snapshot for the lightweight backpressure monitor.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BackpressureMonitorMeta {
     /// Buffer capacity in bytes.
     pub buffer_capacity: usize,
+    /// Current buffer usage percentage.
+    pub usage_percent: f32,
     /// Current backpressure state.
     pub state: BackpressureState,
 }
@@ -467,6 +469,7 @@ impl BackpressureMonitor {
     pub fn meta(&self) -> BackpressureMonitorMeta {
         BackpressureMonitorMeta {
             buffer_capacity: self.config.buffer_size,
+            usage_percent: self.usage_percent(),
             state: self.state(),
         }
     }
@@ -548,14 +551,17 @@ mod tests {
         // Initially normal
         assert_eq!(monitor.state(), BackpressureState::Normal);
         assert_eq!(monitor.meta().buffer_capacity, 1000);
+        assert_eq!(monitor.meta().usage_percent, 0.0);
 
         // Write to reach high watermark
         let state = monitor.on_write(850);
         assert_eq!(state, BackpressureState::HighWatermark);
+        assert_eq!(monitor.meta().usage_percent, 85.0);
 
         // Read to go below low watermark
         let state = monitor.on_read(400);
         assert_eq!(state, BackpressureState::Normal);
+        assert_eq!(monitor.meta().usage_percent, 45.0);
     }
 
     #[tokio::test]

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -41,7 +41,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::io::{DuplexStream, duplex};
 use tracing::{debug, warn};
 
@@ -176,6 +176,8 @@ pub struct BackpressurePipeMeta {
     pub buffer_capacity: usize,
     /// Current backpressure state.
     pub state: BackpressureState,
+    /// Age of the pipe since creation.
+    pub age: Duration,
 }
 
 /// Compact metadata snapshot for the lightweight backpressure monitor.
@@ -239,6 +241,8 @@ pub struct BackpressurePipe {
     total_written: Arc<AtomicUsize>,
     /// Total bytes read.
     total_read: Arc<AtomicUsize>,
+    /// Pipe creation timestamp.
+    created_at: Instant,
 }
 
 impl BackpressurePipe {
@@ -268,6 +272,7 @@ impl BackpressurePipe {
             state: Arc::new(AtomicBool::new(false)),
             total_written: Arc::new(AtomicUsize::new(0)),
             total_read: Arc::new(AtomicUsize::new(0)),
+            created_at: Instant::now(),
         }
     }
 
@@ -313,7 +318,13 @@ impl BackpressurePipe {
         BackpressurePipeMeta {
             buffer_capacity: self.config.buffer_size,
             state: self.state(),
+            age: self.age(),
         }
+    }
+
+    /// Get the age of this pipe.
+    pub fn age(&self) -> Duration {
+        self.created_at.elapsed()
     }
 
     /// Record bytes written (call after successful write).
@@ -553,6 +564,7 @@ mod tests {
         assert_eq!(pipe.capacity(), 4 * 1024 * 1024);
         assert_eq!(pipe.state(), BackpressureState::Normal);
         assert_eq!(pipe.meta().buffer_capacity, 4 * 1024 * 1024);
+        assert!(pipe.age() >= pipe.meta().age);
     }
 
     #[test]

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -324,10 +324,7 @@ impl BackpressurePipe {
     pub fn meta(&self) -> BackpressurePipeMeta {
         BackpressurePipeMeta {
             buffer_capacity: self.config.buffer_size,
-            state: state_from_high_watermark(
-                self.state.load(Ordering::Relaxed),
-                BackpressureState::BackpressureApplied,
-            ),
+            state: state_from_high_watermark(self.state.load(Ordering::Relaxed), BackpressureState::BackpressureApplied),
             age: self.age(),
         }
     }
@@ -360,12 +357,8 @@ impl BackpressurePipe {
     fn update_watermark_state(&self) {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
         let usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32;
-        let (next_state, changed) = apply_watermark_transition(
-            &self.state,
-            usage,
-            self.config.high_watermark_bytes(),
-            self.config.low_watermark_bytes(),
-        );
+        let (next_state, changed) =
+            apply_watermark_transition(&self.state, usage, self.config.high_watermark_bytes(), self.config.low_watermark_bytes());
 
         if changed {
             match next_state {
@@ -480,10 +473,7 @@ impl BackpressureMonitor {
         BackpressureMonitorMeta {
             buffer_capacity: self.config.buffer_size,
             usage_percent: calculate_usage_percent(usage, self.config.buffer_size),
-            state: state_from_high_watermark(
-                self.in_high_watermark.load(Ordering::Relaxed),
-                BackpressureState::HighWatermark,
-            ),
+            state: state_from_high_watermark(self.in_high_watermark.load(Ordering::Relaxed), BackpressureState::HighWatermark),
         }
     }
 

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -554,4 +554,25 @@ mod tests {
         assert_eq!(pipe.state(), BackpressureState::Normal);
         assert_eq!(pipe.meta().buffer_capacity, 4 * 1024 * 1024);
     }
+
+    #[test]
+    fn test_backpressure_pipe_state_transitions() {
+        let config = BackpressureConfig {
+            buffer_size: 1000,
+            high_watermark: 80,
+            low_watermark: 50,
+        };
+        let pipe = BackpressurePipe::with_config(config);
+
+        assert_eq!(pipe.state(), BackpressureState::Normal);
+        assert_eq!(pipe.meta().state, BackpressureState::Normal);
+
+        pipe.record_write(850);
+        assert_eq!(pipe.state(), BackpressureState::BackpressureApplied);
+        assert_eq!(pipe.meta().state, BackpressureState::BackpressureApplied);
+
+        pipe.record_read(400);
+        assert_eq!(pipe.state(), BackpressureState::Normal);
+        assert_eq!(pipe.meta().state, BackpressureState::Normal);
+    }
 }

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -39,7 +39,6 @@
 //!              [High Watermark?] --> Apply Backpressure
 //! ```
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::io::{DuplexStream, duplex};
@@ -48,7 +47,7 @@ use tracing::{debug, warn};
 use metrics::counter;
 
 /// Object-transfer duplex pipe backpressure policy.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ObjectPipeBackpressurePolicy {
     /// Buffer size in bytes (default 4MB).
     pub buffer_size: usize,
@@ -158,7 +157,7 @@ pub enum BackpressureEventType {
 }
 
 /// Snapshot of backpressure state.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct BackpressureSnapshot {
     /// Buffer capacity in bytes.
     pub buffer_capacity: usize,
@@ -171,7 +170,7 @@ pub struct BackpressureSnapshot {
 }
 
 /// Compact metadata snapshot for object-transfer backpressure pipes.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BackpressurePipeMeta {
     /// Buffer capacity in bytes.
     pub buffer_capacity: usize,
@@ -182,7 +181,7 @@ pub struct BackpressurePipeMeta {
 }
 
 /// Compact metadata snapshot for the lightweight backpressure monitor.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BackpressureMonitorMeta {
     /// Buffer capacity in bytes.
     pub buffer_capacity: usize,
@@ -233,6 +232,10 @@ fn apply_watermark_transition(
     (next_state, changed)
 }
 
+fn saturating_sub_atomic(value: &AtomicUsize, delta: usize) {
+    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| Some(current.saturating_sub(delta)));
+}
+
 /// A backpressure-aware pipe wrapping tokio's duplex.
 ///
 /// This provides monitoring and events for backpressure conditions
@@ -245,13 +248,17 @@ pub struct BackpressurePipe {
     /// Configuration.
     config: ObjectPipeBackpressurePolicy,
     /// Current buffer usage (approximate, updated on write).
-    buffer_usage: Arc<AtomicUsize>,
+    buffer_usage: AtomicUsize,
     /// Current backpressure state.
-    state: Arc<AtomicBool>, // true = in high watermark state
+    state: AtomicBool, // true = in high watermark state
     /// Total bytes written.
-    total_written: Arc<AtomicUsize>,
+    total_written: AtomicUsize,
     /// Total bytes read.
-    total_read: Arc<AtomicUsize>,
+    total_read: AtomicUsize,
+    /// Cached high watermark threshold in bytes.
+    high_watermark_bytes: usize,
+    /// Cached low watermark threshold in bytes.
+    low_watermark_bytes: usize,
     /// Pipe creation timestamp.
     created_at: Instant,
 }
@@ -265,13 +272,15 @@ impl BackpressurePipe {
     /// Create a new backpressure-aware pipe with custom configuration.
     pub fn with_config(config: ObjectPipeBackpressurePolicy) -> Self {
         let (reader, writer) = duplex(config.buffer_size);
+        let high_watermark_bytes = config.high_watermark_bytes();
+        let low_watermark_bytes = config.low_watermark_bytes();
 
         debug!(
             buffer_size = config.buffer_size,
             high_watermark = config.high_watermark,
             low_watermark = config.low_watermark,
-            high_watermark_bytes = config.high_watermark_bytes(),
-            low_watermark_bytes = config.low_watermark_bytes(),
+            high_watermark_bytes,
+            low_watermark_bytes,
             "Created backpressure pipe"
         );
 
@@ -279,10 +288,12 @@ impl BackpressurePipe {
             reader,
             writer,
             config,
-            buffer_usage: Arc::new(AtomicUsize::new(0)),
-            state: Arc::new(AtomicBool::new(false)),
-            total_written: Arc::new(AtomicUsize::new(0)),
-            total_read: Arc::new(AtomicUsize::new(0)),
+            buffer_usage: AtomicUsize::new(0),
+            state: AtomicBool::new(false),
+            total_written: AtomicUsize::new(0),
+            total_read: AtomicUsize::new(0),
+            high_watermark_bytes,
+            low_watermark_bytes,
             created_at: Instant::now(),
         }
     }
@@ -349,7 +360,7 @@ impl BackpressurePipe {
     /// Record bytes read (call after successful read).
     pub fn record_read(&self, bytes: usize) {
         self.total_read.fetch_add(bytes, Ordering::Relaxed);
-        self.buffer_usage.fetch_sub(bytes, Ordering::Relaxed);
+        saturating_sub_atomic(&self.buffer_usage, bytes);
         self.update_watermark_state();
     }
 
@@ -358,7 +369,7 @@ impl BackpressurePipe {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
         let usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32;
         let (next_state, changed) =
-            apply_watermark_transition(&self.state, usage, self.config.high_watermark_bytes(), self.config.low_watermark_bytes());
+            apply_watermark_transition(&self.state, usage, self.high_watermark_bytes, self.low_watermark_bytes);
 
         if changed {
             match next_state {
@@ -419,9 +430,13 @@ pub struct BackpressureMonitor {
     /// Configuration.
     config: ObjectPipeBackpressurePolicy,
     /// Current buffer usage.
-    buffer_usage: Arc<AtomicUsize>,
+    buffer_usage: AtomicUsize,
     /// In high watermark state.
-    in_high_watermark: Arc<AtomicBool>,
+    in_high_watermark: AtomicBool,
+    /// Cached high watermark threshold in bytes.
+    high_watermark_bytes: usize,
+    /// Cached low watermark threshold in bytes.
+    low_watermark_bytes: usize,
 }
 
 impl BackpressureMonitor {
@@ -432,10 +447,14 @@ impl BackpressureMonitor {
 
     /// Create a new monitor with custom configuration.
     pub fn with_config(config: ObjectPipeBackpressurePolicy) -> Self {
+        let high_watermark_bytes = config.high_watermark_bytes();
+        let low_watermark_bytes = config.low_watermark_bytes();
         Self {
             config,
-            buffer_usage: Arc::new(AtomicUsize::new(0)),
-            in_high_watermark: Arc::new(AtomicBool::new(false)),
+            buffer_usage: AtomicUsize::new(0),
+            in_high_watermark: AtomicBool::new(false),
+            high_watermark_bytes,
+            low_watermark_bytes,
         }
     }
 
@@ -447,7 +466,7 @@ impl BackpressureMonitor {
 
     /// Record bytes removed from buffer.
     pub fn on_read(&self, bytes: usize) -> BackpressureState {
-        self.buffer_usage.fetch_sub(bytes, Ordering::Relaxed);
+        saturating_sub_atomic(&self.buffer_usage, bytes);
         self.update_state()
     }
 
@@ -481,12 +500,8 @@ impl BackpressureMonitor {
     fn update_state(&self) -> BackpressureState {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
         let usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32;
-        let (next_state, changed) = apply_watermark_transition(
-            &self.in_high_watermark,
-            usage,
-            self.config.high_watermark_bytes(),
-            self.config.low_watermark_bytes(),
-        );
+        let (next_state, changed) =
+            apply_watermark_transition(&self.in_high_watermark, usage, self.high_watermark_bytes, self.low_watermark_bytes);
 
         if matches!(next_state, BackpressureState::HighWatermark) {
             if changed {
@@ -573,7 +588,7 @@ mod tests {
         assert_eq!(pipe.capacity(), 4 * 1024 * 1024);
         assert_eq!(pipe.state(), BackpressureState::Normal);
         assert_eq!(pipe.meta().buffer_capacity, 4 * 1024 * 1024);
-        assert!(pipe.age() >= pipe.meta().age);
+        assert!(pipe.meta().age <= pipe.age());
     }
 
     #[test]

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -199,6 +199,14 @@ fn calculate_usage_percent(usage: usize, capacity: usize) -> f32 {
     }
 }
 
+fn state_from_high_watermark(in_high_watermark: bool, high_state: BackpressureState) -> BackpressureState {
+    if in_high_watermark {
+        high_state
+    } else {
+        BackpressureState::Normal
+    }
+}
+
 fn classify_watermark_state(usage: usize, high: usize, low: usize, currently_high: bool) -> BackpressureState {
     if usage >= high {
         BackpressureState::HighWatermark
@@ -295,16 +303,12 @@ impl BackpressurePipe {
 
     /// Get current backpressure state.
     pub fn state(&self) -> BackpressureState {
-        if self.state.load(Ordering::Relaxed) {
-            BackpressureState::BackpressureApplied
-        } else {
-            BackpressureState::Normal
-        }
+        state_from_high_watermark(self.state.load(Ordering::Relaxed), BackpressureState::BackpressureApplied)
     }
 
     /// Get current buffer usage snapshot.
     pub fn snapshot(&self) -> BackpressureSnapshot {
-        let buffer_used = self.buffer_usage.load(Ordering::Relaxed);
+        let buffer_used = self.usage();
         let usage_percent = calculate_usage_percent(buffer_used, self.config.buffer_size);
 
         BackpressureSnapshot {
@@ -319,7 +323,10 @@ impl BackpressurePipe {
     pub fn meta(&self) -> BackpressurePipeMeta {
         BackpressurePipeMeta {
             buffer_capacity: self.config.buffer_size,
-            state: self.state(),
+            state: state_from_high_watermark(
+                self.state.load(Ordering::Relaxed),
+                BackpressureState::BackpressureApplied,
+            ),
             age: self.age(),
         }
     }
@@ -327,6 +334,11 @@ impl BackpressurePipe {
     /// Get the age of this pipe.
     pub fn age(&self) -> Duration {
         self.created_at.elapsed()
+    }
+
+    /// Get current buffer usage.
+    pub fn usage(&self) -> usize {
+        self.buffer_usage.load(Ordering::Relaxed)
     }
 
     /// Record bytes written (call after successful write).
@@ -447,11 +459,7 @@ impl BackpressureMonitor {
 
     /// Get current state.
     pub fn state(&self) -> BackpressureState {
-        if self.in_high_watermark.load(Ordering::Relaxed) {
-            BackpressureState::HighWatermark
-        } else {
-            BackpressureState::Normal
-        }
+        state_from_high_watermark(self.in_high_watermark.load(Ordering::Relaxed), BackpressureState::HighWatermark)
     }
 
     /// Get current buffer usage.
@@ -467,10 +475,14 @@ impl BackpressureMonitor {
 
     /// Get a compact metadata snapshot for the monitor.
     pub fn meta(&self) -> BackpressureMonitorMeta {
+        let usage = self.buffer_usage.load(Ordering::Relaxed);
         BackpressureMonitorMeta {
             buffer_capacity: self.config.buffer_size,
-            usage_percent: self.usage_percent(),
-            state: self.state(),
+            usage_percent: calculate_usage_percent(usage, self.config.buffer_size),
+            state: state_from_high_watermark(
+                self.in_high_watermark.load(Ordering::Relaxed),
+                BackpressureState::HighWatermark,
+            ),
         }
     }
 

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -169,6 +169,49 @@ pub struct BackpressureSnapshot {
     pub state: BackpressureState,
 }
 
+/// Compact metadata snapshot for object-transfer backpressure pipes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackpressurePipeMeta {
+    /// Buffer capacity in bytes.
+    pub buffer_capacity: usize,
+    /// Current backpressure state.
+    pub state: BackpressureState,
+}
+
+fn calculate_usage_percent(usage: usize, capacity: usize) -> f32 {
+    if capacity > 0 {
+        (usage as f32 / capacity as f32) * 100.0
+    } else {
+        0.0
+    }
+}
+
+fn classify_watermark_state(usage: usize, high: usize, low: usize, currently_high: bool) -> BackpressureState {
+    if usage >= high {
+        BackpressureState::HighWatermark
+    } else if usage <= low {
+        BackpressureState::Normal
+    } else if currently_high {
+        BackpressureState::HighWatermark
+    } else {
+        BackpressureState::Normal
+    }
+}
+
+fn apply_watermark_transition(
+    in_high_watermark: &AtomicBool,
+    usage: usize,
+    _buffer_capacity: usize,
+    high: usize,
+    low: usize,
+) -> (BackpressureState, bool) {
+    let current = in_high_watermark.load(Ordering::Relaxed);
+    let next_state = classify_watermark_state(usage, high, low, current);
+    let next_is_high = matches!(next_state, BackpressureState::HighWatermark);
+    let changed = in_high_watermark.swap(next_is_high, Ordering::Relaxed) != next_is_high;
+    (next_state, changed)
+}
+
 /// A backpressure-aware pipe wrapping tokio's duplex.
 ///
 /// This provides monitoring and events for backpressure conditions
@@ -247,16 +290,20 @@ impl BackpressurePipe {
     /// Get current buffer usage snapshot.
     pub fn snapshot(&self) -> BackpressureSnapshot {
         let buffer_used = self.buffer_usage.load(Ordering::Relaxed);
-        let usage_percent = if self.config.buffer_size > 0 {
-            (buffer_used as f64 / self.config.buffer_size as f64) * 100.0
-        } else {
-            0.0
-        };
+        let usage_percent = calculate_usage_percent(buffer_used, self.config.buffer_size);
 
         BackpressureSnapshot {
             buffer_capacity: self.config.buffer_size,
             buffer_used,
-            usage_percent: usage_percent as f32,
+            usage_percent,
+            state: self.state(),
+        }
+    }
+
+    /// Get a compact metadata snapshot for the pipe.
+    pub fn meta(&self) -> BackpressurePipeMeta {
+        BackpressurePipeMeta {
+            buffer_capacity: self.config.buffer_size,
             state: self.state(),
         }
     }
@@ -278,17 +325,21 @@ impl BackpressurePipe {
     /// Check if high watermark is reached.
     fn check_high_watermark(&self) {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
-        let threshold = self.config.high_watermark_bytes();
+        let (next_state, changed) = apply_watermark_transition(
+            &self.state,
+            usage,
+            self.config.buffer_size,
+            self.config.high_watermark_bytes(),
+            self.config.low_watermark_bytes(),
+        );
 
-        if usage >= threshold && !self.state.load(Ordering::Relaxed) {
-            self.state.store(true, Ordering::Relaxed);
-
+        if changed && matches!(next_state, BackpressureState::HighWatermark) {
             counter!("rustfs_backpressure_events_total", "state" => "high_watermark").increment(1);
 
             warn!(
                 buffer_usage = usage,
                 buffer_capacity = self.config.buffer_size,
-                usage_percent = (usage as f64 / self.config.buffer_size as f64 * 100.0) as u32,
+                usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32,
                 high_watermark = self.config.high_watermark,
                 "Backpressure: high watermark reached"
             );
@@ -298,17 +349,21 @@ impl BackpressurePipe {
     /// Check if low watermark is reached (backpressure can be released).
     fn check_low_watermark(&self) {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
-        let threshold = self.config.low_watermark_bytes();
+        let (next_state, changed) = apply_watermark_transition(
+            &self.state,
+            usage,
+            self.config.buffer_size,
+            self.config.high_watermark_bytes(),
+            self.config.low_watermark_bytes(),
+        );
 
-        if usage <= threshold && self.state.load(Ordering::Relaxed) {
-            self.state.store(false, Ordering::Relaxed);
-
+        if changed && matches!(next_state, BackpressureState::Normal) {
             counter!("rustfs_backpressure_events_total", "state" => "normal").increment(1);
 
             debug!(
                 buffer_usage = usage,
                 buffer_capacity = self.config.buffer_size,
-                usage_percent = (usage as f64 / self.config.buffer_size as f64 * 100.0) as u32,
+                usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32,
                 low_watermark = self.config.low_watermark,
                 "Backpressure: returned to normal"
             );
@@ -394,35 +449,34 @@ impl BackpressureMonitor {
     /// Get usage percentage.
     pub fn usage_percent(&self) -> f32 {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
-        if self.config.buffer_size > 0 {
-            (usage as f32 / self.config.buffer_size as f32) * 100.0
-        } else {
-            0.0
-        }
+        calculate_usage_percent(usage, self.config.buffer_size)
     }
 
     /// Update state based on current usage.
     fn update_state(&self) -> BackpressureState {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
-        let high = self.config.high_watermark_bytes();
-        let low = self.config.low_watermark_bytes();
+        let (next_state, changed) = apply_watermark_transition(
+            &self.in_high_watermark,
+            usage,
+            self.config.buffer_size,
+            self.config.high_watermark_bytes(),
+            self.config.low_watermark_bytes(),
+        );
 
-        if usage >= high {
-            if !self.in_high_watermark.swap(true, Ordering::Relaxed) {
+        if matches!(next_state, BackpressureState::HighWatermark) {
+            if changed {
                 counter!("rustfs_backpressure_events_total", "state" => "high_watermark").increment(1);
 
                 debug!(usage_percent = self.usage_percent() as u32, "Backpressure: entered high watermark");
             }
             BackpressureState::HighWatermark
-        } else if usage <= low {
-            if self.in_high_watermark.swap(false, Ordering::Relaxed) {
+        } else {
+            if changed {
                 counter!("rustfs_backpressure_events_total", "state" => "normal").increment(1);
 
                 debug!(usage_percent = self.usage_percent() as u32, "Backpressure: returned to normal");
             }
             BackpressureState::Normal
-        } else {
-            self.state()
         }
     }
 }
@@ -489,5 +543,6 @@ mod tests {
         let pipe = BackpressurePipe::new();
         assert_eq!(pipe.capacity(), 4 * 1024 * 1024);
         assert_eq!(pipe.state(), BackpressureState::Normal);
+        assert_eq!(pipe.meta().buffer_capacity, 4 * 1024 * 1024);
     }
 }

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -178,6 +178,15 @@ pub struct BackpressurePipeMeta {
     pub state: BackpressureState,
 }
 
+/// Compact metadata snapshot for the lightweight backpressure monitor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackpressureMonitorMeta {
+    /// Buffer capacity in bytes.
+    pub buffer_capacity: usize,
+    /// Current backpressure state.
+    pub state: BackpressureState,
+}
+
 fn calculate_usage_percent(usage: usize, capacity: usize) -> f32 {
     if capacity > 0 {
         (usage as f32 / capacity as f32) * 100.0
@@ -452,6 +461,14 @@ impl BackpressureMonitor {
         calculate_usage_percent(usage, self.config.buffer_size)
     }
 
+    /// Get a compact metadata snapshot for the monitor.
+    pub fn meta(&self) -> BackpressureMonitorMeta {
+        BackpressureMonitorMeta {
+            buffer_capacity: self.config.buffer_size,
+            state: self.state(),
+        }
+    }
+
     /// Update state based on current usage.
     fn update_state(&self) -> BackpressureState {
         let usage = self.buffer_usage.load(Ordering::Relaxed);
@@ -528,6 +545,7 @@ mod tests {
 
         // Initially normal
         assert_eq!(monitor.state(), BackpressureState::Normal);
+        assert_eq!(monitor.meta().buffer_capacity, 1000);
 
         // Write to reach high watermark
         let state = monitor.on_write(850);

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -17,9 +17,6 @@
 //! This module provides backpressure-aware pipes for object data transfer,
 //! preventing buffer overflow and memory exhaustion under high concurrency.
 
-// Allow dead_code for public API that may be used by external modules or future features
-#![allow(dead_code)]
-//!
 //! # Key Features
 //!
 //! - Configurable buffer size with high/low watermarks
@@ -103,10 +100,6 @@ impl ObjectPipeBackpressurePolicy {
     }
 }
 
-/// Backward-compatible alias for the old object pipe config name.
-#[deprecated(note = "use ObjectPipeBackpressurePolicy instead")]
-pub type BackpressureConfig = ObjectPipeBackpressurePolicy;
-
 /// Backpressure state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackpressureState {
@@ -126,47 +119,6 @@ impl std::fmt::Display for BackpressureState {
             BackpressureState::BackpressureApplied => write!(f, "backpressure_applied"),
         }
     }
-}
-
-/// Backpressure event for monitoring.
-#[derive(Debug, Clone)]
-pub struct BackpressureEvent {
-    /// Event timestamp.
-    pub timestamp: Instant,
-    /// Event type.
-    pub event_type: BackpressureEventType,
-    /// Buffer usage at event time.
-    pub buffer_usage: usize,
-    /// Buffer capacity.
-    pub buffer_capacity: usize,
-    /// Usage percentage.
-    pub usage_percent: f32,
-}
-
-/// Backpressure event type.
-#[derive(Debug, Clone, Copy)]
-pub enum BackpressureEventType {
-    /// Entered high watermark state.
-    HighWatermarkReached,
-    /// Exited high watermark state (backpressure released).
-    HighWatermarkExited,
-    /// Backpressure applied to producer.
-    BackpressureApplied,
-    /// Backpressure released.
-    BackpressureReleased,
-}
-
-/// Snapshot of backpressure state.
-#[derive(Debug, Clone, Copy)]
-pub struct BackpressureSnapshot {
-    /// Buffer capacity in bytes.
-    pub buffer_capacity: usize,
-    /// Current buffer usage in bytes (approximate).
-    pub buffer_used: usize,
-    /// Usage percentage.
-    pub usage_percent: f32,
-    /// Current state.
-    pub state: BackpressureState,
 }
 
 /// Compact metadata snapshot for object-transfer backpressure pipes.
@@ -199,41 +151,31 @@ fn calculate_usage_percent(usage: usize, capacity: usize) -> f32 {
     }
 }
 
-fn state_from_high_watermark(in_high_watermark: bool, high_state: BackpressureState) -> BackpressureState {
-    if in_high_watermark {
-        high_state
-    } else {
-        BackpressureState::Normal
-    }
-}
-
-fn classify_watermark_state(usage: usize, high: usize, low: usize, currently_high: bool) -> BackpressureState {
-    if usage >= high {
-        BackpressureState::HighWatermark
-    } else if usage <= low {
-        BackpressureState::Normal
-    } else if currently_high {
-        BackpressureState::HighWatermark
-    } else {
-        BackpressureState::Normal
-    }
-}
-
 fn apply_watermark_transition(
     in_high_watermark: &AtomicBool,
     usage: usize,
     high: usize,
     low: usize,
 ) -> (BackpressureState, bool) {
-    let current = in_high_watermark.load(Ordering::Relaxed);
-    let next_state = classify_watermark_state(usage, high, low, current);
+    let current = in_high_watermark.load(Ordering::Acquire);
+    let next_state = if usage >= high {
+        BackpressureState::HighWatermark
+    } else if usage <= low {
+        BackpressureState::Normal
+    } else if current {
+        BackpressureState::HighWatermark
+    } else {
+        BackpressureState::Normal
+    };
     let next_is_high = matches!(next_state, BackpressureState::HighWatermark);
-    let changed = in_high_watermark.swap(next_is_high, Ordering::Relaxed) != next_is_high;
+    let changed = in_high_watermark.swap(next_is_high, Ordering::AcqRel) != next_is_high;
     (next_state, changed)
 }
 
 fn saturating_sub_atomic(value: &AtomicUsize, delta: usize) {
-    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| Some(current.saturating_sub(delta)));
+    value
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| Some(current.saturating_sub(delta)))
+        .ok();
 }
 
 /// A backpressure-aware pipe wrapping tokio's duplex.
@@ -315,19 +257,10 @@ impl BackpressurePipe {
 
     /// Get current backpressure state.
     pub fn state(&self) -> BackpressureState {
-        state_from_high_watermark(self.state.load(Ordering::Relaxed), BackpressureState::BackpressureApplied)
-    }
-
-    /// Get current buffer usage snapshot.
-    pub fn snapshot(&self) -> BackpressureSnapshot {
-        let buffer_used = self.usage();
-        let usage_percent = calculate_usage_percent(buffer_used, self.config.buffer_size);
-
-        BackpressureSnapshot {
-            buffer_capacity: self.config.buffer_size,
-            buffer_used,
-            usage_percent,
-            state: self.state(),
+        if self.state.load(Ordering::Acquire) {
+            BackpressureState::BackpressureApplied
+        } else {
+            BackpressureState::Normal
         }
     }
 
@@ -335,7 +268,7 @@ impl BackpressurePipe {
     pub fn meta(&self) -> BackpressurePipeMeta {
         BackpressurePipeMeta {
             buffer_capacity: self.config.buffer_size,
-            state: state_from_high_watermark(self.state.load(Ordering::Relaxed), BackpressureState::BackpressureApplied),
+            state: self.state(),
             age: self.age(),
         }
     }
@@ -347,13 +280,13 @@ impl BackpressurePipe {
 
     /// Get current buffer usage.
     pub fn usage(&self) -> usize {
-        self.buffer_usage.load(Ordering::Relaxed)
+        self.buffer_usage.load(Ordering::Acquire)
     }
 
     /// Record bytes written (call after successful write).
     pub fn record_write(&self, bytes: usize) {
         self.total_written.fetch_add(bytes, Ordering::Relaxed);
-        self.buffer_usage.fetch_add(bytes, Ordering::Relaxed);
+        self.buffer_usage.fetch_add(bytes, Ordering::Release);
         self.update_watermark_state();
     }
 
@@ -366,7 +299,7 @@ impl BackpressurePipe {
 
     /// Update watermark state and emit transition signals.
     fn update_watermark_state(&self) {
-        let usage = self.buffer_usage.load(Ordering::Relaxed);
+        let usage = self.buffer_usage.load(Ordering::Acquire);
         let usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32;
         let (next_state, changed) =
             apply_watermark_transition(&self.state, usage, self.high_watermark_bytes, self.low_watermark_bytes);
@@ -460,7 +393,7 @@ impl BackpressureMonitor {
 
     /// Record bytes added to buffer.
     pub fn on_write(&self, bytes: usize) -> BackpressureState {
-        self.buffer_usage.fetch_add(bytes, Ordering::Relaxed);
+        self.buffer_usage.fetch_add(bytes, Ordering::Release);
         self.update_state()
     }
 
@@ -472,33 +405,37 @@ impl BackpressureMonitor {
 
     /// Get current state.
     pub fn state(&self) -> BackpressureState {
-        state_from_high_watermark(self.in_high_watermark.load(Ordering::Relaxed), BackpressureState::HighWatermark)
+        if self.in_high_watermark.load(Ordering::Acquire) {
+            BackpressureState::HighWatermark
+        } else {
+            BackpressureState::Normal
+        }
     }
 
     /// Get current buffer usage.
     pub fn usage(&self) -> usize {
-        self.buffer_usage.load(Ordering::Relaxed)
+        self.buffer_usage.load(Ordering::Acquire)
     }
 
     /// Get usage percentage.
     pub fn usage_percent(&self) -> f32 {
-        let usage = self.buffer_usage.load(Ordering::Relaxed);
+        let usage = self.buffer_usage.load(Ordering::Acquire);
         calculate_usage_percent(usage, self.config.buffer_size)
     }
 
     /// Get a compact metadata snapshot for the monitor.
     pub fn meta(&self) -> BackpressureMonitorMeta {
-        let usage = self.buffer_usage.load(Ordering::Relaxed);
+        let usage = self.buffer_usage.load(Ordering::Acquire);
         BackpressureMonitorMeta {
             buffer_capacity: self.config.buffer_size,
             usage_percent: calculate_usage_percent(usage, self.config.buffer_size),
-            state: state_from_high_watermark(self.in_high_watermark.load(Ordering::Relaxed), BackpressureState::HighWatermark),
+            state: self.state(),
         }
     }
 
     /// Update state based on current usage.
     fn update_state(&self) -> BackpressureState {
-        let usage = self.buffer_usage.load(Ordering::Relaxed);
+        let usage = self.buffer_usage.load(Ordering::Acquire);
         let usage_percent = calculate_usage_percent(usage, self.config.buffer_size) as u32;
         let (next_state, changed) =
             apply_watermark_transition(&self.in_high_watermark, usage, self.high_watermark_bytes, self.low_watermark_bytes);

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -210,7 +210,6 @@ fn classify_watermark_state(usage: usize, high: usize, low: usize, currently_hig
 fn apply_watermark_transition(
     in_high_watermark: &AtomicBool,
     usage: usize,
-    _buffer_capacity: usize,
     high: usize,
     low: usize,
 ) -> (BackpressureState, bool) {
@@ -338,7 +337,6 @@ impl BackpressurePipe {
         let (next_state, changed) = apply_watermark_transition(
             &self.state,
             usage,
-            self.config.buffer_size,
             self.config.high_watermark_bytes(),
             self.config.low_watermark_bytes(),
         );
@@ -469,7 +467,6 @@ impl BackpressureMonitor {
         let (next_state, changed) = apply_watermark_transition(
             &self.in_high_watermark,
             usage,
-            self.config.buffer_size,
             self.config.high_watermark_bytes(),
             self.config.low_watermark_bytes(),
         );

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -47,9 +47,9 @@ use tracing::{debug, warn};
 
 use metrics::counter;
 
-/// Backpressure pipe configuration.
+/// Object-transfer duplex pipe backpressure policy.
 #[derive(Debug, Clone)]
-pub struct BackpressureConfig {
+pub struct ObjectPipeBackpressurePolicy {
     /// Buffer size in bytes (default 4MB).
     pub buffer_size: usize,
     /// High watermark percentage (default 80%).
@@ -60,7 +60,7 @@ pub struct BackpressureConfig {
     pub low_watermark: u32,
 }
 
-impl Default for BackpressureConfig {
+impl Default for ObjectPipeBackpressurePolicy {
     fn default() -> Self {
         Self {
             buffer_size: rustfs_config::DEFAULT_OBJECT_DUPLEX_BUFFER_SIZE,
@@ -70,7 +70,7 @@ impl Default for BackpressureConfig {
     }
 }
 
-impl BackpressureConfig {
+impl ObjectPipeBackpressurePolicy {
     /// Load configuration from environment variables.
     pub fn from_env() -> Self {
         let buffer_size = rustfs_utils::get_env_usize(
@@ -103,6 +103,9 @@ impl BackpressureConfig {
         (self.buffer_size as u64 * self.low_watermark as u64 / 100) as usize
     }
 }
+
+/// Backward-compatible alias for the old object pipe config name.
+pub type BackpressureConfig = ObjectPipeBackpressurePolicy;
 
 /// Backpressure state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -176,7 +179,7 @@ pub struct BackpressurePipe {
     /// Writer end of the duplex pipe.
     writer: DuplexStream,
     /// Configuration.
-    config: BackpressureConfig,
+    config: ObjectPipeBackpressurePolicy,
     /// Current buffer usage (approximate, updated on write).
     buffer_usage: Arc<AtomicUsize>,
     /// Current backpressure state.
@@ -194,7 +197,7 @@ impl BackpressurePipe {
     }
 
     /// Create a new backpressure-aware pipe with custom configuration.
-    pub fn with_config(config: BackpressureConfig) -> Self {
+    pub fn with_config(config: ObjectPipeBackpressurePolicy) -> Self {
         let (reader, writer) = duplex(config.buffer_size);
 
         debug!(

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -401,12 +401,10 @@ impl IoSchedulerConfig {
             load_low_threshold_ms: self.load_low_threshold_ms,
             enable_priority: self.enable_priority,
             storage_detection_enabled: self.storage_detection_enabled,
-            sequential_detection_enabled: true,
-            bandwidth_monitoring_enabled: true,
-            adaptive_buffer_enabled: true,
             base_buffer_size: rustfs_config::DEFAULT_OBJECT_IO_BUFFER_SIZE,
             max_buffer_size: MI_B,
             min_buffer_size: 32 * KI_B,
+            ..Default::default()
         }
     }
 }

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -2068,7 +2068,7 @@ mod tests {
         assert_eq!(config.starvation_threshold_secs, 5);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_scheduler_config_to_core_config() {
         let config = IoSchedulerConfig::default();
@@ -2084,7 +2084,7 @@ mod tests {
         assert_eq!(core.enable_priority, config.enable_priority);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_queue_config_to_core_config() {
         let config = IoPriorityQueueConfig::default();
@@ -2096,7 +2096,7 @@ mod tests {
         assert_eq!(core.starvation_threshold, Duration::from_secs(config.starvation_threshold_secs));
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_queue_config_from_core_config() {
         let core = rustfs_io_core::IoPriorityQueueConfig::default();

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -132,8 +132,8 @@ impl IoPriority {
     pub fn from_size(size: i64) -> Self {
         Self::from_size_with_thresholds(
             size,
-            IoSchedulerConfig::default().high_priority_size_threshold,
-            IoSchedulerConfig::default().low_priority_size_threshold,
+            rustfs_config::DEFAULT_OBJECT_IO_HIGH_PRIORITY_SIZE_THRESHOLD,
+            rustfs_config::DEFAULT_OBJECT_IO_LOW_PRIORITY_SIZE_THRESHOLD,
         )
     }
 
@@ -1037,12 +1037,11 @@ impl IoStrategy {
 
         // Calculate priority based on request size
         let priority = if context.file_size > 0 {
-            let core_config = config.to_core_config();
-            IoPriority::from_core(CoreIoPriority::from_size(
+            IoPriority::from_size_with_thresholds(
                 context.file_size,
-                core_config.high_priority_size_threshold,
-                core_config.low_priority_size_threshold,
-            ))
+                config.high_priority_size_threshold,
+                config.low_priority_size_threshold,
+            )
         } else {
             IoPriority::Normal
         };
@@ -1312,27 +1311,38 @@ impl IoLoadMetrics {
         self.observation_count.load(Ordering::Relaxed)
     }
 }
-pub fn get_concurrency_aware_buffer_size(file_size: i64, base_buffer_size: usize) -> usize {
-    let concurrent_requests = ACTIVE_GET_REQUESTS.load(Ordering::Relaxed);
+#[derive(Debug, Clone, Copy)]
+struct ConcurrencyThresholds {
+    medium: usize,
+    high: usize,
+}
 
-    // Record concurrent request metrics
-    {
-        use metrics::gauge;
-        gauge!("rustfs_concurrent_get_requests").set(concurrent_requests as f64);
+fn load_concurrency_thresholds() -> ConcurrencyThresholds {
+    ConcurrencyThresholds {
+        medium: rustfs_utils::get_env_usize(
+            rustfs_config::ENV_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
+            rustfs_config::DEFAULT_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
+        ),
+        high: rustfs_utils::get_env_usize(
+            rustfs_config::ENV_OBJECT_HIGH_CONCURRENCY_THRESHOLD,
+            rustfs_config::DEFAULT_OBJECT_HIGH_CONCURRENCY_THRESHOLD,
+        ),
     }
+}
+
+fn compute_concurrency_aware_buffer_size(
+    file_size: i64,
+    base_buffer_size: usize,
+    concurrent_requests: usize,
+    thresholds: ConcurrencyThresholds,
+) -> usize {
+    let medium_threshold = thresholds.medium;
+    let high_threshold = thresholds.high;
 
     // For low concurrency, use the base buffer size for maximum throughput
     if concurrent_requests <= 1 {
         return base_buffer_size;
     }
-    let medium_threshold = rustfs_utils::get_env_usize(
-        rustfs_config::ENV_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
-        rustfs_config::DEFAULT_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
-    );
-    let high_threshold = rustfs_utils::get_env_usize(
-        rustfs_config::ENV_OBJECT_HIGH_CONCURRENCY_THRESHOLD,
-        rustfs_config::DEFAULT_OBJECT_HIGH_CONCURRENCY_THRESHOLD,
-    );
 
     // Calculate adaptive multiplier based on concurrency level
     let adaptive_multiplier = if concurrent_requests <= 2 {
@@ -1368,6 +1378,18 @@ pub fn get_concurrency_aware_buffer_size(file_size: i64, base_buffer_size: usize
     adjusted_size.clamp(min_buffer, max_buffer)
 }
 
+pub fn get_concurrency_aware_buffer_size(file_size: i64, base_buffer_size: usize) -> usize {
+    let concurrent_requests = ACTIVE_GET_REQUESTS.load(Ordering::Relaxed);
+
+    // Record concurrent request metrics
+    {
+        use metrics::gauge;
+        gauge!("rustfs_concurrent_get_requests").set(concurrent_requests as f64);
+    }
+
+    compute_concurrency_aware_buffer_size(file_size, base_buffer_size, concurrent_requests, load_concurrency_thresholds())
+}
+
 /// Advanced concurrency-aware buffer sizing with file size optimization
 ///
 /// This enhanced version considers both concurrency level and file size patterns
@@ -1394,6 +1416,7 @@ pub fn get_concurrency_aware_buffer_size(file_size: i64, base_buffer_size: usize
 /// ```
 pub fn get_advanced_buffer_size(file_size: i64, base_buffer_size: usize, is_sequential: bool) -> usize {
     let concurrent_requests = ACTIVE_GET_REQUESTS.load(Ordering::Relaxed);
+    let thresholds = load_concurrency_thresholds();
 
     // For very small files, use smaller buffers regardless of concurrency
     // Replace manual max/min chain with clamp
@@ -1402,15 +1425,10 @@ pub fn get_advanced_buffer_size(file_size: i64, base_buffer_size: usize, is_sequ
     }
 
     // Base calculation from standard function
-    let standard_size = get_concurrency_aware_buffer_size(file_size, base_buffer_size);
-    let medium_threshold = rustfs_utils::get_env_usize(
-        rustfs_config::ENV_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
-        rustfs_config::DEFAULT_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
-    );
-    let high_threshold = rustfs_utils::get_env_usize(
-        rustfs_config::ENV_OBJECT_HIGH_CONCURRENCY_THRESHOLD,
-        rustfs_config::DEFAULT_OBJECT_HIGH_CONCURRENCY_THRESHOLD,
-    );
+    let standard_size = compute_concurrency_aware_buffer_size(file_size, base_buffer_size, concurrent_requests, thresholds);
+
+    let medium_threshold = thresholds.medium;
+    let high_threshold = thresholds.high;
     // For sequential reads, we can be more aggressive with buffer sizes
     if is_sequential && concurrent_requests <= medium_threshold {
         return ((standard_size as f64 * 1.5) as usize).min(2 * MI_B);

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -412,12 +412,7 @@ impl IoSchedulerConfig {
             load_low_threshold_ms: self.load_low_threshold_ms,
             enable_priority: self.enable_priority,
             storage_detection_enabled: self.storage_detection_enabled,
-            sequential_detection_enabled: true,
-            bandwidth_monitoring_enabled: true,
-            adaptive_buffer_enabled: true,
-            base_buffer_size: rustfs_config::DEFAULT_OBJECT_IO_BUFFER_SIZE,
-            max_buffer_size: MI_B,
-            min_buffer_size: 32 * KI_B,
+            ..CoreIoSchedulerConfig::default()
         }
     }
 }
@@ -1600,7 +1595,7 @@ impl IoPriorityQueueConfig {
             queue_high_capacity: config.high_capacity,
             queue_normal_capacity: config.normal_capacity,
             queue_low_capacity: config.low_capacity,
-            starvation_prevention_interval_ms: config.starvation_interval.as_millis() as u64,
+            starvation_prevention_interval_ms: u64::try_from(config.starvation_interval.as_millis()).unwrap_or(u64::MAX),
             starvation_threshold_secs: config.starvation_threshold.as_secs(),
         }
     }

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -1916,9 +1916,8 @@ pub fn get_buffer_size_opt_in(file_size: i64) -> usize {
 mod tests {
     use super::*;
     use serial_test::serial;
-    use tokio::test;
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_queue_basic() {
         let config = IoPriorityQueueConfig::default();
@@ -1937,7 +1936,7 @@ mod tests {
         assert_eq!(queue.len().await, 3);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_queue_dequeue_order() {
         let config = IoPriorityQueueConfig::default();
@@ -1965,7 +1964,7 @@ mod tests {
         assert!(queue.is_empty().await);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_queue_status() {
         let config = IoPriorityQueueConfig::default();
@@ -1983,7 +1982,7 @@ mod tests {
         assert_eq!(status.low_priority_waiting, 1);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_queue_starvation_prevention() {
         let config = IoPriorityQueueConfig {
@@ -2007,7 +2006,7 @@ mod tests {
         assert_eq!(priority, IoPriority::Normal);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_from_size() {
         // High priority: < 1MB
@@ -2023,7 +2022,7 @@ mod tests {
         assert_eq!(IoPriority::from_size(100 * 1024 * 1024), IoPriority::Low);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_load_level_from_wait_duration() {
         use std::time::Duration;
@@ -2041,7 +2040,7 @@ mod tests {
         assert_eq!(IoLoadLevel::from_wait_duration(Duration::from_millis(300)), IoLoadLevel::Critical);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_scheduler_config_default() {
         let config = IoSchedulerConfig::default();
@@ -2083,7 +2082,7 @@ mod tests {
         assert_eq!(core.starvation_threshold, Duration::from_secs(config.starvation_threshold_secs));
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_queue_config_from_scheduler_config() {
         let scheduler_config = IoSchedulerConfig {
@@ -2102,7 +2101,7 @@ mod tests {
         assert_eq!(config.starvation_threshold_secs, 120);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_io_priority_metrics() {
         let metrics = IoPriorityMetrics::new();
@@ -2129,7 +2128,7 @@ mod tests {
     // Multi-Factor Strategy Tests
     // ============================================
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_nvme_sequential_low_load() {
         // NVMe + Sequential + Low load = maximum buffer size
@@ -2156,7 +2155,7 @@ mod tests {
         assert_eq!(strategy.bandwidth_tier, BandwidthTier::High);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_hdd_random_high_load() {
         // HDD + Random + High load = conservative buffer size
@@ -2183,7 +2182,7 @@ mod tests {
         assert!(strategy.bandwidth_limited, "Low bandwidth should be marked");
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_ssd_mixed_medium_load() {
         // SSD + Mixed + Medium load = moderate buffer
@@ -2211,7 +2210,7 @@ mod tests {
         assert_eq!(strategy.access_pattern, AccessPattern::Mixed);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_critical_load_disables_features() {
         // Any media + Critical load = minimal features
@@ -2236,7 +2235,7 @@ mod tests {
         assert!(strategy.buffer_size < 200 * 1024, "Critical load should reduce buffer");
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_buffer_cap_enforcement() {
         // Test that storage media caps are enforced
@@ -2261,7 +2260,7 @@ mod tests {
         assert!(strategy.debug_info.buffer_cap_applied, "Buffer cap should be applied");
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_bandwidth_low_reduces_buffer() {
         // Low bandwidth should reduce buffer
@@ -2285,7 +2284,7 @@ mod tests {
         assert!(strategy.buffer_size < context.base_buffer_size, "Low bandwidth should reduce buffer");
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_high_concurrency_reduction() {
         // High concurrency should reduce buffer
@@ -2308,7 +2307,7 @@ mod tests {
         assert!(strategy.buffer_size < context.base_buffer_size, "High concurrency should reduce buffer");
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_sequential_boost() {
         // Sequential reads should get boost
@@ -2350,7 +2349,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_unknown_media_conservative() {
         // Unknown media should be conservative
@@ -2376,7 +2375,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_priority_classification() {
         // Test priority classification based on file size
@@ -2423,7 +2422,7 @@ mod tests {
         assert_eq!(large_strategy.priority, IoPriority::Low);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_readahead_decision_matrix() {
         // Test readahead enable/disable logic
@@ -2509,7 +2508,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_buffer_multiplier_stages() {
         // Test that all multiplier stages are applied
@@ -2544,7 +2543,7 @@ mod tests {
         assert!(strategy.should_reduce_for_bandwidth);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
     async fn test_multi_factor_strategy_compatibility_path() {
         // Test that compatibility path (from_wait_duration) still works

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -32,9 +32,7 @@
 
 use rustfs_config::{KI_B, MI_B};
 use rustfs_io_core::io_profile::{AccessPattern, StorageMedia, StorageProfile};
-use rustfs_io_core::{
-    IoPriority as CoreIoPriority, IoPriorityQueueConfig as CoreIoPriorityQueueConfig, IoSchedulerConfig as CoreIoSchedulerConfig,
-};
+use rustfs_io_core::{IoPriorityQueueConfig as CoreIoPriorityQueueConfig, IoSchedulerConfig as CoreIoSchedulerConfig};
 use rustfs_io_metrics::bandwidth::{BandwidthSnapshot, BandwidthTier};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -149,15 +147,6 @@ impl IoPriority {
             IoPriority::Low
         } else {
             IoPriority::Normal
-        }
-    }
-
-    /// Convert from io-core priority to storage-layer compatibility priority.
-    pub fn from_core(priority: CoreIoPriority) -> Self {
-        match priority {
-            CoreIoPriority::High => IoPriority::High,
-            CoreIoPriority::Normal => IoPriority::Normal,
-            CoreIoPriority::Low => IoPriority::Low,
         }
     }
 
@@ -412,7 +401,12 @@ impl IoSchedulerConfig {
             load_low_threshold_ms: self.load_low_threshold_ms,
             enable_priority: self.enable_priority,
             storage_detection_enabled: self.storage_detection_enabled,
-            ..CoreIoSchedulerConfig::default()
+            sequential_detection_enabled: true,
+            bandwidth_monitoring_enabled: true,
+            adaptive_buffer_enabled: true,
+            base_buffer_size: rustfs_config::DEFAULT_OBJECT_IO_BUFFER_SIZE,
+            max_buffer_size: MI_B,
+            min_buffer_size: 32 * KI_B,
         }
     }
 }
@@ -1589,14 +1583,14 @@ impl IoPriorityQueueConfig {
         }
     }
 
-    /// Build storage-layer queue config from io-core queue config.
-    pub fn from_core_config(config: &CoreIoPriorityQueueConfig) -> Self {
+    /// Build queue config directly from a scheduler config.
+    pub fn from_scheduler_config(config: &IoSchedulerConfig) -> Self {
         Self {
-            queue_high_capacity: config.high_capacity,
-            queue_normal_capacity: config.normal_capacity,
-            queue_low_capacity: config.low_capacity,
-            starvation_prevention_interval_ms: u64::try_from(config.starvation_interval.as_millis()).unwrap_or(u64::MAX),
-            starvation_threshold_secs: config.starvation_threshold.as_secs(),
+            queue_high_capacity: config.queue_high_capacity,
+            queue_normal_capacity: config.queue_normal_capacity,
+            queue_low_capacity: config.queue_low_capacity,
+            starvation_prevention_interval_ms: config.starvation_prevention_interval_ms,
+            starvation_threshold_secs: config.starvation_threshold_secs,
         }
     }
 }
@@ -2091,16 +2085,23 @@ mod tests {
         assert_eq!(core.starvation_threshold, Duration::from_secs(config.starvation_threshold_secs));
     }
 
-    #[tokio::test]
+    #[test]
     #[serial]
-    async fn test_io_priority_queue_config_from_core_config() {
-        let core = rustfs_io_core::IoPriorityQueueConfig::default();
-        let config = IoPriorityQueueConfig::from_core_config(&core);
-        assert_eq!(config.queue_high_capacity, core.high_capacity);
-        assert_eq!(config.queue_normal_capacity, core.normal_capacity);
-        assert_eq!(config.queue_low_capacity, core.low_capacity);
-        assert_eq!(config.starvation_prevention_interval_ms, core.starvation_interval.as_millis() as u64);
-        assert_eq!(config.starvation_threshold_secs, core.starvation_threshold.as_secs());
+    async fn test_io_priority_queue_config_from_scheduler_config() {
+        let scheduler_config = IoSchedulerConfig {
+            queue_high_capacity: 128,
+            queue_normal_capacity: 256,
+            queue_low_capacity: 512,
+            starvation_prevention_interval_ms: 2000,
+            starvation_threshold_secs: 120,
+            ..Default::default()
+        };
+        let config = IoPriorityQueueConfig::from_scheduler_config(&scheduler_config);
+        assert_eq!(config.queue_high_capacity, 128);
+        assert_eq!(config.queue_normal_capacity, 256);
+        assert_eq!(config.queue_low_capacity, 512);
+        assert_eq!(config.starvation_prevention_interval_ms, 2000);
+        assert_eq!(config.starvation_threshold_secs, 120);
     }
 
     #[test]

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -31,6 +31,10 @@
 //! runtime monitoring features (`IoPriorityMetrics`, `IoStrategyDebugInfo`).
 
 use rustfs_config::{KI_B, MI_B};
+use rustfs_io_core::{
+    IoPriority as CoreIoPriority, IoPriorityQueueConfig as CoreIoPriorityQueueConfig,
+    IoSchedulerConfig as CoreIoSchedulerConfig,
+};
 use rustfs_io_core::io_profile::{AccessPattern, StorageMedia, StorageProfile};
 use rustfs_io_metrics::bandwidth::{BandwidthSnapshot, BandwidthTier};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
@@ -146,6 +150,15 @@ impl IoPriority {
             IoPriority::Low
         } else {
             IoPriority::Normal
+        }
+    }
+
+    /// Convert from io-core priority to storage-layer compatibility priority.
+    pub fn from_core(priority: CoreIoPriority) -> Self {
+        match priority {
+            CoreIoPriority::High => IoPriority::High,
+            CoreIoPriority::Normal => IoPriority::Normal,
+            CoreIoPriority::Low => IoPriority::Low,
         }
     }
 
@@ -378,6 +391,34 @@ impl IoSchedulerConfig {
                 rustfs_config::ENV_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
                 rustfs_config::DEFAULT_OBJECT_MEDIUM_CONCURRENCY_THRESHOLD,
             ),
+        }
+    }
+
+    /// Convert storage-layer scheduler config to io-core scheduler config.
+    ///
+    /// This keeps storage-specific policy loading in place while allowing
+    /// core scheduling components to consume a normalized shared config shape.
+    pub fn to_core_config(&self) -> CoreIoSchedulerConfig {
+        CoreIoSchedulerConfig {
+            max_concurrent_reads: self.max_concurrent_reads,
+            high_priority_size_threshold: self.high_priority_size_threshold,
+            low_priority_size_threshold: self.low_priority_size_threshold,
+            queue_high_capacity: self.queue_high_capacity,
+            queue_normal_capacity: self.queue_normal_capacity,
+            queue_low_capacity: self.queue_low_capacity,
+            starvation_prevention_interval_ms: self.starvation_prevention_interval_ms,
+            starvation_threshold_secs: self.starvation_threshold_secs,
+            load_sample_window: self.load_sample_window,
+            load_high_threshold_ms: self.load_high_threshold_ms,
+            load_low_threshold_ms: self.load_low_threshold_ms,
+            enable_priority: self.enable_priority,
+            storage_detection_enabled: self.storage_detection_enabled,
+            sequential_detection_enabled: true,
+            bandwidth_monitoring_enabled: true,
+            adaptive_buffer_enabled: true,
+            base_buffer_size: rustfs_config::DEFAULT_OBJECT_IO_BUFFER_SIZE,
+            max_buffer_size: MI_B,
+            min_buffer_size: 32 * KI_B,
         }
     }
 }
@@ -997,11 +1038,12 @@ impl IoStrategy {
 
         // Calculate priority based on request size
         let priority = if context.file_size > 0 {
-            IoPriority::from_size_with_thresholds(
+            let core_config = config.to_core_config();
+            IoPriority::from_core(CoreIoPriority::from_size(
                 context.file_size,
-                config.high_priority_size_threshold,
-                config.low_priority_size_threshold,
-            )
+                core_config.high_priority_size_threshold,
+                core_config.low_priority_size_threshold,
+            ))
         } else {
             IoPriority::Normal
         };
@@ -1523,6 +1565,28 @@ impl IoPriorityQueueConfig {
             ),
         }
     }
+
+    /// Convert storage-layer queue config to io-core queue config.
+    pub fn to_core_config(&self) -> CoreIoPriorityQueueConfig {
+        CoreIoPriorityQueueConfig {
+            high_capacity: self.queue_high_capacity,
+            normal_capacity: self.queue_normal_capacity,
+            low_capacity: self.queue_low_capacity,
+            starvation_interval: Duration::from_millis(self.starvation_prevention_interval_ms),
+            starvation_threshold: Duration::from_secs(self.starvation_threshold_secs),
+        }
+    }
+
+    /// Build storage-layer queue config from io-core queue config.
+    pub fn from_core_config(config: &CoreIoPriorityQueueConfig) -> Self {
+        Self {
+            queue_high_capacity: config.high_capacity,
+            queue_normal_capacity: config.normal_capacity,
+            queue_low_capacity: config.low_capacity,
+            starvation_prevention_interval_ms: config.starvation_interval.as_millis() as u64,
+            starvation_threshold_secs: config.starvation_threshold.as_secs(),
+        }
+    }
 }
 
 impl<T> IoPriorityQueue<T> {
@@ -1985,6 +2049,55 @@ mod tests {
         assert_eq!(config.queue_normal_capacity, 64);
         assert_eq!(config.queue_low_capacity, 16);
         assert_eq!(config.starvation_threshold_secs, 5);
+    }
+
+    #[test]
+    #[serial]
+    async fn test_io_scheduler_config_to_core_config() {
+        let config = IoSchedulerConfig::default();
+        let core = config.to_core_config();
+        assert_eq!(core.max_concurrent_reads, config.max_concurrent_reads);
+        assert_eq!(core.high_priority_size_threshold, config.high_priority_size_threshold);
+        assert_eq!(core.low_priority_size_threshold, config.low_priority_size_threshold);
+        assert_eq!(core.queue_high_capacity, config.queue_high_capacity);
+        assert_eq!(core.queue_normal_capacity, config.queue_normal_capacity);
+        assert_eq!(core.queue_low_capacity, config.queue_low_capacity);
+        assert_eq!(core.load_high_threshold_ms, config.load_high_threshold_ms);
+        assert_eq!(core.load_low_threshold_ms, config.load_low_threshold_ms);
+        assert_eq!(core.enable_priority, config.enable_priority);
+    }
+
+    #[test]
+    #[serial]
+    async fn test_io_priority_queue_config_to_core_config() {
+        let config = IoPriorityQueueConfig::default();
+        let core = config.to_core_config();
+        assert_eq!(core.high_capacity, config.queue_high_capacity);
+        assert_eq!(core.normal_capacity, config.queue_normal_capacity);
+        assert_eq!(core.low_capacity, config.queue_low_capacity);
+        assert_eq!(
+            core.starvation_interval,
+            Duration::from_millis(config.starvation_prevention_interval_ms)
+        );
+        assert_eq!(
+            core.starvation_threshold,
+            Duration::from_secs(config.starvation_threshold_secs)
+        );
+    }
+
+    #[test]
+    #[serial]
+    async fn test_io_priority_queue_config_from_core_config() {
+        let core = rustfs_io_core::IoPriorityQueueConfig::default();
+        let config = IoPriorityQueueConfig::from_core_config(&core);
+        assert_eq!(config.queue_high_capacity, core.high_capacity);
+        assert_eq!(config.queue_normal_capacity, core.normal_capacity);
+        assert_eq!(config.queue_low_capacity, core.low_capacity);
+        assert_eq!(
+            config.starvation_prevention_interval_ms,
+            core.starvation_interval.as_millis() as u64
+        );
+        assert_eq!(config.starvation_threshold_secs, core.starvation_threshold.as_secs());
     }
 
     #[test]

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -31,11 +31,10 @@
 //! runtime monitoring features (`IoPriorityMetrics`, `IoStrategyDebugInfo`).
 
 use rustfs_config::{KI_B, MI_B};
-use rustfs_io_core::{
-    IoPriority as CoreIoPriority, IoPriorityQueueConfig as CoreIoPriorityQueueConfig,
-    IoSchedulerConfig as CoreIoSchedulerConfig,
-};
 use rustfs_io_core::io_profile::{AccessPattern, StorageMedia, StorageProfile};
+use rustfs_io_core::{
+    IoPriority as CoreIoPriority, IoPriorityQueueConfig as CoreIoPriorityQueueConfig, IoSchedulerConfig as CoreIoSchedulerConfig,
+};
 use rustfs_io_metrics::bandwidth::{BandwidthSnapshot, BandwidthTier};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -2075,14 +2074,8 @@ mod tests {
         assert_eq!(core.high_capacity, config.queue_high_capacity);
         assert_eq!(core.normal_capacity, config.queue_normal_capacity);
         assert_eq!(core.low_capacity, config.queue_low_capacity);
-        assert_eq!(
-            core.starvation_interval,
-            Duration::from_millis(config.starvation_prevention_interval_ms)
-        );
-        assert_eq!(
-            core.starvation_threshold,
-            Duration::from_secs(config.starvation_threshold_secs)
-        );
+        assert_eq!(core.starvation_interval, Duration::from_millis(config.starvation_prevention_interval_ms));
+        assert_eq!(core.starvation_threshold, Duration::from_secs(config.starvation_threshold_secs));
     }
 
     #[test]
@@ -2093,10 +2086,7 @@ mod tests {
         assert_eq!(config.queue_high_capacity, core.high_capacity);
         assert_eq!(config.queue_normal_capacity, core.normal_capacity);
         assert_eq!(config.queue_low_capacity, core.low_capacity);
-        assert_eq!(
-            config.starvation_prevention_interval_ms,
-            core.starvation_interval.as_millis() as u64
-        );
+        assert_eq!(config.starvation_prevention_interval_ms, core.starvation_interval.as_millis() as u64);
         assert_eq!(config.starvation_threshold_secs, core.starvation_threshold.as_secs());
     }
 

--- a/rustfs/src/storage/concurrency/manager.rs
+++ b/rustfs/src/storage/concurrency/manager.rs
@@ -121,10 +121,8 @@ impl ConcurrencyManager {
         // Keep 1000 samples for P95/P99 calculation
         let metrics_collector = Arc::new(MetricsCollector::new(performance_metrics, 1000));
 
-        // Build queue config through io-core normalized mapping.
-        let queue_config = IoPriorityQueueConfig::from_core_config(
-            &rustfs_io_core::IoPriorityQueueConfig::from_scheduler_config(&scheduler_config.to_core_config()),
-        );
+        // Build queue config directly from scheduler config.
+        let queue_config = IoPriorityQueueConfig::from_scheduler_config(&scheduler_config);
 
         Self {
             disk_read_semaphore: Arc::new(Semaphore::new(max_disk_reads)),

--- a/rustfs/src/storage/concurrency/manager.rs
+++ b/rustfs/src/storage/concurrency/manager.rs
@@ -121,14 +121,10 @@ impl ConcurrencyManager {
         // Keep 1000 samples for P95/P99 calculation
         let metrics_collector = Arc::new(MetricsCollector::new(performance_metrics, 1000));
 
-        // Build priority queue config
-        let queue_config = IoPriorityQueueConfig {
-            queue_high_capacity: scheduler_config.queue_high_capacity,
-            queue_normal_capacity: scheduler_config.queue_normal_capacity,
-            queue_low_capacity: scheduler_config.queue_low_capacity,
-            starvation_prevention_interval_ms: scheduler_config.starvation_prevention_interval_ms,
-            starvation_threshold_secs: scheduler_config.starvation_threshold_secs,
-        };
+        // Build queue config through io-core normalized mapping.
+        let queue_config = IoPriorityQueueConfig::from_core_config(
+            &rustfs_io_core::IoPriorityQueueConfig::from_scheduler_config(&scheduler_config.to_core_config()),
+        );
 
         Self {
             disk_read_semaphore: Arc::new(Semaphore::new(max_disk_reads)),

--- a/rustfs/src/storage/concurrent_fix_test.rs
+++ b/rustfs/src/storage/concurrent_fix_test.rs
@@ -19,13 +19,13 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::backpressure::{BackpressureConfig, BackpressureMonitor, BackpressureState};
+    use crate::storage::backpressure::{BackpressureMonitor, BackpressureState, ObjectPipeBackpressurePolicy};
     use crate::storage::concurrency::{IoLoadLevel, IoPriority};
     use crate::storage::deadlock_detector::{
-        DeadlockDetector, DeadlockDetectorConfig, LockInfo, LockType, RequestResourceTracker,
+        DeadlockDetector, LockInfo, LockType, RequestHangDetectionPolicy, RequestResourceTracker,
     };
     use crate::storage::lock_optimizer::{LockOptimizeConfig, LockOptimizer, LockStats};
-    use crate::storage::timeout_wrapper::{RequestTimeoutWrapper, TimedGetObjectResult, TimeoutConfig};
+    use crate::storage::timeout_wrapper::{GetObjectTimeoutPolicy, RequestTimeoutWrapper, TimedGetObjectResult};
     use std::time::Duration;
 
     // ============================================
@@ -34,7 +34,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_completes_within_timeout() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::from_secs(5),
             ..Default::default()
         };
@@ -52,7 +52,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_times_out() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::from_millis(50),
             ..Default::default()
         };
@@ -76,7 +76,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_returns_error() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::from_secs(5),
             ..Default::default()
         };
@@ -94,7 +94,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_disabled() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::ZERO,
             ..Default::default()
         };
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_config_defaults() {
-        let config = BackpressureConfig::default();
+        let config = ObjectPipeBackpressurePolicy::default();
         assert_eq!(config.buffer_size, 4 * 1024 * 1024); // 4MB
         assert_eq!(config.high_watermark, 80);
         assert_eq!(config.low_watermark, 50);
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_monitor_state_transitions() {
-        let config = BackpressureConfig {
+        let config = ObjectPipeBackpressurePolicy {
             buffer_size: 1000,
             high_watermark: 80,
             low_watermark: 50,
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_backpressure_usage_percent() {
-        let config = BackpressureConfig {
+        let config = ObjectPipeBackpressurePolicy {
             buffer_size: 1000,
             high_watermark: 80,
             low_watermark: 50,
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_deadlock_detector_config_defaults() {
-        let config = DeadlockDetectorConfig::default();
+        let config = RequestHangDetectionPolicy::default();
         assert!(!config.enabled); // Disabled by default
         assert_eq!(config.check_interval, Duration::from_secs(5));
         assert_eq!(config.hang_threshold, Duration::from_secs(10));
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_deadlock_detector_registration() {
-        let config = DeadlockDetectorConfig {
+        let config = RequestHangDetectionPolicy {
             enabled: true,
             ..Default::default()
         };

--- a/rustfs/src/storage/deadlock_detector.rs
+++ b/rustfs/src/storage/deadlock_detector.rs
@@ -58,7 +58,7 @@
 // Allow dead_code for public API that may be used by external modules or future features
 #![allow(dead_code)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
@@ -66,9 +66,7 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, warn};
 
 use metrics::counter;
-use rustfs_io_core::{
-    DeadlockDetector as CoreDeadlockDetector, DeadlockDetectorConfig as CoreDeadlockConfig, LockType as CoreLockType,
-};
+use rustfs_io_core::DeadlockDetectorConfig as CoreDeadlockConfig;
 
 /// Request identifier type.
 pub type RequestId = String;
@@ -133,10 +131,6 @@ impl RequestHangDetectionPolicy {
         }
     }
 }
-
-/// Backward-compatible alias for the old request diagnosis config name.
-#[deprecated(note = "use RequestHangDetectionPolicy instead")]
-pub type DeadlockDetectorConfig = RequestHangDetectionPolicy;
 
 /// Lock information for tracking.
 #[derive(Debug, Clone)]
@@ -513,47 +507,63 @@ impl DeadlockDetector {
         }
     }
 
-    /// Find a cycle in the request-level wait graph by delegating cycle
-    /// detection to the shared io-core deadlock primitive.
+    /// Find a cycle in the wait graph using DFS.
     fn find_cycle(edges: &[WaitGraphEdge]) -> Option<Vec<RequestId>> {
         if edges.is_empty() {
             return None;
         }
 
-        let mut request_ids: HashMap<&RequestId, u64> = HashMap::new();
-        let mut next_id = 1_u64;
-
+        // Build adjacency list: from -> [to]
+        let mut graph: HashMap<&RequestId, Vec<&RequestId>> = HashMap::new();
         for edge in edges {
-            request_ids.entry(&edge.from).or_insert_with(|| {
-                let id = next_id;
-                next_id += 1;
-                id
-            });
-            request_ids.entry(&edge.to).or_insert_with(|| {
-                let id = next_id;
-                next_id += 1;
-                id
-            });
+            graph.entry(&edge.from).or_default().push(&edge.to);
         }
 
-        let reverse_ids: HashMap<u64, RequestId> = request_ids.iter().map(|(req, id)| (*id, (*req).clone())).collect();
-        let core_detector = CoreDeadlockDetector::new(CoreDeadlockConfig {
-            enabled: true,
-            detection_interval: Duration::from_secs(1),
-            max_hold_time: Duration::from_secs(30),
-        });
+        let mut visited: HashSet<&RequestId> = HashSet::new();
+        let mut path: Vec<&RequestId> = Vec::new();
+        let mut path_set: HashSet<&RequestId> = HashSet::new();
 
-        for edge in edges {
-            let waiter = *request_ids.get(&edge.from).expect("request id registered");
-            let waited_for = *request_ids.get(&edge.to).expect("request id registered");
-            let lock_id = core_detector.register_lock(CoreLockType::Mutex);
-            core_detector.record_acquire(lock_id, waited_for);
-            core_detector.record_wait(lock_id, waiter);
+        for start in graph.keys() {
+            if visited.contains(start) {
+                continue;
+            }
+            if Self::dfs_find_cycle(start, &graph, &mut visited, &mut path, &mut path_set) {
+                return Some(path.iter().map(|s| (*s).clone()).collect());
+            }
         }
 
-        core_detector
-            .detect_deadlock()
-            .map(|cycle| cycle.into_iter().filter_map(|id| reverse_ids.get(&id).cloned()).collect())
+        None
+    }
+
+    /// DFS helper for cycle detection.
+    fn dfs_find_cycle<'a>(
+        node: &'a RequestId,
+        graph: &HashMap<&'a RequestId, Vec<&'a RequestId>>,
+        visited: &mut HashSet<&'a RequestId>,
+        path: &mut Vec<&'a RequestId>,
+        path_set: &mut HashSet<&'a RequestId>,
+    ) -> bool {
+        visited.insert(node);
+        path.push(node);
+        path_set.insert(node);
+
+        if let Some(neighbors) = graph.get(&node) {
+            for neighbor in neighbors {
+                if path_set.contains(neighbor) {
+                    // Found cycle - trim path to just the cycle
+                    let cycle_start = path.iter().position(|n| *n == *neighbor).unwrap();
+                    path.drain(0..cycle_start);
+                    return true;
+                }
+                if !visited.contains(neighbor) && Self::dfs_find_cycle(neighbor, graph, visited, path, path_set) {
+                    return true;
+                }
+            }
+        }
+
+        path.pop();
+        path_set.remove(node);
+        false
     }
 }
 

--- a/rustfs/src/storage/deadlock_detector.rs
+++ b/rustfs/src/storage/deadlock_detector.rs
@@ -133,6 +133,7 @@ impl RequestHangDetectionPolicy {
 }
 
 /// Backward-compatible alias for the old request diagnosis config name.
+#[deprecated(note = "use RequestHangDetectionPolicy instead")]
 pub type DeadlockDetectorConfig = RequestHangDetectionPolicy;
 
 /// Lock information for tracking.
@@ -567,7 +568,7 @@ static DEADLOCK_DETECTOR: std::sync::OnceLock<Arc<DeadlockDetector>> = std::sync
 pub fn get_deadlock_detector() -> Arc<DeadlockDetector> {
     DEADLOCK_DETECTOR
         .get_or_init(|| {
-            let config = DeadlockDetectorConfig::from_env();
+            let config = RequestHangDetectionPolicy::from_env();
             Arc::new(DeadlockDetector::new(config))
         })
         .clone()
@@ -593,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_deadlock_detector_config_default() {
-        let config = DeadlockDetectorConfig::default();
+        let config = RequestHangDetectionPolicy::default();
         assert!(!config.enabled);
         assert_eq!(config.check_interval, Duration::from_secs(5));
         assert_eq!(config.hang_threshold, Duration::from_secs(10));
@@ -619,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_deadlock_detector_registration() {
-        let config = DeadlockDetectorConfig {
+        let config = RequestHangDetectionPolicy {
             enabled: true,
             ..Default::default()
         };

--- a/rustfs/src/storage/deadlock_detector.rs
+++ b/rustfs/src/storage/deadlock_detector.rs
@@ -66,7 +66,9 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, warn};
 
 use metrics::counter;
-use rustfs_io_core::{DeadlockDetector as CoreDeadlockDetector, DeadlockDetectorConfig as CoreDeadlockConfig, LockType as CoreLockType};
+use rustfs_io_core::{
+    DeadlockDetector as CoreDeadlockDetector, DeadlockDetectorConfig as CoreDeadlockConfig, LockType as CoreLockType,
+};
 
 /// Request identifier type.
 pub type RequestId = String;

--- a/rustfs/src/storage/deadlock_detector.rs
+++ b/rustfs/src/storage/deadlock_detector.rs
@@ -58,7 +58,7 @@
 // Allow dead_code for public API that may be used by external modules or future features
 #![allow(dead_code)]
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
@@ -66,6 +66,7 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, warn};
 
 use metrics::counter;
+use rustfs_io_core::{DeadlockDetector as CoreDeadlockDetector, DeadlockDetectorConfig as CoreDeadlockConfig, LockType as CoreLockType};
 
 /// Request identifier type.
 pub type RequestId = String;
@@ -118,6 +119,15 @@ impl RequestHangDetectionPolicy {
             check_interval,
             hang_threshold,
             capture_backtrace: false,
+        }
+    }
+
+    /// Convert the request-level policy into the shared io-core deadlock config.
+    pub fn to_core_config(&self) -> CoreDeadlockConfig {
+        CoreDeadlockConfig {
+            enabled: self.enabled,
+            detection_interval: self.check_interval,
+            max_hold_time: self.hang_threshold,
         }
     }
 }
@@ -500,62 +510,47 @@ impl DeadlockDetector {
         }
     }
 
-    /// Find a cycle in the wait graph using DFS.
+    /// Find a cycle in the request-level wait graph by delegating cycle
+    /// detection to the shared io-core deadlock primitive.
     fn find_cycle(edges: &[WaitGraphEdge]) -> Option<Vec<RequestId>> {
-        // Build adjacency list
-        let mut graph: HashMap<&RequestId, Vec<&RequestId>> = HashMap::new();
+        if edges.is_empty() {
+            return None;
+        }
+
+        let mut request_ids: HashMap<&RequestId, u64> = HashMap::new();
+        let mut next_id = 1_u64;
+
         for edge in edges {
-            graph.entry(&edge.from).or_default().push(&edge.to);
+            request_ids.entry(&edge.from).or_insert_with(|| {
+                let id = next_id;
+                next_id += 1;
+                id
+            });
+            request_ids.entry(&edge.to).or_insert_with(|| {
+                let id = next_id;
+                next_id += 1;
+                id
+            });
         }
 
-        // DFS with path tracking
-        let mut visited: HashSet<&RequestId> = HashSet::new();
-        let mut path: Vec<&RequestId> = Vec::new();
-        let mut path_set: HashSet<&RequestId> = HashSet::new();
+        let reverse_ids: HashMap<u64, RequestId> = request_ids.iter().map(|(req, id)| (*id, (*req).clone())).collect();
+        let core_detector = CoreDeadlockDetector::new(CoreDeadlockConfig {
+            enabled: true,
+            detection_interval: Duration::from_secs(1),
+            max_hold_time: Duration::from_secs(30),
+        });
 
-        for start in graph.keys() {
-            if visited.contains(start) {
-                continue;
-            }
-
-            if Self::dfs_find_cycle(start, &graph, &mut visited, &mut path, &mut path_set) {
-                return Some(path.iter().map(|s| (*s).clone()).collect());
-            }
+        for edge in edges {
+            let waiter = *request_ids.get(&edge.from).expect("request id registered");
+            let waited_for = *request_ids.get(&edge.to).expect("request id registered");
+            let lock_id = core_detector.register_lock(CoreLockType::Mutex);
+            core_detector.record_acquire(lock_id, waited_for);
+            core_detector.record_wait(lock_id, waiter);
         }
 
-        None
-    }
-
-    /// DFS helper for cycle detection.
-    fn dfs_find_cycle<'a>(
-        node: &'a RequestId,
-        graph: &HashMap<&'a RequestId, Vec<&'a RequestId>>,
-        visited: &mut HashSet<&'a RequestId>,
-        path: &mut Vec<&'a RequestId>,
-        path_set: &mut HashSet<&'a RequestId>,
-    ) -> bool {
-        visited.insert(node);
-        path.push(node);
-        path_set.insert(node);
-
-        if let Some(neighbors) = graph.get(&node) {
-            for neighbor in neighbors {
-                if path_set.contains(neighbor) {
-                    // Found cycle - trim path to just the cycle
-                    let cycle_start = path.iter().position(|n| *n == *neighbor).unwrap();
-                    path.drain(0..cycle_start);
-                    return true;
-                }
-
-                if !visited.contains(neighbor) && Self::dfs_find_cycle(neighbor, graph, visited, path, path_set) {
-                    return true;
-                }
-            }
-        }
-
-        path.pop();
-        path_set.remove(node);
-        false
+        core_detector
+            .detect_deadlock()
+            .map(|cycle| cycle.into_iter().filter_map(|id| reverse_ids.get(&id).cloned()).collect())
     }
 }
 

--- a/rustfs/src/storage/deadlock_detector.rs
+++ b/rustfs/src/storage/deadlock_detector.rs
@@ -40,9 +40,9 @@
 //! # Usage
 //!
 //! ```ignore
-//! use crate::storage::deadlock_detector::{DeadlockDetector, DeadlockDetectorConfig};
+//! use crate::storage::deadlock_detector::{DeadlockDetector, RequestHangDetectionPolicy};
 //!
-//! let config = DeadlockDetectorConfig::from_env();
+//! let config = RequestHangDetectionPolicy::from_env();
 //! let detector = DeadlockDetector::new(config);
 //! detector.start();
 //!
@@ -73,9 +73,9 @@ pub type RequestId = String;
 /// Lock identifier type.
 pub type LockId = String;
 
-/// Deadlock detector configuration.
+/// Request-level hang and deadlock diagnosis policy.
 #[derive(Debug, Clone)]
-pub struct DeadlockDetectorConfig {
+pub struct RequestHangDetectionPolicy {
     /// Whether deadlock detection is enabled.
     pub enabled: bool,
     /// Detection check interval.
@@ -86,7 +86,7 @@ pub struct DeadlockDetectorConfig {
     pub capture_backtrace: bool,
 }
 
-impl Default for DeadlockDetectorConfig {
+impl Default for RequestHangDetectionPolicy {
     fn default() -> Self {
         Self {
             enabled: rustfs_config::DEFAULT_OBJECT_DEADLOCK_DETECTION_ENABLE,
@@ -97,7 +97,7 @@ impl Default for DeadlockDetectorConfig {
     }
 }
 
-impl DeadlockDetectorConfig {
+impl RequestHangDetectionPolicy {
     /// Load configuration from environment variables.
     pub fn from_env() -> Self {
         let enabled = rustfs_utils::get_env_bool(
@@ -121,6 +121,9 @@ impl DeadlockDetectorConfig {
         }
     }
 }
+
+/// Backward-compatible alias for the old request diagnosis config name.
+pub type DeadlockDetectorConfig = RequestHangDetectionPolicy;
 
 /// Lock information for tracking.
 #[derive(Debug, Clone)]
@@ -247,7 +250,7 @@ pub struct ResourceUsage {
 /// Deadlock detector.
 pub struct DeadlockDetector {
     /// Configuration.
-    config: DeadlockDetectorConfig,
+    config: RequestHangDetectionPolicy,
     /// Active request trackers.
     requests: Arc<RwLock<HashMap<RequestId, RequestResourceTracker>>>,
     /// Detection task handle.
@@ -262,7 +265,7 @@ pub struct DeadlockDetector {
 
 impl DeadlockDetector {
     /// Create a new deadlock detector.
-    pub fn new(config: DeadlockDetectorConfig) -> Self {
+    pub fn new(config: RequestHangDetectionPolicy) -> Self {
         let (shutdown_tx, _) = broadcast::channel(1);
 
         Self {
@@ -426,7 +429,7 @@ impl DeadlockDetector {
     /// Detect deadlock cycles in the lock wait graph.
     fn detect_cycle(
         requests: &Arc<RwLock<HashMap<RequestId, RequestResourceTracker>>>,
-        config: &DeadlockDetectorConfig,
+        config: &RequestHangDetectionPolicy,
         deadlocks_detected: &Arc<AtomicU64>,
     ) {
         let requests_guard = requests.read().unwrap();

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -611,7 +611,6 @@ mod tests {
             bytes_per_second: 1024 * 1024, // 1MB/s
             min_timeout: Duration::from_secs(1),
             max_timeout: Duration::from_secs(30),
-            ..Default::default()
         };
 
         // Tiny object should still honor policy min_timeout (1s),
@@ -628,7 +627,6 @@ mod tests {
             bytes_per_second: 1,
             min_timeout: Duration::from_secs(1),
             max_timeout: Duration::from_secs(300),
-            ..Default::default()
         };
 
         let timeout = config.calculate_timeout_for_size(u64::MAX);
@@ -748,7 +746,6 @@ mod tests {
             bytes_per_second: 1024 * 1024,
             min_timeout: Duration::from_secs(1),
             max_timeout: Duration::from_secs(300),
-            ..Default::default()
         };
         let size = 100 * 1024 * 1024;
         let wrapper = RequestTimeoutWrapper::with_operation_size(config.clone(), Some(size));

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -290,7 +290,8 @@ impl RequestTimeoutWrapper {
 
     /// Get the configured timeout for this operation
     pub fn get_timeout(&self, operation_size_hint: Option<u64>) -> Duration {
-        self.config.get_timeout_for_operation(self.effective_operation_size(operation_size_hint))
+        self.config
+            .get_timeout_for_operation(self.effective_operation_size(operation_size_hint))
     }
 
     fn new_with_parts(
@@ -311,13 +312,6 @@ impl RequestTimeoutWrapper {
 
     fn effective_operation_size(&self, operation_size_hint: Option<u64>) -> Option<u64> {
         operation_size_hint.or(self.operation_size)
-    }
-
-    fn context_fields(&self, context: Option<(&str, &str)>) -> (String, String) {
-        match context {
-            Some((bucket, key)) => (bucket.to_string(), key.to_string()),
-            None => (String::new(), String::new()),
-        }
     }
 
     /// Get the request ID.
@@ -357,7 +351,9 @@ impl RequestTimeoutWrapper {
         if !self.config.is_timeout_enabled() {
             return None;
         }
-        let timeout = self.config.get_timeout_for_operation(self.effective_operation_size(operation_size));
+        let timeout = self
+            .config
+            .get_timeout_for_operation(self.effective_operation_size(operation_size));
         self.core_wrapper.remaining(timeout)
     }
 
@@ -366,7 +362,9 @@ impl RequestTimeoutWrapper {
         if !self.config.is_timeout_enabled() {
             return false;
         }
-        let timeout = self.config.get_timeout_for_operation(self.effective_operation_size(operation_size));
+        let timeout = self
+            .config
+            .get_timeout_for_operation(self.effective_operation_size(operation_size));
         self.core_wrapper.elapsed() >= timeout
     }
 
@@ -418,7 +416,6 @@ impl RequestTimeoutWrapper {
         F: FnOnce(CancellationToken) -> Fut,
         Fut: std::future::Future<Output = Result<T, E>>,
     {
-        let request_id = self.request_id.clone();
         let timeout_duration = self.get_timeout(None);
         let context_refs = context.as_ref().map(|(bucket, key)| (bucket.as_str(), key.as_str()));
 
@@ -445,7 +442,7 @@ impl RequestTimeoutWrapper {
 
         if let Some((bucket, key)) = context_refs {
             debug!(
-                request_id = %request_id,
+                request_id = %self.request_id,
                 bucket = %bucket,
                 key = %key,
                 timeout_secs = timeout_duration.as_secs(),
@@ -453,7 +450,7 @@ impl RequestTimeoutWrapper {
             );
         } else {
             debug!(
-                request_id = %request_id,
+                request_id = %self.request_id,
                 timeout_secs = timeout_duration.as_secs(),
                 "Starting timed operation"
             );
@@ -470,7 +467,7 @@ impl RequestTimeoutWrapper {
 
                 if let Some((bucket, key)) = context_refs {
                     debug!(
-                        request_id = %request_id,
+                        request_id = %self.request_id,
                         bucket = %bucket,
                         key = %key,
                         elapsed_ms = elapsed.as_millis(),
@@ -478,7 +475,7 @@ impl RequestTimeoutWrapper {
                     );
                 } else {
                     debug!(
-                        request_id = %request_id,
+                        request_id = %self.request_id,
                         elapsed_ms = elapsed.as_millis(),
                         "Operation completed successfully"
                     );
@@ -492,7 +489,7 @@ impl RequestTimeoutWrapper {
 
                 if let Some((bucket, key)) = context_refs {
                     debug!(
-                        request_id = %request_id,
+                        request_id = %self.request_id,
                         bucket = %bucket,
                         key = %key,
                         elapsed_ms = elapsed.as_millis(),
@@ -500,7 +497,7 @@ impl RequestTimeoutWrapper {
                     );
                 } else {
                     debug!(
-                        request_id = %request_id,
+                        request_id = %self.request_id,
                         elapsed_ms = elapsed.as_millis(),
                         "Operation failed with error"
                     );
@@ -517,7 +514,7 @@ impl RequestTimeoutWrapper {
 
                 if let Some((bucket, key)) = context_refs {
                     warn!(
-                        request_id = %request_id,
+                        request_id = %self.request_id,
                         bucket = %bucket,
                         key = %key,
                         timeout_secs = timeout_duration.as_secs(),
@@ -526,16 +523,16 @@ impl RequestTimeoutWrapper {
                     );
                 } else {
                     warn!(
-                        request_id = %request_id,
+                        request_id = %self.request_id,
                         timeout_secs = timeout_duration.as_secs(),
                         elapsed_ms = elapsed.as_millis(),
                         "Operation timed out, cancellation signal sent"
                     );
                 }
 
-                let (bucket, key) = self.context_fields(context_refs);
+                let (bucket, key) = context.unwrap_or_default();
                 TimedGetObjectResult::Timeout(TimeoutInfo {
-                    request_id,
+                    request_id: self.request_id,
                     bucket,
                     key,
                     timeout_duration,

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -160,10 +160,15 @@ impl GetObjectTimeoutPolicy {
 
         // Keep storage-layer dynamic-timeout semantics local so request policy
         // bounds remain authoritative. We preserve the historical 1.5x envelope:
-        // 80% effective rate * 1.2 safety margin.
-        let effective_rate_bps = self.bytes_per_second.saturating_mul(4).saturating_div(5).max(1);
-        let estimated_secs = (object_size as f64 / effective_rate_bps as f64) * 1.2;
-        let estimated_duration = Duration::from_secs_f64(estimated_secs);
+        // object_size / (0.8 * bps) * 1.2 == object_size * 1.5 / bps.
+        //
+        // Use integer math to avoid float->Duration conversion panics on extreme
+        // values and keep behavior predictable under saturation.
+        let bytes_per_second = self.bytes_per_second.max(1);
+        let numerator = (object_size as u128).saturating_mul(3);
+        let denominator = (bytes_per_second as u128).saturating_mul(2);
+        let estimated_secs = numerator.checked_div(denominator).unwrap_or(u128::MAX);
+        let estimated_duration = Duration::from_secs(estimated_secs.min(u64::MAX as u128) as u64);
 
         // Clamp to min/max bounds
         estimated_duration
@@ -723,6 +728,21 @@ mod tests {
         // instead of being raised by any external hard floor.
         let timeout = config.calculate_timeout_for_size(1024); // 1KB
         assert_eq!(timeout, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_calculate_timeout_for_size_huge_object_does_not_panic_and_clamps() {
+        let config = GetObjectTimeoutPolicy {
+            get_object_timeout: Duration::from_secs(300),
+            enable_dynamic_timeout: true,
+            bytes_per_second: 1,
+            min_timeout: Duration::from_secs(1),
+            max_timeout: Duration::from_secs(300),
+            ..Default::default()
+        };
+
+        let timeout = config.calculate_timeout_for_size(u64::MAX);
+        assert_eq!(timeout, Duration::from_secs(300));
     }
 
     #[test]

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -47,9 +47,9 @@
 //! # Usage
 //!
 //! ```ignore
-//! use crate::storage::timeout_wrapper::{RequestTimeoutWrapper, TimeoutConfig};
+//! use crate::storage::timeout_wrapper::{GetObjectTimeoutPolicy, RequestTimeoutWrapper};
 //!
-//! let config = TimeoutConfig::from_env();
+//! let config = GetObjectTimeoutPolicy::from_env();
 //! let wrapper = RequestTimeoutWrapper::new(config);
 //!
 //! match wrapper.execute_with_timeout(|cancel_token| async move {
@@ -66,11 +66,11 @@ use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-// Re-export types from rustfs_io_core for convenience
+use rustfs_io_core::calculate_adaptive_timeout;
 
-/// Timeout configuration for GetObject requests.
+/// Request-level timeout policy for GetObject.
 #[derive(Debug, Clone)]
-pub struct TimeoutConfig {
+pub struct GetObjectTimeoutPolicy {
     /// GetObject request overall timeout (default 30s).
     /// After this duration, the request is cancelled and returns 504.
     pub get_object_timeout: Duration,
@@ -96,7 +96,7 @@ pub struct TimeoutConfig {
     pub max_timeout: Duration,
 }
 
-impl Default for TimeoutConfig {
+impl Default for GetObjectTimeoutPolicy {
     fn default() -> Self {
         Self {
             get_object_timeout: Duration::from_secs(rustfs_config::DEFAULT_OBJECT_GET_TIMEOUT),
@@ -110,7 +110,7 @@ impl Default for TimeoutConfig {
     }
 }
 
-impl TimeoutConfig {
+impl GetObjectTimeoutPolicy {
     /// Load configuration from environment variables.
     pub fn from_env() -> Self {
         let get_object_timeout =
@@ -158,12 +158,13 @@ impl TimeoutConfig {
             return self.get_object_timeout;
         }
 
-        // Calculate timeout based on expected transfer speed
-        // Add 50% buffer for network overhead and system load
-        let estimated_seconds = (object_size / self.bytes_per_second) * 3 / 2;
-
-        // Ensure at least 1 second
-        let estimated_duration = Duration::from_secs(estimated_seconds.max(1));
+        // Reuse the core adaptive-timeout estimator while preserving the current
+        // storage-layer 50% safety buffer semantics. The core helper uses a 20%
+        // overhead factor, so we feed it an 80% effective rate to reach the same
+        // 1.5x envelope this request policy historically used.
+        let effective_rate_bps = self.bytes_per_second.saturating_mul(4).saturating_div(5).max(1);
+        let estimated_duration =
+            calculate_adaptive_timeout(Duration::from_secs(1), Some(effective_rate_bps), 0, object_size);
 
         // Clamp to min/max bounds
         estimated_duration
@@ -180,6 +181,9 @@ impl TimeoutConfig {
         }
     }
 }
+
+/// Backward-compatible alias for the old request timeout name.
+pub type TimeoutConfig = GetObjectTimeoutPolicy;
 
 /// Information about a timeout event.
 #[derive(Debug, Clone)]
@@ -223,7 +227,7 @@ pub enum TimedGetObjectResult<T, E> {
 #[derive(Debug)]
 pub struct RequestTimeoutWrapper {
     /// Configuration.
-    config: TimeoutConfig,
+    config: GetObjectTimeoutPolicy,
     /// Request start time.
     start_time: Instant,
     /// Cancellation token for propagating cancellation to sub-tasks.
@@ -237,7 +241,7 @@ impl RequestTimeoutWrapper {
     ///
     /// Note: This uses a sentinel request_id. Prefer `with_request_id()` to pass
     /// the canonical request-id from `RequestContext`.
-    pub fn new(config: TimeoutConfig) -> Self {
+    pub fn new(config: GetObjectTimeoutPolicy) -> Self {
         Self {
             config,
             start_time: Instant::now(),
@@ -247,7 +251,7 @@ impl RequestTimeoutWrapper {
     }
 
     /// Create a new timeout wrapper with a specific request ID.
-    pub fn with_request_id(config: TimeoutConfig, request_id: impl Into<String>) -> Self {
+    pub fn with_request_id(config: GetObjectTimeoutPolicy, request_id: impl Into<String>) -> Self {
         Self {
             config,
             start_time: Instant::now(),
@@ -260,7 +264,7 @@ impl RequestTimeoutWrapper {
     ///
     /// Note: This uses a sentinel request_id. Prefer `with_request_id()` to pass
     /// the canonical request-id from `RequestContext`.
-    pub fn with_operation_size(config: TimeoutConfig, operation_size: Option<u64>) -> Self {
+    pub fn with_operation_size(config: GetObjectTimeoutPolicy, operation_size: Option<u64>) -> Self {
         let _ = operation_size;
         Self {
             config,

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -200,6 +200,7 @@ impl GetObjectTimeoutPolicy {
 }
 
 /// Backward-compatible alias for the old request timeout name.
+#[deprecated(note = "use GetObjectTimeoutPolicy instead")]
 pub type TimeoutConfig = GetObjectTimeoutPolicy;
 
 /// Information about a timeout event.
@@ -565,7 +566,7 @@ mod tests {
 
     #[test]
     fn test_timeout_config_default() {
-        let config = TimeoutConfig::default();
+        let config = GetObjectTimeoutPolicy::default();
         assert_eq!(config.get_object_timeout, Duration::from_secs(30));
         assert_eq!(config.lock_acquire_timeout, Duration::from_secs(5));
         assert_eq!(config.disk_read_timeout, Duration::from_secs(10));
@@ -573,10 +574,10 @@ mod tests {
 
     #[test]
     fn test_timeout_config_is_enabled() {
-        let config = TimeoutConfig::default();
+        let config = GetObjectTimeoutPolicy::default();
         assert!(config.is_timeout_enabled());
 
-        let disabled_config = TimeoutConfig {
+        let disabled_config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::ZERO,
             ..Default::default()
         };
@@ -585,7 +586,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_success() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::from_secs(5),
             ..Default::default()
         };
@@ -603,7 +604,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_timeout() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::from_millis(100),
             ..Default::default()
         };
@@ -626,7 +627,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_error() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::from_secs(5),
             ..Default::default()
         };
@@ -644,7 +645,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_wrapper_disabled() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::ZERO,
             ..Default::default()
         };
@@ -680,7 +681,7 @@ mod tests {
 
     #[test]
     fn test_timeout_config_default_with_dynamic() {
-        let config = TimeoutConfig::default();
+        let config = GetObjectTimeoutPolicy::default();
         assert!(config.enable_dynamic_timeout);
         assert_eq!(config.bytes_per_second, rustfs_config::DEFAULT_OBJECT_BYTES_PER_SECOND);
         assert_eq!(config.min_timeout, Duration::from_secs(rustfs_config::DEFAULT_OBJECT_MIN_TIMEOUT));
@@ -689,7 +690,7 @@ mod tests {
 
     #[test]
     fn test_calculate_timeout_for_size() {
-        let config = TimeoutConfig::default();
+        let config = GetObjectTimeoutPolicy::default();
 
         // Test with small object (should use min timeout)
         let small_timeout = config.calculate_timeout_for_size(1024); // 1KB
@@ -708,7 +709,7 @@ mod tests {
 
     #[test]
     fn test_timeout_with_dynamic_disabled() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             enable_dynamic_timeout: false,
             ..Default::default()
         };
@@ -777,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_should_timeout() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             get_object_timeout: Duration::from_millis(100),
             ..Default::default()
         };
@@ -794,7 +795,7 @@ mod tests {
 
     #[test]
     fn test_should_timeout_with_size() {
-        let config = TimeoutConfig {
+        let config = GetObjectTimeoutPolicy {
             enable_dynamic_timeout: true,
             bytes_per_second: 1024, // 1KB/s
             min_timeout: Duration::from_secs(rustfs_config::DEFAULT_OBJECT_MIN_TIMEOUT),

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -66,7 +66,9 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use rustfs_io_core::{RequestTimeoutWrapper as CoreRequestTimeoutWrapper, TimeoutConfig as CoreTimeoutConfig, calculate_adaptive_timeout};
+use rustfs_io_core::{
+    RequestTimeoutWrapper as CoreRequestTimeoutWrapper, TimeoutConfig as CoreTimeoutConfig, calculate_adaptive_timeout,
+};
 
 /// Request-level timeout policy for GetObject.
 #[derive(Debug, Clone)]
@@ -163,8 +165,7 @@ impl GetObjectTimeoutPolicy {
         // overhead factor, so we feed it an 80% effective rate to reach the same
         // 1.5x envelope this request policy historically used.
         let effective_rate_bps = self.bytes_per_second.saturating_mul(4).saturating_div(5).max(1);
-        let estimated_duration =
-            calculate_adaptive_timeout(Duration::from_secs(1), Some(effective_rate_bps), 0, object_size);
+        let estimated_duration = calculate_adaptive_timeout(Duration::from_secs(1), Some(effective_rate_bps), 0, object_size);
 
         // Clamp to min/max bounds
         estimated_duration

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -66,9 +66,7 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use rustfs_io_core::{
-    RequestTimeoutWrapper as CoreRequestTimeoutWrapper, TimeoutConfig as CoreTimeoutConfig, calculate_adaptive_timeout,
-};
+use rustfs_io_core::{RequestTimeoutWrapper as CoreRequestTimeoutWrapper, TimeoutConfig as CoreTimeoutConfig};
 
 /// Request-level timeout policy for GetObject.
 #[derive(Debug, Clone)]
@@ -160,12 +158,12 @@ impl GetObjectTimeoutPolicy {
             return self.get_object_timeout;
         }
 
-        // Reuse the core adaptive-timeout estimator while preserving the current
-        // storage-layer 50% safety buffer semantics. The core helper uses a 20%
-        // overhead factor, so we feed it an 80% effective rate to reach the same
-        // 1.5x envelope this request policy historically used.
+        // Keep storage-layer dynamic-timeout semantics local so request policy
+        // bounds remain authoritative. We preserve the historical 1.5x envelope:
+        // 80% effective rate * 1.2 safety margin.
         let effective_rate_bps = self.bytes_per_second.saturating_mul(4).saturating_div(5).max(1);
-        let estimated_duration = calculate_adaptive_timeout(Duration::from_secs(1), Some(effective_rate_bps), 0, object_size);
+        let estimated_secs = (object_size as f64 / effective_rate_bps as f64) * 1.2;
+        let estimated_duration = Duration::from_secs_f64(estimated_secs);
 
         // Clamp to min/max bounds
         estimated_duration
@@ -708,6 +706,23 @@ mod tests {
         // Test with very large object (should cap at max_timeout)
         let huge_timeout = config.calculate_timeout_for_size(1000 * 1024 * 1024); // 1GB
         assert!(huge_timeout <= Duration::from_secs(rustfs_config::DEFAULT_OBJECT_MAX_TIMEOUT));
+    }
+
+    #[test]
+    fn test_calculate_timeout_for_size_respects_small_min_timeout() {
+        let config = GetObjectTimeoutPolicy {
+            get_object_timeout: Duration::from_secs(30),
+            enable_dynamic_timeout: true,
+            bytes_per_second: 1024 * 1024, // 1MB/s
+            min_timeout: Duration::from_secs(1),
+            max_timeout: Duration::from_secs(30),
+            ..Default::default()
+        };
+
+        // Tiny object should still honor policy min_timeout (1s),
+        // instead of being raised by any external hard floor.
+        let timeout = config.calculate_timeout_for_size(1024); // 1KB
+        assert_eq!(timeout, Duration::from_secs(1));
     }
 
     #[test]

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -77,6 +77,10 @@ pub struct GetObjectTimeoutPolicy {
     pub max_timeout: Duration,
 }
 
+/// Backward-compatible alias for external callers using the previous name.
+#[deprecated(note = "use GetObjectTimeoutPolicy instead")]
+pub type TimeoutConfig = GetObjectTimeoutPolicy;
+
 impl Default for GetObjectTimeoutPolicy {
     fn default() -> Self {
         Self {

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -62,11 +62,11 @@
 //! }
 //! ```
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use rustfs_io_core::calculate_adaptive_timeout;
+use rustfs_io_core::{RequestTimeoutWrapper as CoreRequestTimeoutWrapper, TimeoutConfig as CoreTimeoutConfig, calculate_adaptive_timeout};
 
 /// Request-level timeout policy for GetObject.
 #[derive(Debug, Clone)]
@@ -180,6 +180,23 @@ impl GetObjectTimeoutPolicy {
             _ => self.get_object_timeout,
         }
     }
+
+    /// Convert the request-level policy into a core timeout configuration.
+    ///
+    /// This is intentionally lossy: request-specific diagnostics remain in the
+    /// storage layer, while the shared timing primitive lives in `io-core`.
+    pub fn to_core_config(&self) -> CoreTimeoutConfig {
+        CoreTimeoutConfig {
+            base_timeout: self.get_object_timeout,
+            timeout_per_mb: Duration::ZERO,
+            max_timeout: self.max_timeout,
+            min_timeout: self.min_timeout,
+            get_object_timeout: self.get_object_timeout,
+            put_object_timeout: self.get_object_timeout,
+            list_objects_timeout: self.get_object_timeout,
+            enable_dynamic_timeout: false,
+        }
+    }
 }
 
 /// Backward-compatible alias for the old request timeout name.
@@ -224,16 +241,25 @@ pub enum TimedGetObjectResult<T, E> {
 }
 
 /// Request timeout wrapper for async operations.
-#[derive(Debug)]
 pub struct RequestTimeoutWrapper {
     /// Configuration.
     config: GetObjectTimeoutPolicy,
-    /// Request start time.
-    start_time: Instant,
+    /// Shared core timing primitive.
+    core_wrapper: CoreRequestTimeoutWrapper,
     /// Cancellation token for propagating cancellation to sub-tasks.
     cancel_token: CancellationToken,
     /// Request ID for logging/metrics.
     request_id: String,
+}
+
+impl std::fmt::Debug for RequestTimeoutWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestTimeoutWrapper")
+            .field("config", &self.config)
+            .field("elapsed", &self.elapsed())
+            .field("request_id", &self.request_id)
+            .finish()
+    }
 }
 
 impl RequestTimeoutWrapper {
@@ -242,9 +268,10 @@ impl RequestTimeoutWrapper {
     /// Note: This uses a sentinel request_id. Prefer `with_request_id()` to pass
     /// the canonical request-id from `RequestContext`.
     pub fn new(config: GetObjectTimeoutPolicy) -> Self {
+        let core_wrapper = CoreRequestTimeoutWrapper::new(config.to_core_config());
         Self {
             config,
-            start_time: Instant::now(),
+            core_wrapper,
             cancel_token: CancellationToken::new(),
             request_id: "no-request-id".to_string(),
         }
@@ -252,12 +279,7 @@ impl RequestTimeoutWrapper {
 
     /// Create a new timeout wrapper with a specific request ID.
     pub fn with_request_id(config: GetObjectTimeoutPolicy, request_id: impl Into<String>) -> Self {
-        Self {
-            config,
-            start_time: Instant::now(),
-            cancel_token: CancellationToken::new(),
-            request_id: request_id.into(),
-        }
+        Self::new_with_parts(config, CancellationToken::new(), request_id.into())
     }
 
     /// Create a new timeout wrapper with operation size for dynamic timeout calculation.
@@ -266,17 +288,29 @@ impl RequestTimeoutWrapper {
     /// the canonical request-id from `RequestContext`.
     pub fn with_operation_size(config: GetObjectTimeoutPolicy, operation_size: Option<u64>) -> Self {
         let _ = operation_size;
-        Self {
-            config,
-            start_time: Instant::now(),
-            cancel_token: CancellationToken::new(),
-            request_id: "no-request-id".to_string(),
-        }
+        Self::new(config)
     }
 
     /// Get the configured timeout for this operation
     pub fn get_timeout(&self, operation_size: Option<u64>) -> Duration {
         self.config.get_timeout_for_operation(operation_size)
+    }
+
+    fn new_with_parts(config: GetObjectTimeoutPolicy, cancel_token: CancellationToken, request_id: String) -> Self {
+        let core_wrapper = CoreRequestTimeoutWrapper::new(config.to_core_config());
+        Self {
+            config,
+            core_wrapper,
+            cancel_token,
+            request_id,
+        }
+    }
+
+    fn context_fields(&self, context: Option<(&str, &str)>) -> (String, String) {
+        match context {
+            Some((bucket, key)) => (bucket.to_string(), key.to_string()),
+            None => (String::new(), String::new()),
+        }
     }
 
     /// Get the request ID.
@@ -297,12 +331,12 @@ impl RequestTimeoutWrapper {
 
     /// Check if the timeout has been exceeded.
     pub fn is_timeout(&self) -> bool {
-        self.config.is_timeout_enabled() && self.elapsed() >= self.config.get_object_timeout
+        self.config.is_timeout_enabled() && self.core_wrapper.elapsed() >= self.config.get_object_timeout
     }
 
     /// Get elapsed time since the request started.
     pub fn elapsed(&self) -> Duration {
-        self.start_time.elapsed()
+        self.core_wrapper.elapsed()
     }
 
     /// Get remaining time before timeout.
@@ -317,8 +351,7 @@ impl RequestTimeoutWrapper {
             return None;
         }
         let timeout = self.config.get_timeout_for_operation(operation_size);
-        let remaining = timeout.saturating_sub(self.elapsed());
-        if remaining == Duration::ZERO { None } else { Some(remaining) }
+        self.core_wrapper.remaining(timeout)
     }
 
     /// Check if the wrapper should timeout based on elapsed time and optional operation size
@@ -327,7 +360,7 @@ impl RequestTimeoutWrapper {
             return false;
         }
         let timeout = self.config.get_timeout_for_operation(operation_size);
-        self.elapsed() >= timeout
+        self.core_wrapper.elapsed() >= timeout
     }
 
     /// Execute an async operation with timeout protection.
@@ -347,95 +380,7 @@ impl RequestTimeoutWrapper {
         F: FnOnce(CancellationToken) -> Fut,
         Fut: std::future::Future<Output = Result<T, E>>,
     {
-        if !self.config.is_timeout_enabled() {
-            // Timeout disabled, run without timeout
-            debug!(
-                request_id = %self.request_id,
-                "Timeout disabled, executing operation without timeout"
-            );
-            return match operation(self.cancel_token).await {
-                Ok(result) => TimedGetObjectResult::Success(result),
-                Err(e) => TimedGetObjectResult::Error(e),
-            };
-        }
-
-        let timeout_duration = self.config.get_object_timeout;
-        let request_id = self.request_id.clone();
-        let start_time = self.start_time;
-
-        debug!(
-            request_id = %request_id,
-            timeout_secs = timeout_duration.as_secs(),
-            "Starting timed operation"
-        );
-
-        // Record start time for metrics
-        rustfs_io_metrics::record_get_object_request_started();
-
-        // Clone cancel_token for the operation, keep original for potential cancellation
-        let cancel_token_for_op = self.cancel_token.clone();
-
-        match tokio::time::timeout(timeout_duration, operation(cancel_token_for_op)).await {
-            Ok(Ok(result)) => {
-                // Operation completed successfully
-                let elapsed = start_time.elapsed();
-
-                rustfs_io_metrics::record_get_object_request_result("success", elapsed.as_secs_f64());
-
-                debug!(
-                    request_id = %request_id,
-                    elapsed_ms = elapsed.as_millis(),
-                    "Operation completed successfully"
-                );
-
-                TimedGetObjectResult::Success(result)
-            }
-            Ok(Err(e)) => {
-                // Operation failed before timeout
-                let elapsed = start_time.elapsed();
-
-                rustfs_io_metrics::record_get_object_request_result("error", elapsed.as_secs_f64());
-
-                debug!(
-                    request_id = %request_id,
-                    elapsed_ms = elapsed.as_millis(),
-                    "Operation failed with error"
-                );
-
-                TimedGetObjectResult::Error(e)
-            }
-            Err(_) => {
-                // Timeout occurred
-                let elapsed = start_time.elapsed();
-
-                // Cancel the operation
-                self.cancel_token.cancel();
-
-                rustfs_io_metrics::record_get_object_timeout(None, Some(elapsed.as_secs_f64()));
-                rustfs_io_metrics::record_get_object_request_result("timeout", elapsed.as_secs_f64());
-
-                warn!(
-                    request_id = %request_id,
-                    timeout_secs = timeout_duration.as_secs(),
-                    elapsed_ms = elapsed.as_millis(),
-                    "Operation timed out, cancellation signal sent"
-                );
-
-                TimedGetObjectResult::Timeout(TimeoutInfo {
-                    request_id,
-                    bucket: String::new(),
-                    key: String::new(),
-                    timeout_duration,
-                    elapsed,
-                    bytes_transferred: 0,
-                    lock_hold_time: None,
-                    disk_reads_completed: 0,
-                    disk_reads_pending: 0,
-                    object_size: None,
-                    progress_percent: None,
-                })
-            }
-        }
+        self.execute_with_timeout_internal(None, operation).await
     }
 
     /// Execute an async operation with timeout and context information.
@@ -454,84 +399,134 @@ impl RequestTimeoutWrapper {
     {
         let bucket = bucket.into();
         let key = key.into();
+        self.execute_with_timeout_internal(Some((bucket, key)), operation).await
+    }
+
+    async fn execute_with_timeout_internal<F, Fut, T, E>(
+        self,
+        context: Option<(String, String)>,
+        operation: F,
+    ) -> TimedGetObjectResult<T, E>
+    where
+        F: FnOnce(CancellationToken) -> Fut,
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        let request_id = self.request_id.clone();
+        let timeout_duration = self.get_timeout(None);
+        let context_refs = context.as_ref().map(|(bucket, key)| (bucket.as_str(), key.as_str()));
 
         if !self.config.is_timeout_enabled() {
-            debug!(
-                request_id = %self.request_id,
-                bucket = %bucket,
-                key = %key,
-                "Timeout disabled, executing operation without timeout"
-            );
+            if let Some((bucket, key)) = context_refs {
+                debug!(
+                    request_id = %self.request_id,
+                    bucket = %bucket,
+                    key = %key,
+                    "Timeout disabled, executing operation without timeout"
+                );
+            } else {
+                debug!(
+                    request_id = %self.request_id,
+                    "Timeout disabled, executing operation without timeout"
+                );
+            }
+
             return match operation(self.cancel_token).await {
                 Ok(result) => TimedGetObjectResult::Success(result),
                 Err(e) => TimedGetObjectResult::Error(e),
             };
         }
 
-        let timeout_duration = self.config.get_object_timeout;
-        let request_id = self.request_id.clone();
-        let start_time = self.start_time;
-
-        debug!(
-            request_id = %request_id,
-            bucket = %bucket,
-            key = %key,
-            timeout_secs = timeout_duration.as_secs(),
-            "Starting timed operation"
-        );
+        if let Some((bucket, key)) = context_refs {
+            debug!(
+                request_id = %request_id,
+                bucket = %bucket,
+                key = %key,
+                timeout_secs = timeout_duration.as_secs(),
+                "Starting timed operation"
+            );
+        } else {
+            debug!(
+                request_id = %request_id,
+                timeout_secs = timeout_duration.as_secs(),
+                "Starting timed operation"
+            );
+        }
 
         rustfs_io_metrics::record_get_object_request_started();
 
-        // Clone cancel_token for the operation, keep original for potential cancellation
         let cancel_token_for_op = self.cancel_token.clone();
 
         match tokio::time::timeout(timeout_duration, operation(cancel_token_for_op)).await {
             Ok(Ok(result)) => {
-                let elapsed = start_time.elapsed();
-
+                let elapsed = self.elapsed();
                 rustfs_io_metrics::record_get_object_request_result("success", elapsed.as_secs_f64());
 
-                debug!(
-                    request_id = %request_id,
-                    bucket = %bucket,
-                    key = %key,
-                    elapsed_ms = elapsed.as_millis(),
-                    "Operation completed successfully"
-                );
+                if let Some((bucket, key)) = context_refs {
+                    debug!(
+                        request_id = %request_id,
+                        bucket = %bucket,
+                        key = %key,
+                        elapsed_ms = elapsed.as_millis(),
+                        "Operation completed successfully"
+                    );
+                } else {
+                    debug!(
+                        request_id = %request_id,
+                        elapsed_ms = elapsed.as_millis(),
+                        "Operation completed successfully"
+                    );
+                }
 
                 TimedGetObjectResult::Success(result)
             }
             Ok(Err(e)) => {
-                let elapsed = start_time.elapsed();
-
+                let elapsed = self.elapsed();
                 rustfs_io_metrics::record_get_object_request_result("error", elapsed.as_secs_f64());
 
-                debug!(
-                    request_id = %request_id,
-                    bucket = %bucket,
-                    key = %key,
-                    elapsed_ms = elapsed.as_millis(),
-                    "Operation failed with error"
-                );
+                if let Some((bucket, key)) = context_refs {
+                    debug!(
+                        request_id = %request_id,
+                        bucket = %bucket,
+                        key = %key,
+                        elapsed_ms = elapsed.as_millis(),
+                        "Operation failed with error"
+                    );
+                } else {
+                    debug!(
+                        request_id = %request_id,
+                        elapsed_ms = elapsed.as_millis(),
+                        "Operation failed with error"
+                    );
+                }
 
                 TimedGetObjectResult::Error(e)
             }
             Err(_) => {
-                let elapsed = start_time.elapsed();
+                let elapsed = self.elapsed();
                 self.cancel_token.cancel();
 
                 rustfs_io_metrics::record_get_object_timeout(None, Some(elapsed.as_secs_f64()));
                 rustfs_io_metrics::record_get_object_request_result("timeout", elapsed.as_secs_f64());
 
-                warn!(
-                    request_id = %request_id,
-                    bucket = %bucket,
-                    key = %key,
-                    timeout_secs = timeout_duration.as_secs(),
-                    elapsed_ms = elapsed.as_millis(),
-                    "Operation timed out, cancellation signal sent"
-                );
+                if let Some((bucket, key)) = context_refs {
+                    warn!(
+                        request_id = %request_id,
+                        bucket = %bucket,
+                        key = %key,
+                        timeout_secs = timeout_duration.as_secs(),
+                        elapsed_ms = elapsed.as_millis(),
+                        "Operation timed out, cancellation signal sent"
+                    );
+                } else {
+                    warn!(
+                        request_id = %request_id,
+                        timeout_secs = timeout_duration.as_secs(),
+                        elapsed_ms = elapsed.as_millis(),
+                        "Operation timed out, cancellation signal sent"
+                    );
+                }
 
+                let (bucket, key) = self.context_fields(context_refs);
                 TimedGetObjectResult::Timeout(TimeoutInfo {
                     request_id,
                     bucket,

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -33,15 +33,6 @@
 //!
 //! - Configurable request-level timeout (default 30 seconds)
 //! - Automatic cancellation of sub-tasks on timeout
-//! - Resource cleanup on timeout (locks, memory, file handles)
-//! - Timeout metrics emitted through `rustfs-io-metrics`
-
-// Allow dead_code for public API that may be used by external modules or future features
-#![allow(dead_code)]
-//!
-//! - Configurable request-level timeout (default 30 seconds)
-//! - Automatic cancellation of sub-tasks on timeout
-//! - Resource cleanup on timeout (locks, memory, file handles)
 //! - Timeout metrics emitted through `rustfs-io-metrics`
 //!
 //! # Usage
@@ -62,11 +53,9 @@
 //! }
 //! ```
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
-
-use rustfs_io_core::{RequestTimeoutWrapper as CoreRequestTimeoutWrapper, TimeoutConfig as CoreTimeoutConfig};
 
 /// Request-level timeout policy for GetObject.
 #[derive(Debug, Clone)]
@@ -74,14 +63,6 @@ pub struct GetObjectTimeoutPolicy {
     /// GetObject request overall timeout (default 30s).
     /// After this duration, the request is cancelled and returns 504.
     pub get_object_timeout: Duration,
-
-    /// Lock acquisition timeout (default 5s).
-    /// Time to wait for a lock before giving up.
-    pub lock_acquire_timeout: Duration,
-
-    /// Disk read operation timeout (default 10s).
-    /// Individual disk read operations that exceed this are cancelled.
-    pub disk_read_timeout: Duration,
 
     /// Enable dynamic timeout calculation based on object size
     pub enable_dynamic_timeout: bool,
@@ -100,8 +81,6 @@ impl Default for GetObjectTimeoutPolicy {
     fn default() -> Self {
         Self {
             get_object_timeout: Duration::from_secs(rustfs_config::DEFAULT_OBJECT_GET_TIMEOUT),
-            lock_acquire_timeout: Duration::from_secs(rustfs_config::DEFAULT_OBJECT_LOCK_ACQUIRE_TIMEOUT),
-            disk_read_timeout: Duration::from_secs(rustfs_config::DEFAULT_OBJECT_DISK_READ_TIMEOUT),
             enable_dynamic_timeout: rustfs_config::DEFAULT_OBJECT_DYNAMIC_TIMEOUT_ENABLE,
             bytes_per_second: rustfs_config::DEFAULT_OBJECT_BYTES_PER_SECOND,
             min_timeout: Duration::from_secs(rustfs_config::DEFAULT_OBJECT_MIN_TIMEOUT),
@@ -115,16 +94,6 @@ impl GetObjectTimeoutPolicy {
     pub fn from_env() -> Self {
         let get_object_timeout =
             rustfs_utils::get_env_u64(rustfs_config::ENV_OBJECT_GET_TIMEOUT, rustfs_config::DEFAULT_OBJECT_GET_TIMEOUT);
-        let lock_acquire_timeout = rustfs_utils::get_env_u64(
-            rustfs_config::ENV_OBJECT_LOCK_ACQUIRE_TIMEOUT,
-            rustfs_config::DEFAULT_OBJECT_LOCK_ACQUIRE_TIMEOUT,
-        );
-        let disk_read_timeout = rustfs_utils::get_env_u64(
-            rustfs_config::ENV_OBJECT_DISK_READ_TIMEOUT,
-            rustfs_config::DEFAULT_OBJECT_DISK_READ_TIMEOUT,
-        );
-
-        // Dynamic timeout settings
         let enable_dynamic_timeout = rustfs_utils::get_env_bool(
             rustfs_config::ENV_OBJECT_DYNAMIC_TIMEOUT_ENABLE,
             rustfs_config::DEFAULT_OBJECT_DYNAMIC_TIMEOUT_ENABLE,
@@ -138,8 +107,6 @@ impl GetObjectTimeoutPolicy {
 
         Self {
             get_object_timeout: Duration::from_secs(get_object_timeout),
-            lock_acquire_timeout: Duration::from_secs(lock_acquire_timeout),
-            disk_read_timeout: Duration::from_secs(disk_read_timeout),
             enable_dynamic_timeout,
             bytes_per_second,
             min_timeout: Duration::from_secs(min_timeout_secs),
@@ -184,28 +151,7 @@ impl GetObjectTimeoutPolicy {
             _ => self.get_object_timeout,
         }
     }
-
-    /// Convert the request-level policy into a core timeout configuration.
-    ///
-    /// This is intentionally lossy: request-specific diagnostics remain in the
-    /// storage layer, while the shared timing primitive lives in `io-core`.
-    pub fn to_core_config(&self) -> CoreTimeoutConfig {
-        CoreTimeoutConfig {
-            base_timeout: self.get_object_timeout,
-            timeout_per_mb: Duration::ZERO,
-            max_timeout: self.max_timeout,
-            min_timeout: self.min_timeout,
-            get_object_timeout: self.get_object_timeout,
-            put_object_timeout: self.get_object_timeout,
-            list_objects_timeout: self.get_object_timeout,
-            enable_dynamic_timeout: false,
-        }
-    }
 }
-
-/// Backward-compatible alias for the old request timeout name.
-#[deprecated(note = "use GetObjectTimeoutPolicy instead")]
-pub type TimeoutConfig = GetObjectTimeoutPolicy;
 
 /// Information about a timeout event.
 #[derive(Debug, Clone)]
@@ -249,8 +195,8 @@ pub enum TimedGetObjectResult<T, E> {
 pub struct RequestTimeoutWrapper {
     /// Configuration.
     config: GetObjectTimeoutPolicy,
-    /// Shared core timing primitive.
-    core_wrapper: CoreRequestTimeoutWrapper,
+    /// Request start time.
+    start_time: Instant,
     /// Optional operation size hint for dynamic timeout decisions.
     operation_size: Option<u64>,
     /// Cancellation token for propagating cancellation to sub-tasks.
@@ -303,10 +249,9 @@ impl RequestTimeoutWrapper {
         cancel_token: CancellationToken,
         request_id: String,
     ) -> Self {
-        let core_wrapper = CoreRequestTimeoutWrapper::new(config.to_core_config());
         Self {
             config,
-            core_wrapper,
+            start_time: Instant::now(),
             operation_size,
             cancel_token,
             request_id,
@@ -335,12 +280,12 @@ impl RequestTimeoutWrapper {
 
     /// Check if the timeout has been exceeded.
     pub fn is_timeout(&self) -> bool {
-        self.config.is_timeout_enabled() && self.core_wrapper.elapsed() >= self.get_timeout(None)
+        self.config.is_timeout_enabled() && self.start_time.elapsed() >= self.get_timeout(None)
     }
 
     /// Get elapsed time since the request started.
     pub fn elapsed(&self) -> Duration {
-        self.core_wrapper.elapsed()
+        self.start_time.elapsed()
     }
 
     /// Get remaining time before timeout.
@@ -357,7 +302,8 @@ impl RequestTimeoutWrapper {
         let timeout = self
             .config
             .get_timeout_for_operation(self.effective_operation_size(operation_size));
-        self.core_wrapper.remaining(timeout)
+        let remaining = timeout.saturating_sub(self.start_time.elapsed());
+        if remaining == Duration::ZERO { None } else { Some(remaining) }
     }
 
     /// Check if the wrapper should timeout based on elapsed time and optional operation size
@@ -368,7 +314,7 @@ impl RequestTimeoutWrapper {
         let timeout = self
             .config
             .get_timeout_for_operation(self.effective_operation_size(operation_size));
-        self.core_wrapper.elapsed() >= timeout
+        self.start_time.elapsed() >= timeout
     }
 
     /// Execute an async operation with timeout protection.
@@ -420,22 +366,24 @@ impl RequestTimeoutWrapper {
         Fut: std::future::Future<Output = Result<T, E>>,
     {
         let timeout_duration = self.get_timeout(None);
-        let context_refs = context.as_ref().map(|(bucket, key)| (bucket.as_str(), key.as_str()));
+
+        // Build a tracing span that carries request context for all log events.
+        let span = match &context {
+            Some((bucket, key)) => tracing::info_span!(
+                "timeout_operation",
+                request_id = %self.request_id,
+                bucket = %bucket,
+                key = %key,
+            ),
+            None => tracing::info_span!(
+                "timeout_operation",
+                request_id = %self.request_id,
+            ),
+        };
+        let _guard = span.enter();
 
         if !self.config.is_timeout_enabled() {
-            if let Some((bucket, key)) = context_refs {
-                debug!(
-                    request_id = %self.request_id,
-                    bucket = %bucket,
-                    key = %key,
-                    "Timeout disabled, executing operation without timeout"
-                );
-            } else {
-                debug!(
-                    request_id = %self.request_id,
-                    "Timeout disabled, executing operation without timeout"
-                );
-            }
+            debug!("Timeout disabled, executing operation without timeout");
 
             return match operation(self.cancel_token).await {
                 Ok(result) => TimedGetObjectResult::Success(result),
@@ -443,21 +391,7 @@ impl RequestTimeoutWrapper {
             };
         }
 
-        if let Some((bucket, key)) = context_refs {
-            debug!(
-                request_id = %self.request_id,
-                bucket = %bucket,
-                key = %key,
-                timeout_secs = timeout_duration.as_secs(),
-                "Starting timed operation"
-            );
-        } else {
-            debug!(
-                request_id = %self.request_id,
-                timeout_secs = timeout_duration.as_secs(),
-                "Starting timed operation"
-            );
-        }
+        debug!(timeout_secs = timeout_duration.as_secs(), "Starting timed operation");
 
         rustfs_io_metrics::record_get_object_request_started();
 
@@ -467,44 +401,14 @@ impl RequestTimeoutWrapper {
             Ok(Ok(result)) => {
                 let elapsed = self.elapsed();
                 rustfs_io_metrics::record_get_object_request_result("success", elapsed.as_secs_f64());
-
-                if let Some((bucket, key)) = context_refs {
-                    debug!(
-                        request_id = %self.request_id,
-                        bucket = %bucket,
-                        key = %key,
-                        elapsed_ms = elapsed.as_millis(),
-                        "Operation completed successfully"
-                    );
-                } else {
-                    debug!(
-                        request_id = %self.request_id,
-                        elapsed_ms = elapsed.as_millis(),
-                        "Operation completed successfully"
-                    );
-                }
+                debug!(elapsed_ms = elapsed.as_millis(), "Operation completed successfully");
 
                 TimedGetObjectResult::Success(result)
             }
             Ok(Err(e)) => {
                 let elapsed = self.elapsed();
                 rustfs_io_metrics::record_get_object_request_result("error", elapsed.as_secs_f64());
-
-                if let Some((bucket, key)) = context_refs {
-                    debug!(
-                        request_id = %self.request_id,
-                        bucket = %bucket,
-                        key = %key,
-                        elapsed_ms = elapsed.as_millis(),
-                        "Operation failed with error"
-                    );
-                } else {
-                    debug!(
-                        request_id = %self.request_id,
-                        elapsed_ms = elapsed.as_millis(),
-                        "Operation failed with error"
-                    );
-                }
+                debug!(elapsed_ms = elapsed.as_millis(), "Operation failed with error");
 
                 TimedGetObjectResult::Error(e)
             }
@@ -515,23 +419,11 @@ impl RequestTimeoutWrapper {
                 rustfs_io_metrics::record_get_object_timeout(None, Some(elapsed.as_secs_f64()));
                 rustfs_io_metrics::record_get_object_request_result("timeout", elapsed.as_secs_f64());
 
-                if let Some((bucket, key)) = context_refs {
-                    warn!(
-                        request_id = %self.request_id,
-                        bucket = %bucket,
-                        key = %key,
-                        timeout_secs = timeout_duration.as_secs(),
-                        elapsed_ms = elapsed.as_millis(),
-                        "Operation timed out, cancellation signal sent"
-                    );
-                } else {
-                    warn!(
-                        request_id = %self.request_id,
-                        timeout_secs = timeout_duration.as_secs(),
-                        elapsed_ms = elapsed.as_millis(),
-                        "Operation timed out, cancellation signal sent"
-                    );
-                }
+                warn!(
+                    timeout_secs = timeout_duration.as_secs(),
+                    elapsed_ms = elapsed.as_millis(),
+                    "Operation timed out, cancellation signal sent"
+                );
 
                 let (bucket, key) = context.unwrap_or_default();
                 TimedGetObjectResult::Timeout(TimeoutInfo {
@@ -574,8 +466,6 @@ mod tests {
     fn test_timeout_config_default() {
         let config = GetObjectTimeoutPolicy::default();
         assert_eq!(config.get_object_timeout, Duration::from_secs(30));
-        assert_eq!(config.lock_acquire_timeout, Duration::from_secs(5));
-        assert_eq!(config.disk_read_timeout, Duration::from_secs(10));
     }
 
     #[test]

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -248,6 +248,8 @@ pub struct RequestTimeoutWrapper {
     config: GetObjectTimeoutPolicy,
     /// Shared core timing primitive.
     core_wrapper: CoreRequestTimeoutWrapper,
+    /// Optional operation size hint for dynamic timeout decisions.
+    operation_size: Option<u64>,
     /// Cancellation token for propagating cancellation to sub-tasks.
     cancel_token: CancellationToken,
     /// Request ID for logging/metrics.
@@ -270,18 +272,12 @@ impl RequestTimeoutWrapper {
     /// Note: This uses a sentinel request_id. Prefer `with_request_id()` to pass
     /// the canonical request-id from `RequestContext`.
     pub fn new(config: GetObjectTimeoutPolicy) -> Self {
-        let core_wrapper = CoreRequestTimeoutWrapper::new(config.to_core_config());
-        Self {
-            config,
-            core_wrapper,
-            cancel_token: CancellationToken::new(),
-            request_id: "no-request-id".to_string(),
-        }
+        Self::new_with_parts(config, None, CancellationToken::new(), "no-request-id".to_string())
     }
 
     /// Create a new timeout wrapper with a specific request ID.
     pub fn with_request_id(config: GetObjectTimeoutPolicy, request_id: impl Into<String>) -> Self {
-        Self::new_with_parts(config, CancellationToken::new(), request_id.into())
+        Self::new_with_parts(config, None, CancellationToken::new(), request_id.into())
     }
 
     /// Create a new timeout wrapper with operation size for dynamic timeout calculation.
@@ -289,23 +285,32 @@ impl RequestTimeoutWrapper {
     /// Note: This uses a sentinel request_id. Prefer `with_request_id()` to pass
     /// the canonical request-id from `RequestContext`.
     pub fn with_operation_size(config: GetObjectTimeoutPolicy, operation_size: Option<u64>) -> Self {
-        let _ = operation_size;
-        Self::new(config)
+        Self::new_with_parts(config, operation_size, CancellationToken::new(), "no-request-id".to_string())
     }
 
     /// Get the configured timeout for this operation
-    pub fn get_timeout(&self, operation_size: Option<u64>) -> Duration {
-        self.config.get_timeout_for_operation(operation_size)
+    pub fn get_timeout(&self, operation_size_hint: Option<u64>) -> Duration {
+        self.config.get_timeout_for_operation(self.effective_operation_size(operation_size_hint))
     }
 
-    fn new_with_parts(config: GetObjectTimeoutPolicy, cancel_token: CancellationToken, request_id: String) -> Self {
+    fn new_with_parts(
+        config: GetObjectTimeoutPolicy,
+        operation_size: Option<u64>,
+        cancel_token: CancellationToken,
+        request_id: String,
+    ) -> Self {
         let core_wrapper = CoreRequestTimeoutWrapper::new(config.to_core_config());
         Self {
             config,
             core_wrapper,
+            operation_size,
             cancel_token,
             request_id,
         }
+    }
+
+    fn effective_operation_size(&self, operation_size_hint: Option<u64>) -> Option<u64> {
+        operation_size_hint.or(self.operation_size)
     }
 
     fn context_fields(&self, context: Option<(&str, &str)>) -> (String, String) {
@@ -333,7 +338,7 @@ impl RequestTimeoutWrapper {
 
     /// Check if the timeout has been exceeded.
     pub fn is_timeout(&self) -> bool {
-        self.config.is_timeout_enabled() && self.core_wrapper.elapsed() >= self.config.get_object_timeout
+        self.config.is_timeout_enabled() && self.core_wrapper.elapsed() >= self.get_timeout(None)
     }
 
     /// Get elapsed time since the request started.
@@ -352,7 +357,7 @@ impl RequestTimeoutWrapper {
         if !self.config.is_timeout_enabled() {
             return None;
         }
-        let timeout = self.config.get_timeout_for_operation(operation_size);
+        let timeout = self.config.get_timeout_for_operation(self.effective_operation_size(operation_size));
         self.core_wrapper.remaining(timeout)
     }
 
@@ -361,7 +366,7 @@ impl RequestTimeoutWrapper {
         if !self.config.is_timeout_enabled() {
             return false;
         }
-        let timeout = self.config.get_timeout_for_operation(operation_size);
+        let timeout = self.config.get_timeout_for_operation(self.effective_operation_size(operation_size));
         self.core_wrapper.elapsed() >= timeout
     }
 
@@ -539,7 +544,7 @@ impl RequestTimeoutWrapper {
                     lock_hold_time: None,
                     disk_reads_completed: 0,
                     disk_reads_pending: 0,
-                    object_size: None,
+                    object_size: self.operation_size,
                     progress_percent: None,
                 })
             }
@@ -811,5 +816,25 @@ mod tests {
 
         // Large size should calculate longer timeout
         assert!(!wrapper.should_timeout(Some(10 * 1024 * 1024)));
+    }
+
+    #[test]
+    fn test_wrapper_operation_size_hint_is_applied() {
+        let config = GetObjectTimeoutPolicy {
+            get_object_timeout: Duration::from_secs(300),
+            enable_dynamic_timeout: true,
+            bytes_per_second: 1024 * 1024,
+            min_timeout: Duration::from_secs(1),
+            max_timeout: Duration::from_secs(300),
+            ..Default::default()
+        };
+        let size = 100 * 1024 * 1024;
+        let wrapper = RequestTimeoutWrapper::with_operation_size(config.clone(), Some(size));
+
+        let expected_dynamic = config.get_timeout_for_operation(Some(size));
+        let baseline_no_size = config.get_timeout_for_operation(None);
+
+        assert_ne!(expected_dynamic, baseline_no_size);
+        assert_eq!(wrapper.get_timeout(None), expected_dynamic);
     }
 }


### PR DESCRIPTION
## Related Issues
- https://github.com/rustfs/backlog/issues/633 .

## Summary of Changes
This PR performs a focused cleanup of issue-633 follow-up edits in storage I/O hot paths to remove patch-on-patch layering while preserving behavior.

Main changes:
- `rustfs/src/storage/backpressure.rs`
  - Removed unnecessary `Arc<Atomic*>` indirection in local pipe/monitor state.
  - Added cached watermark byte thresholds to avoid repeated per-update recomputation.
  - Switched read-side usage decrement to saturating atomic subtraction to prevent underflow-induced state distortion.
  - Kept state-transition behavior and metrics semantics intact.
- `rustfs/src/storage/timeout_wrapper.rs`
  - Simplified the timeout execution path by removing redundant context conversion and request-id cloning.
  - Kept request-level timeout/cancellation behavior unchanged.
- `rustfs/src/storage/concurrency/io_schedule.rs`
  - Removed redundant priority mapping through temporary core-config conversion in the multi-factor strategy path.
  - Reused one threshold-loading path for concurrency-aware and advanced buffer-size calculations.
  - Reduced repeated default-config and env-read overhead in scheduling helpers.
- Minor pre-commit-driven cleanup in `crates/concurrency/src/{backpressure,config,scheduler}.rs`.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs timeout_wrapper -- --nocapture`
- `cargo test -p rustfs concurrent_get_object_test -- --nocapture`
- `cargo test -p rustfs multi_factor_scheduler_integration_test -- --nocapture`
- `cargo test -p rustfs backpressure::tests::test_backpressure_pipe_creation -- --nocapture`
- `make pre-commit`

## Impact
- No intended API break for callers.
- No configuration key/default changes.
- Internal hot-path overhead and state robustness are improved in storage I/O scheduling/backpressure/timeout execution paths.

## Additional Notes
N/A.
