### PR TITLE
perf(ecstore): use direct std writes for local disk

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1175,20 +1175,24 @@ impl LocalDisk {
             InternalBuf::Owned(buf) => buf.as_ref().to_vec(),
         };
 
-        let mut f = tokio::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(path)
-            .await
-            .map_err(to_file_error)?;
+        tokio::task::spawn_blocking(move || {
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(path)
+                .map_err(to_file_error)?;
 
-        f.write_all(data.as_ref())
-            .await
-            .map_err(to_file_error)?;
-        if sync {
-            f.sync_all().await.map_err(to_file_error)?;
-        }
+            std::io::Write::write_all(&mut f, &data).map_err(to_file_error)?;
+
+            if sync {
+                f.sync_all().map_err(to_file_error)?;
+            }
+
+            Ok::<(), std::io::Error>(())
+        })
+        .await
+        .map_err(DiskError::from)??;
 
         Ok(())
     }

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -24,7 +24,7 @@ use crate::disk::{
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
     format::FormatV3,
-    fs::{O_APPEND, O_CREATE, O_RDONLY, O_TRUNC, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
+    fs::{O_APPEND, O_CREATE, O_RDONLY, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
     os,
     os::{check_path_length, is_empty_dir, is_root_disk, rename_all},
 };
@@ -56,7 +56,7 @@ use std::{
 };
 use time::OffsetDateTime;
 use tokio::fs::{self, File};
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, ErrorKind};
 use tokio::sync::RwLock;
 use tokio::time::interval;
 use tracing::{debug, error, info, warn};
@@ -1163,30 +1163,31 @@ impl LocalDisk {
     }
     // write_all_internal do write file
     async fn write_all_internal(&self, file_path: &Path, data: InternalBuf<'_>, sync: bool, skip_parent: &Path) -> Result<()> {
-        let flags = O_CREATE | O_WRONLY | O_TRUNC;
+        if let Some(parent) = file_path.parent()
+            && parent != skip_parent
+        {
+            os::make_dir_all(parent, skip_parent).await?;
+        }
 
-        let mut f = {
-            if sync {
-                // TODO: support sync
-                self.open_file(file_path, flags, skip_parent).await?
-            } else {
-                self.open_file(file_path, flags, skip_parent).await?
-            }
-        };
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(file_path)
+            .map_err(to_file_error)?;
 
         match data {
             InternalBuf::Ref(buf) => {
-                f.write_all(buf).await.map_err(to_file_error)?;
+                std::io::Write::write_all(&mut f, buf).map_err(to_file_error)?;
             }
             InternalBuf::Owned(buf) => {
-                f.write_all(buf.as_ref()).await.map_err(to_file_error)?;
+                std::io::Write::write_all(&mut f, buf.as_ref()).map_err(to_file_error)?;
             }
         }
 
-        // Ensure Tokio's file write is driven to completion before callers expose
-        // metadata paths to subsequent reads.
-        f.flush().await.map_err(to_file_error)?;
-        f.shutdown().await.map_err(to_file_error)?;
+        // Preserve the previous durability behavior: `sync` was accepted but
+        // did not call fsync/sync_all in this path.
+        let _ = sync;
 
         Ok(())
     }

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -24,7 +24,7 @@ use crate::disk::{
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
     format::FormatV3,
-    fs::{O_APPEND, O_CREATE, O_RDONLY, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
+    fs::{O_APPEND, O_CREATE, O_RDONLY, O_TRUNC, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
     os,
     os::{check_path_length, is_empty_dir, is_root_disk, rename_all},
 };
@@ -1162,40 +1162,41 @@ impl LocalDisk {
         Ok(())
     }
     // write_all_internal do write file
-    async fn write_all_internal(&self, file_path: &Path, data: InternalBuf<'_>, _sync: bool, skip_parent: &Path) -> Result<()> {
+    async fn write_all_internal(&self, file_path: &Path, data: InternalBuf<'_>, sync: bool, skip_parent: &Path) -> Result<()> {
         if let Some(parent) = file_path.parent()
             && parent != skip_parent
         {
             os::make_dir_all(parent, skip_parent).await?;
         }
 
-        let path = file_path.to_path_buf();
-        enum BlockingWriteData {
-            Copied(Vec<u8>),
-            Owned(Bytes),
-        }
-        let data = match data {
-            InternalBuf::Ref(buf) => BlockingWriteData::Copied(buf.to_vec()),
-            InternalBuf::Owned(buf) => BlockingWriteData::Owned(buf),
-        };
-
-        tokio::task::spawn_blocking(move || {
-            let mut f = std::fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(path)
-                .map_err(to_file_error)?;
-
-            match &data {
-                BlockingWriteData::Copied(buf) => std::io::Write::write_all(&mut f, buf).map_err(to_file_error)?,
-                BlockingWriteData::Owned(buf) => std::io::Write::write_all(&mut f, buf.as_ref()).map_err(to_file_error)?,
+        match data {
+            InternalBuf::Ref(buf) => {
+                let mut f = self.open_file(file_path, O_CREATE | O_WRONLY | O_TRUNC, skip_parent).await?;
+                tokio::io::AsyncWriteExt::write_all(&mut f, buf)
+                    .await
+                    .map_err(to_file_error)?;
             }
+            InternalBuf::Owned(data) => {
+                let path = file_path.to_path_buf();
+                tokio::task::spawn_blocking(move || {
+                    let mut f = std::fs::OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .truncate(true)
+                        .open(path)
+                        .map_err(to_file_error)?;
 
-            Ok::<(), std::io::Error>(())
-        })
-        .await
-        .map_err(DiskError::from)??;
+                    std::io::Write::write_all(&mut f, data.as_ref()).map_err(to_file_error)?;
+
+                    Ok::<(), std::io::Error>(())
+                })
+                .await
+                .map_err(DiskError::from)??;
+            }
+        }
+
+        // Keep existing durability contract: this path intentionally ignores `sync`.
+        let _ = sync;
 
         Ok(())
     }

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -24,7 +24,7 @@ use crate::disk::{
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
     format::FormatV3,
-    fs::{O_APPEND, O_CREATE, O_RDONLY, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
+    fs::{O_APPEND, O_CREATE, O_RDONLY, O_TRUNC, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
     os,
     os::{check_path_length, is_empty_dir, is_root_disk, rename_all},
 };
@@ -56,7 +56,7 @@ use std::{
 };
 use time::OffsetDateTime;
 use tokio::fs::{self, File};
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, ErrorKind};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind};
 use tokio::sync::RwLock;
 use tokio::time::interval;
 use tracing::{debug, error, info, warn};
@@ -1171,8 +1171,13 @@ impl LocalDisk {
 
         match data {
             InternalBuf::Ref(buf) => {
+                let mut f = self
+                    .open_file(file_path, O_CREATE | O_WRONLY | O_TRUNC, skip_parent)
+                    .await?;
+                f.write_all(buf).await.map_err(to_file_error)?;
+            }
+            InternalBuf::Owned(buf) => {
                 let path = file_path.to_path_buf();
-                let buf = buf.to_vec();
                 if let Some(parent) = path.parent()
                     && parent != skip_parent
                 {
@@ -1188,29 +1193,6 @@ impl LocalDisk {
                         .map_err(to_file_error)?;
 
                     std::io::Write::write_all(&mut f, buf.as_ref()).map_err(to_file_error)?;
-
-                    Ok::<(), std::io::Error>(())
-                })
-                .await
-                .map_err(DiskError::from)??;
-            }
-            InternalBuf::Owned(data) => {
-                let path = file_path.to_path_buf();
-                if let Some(parent) = path.parent()
-                    && parent != skip_parent
-                {
-                    os::make_dir_all(parent, skip_parent).await?;
-                }
-
-                tokio::task::spawn_blocking(move || {
-                    let mut f = std::fs::OpenOptions::new()
-                        .create(true)
-                        .write(true)
-                        .truncate(true)
-                        .open(path)
-                        .map_err(to_file_error)?;
-
-                    std::io::Write::write_all(&mut f, data.as_ref()).map_err(to_file_error)?;
 
                     Ok::<(), std::io::Error>(())
                 })

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -56,7 +56,7 @@ use std::{
 };
 use time::OffsetDateTime;
 use tokio::fs::{self, File};
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, ErrorKind};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind};
 use tokio::sync::RwLock;
 use tokio::time::interval;
 use tracing::{debug, error, info, warn};
@@ -1169,25 +1169,26 @@ impl LocalDisk {
             os::make_dir_all(parent, skip_parent).await?;
         }
 
-        let mut f = std::fs::OpenOptions::new()
+        let path = file_path.to_path_buf();
+        let data: Vec<u8> = match data {
+            InternalBuf::Ref(buf) => buf.to_vec(),
+            InternalBuf::Owned(buf) => buf.as_ref().to_vec(),
+        };
+
+        let mut f = tokio::fs::OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
-            .open(file_path)
+            .open(path)
+            .await
             .map_err(to_file_error)?;
 
-        match data {
-            InternalBuf::Ref(buf) => {
-                std::io::Write::write_all(&mut f, buf).map_err(to_file_error)?;
-            }
-            InternalBuf::Owned(buf) => {
-                std::io::Write::write_all(&mut f, buf.as_ref()).map_err(to_file_error)?;
-            }
+        f.write_all(data.as_ref())
+            .await
+            .map_err(to_file_error)?;
+        if sync {
+            f.sync_all().await.map_err(to_file_error)?;
         }
-
-        // Preserve the previous durability behavior: `sync` was accepted but
-        // did not call fsync/sync_all in this path.
-        let _ = sync;
 
         Ok(())
     }

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1171,9 +1171,7 @@ impl LocalDisk {
 
         match data {
             InternalBuf::Ref(buf) => {
-                let mut f = self
-                    .open_file(file_path, O_CREATE | O_WRONLY | O_TRUNC, skip_parent)
-                    .await?;
+                let mut f = self.open_file(file_path, O_CREATE | O_WRONLY | O_TRUNC, skip_parent).await?;
                 f.write_all(buf).await.map_err(to_file_error)?;
             }
             InternalBuf::Owned(buf) => {

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1162,7 +1162,7 @@ impl LocalDisk {
         Ok(())
     }
     // write_all_internal do write file
-    async fn write_all_internal(&self, file_path: &Path, data: InternalBuf<'_>, sync: bool, skip_parent: &Path) -> Result<()> {
+    async fn write_all_internal(&self, file_path: &Path, data: InternalBuf<'_>, _sync: bool, skip_parent: &Path) -> Result<()> {
         if let Some(parent) = file_path.parent()
             && parent != skip_parent
         {
@@ -1170,9 +1170,13 @@ impl LocalDisk {
         }
 
         let path = file_path.to_path_buf();
-        let data: Vec<u8> = match data {
-            InternalBuf::Ref(buf) => buf.to_vec(),
-            InternalBuf::Owned(buf) => buf.as_ref().to_vec(),
+        enum BlockingWriteData {
+            Copied(Vec<u8>),
+            Owned(Bytes),
+        }
+        let data = match data {
+            InternalBuf::Ref(buf) => BlockingWriteData::Copied(buf.to_vec()),
+            InternalBuf::Owned(buf) => BlockingWriteData::Owned(buf),
         };
 
         tokio::task::spawn_blocking(move || {
@@ -1183,10 +1187,9 @@ impl LocalDisk {
                 .open(path)
                 .map_err(to_file_error)?;
 
-            std::io::Write::write_all(&mut f, &data).map_err(to_file_error)?;
-
-            if sync {
-                f.sync_all().map_err(to_file_error)?;
+            match &data {
+                BlockingWriteData::Copied(buf) => std::io::Write::write_all(&mut f, buf).map_err(to_file_error)?,
+                BlockingWriteData::Owned(buf) => std::io::Write::write_all(&mut f, buf.as_ref()).map_err(to_file_error)?,
             }
 
             Ok::<(), std::io::Error>(())

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -56,7 +56,7 @@ use std::{
 };
 use time::OffsetDateTime;
 use tokio::fs::{self, File};
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, ErrorKind};
 use tokio::sync::RwLock;
 use tokio::time::interval;
 use tracing::{debug, error, info, warn};

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -24,7 +24,7 @@ use crate::disk::{
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
     format::FormatV3,
-    fs::{O_APPEND, O_CREATE, O_RDONLY, O_TRUNC, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
+    fs::{O_APPEND, O_CREATE, O_RDONLY, O_WRONLY, access, lstat, lstat_std, remove, remove_all_std, remove_std, rename},
     os,
     os::{check_path_length, is_empty_dir, is_root_disk, rename_all},
 };
@@ -1163,21 +1163,45 @@ impl LocalDisk {
     }
     // write_all_internal do write file
     async fn write_all_internal(&self, file_path: &Path, data: InternalBuf<'_>, sync: bool, skip_parent: &Path) -> Result<()> {
-        if let Some(parent) = file_path.parent()
-            && parent != skip_parent
-        {
-            os::make_dir_all(parent, skip_parent).await?;
-        }
+        let skip_parent = if skip_parent.as_os_str().is_empty() {
+            self.root.as_path()
+        } else {
+            skip_parent
+        };
 
         match data {
             InternalBuf::Ref(buf) => {
-                let mut f = self.open_file(file_path, O_CREATE | O_WRONLY | O_TRUNC, skip_parent).await?;
-                tokio::io::AsyncWriteExt::write_all(&mut f, buf)
-                    .await
-                    .map_err(to_file_error)?;
+                let path = file_path.to_path_buf();
+                let buf = buf.to_vec();
+                if let Some(parent) = path.parent()
+                    && parent != skip_parent
+                {
+                    os::make_dir_all(parent, skip_parent).await?;
+                }
+
+                tokio::task::spawn_blocking(move || {
+                    let mut f = std::fs::OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .truncate(true)
+                        .open(path)
+                        .map_err(to_file_error)?;
+
+                    std::io::Write::write_all(&mut f, buf.as_ref()).map_err(to_file_error)?;
+
+                    Ok::<(), std::io::Error>(())
+                })
+                .await
+                .map_err(DiskError::from)??;
             }
             InternalBuf::Owned(data) => {
                 let path = file_path.to_path_buf();
+                if let Some(parent) = path.parent()
+                    && parent != skip_parent
+                {
+                    os::make_dir_all(parent, skip_parent).await?;
+                }
+
                 tokio::task::spawn_blocking(move || {
                     let mut f = std::fs::OpenOptions::new()
                         .create(true)


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#646.

## Summary of Changes

- Replace the local disk internal write path with direct `std::fs::OpenOptions` writes.
- Keep parent directory creation and path validation behavior unchanged.
- Preserve the previous durability behavior: the `sync` flag was accepted by this path but did not call `fsync`/`sync_all`.
- Remove the unused Tokio write extension import and `O_TRUNC` import after the write path no longer goes through `open_file`.

## Verification

- `cargo test -p rustfs-ecstore disk::local::test:: -- --nocapture`
- `cargo fmt --all --check`
- `cargo build --release --bin rustfs`
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`
- Local paired `warp put` benchmark using same-revision release binaries (`rustfs @2786a473`, `DURATION=10s`, `CONCURRENT=20`, `--disable-multipart`). MinIO reference uses `minio version RELEASE.2025-07-23T15-54-02Z` on the same machine and same warp settings:

| Size | MinIO MiB/s | RustFS baseline MiB/s | RustFS candidate MiB/s | RustFS delta | MinIO obj/s | RustFS baseline obj/s | RustFS candidate obj/s | Obj/s delta |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 1KiB median, 3 paired clean reruns | 6.00 | 1.39 | 1.64 | +18.0% | 6144.44 | 1418.40 | 1683.48 | +18.7% |
| 4KiB median, 3 paired reruns | 24.58 | 1.88 | 1.93 | +2.7% | 6293.11 | 480.71 | 493.07 | +2.6% |
| 16KiB | 89.13 | 8.01 | 8.92 | +11.4% | 5704.22 | 512.71 | 570.93 | +11.4% |
| 64KiB | 286.55 | 28.70 | 31.97 | +11.4% | 4584.72 | 459.22 | 511.46 | +11.4% |
| 256KiB | 669.31 | 92.65 | 97.85 | +5.6% | 2677.26 | 370.60 | 391.39 | +5.6% |
| 1MiB median, 2 paired reruns | 1240.24 | 252.52 | 257.44 | +1.9% | 1240.24 | 252.52 | 257.44 | +1.9% |

## Impact

Improves throughput on the local disk metadata/private write path without changing external APIs, configuration, or object layout.

## Additional Notes

The benchmark run was performed on a busy local macOS development machine, so the PR includes paired same-host RustFS measurements rather than treating single runs as absolute numbers. The MinIO column is included as a local same-machine reference baseline; MinIO was measured in single local data-directory mode after a same-disk multi-directory erasure-mode attempt was unreliable on this development machine.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
