### PR TITLE
fix(ecstore): offload erasure encoding from async workers

### DIFF
--- a/crates/ecstore/src/erasure_coding/encode.rs
+++ b/crates/ecstore/src/erasure_coding/encode.rs
@@ -227,10 +227,15 @@ impl Erasure {
                     Ok(n) if n > 0 => {
                         total += n;
                         let erasure = self.clone();
-                        let block = buf[..n].to_vec();
-                        let res = tokio::task::spawn_blocking(move || erasure.encode_data(&block))
-                            .await
-                            .map_err(|err| std::io::Error::other(format!("EC encode task failed: {err}")))??;
+                        let encode_buf = std::mem::take(&mut buf);
+                        let (res, returned_buf) = tokio::task::spawn_blocking(move || {
+                            let res = erasure.encode_data(&encode_buf[..n]);
+                            (res, encode_buf)
+                        })
+                        .await
+                        .map_err(|err| std::io::Error::other(format!("EC encode task failed: {err}")))?;
+                        buf = returned_buf;
+                        let res = res?;
                         let queued_bytes = queued_block_bytes(&res);
                         rustfs_io_metrics::add_ec_encode_inflight_bytes(queued_bytes);
                         if let Err(err) = tx.send(res).await {

--- a/crates/ecstore/src/erasure_coding/encode.rs
+++ b/crates/ecstore/src/erasure_coding/encode.rs
@@ -226,7 +226,11 @@ impl Erasure {
                 match rustfs_utils::read_full(&mut reader, &mut buf).await {
                     Ok(n) if n > 0 => {
                         total += n;
-                        let res = self.encode_data(&buf[..n])?;
+                        let erasure = self.clone();
+                        let block = buf[..n].to_vec();
+                        let res = tokio::task::spawn_blocking(move || erasure.encode_data(&block))
+                            .await
+                            .map_err(|err| std::io::Error::other(format!("EC encode task failed: {err}")))??;
                         let queued_bytes = queued_block_bytes(&res);
                         rustfs_io_metrics::add_ec_encode_inflight_bytes(queued_bytes);
                         if let Err(err) = tx.send(res).await {

--- a/crates/ecstore/src/erasure_coding/erasure.rs
+++ b/crates/ecstore/src/erasure_coding/erasure.rs
@@ -587,7 +587,12 @@ impl Erasure {
                 Ok(n) if n > 0 => {
                     warn!("encode_stream_callback_async read n={}", n);
                     total += n;
-                    let res = self.encode_data(&buf[..n]);
+                    let erasure = self.clone();
+                    let block = buf[..n].to_vec();
+                    let res = match tokio::task::spawn_blocking(move || erasure.encode_data(&block)).await {
+                        Ok(res) => res,
+                        Err(err) => Err(std::io::Error::other(format!("EC encode task failed: {err}"))),
+                    };
                     on_block(res).await?
                 }
                 Ok(_) => {

--- a/crates/ecstore/src/erasure_coding/erasure.rs
+++ b/crates/ecstore/src/erasure_coding/erasure.rs
@@ -588,11 +588,20 @@ impl Erasure {
                     warn!("encode_stream_callback_async read n={}", n);
                     total += n;
                     let erasure = self.clone();
-                    let block = buf[..n].to_vec();
-                    let res = match tokio::task::spawn_blocking(move || erasure.encode_data(&block)).await {
-                        Ok(res) => res,
-                        Err(err) => Err(std::io::Error::other(format!("EC encode task failed: {err}"))),
+                    let encode_buf = std::mem::take(&mut buf);
+                    let (res, returned_buf) = match tokio::task::spawn_blocking(move || {
+                        let res = erasure.encode_data(&encode_buf[..n]);
+                        (res, encode_buf)
+                    })
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(err) => {
+                            on_block(Err(std::io::Error::other(format!("EC encode task failed: {err}")))).await?;
+                            break;
+                        }
                     };
+                    buf = returned_buf;
                     on_block(res).await?
                 }
                 Ok(_) => {


### PR DESCRIPTION
## Related Issues
Fixes #3097.

## Summary of Changes
- Offload erasure block encoding in the async write pipeline to Tokio's blocking pool.
- Apply the same scheduling behavior to the async erasure callback helper.
- Keep the existing shard encoding logic and write quorum flow unchanged.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore erasure_coding::encode::tests::encode_shutdowns_writers_after_small_shards`
- `cargo test -p rustfs-ecstore erasure_coding::erasure::tests::test_encode_stream_callback_async_channel_decode`

## Impact
High-concurrency PutObject workloads spend EC encoding CPU time outside Tokio worker threads, reducing the chance that lock RPC and other async tasks are starved by synchronous Reed-Solomon work.

## Additional Notes
This is intentionally scoped to the EC encoding starvation path. Lock retry behavior and PutObject lock semantics are left unchanged.