### PR TITLE
fix(heal): restore single disk data during deep heal

### DIFF
--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -70,7 +70,7 @@ fn ensure_non_empty_listing_disks(bucket: &str, path: &str, disks: &[DiskStore])
 fn walk_result_from_set_errors(errs: &[Option<Error>]) -> Result<()> {
     if is_all_not_found(errs) {
         if is_all_volume_not_found(errs) {
-            warn!(?errs, "treating all-volume-not-found listing result as empty during walk");
+            return Err(StorageError::VolumeNotFound);
         }
 
         return Ok(());
@@ -1660,9 +1660,9 @@ mod test {
     }
 
     #[test]
-    fn walk_result_from_set_errors_treats_all_volume_not_found_as_empty_listing() {
+    fn walk_result_from_set_errors_returns_volume_not_found_when_all_sets_report_missing_volume() {
         walk_result_from_set_errors(&[Some(StorageError::VolumeNotFound), Some(StorageError::VolumeNotFound)])
-            .expect("all volume-not-found set errors should be treated as an empty listing");
+            .expect_err("all volume-not-found set errors should stay fatal for generic walk callers");
     }
 
     #[test]

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -70,7 +70,7 @@ fn ensure_non_empty_listing_disks(bucket: &str, path: &str, disks: &[DiskStore])
 fn walk_result_from_set_errors(errs: &[Option<Error>]) -> Result<()> {
     if is_all_not_found(errs) {
         if is_all_volume_not_found(errs) {
-            return Err(StorageError::VolumeNotFound);
+            warn!(?errs, "treating all-volume-not-found listing result as empty during walk");
         }
 
         return Ok(());
@@ -1660,11 +1660,9 @@ mod test {
     }
 
     #[test]
-    fn walk_result_from_set_errors_preserves_volume_not_found() {
-        let err = walk_result_from_set_errors(&[Some(StorageError::VolumeNotFound), Some(StorageError::VolumeNotFound)])
-            .expect_err("all volume-not-found set errors should remain visible");
-
-        assert_eq!(err, StorageError::VolumeNotFound);
+    fn walk_result_from_set_errors_treats_all_volume_not_found_as_empty_listing() {
+        walk_result_from_set_errors(&[Some(StorageError::VolumeNotFound), Some(StorageError::VolumeNotFound)])
+            .expect("all volume-not-found set errors should be treated as an empty listing");
     }
 
     #[test]

--- a/crates/heal/src/heal/erasure_healer.rs
+++ b/crates/heal/src/heal/erasure_healer.rs
@@ -35,6 +35,7 @@ pub struct ErasureSetHealer {
     progress: Arc<RwLock<HealProgress>>,
     cancel_token: tokio_util::sync::CancellationToken,
     disk: DiskStore,
+    heal_opts: HealOpts,
 }
 
 impl ErasureSetHealer {
@@ -61,17 +62,27 @@ impl ErasureSetHealer {
         }
     }
 
+    fn effective_heal_page_object_concurrency_for_scan_mode(scan_mode: HealScanMode) -> usize {
+        if matches!(scan_mode, HealScanMode::Deep) {
+            1
+        } else {
+            Self::effective_heal_page_object_concurrency()
+        }
+    }
+
     pub fn new(
         storage: Arc<dyn HealStorageAPI>,
         progress: Arc<RwLock<HealProgress>>,
         cancel_token: tokio_util::sync::CancellationToken,
         disk: DiskStore,
+        heal_opts: HealOpts,
     ) -> Self {
         Self {
             storage,
             progress,
             cancel_token,
             disk,
+            heal_opts,
         }
     }
 
@@ -289,7 +300,7 @@ impl ErasureSetHealer {
         // 2. process objects with pagination to avoid loading all objects into memory
         let mut continuation_token: Option<String> = None;
         let mut global_obj_idx = 0usize;
-        let page_concurrency_limit = Self::effective_heal_page_object_concurrency();
+        let page_concurrency_limit = Self::effective_heal_page_object_concurrency_for_scan_mode(self.heal_opts.scan_mode);
         let in_flight = Arc::new(AtomicUsize::new(0));
 
         loop {
@@ -325,21 +336,26 @@ impl ErasureSetHealer {
                 let cancel_token = self.cancel_token.clone();
                 let in_flight = in_flight.clone();
                 let set_label = set_disk_id.to_string();
-                let permit = semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .map_err(|e| Error::other(format!("Failed to acquire page concurrency permit: {e}")))?;
-
-                let current_in_flight = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-                gauge!(
-                    "rustfs_heal_page_concurrency_current",
-                    "set" => set_label.clone()
-                )
-                .set(current_in_flight as f64);
-
+                let semaphore = semaphore.clone();
                 page_tasks.push(async move {
-                    let _permit = permit;
+                    let permit = semaphore
+                        .clone()
+                        .acquire_owned()
+                        .await
+                        .map_err(|e| Error::other(format!("Failed to acquire page concurrency permit: {e}")));
+
+                    let _permit = match permit {
+                        Ok(permit) => permit,
+                        Err(err) => return (object_name, Err(err)),
+                    };
+
+                    let current_in_flight = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    gauge!(
+                        "rustfs_heal_page_concurrency_current",
+                        "set" => set_label.clone()
+                    )
+                    .set(current_in_flight as f64);
+
                     let result = if cancel_token.is_cancelled() {
                         Err(Error::TaskCancelled)
                     } else {
@@ -375,12 +391,7 @@ impl ErasureSetHealer {
                         if !object_exists {
                             Ok(false)
                         } else {
-                            let heal_opts = HealOpts {
-                                scan_mode: HealScanMode::Normal,
-                                remove: true,
-                                recreate: true,
-                                ..Default::default()
-                            };
+                            let heal_opts = self.heal_opts;
                             match storage.heal_object(&bucket_name, &object_name, None, &heal_opts).await {
                                 Ok((_result, None)) => Ok(true),
                                 Ok((_, Some(err))) => Err(Error::other(err)),
@@ -678,6 +689,7 @@ impl ErasureSetHealer {
 #[cfg(test)]
 mod tests {
     use super::ErasureSetHealer;
+    use rustfs_common::heal_channel::HealScanMode;
 
     #[test]
     fn heal_page_object_concurrency_uses_default_when_env_is_unset() {
@@ -702,6 +714,26 @@ mod tests {
             temp_env::with_var(rustfs_config::ENV_HEAL_PAGE_OBJECT_CONCURRENCY, Some("11"), || {
                 assert_eq!(ErasureSetHealer::effective_heal_page_object_concurrency(), 1);
             });
+        });
+    }
+
+    #[test]
+    fn deep_scan_heal_page_object_concurrency_is_serial() {
+        temp_env::with_var(rustfs_config::ENV_HEAL_PAGE_OBJECT_CONCURRENCY, Some("11"), || {
+            assert_eq!(
+                ErasureSetHealer::effective_heal_page_object_concurrency_for_scan_mode(HealScanMode::Deep),
+                1
+            );
+        });
+    }
+
+    #[test]
+    fn normal_scan_heal_page_object_concurrency_uses_effective_limit() {
+        temp_env::with_var(rustfs_config::ENV_HEAL_PAGE_OBJECT_CONCURRENCY, Some("11"), || {
+            assert_eq!(
+                ErasureSetHealer::effective_heal_page_object_concurrency_for_scan_mode(HealScanMode::Normal),
+                11
+            );
         });
     }
 }

--- a/crates/heal/src/heal/erasure_healer.rs
+++ b/crates/heal/src/heal/erasure_healer.rs
@@ -70,6 +70,10 @@ impl ErasureSetHealer {
         }
     }
 
+    fn is_object_not_found_message(message: &str) -> bool {
+        message.contains("File not found") || message.contains("not found")
+    }
+
     pub fn new(
         storage: Arc<dyn HealStorageAPI>,
         progress: Arc<RwLock<HealProgress>>,
@@ -358,6 +362,27 @@ impl ErasureSetHealer {
 
                     let result = if cancel_token.is_cancelled() {
                         Err(Error::TaskCancelled)
+                    } else if matches!(self.heal_opts.scan_mode, HealScanMode::Deep) {
+                        let heal_opts = self.heal_opts;
+                        match storage.heal_object(&bucket_name, &object_name, None, &heal_opts).await {
+                            Ok((_result, None)) => Ok(true),
+                            Ok((_, Some(err))) => {
+                                let err_msg = err.to_string();
+                                if Self::is_object_not_found_message(&err_msg) {
+                                    Ok(false)
+                                } else {
+                                    Err(Error::other(err))
+                                }
+                            }
+                            Err(err) => {
+                                let err_msg = err.to_string();
+                                if Self::is_object_not_found_message(&err_msg) {
+                                    Ok(false)
+                                } else {
+                                    Err(err)
+                                }
+                            }
+                        }
                     } else {
                         let object_exists = match storage.object_exists(&bucket_name, &object_name).await {
                             Ok(exists) => exists,

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -659,7 +659,11 @@ impl HealTask {
         let heal_opts = HealOpts {
             recursive: self.options.recursive,
             dry_run: self.options.dry_run,
-            remove: self.options.remove_corrupted,
+            remove: if self.options.recursive {
+                false
+            } else {
+                self.options.remove_corrupted
+            },
             recreate: self.options.recreate_missing,
             scan_mode: self.options.scan_mode,
             update_parity: self.options.update_parity,
@@ -1141,9 +1145,22 @@ impl HealTask {
             }
         }
 
+        let heal_opts = HealOpts {
+            recursive: true,
+            dry_run: self.options.dry_run,
+            remove: self.options.remove_corrupted,
+            recreate: self.options.recreate_missing,
+            scan_mode: self.options.scan_mode,
+            update_parity: self.options.update_parity,
+            no_lock: false,
+            pool: self.options.pool_index,
+            set: self.options.set_index,
+        };
+
         // Step 3: Create erasure set healer with resume support
         info!("Step 3: Creating erasure set healer with resume support");
-        let erasure_healer = ErasureSetHealer::new(self.storage.clone(), self.progress.clone(), self.cancel_token.clone(), disk);
+        let erasure_healer =
+            ErasureSetHealer::new(self.storage.clone(), self.progress.clone(), self.cancel_token.clone(), disk, heal_opts);
 
         {
             let mut progress = self.progress.write().await;
@@ -1202,6 +1219,8 @@ mod tests {
     struct MockStorage {
         listed: Mutex<bool>,
         healed_objects: Mutex<Vec<String>>,
+        bucket_heal_opts: Mutex<Vec<HealOpts>>,
+        object_heal_opts: Mutex<Vec<HealOpts>>,
     }
 
     #[async_trait::async_trait]
@@ -1270,9 +1289,10 @@ mod tests {
             _bucket: &str,
             object: &str,
             _version_id: Option<&str>,
-            _opts: &HealOpts,
+            opts: &HealOpts,
         ) -> Result<(HealResultItem, Option<Error>)> {
             self.healed_objects.lock().unwrap().push(object.to_string());
+            self.object_heal_opts.lock().unwrap().push(*opts);
             Ok((
                 HealResultItem {
                     object_size: 1,
@@ -1282,7 +1302,8 @@ mod tests {
             ))
         }
 
-        async fn heal_bucket(&self, _bucket: &str, _opts: &HealOpts) -> Result<HealResultItem> {
+        async fn heal_bucket(&self, _bucket: &str, opts: &HealOpts) -> Result<HealResultItem> {
+            self.bucket_heal_opts.lock().unwrap().push(*opts);
             Ok(HealResultItem::default())
         }
 
@@ -1344,5 +1365,41 @@ mod tests {
         let result_items = task.get_result_items().await;
         assert_eq!(result_items.len(), 3);
         assert_eq!(result_items.iter().filter(|item| item.object_size == 1).count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_recursive_bucket_heal_does_not_remove_bucket_metadata() {
+        let storage = Arc::new(MockStorage::default());
+        let request = HealRequest::new(
+            HealType::Bucket {
+                bucket: "bucket-a".to_string(),
+            },
+            HealOptions {
+                recursive: true,
+                remove_corrupted: true,
+                recreate_missing: true,
+                scan_mode: HealScanMode::Deep,
+                timeout: None,
+                ..Default::default()
+            },
+            HealPriority::Normal,
+        );
+        let task = HealTask::from_request(request, storage.clone());
+
+        task.heal_bucket("bucket-a")
+            .await
+            .expect("recursive bucket heal should succeed");
+
+        let bucket_opts = storage.bucket_heal_opts.lock().unwrap();
+        assert_eq!(bucket_opts.len(), 1);
+        assert!(!bucket_opts[0].remove);
+        assert!(bucket_opts[0].recreate);
+        assert_eq!(bucket_opts[0].scan_mode, HealScanMode::Deep);
+
+        let object_opts = storage.object_heal_opts.lock().unwrap();
+        assert_eq!(object_opts.len(), 2);
+        assert!(object_opts.iter().all(|opts| opts.remove));
+        assert!(object_opts.iter().all(|opts| opts.recreate));
+        assert!(object_opts.iter().all(|opts| opts.scan_mode == HealScanMode::Deep));
     }
 }

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -1157,8 +1157,8 @@ impl HealTask {
             set: self.options.set_index,
         };
 
-        // Step 3: Create erasure set healer with resume support
-        info!("Step 3: Creating erasure set healer with resume support");
+        // Create erasure set healer with resume support
+        info!("Creating erasure set healer with resume support");
         let erasure_healer =
             ErasureSetHealer::new(self.storage.clone(), self.progress.clone(), self.cancel_token.clone(), disk, heal_opts);
 

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -1131,17 +1131,35 @@ impl HealTask {
 
         // Step 3: Heal bucket structure
         // Check control flags before each iteration to ensure timely cancellation.
-        // Each heal_bucket call may handle timeout/cancellation internally, see its implementation for details.
+        let bucket_heal_opts = HealOpts {
+            recursive: false,
+            dry_run: self.options.dry_run,
+            remove: false,
+            recreate: self.options.recreate_missing,
+            scan_mode: self.options.scan_mode,
+            update_parity: self.options.update_parity,
+            no_lock: false,
+            pool: self.options.pool_index,
+            set: self.options.set_index,
+        };
+
         for bucket in buckets.iter() {
             // Check control flags before starting each bucket heal
             self.check_control_flags().await?;
-            // heal_bucket internally uses await_with_control for timeout/cancellation handling
-            if let Err(err) = self.heal_bucket(bucket).await {
-                // Check if error is due to cancellation or timeout
-                if matches!(err, Error::TaskCancelled | Error::TaskTimeout) {
-                    return Err(err);
+            let heal_result = self
+                .await_with_control(self.storage.heal_bucket(bucket, &bucket_heal_opts))
+                .await;
+            match heal_result {
+                Ok(result) => {
+                    self.record_result_item(result).await;
                 }
-                info!("Bucket heal failed: {}", err.to_string());
+                Err(err) => {
+                    // Check if error is due to cancellation or timeout
+                    if matches!(err, Error::TaskCancelled | Error::TaskTimeout) {
+                        return Err(err);
+                    }
+                    info!("Bucket heal failed: {}", err.to_string());
+                }
             }
         }
 


### PR DESCRIPTION
  ## Related Issues

  Fixes https://github.com/orgs/rustfs/discussions/2964

  ## Summary of Changes

  Fix admin deep heal for a single-server, four-disk deployment when one disk's bucket data is cleared.

  - Treat all-volume-not-found listing results as an empty listing during object walk so heal can continue using the remaining disks.
  - Prevent recursive bucket heal from passing `remove=true` into the bucket metadata heal step, avoiding deletion of healthy source bucket data before
  object repair.
  - Keep object-level recursive bucket heal using the requested `remove`, `recreate`, and `scanMode` options.
  - Pass admin heal options into erasure-set object heal instead of hard-coding normal scan options.
  - Serialize deep erasure-set page object healing to avoid namespace write-lock contention.
  - Move page concurrency semaphore acquisition inside the queued future to avoid blocking the producer before futures can run.
  - Add focused regression coverage for listing behavior, deep scan concurrency, and recursive bucket heal option handling.

  ## Verification

  - `cargo fmt --all -- --check`
  - `RUSTFLAGS="--cfg tokio_unstable" cargo build --bin rustfs`
  - `RUSTFLAGS="--cfg tokio_unstable" cargo test -p rustfs-heal --lib recursive_bucket_heal -- --nocapture`
  - `RUSTFLAGS="--cfg tokio_unstable" cargo test -p rustfs-heal --lib erasure_healer -- --nocapture`
  - `RUSTFLAGS="--cfg tokio_unstable" cargo test -p rustfs-ecstore walk_result_from_set_errors -- --nocapture`
  - Manual reproduction: single server with four local disks, uploaded 2000 1 MiB objects, stopped server, removed one disk's bucket data, restarted without
  GET/read-repair, ran admin deep heal, verified the cleared disk restored 2000 `xl.meta` files and 2000 `part.1` files.

  ## Impact

  Admin deep heal can now restore object metadata and parts on a cleared single disk in a four-disk erasure set without relying on read-repair first.

  Deep erasure-set page object healing now prioritizes correctness by running object repairs serially for deep scans.

  ## Additional Notes

  N/A