### PR TITLE
fix(iam): scope service account updates

### DIFF
--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -667,6 +667,27 @@ async fn get_account_info(
     Ok(response.json().await?)
 }
 
+async fn get_service_account_info(
+    env: &RustFSTestEnvironment,
+    signer_access_key: &str,
+    signer_secret_key: &str,
+    access_key: &str,
+) -> Result<serde_json::Value, Box<dyn Error + Send + Sync>> {
+    let url = format!(
+        "{}/rustfs/admin/v3/info-service-account?accessKey={}",
+        env.url,
+        urlencoding::encode(access_key)
+    );
+    let response = signed_request(http::Method::GET, &url, signer_access_key, signer_secret_key, None, None).await?;
+    if response.status() != StatusCode::OK {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("service account info failed: {status} {body}").into());
+    }
+
+    Ok(response.json().await?)
+}
+
 async fn wait_for_service_accounts(
     env: &RustFSTestEnvironment,
     signer_access_key: &str,
@@ -2441,6 +2462,31 @@ async fn test_service_account_policy_from_accountinfo_round_trips_real_single_no
             .any(|account| account.access_key == "svcacct-info-sample"),
         "created service account should be listed for parent user: {:?}",
         listed.accounts
+    );
+
+    let info = get_service_account_info(&env, &env.access_key, &env.secret_key, "svcacct-info-sample").await?;
+    assert_eq!(info.get("name").and_then(|value| value.as_str()), Some("svcacct-info-sample"));
+    assert_eq!(
+        info.get("description").and_then(|value| value.as_str()),
+        Some("service account created from accountinfo sample policy")
+    );
+    assert_eq!(info.get("accountStatus").and_then(|value| value.as_str()), Some("on"));
+    assert_eq!(
+        info.get("impliedPolicy").and_then(|value| value.as_bool()),
+        Some(false),
+        "created service account should keep the embedded policy"
+    );
+    let returned_policy = info
+        .get("policy")
+        .and_then(|value| value.as_str())
+        .ok_or("info-service-account should return embedded policy")?;
+    let returned_policy: serde_json::Value = serde_json::from_str(returned_policy)?;
+    assert!(
+        returned_policy
+            .get("Statement")
+            .and_then(|value| value.as_array())
+            .is_some_and(|statements| !statements.is_empty()),
+        "info-service-account should return a non-empty policy: {returned_policy}"
     );
 
     Ok(())

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -1800,6 +1800,126 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_service_account_session_policy_without_update_admin_cannot_update_service_accounts() {
+        ensure_test_global_credentials();
+
+        let store = StsTestMockStore { empty_policies: false };
+        let cache_manager = IamCache::new(store).await.unwrap();
+        let iam_sys = IamSys::new(cache_manager);
+        let root_access_key = get_global_action_cred()
+            .expect("root credentials should be initialized")
+            .access_key;
+        let session_policy = Policy::parse_config(
+            br#"{
+  "Version":"2012-10-17",
+  "Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::public/*"]}]
+}"#,
+        )
+        .expect("session policy should parse");
+
+        let (cred, _) = iam_sys
+            .new_service_account(
+                &root_access_key,
+                None,
+                NewServiceAccountOpts {
+                    access_key: "svc-no-update-admin".to_string(),
+                    secret_key: "svcNoUpdateAdminSecret".to_string(),
+                    session_policy: Some(session_policy),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("service account should be created");
+        let stored = iam_sys
+            .get_user(&cred.access_key)
+            .await
+            .expect("service account should exist");
+        let claims = stored
+            .credentials
+            .claims
+            .as_ref()
+            .expect("service account should have claims");
+
+        let groups = stored.credentials.groups.clone();
+        let args = Args {
+            account: &stored.credentials.access_key,
+            groups: &groups,
+            action: Action::AdminAction(AdminAction::UpdateServiceAccountAdminAction),
+            bucket: "",
+            conditions: &HashMap::new(),
+            is_owner: false,
+            object: "",
+            claims,
+            deny_only: false,
+        };
+
+        assert!(
+            !iam_sys.is_allowed(&args).await,
+            "service account session policy without UpdateServiceAccount must not self-escalate"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_service_account_session_policy_with_update_admin_can_update_service_accounts() {
+        ensure_test_global_credentials();
+
+        let store = StsTestMockStore { empty_policies: false };
+        let cache_manager = IamCache::new(store).await.unwrap();
+        let iam_sys = IamSys::new(cache_manager);
+        let root_access_key = get_global_action_cred()
+            .expect("root credentials should be initialized")
+            .access_key;
+        let session_policy = Policy::parse_config(
+            br#"{
+  "Version":"2012-10-17",
+  "Statement":[{"Effect":"Allow","Action":["admin:UpdateServiceAccount"]}]
+}"#,
+        )
+        .expect("session policy should parse");
+
+        let (cred, _) = iam_sys
+            .new_service_account(
+                &root_access_key,
+                None,
+                NewServiceAccountOpts {
+                    access_key: "svc-with-update-admin".to_string(),
+                    secret_key: "svcWithUpdateAdminSecret".to_string(),
+                    session_policy: Some(session_policy),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("service account should be created");
+        let stored = iam_sys
+            .get_user(&cred.access_key)
+            .await
+            .expect("service account should exist");
+        let claims = stored
+            .credentials
+            .claims
+            .as_ref()
+            .expect("service account should have claims");
+
+        let groups = stored.credentials.groups.clone();
+        let args = Args {
+            account: &stored.credentials.access_key,
+            groups: &groups,
+            action: Action::AdminAction(AdminAction::UpdateServiceAccountAdminAction),
+            bucket: "",
+            conditions: &HashMap::new(),
+            is_owner: false,
+            object: "",
+            claims,
+            deny_only: false,
+        };
+
+        assert!(
+            iam_sys.is_allowed(&args).await,
+            "service account with explicit UpdateServiceAccount admin permission should be allowed"
+        );
+    }
+
+    #[tokio::test]
     async fn test_created_sts_credentials_authorize_with_session_token_claims() {
         ensure_test_global_credentials();
 

--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -92,16 +92,6 @@ fn merge_derived_service_account_claims(
     }
 }
 
-fn is_service_account_owner_of(caller: &StoredCredentials, target_parent_user: &str) -> bool {
-    let caller_parent = if caller.parent_user.is_empty() {
-        caller.access_key.as_str()
-    } else {
-        caller.parent_user.as_str()
-    };
-
-    caller_parent == target_parent_user
-}
-
 fn map_service_account_lookup_error(err: rustfs_iam::error::Error, action: &str) -> S3Error {
     debug!("{action}, e: {:?}", err);
     if is_err_no_such_service_account(&err) {
@@ -403,6 +393,10 @@ fn request_user_name(cred: &StoredCredentials) -> &str {
     }
 }
 
+fn can_update_service_account_target(caller: &StoredCredentials, owner: bool, target_parent_user: &str) -> bool {
+    owner || request_user_name(caller) == target_parent_user
+}
+
 async fn build_info_service_account_resp<T: IamStore>(
     iam_store: &rustfs_iam::sys::IamSys<T>,
     account: &StoredCredentials,
@@ -528,11 +522,6 @@ impl Operation for UpdateServiceAccount {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
-        // let svc_account = iam_store.get_service_account(&access_key).await.map_err(|e| {
-        //     debug!("get service account failed, e: {:?}", e);
-        //     s3_error!(InternalError, "get service account failed")
-        // })?;
-
         let body =
             read_compatible_admin_body(req.input, MAX_ADMIN_REQUEST_BODY_SIZE, req.uri.path(), input_cred.secret_key.expose())
                 .await?;
@@ -573,7 +562,7 @@ impl Operation for UpdateServiceAccount {
             .await
             .map_err(|e| map_service_account_lookup_error(e, "get service account failed"))?;
 
-        if !is_service_account_owner_of(&cred, &svc_account.parent_user) {
+        if !can_update_service_account_target(&cred, owner, &svc_account.parent_user) {
             return Err(s3_error!(AccessDenied, "access denied"));
         }
 
@@ -1552,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    fn update_service_account_requires_requester_parent_match() {
+    fn update_service_account_target_scope_allows_owner_or_matching_parent() {
         let parent_owner = StoredCredentials {
             access_key: "owner-user".to_string(),
             parent_user: String::new(),
@@ -1569,9 +1558,10 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(is_service_account_owner_of(&parent_owner, "owner-user"));
-        assert!(is_service_account_owner_of(&derived_owner, "owner-user"));
-        assert!(!is_service_account_owner_of(&foreign_user, "owner-user"));
+        assert!(can_update_service_account_target(&parent_owner, false, "owner-user"));
+        assert!(can_update_service_account_target(&derived_owner, false, "owner-user"));
+        assert!(!can_update_service_account_target(&foreign_user, false, "owner-user"));
+        assert!(can_update_service_account_target(&foreign_user, true, "owner-user"));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Restore target service account lookup before update so missing targets are handled consistently.
- Require non-owner callers to match the target service account parent before updating secrets, status, metadata, expiration, or embedded policy.
- Keep root/owner callers explicitly allowed for cross-parent service account updates.
- Add IAM regression coverage for service account session policies with and without `admin:UpdateServiceAccount`, and extend the e2e replication/account-info path to verify embedded policy round-tripping.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs update_service_account_target_scope_allows_owner_or_matching_parent -- --nocapture`
- `cargo test -p rustfs-iam service_account_session_policy -- --nocapture`

`make pre-commit` was not run per maintainer request.

## Impact
Non-owner callers with `admin:UpdateServiceAccount` can only update service accounts under their own resolved parent identity. Root/owner callers can still update service accounts across parents.

## Additional Notes
The branch was committed with `--no-verify` to avoid running local pre-commit hooks after the maintainer requested skipping pre-commit.
