### PR TITLE
fix: derive run script CORS console port

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -66,7 +66,11 @@ export RUSTFS_REGION="${RUSTFS_REGION:-us-east-1}"
 export RUSTFS_CONSOLE_ENABLE="${RUSTFS_CONSOLE_ENABLE:-true}"
 export RUSTFS_CONSOLE_ADDRESS="${RUSTFS_CONSOLE_ADDRESS:-127.0.0.1:9001}"
 if [ -z "${RUSTFS_CORS_ALLOWED_ORIGINS+x}" ]; then
-    export RUSTFS_CORS_ALLOWED_ORIGINS="http://127.0.0.1:9001,http://localhost:9001,http://127.0.0.1:3000,http://localhost:3000"
+    console_port="${RUSTFS_CONSOLE_ADDRESS##*:}"
+    if [ -z "$console_port" ] || [ "$console_port" = "$RUSTFS_CONSOLE_ADDRESS" ]; then
+        console_port=9001
+    fi
+    export RUSTFS_CORS_ALLOWED_ORIGINS="http://127.0.0.1:${console_port},http://localhost:${console_port},http://127.0.0.1:3000,http://localhost:3000"
 fi
 # export RUSTFS_SERVER_DOMAINS="localhost:9000"
 # HTTPS certificate directory


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Derive the default `RUSTFS_CORS_ALLOWED_ORIGINS` console port from `RUSTFS_CONSOLE_ADDRESS` in `scripts/run.sh` instead of hard-coding `9001`.

This keeps the local console-to-S3 CORS allow-list aligned when developers override the console port.

## Verification
- `bash -n scripts/run.sh`
- `git diff --check`
- Sourced the updated environment block with default, custom `RUSTFS_CONSOLE_ADDRESS=127.0.0.1:9101`, and explicit `RUSTFS_CORS_ALLOWED_ORIGINS` values.

## Impact
Only affects the local development run script default CORS allow-list. Explicit `RUSTFS_CORS_ALLOWED_ORIGINS` values are still preserved.

## Additional Notes
N/A
