### PR TITLE
ci(build): enable cross-compilation for macOS x86_64 target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
             {"target_id":"linux-x86_64-gnu","os":"ubicloud-standard-2","target":"x86_64-unknown-linux-gnu","cross":false,"platform":"linux","rustflags":""},
             {"target_id":"linux-aarch64-gnu","os":"ubicloud-standard-2","target":"aarch64-unknown-linux-gnu","cross":true,"platform":"linux","rustflags":""},
             {"target_id":"macos-aarch64","os":"macos-latest","target":"aarch64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
-            {"target_id":"macos-x86_64","os":"macos-15-intel","target":"x86_64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
+            {"target_id":"macos-x86_64","os":"macos-15-intel","target":"x86_64-apple-darwin","cross":true,"platform":"macos","rustflags":""},
             {"target_id":"windows-x86_64","os":"windows-latest","target":"x86_64-pc-windows-msvc","cross":false,"platform":"windows","rustflags":""}
           ]}'
 


### PR DESCRIPTION
## Summary

  - Set `cross=true` for the `macos-x86_64` build matrix entry so that the `x86_64-apple-darwin` target is cross-compiled rather than built natively on the runner.

  ## Background

  The macOS x86_64 build previously ran with `cross=false` on `macos-15-intel`, relying on a native Intel macOS runner. By enabling cross-compilation, the build can be performed on an ARM-based macOS runner targeting x86_64,
  which may improve CI availability and reduce dependency on dedicated Intel runners.

  ## Changes

  - `.github/workflows/build.yml`: change `cross` from `false` to `true` for the `macos-x86_64` matrix entry.

  ## Test plan

  - [ ] Verify the CI workflow passes for the `macos-x86_64` target with cross-compilation enabled.
  - [ ] Confirm the produced binary runs correctly on an x86_64 macOS environment.
  - [ ] Check that other build targets (`linux-*`, `macos-aarch64`, `windows-x86_64`) are not affected.