### PR TITLE
fix(utils): map verified Linux filesystem magic values

### DIFF
--- a/crates/utils/src/os/fs_type.rs
+++ b/crates/utils/src/os/fs_type.rs
@@ -23,7 +23,6 @@
 /// "61756673" => "AUFS",
 /// "ef51" => "EXT2OLD",
 /// "2fc12fc1" => "zfs",
-/// "ff534d42" => "cifs",
 /// "53464846" => "wslfs",
 pub(crate) fn get_fs_type(fs_type: u64) -> &'static str {
     // Magic numbers for various filesystems.
@@ -37,6 +36,16 @@ pub(crate) fn get_fs_type(fs_type: u64) -> &'static str {
         0x52654973 => "REISERFS",
         0x58465342 => "XFS",
         0x9123683E => "BTRFS",
+        0x00c36400 => "CEPH",
+        0x2011BAB0 => "EXFAT",
+        0xE0F5E1E2 => "EROFS",
+        0xF2F52010 => "F2FS",
+        0x9660 => "ISOFS",
+        0x65735546 => "FUSE",
+        0x73717368 => "SQUASHFS",
+        0xFF534D42 => "CIFS",
+        0xFE534D42 => "SMB2",
+        0xca451a4e => "BCACHEFS",
         _ => "UNKNOWN",
     }
 }
@@ -49,5 +58,19 @@ mod tests {
     fn map_common_linux_filesystem_magic_numbers() {
         assert_eq!(get_fs_type(0x58465342), "XFS");
         assert_eq!(get_fs_type(0x9123683E), "BTRFS");
+    }
+
+    #[test]
+    fn map_verified_linux_uapi_filesystem_magic_numbers() {
+        assert_eq!(get_fs_type(0x00c36400), "CEPH");
+        assert_eq!(get_fs_type(0x2011BAB0), "EXFAT");
+        assert_eq!(get_fs_type(0xE0F5E1E2), "EROFS");
+        assert_eq!(get_fs_type(0xF2F52010), "F2FS");
+        assert_eq!(get_fs_type(0x9660), "ISOFS");
+        assert_eq!(get_fs_type(0x65735546), "FUSE");
+        assert_eq!(get_fs_type(0x73717368), "SQUASHFS");
+        assert_eq!(get_fs_type(0xFF534D42), "CIFS");
+        assert_eq!(get_fs_type(0xFE534D42), "SMB2");
+        assert_eq!(get_fs_type(0xca451a4e), "BCACHEFS");
     }
 }

--- a/crates/utils/src/os/mod.rs
+++ b/crates/utils/src/os/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 mod fs_type;
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#646

## Summary of Changes

- Map additional Linux filesystem magic values that are explicitly defined in Linux `include/uapi/linux/magic.h`.
- Keep unverified legacy/commented values in the TODO list instead of guessing.
- Make the Linux fs-type mapper unit tests runnable on non-Linux hosts under `cfg(test)` so these pure mapping tests are locally verifiable.

## Verification

- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-utils --features os map_verified_linux_uapi_filesystem_magic_numbers -- --nocapture` (RED before implementation, then PASS)
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p rustfs-utils --features os os:: -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p rustfs-utils --features os --tests -- -D warnings`

## Impact

Linux disk info can now report CEPH, EXFAT, EROFS, F2FS, ISOFS, FUSE, SQUASHFS, CIFS, SMB2, and BCACHEFS instead of `UNKNOWN` when `statfs` returns those magic values. The runtime implementation remains a single `match`, so this does not add allocation, I/O, or extra probing.

## Additional Notes

The remaining TODO values are intentionally left in place because they were not verified against Linux `include/uapi/linux/magic.h` in this pass.
