### PR TITLE
test(utils): cover bracketed IPv6 zone host parsing

### DIFF
--- a/crates/utils/src/notify/net.rs
+++ b/crates/utils/src/notify/net.rs
@@ -458,6 +458,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_host_with_bracketed_ipv6_zone_and_port() {
+        let result = parse_host("[fe80::1%eth0]:9000");
+        assert!(result.is_ok());
+        let host = result.unwrap();
+        assert_eq!(host.name, "fe80::1%eth0");
+        assert_eq!(host.port, Some(9000));
+    }
+
+    #[test]
     fn parse_host_with_bracketed_ipv6_without_port() {
         let result = parse_host("[::1]");
         assert!(result.is_ok());


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add regression coverage for notify host parsing with bracketed IPv6 zone identifiers and ports.
- Keep the change limited to the existing `parse_host` unit tests.

## Verification
- `cargo test -p rustfs-utils --features notify parse_host_with_bracketed_ipv6_zone_and_port --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
No production behavior change. Test-only coverage for IPv6 zone host parsing.

## Additional Notes
N/A
