### PR TITLE
closed: exploratory internode transport simulator spike

### DIFF
--- a/INTERNODE_DATA_TRANSPORT_RFC.md
+++ b/INTERNODE_DATA_TRANSPORT_RFC.md
@@ -1,7 +1,7 @@
 # RFC: Pluggable Internode Data Transport
 
 > Status: draft
-> Last updated: 2026-05-21
+> Last updated: 2026-05-22
 > Scope: internode data-path analysis, benchmark baseline, and transport boundary
 
 ## Summary
@@ -32,6 +32,9 @@ Current implementation status:
   transport.
 - `NodeService` gRPC remains the internode control plane and continues to carry
   metadata/control operations.
+- `rdma-sim` is available only with the `experimental-rdma-sim` feature as a
+  removable architecture spike for `read_file_stream`. It is not real RDMA and
+  is not a production backend.
 
 ## Goals
 

--- a/crates/config/src/constants/internode.rs
+++ b/crates/config/src/constants/internode.rs
@@ -39,6 +39,11 @@ pub const DEFAULT_INTERNODE_DATA_TRANSPORT: &str = "tcp-http";
 /// Legacy alias for "tcp-http". Both values select the TCP/HTTP transport backend.
 pub const INTERNODE_DATA_TRANSPORT_TCP: &str = "tcp";
 
+/// Experimental RDMA-like simulator backend. Accepted only by crates that enable
+/// their own `experimental-rdma-sim` feature.
+pub const INTERNODE_DATA_TRANSPORT_RDMA_SIM: &str = "rdma-sim";
+pub const INTERNODE_DATA_TRANSPORT_RDMA_SIM_FEATURE: &str = "experimental-rdma-sim";
+
 /// Known internode transport backend names accepted by the config parser.
 pub const KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS: &[&str] = &[DEFAULT_INTERNODE_DATA_TRANSPORT, INTERNODE_DATA_TRANSPORT_TCP];
 
@@ -71,6 +76,8 @@ mod tests {
         assert_eq!(ENV_RUSTFS_INTERNODE_DATA_TRANSPORT, "RUSTFS_INTERNODE_DATA_TRANSPORT");
         assert_eq!(DEFAULT_INTERNODE_DATA_TRANSPORT, "tcp-http");
         assert_eq!(INTERNODE_DATA_TRANSPORT_TCP, "tcp");
+        assert_eq!(INTERNODE_DATA_TRANSPORT_RDMA_SIM, "rdma-sim");
+        assert_eq!(INTERNODE_DATA_TRANSPORT_RDMA_SIM_FEATURE, "experimental-rdma-sim");
         assert_eq!(KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS, &["tcp-http", "tcp"]);
     }
 }

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -32,6 +32,7 @@ workspace = true
 
 [features]
 default = []
+experimental-rdma-sim = []
 
 [dependencies]
 rustfs-filemeta.workspace = true

--- a/crates/ecstore/src/rpc/internode_data_transport.rs
+++ b/crates/ecstore/src/rpc/internode_data_transport.rs
@@ -16,14 +16,39 @@ use crate::disk::error::{Error, Result};
 use crate::disk::{FileReader, FileWriter};
 use crate::rpc::build_auth_headers;
 use async_trait::async_trait;
+#[cfg(feature = "experimental-rdma-sim")]
+use bytes::Bytes;
+#[cfg(feature = "experimental-rdma-sim")]
+use futures_util::{Stream, TryStreamExt};
 use http::{HeaderMap, HeaderValue, Method, header::CONTENT_TYPE};
+#[cfg(feature = "experimental-rdma-sim")]
+use pin_project_lite::pin_project;
+#[cfg(not(feature = "experimental-rdma-sim"))]
+use rustfs_config::INTERNODE_DATA_TRANSPORT_RDMA_SIM_FEATURE;
 use rustfs_config::{
-    DEFAULT_INTERNODE_DATA_TRANSPORT, ENV_RUSTFS_INTERNODE_DATA_TRANSPORT, INTERNODE_DATA_TRANSPORT_TCP,
-    KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS,
+    DEFAULT_INTERNODE_DATA_TRANSPORT, ENV_RUSTFS_INTERNODE_DATA_TRANSPORT, INTERNODE_DATA_TRANSPORT_RDMA_SIM,
+    INTERNODE_DATA_TRANSPORT_TCP, KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS,
+};
+#[cfg(feature = "experimental-rdma-sim")]
+use rustfs_io_metrics::internode_metrics::{
+    INTERNODE_OPERATION_PUT_FILE_STREAM, INTERNODE_OPERATION_READ_FILE_STREAM, INTERNODE_OPERATION_WALK_DIR,
+    INTERNODE_TRANSPORT_BACKEND_RDMA_SIM, global_internode_metrics,
 };
 use rustfs_rio::{HttpReader, HttpWriter};
+#[cfg(feature = "experimental-rdma-sim")]
+use std::collections::HashMap;
+#[cfg(feature = "experimental-rdma-sim")]
+use std::io;
+#[cfg(feature = "experimental-rdma-sim")]
+use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
+#[cfg(feature = "experimental-rdma-sim")]
+use std::task::{Context, Poll};
 use std::time::Duration;
+#[cfg(feature = "experimental-rdma-sim")]
+use tokio::io::{AsyncRead, ReadBuf};
+#[cfg(feature = "experimental-rdma-sim")]
+use tokio_util::io::StreamReader;
 
 static INTERNODE_DATA_TRANSPORT: OnceLock<std::result::Result<Arc<dyn InternodeDataTransport>, String>> = OnceLock::new();
 
@@ -35,7 +60,28 @@ const CONTENT_TYPE_JSON: &str = "application/json";
 fn unsupported_transport_message(transport: &str) -> String {
     format!(
         "invalid {ENV_RUSTFS_INTERNODE_DATA_TRANSPORT}={transport:?}; supported values: {}",
-        KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS.join(", ")
+        supported_transport_backends().join(", ")
+    )
+}
+
+fn supported_transport_backends() -> Vec<&'static str> {
+    #[cfg(feature = "experimental-rdma-sim")]
+    {
+        let mut backends = KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS.to_vec();
+        backends.push(INTERNODE_DATA_TRANSPORT_RDMA_SIM);
+        backends
+    }
+
+    #[cfg(not(feature = "experimental-rdma-sim"))]
+    {
+        KNOWN_INTERNODE_DATA_TRANSPORT_BACKENDS.to_vec()
+    }
+}
+
+#[cfg(not(feature = "experimental-rdma-sim"))]
+fn rdma_sim_feature_disabled_message() -> String {
+    format!(
+        "invalid {ENV_RUSTFS_INTERNODE_DATA_TRANSPORT}={INTERNODE_DATA_TRANSPORT_RDMA_SIM:?}; backend requires feature {INTERNODE_DATA_TRANSPORT_RDMA_SIM_FEATURE}"
     )
 }
 
@@ -70,6 +116,20 @@ impl InternodeDataTransportCapabilities {
             ordered_delivery: true,
             max_transfer_size: None,
             fallback_supported: true,
+        }
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    pub const fn rdma_sim() -> Self {
+        Self {
+            streaming_read: true,
+            streaming_write: false,
+            streaming_walk_dir: false,
+            zero_copy_candidate: true,
+            registered_memory_required: true,
+            ordered_delivery: true,
+            max_transfer_size: None,
+            fallback_supported: false,
         }
     }
 }
@@ -153,6 +213,319 @@ impl InternodeDataTransport for TcpHttpInternodeDataTransport {
     }
 }
 
+#[cfg(feature = "experimental-rdma-sim")]
+#[derive(Debug, Clone)]
+pub struct RdmaSimInternodeDataTransport {
+    client: reqwest::Client,
+    fault: Option<RdmaSimFault>,
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+impl Default for RdmaSimInternodeDataTransport {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            fault: None,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "experimental-rdma-sim"))]
+impl RdmaSimInternodeDataTransport {
+    fn with_fault(fault: RdmaSimFault) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            fault: Some(fault),
+        }
+    }
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+#[async_trait]
+impl InternodeDataTransport for RdmaSimInternodeDataTransport {
+    async fn open_read(&self, request: ReadStreamRequest) -> Result<FileReader> {
+        let url = build_read_file_stream_url(&request);
+        let mut headers = json_headers();
+        build_auth_headers(&url, &Method::GET, &mut headers).map_err(|err| {
+            record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+            Error::other(format!("rdma-sim read_file_stream auth failed: {err}"))
+        })?;
+
+        let response = self
+            .client
+            .request(Method::GET, url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|err| {
+                record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+                Error::other(format!("rdma-sim read_file_stream request failed: {err}"))
+            })?;
+
+        if !response.status().is_success() {
+            record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+            return Err(Error::other(format!(
+                "rdma-sim read_file_stream request failed with status {}",
+                response.status()
+            )));
+        }
+
+        global_internode_metrics().record_outgoing_request_for_operation_and_backend(
+            INTERNODE_OPERATION_READ_FILE_STREAM,
+            INTERNODE_TRANSPORT_BACKEND_RDMA_SIM,
+        );
+
+        let stream = response.bytes_stream().map_err(|err| {
+            record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+            io::Error::other(format!("rdma-sim read_file_stream stream failed: {err}"))
+        });
+
+        Ok(Box::new(RdmaSimReader::new(StreamReader::new(Box::pin(stream)), self.fault)))
+    }
+
+    async fn open_write(&self, _request: WriteStreamRequest) -> Result<FileWriter> {
+        record_rdma_sim_error(INTERNODE_OPERATION_PUT_FILE_STREAM);
+        Err(Error::other(rdma_sim_unsupported_operation_message("put_file_stream")))
+    }
+
+    async fn open_walk_dir(&self, _request: WalkDirStreamRequest) -> Result<FileReader> {
+        record_rdma_sim_error(INTERNODE_OPERATION_WALK_DIR);
+        Err(Error::other(rdma_sim_unsupported_operation_message("walk_dir")))
+    }
+
+    fn name(&self) -> &'static str {
+        INTERNODE_DATA_TRANSPORT_RDMA_SIM
+    }
+
+    fn capabilities(&self) -> InternodeDataTransportCapabilities {
+        InternodeDataTransportCapabilities::rdma_sim()
+    }
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+fn rdma_sim_unsupported_operation_message(operation: &str) -> String {
+    format!("rdma-sim internode transport only supports read_file_stream in this spike; {operation} is unsupported")
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+fn record_rdma_sim_error(operation: &'static str) {
+    global_internode_metrics().record_error_for_operation_and_backend(operation, INTERNODE_TRANSPORT_BACKEND_RDMA_SIM);
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+struct SimulatedMemoryKey(u64);
+
+#[cfg(feature = "experimental-rdma-sim")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct SimulatedMemoryRegion {
+    len: usize,
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct RegisteredBufferHandle {
+    key: SimulatedMemoryKey,
+    len: usize,
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+#[derive(Debug, Default)]
+struct SimulatedMemoryRegistry {
+    next_key: u64,
+    regions: HashMap<SimulatedMemoryKey, SimulatedMemoryRegion>,
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+impl SimulatedMemoryRegistry {
+    fn register(&mut self, len: usize) -> io::Result<RegisteredBufferHandle> {
+        self.next_key = self
+            .next_key
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("rdma-sim memory key space exhausted"))?;
+        let key = SimulatedMemoryKey(self.next_key);
+        self.regions.insert(key, SimulatedMemoryRegion { len });
+        Ok(RegisteredBufferHandle { key, len })
+    }
+
+    fn validate(&self, handle: RegisteredBufferHandle) -> io::Result<()> {
+        let Some(region) = self.regions.get(&handle.key) else {
+            return Err(io::Error::other("rdma-sim memory region is not registered"));
+        };
+        if region.len < handle.len {
+            return Err(io::Error::other("rdma-sim memory region length is smaller than requested transfer"));
+        }
+        Ok(())
+    }
+
+    fn unregister(&mut self, handle: RegisteredBufferHandle) -> io::Result<()> {
+        self.regions
+            .remove(&handle.key)
+            .map(|_| ())
+            .ok_or_else(|| io::Error::other("rdma-sim memory region is already unregistered"))
+    }
+
+    fn invalidate(&mut self, handle: RegisteredBufferHandle) {
+        self.regions.remove(&handle.key);
+    }
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum SimulatedCompletionState {
+    Idle,
+    Submitted,
+    Completed,
+    Failed,
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RdmaSimFault {
+    RegistrationFailed,
+    InvalidMemoryKey,
+    CompletionError,
+    Timeout,
+    PartialTransfer,
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+pin_project! {
+    struct RdmaSimReader {
+        #[pin]
+        inner: StreamReader<Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send + Sync>>, Bytes>,
+        registry: SimulatedMemoryRegistry,
+        pending: Option<RegisteredBufferHandle>,
+        completion: SimulatedCompletionState,
+        fault: Option<RdmaSimFault>,
+        fault_fired: bool,
+    }
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+impl RdmaSimReader {
+    fn new(
+        inner: StreamReader<Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send + Sync>>, Bytes>,
+        fault: Option<RdmaSimFault>,
+    ) -> Self {
+        Self {
+            inner,
+            registry: SimulatedMemoryRegistry::default(),
+            pending: None,
+            completion: SimulatedCompletionState::Idle,
+            fault,
+            fault_fired: false,
+        }
+    }
+}
+
+#[cfg(feature = "experimental-rdma-sim")]
+impl AsyncRead for RdmaSimReader {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let mut this = self.project();
+
+        if matches!(*this.fault, Some(RdmaSimFault::Timeout)) && !*this.fault_fired {
+            *this.fault_fired = true;
+            *this.completion = SimulatedCompletionState::Failed;
+            record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+            return Poll::Ready(Err(io::Error::new(io::ErrorKind::TimedOut, "rdma-sim completion timeout")));
+        }
+
+        if this.pending.is_none() {
+            if matches!(*this.fault, Some(RdmaSimFault::RegistrationFailed)) && !*this.fault_fired {
+                *this.fault_fired = true;
+                *this.completion = SimulatedCompletionState::Failed;
+                record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+                return Poll::Ready(Err(io::Error::other("rdma-sim memory registration failed")));
+            }
+
+            let handle = match this.registry.register(buf.remaining()) {
+                Ok(handle) => handle,
+                Err(err) => {
+                    *this.completion = SimulatedCompletionState::Failed;
+                    record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+                    return Poll::Ready(Err(err));
+                }
+            };
+            *this.pending = Some(handle);
+            *this.completion = SimulatedCompletionState::Submitted;
+
+            if matches!(*this.fault, Some(RdmaSimFault::InvalidMemoryKey)) && !*this.fault_fired {
+                *this.fault_fired = true;
+                this.registry.invalidate(handle);
+            }
+        }
+
+        let handle = this
+            .pending
+            .expect("rdma-sim reader must have a registered buffer before polling the inner stream");
+
+        if let Err(err) = this.registry.validate(handle) {
+            *this.pending = None;
+            *this.completion = SimulatedCompletionState::Failed;
+            record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+            return Poll::Ready(Err(err));
+        }
+
+        if matches!(*this.fault, Some(RdmaSimFault::CompletionError)) && !*this.fault_fired {
+            *this.fault_fired = true;
+            let _ = this.registry.unregister(handle);
+            *this.pending = None;
+            *this.completion = SimulatedCompletionState::Failed;
+            record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+            return Poll::Ready(Err(io::Error::other("rdma-sim completion error")));
+        }
+
+        if matches!(*this.fault, Some(RdmaSimFault::PartialTransfer)) && !*this.fault_fired {
+            *this.fault_fired = true;
+            let _ = this.registry.unregister(handle);
+            *this.pending = None;
+            *this.completion = SimulatedCompletionState::Failed;
+            record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+            return Poll::Ready(Err(io::Error::new(io::ErrorKind::UnexpectedEof, "rdma-sim partial transfer")));
+        }
+
+        let filled_before = buf.filled().len();
+
+        match this.inner.as_mut().poll_read(cx, buf) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(())) => {
+                if let Err(err) = this.registry.unregister(handle) {
+                    *this.pending = None;
+                    *this.completion = SimulatedCompletionState::Failed;
+                    record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+                    return Poll::Ready(Err(err));
+                }
+
+                *this.pending = None;
+                let bytes_read = buf.filled().len().saturating_sub(filled_before);
+
+                if bytes_read > 0 {
+                    global_internode_metrics().record_recv_bytes_for_operation_and_backend(
+                        INTERNODE_OPERATION_READ_FILE_STREAM,
+                        INTERNODE_TRANSPORT_BACKEND_RDMA_SIM,
+                        bytes_read,
+                    );
+                }
+
+                *this.completion = SimulatedCompletionState::Completed;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(err)) => {
+                let _ = this.registry.unregister(handle);
+                *this.pending = None;
+                *this.completion = SimulatedCompletionState::Failed;
+                record_rdma_sim_error(INTERNODE_OPERATION_READ_FILE_STREAM);
+                Poll::Ready(Err(err))
+            }
+        }
+    }
+}
+
 fn build_read_file_stream_url(request: &ReadStreamRequest) -> String {
     format!(
         "{}{}?disk={}&volume={}&path={}&offset={}&length={}",
@@ -199,6 +572,14 @@ fn build_internode_data_transport_result(
                 || transport.eq_ignore_ascii_case(INTERNODE_DATA_TRANSPORT_TCP) =>
         {
             Ok(Arc::new(TcpHttpInternodeDataTransport))
+        }
+        #[cfg(feature = "experimental-rdma-sim")]
+        Some(transport) if transport.eq_ignore_ascii_case(INTERNODE_DATA_TRANSPORT_RDMA_SIM) => {
+            Ok(Arc::new(RdmaSimInternodeDataTransport::default()))
+        }
+        #[cfg(not(feature = "experimental-rdma-sim"))]
+        Some(transport) if transport.eq_ignore_ascii_case(INTERNODE_DATA_TRANSPORT_RDMA_SIM) => {
+            Err(rdma_sim_feature_disabled_message())
         }
         Some(transport) => Err(unsupported_transport_message(transport)),
     }
@@ -344,11 +725,266 @@ mod tests {
     }
 
     #[test]
+    fn transport_config_rejects_real_rdma_backend_names() {
+        for configured in ["rdma", "real-rdma"] {
+            let err = build_internode_data_transport(Some(configured)).expect_err("real RDMA names should fail closed");
+
+            assert!(err.to_string().contains(ENV_RUSTFS_INTERNODE_DATA_TRANSPORT));
+            assert!(err.to_string().contains(configured));
+        }
+    }
+
+    #[cfg(not(feature = "experimental-rdma-sim"))]
+    #[test]
+    fn transport_config_rejects_rdma_sim_without_feature() {
+        let err = build_internode_data_transport(Some(INTERNODE_DATA_TRANSPORT_RDMA_SIM))
+            .expect_err("rdma-sim should require the experimental feature");
+        let err = err.to_string();
+
+        assert!(err.contains(ENV_RUSTFS_INTERNODE_DATA_TRANSPORT));
+        assert!(err.contains(INTERNODE_DATA_TRANSPORT_RDMA_SIM));
+        assert!(err.contains(INTERNODE_DATA_TRANSPORT_RDMA_SIM_FEATURE));
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[test]
+    fn transport_config_accepts_rdma_sim_with_feature() {
+        let transport = build_internode_data_transport(Some(INTERNODE_DATA_TRANSPORT_RDMA_SIM)).unwrap();
+
+        assert_eq!(transport.name(), INTERNODE_DATA_TRANSPORT_RDMA_SIM);
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[test]
+    fn rdma_sim_capabilities_are_honest_for_the_spike() {
+        let transport = RdmaSimInternodeDataTransport::default();
+
+        assert_eq!(transport.name(), INTERNODE_DATA_TRANSPORT_RDMA_SIM);
+        assert_eq!(
+            transport.capabilities(),
+            InternodeDataTransportCapabilities {
+                streaming_read: true,
+                streaming_write: false,
+                streaming_walk_dir: false,
+                zero_copy_candidate: true,
+                registered_memory_required: true,
+                ordered_delivery: true,
+                max_transfer_size: None,
+                fallback_supported: false,
+            }
+        );
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[test]
+    fn rdma_sim_memory_registry_requires_registered_regions() {
+        let mut registry = SimulatedMemoryRegistry::default();
+        let handle = registry.register(16).expect("registration should succeed");
+
+        registry.validate(handle).expect("registered region should validate");
+        registry.unregister(handle).expect("registered region should unregister");
+
+        let validate_err = registry
+            .validate(handle)
+            .expect_err("unregistered region should fail validation");
+        assert!(validate_err.to_string().contains("not registered"));
+
+        let unregister_err = registry.unregister(handle).expect_err("double unregister should fail");
+        assert!(unregister_err.to_string().contains("already unregistered"));
+
+        let invalid_handle = RegisteredBufferHandle {
+            key: SimulatedMemoryKey(999),
+            len: 4,
+        };
+        let invalid_err = registry.validate(invalid_handle).expect_err("invalid memory key should fail");
+        assert!(invalid_err.to_string().contains("not registered"));
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[tokio::test]
+    async fn rdma_sim_read_file_stream_happy_path_records_backend_metrics() {
+        use tokio::io::AsyncReadExt as _;
+
+        ensure_test_rpc_secret();
+        let body = b"rdma-sim read bytes".to_vec();
+        let endpoint = start_read_file_stream_server(body.clone()).await;
+        let metrics = global_internode_metrics();
+        let before = metrics.snapshot();
+        let transport = RdmaSimInternodeDataTransport::default();
+
+        let mut reader = transport
+            .open_read(read_request_for_endpoint(endpoint))
+            .await
+            .expect("rdma-sim read should open");
+        let mut actual = Vec::new();
+        reader.read_to_end(&mut actual).await.expect("rdma-sim read should complete");
+
+        assert_eq!(actual, body);
+        let after = metrics.snapshot();
+        assert!(after.outgoing_requests_total > before.outgoing_requests_total);
+        assert!(after.recv_bytes_total >= before.recv_bytes_total + body.len() as u64);
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[tokio::test]
+    async fn rdma_sim_completion_error_propagates() {
+        use tokio::io::AsyncReadExt as _;
+
+        ensure_test_rpc_secret();
+        let endpoint = start_read_file_stream_server(b"completion".to_vec()).await;
+        let transport = RdmaSimInternodeDataTransport::with_fault(RdmaSimFault::CompletionError);
+        let mut reader = transport
+            .open_read(read_request_for_endpoint(endpoint))
+            .await
+            .expect("rdma-sim read should open before completion failure");
+        let mut actual = Vec::new();
+
+        let err = reader
+            .read_to_end(&mut actual)
+            .await
+            .expect_err("completion failure should propagate");
+
+        assert!(err.to_string().contains("completion error"));
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[tokio::test]
+    async fn rdma_sim_invalid_memory_key_fails_lifecycle_validation() {
+        use tokio::io::AsyncReadExt as _;
+
+        ensure_test_rpc_secret();
+        let endpoint = start_read_file_stream_server(b"invalid-key".to_vec()).await;
+        let transport = RdmaSimInternodeDataTransport::with_fault(RdmaSimFault::InvalidMemoryKey);
+        let mut reader = transport
+            .open_read(read_request_for_endpoint(endpoint))
+            .await
+            .expect("rdma-sim read should open before lifecycle failure");
+        let mut actual = Vec::new();
+
+        let err = reader
+            .read_to_end(&mut actual)
+            .await
+            .expect_err("invalid memory key should propagate");
+
+        assert!(err.to_string().contains("not registered"));
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[tokio::test]
+    async fn rdma_sim_fault_injection_modes_propagate_errors() {
+        use tokio::io::AsyncReadExt as _;
+
+        ensure_test_rpc_secret();
+        for (fault, expected) in [
+            (RdmaSimFault::RegistrationFailed, "registration failed"),
+            (RdmaSimFault::Timeout, "completion timeout"),
+            (RdmaSimFault::PartialTransfer, "partial transfer"),
+        ] {
+            let endpoint = start_read_file_stream_server(b"fault".to_vec()).await;
+            let transport = RdmaSimInternodeDataTransport::with_fault(fault);
+            let mut reader = transport
+                .open_read(read_request_for_endpoint(endpoint))
+                .await
+                .expect("rdma-sim read should open before injected failure");
+            let mut actual = Vec::new();
+
+            let err = reader
+                .read_to_end(&mut actual)
+                .await
+                .expect_err("injected failure should propagate");
+
+            assert!(err.to_string().contains(expected), "{err}");
+        }
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    #[tokio::test]
+    async fn rdma_sim_unsupported_operations_return_clear_errors() {
+        let transport = RdmaSimInternodeDataTransport::default();
+
+        let write_err = match transport
+            .open_write(WriteStreamRequest {
+                endpoint: "http://127.0.0.1:1".to_string(),
+                disk: "disk".to_string(),
+                volume: "bucket".to_string(),
+                path: "object".to_string(),
+                append: false,
+                size: 1,
+            })
+            .await
+        {
+            Ok(_) => panic!("rdma-sim write should be unsupported"),
+            Err(err) => err,
+        };
+        assert!(write_err.to_string().contains("rdma-sim"));
+        assert!(write_err.to_string().contains("put_file_stream"));
+        assert!(write_err.to_string().contains("unsupported"));
+
+        let walk_err = match transport
+            .open_walk_dir(WalkDirStreamRequest {
+                endpoint: "http://127.0.0.1:1".to_string(),
+                disk: "disk".to_string(),
+                body: Vec::new(),
+                stall_timeout: None,
+            })
+            .await
+        {
+            Ok(_) => panic!("rdma-sim walk-dir should be unsupported"),
+            Err(err) => err,
+        };
+        assert!(walk_err.to_string().contains("rdma-sim"));
+        assert!(walk_err.to_string().contains("walk_dir"));
+        assert!(walk_err.to_string().contains("unsupported"));
+    }
+
+    #[test]
     fn cached_transport_config_error_uses_raw_message() {
         let err = build_internode_data_transport_result(Some("rdma")).expect_err("unknown backend should fail closed");
 
         assert!(!err.starts_with("io error "));
         assert!(err.contains(ENV_RUSTFS_INTERNODE_DATA_TRANSPORT));
         assert!(err.contains("rdma"));
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    fn ensure_test_rpc_secret() {
+        let _ = rustfs_credentials::GLOBAL_RUSTFS_RPC_SECRET.set("test-rpc-secret".to_string());
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    fn read_request_for_endpoint(endpoint: String) -> ReadStreamRequest {
+        ReadStreamRequest {
+            endpoint,
+            disk: "disk".to_string(),
+            volume: "bucket".to_string(),
+            path: "object/part.1".to_string(),
+            offset: 0,
+            length: 1024,
+        }
+    }
+
+    #[cfg(feature = "experimental-rdma-sim")]
+    async fn start_read_file_stream_server(body: Vec<u8>) -> String {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind a loopback port");
+        let addr = listener.local_addr().expect("test server should expose its local address");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("test server should accept one request");
+            let mut request = [0_u8; 4096];
+            let _ = socket.read(&mut request).await.expect("test server should read request");
+            let response_headers = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", body.len());
+            socket
+                .write_all(response_headers.as_bytes())
+                .await
+                .expect("test server should write response headers");
+            socket.write_all(&body).await.expect("test server should write response body");
+        });
+
+        format!("http://{addr}")
     }
 }

--- a/crates/ecstore/src/rpc/mod.rs
+++ b/crates/ecstore/src/rpc/mod.rs
@@ -25,6 +25,8 @@ pub use client::{
     TonicInterceptor, gen_tonic_signature_interceptor, node_service_time_out_client, node_service_time_out_client_no_auth,
 };
 pub use http_auth::{TONIC_RPC_PREFIX, build_auth_headers, gen_signature_headers, verify_rpc_signature};
+#[cfg(feature = "experimental-rdma-sim")]
+pub use internode_data_transport::RdmaSimInternodeDataTransport;
 pub use internode_data_transport::{
     InternodeDataTransport, InternodeDataTransportCapabilities, ReadStreamRequest, TcpHttpInternodeDataTransport,
     WalkDirStreamRequest, WriteStreamRequest, build_internode_data_transport, build_internode_data_transport_from_env,

--- a/crates/io-metrics/src/internode_metrics.rs
+++ b/crates/io-metrics/src/internode_metrics.rs
@@ -26,6 +26,7 @@ pub const INTERNODE_OPERATION_GRPC_READ_ALL: &str = "grpc_read_all";
 pub const INTERNODE_OPERATION_GRPC_WRITE_ALL: &str = "grpc_write_all";
 pub const INTERNODE_TRANSPORT_BACKEND_TCP_HTTP: &str = "tcp-http";
 pub const INTERNODE_TRANSPORT_BACKEND_GRPC: &str = "grpc";
+pub const INTERNODE_TRANSPORT_BACKEND_RDMA_SIM: &str = "rdma-sim";
 pub const INTERNODE_TRANSPORT_BACKEND_UNKNOWN: &str = "unknown";
 
 const OPERATION_LABEL: &str = "operation";

--- a/docs/design/internode-rdma-sim-transport.md
+++ b/docs/design/internode-rdma-sim-transport.md
@@ -1,0 +1,149 @@
+# Internode RDMA Simulator Transport
+
+`rdma-sim` is an experimental internode data transport backend used to validate
+whether `InternodeDataTransport` can host RDMA-like semantics. It is not a
+production RDMA backend, does not use RDMA hardware, and does not link
+`libibverbs`, `rdma-core`, DOCA, DPDK, SPDK, EFA, RoCE, or InfiniBand
+libraries.
+
+The default backend remains `tcp-http`. The simulator makes no performance
+claim and should not be used as evidence of RDMA throughput or latency.
+
+## Selection
+
+The backend is compiled only with the `experimental-rdma-sim` Cargo feature.
+The feature is not enabled by default.
+
+| `RUSTFS_INTERNODE_DATA_TRANSPORT` | Feature disabled | Feature enabled |
+| --- | --- | --- |
+| unset or blank | `tcp-http` | `tcp-http` |
+| `tcp-http` | `tcp-http` | `tcp-http` |
+| `tcp` | `tcp-http` alias | `tcp-http` alias |
+| `rdma-sim` | fails closed with an error naming `experimental-rdma-sim` | selects `rdma-sim` |
+| `rdma` or `real-rdma` | fails closed | fails closed |
+| unknown value | fails closed | fails closed |
+
+The simulator does not silently fall back to `tcp-http`. The P2 fallback design
+requires fallback to be explicit and observable before it becomes runtime
+behavior.
+
+## Supported Operation
+
+The MVP operation is `read_file_stream`, implemented through
+`InternodeDataTransport::open_read`.
+
+The simulator uses the existing HTTP read route as the byte source so the spike
+can validate the client-side transport boundary without changing the
+server-side control plane, S3 API, gRPC surface, or disk handlers. Metrics are
+recorded with `operation=read_file_stream` and `backend=rdma-sim`.
+
+`put_file_stream` and `walk_dir` return clear unsupported-operation errors.
+They are not delegated to `tcp-http`.
+
+## Capabilities
+
+`rdma-sim` reports capabilities that describe simulator semantics only:
+
+| Capability | Value |
+| --- | --- |
+| backend name | `rdma-sim` |
+| streaming read | `true` |
+| streaming write | `false` |
+| streaming walk-dir | `false` |
+| zero-copy candidate | `true` |
+| registered memory required | `true` |
+| ordered delivery | `true` |
+| max transfer size | none at the RustFS abstraction layer |
+| fallback supported | `false` |
+
+The `zero-copy candidate` flag means the abstraction can describe a future
+registered-buffer data path. It does not mean this simulator avoids copies or
+improves performance.
+
+## Memory Registration Simulation
+
+`read_file_stream` wraps receive-side reads with an internal registration
+lifecycle:
+
+| Type | Purpose |
+| --- | --- |
+| `SimulatedMemoryRegistry` | Tracks registered receive regions by simulated memory key. |
+| `SimulatedMemoryRegion` | Records the region length accepted by the simulator. |
+| `SimulatedMemoryKey` | Represents an opaque key that must match a registered region. |
+| `RegisteredBufferHandle` | Carries the key and requested transfer length for validation. |
+
+The simulator enforces that a receive region is registered before a simulated
+operation completes. Validation fails if the key is invalid or the region has
+already been unregistered. The registry does not pin memory, does not register
+real DMA memory, and does not use unsafe RDMA APIs.
+
+The current `read_file_stream` API does not accept caller-provided buffers, so
+the simulator registers internal receive-side read buffers around `AsyncRead`
+polls. A hardware-backed backend would need a stronger buffer ownership
+contract before it can use caller-owned registered memory directly.
+
+## Completion Simulation
+
+The reader tracks a small internal completion state:
+
+| State | Meaning |
+| --- | --- |
+| `Idle` | No simulated operation is active. |
+| `Submitted` | A receive buffer has been registered and the inner stream is being polled. |
+| `Completed` | The read completed successfully and the region was unregistered. |
+| `Failed` | Registration, key validation, timeout, partial transfer, or completion failed. |
+
+Fault injection is available only through test constructors. Covered modes
+include registration failure, invalid memory key, completion error, timeout,
+and partial transfer. Errors propagate through the existing `AsyncRead` /
+`InternodeDataTransport` boundary rather than exposing low-level RDMA verbs.
+
+## Observability
+
+The simulator records internode operation metrics with low-cardinality labels:
+
+| Metric behavior | Labels |
+| --- | --- |
+| outgoing read request | `operation=read_file_stream`, `backend=rdma-sim` |
+| received bytes | `operation=read_file_stream`, `backend=rdma-sim` |
+| simulator errors | operation-specific, `backend=rdma-sim` |
+
+The implementation does not add object names, full URLs, full paths, or peer
+identity strings as metric labels.
+
+## Known Abstraction Gaps
+
+| Area | Current state |
+| --- | --- |
+| Caller-owned buffers | `read_file_stream` returns `AsyncRead`; it does not let the caller provide registered receive buffers. |
+| Server-side data plane | The simulator validates the client-side transport boundary and still uses the existing HTTP read handler as its byte source. |
+| Write path | `put_file_stream` remains unsupported in `rdma-sim`, so send-buffer ownership is not validated here. |
+| Walk-dir path | `walk_dir` remains unsupported because it is metadata-oriented and not the primary RDMA-like data path. |
+| Runtime fallback | No automatic fallback is implemented for `rdma-sim`; selection failures and operation failures are explicit errors. |
+| Hardware semantics | Pinning, memory registration lifetime across async tasks, queue pairs, completion queues, ordering guarantees from hardware, and peer negotiation are not modeled. |
+
+These gaps mean a hardware-backed P3-B spike can be considered only as a
+separate experiment behind its own feature gate and dependency boundary. It
+would still need to keep `tcp-http` as the default, preserve correctness
+semantics, and avoid claiming performance improvement without measured data.
+
+## Validation
+
+Default TCP/HTTP behavior:
+
+```bash
+cargo test -p rustfs-ecstore rpc::internode_data_transport
+```
+
+Simulator behavior:
+
+```bash
+cargo test -p rustfs-ecstore --features experimental-rdma-sim rpc::internode_data_transport
+cargo test -p rustfs-ecstore --features experimental-rdma-sim rdma_sim
+```
+
+Formatting:
+
+```bash
+cargo fmt --check
+```


### PR DESCRIPTION
This was an exploratory spike around the internode transport boundary.

After maintainer feedback, I am narrowing the OSS scope. The follow-up work will focus only on the backend-neutral `InternodeDataTransport` adapter boundary and the existing `tcp-http` path.

This PR is superseded by a smaller OSS-scoped cleanup PR. The replacement PR will avoid simulator code, hardware-specific transport wording, and non-default backend implementation details.
