### PR TITLE
fix: retry namespace lock quorum contention

### DIFF
--- a/crates/e2e_test/src/lib.rs
+++ b/crates/e2e_test/src/lib.rs
@@ -142,4 +142,7 @@ mod replication_extension_test;
 #[cfg(test)]
 mod snowball_auto_extract_test;
 
+#[cfg(test)]
+mod namespace_lock_quorum_test;
+
 pub mod tls_gen;

--- a/crates/e2e_test/src/namespace_lock_quorum_test.rs
+++ b/crates/e2e_test/src/namespace_lock_quorum_test.rs
@@ -1,0 +1,119 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::RustFSTestClusterEnvironment;
+use aws_sdk_s3::Client;
+use aws_sdk_s3::error::SdkError;
+use bytes::Bytes;
+use serial_test::serial;
+use std::sync::Arc;
+use tokio::sync::Barrier;
+use tracing::{info, warn};
+
+const BUCKET: &str = "namespace-lock-quorum-bucket";
+const KEY: &str = "thumb/79/concurrent-overwrite.jpg";
+
+type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+async fn put_object(client: Client, payload: Vec<u8>, writer_id: usize) -> Result<(), String> {
+    client
+        .put_object()
+        .bucket(BUCKET)
+        .key(KEY)
+        .body(Bytes::from(payload).into())
+        .send()
+        .await
+        .map(|_| ())
+        .map_err(|err| format_s3_error(err, writer_id))
+}
+
+fn format_s3_error(err: SdkError<aws_sdk_s3::operation::put_object::PutObjectError>, writer_id: usize) -> String {
+    match err {
+        SdkError::ServiceError(service_err) => {
+            let err = service_err.err();
+            let code = err.meta().code().unwrap_or("<unknown>");
+            let message = err.meta().message().unwrap_or("<empty>");
+            format!("writer {writer_id} returned service error {code}: {message}")
+        }
+        other => format!("writer {writer_id} returned SDK error: {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concurrent_cluster_overwrites_do_not_fail_namespace_lock_quorum() -> TestResult {
+    crate::common::init_logging();
+    info!("Starting namespace lock quorum regression test with auto cluster");
+
+    let mut cluster = RustFSTestClusterEnvironment::new(4).await?;
+    cluster.start().await?;
+    cluster.create_test_bucket(BUCKET).await?;
+
+    let clients = cluster.create_all_clients()?;
+    let first_payload = b"initial object contents".to_vec();
+    put_object(clients[0].clone(), first_payload, 0).await?;
+
+    let writer_count = clients.len() * 2;
+    let barrier = Arc::new(Barrier::new(writer_count));
+    let mut handles = Vec::with_capacity(writer_count);
+
+    for writer_id in 0..writer_count {
+        let client = clients[writer_id % clients.len()].clone();
+        let barrier = barrier.clone();
+        let payload = format!("replacement payload from writer {writer_id:02}").into_bytes();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            put_object(client, payload, writer_id).await
+        }));
+    }
+
+    let mut failures = Vec::new();
+    for handle in handles {
+        match handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => failures.push(err),
+            Err(err) => failures.push(format!("writer task join failed: {err}")),
+        }
+    }
+
+    if !failures.is_empty() {
+        for failure in &failures {
+            warn!("concurrent overwrite failure: {}", failure);
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "concurrent overwrites must not surface namespace lock quorum failures: {failures:#?}"
+    );
+
+    let body = clients[0]
+        .get_object()
+        .bucket(BUCKET)
+        .key(KEY)
+        .send()
+        .await?
+        .body
+        .collect()
+        .await?
+        .into_bytes();
+    let body = std::str::from_utf8(&body)?;
+    assert!(
+        body.starts_with("replacement payload from writer "),
+        "final object body should be one of the successful overwrite payloads, got {body:?}"
+    );
+
+    clients[0].delete_object().bucket(BUCKET).key(KEY).send().await.ok();
+    Ok(())
+}

--- a/crates/e2e_test/src/namespace_lock_quorum_test.rs
+++ b/crates/e2e_test/src/namespace_lock_quorum_test.rs
@@ -57,6 +57,9 @@ async fn test_concurrent_cluster_overwrites_do_not_fail_namespace_lock_quorum() 
     info!("Starting namespace lock quorum regression test with auto cluster");
 
     let mut cluster = RustFSTestClusterEnvironment::new(4).await?;
+    // Keep the regression focused on false quorum-loss errors, not ordinary lock
+    // wait exhaustion under a heavily contended same-key overwrite workload.
+    cluster.set_env("RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT", "20");
     cluster.start().await?;
     cluster.create_test_bucket(BUCKET).await?;
 

--- a/crates/e2e_test/src/namespace_lock_quorum_test.rs
+++ b/crates/e2e_test/src/namespace_lock_quorum_test.rs
@@ -117,6 +117,6 @@ async fn test_concurrent_cluster_overwrites_do_not_fail_namespace_lock_quorum() 
         "final object body should be one of the successful overwrite payloads, got {body:?}"
     );
 
-    clients[0].delete_object().bucket(BUCKET).key(KEY).send().await.ok();
+    clients[0].delete_object().bucket(BUCKET).key(KEY).send().await?;
     Ok(())
 }

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -131,7 +131,7 @@ aws-smithy-http-client.workspace = true
 metrics = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 criterion = { workspace = true, features = ["html_reports"] }
 temp-env = { workspace = true, features = ["async_closure"] }
 tracing-subscriber = { workspace = true }

--- a/crates/ecstore/src/batch_processor.rs
+++ b/crates/ecstore/src/batch_processor.rs
@@ -274,10 +274,10 @@ mod tests {
         assert!(successes.len() >= 2);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_batch_processor_quorum_returns_before_slow_tail() {
         let processor = AsyncBatchProcessor::new(4);
-        let started = std::time::Instant::now();
+        let started = tokio::time::Instant::now();
 
         let tasks: Vec<_> = [(10_u64, Ok(1_i32)), (15, Ok(2)), (250, Ok(3))]
             .into_iter()
@@ -295,10 +295,10 @@ mod tests {
         assert!(started.elapsed() < Duration::from_millis(100));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_batch_processor_quorum_fails_once_quorum_becomes_impossible() {
         let processor = AsyncBatchProcessor::new(4);
-        let started = std::time::Instant::now();
+        let started = tokio::time::Instant::now();
 
         let tasks: Vec<_> = vec![
             (10_u64, Ok(1_i32)),

--- a/crates/ecstore/src/rpc/remote_locker.rs
+++ b/crates/ecstore/src/rpc/remote_locker.rs
@@ -101,11 +101,12 @@ impl RemoteClient {
             }
             Err(_) => {
                 let reason = format!("RPC timed out after {:?}", lock_timeout);
+                self.evict_connection(op, &reason).await;
                 warn!(
                     addr = %self.addr,
                     op,
                     reason,
-                    "Remote lock RPC timed out without evicting cached connection"
+                    "Remote lock RPC timed out and evicted cached connection"
                 );
                 Err(LockError::timeout(format!("remote lock RPC {op} on {}", self.addr), lock_timeout))
             }

--- a/crates/ecstore/src/rpc/remote_locker.rs
+++ b/crates/ecstore/src/rpc/remote_locker.rs
@@ -102,12 +102,6 @@ impl RemoteClient {
             Err(_) => {
                 let reason = format!("RPC timed out after {:?}", lock_timeout);
                 self.evict_connection(op, &reason).await;
-                warn!(
-                    addr = %self.addr,
-                    op,
-                    reason,
-                    "Remote lock RPC timed out and evicted cached connection"
-                );
                 Err(LockError::timeout(format!("remote lock RPC {op} on {}", self.addr), lock_timeout))
             }
         }

--- a/crates/ecstore/src/rpc/remote_locker.rs
+++ b/crates/ecstore/src/rpc/remote_locker.rs
@@ -27,6 +27,8 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing::{info, warn};
 
+const REMOTE_LOCK_RPC_TIMEOUT_GRACE: Duration = Duration::from_millis(500);
+
 /// Remote lock client implementation
 #[derive(Debug, Clone)]
 pub struct RemoteClient {
@@ -82,6 +84,10 @@ impl RemoteClient {
         }
     }
 
+    fn rpc_deadline(timeout_duration: Duration) -> Duration {
+        Self::rpc_timeout(timeout_duration).saturating_add(REMOTE_LOCK_RPC_TIMEOUT_GRACE)
+    }
+
     async fn execute_rpc<T, F>(
         &self,
         op: &'static str,
@@ -91,8 +97,9 @@ impl RemoteClient {
     where
         F: std::future::Future<Output = std::result::Result<T, tonic::Status>>,
     {
-        let timeout_duration = Self::rpc_timeout(timeout_duration);
-        match timeout(timeout_duration, future).await {
+        let lock_timeout = Self::rpc_timeout(timeout_duration);
+        let rpc_deadline = Self::rpc_deadline(timeout_duration);
+        match timeout(rpc_deadline, future).await {
             Ok(Ok(response)) => Ok(response),
             Ok(Err(err)) => {
                 let reason = err.to_string();
@@ -100,29 +107,32 @@ impl RemoteClient {
                 Err(LockError::internal(format!("{op} RPC failed: {reason}")))
             }
             Err(_) => {
-                let reason = format!("RPC timed out after {:?}", timeout_duration);
+                let reason = format!("RPC timed out after {:?}", rpc_deadline);
                 self.evict_connection(op, &reason).await;
-                Err(LockError::timeout(format!("remote lock RPC {op} on {}", self.addr), timeout_duration))
+                Err(LockError::timeout(format!("remote lock RPC {op} on {}", self.addr), lock_timeout))
             }
         }
     }
 
-    fn timeout_failure_response(request: &LockRequest) -> LockResponse {
-        LockResponse::failure("Lock acquisition timeout", request.acquire_timeout)
+    fn rpc_timeout_failure_response(request: &LockRequest, err: &LockError) -> LockResponse {
+        LockResponse::failure(format!("Remote lock RPC timed out: {err}"), request.acquire_timeout)
     }
 
     fn rpc_failure_response(_request: &LockRequest, err: &LockError) -> LockResponse {
         LockResponse::failure(format!("Remote lock RPC failed: {err}"), Duration::ZERO)
     }
 
-    fn timeout_failure_batch(requests: &[LockRequest]) -> Vec<LockResponse> {
-        requests.iter().map(Self::timeout_failure_response).collect()
-    }
-
     fn rpc_failure_batch(requests: &[LockRequest], err: &LockError) -> Vec<LockResponse> {
         requests
             .iter()
             .map(|request| Self::rpc_failure_response(request, err))
+            .collect()
+    }
+
+    fn rpc_timeout_failure_batch(requests: &[LockRequest], err: &LockError) -> Vec<LockResponse> {
+        requests
+            .iter()
+            .map(|request| Self::rpc_timeout_failure_response(request, err))
             .collect()
     }
 
@@ -186,7 +196,7 @@ impl LockClient for RemoteClient {
 
         let resp = match self.execute_rpc("lock", request.acquire_timeout, client.lock(req)).await {
             Ok(resp) => resp.into_inner(),
-            Err(LockError::Timeout { .. }) => return Ok(Self::timeout_failure_response(request)),
+            Err(err @ LockError::Timeout { .. }) => return Ok(Self::rpc_timeout_failure_response(request, &err)),
             Err(err) => return Ok(Self::rpc_failure_response(request, &err)),
         };
 
@@ -226,7 +236,7 @@ impl LockClient for RemoteClient {
             .await
         {
             Ok(resp) => resp.into_inner(),
-            Err(LockError::Timeout { .. }) => return Ok(Self::timeout_failure_batch(requests)),
+            Err(err @ LockError::Timeout { .. }) => return Ok(Self::rpc_timeout_failure_batch(requests, &err)),
             Err(err) => return Ok(Self::rpc_failure_batch(requests, &err)),
         };
 
@@ -511,7 +521,14 @@ mod tests {
             "remote lock RPC should honor request timeout"
         );
         assert!(!response.success, "timed out lock acquisition should fail");
-        assert_eq!(response.error.as_deref(), Some("Lock acquisition timeout"));
+        assert!(
+            response
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("Remote lock RPC timed out")),
+            "expected remote RPC timeout marker, got {:?}",
+            response.error
+        );
         assert!(
             !GLOBAL_CONN_MAP.read().await.contains_key(&addr),
             "timeout should evict cached connection"
@@ -539,7 +556,14 @@ mod tests {
         );
         assert_eq!(responses.len(), 1);
         assert!(!responses[0].success, "timed out batch lock acquisition should fail");
-        assert_eq!(responses[0].error.as_deref(), Some("Lock acquisition timeout"));
+        assert!(
+            responses[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("Remote lock RPC timed out")),
+            "expected remote RPC timeout marker, got {:?}",
+            responses[0].error
+        );
         assert!(
             !GLOBAL_CONN_MAP.read().await.contains_key(&addr),
             "batch timeout should evict cached connection"

--- a/crates/ecstore/src/rpc/remote_locker.rs
+++ b/crates/ecstore/src/rpc/remote_locker.rs
@@ -27,8 +27,6 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing::{info, warn};
 
-const REMOTE_LOCK_RPC_TIMEOUT_GRACE: Duration = Duration::from_millis(500);
-
 /// Remote lock client implementation
 #[derive(Debug, Clone)]
 pub struct RemoteClient {
@@ -84,10 +82,6 @@ impl RemoteClient {
         }
     }
 
-    fn rpc_deadline(timeout_duration: Duration) -> Duration {
-        Self::rpc_timeout(timeout_duration).saturating_add(REMOTE_LOCK_RPC_TIMEOUT_GRACE)
-    }
-
     async fn execute_rpc<T, F>(
         &self,
         op: &'static str,
@@ -98,8 +92,7 @@ impl RemoteClient {
         F: std::future::Future<Output = std::result::Result<T, tonic::Status>>,
     {
         let lock_timeout = Self::rpc_timeout(timeout_duration);
-        let rpc_deadline = Self::rpc_deadline(timeout_duration);
-        match timeout(rpc_deadline, future).await {
+        match timeout(lock_timeout, future).await {
             Ok(Ok(response)) => Ok(response),
             Ok(Err(err)) => {
                 let reason = err.to_string();
@@ -107,7 +100,7 @@ impl RemoteClient {
                 Err(LockError::internal(format!("{op} RPC failed: {reason}")))
             }
             Err(_) => {
-                let reason = format!("RPC timed out after {:?}", rpc_deadline);
+                let reason = format!("RPC timed out after {:?}", lock_timeout);
                 self.evict_connection(op, &reason).await;
                 Err(LockError::timeout(format!("remote lock RPC {op} on {}", self.addr), lock_timeout))
             }

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -23,13 +23,16 @@ use rustfs_io_metrics::{
     record_read_lock_held_acquire, record_read_lock_held_release, record_write_lock_held_acquire, record_write_lock_held_release,
 };
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
 const UNLOCK_RETRY_ATTEMPTS: usize = 3;
 const UNLOCK_RETRY_BACKOFF: Duration = Duration::from_millis(100);
+const QUORUM_RETRY_BACKOFF_MIN: Duration = Duration::from_millis(5);
+const QUORUM_RETRY_BACKOFF_MAX: Duration = Duration::from_millis(50);
+const QUORUM_ATTEMPT_TIMEOUT_MAX: Duration = Duration::from_millis(250);
 
 /// Generate a new aggregate lock ID for multiple client locks
 fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
@@ -185,53 +188,88 @@ impl DistributedLock {
         }
 
         let required_quorum = self.required_quorum(request.lock_type);
-        let (resp, individual_locks) = self.acquire_lock_quorum(request).await?;
-        if resp.success {
-            // Use aggregate lock_id from LockResponse's LockInfo
-            // The aggregate id is what we expose to callers; individual_locks carries
-            // the real (LockId, client) pairs that must be released.
-            let aggregate_lock_id = resp
-                .lock_info
-                .as_ref()
-                .map(|info| info.id.clone())
-                .unwrap_or_else(|| LockId::new_unique(&request.resource));
+        let deadline = Instant::now() + request.acquire_timeout;
+        let mut attempt = 0u32;
+        let mut best_achieved = 0usize;
+        let mut last_quorum_error = false;
 
-            Ok(Some(DistributedLockGuard::new(aggregate_lock_id, individual_locks, request.lock_type)))
-        } else {
-            // Check if it's a timeout or quorum failure
-            if let Some(error_msg) = &resp.error {
-                if request.suppress_contention_logs {
-                    tracing::debug!(
-                        resource = %request.resource,
-                        owner = %request.owner,
-                        "acquire_lock_quorum contention: {}",
-                        error_msg
-                    );
-                } else {
-                    warn!(
-                        resource = %request.resource,
-                        owner = %request.owner,
-                        "acquire_lock_quorum error: {}",
-                        error_msg
-                    );
-                }
-                if error_msg.contains("quorum") {
-                    // This is a quorum failure - return appropriate error
-                    let achieved = individual_locks.len();
-                    Err(LockError::QuorumNotReached {
-                        required: required_quorum,
-                        achieved,
-                    })
-                } else if error_msg.contains("timeout") || resp.wait_time >= request.acquire_timeout {
-                    // This is a timeout - return None so caller can convert to timeout error
-                    Ok(None)
-                } else {
-                    // Other failure - return None for backward compatibility
-                    Ok(None)
-                }
-            } else {
-                Ok(None)
+        loop {
+            let mut attempt_request = request.clone();
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
             }
+            attempt_request.acquire_timeout = remaining.min(QUORUM_ATTEMPT_TIMEOUT_MAX);
+
+            let (resp, individual_locks) = self.acquire_lock_quorum(&attempt_request).await?;
+            if resp.success {
+                // Use aggregate lock_id from LockResponse's LockInfo
+                // The aggregate id is what we expose to callers; individual_locks carries
+                // the real (LockId, client) pairs that must be released.
+                let aggregate_lock_id = resp
+                    .lock_info
+                    .as_ref()
+                    .map(|info| info.id.clone())
+                    .unwrap_or_else(|| LockId::new_unique(&request.resource));
+
+                return Ok(Some(DistributedLockGuard::new(aggregate_lock_id, individual_locks, request.lock_type)));
+            }
+
+            let error_msg = resp.error.unwrap_or_default();
+            if request.suppress_contention_logs {
+                tracing::debug!(
+                    resource = %request.resource,
+                    owner = %request.owner,
+                    attempt,
+                    "acquire_lock_quorum contention: {}",
+                    error_msg
+                );
+            } else {
+                warn!(
+                    resource = %request.resource,
+                    owner = %request.owner,
+                    attempt,
+                    "acquire_lock_quorum error: {}",
+                    error_msg
+                );
+            }
+
+            let error_msg_lower = error_msg.to_lowercase();
+            if error_msg_lower.contains("unrecoverable") {
+                return Err(LockError::QuorumNotReached {
+                    required: required_quorum,
+                    achieved: individual_locks.len(),
+                });
+            }
+
+            if error_msg_lower.contains("quorum") {
+                last_quorum_error = true;
+                best_achieved = best_achieved.max(individual_locks.len());
+                attempt += 1;
+
+                let backoff = (QUORUM_RETRY_BACKOFF_MIN * attempt).min(QUORUM_RETRY_BACKOFF_MAX);
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining <= backoff {
+                    break;
+                }
+                tokio::time::sleep(backoff).await;
+                continue;
+            }
+
+            if error_msg.contains("timeout") || resp.wait_time >= attempt_request.acquire_timeout {
+                return Ok(None);
+            }
+
+            return Ok(None);
+        }
+
+        if last_quorum_error {
+            Err(LockError::QuorumNotReached {
+                required: required_quorum,
+                achieved: best_achieved,
+            })
+        } else {
+            Ok(None)
         }
     }
 
@@ -415,6 +453,7 @@ impl DistributedLock {
         let required_quorum = self.required_quorum(request.lock_type);
         let mut pending = self.spawn_lock_requests(request);
         let mut individual_locks: Vec<(LockId, Arc<dyn LockClient>)> = Vec::new();
+        let mut hard_failures = 0usize;
         let fallback_lock_id = request.lock_id.clone();
 
         while let Some(join_result) = pending.join_next().await {
@@ -438,9 +477,11 @@ impl DistributedLock {
                     }
                 }
                 Ok((idx, Err(err))) => {
+                    hard_failures += 1;
                     tracing::warn!("Failed to acquire lock on client {}: {}", idx, err);
                 }
                 Err(err) => {
+                    hard_failures += 1;
                     tracing::warn!("Lock acquisition task join failed: {}", err);
                 }
             }
@@ -482,9 +523,9 @@ impl DistributedLock {
                 return Ok((resp, individual_locks));
             }
 
-            if individual_locks.len() + pending.len() < required_quorum {
+            if self.clients.len().saturating_sub(hard_failures) < required_quorum {
                 let rollback_count = individual_locks.len();
-                Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
+                Self::release_entries(individual_locks.clone(), "distributed_lock_quorum_rollback").await;
                 if !pending.is_empty() {
                     Self::spawn_pending_cleanup(
                         pending,
@@ -495,7 +536,9 @@ impl DistributedLock {
                 }
 
                 let resp = LockResponse::failure(
-                    format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required"),
+                    format!(
+                        "Unrecoverable quorum failure: {rollback_count}/{required_quorum} required; {hard_failures} clients failed"
+                    ),
                     Duration::ZERO,
                 );
                 return Ok((resp, individual_locks));
@@ -503,7 +546,7 @@ impl DistributedLock {
         }
 
         let rollback_count = individual_locks.len();
-        Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
+        Self::release_entries(individual_locks.clone(), "distributed_lock_quorum_rollback").await;
         let resp = LockResponse::failure(
             format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required"),
             Duration::ZERO,

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -23,42 +23,55 @@ use rustfs_io_metrics::{
     record_read_lock_held_acquire, record_read_lock_held_release, record_write_lock_held_acquire, record_write_lock_held_release,
 };
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::task::JoinSet;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
 const UNLOCK_RETRY_ATTEMPTS: usize = 3;
 const UNLOCK_RETRY_BACKOFF: Duration = Duration::from_millis(100);
-const QUORUM_RETRY_BACKOFF_MIN: Duration = Duration::from_millis(5);
-const QUORUM_RETRY_BACKOFF_MAX: Duration = Duration::from_millis(50);
-const QUORUM_ATTEMPT_TIMEOUT_MAX: Duration = Duration::from_millis(250);
-const REMOTE_LOCK_RPC_FAILURE_PREFIX: &str = "Remote lock RPC failed:";
-const REMOTE_LOCK_RPC_TIMEOUT_PREFIX: &str = "Remote lock RPC timed out:";
+const LOCK_ACQUIRE_RETRY_ATTEMPTS: usize = 3;
+const LOCK_ACQUIRE_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+const REMOTE_LOCK_RPC_FAILED_PREFIX: &str = "remote lock rpc failed:";
+const UNRECOVERABLE_QUORUM_FAILURE_PREFIX: &str = "unrecoverable quorum failure";
+
+#[derive(Debug)]
+enum LockAcquireFailureKind {
+    NonRetryable,
+    RetryableContention,
+    UnrecoverableQuorum,
+}
 
 /// Generate a new aggregate lock ID for multiple client locks
 fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
     LockId {
         resource: resource.clone(),
-        uuid: format!("aggregate-{}", Uuid::new_v4()),
+        uuid: Uuid::new_v4().to_string(),
     }
 }
 
-fn has_case_insensitive_prefix(error: &str, prefix: &str) -> bool {
-    error
-        .get(..prefix.len())
-        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
-}
-
 fn is_remote_lock_rpc_failure(error: &str) -> bool {
-    has_case_insensitive_prefix(error, REMOTE_LOCK_RPC_FAILURE_PREFIX)
-        || has_case_insensitive_prefix(error, REMOTE_LOCK_RPC_TIMEOUT_PREFIX)
+    error
+        .get(0..REMOTE_LOCK_RPC_FAILED_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(REMOTE_LOCK_RPC_FAILED_PREFIX))
 }
 
-fn checked_deadline_from_now(timeout: Duration) -> crate::error::Result<Instant> {
-    Instant::now()
-        .checked_add(timeout)
-        .ok_or_else(|| LockError::configuration("acquire timeout exceeds system deadline"))
+fn is_unrecoverable_quorum_error(error: &str) -> bool {
+    error
+        .get(0..UNRECOVERABLE_QUORUM_FAILURE_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(UNRECOVERABLE_QUORUM_FAILURE_PREFIX))
+}
+
+fn classify_lock_failure(error: &str) -> LockAcquireFailureKind {
+    if is_unrecoverable_quorum_error(error) {
+        return LockAcquireFailureKind::UnrecoverableQuorum;
+    }
+
+    if error.to_ascii_lowercase().contains("timeout") || is_remote_lock_rpc_failure(error) {
+        return LockAcquireFailureKind::RetryableContention;
+    }
+
+    LockAcquireFailureKind::NonRetryable
 }
 
 /// A RAII guard for distributed locks that releases the lock asynchronously when dropped.
@@ -153,6 +166,13 @@ pub struct DistributedLock {
 
 type LockAcquireTaskResult = (usize, Result<LockResponse>);
 
+struct LockAcquireQuorumResult {
+    response: LockResponse,
+    individual_locks: Vec<(LockId, Arc<dyn LockClient>)>,
+    pending_cleanup_spawned: bool,
+    failure_kind: Option<LockAcquireFailureKind>,
+}
+
 impl DistributedLock {
     /// Create new distributed lock
     pub fn new(namespace: String, clients: Vec<Arc<dyn LockClient>>, quorum: usize) -> Self {
@@ -207,103 +227,69 @@ impl DistributedLock {
         }
 
         let required_quorum = self.required_quorum(request.lock_type);
-        let deadline = checked_deadline_from_now(request.acquire_timeout)?;
-        let mut attempt = 0u32;
+        let LockAcquireQuorumResult {
+            response: resp,
+            individual_locks,
+            failure_kind,
+            ..
+        } = self.acquire_lock_quorum_with_retry(request).await?;
+        if resp.success {
+            // Use aggregate lock_id from LockResponse's LockInfo
+            // The aggregate id is what we expose to callers; individual_locks carries
+            // the real (LockId, client) pairs that must be released.
+            let aggregate_lock_id = resp
+                .lock_info
+                .as_ref()
+                .map(|info| info.id.clone())
+                .unwrap_or_else(|| LockId::new_unique(&request.resource));
 
-        loop {
-            let mut attempt_request = request.clone();
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            attempt_request.acquire_timeout = remaining.min(QUORUM_ATTEMPT_TIMEOUT_MAX);
-
-            let (resp, individual_locks) = self.acquire_lock_quorum(&attempt_request).await?;
-            if resp.success {
-                // Use aggregate lock_id from LockResponse's LockInfo
-                // The aggregate id is what we expose to callers; individual_locks carries
-                // the real (LockId, client) pairs that must be released.
-                let aggregate_lock_id = resp
-                    .lock_info
-                    .as_ref()
-                    .map(|info| info.id.clone())
-                    .unwrap_or_else(|| LockId::new_unique(&request.resource));
-
-                return Ok(Some(DistributedLockGuard::new(aggregate_lock_id, individual_locks, request.lock_type)));
-            }
-
-            let error_msg = resp.error.unwrap_or_default();
-            let error_msg_lower = error_msg.to_lowercase();
-            let is_unrecoverable_quorum_failure = error_msg_lower.contains("unrecoverable quorum failure");
-            let is_quorum_contention = error_msg_lower.contains("quorum") && !is_unrecoverable_quorum_failure;
-            if is_unrecoverable_quorum_failure {
-                warn!(
-                    resource = %request.resource,
-                    owner = %request.owner,
-                    attempt,
-                    "acquire_lock_quorum unrecoverable failure: {}",
-                    error_msg
-                );
-            } else if is_quorum_contention || request.suppress_contention_logs {
-                tracing::debug!(
-                    resource = %request.resource,
-                    owner = %request.owner,
-                    attempt,
-                    "acquire_lock_quorum contention: {}",
-                    error_msg
-                );
-            } else {
-                warn!(
-                    resource = %request.resource,
-                    owner = %request.owner,
-                    attempt,
-                    "acquire_lock_quorum error: {}",
-                    error_msg
-                );
-            }
-            if is_unrecoverable_quorum_failure {
-                return Err(LockError::QuorumNotReached {
-                    required: required_quorum,
-                    achieved: individual_locks.len(),
-                });
-            }
-            if is_quorum_contention {
-                attempt += 1;
-
-                let backoff = (QUORUM_RETRY_BACKOFF_MIN * attempt).min(QUORUM_RETRY_BACKOFF_MAX);
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                if remaining <= backoff {
-                    if is_quorum_contention || request.suppress_contention_logs {
-                        tracing::debug!(
-                            resource = %request.resource,
-                            owner = %request.owner,
-                            attempt,
-                            "acquire_lock_quorum contention timed out after retries: {}",
-                            error_msg
-                        );
-                    } else {
-                        warn!(
-                            resource = %request.resource,
-                            owner = %request.owner,
-                            attempt,
-                            "acquire_lock_quorum contention timed out after retries: {}",
-                            error_msg
-                        );
-                    }
-                    return Ok(None);
+            Ok(Some(DistributedLockGuard::new(aggregate_lock_id, individual_locks, request.lock_type)))
+        } else {
+            // Check if it's a timeout or quorum failure
+            if let Some(error_msg) = &resp.error {
+                if request.suppress_contention_logs {
+                    tracing::debug!(
+                        resource = %request.resource,
+                        owner = %request.owner,
+                        "acquire_lock_quorum contention: {}",
+                        error_msg
+                    );
+                } else if matches!(failure_kind, Some(LockAcquireFailureKind::NonRetryable)) {
+                    warn!(
+                        resource = %request.resource,
+                        owner = %request.owner,
+                        "acquire_lock_quorum error: {}",
+                        error_msg
+                    );
+                } else if matches!(failure_kind, Some(LockAcquireFailureKind::RetryableContention)) {
+                    debug!(
+                        resource = %request.resource,
+                        owner = %request.owner,
+                        "acquire_lock_quorum contention: {}",
+                        error_msg
+                    );
+                } else {
+                    debug!(
+                        resource = %request.resource,
+                        owner = %request.owner,
+                        "acquire_lock_quorum final failure: {}",
+                        error_msg
+                    );
                 }
-                tokio::time::sleep(backoff).await;
-                continue;
-            }
 
-            if error_msg_lower.contains("timeout") || resp.wait_time >= attempt_request.acquire_timeout {
-                return Ok(None);
+                if matches!(failure_kind, Some(LockAcquireFailureKind::UnrecoverableQuorum)) {
+                    let achieved = individual_locks.len();
+                    Err(LockError::QuorumNotReached {
+                        required: required_quorum,
+                        achieved,
+                    })
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Ok(None)
             }
-
-            return Ok(None);
         }
-
-        Ok(None)
     }
 
     /// Convenience: acquire exclusive lock as a guard
@@ -356,6 +342,16 @@ impl DistributedLock {
             pending.spawn(async move { (idx, client.acquire_lock(&request).await) });
         }
         pending
+    }
+
+    fn lock_acquire_retry_backoff(attempt: usize) -> Duration {
+        LOCK_ACQUIRE_RETRY_INITIAL_BACKOFF * attempt as u32
+    }
+
+    fn is_retryable_lock_failure(resp: &LockResponse) -> bool {
+        resp.error
+            .as_deref()
+            .is_some_and(|error| matches!(classify_lock_failure(error), LockAcquireFailureKind::RetryableContention))
     }
 
     async fn release_entries(entries: Vec<(LockId, Arc<dyn LockClient>)>, context: &'static str) {
@@ -479,15 +475,59 @@ impl DistributedLock {
         }
     }
 
+    async fn acquire_lock_quorum_with_retry(&self, request: &LockRequest) -> Result<LockAcquireQuorumResult> {
+        let start = std::time::Instant::now();
+        let mut attempt = 1;
+        let mut last_result = None;
+
+        loop {
+            let elapsed = start.elapsed();
+            if elapsed >= request.acquire_timeout {
+                break;
+            }
+
+            let remaining = request.acquire_timeout - elapsed;
+            let mut attempt_request = request.clone();
+            attempt_request.acquire_timeout = remaining;
+
+            let result = self.acquire_lock_quorum_once(&attempt_request).await?;
+            if result.response.success
+                || !result.individual_locks.is_empty()
+                || result.pending_cleanup_spawned
+                || !Self::is_retryable_lock_failure(&result.response)
+                || attempt >= LOCK_ACQUIRE_RETRY_ATTEMPTS
+            {
+                return Ok(result);
+            }
+
+            last_result = Some(result);
+            let backoff = Self::lock_acquire_retry_backoff(attempt);
+            if start.elapsed().saturating_add(backoff) >= request.acquire_timeout {
+                break;
+            }
+
+            tokio::time::sleep(backoff).await;
+            attempt += 1;
+        }
+
+        Ok(last_result.unwrap_or_else(|| LockAcquireQuorumResult {
+            response: LockResponse::failure("Lock acquisition timeout", request.acquire_timeout),
+            individual_locks: Vec::new(),
+            pending_cleanup_spawned: false,
+            failure_kind: Some(LockAcquireFailureKind::RetryableContention),
+        }))
+    }
+
     /// Quorum-based lock acquisition: success if at least the required quorum succeeds.
     /// Collects all individual lock_ids from successful clients and creates an aggregate lock_id.
     /// Returns the LockResponse with aggregate lock_id and individual lock mappings.
-    async fn acquire_lock_quorum(&self, request: &LockRequest) -> Result<(LockResponse, Vec<(LockId, Arc<dyn LockClient>)>)> {
+    async fn acquire_lock_quorum_once(&self, request: &LockRequest) -> Result<LockAcquireQuorumResult> {
         let required_quorum = self.required_quorum(request.lock_type);
         let mut pending = self.spawn_lock_requests(request);
         let mut individual_locks: Vec<(LockId, Arc<dyn LockClient>)> = Vec::new();
-        let mut hard_failures = 0usize;
         let fallback_lock_id = request.lock_id.clone();
+        let mut last_failure = None;
+        let mut hard_failures = 0usize;
 
         while let Some(join_result) = pending.join_next().await {
             match join_result {
@@ -509,22 +549,26 @@ impl DistributedLock {
                         if is_remote_lock_rpc_failure(&error) {
                             hard_failures += 1;
                         }
-                        self.log_failed_lock_response(request, idx, error);
+                        self.log_failed_lock_response(request, idx, error.clone());
+                        last_failure = Some(error);
                     }
                 }
                 Ok((idx, Err(err))) => {
                     hard_failures += 1;
                     tracing::warn!("Failed to acquire lock on client {}: {}", idx, err);
+                    last_failure = Some(err.to_string());
                 }
                 Err(err) => {
                     hard_failures += 1;
                     tracing::warn!("Lock acquisition task join failed: {}", err);
+                    last_failure = Some(err.to_string());
                 }
             }
 
             if self.clients.len().saturating_sub(hard_failures) < required_quorum {
                 let rollback_count = individual_locks.len();
                 Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
+                let pending_cleanup_spawned = !pending.is_empty();
                 if !pending.is_empty() {
                     Self::spawn_pending_cleanup(
                         pending,
@@ -534,35 +578,24 @@ impl DistributedLock {
                     );
                 }
 
-                let resp = LockResponse::failure(
-                    format!(
-                        "Unrecoverable quorum failure: {rollback_count}/{required_quorum} required; {hard_failures} clients failed"
-                    ),
-                    Duration::ZERO,
+                let mut error = format!(
+                    "Unrecoverable quorum failure: {rollback_count}/{required_quorum} required; {hard_failures} clients failed"
                 );
-                return Ok((resp, individual_locks));
-            }
-
-            if individual_locks.len() + pending.len() < required_quorum {
-                let rollback_count = individual_locks.len();
-                Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
-                if !pending.is_empty() {
-                    Self::spawn_pending_cleanup(
-                        pending,
-                        self.clients.clone(),
-                        fallback_lock_id.clone(),
-                        "distributed_lock_failure_cleanup",
-                    );
+                if let Some(last_failure) = last_failure {
+                    error.push_str("; last failure: ");
+                    error.push_str(&last_failure);
                 }
-
-                let resp = LockResponse::failure(
-                    format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required"),
-                    Duration::ZERO,
-                );
-                return Ok((resp, individual_locks));
+                let resp = LockResponse::failure(error, Duration::ZERO);
+                return Ok(LockAcquireQuorumResult {
+                    response: resp,
+                    individual_locks,
+                    pending_cleanup_spawned,
+                    failure_kind: Some(LockAcquireFailureKind::UnrecoverableQuorum),
+                });
             }
 
             if individual_locks.len() >= required_quorum {
+                let pending_cleanup_spawned = !pending.is_empty();
                 if !pending.is_empty() {
                     Self::spawn_pending_cleanup(
                         pending,
@@ -596,17 +629,69 @@ impl DistributedLock {
                     },
                     Duration::ZERO,
                 );
-                return Ok((resp, individual_locks));
+                return Ok(LockAcquireQuorumResult {
+                    response: resp,
+                    individual_locks,
+                    pending_cleanup_spawned,
+                    failure_kind: None,
+                });
+            }
+
+            if !individual_locks.is_empty() && individual_locks.len() + pending.len() < required_quorum {
+                let rollback_count = individual_locks.len();
+                Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
+                let pending_cleanup_spawned = !pending.is_empty();
+                if !pending.is_empty() {
+                    Self::spawn_pending_cleanup(
+                        pending,
+                        self.clients.clone(),
+                        fallback_lock_id.clone(),
+                        "distributed_lock_failure_cleanup",
+                    );
+                }
+
+                let mut error = format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required");
+                let failure_kind = if hard_failures > 0 {
+                    error = format!(
+                        "Unrecoverable quorum failure: {rollback_count}/{required_quorum} required; {hard_failures} clients failed; {error}"
+                    );
+                    LockAcquireFailureKind::UnrecoverableQuorum
+                } else {
+                    LockAcquireFailureKind::RetryableContention
+                };
+                if let Some(last_failure) = last_failure {
+                    error.push_str("; last failure: ");
+                    error.push_str(&last_failure);
+                }
+                let resp = LockResponse::failure(error, Duration::ZERO);
+                return Ok(LockAcquireQuorumResult {
+                    response: resp,
+                    individual_locks,
+                    pending_cleanup_spawned,
+                    failure_kind: Some(failure_kind),
+                });
             }
         }
 
         let rollback_count = individual_locks.len();
         Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
-        let resp = LockResponse::failure(
-            format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required"),
-            Duration::ZERO,
-        );
-        Ok((resp, individual_locks))
+        let mut error = format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required");
+        if let Some(last_failure) = &last_failure {
+            error.push_str("; last failure: ");
+            error.push_str(&last_failure);
+        }
+        let resp = LockResponse::failure(error, Duration::ZERO);
+        Ok(LockAcquireQuorumResult {
+            response: resp,
+            individual_locks,
+            pending_cleanup_spawned: false,
+            failure_kind: Some(if hard_failures > 0 {
+                LockAcquireFailureKind::UnrecoverableQuorum
+            } else {
+                let fallback_kind = last_failure.as_deref().map(classify_lock_failure);
+                fallback_kind.unwrap_or(LockAcquireFailureKind::RetryableContention)
+            }),
+        })
     }
 }
 
@@ -628,8 +713,75 @@ fn record_lock_held_release(lock_type: LockType) {
 
 #[cfg(test)]
 mod tests {
-    use super::is_remote_lock_rpc_failure;
-    use std::time::Duration;
+    use super::{DistributedLock, is_remote_lock_rpc_failure};
+    use crate::{LockError, LockId, LockInfo, LockRequest, LockResponse, LockStats, LockType, ObjectKey, client::LockClient};
+    use std::{sync::Arc, time::Duration};
+
+    #[derive(Debug)]
+    struct ResponseClient {
+        response: LockResponse,
+        delay: Duration,
+    }
+
+    impl ResponseClient {
+        fn new(response: LockResponse) -> Self {
+            Self {
+                response,
+                delay: Duration::ZERO,
+            }
+        }
+
+        fn with_delay(mut self, delay: Duration) -> Self {
+            self.delay = delay;
+            self
+        }
+
+        fn into_client(self) -> Arc<dyn LockClient> {
+            Arc::new(self)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LockClient for ResponseClient {
+        async fn acquire_lock(&self, _request: &LockRequest) -> crate::Result<LockResponse> {
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+            Ok(self.response.clone())
+        }
+
+        async fn release(&self, _lock_id: &LockId) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        async fn refresh(&self, _lock_id: &LockId) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        async fn force_release(&self, _lock_id: &LockId) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        async fn check_status(&self, _lock_id: &LockId) -> crate::Result<Option<LockInfo>> {
+            Ok(None)
+        }
+
+        async fn get_stats(&self) -> crate::Result<LockStats> {
+            Ok(LockStats::default())
+        }
+
+        async fn close(&self) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn is_online(&self) -> bool {
+            true
+        }
+
+        async fn is_local(&self) -> bool {
+            false
+        }
+    }
 
     #[test]
     fn test_is_remote_lock_rpc_failure() {
@@ -639,11 +791,51 @@ mod tests {
         assert!(!is_remote_lock_rpc_failure("acquired lock failed for other reason"));
     }
 
-    #[test]
-    fn test_checked_deadline_from_now_overflow_protected() {
+    #[tokio::test]
+    async fn acquire_guard_returns_quorum_error_when_rpc_failures_make_quorum_impossible() {
+        let clients: Vec<Arc<dyn LockClient>> = vec![
+            ResponseClient::new(LockResponse::failure("Remote lock RPC failed: node unavailable", Duration::ZERO)).into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO))
+                .with_delay(Duration::from_millis(50))
+                .into_client(),
+            ResponseClient::new(LockResponse::failure("Remote lock RPC failed: connection refused", Duration::ZERO))
+                .into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO))
+                .with_delay(Duration::from_millis(50))
+                .into_client(),
+        ];
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Exclusive, "owner")
+            .with_acquire_timeout(Duration::from_secs(1));
+
+        let result = lock.acquire_guard(&request).await;
+
         assert!(
-            super::checked_deadline_from_now(Duration::MAX).is_err(),
-            "checked_deadline_from_now should reject overflowing durations"
+            matches!(
+                result,
+                Err(LockError::QuorumNotReached {
+                    required: 3,
+                    achieved: 0
+                })
+            ),
+            "unexpected result: {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn acquire_guard_returns_timeout_when_quorum_remains_contended() {
+        let clients: Vec<Arc<dyn LockClient>> = vec![
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO)).into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO)).into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO)).into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO)).into_client(),
+        ];
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Exclusive, "owner")
+            .with_acquire_timeout(Duration::from_millis(120));
+
+        let result = lock.acquire_guard(&request).await;
+
+        assert!(matches!(result, Ok(None)), "unexpected result: {result:?}");
     }
 }

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -192,10 +192,19 @@ impl DistributedLock {
         }
 
         let required_quorum = self.required_quorum(request.lock_type);
-        let deadline = Instant::now() + request.acquire_timeout;
+        let deadline = match Instant::now().checked_add(request.acquire_timeout) {
+            Some(deadline) => deadline,
+            None => {
+                warn!(
+                    resource = %request.resource,
+                    owner = %request.owner,
+                    request_timeout_ms = request.acquire_timeout.as_millis(),
+                    "acquire_lock_quorum request timeout overflow, failing fast"
+                );
+                return Ok(None);
+            }
+        };
         let mut attempt = 0u32;
-        let mut best_achieved = 0usize;
-        let mut last_quorum_error = false;
 
         loop {
             let mut attempt_request = request.clone();
@@ -239,7 +248,7 @@ impl DistributedLock {
             }
 
             let error_msg_lower = error_msg.to_lowercase();
-            if error_msg_lower.contains("unrecoverable") {
+            if error_msg_lower.contains("unrecoverable quorum failure") {
                 return Err(LockError::QuorumNotReached {
                     required: required_quorum,
                     achieved: individual_locks.len(),
@@ -247,8 +256,6 @@ impl DistributedLock {
             }
 
             if error_msg_lower.contains("quorum") {
-                last_quorum_error = true;
-                best_achieved = best_achieved.max(individual_locks.len());
                 attempt += 1;
 
                 let backoff = (QUORUM_RETRY_BACKOFF_MIN * attempt).min(QUORUM_RETRY_BACKOFF_MAX);
@@ -267,14 +274,7 @@ impl DistributedLock {
             return Ok(None);
         }
 
-        if last_quorum_error {
-            Err(LockError::QuorumNotReached {
-                required: required_quorum,
-                achieved: best_achieved,
-            })
-        } else {
-            Ok(None)
-        }
+        Ok(None)
     }
 
     /// Convenience: acquire exclusive lock as a guard
@@ -532,7 +532,7 @@ impl DistributedLock {
 
             if self.clients.len().saturating_sub(hard_failures) < required_quorum {
                 let rollback_count = individual_locks.len();
-                Self::release_entries(individual_locks.clone(), "distributed_lock_quorum_rollback").await;
+                Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
                 if !pending.is_empty() {
                     Self::spawn_pending_cleanup(
                         pending,
@@ -553,7 +553,7 @@ impl DistributedLock {
         }
 
         let rollback_count = individual_locks.len();
-        Self::release_entries(individual_locks.clone(), "distributed_lock_quorum_rollback").await;
+        Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
         let resp = LockResponse::failure(
             format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required"),
             Duration::ZERO,

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -33,6 +33,7 @@ const UNLOCK_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 const QUORUM_RETRY_BACKOFF_MIN: Duration = Duration::from_millis(5);
 const QUORUM_RETRY_BACKOFF_MAX: Duration = Duration::from_millis(50);
 const QUORUM_ATTEMPT_TIMEOUT_MAX: Duration = Duration::from_millis(250);
+const REMOTE_LOCK_RPC_FAILURE_PREFIX: &str = "Remote lock RPC failed:";
 
 /// Generate a new aggregate lock ID for multiple client locks
 fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
@@ -43,7 +44,9 @@ fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
 }
 
 fn is_remote_lock_rpc_failure(error: &str) -> bool {
-    error.to_lowercase().contains("remote lock rpc failed")
+    error
+        .get(..REMOTE_LOCK_RPC_FAILURE_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(REMOTE_LOCK_RPC_FAILURE_PREFIX))
 }
 
 fn checked_deadline_from_now(timeout: Duration) -> crate::error::Result<Instant> {
@@ -224,14 +227,26 @@ impl DistributedLock {
             }
 
             let error_msg = resp.error.unwrap_or_default();
-            if request.suppress_contention_logs {
-                tracing::debug!(
-                    resource = %request.resource,
-                    owner = %request.owner,
-                    attempt,
-                    "acquire_lock_quorum contention: {}",
-                    error_msg
-                );
+            let is_quorum_miss = error_msg.to_lowercase().contains("quorum");
+
+            if request.suppress_contention_logs || is_quorum_miss {
+                if is_quorum_miss {
+                    debug!(
+                        resource = %request.resource,
+                        owner = %request.owner,
+                        attempt,
+                        "acquire_lock_quorum contention: {}",
+                        error_msg
+                    );
+                } else {
+                    tracing::debug!(
+                        resource = %request.resource,
+                        owner = %request.owner,
+                        attempt,
+                        "acquire_lock_quorum error: {}",
+                        error_msg
+                    );
+                }
             } else {
                 warn!(
                     resource = %request.resource,
@@ -241,7 +256,6 @@ impl DistributedLock {
                     error_msg
                 );
             }
-
             let error_msg_lower = error_msg.to_lowercase();
             if error_msg_lower.contains("unrecoverable quorum failure") {
                 return Err(LockError::QuorumNotReached {
@@ -486,6 +500,25 @@ impl DistributedLock {
                     hard_failures += 1;
                     tracing::warn!("Lock acquisition task join failed: {}", err);
                 }
+            }
+
+            if individual_locks.len() + pending.len() < required_quorum {
+                let rollback_count = individual_locks.len();
+                Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
+                if !pending.is_empty() {
+                    Self::spawn_pending_cleanup(
+                        pending,
+                        self.clients.clone(),
+                        fallback_lock_id.clone(),
+                        "distributed_lock_failure_cleanup",
+                    );
+                }
+
+                let resp = LockResponse::failure(
+                    format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required"),
+                    Duration::ZERO,
+                );
+                return Ok((resp, individual_locks));
             }
 
             if individual_locks.len() >= required_quorum {

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -34,18 +34,25 @@ const QUORUM_RETRY_BACKOFF_MIN: Duration = Duration::from_millis(5);
 const QUORUM_RETRY_BACKOFF_MAX: Duration = Duration::from_millis(50);
 const QUORUM_ATTEMPT_TIMEOUT_MAX: Duration = Duration::from_millis(250);
 const REMOTE_LOCK_RPC_FAILURE_PREFIX: &str = "Remote lock RPC failed:";
+const REMOTE_LOCK_RPC_TIMEOUT_PREFIX: &str = "Remote lock RPC timed out:";
 
 /// Generate a new aggregate lock ID for multiple client locks
 fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
     LockId {
         resource: resource.clone(),
-        uuid: Uuid::new_v4().to_string(),
+        uuid: format!("aggregate-{}", Uuid::new_v4()),
     }
 }
 
+fn has_case_insensitive_prefix(error: &str, prefix: &str) -> bool {
+    error
+        .get(..prefix.len())
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
+}
+
 fn is_remote_lock_rpc_failure(error: &str) -> bool {
-    const REMOTE_LOCK_RPC_FAILED_PREFIX: &str = "Remote lock RPC failed:";
-    error.starts_with(REMOTE_LOCK_RPC_FAILED_PREFIX) || error.starts_with("remote lock rpc failed:")
+    has_case_insensitive_prefix(error, REMOTE_LOCK_RPC_FAILURE_PREFIX)
+        || has_case_insensitive_prefix(error, REMOTE_LOCK_RPC_TIMEOUT_PREFIX)
 }
 
 fn checked_deadline_from_now(timeout: Duration) -> crate::error::Result<Instant> {
@@ -515,6 +522,27 @@ impl DistributedLock {
                 }
             }
 
+            if self.clients.len().saturating_sub(hard_failures) < required_quorum {
+                let rollback_count = individual_locks.len();
+                Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
+                if !pending.is_empty() {
+                    Self::spawn_pending_cleanup(
+                        pending,
+                        self.clients.clone(),
+                        fallback_lock_id.clone(),
+                        "distributed_lock_failure_cleanup",
+                    );
+                }
+
+                let resp = LockResponse::failure(
+                    format!(
+                        "Unrecoverable quorum failure: {rollback_count}/{required_quorum} required; {hard_failures} clients failed"
+                    ),
+                    Duration::ZERO,
+                );
+                return Ok((resp, individual_locks));
+            }
+
             if individual_locks.len() + pending.len() < required_quorum {
                 let rollback_count = individual_locks.len();
                 Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
@@ -566,27 +594,6 @@ impl DistributedLock {
                         priority: request.priority,
                         wait_start_time: None,
                     },
-                    Duration::ZERO,
-                );
-                return Ok((resp, individual_locks));
-            }
-
-            if self.clients.len().saturating_sub(hard_failures) < required_quorum {
-                let rollback_count = individual_locks.len();
-                Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
-                if !pending.is_empty() {
-                    Self::spawn_pending_cleanup(
-                        pending,
-                        self.clients.clone(),
-                        fallback_lock_id.clone(),
-                        "distributed_lock_failure_cleanup",
-                    );
-                }
-
-                let resp = LockResponse::failure(
-                    format!(
-                        "Unrecoverable quorum failure: {rollback_count}/{required_quorum} required; {hard_failures} clients failed"
-                    ),
                     Duration::ZERO,
                 );
                 return Ok((resp, individual_locks));

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -678,7 +678,7 @@ impl DistributedLock {
         let mut error = format!("Failed to acquire quorum: {rollback_count}/{required_quorum} required");
         if let Some(last_failure) = &last_failure {
             error.push_str("; last failure: ");
-            error.push_str(&last_failure);
+            error.push_str(last_failure);
         }
         let resp = LockResponse::failure(error, Duration::ZERO);
         Ok(LockAcquireQuorumResult {

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -643,7 +643,7 @@ impl DistributedLock {
                 });
             }
 
-            if !individual_locks.is_empty() && individual_locks.len() + pending.len() < required_quorum {
+            if individual_locks.len() + pending.len() < required_quorum {
                 let rollback_count = individual_locks.len();
                 Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
                 let pending_cleanup_spawned = !pending.is_empty();
@@ -864,6 +864,32 @@ mod tests {
                 })
             ),
             "unexpected result: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_guard_returns_timeout_when_zero_locks_make_quorum_impossible_for_attempt() {
+        let clients: Vec<Arc<dyn LockClient>> = vec![
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO)).into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO)).into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO))
+                .with_delay(Duration::from_secs(1))
+                .into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO))
+                .with_delay(Duration::from_secs(1))
+                .into_client(),
+        ];
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Exclusive, "owner")
+            .with_acquire_timeout(Duration::from_secs(2));
+
+        let started = tokio::time::Instant::now();
+        let result = lock.acquire_guard(&request).await;
+
+        assert!(matches!(result, Ok(None)), "unexpected result: {result:?}");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "acquire should fail this attempt before waiting for delayed impossible-quorum tasks"
         );
     }
 

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -46,6 +46,12 @@ fn is_remote_lock_rpc_failure(error: &str) -> bool {
     error.to_lowercase().contains("remote lock rpc failed")
 }
 
+fn checked_deadline_from_now(timeout: Duration) -> crate::error::Result<Instant> {
+    Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(|| LockError::configuration("acquire timeout exceeds system deadline"))
+}
+
 /// A RAII guard for distributed locks that releases the lock asynchronously when dropped.
 #[derive(Debug)]
 pub struct DistributedLockGuard {
@@ -192,18 +198,7 @@ impl DistributedLock {
         }
 
         let required_quorum = self.required_quorum(request.lock_type);
-        let deadline = match Instant::now().checked_add(request.acquire_timeout) {
-            Some(deadline) => deadline,
-            None => {
-                warn!(
-                    resource = %request.resource,
-                    owner = %request.owner,
-                    request_timeout_ms = request.acquire_timeout.as_millis(),
-                    "acquire_lock_quorum request timeout overflow, failing fast"
-                );
-                return Ok(None);
-            }
-        };
+        let deadline = checked_deadline_from_now(request.acquire_timeout)?;
         let mut attempt = 0u32;
 
         loop {
@@ -261,7 +256,7 @@ impl DistributedLock {
                 let backoff = (QUORUM_RETRY_BACKOFF_MIN * attempt).min(QUORUM_RETRY_BACKOFF_MAX);
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining <= backoff {
-                    break;
+                    return Ok(None);
                 }
                 tokio::time::sleep(backoff).await;
                 continue;
@@ -581,6 +576,7 @@ fn record_lock_held_release(lock_type: LockType) {
 #[cfg(test)]
 mod tests {
     use super::is_remote_lock_rpc_failure;
+    use std::time::Duration;
 
     #[test]
     fn test_is_remote_lock_rpc_failure() {
@@ -588,5 +584,13 @@ mod tests {
         assert!(is_remote_lock_rpc_failure("remote lock rpc failed: temporary network issue"));
         assert!(!is_remote_lock_rpc_failure("Lock is already held"));
         assert!(!is_remote_lock_rpc_failure("acquired lock failed for other reason"));
+    }
+
+    #[test]
+    fn test_checked_deadline_from_now_overflow_protected() {
+        assert!(
+            super::checked_deadline_from_now(Duration::MAX).is_err(),
+            "checked_deadline_from_now should reject overflowing durations"
+        );
     }
 }

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -42,6 +42,10 @@ fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
     }
 }
 
+fn is_remote_lock_rpc_failure(error: &str) -> bool {
+    error.to_lowercase().contains("remote lock rpc failed")
+}
+
 /// A RAII guard for distributed locks that releases the lock asynchronously when dropped.
 #[derive(Debug)]
 pub struct DistributedLockGuard {
@@ -473,6 +477,9 @@ impl DistributedLock {
                         }
                     } else {
                         let error = resp.error.unwrap_or_else(|| "unknown error".to_string());
+                        if is_remote_lock_rpc_failure(&error) {
+                            hard_failures += 1;
+                        }
                         self.log_failed_lock_response(request, idx, error);
                     }
                 }
@@ -568,5 +575,18 @@ fn record_lock_held_release(lock_type: LockType) {
     match lock_type {
         LockType::Shared => record_read_lock_held_release(),
         LockType::Exclusive => record_write_lock_held_release(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_remote_lock_rpc_failure;
+
+    #[test]
+    fn test_is_remote_lock_rpc_failure() {
+        assert!(is_remote_lock_rpc_failure("Remote lock RPC failed: backend unreachable"));
+        assert!(is_remote_lock_rpc_failure("remote lock rpc failed: temporary network issue"));
+        assert!(!is_remote_lock_rpc_failure("Lock is already held"));
+        assert!(!is_remote_lock_rpc_failure("acquired lock failed for other reason"));
     }
 }

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -33,6 +33,7 @@ const UNLOCK_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 const LOCK_ACQUIRE_RETRY_ATTEMPTS: usize = 3;
 const LOCK_ACQUIRE_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
 const REMOTE_LOCK_RPC_FAILED_PREFIX: &str = "remote lock rpc failed:";
+const REMOTE_LOCK_RPC_TIMED_OUT_PREFIX: &str = "remote lock rpc timed out:";
 const UNRECOVERABLE_QUORUM_FAILURE_PREFIX: &str = "unrecoverable quorum failure";
 
 #[derive(Debug)]
@@ -51,9 +52,14 @@ fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
 }
 
 fn is_remote_lock_rpc_failure(error: &str) -> bool {
+    has_case_insensitive_prefix(error, REMOTE_LOCK_RPC_FAILED_PREFIX)
+        || has_case_insensitive_prefix(error, REMOTE_LOCK_RPC_TIMED_OUT_PREFIX)
+}
+
+fn has_case_insensitive_prefix(error: &str, expected_prefix: &str) -> bool {
     error
-        .get(0..REMOTE_LOCK_RPC_FAILED_PREFIX.len())
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(REMOTE_LOCK_RPC_FAILED_PREFIX))
+        .get(0..expected_prefix.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(expected_prefix))
 }
 
 fn is_unrecoverable_quorum_error(error: &str) -> bool {
@@ -787,6 +793,7 @@ mod tests {
     fn test_is_remote_lock_rpc_failure() {
         assert!(is_remote_lock_rpc_failure("Remote lock RPC failed: backend unreachable"));
         assert!(is_remote_lock_rpc_failure("remote lock rpc failed: temporary network issue"));
+        assert!(is_remote_lock_rpc_failure("Remote lock RPC timed out: RPC timed out after 50ms"));
         assert!(!is_remote_lock_rpc_failure("Lock is already held"));
         assert!(!is_remote_lock_rpc_failure("acquired lock failed for other reason"));
     }
@@ -800,6 +807,44 @@ mod tests {
                 .into_client(),
             ResponseClient::new(LockResponse::failure("Remote lock RPC failed: connection refused", Duration::ZERO))
                 .into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO))
+                .with_delay(Duration::from_millis(50))
+                .into_client(),
+        ];
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Exclusive, "owner")
+            .with_acquire_timeout(Duration::from_secs(1));
+
+        let result = lock.acquire_guard(&request).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(LockError::QuorumNotReached {
+                    required: 3,
+                    achieved: 0
+                })
+            ),
+            "unexpected result: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_guard_returns_quorum_error_when_rpc_timeouts_make_quorum_impossible() {
+        let clients: Vec<Arc<dyn LockClient>> = vec![
+            ResponseClient::new(LockResponse::failure(
+                "Remote lock RPC timed out: RPC timed out after 50ms",
+                Duration::ZERO,
+            ))
+            .into_client(),
+            ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO))
+                .with_delay(Duration::from_millis(50))
+                .into_client(),
+            ResponseClient::new(LockResponse::failure(
+                "Remote lock RPC timed out: RPC timed out after 50ms",
+                Duration::ZERO,
+            ))
+            .into_client(),
             ResponseClient::new(LockResponse::failure("lock already held", Duration::ZERO))
                 .with_delay(Duration::from_millis(50))
                 .into_client(),

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -175,7 +175,6 @@ type LockAcquireTaskResult = (usize, Result<LockResponse>);
 struct LockAcquireQuorumResult {
     response: LockResponse,
     individual_locks: Vec<(LockId, Arc<dyn LockClient>)>,
-    pending_cleanup_spawned: bool,
     failure_kind: Option<LockAcquireFailureKind>,
 }
 
@@ -499,7 +498,6 @@ impl DistributedLock {
             let result = self.acquire_lock_quorum_once(&attempt_request).await?;
             if result.response.success
                 || !result.individual_locks.is_empty()
-                || result.pending_cleanup_spawned
                 || !Self::is_retryable_lock_failure(&result.response)
                 || attempt >= LOCK_ACQUIRE_RETRY_ATTEMPTS
             {
@@ -519,7 +517,6 @@ impl DistributedLock {
         Ok(last_result.unwrap_or_else(|| LockAcquireQuorumResult {
             response: LockResponse::failure("Lock acquisition timeout", request.acquire_timeout),
             individual_locks: Vec::new(),
-            pending_cleanup_spawned: false,
             failure_kind: Some(LockAcquireFailureKind::RetryableContention),
         }))
     }
@@ -574,7 +571,6 @@ impl DistributedLock {
             if self.clients.len().saturating_sub(hard_failures) < required_quorum {
                 let rollback_count = individual_locks.len();
                 Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
-                let pending_cleanup_spawned = !pending.is_empty();
                 if !pending.is_empty() {
                     Self::spawn_pending_cleanup(
                         pending,
@@ -595,13 +591,11 @@ impl DistributedLock {
                 return Ok(LockAcquireQuorumResult {
                     response: resp,
                     individual_locks,
-                    pending_cleanup_spawned,
                     failure_kind: Some(LockAcquireFailureKind::UnrecoverableQuorum),
                 });
             }
 
             if individual_locks.len() >= required_quorum {
-                let pending_cleanup_spawned = !pending.is_empty();
                 if !pending.is_empty() {
                     Self::spawn_pending_cleanup(
                         pending,
@@ -638,7 +632,6 @@ impl DistributedLock {
                 return Ok(LockAcquireQuorumResult {
                     response: resp,
                     individual_locks,
-                    pending_cleanup_spawned,
                     failure_kind: None,
                 });
             }
@@ -646,7 +639,6 @@ impl DistributedLock {
             if individual_locks.len() + pending.len() < required_quorum {
                 let rollback_count = individual_locks.len();
                 Self::spawn_release_cleanup(individual_locks.clone(), "distributed_lock_quorum_rollback");
-                let pending_cleanup_spawned = !pending.is_empty();
                 if !pending.is_empty() {
                     Self::spawn_pending_cleanup(
                         pending,
@@ -673,7 +665,6 @@ impl DistributedLock {
                 return Ok(LockAcquireQuorumResult {
                     response: resp,
                     individual_locks,
-                    pending_cleanup_spawned,
                     failure_kind: Some(failure_kind),
                 });
             }
@@ -690,7 +681,6 @@ impl DistributedLock {
         Ok(LockAcquireQuorumResult {
             response: resp,
             individual_locks,
-            pending_cleanup_spawned: false,
             failure_kind: Some(if hard_failures > 0 {
                 LockAcquireFailureKind::UnrecoverableQuorum
             } else {
@@ -890,6 +880,45 @@ mod tests {
         assert!(
             started.elapsed() < Duration::from_secs(1),
             "acquire should fail this attempt before waiting for delayed impossible-quorum tasks"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_guard_retries_transient_timeout_before_quorum() {
+        let clients: Vec<Arc<dyn LockClient>> = vec![
+            ResponseClient::new(LockResponse::failure(
+                "Timeout { resource: \"bucket/object-flaky-acquire@latest\", timeout: 1s }",
+                Duration::ZERO,
+            ))
+            .into_client(),
+            ResponseClient::new(LockResponse::failure(
+                "Timeout { resource: \"bucket/object-flaky-acquire@latest\", timeout: 1s }",
+                Duration::ZERO,
+            ))
+            .into_client(),
+            ResponseClient::new(LockResponse::failure(
+                "Timeout { resource: \"bucket/object-flaky-acquire@latest\", timeout: 1s }",
+                Duration::ZERO,
+            ))
+            .into_client(),
+            ResponseClient::new(LockResponse::failure(
+                "Timeout { resource: \"bucket/object-flaky-acquire@latest\", timeout: 1s }",
+                Duration::ZERO,
+            ))
+            .into_client(),
+        ];
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Exclusive, "owner")
+            .with_acquire_timeout(Duration::from_millis(900));
+
+        let started = tokio::time::Instant::now();
+        let result = lock.acquire_guard(&request).await;
+        let elapsed = started.elapsed();
+
+        assert!(matches!(result, Ok(None)), "unexpected result: {result:?}");
+        assert!(
+            elapsed >= Duration::from_millis(250),
+            "expected at least one retry attempt for transient timeout, got {elapsed:?}"
         );
     }
 

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -44,9 +44,8 @@ fn generate_aggregate_lock_id(resource: &ObjectKey) -> LockId {
 }
 
 fn is_remote_lock_rpc_failure(error: &str) -> bool {
-    error
-        .get(..REMOTE_LOCK_RPC_FAILURE_PREFIX.len())
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(REMOTE_LOCK_RPC_FAILURE_PREFIX))
+    const REMOTE_LOCK_RPC_FAILED_PREFIX: &str = "Remote lock RPC failed:";
+    error.starts_with(REMOTE_LOCK_RPC_FAILED_PREFIX) || error.starts_with("remote lock rpc failed:")
 }
 
 fn checked_deadline_from_now(timeout: Duration) -> crate::error::Result<Instant> {
@@ -227,26 +226,25 @@ impl DistributedLock {
             }
 
             let error_msg = resp.error.unwrap_or_default();
-            let is_quorum_miss = error_msg.to_lowercase().contains("quorum");
-
-            if request.suppress_contention_logs || is_quorum_miss {
-                if is_quorum_miss {
-                    debug!(
-                        resource = %request.resource,
-                        owner = %request.owner,
-                        attempt,
-                        "acquire_lock_quorum contention: {}",
-                        error_msg
-                    );
-                } else {
-                    tracing::debug!(
-                        resource = %request.resource,
-                        owner = %request.owner,
-                        attempt,
-                        "acquire_lock_quorum error: {}",
-                        error_msg
-                    );
-                }
+            let error_msg_lower = error_msg.to_lowercase();
+            let is_unrecoverable_quorum_failure = error_msg_lower.contains("unrecoverable quorum failure");
+            let is_quorum_contention = error_msg_lower.contains("quorum") && !is_unrecoverable_quorum_failure;
+            if is_unrecoverable_quorum_failure {
+                warn!(
+                    resource = %request.resource,
+                    owner = %request.owner,
+                    attempt,
+                    "acquire_lock_quorum unrecoverable failure: {}",
+                    error_msg
+                );
+            } else if is_quorum_contention || request.suppress_contention_logs {
+                tracing::debug!(
+                    resource = %request.resource,
+                    owner = %request.owner,
+                    attempt,
+                    "acquire_lock_quorum contention: {}",
+                    error_msg
+                );
             } else {
                 warn!(
                     resource = %request.resource,
@@ -256,27 +254,42 @@ impl DistributedLock {
                     error_msg
                 );
             }
-            let error_msg_lower = error_msg.to_lowercase();
-            if error_msg_lower.contains("unrecoverable quorum failure") {
+            if is_unrecoverable_quorum_failure {
                 return Err(LockError::QuorumNotReached {
                     required: required_quorum,
                     achieved: individual_locks.len(),
                 });
             }
-
-            if error_msg_lower.contains("quorum") {
+            if is_quorum_contention {
                 attempt += 1;
 
                 let backoff = (QUORUM_RETRY_BACKOFF_MIN * attempt).min(QUORUM_RETRY_BACKOFF_MAX);
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining <= backoff {
+                    if is_quorum_contention || request.suppress_contention_logs {
+                        tracing::debug!(
+                            resource = %request.resource,
+                            owner = %request.owner,
+                            attempt,
+                            "acquire_lock_quorum contention timed out after retries: {}",
+                            error_msg
+                        );
+                    } else {
+                        warn!(
+                            resource = %request.resource,
+                            owner = %request.owner,
+                            attempt,
+                            "acquire_lock_quorum contention timed out after retries: {}",
+                            error_msg
+                        );
+                    }
                     return Ok(None);
                 }
                 tokio::time::sleep(backoff).await;
                 continue;
             }
 
-            if error_msg.contains("timeout") || resp.wait_time >= attempt_request.acquire_timeout {
+            if error_msg_lower.contains("timeout") || resp.wait_time >= attempt_request.acquire_timeout {
                 return Ok(None);
             }
 

--- a/crates/lock/src/namespace/tests.rs
+++ b/crates/lock/src/namespace/tests.rs
@@ -65,6 +65,50 @@ impl crate::client::LockClient for FailingClient {
 }
 
 #[derive(Debug)]
+struct FailureResponseClient {
+    error: &'static str,
+}
+
+#[async_trait::async_trait]
+impl crate::client::LockClient for FailureResponseClient {
+    async fn acquire_lock(&self, _request: &LockRequest) -> crate::Result<LockResponse> {
+        Ok(LockResponse::failure(self.error, Duration::ZERO))
+    }
+
+    async fn release(&self, _lock_id: &LockId) -> crate::Result<bool> {
+        Ok(false)
+    }
+
+    async fn refresh(&self, _lock_id: &LockId) -> crate::Result<bool> {
+        Ok(false)
+    }
+
+    async fn force_release(&self, _lock_id: &LockId) -> crate::Result<bool> {
+        Ok(false)
+    }
+
+    async fn check_status(&self, _lock_id: &LockId) -> crate::Result<Option<LockInfo>> {
+        Ok(None)
+    }
+
+    async fn get_stats(&self) -> crate::Result<LockStats> {
+        Ok(LockStats::default())
+    }
+
+    async fn close(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn is_online(&self) -> bool {
+        true
+    }
+
+    async fn is_local(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Debug)]
 struct DelayedClient {
     inner: Arc<dyn crate::client::LockClient>,
     delay: Duration,
@@ -633,10 +677,10 @@ async fn test_namespace_lock_distributed_eight_node_write_releases_all_nodes() {
         .get_write_lock(resource.clone(), "owner-b", Duration::from_millis(100))
         .await
         .expect_err("owner-b should not acquire while owner-a holds all node locks");
-    let err_str = err.to_string();
+    let err_str = err.to_string().to_lowercase();
     assert!(
-        err_str.contains("required 5") && err_str.contains("achieved"),
-        "expected 8-node quorum failure below required write quorum, got: {err}"
+        err_str.contains("timeout"),
+        "expected owner-b contention to exhaust acquire timeout, got: {err}"
     );
 
     assert!(guard.release(), "distributed guard should enqueue release");
@@ -742,6 +786,68 @@ async fn test_namespace_lock_distributed_write_lock_fails_with_two_nodes_one_off
     assert!(
         err_str.contains("quorum") || err_str.contains("not reached"),
         "expected quorum error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_namespace_lock_distributed_remote_rpc_failures_are_hard_quorum_failures() {
+    let manager = Arc::new(GlobalLockManager::new());
+    let client_ok: Arc<dyn LockClient> = Arc::new(LocalClient::with_manager(manager));
+    let client_rpc_failed: Arc<dyn LockClient> = Arc::new(FailureResponseClient {
+        error: "Remote lock RPC failed: connection refused",
+    });
+    let client_rpc_timed_out: Arc<dyn LockClient> = Arc::new(FailureResponseClient {
+        error: "Remote lock RPC timed out: RPC timed out after 50ms",
+    });
+    let client_rpc_failed_2: Arc<dyn LockClient> = Arc::new(FailureResponseClient {
+        error: "Remote lock RPC failed: transport error",
+    });
+    let clients: Vec<Arc<dyn LockClient>> = vec![client_ok, client_rpc_failed, client_rpc_timed_out, client_rpc_failed_2];
+    let lock = NamespaceLock::with_clients("remote-rpc-hard-failure".to_string(), clients);
+    let resource = create_test_object_key("bucket", "object-rpc-hard-failure");
+
+    let started = tokio::time::Instant::now();
+    let err = lock
+        .get_write_lock(resource, "owner-a", Duration::from_secs(1))
+        .await
+        .expect_err("write lock should fail as soon as remote RPC failures make quorum impossible");
+
+    assert!(
+        started.elapsed() < Duration::from_millis(150),
+        "remote RPC failures should not retry until the full acquire timeout"
+    );
+    let err_str = err.to_string().to_lowercase();
+    assert!(
+        err_str.contains("quorum") || err_str.contains("not reached"),
+        "expected hard quorum failure, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_namespace_lock_distributed_contention_quorum_miss_times_out() {
+    let client_timeout_1: Arc<dyn LockClient> = Arc::new(FailureResponseClient {
+        error: "Lock acquisition timeout",
+    });
+    let client_timeout_2: Arc<dyn LockClient> = Arc::new(FailureResponseClient {
+        error: "Lock acquisition timeout",
+    });
+    let client_timeout_3: Arc<dyn LockClient> = Arc::new(FailureResponseClient {
+        error: "Lock acquisition timeout",
+    });
+    let clients: Vec<Arc<dyn LockClient>> = vec![client_timeout_1, client_timeout_2, client_timeout_3];
+    let lock = NamespaceLock::with_clients("contention-timeout".to_string(), clients);
+    let resource = create_test_object_key("bucket", "object-contention-timeout");
+
+    let err = lock
+        .get_write_lock(resource, "owner-a", Duration::from_millis(40))
+        .await
+        .expect_err("ordinary contention should exhaust acquire timeout");
+
+    let err_str = err.to_string().to_lowercase();
+    assert!(err_str.contains("timeout"), "expected timeout after contention retries, got: {err}");
+    assert!(
+        !err_str.contains("quorum not reached"),
+        "ordinary contention should not surface as quorum loss: {err}"
     );
 }
 


### PR DESCRIPTION
## Summary
- retry recoverable namespace lock quorum misses within the configured acquire timeout
- treat only client/task failures as unrecoverable quorum loss, not ordinary lock contention responses
- add a clustered concurrent overwrite regression test for namespace lock quorum errors

## Validation
- cargo fmt --all --check
- cargo test -p rustfs-lock namespace_lock -- --nocapture
- cargo build -p rustfs
- RUST_LOG=warn cargo test -p e2e_test namespace_lock_quorum_test::test_concurrent_cluster_overwrites_do_not_fail_namespace_lock_quorum -- --nocapture