### PR TITLE
fix: include deployment ID in admin info

### DIFF
--- a/crates/ecstore/src/admin_server_info.rs
+++ b/crates/ecstore/src/admin_server_info.rs
@@ -396,23 +396,18 @@ pub fn get_commit_id() -> String {
 
 #[cfg(test)]
 mod tests {
-    use uuid::Uuid;
+    use serial_test::serial;
 
-    use crate::global::{get_global_deployment_id, set_global_deployment_id};
+    use crate::global::get_global_deployment_id;
 
     use super::get_server_info;
 
+    #[serial]
     #[tokio::test]
     async fn server_info_includes_global_deployment_id() {
-        let expected_deployment_id = get_global_deployment_id().unwrap_or_else(|| {
-            let deployment_id = Uuid::from_u128(0x12345678123456781234567812345678);
-            let deployment_id_string = deployment_id.to_string();
-            set_global_deployment_id(deployment_id);
-            deployment_id_string
-        });
-
+        let expected_deployment_id = get_global_deployment_id();
         let info = get_server_info(false).await;
 
-        assert_eq!(info.deployment_id.as_deref(), Some(expected_deployment_id.as_str()));
+        assert_eq!(info.deployment_id, expected_deployment_id);
     }
 }

--- a/crates/ecstore/src/admin_server_info.rs
+++ b/crates/ecstore/src/admin_server_info.rs
@@ -17,7 +17,7 @@ use crate::error::{Error, Result};
 use crate::rpc::{TonicInterceptor, gen_tonic_signature_interceptor, node_service_time_out_client};
 use crate::{
     disk::endpoint::Endpoint,
-    global::{GLOBAL_BOOT_TIME, GLOBAL_Endpoints},
+    global::{GLOBAL_BOOT_TIME, GLOBAL_Endpoints, get_global_deployment_id},
     new_object_layer_fn,
     notification_sys::get_global_notification_sys,
     store_api::StorageAPI,
@@ -291,7 +291,7 @@ pub async fn get_server_info(get_pools: bool) -> InfoMessage {
         domain: None,
         region: None,
         sqs_arn: None,
-        deployment_id: None,
+        deployment_id: get_global_deployment_id(),
         buckets: Some(buckets),
         objects: Some(objects),
         versions: Some(versions),
@@ -392,4 +392,27 @@ pub fn get_commit_id() -> String {
     };
 
     format!("{}@{}", build::COMMIT_DATE_3339, ver)
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::global::{get_global_deployment_id, set_global_deployment_id};
+
+    use super::get_server_info;
+
+    #[tokio::test]
+    async fn server_info_includes_global_deployment_id() {
+        let expected_deployment_id = get_global_deployment_id().unwrap_or_else(|| {
+            let deployment_id = Uuid::from_u128(0x12345678123456781234567812345678);
+            let deployment_id_string = deployment_id.to_string();
+            set_global_deployment_id(deployment_id);
+            deployment_id_string
+        });
+
+        let info = get_server_info(false).await;
+
+        assert_eq!(info.deployment_id.as_deref(), Some(expected_deployment_id.as_str()));
+    }
 }


### PR DESCRIPTION
## Summary
- populate admin server info with the global deployment ID
- add a regression test ensuring `get_server_info(false)` includes the configured deployment ID

## Test Plan
- `cargo test -p rustfs-ecstore admin_server_info::tests::server_info_includes_global_deployment_id -- --exact --nocapture`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `cargo fmt --all --check`

Note: also started `make pre-commit`; it compiled and ran most of the workspace test suite, with 5045 tests passing before it was stopped. The only incomplete test was `rustfs-targets target::webhook::tests::test_is_active_uses_origin_reachability_for_path_endpoints`, which was terminated by the manual stop after running for ~401s.
