### PR TITLE
fix(tooling): harden internode transport benchmark setup

### DIFF
--- a/.agents/skills/rustfs-release-version-bump/SKILL.md
+++ b/.agents/skills/rustfs-release-version-bump/SKILL.md
@@ -1,11 +1,7 @@
---- name: rustfs-release-version-bump
-description: >
-  Automate RustFS release version bump workflow, including updating version
-  files, changelog entries, release notes, and validation steps. 
-flow: confirm target version and scope, update workspace and release assets (including strict rustfs.spec 
-changelog identity/date/version format), run required verification, and finish with commit, push, and GitHub PR 
-creation. ---
-
+---
+name: rustfs-release-version-bump
+description: Publish a RustFS alpha/beta/stable release with an auditable flow: confirm target version and scope, update workspace and release assets (including strict rustfs.spec changelog identity/date/version format), run required verification, and finish with commit, push, and GitHub PR creation.
+---
 # RustFS Release Version Bump
 
 Use this skill to publish a RustFS release (alpha, beta, or stable) with a minimal, auditable diff and a complete ship flow (`edit -> verify -> commit -> push -> PR`).

--- a/.agents/skills/rustfs-release-version-bump/SKILL.md
+++ b/.agents/skills/rustfs-release-version-bump/SKILL.md
@@ -1,7 +1,10 @@
----
-name: rustfs-release-version-bump
-description: Publish a RustFS alpha/beta/stable release with an auditable flow: confirm target version and scope, update workspace and release assets (including strict rustfs.spec changelog identity/date/version format), run required verification, and finish with commit, push, and GitHub PR creation.
----
+--- name: rustfs-release-version-bump
+description: >
+  Automate RustFS release version bump workflow, including updating version
+  files, changelog entries, release notes, and validation steps. 
+flow: confirm target version and scope, update workspace and release assets (including strict rustfs.spec 
+changelog identity/date/version format), run required verification, and finish with commit, push, and GitHub PR 
+creation. ---
 
 # RustFS Release Version Bump
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -59,7 +59,7 @@ runs:
     - name: Install protoc
       uses: rustfs/setup-protoc@v3.0.1
       with:
-        version: "29.3"
+        version: "33.1"
         repo-token: ${{ github.token }}
 
     - name: Install flatc

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -59,7 +59,7 @@ runs:
     - name: Install protoc
       uses: rustfs/setup-protoc@v3.0.1
       with:
-        version: "33.1"
+        version: "34.1"
         repo-token: ${{ github.token }}
 
     - name: Install flatc

--- a/crates/config/src/constants/internode.rs
+++ b/crates/config/src/constants/internode.rs
@@ -36,6 +36,12 @@ pub const DEFAULT_INTERNODE_RPC_TIMEOUT_SECS: u64 = 10;
 pub const ENV_RUSTFS_INTERNODE_DATA_TRANSPORT: &str = "RUSTFS_INTERNODE_DATA_TRANSPORT";
 pub const DEFAULT_INTERNODE_DATA_TRANSPORT: &str = "tcp-http";
 
+/// Legacy alias for "tcp-http". Both values select the TCP/HTTP transport backend.
+pub const INTERNODE_DATA_TRANSPORT_TCP: &str = "tcp";
+
+/// Known internode transport backend names accepted by the config parser.
+pub const KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS: &[&str] = &[DEFAULT_INTERNODE_DATA_TRANSPORT, INTERNODE_DATA_TRANSPORT_TCP];
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +70,7 @@ mod tests {
         assert_eq!(ENV_INTERNODE_RPC_TIMEOUT_SECS, "RUSTFS_INTERNODE_RPC_TIMEOUT_SECS");
         assert_eq!(ENV_RUSTFS_INTERNODE_DATA_TRANSPORT, "RUSTFS_INTERNODE_DATA_TRANSPORT");
         assert_eq!(DEFAULT_INTERNODE_DATA_TRANSPORT, "tcp-http");
+        assert_eq!(INTERNODE_DATA_TRANSPORT_TCP, "tcp");
+        assert_eq!(KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS, &["tcp-http", "tcp"]);
     }
 }

--- a/crates/ecstore/src/rpc/internode_data_transport.rs
+++ b/crates/ecstore/src/rpc/internode_data_transport.rs
@@ -17,12 +17,14 @@ use crate::disk::{FileReader, FileWriter};
 use crate::rpc::build_auth_headers;
 use async_trait::async_trait;
 use http::{HeaderMap, HeaderValue, Method, header::CONTENT_TYPE};
-use rustfs_config::{DEFAULT_INTERNODE_DATA_TRANSPORT, ENV_RUSTFS_INTERNODE_DATA_TRANSPORT};
+use rustfs_config::{
+    DEFAULT_INTERNODE_DATA_TRANSPORT, ENV_RUSTFS_INTERNODE_DATA_TRANSPORT, INTERNODE_DATA_TRANSPORT_TCP,
+    KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS,
+};
 use rustfs_rio::{HttpReader, HttpWriter};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-pub const INTERNODE_DATA_TRANSPORT_TCP: &str = "tcp";
 static INTERNODE_DATA_TRANSPORT: OnceLock<std::result::Result<Arc<dyn InternodeDataTransport>, String>> = OnceLock::new();
 
 const READ_FILE_STREAM_PATH: &str = "/rustfs/rpc/read_file_stream";
@@ -32,7 +34,8 @@ const CONTENT_TYPE_JSON: &str = "application/json";
 
 fn unsupported_transport_message(transport: &str) -> String {
     format!(
-        "invalid {ENV_RUSTFS_INTERNODE_DATA_TRANSPORT}={transport:?}; supported values: {DEFAULT_INTERNODE_DATA_TRANSPORT}, {INTERNODE_DATA_TRANSPORT_TCP}"
+        "invalid {ENV_RUSTFS_INTERNODE_DATA_TRANSPORT}={transport:?}; supported values: {}",
+        KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS.join(", ")
     )
 }
 

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install protoc 33.1 on macOS
+# Install protoc 33.1 on macOS and Linux
 
 set -e
 
@@ -8,15 +8,35 @@ ARCH=$(uname -m)
 INSTALL_DIR="${HOME}/.local/bin"
 PROTOC_BIN="${INSTALL_DIR}/protoc"
 
-# Select download URL based on architecture
-if [ "$ARCH" = "arm64" ]; then
-    # Apple Silicon (M1/M2/M3)
-    PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-aarch_64.zip"
-elif [ "$ARCH" = "x86_64" ]; then
-    # Intel Mac
-    PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-x86_64.zip"
+# Detect OS
+OS="$(uname -s)"
+
+# Select download URL based on OS and architecture
+if [ "$OS" = "Darwin" ]; then
+    if [ "$ARCH" = "arm64" ]; then
+        # Apple Silicon (M1/M2/M3)
+        PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-aarch_64.zip"
+    elif [ "$ARCH" = "x86_64" ]; then
+        # Intel Mac
+        PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-x86_64.zip"
+    else
+        echo "Error: Unsupported macOS architecture $ARCH"
+        exit 1
+    fi
+elif [ "$OS" = "Linux" ]; then
+    if [ "$ARCH" = "x86_64" ]; then
+        PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+    elif [ "$ARCH" = "aarch64" ]; then
+        PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-aarch_64.zip"
+    else
+        echo "Error: Unsupported Linux architecture $ARCH"
+        exit 1
+    fi
 else
-    echo "Error: Unsupported architecture $ARCH"
+    echo "Error: Unsupported OS $OS"
+    echo "On Windows, install protoc via:"
+    echo "  choco install protoc --version=${PROTOC_VERSION}"
+    echo "  or download from https://github.com/protocolbuffers/protobuf/releases"
     exit 1
 fi
 

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Install protoc 33.1 on macOS and Linux
+# Install protoc 34.1 on macOS and Linux
 
 set -e
 
-PROTOC_VERSION="33.1"
+PROTOC_VERSION="34.1"
 ARCH=$(uname -m)
 INSTALL_DIR="${HOME}/.local/bin"
 PROTOC_BIN="${INSTALL_DIR}/protoc"

--- a/scripts/run_internode_transport_baseline.sh
+++ b/scripts/run_internode_transport_baseline.sh
@@ -125,7 +125,7 @@ setup_output() {
     OUT_DIR="target/bench/internode-transport-$(date +%Y%m%d-%H%M%S)"
   fi
   mkdir -p "${OUT_DIR}"
-  echo "scenario,endpoint,workload,concurrency,size,status,throughput,requests_per_sec,avg_latency,log_file,run_dir" > "${OUT_DIR}/summary.csv"
+  echo "scenario,endpoint,workload,concurrency,size,status,throughput,requests_per_sec,avg_latency,error_count,log_file,run_dir" > "${OUT_DIR}/summary.csv"
   if [[ -n "${INTERNODE_METRICS_URL}" ]]; then
     echo "scenario,workload,concurrency,size,metric,operation,before,after,delta" > "${OUT_DIR}/internode_metric_deltas.csv"
   fi
@@ -253,7 +253,7 @@ append_object_summary() {
   awk -F',' -v scenario="${scenario}" -v endpoint="${endpoint}" -v workload="${workload}" -v run_dir="${run_dir}" '
     NR == 1 { next }
     {
-      printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n", scenario, endpoint, workload, $3, $1, $4, $5, $6, $7, $8, run_dir
+      printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n", scenario, endpoint, workload, $3, $1, $4, $5, $6, $7, $8, $9, run_dir
     }
   ' "${src}" >> "${OUT_DIR}/summary.csv"
 }

--- a/scripts/run_object_batch_bench.sh
+++ b/scripts/run_object_batch_bench.sh
@@ -187,7 +187,7 @@ setup_output() {
   fi
   mkdir -p "$OUT_DIR"
   SUMMARY_CSV="$OUT_DIR/summary.csv"
-  echo "size,tool,concurrency,status,throughput,requests_per_sec,avg_latency,log_file" > "$SUMMARY_CSV"
+  echo "size,tool,concurrency,status,throughput,requests_per_sec,avg_latency,error_count,log_file" > "$SUMMARY_CSV"
 }
 
 resolve_bucket() {
@@ -212,6 +212,27 @@ collect_metrics() {
   reqps="$(extract_value '([0-9]+(\\.[0-9]+)?\\s*(req/s|ops/s|requests/s))' "$log_file")"
   latency="$(extract_value '([0-9]+(\\.[0-9]+)?\\s*(ms|us|µs|s))(\\s*(avg|mean))?' "$log_file")"
   echo "${throughput:-N/A},${reqps:-N/A},${latency:-N/A}"
+}
+
+collect_error_count() {
+  local log_file="$1"
+  local count
+
+  count="$(
+    { rg -io '(errors?|failures?)[[:space:]:=]+[0-9]+' "$log_file" || true; } \
+      | awk '{ value = $0; gsub(/[^0-9]/, "", value); if (value != "") sum += value } END { if (NR > 0) print sum }'
+  )"
+  if [[ -n "$count" ]]; then
+    echo "$count"
+    return
+  fi
+
+  if [[ "$TOOL" == "warp" ]]; then
+    count="$(rg -c 'warp: <ERROR>' "$log_file" || true)"
+  else
+    count="$(rg -ci '(^|[[:space:]])(error|failed|failure)(:|[[:space:]])' "$log_file" || true)"
+  fi
+  echo "${count:-0}"
 }
 
 run_one() {
@@ -279,27 +300,25 @@ run_one() {
     fi
   fi
 
-  if [[ "$DRY_RUN" != "true" ]] && [[ "$TOOL" == "warp" ]]; then
-    # Warp may still exit with code 0 even when it prints runtime failures.
-    # Treat explicit error lines as failed runs to keep summary.csv reliable.
-    if rg -q 'warp: <ERROR>' "$log_file"; then
-      status="failed"
-    fi
-  fi
-
-  local metrics throughput reqps latency
+  local metrics throughput reqps latency error_count
   if [[ "$DRY_RUN" != "true" ]]; then
     metrics="$(collect_metrics "$log_file")"
     throughput="$(echo "$metrics" | cut -d',' -f1)"
     reqps="$(echo "$metrics" | cut -d',' -f2)"
     latency="$(echo "$metrics" | cut -d',' -f3)"
+    error_count="$(collect_error_count "$log_file")"
+    # Warp may still exit with code 0 even when it prints runtime failures.
+    if [[ "$TOOL" == "warp" && "$error_count" != "0" ]]; then
+      status="failed"
+    fi
   else
     throughput="N/A"
     reqps="N/A"
     latency="N/A"
+    error_count="N/A"
   fi
 
-  echo "$size,$TOOL,$CONCURRENCY,$status,$throughput,$reqps,$latency,$log_file" >> "$SUMMARY_CSV"
+  echo "$size,$TOOL,$CONCURRENCY,$status,$throughput,$reqps,$latency,$error_count,$log_file" >> "$SUMMARY_CSV"
 }
 
 main() {
@@ -308,6 +327,7 @@ main() {
   resolve_bucket
   if [[ "$DRY_RUN" != "true" ]]; then
     require_cmd rg
+    require_cmd awk
     if [[ "$TOOL" == "warp" ]]; then
       require_cmd "$WARP_BIN"
     else

--- a/scripts/run_object_batch_bench.sh
+++ b/scripts/run_object_batch_bench.sh
@@ -279,7 +279,7 @@ run_one() {
     fi
   fi
 
-  if [[ "$TOOL" == "warp" ]]; then
+  if [[ "$DRY_RUN" != "true" ]] && [[ "$TOOL" == "warp" ]]; then
     # Warp may still exit with code 0 even when it prints runtime failures.
     # Treat explicit error lines as failed runs to keep summary.csv reliable.
     if rg -q 'warp: <ERROR>' "$log_file"; then
@@ -288,10 +288,16 @@ run_one() {
   fi
 
   local metrics throughput reqps latency
-  metrics="$(collect_metrics "$log_file")"
-  throughput="$(echo "$metrics" | cut -d',' -f1)"
-  reqps="$(echo "$metrics" | cut -d',' -f2)"
-  latency="$(echo "$metrics" | cut -d',' -f3)"
+  if [[ "$DRY_RUN" != "true" ]]; then
+    metrics="$(collect_metrics "$log_file")"
+    throughput="$(echo "$metrics" | cut -d',' -f1)"
+    reqps="$(echo "$metrics" | cut -d',' -f2)"
+    latency="$(echo "$metrics" | cut -d',' -f3)"
+  else
+    throughput="N/A"
+    reqps="N/A"
+    latency="N/A"
+  fi
 
   echo "$size,$TOOL,$CONCURRENCY,$status,$throughput,$reqps,$latency,$log_file" >> "$SUMMARY_CSV"
 }
@@ -300,8 +306,8 @@ main() {
   parse_args "$@"
   validate_args
   resolve_bucket
-  require_cmd rg
   if [[ "$DRY_RUN" != "true" ]]; then
+    require_cmd rg
     if [[ "$TOOL" == "warp" ]]; then
       require_cmd "$WARP_BIN"
     else


### PR DESCRIPTION
## Related Issues
  N/A

  ## Summary of Changes
  - Update the shared setup action to install protoc 34.1.
  - Extend  to support Linux and macOS.
  - Keep benchmark dry-run mode independent of ripgrep.
  - Add  to internode transport benchmark summaries and object batch summaries.

  ## Verification
  -  passed.

  ## Impact
  - CI and local tooling now use protoc 34.1.
  - Benchmark CSV output includes an additional  column.

  ## Additional Notes
  N/A