### PR TITLE
fix(scanner): support PBS subfolder alert threshold

### DIFF
--- a/crates/config/src/constants/scanner.rs
+++ b/crates/config/src/constants/scanner.rs
@@ -65,11 +65,12 @@ pub const ENV_SCANNER_ALERT_EXCESS_VERSION_SIZE: &str = "RUSTFS_SCANNER_ALERT_EX
 pub const DEFAULT_SCANNER_ALERT_EXCESS_VERSION_SIZE: u64 = 1024 * 1024 * 1024 * 1024;
 
 /// Environment variable that controls how many subfolders trigger scanner alerts.
-/// - Example: `export RUSTFS_SCANNER_ALERT_EXCESS_FOLDERS=50000`
+/// - Example: `export RUSTFS_SCANNER_ALERT_EXCESS_FOLDERS=65538`
 pub const ENV_SCANNER_ALERT_EXCESS_FOLDERS: &str = "RUSTFS_SCANNER_ALERT_EXCESS_FOLDERS";
 
 /// Default subfolder count that triggers scanner alerts.
-pub const DEFAULT_SCANNER_ALERT_EXCESS_FOLDERS: u64 = 50_000;
+/// Allows Proxmox Backup Server's chunk namespace layout.
+pub const DEFAULT_SCANNER_ALERT_EXCESS_FOLDERS: u64 = 65_538;
 
 /// Environment variable that controls whether the scanner sleeps between operations.
 /// When `true` (default), the scanner throttles itself. When `false`, it runs at full speed.

--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -1666,7 +1666,7 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::{PermissionsExt, symlink};
     use std::sync::atomic::AtomicBool;
-    use temp_env::with_var;
+    use temp_env::{with_var, with_var_unset};
     use uuid::Uuid;
 
     async fn build_test_scanner() -> (FolderScanner, std::path::PathBuf) {
@@ -1805,6 +1805,14 @@ mod tests {
     fn test_excessive_folders_threshold_uses_env() {
         with_var(rustfs_config::ENV_SCANNER_ALERT_EXCESS_FOLDERS, Some("3"), || {
             assert_eq!(scanner_excess_folders_threshold(), 3);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_excessive_folders_threshold_default_supports_pbs_layout() {
+        with_var_unset(rustfs_config::ENV_SCANNER_ALERT_EXCESS_FOLDERS, || {
+            assert_eq!(scanner_excess_folders_threshold(), 65_538);
         });
     }
 


### PR DESCRIPTION
  ## Related Issues

  Fixes #3126.

  ## Summary of Changes

  Raise the default scanner excessive-folder alert threshold from `50_000` to `65_538` so the default configuration supports Proxmox
  Backup Server's pre-created `.chunks` namespace layout.

  Add a focused regression test for the default threshold while preserving the existing `RUSTFS_SCANNER_ALERT_EXCESS_FOLDERS`
  environment override behavior.

  ## Verification

  - `cargo fmt --all`
  - `cargo fmt --all --check`
  - `cargo test -p rustfs-scanner excessive_folders_threshold`
  - `git diff --check`

  Not run:
  - `make pre-commit` per request.

  ## Impact

  The scanner no longer emits excessive direct-subfolder alerts by default for PBS-compatible chunk directory layouts. Deployments
  can still override the threshold with `RUSTFS_SCANNER_ALERT_EXCESS_FOLDERS`.

  No API, storage format, or migration impact.

  ## Additional Notes

  N/A