### PR TITLE
chore(release): prepare 1.0.0-beta.4

### DIFF
--- a/.agents/skills/rustfs-release-version-bump/SKILL.md
+++ b/.agents/skills/rustfs-release-version-bump/SKILL.md
@@ -1,22 +1,33 @@
 ---
 name: rustfs-release-version-bump
-description: Prepare a RustFS release branch like PR #2957 by bumping versioned files, aligning release assets, running required verification, and finishing with commit, push, and gh PR creation. Use when publishing a new RustFS alpha, beta, or stable release.
+description: Publish a RustFS alpha/beta/stable release with an auditable flow: confirm target version and scope, update workspace and release assets (including strict rustfs.spec changelog identity/date/version format), run required verification, and finish with commit, push, and GitHub PR creation.
 ---
 
 # RustFS Release Version Bump
 
-Use this skill when the task is to prepare a new RustFS version release branch following the pattern validated in PR `#2957`.
+Use this skill to publish a RustFS release (alpha, beta, or stable) with a minimal, auditable diff and a complete ship flow (`edit -> verify -> commit -> push -> PR`).
 
-## Read first
+Validated baseline: release pattern used in PR `#2957`.
 
-- Read `AGENTS.md`.
-- Read `.github/pull_request_template.md`.
-- Inspect the current branch diff against `origin/main`.
-- Do not assume every release file should change in the same way every time.
+## Required inputs
 
-## Scope validated by PR #2957
+- Exact target version, for example `1.0.0-beta.4`.
+- Delivery scope:
+- Local only (`edit/verify`).
+- Local + git (`commit/push`).
+- Full GitHub flow (`commit/push/PR`).
 
-The `1.0.0-beta.3` release branch updated these files:
+If target version is missing or ambiguous, stop and ask before editing.
+
+## Read before editing
+
+- `AGENTS.md` (root and nearest path-specific files).
+- `.github/pull_request_template.md`.
+- Current branch status and diff against `origin/main`.
+
+## Default release file scope
+
+Treat the following file list as the default checklist for each release bump:
 
 - `Cargo.toml`
 - `Cargo.lock`
@@ -26,86 +37,89 @@ The `1.0.0-beta.3` release branch updated these files:
 - `helm/rustfs/Chart.yaml`
 - `rustfs.spec`
 
-Treat this file list as the default checklist for future release bumps. Only drop a file if the repository's current release pattern clearly says it is no longer part of the publish flow.
+Only drop a file when the current repository release process clearly no longer requires it.
 
-## Workflow
+## Hard release policy
 
-1. Confirm release intent
-- Identify the target version string exactly, for example `1.0.0-beta.4`.
-- Check whether the user wants only local commit preparation or the full `commit + push + PR` flow.
-- Compare the branch against `origin/main` and isolate only release-related edits.
-- If the target version is not explicit, stop and ask for it before editing.
+- Docker doc tags use `<version>` (for example `rustfs/rustfs:1.0.0-beta.4`), not `v<version>`.
+- Helm chart version mapping follows `beta.N -> 0.N.0`.
+- `rustfs.spec` `Release` uses prerelease suffix only (for example `beta.4`).
+- Do not change these rules without explicit confirmation.
 
-2. Update core Rust workspace versions
-- Bump the workspace version in `Cargo.toml`.
-- Bump all internal workspace crate versions in `Cargo.toml`.
-- Ensure `Cargo.lock` reflects the same release version for workspace packages.
-- Re-read the diff and verify there are no partial version leftovers.
+## Step-by-step workflow
 
-3. Align release assets
-- Update versioned Docker examples in `README.md` and `README_ZH.md` using the `<version>` tag form, for example `rustfs/rustfs:1.0.0-beta.4`.
-- Update `flake.nix` package version.
-- Update `helm/rustfs/Chart.yaml` `appVersion`.
-- Update `helm/rustfs/Chart.yaml` `version` using the release-chart rule:
+1. Confirm intent and isolate scope
+- Confirm target version string exactly.
+- Confirm whether user requested local-only or full GitHub flow.
+- Inspect current branch and ensure only release-related files are touched for this task.
+
+2. Update workspace versions
+- Bump `[workspace.package].version` in `Cargo.toml`.
+- Bump internal workspace crate dependency versions in `Cargo.toml`.
+- Update `Cargo.lock` so workspace package versions match target version.
+- Re-scan for partial leftovers.
+
+3. Update release assets
+- `README.md` and `README_ZH.md`: update versioned Docker examples to target version.
+- `flake.nix`: update package version to target version.
+- `helm/rustfs/Chart.yaml`:
+- `appVersion` = target version.
+- `version` follows chart mapping rule, for example:
 - `1.0.0-beta.3` -> `0.3.0`
 - `1.0.0-beta.4` -> `0.4.0`
-- Follow the same pattern for later beta releases unless the repository rule changes.
-- Update `rustfs.spec` release metadata and changelog entry.
-- Set `rustfs.spec` `Release` to the prerelease suffix without the base version, for example `beta.3` for `1.0.0-beta.3`.
-- `rustfs.spec` changelog must include date, git user name, git email, and target RustFS version in this format:
+- `rustfs.spec`:
+- Set `Release` to prerelease suffix (example `beta.4`).
+- Add/update top changelog entry with exact format:
 - `* Thu May 20 2026 houseme <housemecn@gmail.com>`
 - `- Update RPM package to RustFS 1.0.0-beta.4`
-- Resolve identity from local git config before editing changelog:
+- Changelog identity and time must come from current environment:
 - `git config --get user.name`
 - `git config --get user.email`
-- Generate date in rpm changelog style (for example): `date '+%a %b %d %Y'`
-- Ensure the changelog version text matches the exact target version string for this release task.
-- Keep the release asset changes in a separate commit from the core Rust workspace version bump when the branch contains both.
+- `date '+%a %b %d %Y'`
+- Changelog version text must match target release version exactly.
 
-4. Stop and discuss before changing release policy
-- Ask before changing the established Docker tag style away from `<version>`.
-- Ask before changing the established Helm chart version mapping away from `beta.N -> 0.N.0`.
-- Ask before changing the established `rustfs.spec` `Release` rule away from the release suffix form such as `beta.N`.
-- Ask before widening the release scope beyond the files already validated in PR `#2957`.
+4. Verify before shipping
+- Run:
+- `cargo fmt --all`
+- `cargo fmt --all --check`
+- `make pre-commit`
+- If verification passes, run `cargo clean`.
+- If `make pre-commit` fails, return `BLOCKED` with root cause and do not silently widen scope to fix unrelated issues unless user asks.
 
-5. Verify before shipping
-- Run `make pre-commit`.
-- If verification succeeds, run `cargo clean` to remove generated build artifacts before wrapping up.
-- If `make pre-commit` fails, stop and return `BLOCKED`.
+5. Commit strategy
+- Preferred split when both parts changed:
+- `chore(release): prepare <version>` for `Cargo.toml` and `Cargo.lock`.
+- `chore(release): align release assets for <version>` for docs and packaging files.
+- If user asks for one commit, use one commit.
+- Stage only intended release files; do not include unrelated working tree changes.
 
-6. Commit structure
-- Prefer two commits when the change naturally splits:
-- `chore(release): prepare <version>` for `Cargo.toml` and `Cargo.lock`
-- `chore(release): align release assets for <version>` for docs and packaging metadata
-- If the user asks for a single commit, follow that request.
+6. Push and PR
+- Push branch:
+- `git push -u origin <branch>` (first push), or `git push` (tracking already exists).
+- Create PR with template headings unchanged:
+- `gh pr create --base main --head <branch> --title ... --body-file ...`
+- PR title/body must be English.
+- Use `N/A` for non-applicable template sections.
+- Include verification commands and any `BLOCKED` reason clearly.
 
-7. Push and PR
-- Push the release branch with `git push -u origin <branch>` or `git push` if upstream already exists.
-- Create the PR with `gh pr create --base main --head <branch> --title ... --body-file ...`.
-- Keep the PR title and body in English.
-- Keep the `.github/pull_request_template.md` headings exactly.
+## Recommended check commands
 
-## Ready-to-check commands
-
+- `git status --short --branch`
 - `git diff --name-only origin/main...HEAD`
 - `git diff --stat origin/main...HEAD`
+- `rg -n "<old_version>|<new_version>" Cargo.toml Cargo.lock README.md README_ZH.md flake.nix helm/rustfs/Chart.yaml rustfs.spec`
+- `cargo fmt --all`
+- `cargo fmt --all --check`
 - `make pre-commit`
 - `cargo clean`
-- `git status --short --branch`
 
-## Output expectations
+## Output contract
 
-When using this skill, return:
+When using this skill, always report:
 
-- The files changed for the release bump
-- Any uncertainty that needs user confirmation before editing
-- Verification status
-- Commit messages used
-- Push status and PR URL when the GitHub flow was requested
-
-## Established release policy
-
-- Docs use Docker tags in `<version>` form, not `v<version>`.
-- `helm/rustfs/Chart.yaml` `version` follows `beta.N -> 0.N.0` based on the current release policy.
-- `rustfs.spec` `Release` follows the release suffix form, for example `beta.3`.
-- If any of these rules need to change in the future, pause and confirm before editing.
+- Target version.
+- Files changed.
+- Any assumptions or uncertainties requiring confirmation.
+- Verification result (`PASSED` or `BLOCKED`) with key evidence.
+- Commit message(s) used.
+- Push status and PR URL when GitHub flow is requested.

--- a/.agents/skills/rustfs-release-version-bump/SKILL.md
+++ b/.agents/skills/rustfs-release-version-bump/SKILL.md
@@ -52,6 +52,14 @@ Treat this file list as the default checklist for future release bumps. Only dro
 - Follow the same pattern for later beta releases unless the repository rule changes.
 - Update `rustfs.spec` release metadata and changelog entry.
 - Set `rustfs.spec` `Release` to the prerelease suffix without the base version, for example `beta.3` for `1.0.0-beta.3`.
+- `rustfs.spec` changelog must include date, git user name, git email, and target RustFS version in this format:
+- `* Thu May 20 2026 houseme <housemecn@gmail.com>`
+- `- Update RPM package to RustFS 1.0.0-beta.4`
+- Resolve identity from local git config before editing changelog:
+- `git config --get user.name`
+- `git config --get user.email`
+- Generate date in rpm changelog style (for example): `date '+%a %b %d %Y'`
+- Ensure the changelog version text matches the exact target version string for this release task.
 - Keep the release asset changes in a separate commit from the core Rust workspace version bump when the branch contains both.
 
 4. Stop and discuss before changing release policy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9269,7 +9269,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "anyhow",
@@ -9385,7 +9385,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9409,7 +9409,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9423,7 +9423,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "chrono",
  "metrics",
@@ -9438,7 +9438,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "rustfs-io-core",
  "rustfs-io-metrics",
@@ -9450,14 +9450,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "const-str",
 ]
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "base64-simd",
  "rand 0.10.1",
@@ -9468,7 +9468,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "argon2 0.6.0-rc.8",
@@ -9488,7 +9488,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -9499,7 +9499,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "async-channel",
@@ -9602,7 +9602,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9626,7 +9626,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9689,7 +9689,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "bytes",
  "memmap2 0.9.10",
@@ -9700,7 +9700,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "criterion",
  "metrics",
@@ -9762,7 +9762,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "bytes",
  "futures",
@@ -9787,7 +9787,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "arc-swap",
@@ -9816,7 +9816,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9837,7 +9837,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "chrono",
  "humantime",
@@ -9850,7 +9850,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9884,7 +9884,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "criterion",
  "futures",
@@ -9902,7 +9902,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9948,7 +9948,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9976,7 +9976,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -10034,7 +10034,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "flatbuffers",
  "prost 0.14.3",
@@ -10050,7 +10050,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "axum",
@@ -10084,14 +10084,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "rustfs-s3-types",
 ]
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -10099,7 +10099,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10126,7 +10126,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10143,7 +10143,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10175,7 +10175,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10191,7 +10191,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -10233,7 +10233,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -10257,7 +10257,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "base64-simd",
  "blake2 0.11.0-rc.6",
@@ -10302,7 +10302,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.95.0"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -76,42 +76,42 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.3" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.3" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.3" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.3" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.3" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.3" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.3" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.3" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.3" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.3" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.3" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.3" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.3" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.3" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.3" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.3" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.3" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.3" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.3" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.3" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.3" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.3" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.3" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.3" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.3" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.3" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.3" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.3" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.3" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.3" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.3" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.3" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.3" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.3" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.3" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.3" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.4" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.4" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.4" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.4" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.4" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.4" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.4" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.4" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.4" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.4" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.4" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.4" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.4" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.4" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.4" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.4" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.4" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.4" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.4" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.4" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.4" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.4" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.4" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.4" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.4" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.4" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.4" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.4" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.4" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.4" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.4" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.4" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.4" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.4" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.4" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.4" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.3
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.4
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ RustFS 容器以非 root 用户 `rustfs` (UID `10001`) 运行。如果您使用 
  docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
  # 使用指定版本运行
- docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.3
+ docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.4
 ```
 
 您也可以使用 Docker Compose。使用根目录下的 `docker-compose.yml` 文件：

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.3";
+            version = "1.0.0-beta.4";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.3.0"
-appVersion: "1.0.0-beta.3"
+version: "0.4.0"
+appVersion: "1.0.0-beta.4"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -2,7 +2,7 @@
 %global _empty_manifest_terminate_build 0
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.3
+Release:        beta.4
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -57,6 +57,9 @@ install %_builddir/%{name}-%{version}-%{release}/target/%_arch/%_arch-unknown-li
 %_bindir/rustfs
 
 %changelog
+* Thu May 20 2026 houseme <housemecn@gmail.com>
+- Update RPM package to RustFS 1.0.0-beta.4
+
 * Thu May 14 2026 houseme <housemecn@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.3
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Bump RustFS workspace and internal crate versions to `1.0.0-beta.4` in `Cargo.toml` and `Cargo.lock`.
- Align release assets for beta.4:
  - Update Docker example tags in `README.md` and `README_ZH.md` to `rustfs/rustfs:1.0.0-beta.4`.
  - Update `flake.nix` package version to `1.0.0-beta.4`.
  - Update Helm chart `appVersion` to `1.0.0-beta.4` and chart `version` to `0.4.0`.
  - Update `rustfs.spec` release metadata and changelog for `beta.4`.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit` (blocked by existing repository issue: `crates/utils/src/os/fs_type.rs` has an unused function `get_fs_type`, which fails with `-D warnings` during clippy)

## Impact
- Enables publishing RustFS `1.0.0-beta.4` with synchronized workspace, packaging, and documentation version metadata.

## Additional Notes
- This PR intentionally scopes to release-version files only.
