### PR TITLE
chore(release): prepare 1.0.0-beta.6

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -47,6 +47,7 @@ jobs:
     timeout-minutes: 60
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      NIX_CURL_FLAGS: "--user-agent rustfs-nix-ci/1.0 (+https://github.com/rustfs/rustfs)"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,8 +44,6 @@ jobs:
     name: Nix Build & Check
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -48,27 +48,31 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NIX_CURL_FLAGS: "--user-agent rustfs-nix-ci/1.0 (+https://github.com/rustfs/rustfs)"
+      CARGO_HTTP_USER_AGENT: "cargo/rustfs-nix-ci"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Check Nix Flake Inputs
+        uses: DeterminateSystems/flake-checker-action@v12
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          fail-mode: true
+          ignore-missing-flake-lock: false
+
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf: |
             experimental-features = nix-command flakes
             max-jobs = 1
-
-      - name: Setup Flake Checker
-        uses: DeterminateSystems/flake-checker-action@v12
 
       - name: Verify Flake
         run: |
           echo "Checking flake structure and evaluation..."
           nix flake show
           for attempt in 1 2 3; do
-            if nix flake check --print-build-logs --fallback; then
+            if nix flake check --print-build-logs --fallback --option fallback true; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
@@ -82,7 +86,7 @@ jobs:
         run: |
           echo "Building the default package..."
           for attempt in 1 2 3; do
-            if nix build .#default --print-build-logs --fallback; then
+            if nix build .#default --print-build-logs --fallback --option fallback true; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -53,20 +53,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Check Nix Flake Inputs
-        uses: DeterminateSystems/flake-checker-action@v12
-        with:
-          fail-mode: true
-          ignore-missing-flake-lock: false
-
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
+        uses: DeterminateSystems/determinate-nix-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
             experimental-features = nix-command flakes
             max-jobs = 1
-            user-agent-suffix = rustfs-ci-pr3104
+            user-agent-suffix = rustfs-ci-nix
+
+      - name: Cache Nix
+        uses: DeterminateSystems/flakehub-cache-action@v3.20.0
+
+      - name: Check Nix Flake Inputs
+        uses: DeterminateSystems/flake-checker-action@main
+        with:
+          fail-mode: true
+          ignore-missing-flake-lock: false
 
       - name: Verify Flake
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -63,7 +63,10 @@ jobs:
             user-agent-suffix = rustfs-ci-nix
 
       - name: Cache Nix
-        uses: DeterminateSystems/flakehub-cache-action@v3.20.0
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+          use-gha-cache: true
 
       - name: Check Nix Flake Inputs
         uses: DeterminateSystems/flake-checker-action@v12

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,20 +44,23 @@ jobs:
     name: Nix Build & Check
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: DeterminateSystems/determinate-nix-action@v3.21.0
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf: |
             experimental-features = nix-command flakes
             max-jobs = 1
 
       - name: Cache Nix
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: DeterminateSystems/flakehub-cache-action@v3.21.0
 
       - name: Check Nix Flake Inputs
         uses: DeterminateSystems/flake-checker-action@v12

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -38,6 +38,7 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   nix-validation:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -57,11 +57,7 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           extra_nix_config: |
             experimental-features = nix-command flakes
-
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
-        with:
-          use-flakehub: false
+            max-jobs = 1
 
       - name: Setup Flake Checker
         uses: DeterminateSystems/flake-checker-action@v12
@@ -71,7 +67,7 @@ jobs:
           echo "Checking flake structure and evaluation..."
           nix flake show
           for attempt in 1 2 3; do
-            if nix flake check --print-build-logs; then
+            if nix flake check --print-build-logs --fallback; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
@@ -85,7 +81,7 @@ jobs:
         run: |
           echo "Building the default package..."
           for attempt in 1 2 3; do
-            if nix build .#default --print-build-logs; then
+            if nix build .#default --print-build-logs --fallback; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -38,7 +38,6 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   nix-validation:
@@ -47,26 +46,20 @@ jobs:
     timeout-minutes: 60
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-      NIX_CURL_FLAGS: "--user-agent rustfs-nix-ci/1.0 (+https://github.com/rustfs/rustfs)"
-      CARGO_HTTP_USER_AGENT: "cargo/rustfs-nix-ci"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-conf: |
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
             experimental-features = nix-command flakes
             max-jobs = 1
-            user-agent-suffix = rustfs-ci-nix
 
       - name: Cache Nix
         uses: DeterminateSystems/magic-nix-cache-action@v13
-        with:
-          use-flakehub: false
-          use-gha-cache: true
 
       - name: Check Nix Flake Inputs
         uses: DeterminateSystems/flake-checker-action@v12

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -55,9 +55,6 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             max-jobs = 1
-            trusted-users = root runner
-            substituters = http://127.0.0.1:37515 https://cache.nixos.org
-            trusted-substituters = http://127.0.0.1:37515
 
       - name: Cache Nix
         uses: DeterminateSystems/magic-nix-cache-action@v13

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@main
+        uses: DeterminateSystems/determinate-nix-action@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
@@ -66,7 +66,7 @@ jobs:
         uses: DeterminateSystems/flakehub-cache-action@v3.20.0
 
       - name: Check Nix Flake Inputs
-        uses: DeterminateSystems/flake-checker-action@main
+        uses: DeterminateSystems/flake-checker-action@v12
         with:
           fail-mode: true
           ignore-missing-flake-lock: false

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -57,6 +57,9 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             max-jobs = 1
+            trusted-users = root runner
+            substituters = http://127.0.0.1:37515 https://cache.nixos.org
+            trusted-substituters = http://127.0.0.1:37515
 
       - name: Cache Nix
         uses: DeterminateSystems/magic-nix-cache-action@v13

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -66,6 +66,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             max-jobs = 1
+            user-agent-suffix = rustfs-ci-pr3104
 
       - name: Verify Flake
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -38,6 +38,7 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   nix-validation:
@@ -59,6 +60,8 @@ jobs:
 
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
 
       - name: Setup Flake Checker
         uses: DeterminateSystems/flake-checker-action@v12
@@ -67,12 +70,30 @@ jobs:
         run: |
           echo "Checking flake structure and evaluation..."
           nix flake show
-          nix flake check --print-build-logs
+          for attempt in 1 2 3; do
+            if nix flake check --print-build-logs; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "nix flake check failed after 3 attempts."
+              exit 1
+            fi
+            sleep $((attempt * 15))
+          done
 
       - name: Build RustFS
         run: |
           echo "Building the default package..."
-          nix build .#default --print-build-logs
+          for attempt in 1 2 3; do
+            if nix build .#default --print-build-logs; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "nix build failed after 3 attempts."
+              exit 1
+            fi
+            sleep $((attempt * 15))
+          done
 
       - name: Test Binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,7 +3614,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9055,7 +9055,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9174,7 +9174,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9197,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9211,7 +9211,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "chrono",
  "metrics",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "rustfs-io-core",
  "rustfs-io-metrics",
@@ -9238,14 +9238,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "const-str",
 ]
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9258,7 +9258,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9278,7 +9278,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "aes-gcm",
  "async-channel",
@@ -9393,7 +9393,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9417,7 +9417,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9445,7 +9445,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9479,7 +9479,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "bytes",
  "memmap2 0.9.10",
@@ -9490,7 +9490,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "criterion",
  "metrics",
@@ -9552,7 +9552,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "bytes",
  "futures",
@@ -9577,7 +9577,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9606,7 +9606,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9627,7 +9627,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "chrono",
  "humantime",
@@ -9640,7 +9640,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9674,7 +9674,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "criterion",
  "futures",
@@ -9692,7 +9692,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9738,7 +9738,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9766,7 +9766,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -9824,7 +9824,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "flatbuffers",
  "prost 0.14.3",
@@ -9842,7 +9842,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -9877,14 +9877,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "rustfs-s3-types",
 ]
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -9892,7 +9892,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9919,7 +9919,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9936,7 +9936,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9967,7 +9967,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9983,7 +9983,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "arc-swap",
  "metrics",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -10073,7 +10073,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "base64-simd",
  "blake2 0.11.0-rc.6",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.95.0"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -77,43 +77,43 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.4" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.4" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.4" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.4" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.4" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.4" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.4" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.4" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.4" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.4" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.4" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.4" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.4" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.4" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.4" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.4" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.4" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.4" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.4" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.4" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.4" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.4" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.4" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.4" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.4" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.4" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.4" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.4" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.4" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.4" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.4" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.4" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.4" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.4" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.4" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.4" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.4" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.6" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.6" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.6" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.6" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.6" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.6" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.6" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.6" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.6" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.6" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.6" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.6" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.6" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.6" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.6" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.6" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.6" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.6" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.6" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.6" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.6" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.6" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.6" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.6" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.6" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.6" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.6" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.6" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.6" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.6" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.6" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.6" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.6" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.6" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.6" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.6" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.6" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.4
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.6
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ RustFS 容器以非 root 用户 `rustfs` (UID `10001`) 运行。如果您使用 
  docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
  # 使用指定版本运行
- docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.4
+ docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.6
 ```
 
 您也可以使用 Docker Compose。使用根目录下的 `docker-compose.yml` 文件：

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.4";
+            version = "1.0.0-beta.6";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.4.1"
-appVersion: "1.0.0-beta.4"
+version: "0.6.0"
+appVersion: "1.0.0-beta.6"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -2,7 +2,7 @@
 %global _empty_manifest_terminate_build 0
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.4
+Release:        beta.6
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -57,6 +57,9 @@ install %_builddir/%{name}-%{version}-%{release}/target/%_arch/%_arch-unknown-li
 %_bindir/rustfs
 
 %changelog
+* Thu May 28 2026 houseme <housemecn@gmail.com>
+- Update RPM package to RustFS 1.0.0-beta.6
+
 * Thu May 20 2026 houseme <housemecn@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.4
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Bump RustFS workspace and internal crate versions to `1.0.0-beta.6` in `Cargo.toml` and `Cargo.lock`.
- Align release assets with `1.0.0-beta.6`:
  - Update versioned Docker quickstart examples in `README.md` and `README_ZH.md`.
  - Update Nix package version in `flake.nix`.
  - Update Helm chart `appVersion` to `1.0.0-beta.6` and chart `version` to `0.6.0`.
  - Update RPM `Release` to `beta.6` and add a new `%changelog` entry with current maintainer/date metadata.
- Stabilize Nix CI workflow behavior for this PR troubleshooting cycle:
  - Migrate to Determinate stack (`determinate-nix-action@v3`, `flake-checker-action@v12`, `flakehub-cache-action@v3.20.0`).
  - Keep bounded retries for `nix flake check` and `nix build` with fallback enabled.
  - Keep explicit Nix/Cargo user-agent settings to reduce fetch-side filtering variance.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`
- `cargo clean`

## Impact
- Release metadata and packaging assets are aligned for publishing `1.0.0-beta.6`.
- CI workflow scope in this PR now explicitly includes Nix pipeline hardening/migration work.
- No RustFS runtime logic changes are introduced by this PR.

## Additional Notes
- Nix failures observed on this PR are repeatedly in external crates.io fetch (`403`) during Nix dependency download, not in RustFS binary behavior.
