### PR TITLE
feat(obs): add prometheus metrics endpoint exporter

### DIFF
--- a/crates/obs/src/global.rs
+++ b/crates/obs/src/global.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{AppConfig, GlobalError, OtelConfig, OtelGuard, telemetry::init_telemetry};
+use crate::{AppConfig, GlobalError, OtelConfig, OtelGuard, Recorder, telemetry::init_telemetry};
 use std::sync::{Arc, Mutex};
 use tokio::sync::OnceCell;
 use tracing::{info, warn};
 
 /// Global guard for OpenTelemetry tracing
 static GLOBAL_GUARD: OnceCell<Arc<Mutex<OtelGuard>>> = OnceCell::const_new();
+/// Global handle to the metrics recorder when observability metrics are enabled.
+static GLOBAL_METRICS_RECORDER: OnceCell<Recorder> = OnceCell::const_new();
 
 /// Flag indicating if observability metric is enabled
 pub(crate) static OBSERVABILITY_METRIC_ENABLED: OnceCell<bool> = OnceCell::const_new();
@@ -38,6 +40,18 @@ pub(crate) const METRIC_LOG_CLEANER_ACTIVE_FILE_SIZE_BYTES: &str = "rustfs_log_c
 /// Check whether Observability metric is enabled
 pub fn observability_metric_enabled() -> bool {
     OBSERVABILITY_METRIC_ENABLED.get().copied().unwrap_or(false)
+}
+
+/// Store the global metrics recorder once so other modules can export snapshots.
+pub(crate) fn set_global_metrics_recorder(recorder: Recorder) {
+    if GLOBAL_METRICS_RECORDER.set(recorder).is_err() {
+        warn!("GLOBAL_METRICS_RECORDER was already initialized; keeping original recorder");
+    }
+}
+
+/// Get the global metrics recorder if observability metrics are enabled.
+pub fn get_global_metrics_recorder() -> Option<Recorder> {
+    GLOBAL_METRICS_RECORDER.get().cloned()
 }
 
 /// Set the global observability metrics flag once.

--- a/crates/obs/src/lib.rs
+++ b/crates/obs/src/lib.rs
@@ -72,6 +72,7 @@ pub use global::*;
 pub use metrics::schema::*;
 pub use metrics::{init_metrics_collectors, init_metrics_runtime};
 pub use telemetry::{OtelGuard, Recorder};
+pub use global::get_global_metrics_recorder;
 
 // Dial9 Tokio runtime telemetry
 // Re-export dial9 types at crate root level for easier access

--- a/crates/obs/src/telemetry/local.rs
+++ b/crates/obs/src/telemetry/local.rs
@@ -31,14 +31,20 @@
 //! construction while still allowing periodic housekeeping in the background.
 
 use super::guard::OtelGuard;
+use super::recorder::Recorder;
 use crate::TelemetryError;
 use crate::cleaner::LogCleaner;
 use crate::cleaner::types::{CompressionAlgorithm, FileMatchMode};
 use crate::config::OtelConfig;
-use crate::global::{METRIC_LOG_CLEANER_RUN_FAILURES_TOTAL, METRIC_LOG_CLEANER_RUNS_TOTAL, set_observability_metric_enabled};
+use crate::global::{
+    METRIC_LOG_CLEANER_RUN_FAILURES_TOTAL, METRIC_LOG_CLEANER_RUNS_TOTAL, set_global_metrics_recorder,
+    set_observability_metric_enabled,
+};
 use crate::telemetry::filter::build_env_filter;
 use crate::telemetry::rolling::{RollingAppender, Rotation};
 use metrics::counter;
+use opentelemetry::global;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use rustfs_config::observability::{
     DEFAULT_OBS_LOG_CLEANUP_INTERVAL_SECONDS, DEFAULT_OBS_LOG_COMPRESS_OLD_FILES, DEFAULT_OBS_LOG_COMPRESSED_FILE_RETENTION_DAYS,
     DEFAULT_OBS_LOG_COMPRESSION_ALGORITHM, DEFAULT_OBS_LOG_DELETE_EMPTY_FILES, DEFAULT_OBS_LOG_DRY_RUN,
@@ -118,10 +124,10 @@ pub(super) fn init_local_logging(
 /// identifiers, file/line information, and span context.
 ///
 /// # Arguments
-/// * `_config` - Unused at the moment; reserved for future configuration.
+/// * `config` - Observability configuration (service name is used for metrics scope).
 /// * `logger_level` - Effective log level string.
 /// * `is_production` - Controls span event verbosity.
-fn init_stdout_only(_config: &OtelConfig, logger_level: &str, is_production: bool) -> OtelGuard {
+fn init_stdout_only(config: &OtelConfig, logger_level: &str, is_production: bool) -> OtelGuard {
     let env_filter = build_env_filter(logger_level, None);
     let (nb, guard) = tracing_appender::non_blocking(std::io::stdout());
 
@@ -147,13 +153,14 @@ fn init_stdout_only(_config: &OtelConfig, logger_level: &str, is_production: boo
         .with(fmt_layer)
         .init();
 
-    set_observability_metric_enabled(false);
+    let meter_provider = init_local_metrics_recorder(config.service_name.as_deref().unwrap_or(APP_NAME));
+    set_observability_metric_enabled(meter_provider.is_some());
     counter!("rustfs_start_total").increment(1);
     info!("Init stdout logging (level: {})", logger_level);
 
     OtelGuard {
         tracer_provider: None,
-        meter_provider: None,
+        meter_provider,
         logger_provider: None,
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         profiling_agent: None,
@@ -275,7 +282,8 @@ fn init_file_logging_internal(
         .with(stdout_layer)
         .init();
 
-    set_observability_metric_enabled(false);
+    let meter_provider = init_local_metrics_recorder(service_name);
+    set_observability_metric_enabled(meter_provider.is_some());
 
     // ── 5. Start background cleanup task ─────────────────────────────────────
     let cleanup_handle = spawn_cleanup_task(config, log_directory, log_filename, keep_files);
@@ -287,7 +295,7 @@ fn init_file_logging_internal(
 
     Ok(OtelGuard {
         tracer_provider: None,
-        meter_provider: None,
+        meter_provider,
         logger_provider: None,
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         profiling_agent: None,
@@ -295,6 +303,22 @@ fn init_file_logging_internal(
         stdout_guard,
         cleanup_handle: Some(cleanup_handle),
     })
+}
+
+fn init_local_metrics_recorder(service_name: &str) -> Option<SdkMeterProvider> {
+    let (provider, recorder) = Recorder::builder(service_name.to_string()).build();
+
+    match metrics::set_global_recorder(recorder.clone()) {
+        Ok(_) => {
+            global::set_meter_provider(provider.clone());
+            set_global_metrics_recorder(recorder);
+            Some(provider)
+        }
+        Err(err) => {
+            tracing::warn!("Failed to install local metrics recorder: {}", err);
+            None
+        }
+    }
 }
 
 // ─── Directory permissions (Unix) ─────────────────────────────────────────────

--- a/crates/obs/src/telemetry/otel.rs
+++ b/crates/obs/src/telemetry/otel.rs
@@ -38,7 +38,7 @@
 
 use crate::cleaner::types::FileMatchMode;
 use crate::config::OtelConfig;
-use crate::global::set_observability_metric_enabled;
+use crate::global::{set_global_metrics_recorder, set_observability_metric_enabled};
 use crate::telemetry::filter::build_env_filter;
 use crate::telemetry::guard::OtelGuard;
 use crate::telemetry::local::spawn_cleanup_task;
@@ -443,7 +443,8 @@ fn build_meter_provider(
         .build();
 
     global::set_meter_provider(provider.clone());
-    metrics::set_global_recorder(recorder).map_err(|e| TelemetryError::InstallMetricsRecorder(e.to_string()))?;
+    metrics::set_global_recorder(recorder.clone()).map_err(|e| TelemetryError::InstallMetricsRecorder(e.to_string()))?;
+    set_global_metrics_recorder(recorder);
     set_observability_metric_enabled(true);
     Ok(Some(provider))
 }

--- a/crates/obs/src/telemetry/recorder.rs
+++ b/crates/obs/src/telemetry/recorder.rs
@@ -125,6 +125,7 @@ pub struct Recorder {
     cached_counters: Arc<RwLock<HashMap<Key, Counter>>>,
     cached_gauges: Arc<RwLock<HashMap<Key, Gauge>>>,
     cached_histograms: Arc<RwLock<HashMap<Key, Histogram>>>,
+    metric_snapshots: Arc<RwLock<HashMap<Key, MetricSnapshot>>>,
 }
 
 impl Recorder {
@@ -144,6 +145,7 @@ impl Recorder {
             cached_counters: Default::default(),
             cached_gauges: Default::default(),
             cached_histograms: Default::default(),
+            metric_snapshots: Default::default(),
         }
     }
 
@@ -194,6 +196,152 @@ impl Recorder {
     fn get_metadata_for_builder(&self, key_name: &str) -> Option<MetricMetadata> {
         self.with_metadata_lock(|metadata| metadata.remove(key_name))
     }
+
+    fn snapshot_write_lock(&self) -> std::sync::RwLockWriteGuard<'_, HashMap<Key, MetricSnapshot>> {
+        self.metric_snapshots.write().unwrap_or_else(|e| {
+            error!("metric_snapshots write lock poisoned: {}", e);
+            e.into_inner()
+        })
+    }
+
+    fn snapshot_read_lock(&self) -> std::sync::RwLockReadGuard<'_, HashMap<Key, MetricSnapshot>> {
+        self.metric_snapshots.read().unwrap_or_else(|e| {
+            error!("metric_snapshots read lock poisoned: {}", e);
+            e.into_inner()
+        })
+    }
+
+    fn ensure_counter_snapshot(
+        &self,
+        key: &Key,
+        value: Arc<AtomicU64>,
+        description: Option<SharedString>,
+        _unit: Option<Unit>,
+    ) {
+        let mut snapshots = self.snapshot_write_lock();
+        snapshots.entry(key.clone()).or_insert_with(|| {
+            MetricSnapshot::Counter(CounterSnapshot {
+                value,
+                description: description.as_deref().unwrap_or_default().to_string(),
+            })
+        });
+    }
+
+    fn ensure_gauge_snapshot(
+        &self,
+        key: &Key,
+        value: Arc<AtomicU64>,
+        description: Option<SharedString>,
+        _unit: Option<Unit>,
+    ) {
+        let mut snapshots = self.snapshot_write_lock();
+        snapshots.entry(key.clone()).or_insert_with(|| {
+            MetricSnapshot::Gauge(GaugeSnapshot {
+                value,
+                description: description.as_deref().unwrap_or_default().to_string(),
+            })
+        });
+    }
+
+    fn ensure_histogram_snapshot(
+        &self,
+        key: &Key,
+        count: Arc<AtomicU64>,
+        sum_bits: Arc<AtomicU64>,
+        description: Option<SharedString>,
+        _unit: Option<Unit>,
+    ) {
+        let mut snapshots = self.snapshot_write_lock();
+        snapshots.entry(key.clone()).or_insert_with(|| {
+            MetricSnapshot::Histogram(HistogramSnapshot {
+                count,
+                sum_bits,
+                description: description.as_deref().unwrap_or_default().to_string(),
+            })
+        });
+    }
+
+    pub fn render_prometheus_text(&self) -> String {
+        let snapshots = self.snapshot_read_lock();
+        let mut families: std::collections::BTreeMap<String, MetricFamily> = std::collections::BTreeMap::new();
+
+        for (key, snapshot) in snapshots.iter() {
+            let metric_name = sanitize_prometheus_metric_name(key.name());
+            let labels = format_prometheus_labels(key);
+            match snapshot {
+                MetricSnapshot::Counter(counter) => {
+                    let help = counter.description_or_name(&metric_name);
+                    let value = counter.value.load(Ordering::Relaxed);
+                    append_family_sample(
+                        &mut families,
+                        &metric_name,
+                        "counter",
+                        help.to_string(),
+                        format!("{metric_name}{labels} {value}"),
+                    );
+                }
+                MetricSnapshot::Gauge(gauge) => {
+                    let help = gauge.description_or_name(&metric_name);
+                    let value = f64::from_bits(gauge.value.load(Ordering::Relaxed));
+                    append_family_sample(
+                        &mut families,
+                        &metric_name,
+                        "gauge",
+                        help.to_string(),
+                        format!("{metric_name}{labels} {}", format_prometheus_float(value)),
+                    );
+                }
+                MetricSnapshot::Histogram(histogram) => {
+                    let help = histogram.description_or_name(&metric_name);
+                    let count = histogram.count.load(Ordering::Relaxed);
+                    let sum = f64::from_bits(histogram.sum_bits.load(Ordering::Relaxed));
+                    append_family_sample(
+                        &mut families,
+                        &metric_name,
+                        "histogram",
+                        help.to_string(),
+                        format!(
+                            "{metric_name}_bucket{} {}",
+                            labels_with_extra(&labels, "le", "+Inf"),
+                            count
+                        ),
+                    );
+                    append_family_sample(
+                        &mut families,
+                        &metric_name,
+                        "histogram",
+                        help.to_string(),
+                        format!("{metric_name}_sum{labels} {}", format_prometheus_float(sum)),
+                    );
+                    append_family_sample(
+                        &mut families,
+                        &metric_name,
+                        "histogram",
+                        help.to_string(),
+                        format!("{metric_name}_count{labels} {count}"),
+                    );
+                }
+            }
+        }
+
+        if families.is_empty() {
+            return String::new();
+        }
+
+        let mut lines = Vec::new();
+        for (metric_name, family) in families {
+            lines.push(format!("# HELP {metric_name} {}", escape_prometheus_help(&family.help)));
+            lines.push(format!("# TYPE {metric_name} {}", family.metric_type));
+            lines.extend(family.samples);
+        }
+
+        lines.push(String::new());
+        lines.join("\n")
+    }
+
+    pub fn metric_count(&self) -> usize {
+        self.snapshot_read_lock().len()
+    }
 }
 
 impl Deref for Recorder {
@@ -224,6 +372,8 @@ impl metrics::Recorder for Recorder {
 
         let builder = self.meter.u64_counter(key.name().to_owned());
         let metadata = self.get_metadata_for_builder(key.name());
+        let meta_description = metadata.as_ref().map(|m| m.description.clone());
+        let meta_unit = metadata.as_ref().and_then(|m| m.unit.clone());
         let builder = configure_builder!(builder, metadata);
 
         let counter = builder.build();
@@ -232,12 +382,14 @@ impl metrics::Recorder for Recorder {
             .map(|label| KeyValue::new(label.key().to_owned(), label.value().to_owned()))
             .collect();
 
+        let value = Arc::new(AtomicU64::new(0));
         let handle = Counter::from_arc(Arc::new(WrappedCounter {
             counter,
             labels,
-            value: AtomicU64::new(0),
+            value: Arc::clone(&value),
         }));
 
+        self.ensure_counter_snapshot(key, value, meta_description, meta_unit);
         Self::insert_cached_metric(&self.cached_counters, key.clone(), handle, "counter")
     }
 
@@ -248,6 +400,8 @@ impl metrics::Recorder for Recorder {
 
         let builder = self.meter.f64_gauge(key.name().to_owned());
         let metadata = self.get_metadata_for_builder(key.name());
+        let meta_description = metadata.as_ref().map(|m| m.description.clone());
+        let meta_unit = metadata.as_ref().and_then(|m| m.unit.clone());
         let builder = configure_builder!(builder, metadata);
 
         let gauge = builder.build();
@@ -256,12 +410,14 @@ impl metrics::Recorder for Recorder {
             .map(|label| KeyValue::new(label.key().to_owned(), label.value().to_owned()))
             .collect();
 
+        let value = Arc::new(AtomicU64::new(0));
         let handle = Gauge::from_arc(Arc::new(WrappedGauge {
             gauge,
             labels,
-            value: AtomicU64::new(0),
+            value: Arc::clone(&value),
         }));
 
+        self.ensure_gauge_snapshot(key, value, meta_description, meta_unit);
         Self::insert_cached_metric(&self.cached_gauges, key.clone(), handle, "gauge")
     }
 
@@ -272,6 +428,8 @@ impl metrics::Recorder for Recorder {
 
         let builder = self.meter.f64_histogram(key.name().to_owned());
         let metadata = self.get_metadata_for_builder(key.name());
+        let meta_description = metadata.as_ref().map(|m| m.description.clone());
+        let meta_unit = metadata.as_ref().and_then(|m| m.unit.clone());
         let builder = configure_builder!(builder, metadata);
 
         let histogram = builder.build();
@@ -280,8 +438,16 @@ impl metrics::Recorder for Recorder {
             .map(|label| KeyValue::new(label.key().to_owned(), label.value().to_owned()))
             .collect();
 
-        let handle = Histogram::from_arc(Arc::new(WrappedHistogram { histogram, labels }));
+        let count = Arc::new(AtomicU64::new(0));
+        let sum_bits = Arc::new(AtomicU64::new(0f64.to_bits()));
+        let handle = Histogram::from_arc(Arc::new(WrappedHistogram {
+            histogram,
+            labels,
+            count: Arc::clone(&count),
+            sum_bits: Arc::clone(&sum_bits),
+        }));
 
+        self.ensure_histogram_snapshot(key, count, sum_bits, meta_description, meta_unit);
         Self::insert_cached_metric(&self.cached_histograms, key.clone(), handle, "histogram")
     }
 }
@@ -289,7 +455,7 @@ impl metrics::Recorder for Recorder {
 struct WrappedCounter {
     counter: opentelemetry::metrics::Counter<u64>,
     labels: Vec<KeyValue>,
-    value: AtomicU64,
+    value: Arc<AtomicU64>,
 }
 
 impl CounterFn for WrappedCounter {
@@ -308,7 +474,7 @@ impl CounterFn for WrappedCounter {
 struct WrappedGauge {
     gauge: opentelemetry::metrics::Gauge<f64>,
     labels: Vec<KeyValue>,
-    value: AtomicU64,
+    value: Arc<AtomicU64>,
 }
 
 impl GaugeFn for WrappedGauge {
@@ -349,17 +515,224 @@ impl GaugeFn for WrappedGauge {
 struct WrappedHistogram {
     histogram: opentelemetry::metrics::Histogram<f64>,
     labels: Vec<KeyValue>,
+    count: Arc<AtomicU64>,
+    sum_bits: Arc<AtomicU64>,
 }
 
 impl HistogramFn for WrappedHistogram {
     fn record(&self, value: f64) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        let mut current = self.sum_bits.load(Ordering::Relaxed);
+        loop {
+            let next = f64::from_bits(current) + value;
+            match self
+                .sum_bits
+                .compare_exchange(current, next.to_bits(), Ordering::AcqRel, Ordering::Relaxed)
+            {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
         self.histogram.record(value, &self.labels);
     }
 
     fn record_many(&self, value: f64, count: usize) {
+        let count = count as u64;
+        self.count.fetch_add(count, Ordering::Relaxed);
+        let increment = value * count as f64;
+        let mut current = self.sum_bits.load(Ordering::Relaxed);
+        loop {
+            let next = f64::from_bits(current) + increment;
+            match self
+                .sum_bits
+                .compare_exchange(current, next.to_bits(), Ordering::AcqRel, Ordering::Relaxed)
+            {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+
         for _ in 0..count {
             self.histogram.record(value, &self.labels);
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MetricSnapshot {
+    Counter(CounterSnapshot),
+    Gauge(GaugeSnapshot),
+    Histogram(HistogramSnapshot),
+}
+
+#[derive(Debug, Clone)]
+struct MetricFamily {
+    metric_type: &'static str,
+    help: String,
+    samples: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CounterSnapshot {
+    value: Arc<AtomicU64>,
+    description: String,
+}
+
+impl CounterSnapshot {
+    fn description_or_name<'a>(&'a self, metric_name: &'a str) -> &'a str {
+        if self.description.is_empty() { metric_name } else { &self.description }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GaugeSnapshot {
+    value: Arc<AtomicU64>,
+    description: String,
+}
+
+impl GaugeSnapshot {
+    fn description_or_name<'a>(&'a self, metric_name: &'a str) -> &'a str {
+        if self.description.is_empty() { metric_name } else { &self.description }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HistogramSnapshot {
+    count: Arc<AtomicU64>,
+    sum_bits: Arc<AtomicU64>,
+    description: String,
+}
+
+impl HistogramSnapshot {
+    fn description_or_name<'a>(&'a self, metric_name: &'a str) -> &'a str {
+        if self.description.is_empty() { metric_name } else { &self.description }
+    }
+}
+
+fn append_family_sample(
+    families: &mut std::collections::BTreeMap<String, MetricFamily>,
+    metric_name: &str,
+    metric_type: &'static str,
+    help: String,
+    sample: String,
+) {
+    use std::collections::btree_map::Entry;
+
+    match families.entry(metric_name.to_string()) {
+        Entry::Vacant(v) => {
+            v.insert(MetricFamily {
+                metric_type,
+                help,
+                samples: vec![sample],
+            });
+        }
+        Entry::Occupied(mut o) => {
+            let family = o.get_mut();
+            if family.metric_type != metric_type {
+                error!(
+                    metric_name,
+                    existing_type = family.metric_type,
+                    requested_type = metric_type,
+                    "conflicting metric type for prometheus family; dropping sample"
+                );
+                return;
+            }
+
+            if family.help.is_empty() && !help.is_empty() {
+                family.help = help;
+            }
+            family.samples.push(sample);
+        }
+    }
+}
+
+fn sanitize_prometheus_metric_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for (idx, ch) in name.chars().enumerate() {
+        let valid = ch.is_ascii_alphanumeric() || ch == '_';
+        let first_valid = ch.is_ascii_alphabetic() || ch == '_';
+        if (idx == 0 && !first_valid) || !valid {
+            out.push('_');
+        } else {
+            out.push(ch);
+        }
+    }
+    if out.is_empty() {
+        out.push('_');
+    }
+    out
+}
+
+fn format_prometheus_labels(key: &Key) -> String {
+    let mut labels = Vec::new();
+    for label in key.labels() {
+        labels.push(format!(
+            "{}=\"{}\"",
+            sanitize_prometheus_label_name(label.key()),
+            escape_prometheus_label_value(label.value())
+        ));
+    }
+
+    if labels.is_empty() {
+        String::new()
+    } else {
+        format!("{{{}}}", labels.join(","))
+    }
+}
+
+fn labels_with_extra(labels: &str, key: &str, value: &str) -> String {
+    if labels.is_empty() {
+        format!("{{{}=\"{}\"}}", sanitize_prometheus_label_name(key), escape_prometheus_label_value(value))
+    } else {
+        let inner = labels.strip_prefix('{').and_then(|s| s.strip_suffix('}')).unwrap_or(labels);
+        format!(
+            "{{{},{}=\"{}\"}}",
+            inner,
+            sanitize_prometheus_label_name(key),
+            escape_prometheus_label_value(value)
+        )
+    }
+}
+
+fn sanitize_prometheus_label_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for (idx, ch) in name.chars().enumerate() {
+        let valid = ch.is_ascii_alphanumeric() || ch == '_';
+        let first_valid = ch.is_ascii_alphabetic() || ch == '_';
+        if (idx == 0 && !first_valid) || !valid {
+            out.push('_');
+        } else {
+            out.push(ch);
+        }
+    }
+    if out.is_empty() {
+        out.push('_');
+    }
+    out
+}
+
+fn escape_prometheus_help(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('\n', "\\n")
+}
+
+fn escape_prometheus_label_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+fn format_prometheus_float(value: f64) -> String {
+    if value.is_nan() {
+        "NaN".to_string()
+    } else if value.is_infinite() {
+        if value.is_sign_negative() {
+            "-Inf".to_string()
+        } else {
+            "+Inf".to_string()
+        }
+    } else {
+        value.to_string()
     }
 }
 
@@ -468,5 +841,38 @@ mod tests {
 
         let cache = shared.cached_counters.read().unwrap();
         assert_eq!(cache.len(), 1, "concurrent registrations should produce exactly one cache entry");
+    }
+
+    #[test]
+    fn render_prometheus_text_includes_counter_gauge_and_histogram_samples() {
+        let recorder = test_recorder();
+        let meta = test_metadata();
+
+        let counter_key = Key::from_name("requests_total");
+        let counter = recorder.register_counter(&counter_key, &meta);
+        counter.increment(3);
+
+        let gauge_key = Key::from_name("queue_depth");
+        let gauge = recorder.register_gauge(&gauge_key, &meta);
+        gauge.set(7.5);
+
+        let histogram_key = Key::from_name("request_latency_seconds");
+        let histogram = recorder.register_histogram(&histogram_key, &meta);
+        histogram.record(0.5);
+        histogram.record_many(1.0, 2);
+
+        let text = recorder.render_prometheus_text();
+
+        assert!(text.contains("# TYPE requests_total counter"));
+        assert!(text.contains("requests_total 3"));
+
+        assert!(text.contains("# TYPE queue_depth gauge"));
+        assert!(text.contains("queue_depth 7.5"));
+
+        assert!(text.contains("# TYPE request_latency_seconds histogram"));
+        assert!(text.contains("request_latency_seconds_bucket{le=\"+Inf\"} 3"));
+        assert!(text.contains("request_latency_seconds_sum 2.5"));
+        assert!(text.contains("request_latency_seconds_count 3"));
+        assert_eq!(text.matches("# TYPE request_latency_seconds histogram").count(), 1);
     }
 }

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -715,7 +715,7 @@ fn process_connection(
         // 17. RedirectLayer                          — console redirect (conditional)
         // 18. BodylessStatusFixLayer                 — clears body for 1xx/204/205/304 responses
         // 19. HeadRequestBodyFixLayer                — strips actual body bytes from HEAD responses
-        // 20. PublicHealthEndpointLayer              — handles public health before s3s host parsing
+        // 20. PublicHealthEndpointLayer              — handles public health/metrics before s3s host parsing
         // ─────────────────────────────────────────────────────────────
         let hybrid_service = ServiceBuilder::new()
             // NOTE: Both extension types are intentionally inserted to maintain compatibility:
@@ -902,9 +902,9 @@ fn process_connection(
             // HEAD responses must not send body bytes even when the inner S3 layer
             // serializes an XML error payload.
             .layer(HeadRequestBodyFixLayer)
-            // Health probes are public admin routes, but s3s parses virtual-host
+            // Health probes and /metrics are public routes, but s3s parses virtual-host
             // buckets before custom routes. Handle them here so SERVER_DOMAINS
-            // cannot turn /health into an S3 bucket request.
+            // cannot turn these probe paths into S3 bucket requests.
             .layer(PublicHealthEndpointLayer)
             .service(service);
 

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -18,8 +18,8 @@ use crate::error::ApiError;
 use crate::server::cors;
 use crate::server::hybrid::HybridBody;
 use crate::server::{
-    ADMIN_PREFIX, CONSOLE_PREFIX, HEALTH_PREFIX, HEALTH_READY_PATH, MINIO_ADMIN_PREFIX, MINIO_ADMIN_V3_PREFIX, RPC_PREFIX,
-    RUSTFS_ADMIN_PREFIX,
+    ADMIN_PREFIX, CONSOLE_PREFIX, HEALTH_PREFIX, HEALTH_READY_PATH, METRICS_PATH, MINIO_ADMIN_PREFIX, MINIO_ADMIN_V3_PREFIX,
+    PROFILE_CPU_PATH, PROFILE_MEMORY_PATH, RPC_PREFIX, RUSTFS_ADMIN_PREFIX,
 };
 use crate::storage::apply_cors_headers;
 use crate::storage::request_context::{RequestContext, extract_request_id_from_headers};
@@ -631,6 +631,32 @@ fn is_public_health_endpoint_request(method: &Method, path: &str) -> bool {
         && health_endpoint_enabled()
 }
 
+fn is_public_metrics_endpoint_request(method: &Method, path: &str) -> bool {
+    (method == Method::GET || method == Method::HEAD) && path == METRICS_PATH
+}
+
+fn build_public_metrics_http_response<RestBody, GrpcBody>(method: Method) -> Response<HybridBody<RestBody, GrpcBody>>
+where
+    RestBody: From<Bytes>,
+{
+    let body = if method == Method::HEAD {
+        Bytes::new()
+    } else {
+        let metrics = rustfs_obs::get_global_metrics_recorder()
+            .map(|recorder| recorder.render_prometheus_text())
+            .unwrap_or_default();
+        Bytes::from(metrics)
+    };
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")
+        .body(HybridBody::Rest {
+            rest_body: RestBody::from(body),
+        })
+        .expect("failed to build metrics response")
+}
+
 async fn build_public_health_http_response<RestBody, GrpcBody>(
     method: Method,
     path: String,
@@ -681,6 +707,11 @@ where
             let method = method.clone();
             let path = path.to_owned();
             return Box::pin(async move { Ok(build_public_health_http_response(method, path).await) });
+        }
+
+        if is_public_metrics_endpoint_request(method, path) {
+            let method = method.clone();
+            return Box::pin(async move { Ok(build_public_metrics_http_response(method)) });
         }
 
         let mut inner = self.inner.clone();
@@ -818,7 +849,8 @@ impl ConditionalCorsLayer {
     }
 
     /// Exact paths that should be excluded from being treated as S3 paths.
-    const EXCLUDED_EXACT_PATHS: &'static [&'static str] = &["/health", "/health/ready", "/profile/cpu", "/profile/memory"];
+    const EXCLUDED_EXACT_PATHS: &'static [&'static str] =
+        &[HEALTH_PREFIX, HEALTH_READY_PATH, METRICS_PATH, PROFILE_CPU_PATH, PROFILE_MEMORY_PATH];
 
     fn is_s3_path(path: &str) -> bool {
         // Exclude Admin, Console, RPC, and configured special paths
@@ -1253,6 +1285,57 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
+    #[tokio::test]
+    async fn public_health_endpoint_layer_handles_metrics_before_inner_service() {
+        let inner = CountingHybridService::default();
+        let calls = inner.calls();
+        let mut service = PublicHealthEndpointLayer.layer(inner);
+
+        let response = service
+            .call(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(METRICS_PATH)
+                    .body(Full::<Bytes>::from(Bytes::new()))
+                    .expect("request"),
+            )
+            .await
+            .expect("metrics response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/plain; version=0.0.4; charset=utf-8")
+        );
+    }
+
+    #[tokio::test]
+    async fn public_health_endpoint_layer_handles_metrics_head_before_inner_service() {
+        let inner = CountingHybridService::default();
+        let calls = inner.calls();
+        let mut service = PublicHealthEndpointLayer.layer(inner);
+
+        let response = service
+            .call(
+                Request::builder()
+                    .method(Method::HEAD)
+                    .uri(METRICS_PATH)
+                    .body(Full::<Bytes>::from(Bytes::new()))
+                    .expect("request"),
+            )
+            .await
+            .expect("metrics response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        let body = BodyExt::collect(response.into_body()).await.expect("body").to_bytes();
+        assert!(body.is_empty());
+    }
+
     #[test]
     fn admin_chunked_put_without_content_length_is_normalized() {
         let request = Request::builder()
@@ -1605,6 +1688,7 @@ mod tests {
         assert!(!ConditionalCorsLayer::is_s3_path("/minio/admin/v3/info"));
         assert!(!ConditionalCorsLayer::is_s3_path("/health"));
         assert!(!ConditionalCorsLayer::is_s3_path("/health/ready"));
+        assert!(!ConditionalCorsLayer::is_s3_path("/metrics"));
     }
 
     #[test]

--- a/rustfs/src/server/mod.rs
+++ b/rustfs/src/server/mod.rs
@@ -45,7 +45,7 @@ pub(crate) use module_switch::{
     refresh_persisted_module_switches_from_store, save_persisted_module_switches_to_store, validate_module_switch_update,
 };
 pub(crate) use prefix::{
-    ADMIN_PREFIX, CONSOLE_PREFIX, FAVICON_PATH, HEALTH_PREFIX, HEALTH_READY_PATH, LICENSE, MINIO_ADMIN_PREFIX,
+    ADMIN_PREFIX, CONSOLE_PREFIX, FAVICON_PATH, HEALTH_PREFIX, HEALTH_READY_PATH, LICENSE, METRICS_PATH, MINIO_ADMIN_PREFIX,
     MINIO_ADMIN_V3_PREFIX, PROFILE_CPU_PATH, PROFILE_MEMORY_PATH, RPC_PREFIX, RUSTFS_ADMIN_PREFIX, TONIC_PREFIX, VERSION,
 };
 pub(crate) use readiness::ReadinessGateLayer;

--- a/rustfs/src/server/prefix.rs
+++ b/rustfs/src/server/prefix.rs
@@ -31,6 +31,9 @@ pub(crate) const HEALTH_PREFIX: &str = "/health";
 /// This path is used to check dependency readiness and may return 503.
 pub(crate) const HEALTH_READY_PATH: &str = "/health/ready";
 
+/// Predefined Prometheus metrics exposition path for RustFS server.
+pub(crate) const METRICS_PATH: &str = "/metrics";
+
 /// Predefined administrative prefix for RustFS server routes.
 /// This prefix is used for endpoints that handle administrative tasks
 /// such as configuration, monitoring, and management.


### PR DESCRIPTION
## Related Issues

  N/A

  ## Summary of Changes

  - Added a public Prometheus metrics HTTP endpoint at GET /metrics and HEAD /metrics in the server middleware path before S3 routing.
  - Implemented Prometheus text rendering from the existing in-process metrics recorder, including counter, gauge, and histogram samples.
  - Registered and exposed a global metrics recorder accessor so the HTTP layer can export current metrics snapshots.
  - Wired local and OTLP telemetry initialization to store the recorder globally when metrics recording is enabled.
  - Updated server path constants and middleware behavior so /metrics is treated as a public observability endpoint and excluded from S3 path classification/
    CORS bucket logic.
  - Added focused unit/integration-style tests for /metrics middleware interception and Prometheus text rendering.

  ## Verification

  - cargo test -p rustfs-obs render_prometheus_text_includes_counter_gauge_and_histogram_samples (blocked: local toolchain too old for workspace resolver 3)
  - cargo test -p rustfs public_health_endpoint_layer_handles_metrics (blocked: local toolchain too old for workspace resolver 3)
  - cargo fmt --all --check (not run for same toolchain constraint)
  - make pre-commit (not run for same toolchain constraint)

  ## Impact

  - User-facing: Adds a new public endpoint: /metrics for Prometheus scraping.
  - Compatibility: No breaking API changes to existing S3/admin endpoints; middleware now intercepts /metrics similarly to existing health/profiling public
    endpoints.
  - Deployment/ops: Prometheus can scrape RustFS directly without adding a separate exporter process.
  - Configuration: Works with existing observability initialization paths (local and OTLP-backed metrics recorder setup).

  ## Additional Notes

  - Commit created locally: ea59ead8 (feat(obs): add prometheus metrics endpoint exporter).
  - Push was not completed in this environment due to DNS/network restriction (Could not resolve host: github.com).
