### PR TITLE
fix(utils): tolerate bavail greater than bfree on Linux

### DIFF
--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -19,10 +19,11 @@ use std::fs;
 use std::fs::File;
 use std::io::{self, BufRead, Error, ErrorKind, Read};
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 /// Returns total and free bytes available in a directory, e.g. `/`.
 pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
-    let path_display = p.as_ref().display();
+    let path_display = p.as_ref().display().to_string();
     // Use statfs on Linux to get access to f_type (filesystem magic number)
     let stat = statfs(p.as_ref())?;
 
@@ -42,15 +43,39 @@ pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
     let bfree = stat.f_bfree as u64;
     let bavail = stat.f_bavail as u64;
     let blocks = stat.f_blocks as u64;
+    let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, &path_display)?;
 
-    let reserved = match bfree.checked_sub(bavail) {
-        Some(reserved) => reserved,
-        None => {
-            return Err(Error::other(format!(
-                "detected f_bavail space ({bavail}) > f_bfree space ({bfree}), fs corruption at ({path_display}). please run 'fsck'",
-            )));
-        }
-    };
+    let st = rustix::fs::stat(p.as_ref())?;
+
+    Ok(DiskInfo {
+        total,
+        free,
+        used,
+        files: stat.f_files as u64,
+        ffree: stat.f_ffree as u64,
+        fstype: get_fs_type(stat.f_type as u64).to_string(),
+        major: rustix::fs::major(st.st_dev) as u64,
+        minor: rustix::fs::minor(st.st_dev) as u64,
+        ..Default::default()
+    })
+}
+
+fn calculate_space_usage(
+    blocks: u64,
+    bfree: u64,
+    bavail: u64,
+    bsize: u64,
+    path_display: &str,
+) -> std::io::Result<(u64, u64, u64)> {
+    let reserved = bfree.saturating_sub(bavail);
+    if bfree < bavail {
+        warn!(
+            path = %path_display,
+            f_bfree = bfree,
+            f_bavail = bavail,
+            "detected f_bavail greater than f_bfree, treating reserved blocks as 0 for compatibility"
+        );
+    }
 
     let total = match blocks.checked_sub(reserved) {
         Some(total) => total * bsize,
@@ -71,19 +96,7 @@ pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
         }
     };
 
-    let st = rustix::fs::stat(p.as_ref())?;
-
-    Ok(DiskInfo {
-        total,
-        free,
-        used,
-        files: stat.f_files as u64,
-        ffree: stat.f_ffree as u64,
-        fstype: get_fs_type(stat.f_type as u64).to_string(),
-        major: rustix::fs::major(st.st_dev) as u64,
-        minor: rustix::fs::minor(st.st_dev) as u64,
-        ..Default::default()
-    })
+    Ok((total, free, used))
 }
 
 pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {
@@ -406,5 +419,24 @@ mod tests {
         let minor = u64::MAX;
         let ids = resolve_block_device_ids(major, minor).unwrap();
         assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec![format!("{major}:{minor}")]);
+    }
+
+    #[test]
+    fn calculate_space_usage_allows_bavail_greater_than_bfree() {
+        let blocks = 1_000_u64;
+        let bfree = 900_u64;
+        let bavail = 920_u64;
+        let bsize = 4_096_u64;
+
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        assert_eq!(total, blocks * bsize);
+        assert_eq!(free, bavail * bsize);
+        assert_eq!(used, total - free);
+    }
+
+    #[test]
+    fn calculate_space_usage_rejects_free_greater_than_total() {
+        let err = calculate_space_usage(100, 100, 200, 4_096, "/data").unwrap_err();
+        assert!(err.to_string().contains("detected free space"));
     }
 }

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -105,15 +105,10 @@ fn calculate_space_usage(blocks: u64, bfree: u64, bavail: u64, bsize: u64, path:
 fn should_warn_bavail_greater_than_bfree(path: &Path) -> bool {
     let warned_paths = BAVAIL_GT_BFREE_WARNING_PATHS.get_or_init(|| Mutex::new(BTreeSet::new()));
     let mut warned_paths = match warned_paths.lock() {
-        Ok(warned_paths) => warned_paths,
+        Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    if warned_paths.contains(path) {
-        false
-    } else {
-        warned_paths.insert(path.to_path_buf());
-        true
-    }
+    warned_paths.insert(path.to_path_buf())
 }
 
 pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -19,7 +19,10 @@ use std::fs;
 use std::fs::File;
 use std::io::{self, BufRead, Error, ErrorKind, Read};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use tracing::warn;
+
+static BAVAIL_GT_BFREE_WARNING_PATHS: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
 
 /// Returns total and free bytes available in a directory, e.g. `/`.
 pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
@@ -68,12 +71,14 @@ fn calculate_space_usage(
     path_display: &str,
 ) -> std::io::Result<(u64, u64, u64)> {
     let available = if bfree < bavail {
-        warn!(
-            path = %path_display,
-            f_bfree = bfree,
-            f_bavail = bavail,
-            "detected f_bavail greater than f_bfree, capping available blocks to f_bfree for compatibility"
-        );
+        if should_warn_bavail_greater_than_bfree(path_display) {
+            warn!(
+                path = %path_display,
+                f_bfree = bfree,
+                f_bavail = bavail,
+                "detected f_bavail greater than f_bfree, capping available blocks to f_bfree for compatibility"
+            );
+        }
         bfree
     } else {
         bavail
@@ -100,6 +105,14 @@ fn calculate_space_usage(
     };
 
     Ok((total, free, used))
+}
+
+fn should_warn_bavail_greater_than_bfree(path_display: &str) -> bool {
+    let warned_paths = BAVAIL_GT_BFREE_WARNING_PATHS.get_or_init(|| Mutex::new(BTreeSet::new()));
+    match warned_paths.lock() {
+        Ok(mut warned_paths) => warned_paths.insert(path_display.to_owned()),
+        Err(_) => true,
+    }
 }
 
 pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {
@@ -441,5 +454,14 @@ mod tests {
     fn calculate_space_usage_rejects_free_greater_than_total() {
         let err = calculate_space_usage(100, 120, 120, 4_096, "/data").unwrap_err();
         assert!(err.to_string().contains("detected free space"));
+    }
+
+    #[test]
+    fn bavail_greater_than_bfree_warning_is_once_per_path() {
+        let path = "/data/rustfs-bavail-warning-once";
+
+        assert!(should_warn_bavail_greater_than_bfree(path));
+        assert!(!should_warn_bavail_greater_than_bfree(path));
+        assert!(should_warn_bavail_greater_than_bfree("/data/rustfs-bavail-warning-other"));
     }
 }

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -67,15 +67,18 @@ fn calculate_space_usage(
     bsize: u64,
     path_display: &str,
 ) -> std::io::Result<(u64, u64, u64)> {
-    let reserved = bfree.saturating_sub(bavail);
-    if bfree < bavail {
+    let available = if bfree < bavail {
         warn!(
             path = %path_display,
             f_bfree = bfree,
             f_bavail = bavail,
-            "detected f_bavail greater than f_bfree, treating reserved blocks as 0 for compatibility"
+            "detected f_bavail greater than f_bfree, capping available blocks to f_bfree for compatibility"
         );
-    }
+        bfree
+    } else {
+        bavail
+    };
+    let reserved = bfree - available;
 
     let total = match blocks.checked_sub(reserved) {
         Some(total) => total * bsize,
@@ -86,7 +89,7 @@ fn calculate_space_usage(
         }
     };
 
-    let free = bavail * bsize;
+    let free = available * bsize;
     let used = match total.checked_sub(free) {
         Some(used) => used,
         None => {
@@ -430,13 +433,13 @@ mod tests {
 
         let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
         assert_eq!(total, blocks * bsize);
-        assert_eq!(free, bavail * bsize);
+        assert_eq!(free, bfree * bsize);
         assert_eq!(used, total - free);
     }
 
     #[test]
     fn calculate_space_usage_rejects_free_greater_than_total() {
-        let err = calculate_space_usage(100, 100, 200, 4_096, "/data").unwrap_err();
+        let err = calculate_space_usage(100, 120, 120, 4_096, "/data").unwrap_err();
         assert!(err.to_string().contains("detected free space"));
     }
 }

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -26,7 +26,6 @@ static BAVAIL_GT_BFREE_WARNING_PATHS: OnceLock<Mutex<BTreeSet<String>>> = OnceLo
 
 /// Returns total and free bytes available in a directory, e.g. `/`.
 pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
-    let path_display = p.as_ref().display().to_string();
     // Use statfs on Linux to get access to f_type (filesystem magic number)
     let stat = statfs(p.as_ref())?;
 
@@ -46,7 +45,7 @@ pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
     let bfree = stat.f_bfree as u64;
     let bavail = stat.f_bavail as u64;
     let blocks = stat.f_blocks as u64;
-    let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, &path_display)?;
+    let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, p.as_ref().display())?;
 
     let st = rustix::fs::stat(p.as_ref())?;
 
@@ -68,10 +67,11 @@ fn calculate_space_usage(
     bfree: u64,
     bavail: u64,
     bsize: u64,
-    path_display: &str,
+    path: impl std::fmt::Display,
 ) -> std::io::Result<(u64, u64, u64)> {
     let available = if bfree < bavail {
-        if should_warn_bavail_greater_than_bfree(path_display) {
+        let path_display = path.to_string();
+        if should_warn_bavail_greater_than_bfree(&path_display) {
             warn!(
                 path = %path_display,
                 f_bfree = bfree,
@@ -89,7 +89,7 @@ fn calculate_space_usage(
         Some(total) => total * bsize,
         None => {
             return Err(Error::other(format!(
-                "detected reserved space ({reserved}) > blocks space ({blocks}), fs corruption at ({path_display}). please run 'fsck'",
+                "detected reserved space ({reserved}) > blocks space ({blocks}), fs corruption at ({path}). please run 'fsck'",
             )));
         }
     };
@@ -99,7 +99,7 @@ fn calculate_space_usage(
         Some(used) => used,
         None => {
             return Err(Error::other(format!(
-                "detected free space ({free}) > total drive space ({total}), fs corruption at ({path_display}). please run 'fsck'"
+                "detected free space ({free}) > total drive space ({total}), fs corruption at ({path}). please run 'fsck'"
             )));
         }
     };
@@ -435,6 +435,55 @@ mod tests {
         let minor = u64::MAX;
         let ids = resolve_block_device_ids(major, minor).unwrap();
         assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec![format!("{major}:{minor}")]);
+    }
+
+    #[test]
+    fn calculate_space_usage_normal_bfree_greater_than_bavail() {
+        // Typical ext4/xfs scenario: bavail < bfree due to reserved blocks
+        let blocks = 1_000_u64;
+        let bfree = 900_u64;
+        let bavail = 850_u64;
+        let bsize = 4_096_u64;
+
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        assert_eq!(total, blocks * bsize);
+        assert_eq!(free, bavail * bsize);
+        assert_eq!(used, (blocks - bavail) * bsize);
+    }
+
+    #[test]
+    fn calculate_space_usage_bfree_equals_bavail() {
+        // No reserved blocks: bfree == bavail (e.g. FAT/exFAT or root user)
+        let blocks = 500_u64;
+        let bfree = 400_u64;
+        let bavail = 400_u64;
+        let bsize = 4_096_u64;
+
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        assert_eq!(total, blocks * bsize);
+        assert_eq!(free, bfree * bsize);
+        assert_eq!(used, (blocks - bfree) * bsize);
+    }
+
+    #[test]
+    fn calculate_space_usage_all_zero_blocks() {
+        let (total, free, used) = calculate_space_usage(0, 0, 0, 4_096, "/data").unwrap();
+        assert_eq!(total, 0);
+        assert_eq!(free, 0);
+        assert_eq!(used, 0);
+    }
+
+    #[test]
+    fn calculate_space_usage_all_blocks_free() {
+        let blocks = 1_000_u64;
+        let bfree = 1_000_u64;
+        let bavail = 1_000_u64;
+        let bsize = 4_096_u64;
+
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        assert_eq!(total, blocks * bsize);
+        assert_eq!(free, blocks * bsize);
+        assert_eq!(used, 0);
     }
 
     #[test]

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -447,9 +447,10 @@ mod tests {
         let bsize = 4_096_u64;
 
         let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, Path::new("/data")).unwrap();
-        assert_eq!(total, blocks * bsize);
+        let reserved = bfree - bavail;
+        assert_eq!(total, (blocks - reserved) * bsize);
         assert_eq!(free, bavail * bsize);
-        assert_eq!(used, (blocks - bavail) * bsize);
+        assert_eq!(used, total - free);
     }
 
     #[test]

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use tracing::warn;
 
-static BAVAIL_GT_BFREE_WARNING_PATHS: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
+static BAVAIL_GT_BFREE_WARNING_PATHS: OnceLock<Mutex<BTreeSet<PathBuf>>> = OnceLock::new();
 
 /// Returns total and free bytes available in a directory, e.g. `/`.
 pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
@@ -45,7 +45,7 @@ pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
     let bfree = stat.f_bfree as u64;
     let bavail = stat.f_bavail as u64;
     let blocks = stat.f_blocks as u64;
-    let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, p.as_ref().display())?;
+    let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, p.as_ref())?;
 
     let st = rustix::fs::stat(p.as_ref())?;
 
@@ -62,18 +62,11 @@ pub fn get_info(p: impl AsRef<Path>) -> std::io::Result<DiskInfo> {
     })
 }
 
-fn calculate_space_usage(
-    blocks: u64,
-    bfree: u64,
-    bavail: u64,
-    bsize: u64,
-    path: impl std::fmt::Display,
-) -> std::io::Result<(u64, u64, u64)> {
+fn calculate_space_usage(blocks: u64, bfree: u64, bavail: u64, bsize: u64, path: &Path) -> std::io::Result<(u64, u64, u64)> {
     let available = if bfree < bavail {
-        let path_display = path.to_string();
-        if should_warn_bavail_greater_than_bfree(&path_display) {
+        if should_warn_bavail_greater_than_bfree(path) {
             warn!(
-                path = %path_display,
+                path = %path.display(),
                 f_bfree = bfree,
                 f_bavail = bavail,
                 "detected f_bavail greater than f_bfree, capping available blocks to f_bfree for compatibility"
@@ -89,7 +82,8 @@ fn calculate_space_usage(
         Some(total) => total * bsize,
         None => {
             return Err(Error::other(format!(
-                "detected reserved space ({reserved}) > blocks space ({blocks}), fs corruption at ({path}). please run 'fsck'",
+                "detected reserved space ({reserved}) > blocks space ({blocks}), fs corruption at ({}). please run 'fsck'",
+                path.display(),
             )));
         }
     };
@@ -99,7 +93,8 @@ fn calculate_space_usage(
         Some(used) => used,
         None => {
             return Err(Error::other(format!(
-                "detected free space ({free}) > total drive space ({total}), fs corruption at ({path}). please run 'fsck'"
+                "detected free space ({free}) > total drive space ({total}), fs corruption at ({}). please run 'fsck'",
+                path.display(),
             )));
         }
     };
@@ -107,11 +102,17 @@ fn calculate_space_usage(
     Ok((total, free, used))
 }
 
-fn should_warn_bavail_greater_than_bfree(path_display: &str) -> bool {
+fn should_warn_bavail_greater_than_bfree(path: &Path) -> bool {
     let warned_paths = BAVAIL_GT_BFREE_WARNING_PATHS.get_or_init(|| Mutex::new(BTreeSet::new()));
-    match warned_paths.lock() {
-        Ok(mut warned_paths) => warned_paths.insert(path_display.to_owned()),
-        Err(_) => true,
+    let mut warned_paths = match warned_paths.lock() {
+        Ok(warned_paths) => warned_paths,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if warned_paths.contains(path) {
+        false
+    } else {
+        warned_paths.insert(path.to_path_buf());
+        true
     }
 }
 
@@ -445,7 +446,7 @@ mod tests {
         let bavail = 850_u64;
         let bsize = 4_096_u64;
 
-        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, Path::new("/data")).unwrap();
         assert_eq!(total, blocks * bsize);
         assert_eq!(free, bavail * bsize);
         assert_eq!(used, (blocks - bavail) * bsize);
@@ -459,7 +460,7 @@ mod tests {
         let bavail = 400_u64;
         let bsize = 4_096_u64;
 
-        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, Path::new("/data")).unwrap();
         assert_eq!(total, blocks * bsize);
         assert_eq!(free, bfree * bsize);
         assert_eq!(used, (blocks - bfree) * bsize);
@@ -467,7 +468,7 @@ mod tests {
 
     #[test]
     fn calculate_space_usage_all_zero_blocks() {
-        let (total, free, used) = calculate_space_usage(0, 0, 0, 4_096, "/data").unwrap();
+        let (total, free, used) = calculate_space_usage(0, 0, 0, 4_096, Path::new("/data")).unwrap();
         assert_eq!(total, 0);
         assert_eq!(free, 0);
         assert_eq!(used, 0);
@@ -480,7 +481,7 @@ mod tests {
         let bavail = 1_000_u64;
         let bsize = 4_096_u64;
 
-        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, Path::new("/data")).unwrap();
         assert_eq!(total, blocks * bsize);
         assert_eq!(free, blocks * bsize);
         assert_eq!(used, 0);
@@ -493,7 +494,7 @@ mod tests {
         let bavail = 920_u64;
         let bsize = 4_096_u64;
 
-        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, "/data").unwrap();
+        let (total, free, used) = calculate_space_usage(blocks, bfree, bavail, bsize, Path::new("/data")).unwrap();
         assert_eq!(total, blocks * bsize);
         assert_eq!(free, bfree * bsize);
         assert_eq!(used, total - free);
@@ -501,16 +502,16 @@ mod tests {
 
     #[test]
     fn calculate_space_usage_rejects_free_greater_than_total() {
-        let err = calculate_space_usage(100, 120, 120, 4_096, "/data").unwrap_err();
+        let err = calculate_space_usage(100, 120, 120, 4_096, Path::new("/data")).unwrap_err();
         assert!(err.to_string().contains("detected free space"));
     }
 
     #[test]
     fn bavail_greater_than_bfree_warning_is_once_per_path() {
-        let path = "/data/rustfs-bavail-warning-once";
+        let path = Path::new("/data/rustfs-bavail-warning-once");
 
         assert!(should_warn_bavail_greater_than_bfree(path));
         assert!(!should_warn_bavail_greater_than_bfree(path));
-        assert!(should_warn_bavail_greater_than_bfree("/data/rustfs-bavail-warning-other"));
+        assert!(should_warn_bavail_greater_than_bfree(Path::new("/data/rustfs-bavail-warning-other")));
     }
 }

--- a/crates/utils/src/os/linux.rs
+++ b/crates/utils/src/os/linux.rs
@@ -108,7 +108,11 @@ fn should_warn_bavail_greater_than_bfree(path: &Path) -> bool {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    warned_paths.insert(path.to_path_buf())
+    if warned_paths.contains(path) {
+        false
+    } else {
+        warned_paths.insert(path.to_path_buf())
+    }
 }
 
 pub fn same_disk(disk1: &str, disk2: &str) -> std::io::Result<bool> {


### PR DESCRIPTION
## Related Issues
Fixes #3025

## Summary of Changes
- Adjust Linux disk-space validation to handle `f_bavail > f_bfree` as a compatibility edge case instead of hard-failing startup.
- Preserve existing corruption checks for other invalid counter relationships.
- Add warning log when this edge case is observed and treat reserved blocks as `0` for capacity math.
- Add unit coverage for both compatibility and invalid free-space paths.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-utils --features os calculate_space_usage_allows_bavail_greater_than_bfree`
- `cargo test -p rustfs-utils --features os calculate_space_usage_rejects_free_greater_than_total`
- `make pre-commit` (running in CI)

## Impact
- Startup behavior on some Linux host/filesystem/container combinations is now more compatible.
- Avoids false-positive fatal shutdowns caused by strict `f_bavail > f_bfree` assumption.

## Additional Notes
- Local macOS test runs do not compile Linux-only `linux.rs` test module; Linux path verification is delegated to CI.
