### PR TITLE
fix(rio): map truncated put bodies to incompletebody

### DIFF
--- a/crates/ecstore/src/erasure_coding/encode.rs
+++ b/crates/ecstore/src/erasure_coding/encode.rs
@@ -223,8 +223,8 @@ impl Erasure {
             let mut total = 0;
             let mut buf = vec![0u8; block_size];
             loop {
-                match rustfs_utils::read_full(&mut reader, &mut buf).await {
-                    Ok(n) if n > 0 => {
+                match rustfs_utils::read_full_or_eof(&mut reader, &mut buf).await {
+                    Ok(Some(n)) if n > 0 => {
                         total += n;
                         let erasure = self.clone();
                         let encode_buf = std::mem::take(&mut buf);
@@ -243,7 +243,7 @@ impl Erasure {
                             return Err(std::io::Error::other(format!("Failed to send encoded data : {err}")));
                         }
                     }
-                    Ok(_) => {
+                    Ok(None) => {
                         break;
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
@@ -255,6 +255,7 @@ impl Erasure {
                         }
                         return Err(e);
                     }
+                    Ok(Some(_)) => unreachable!("read_full_or_eof never returns Some(0)"),
                     Err(e) => {
                         return Err(e);
                     }

--- a/crates/ecstore/src/erasure_coding/encode.rs
+++ b/crates/ecstore/src/erasure_coding/encode.rs
@@ -209,6 +209,13 @@ impl Erasure {
     where
         R: AsyncRead + Send + Sync + Unpin + 'static,
     {
+        if self.block_size == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "erasure block_size must be non-zero",
+            ));
+        }
+
         // Bound queued encoded blocks by memory budget to avoid per-request spikes.
         let expanded_block_bytes = self.shard_size().saturating_mul(self.total_shard_count());
         let max_inflight_bytes = rustfs_utils::get_env_usize(
@@ -224,7 +231,8 @@ impl Erasure {
             let mut buf = vec![0u8; block_size];
             loop {
                 match rustfs_utils::read_full_or_eof(&mut reader, &mut buf).await {
-                    Ok(Some(n)) if n > 0 => {
+                    Ok(Some(n)) => {
+                        debug_assert!(n > 0, "non-zero block_size prevents zero-length reads");
                         total += n;
                         let erasure = self.clone();
                         let encode_buf = std::mem::take(&mut buf);
@@ -255,7 +263,6 @@ impl Erasure {
                         }
                         return Err(e);
                     }
-                    Ok(Some(_)) => unreachable!("read_full_or_eof never returns Some(0)"),
                     Err(e) => {
                         return Err(e);
                     }
@@ -406,6 +413,27 @@ mod tests {
         };
 
         assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn encode_rejects_zero_block_size() {
+        let committed = Arc::new(Mutex::new(Vec::new()));
+        let writer = DeferredCommitWriter::new(committed);
+        let mut writers = vec![Some(BitrotWriterWrapper::new(
+            CustomWriter::new_tokio_writer(writer),
+            16,
+            HashAlgorithm::HighwayHash256S,
+        ))];
+
+        let erasure = Arc::new(Erasure::new(1, 0, 0));
+        let reader = tokio::io::BufReader::new(std::io::Cursor::new(b"payload".to_vec()));
+        let err = erasure
+            .encode(reader, &mut writers, 1)
+            .await
+            .expect_err("zero block size must be rejected");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("block_size"));
     }
 
     /// encode_inline_small: empty reader returns (reader, 0) without writing to any shard.

--- a/crates/ecstore/src/erasure_coding/encode.rs
+++ b/crates/ecstore/src/erasure_coding/encode.rs
@@ -253,7 +253,7 @@ impl Erasure {
                         {
                             return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()));
                         }
-                        break;
+                        return Err(e);
                     }
                     Err(e) => {
                         return Err(e);
@@ -327,7 +327,9 @@ impl Erasure {
 mod tests {
     use super::*;
     use crate::erasure_coding::{BitrotWriterWrapper, CustomWriter};
+    use rustfs_rio::HardLimitReader;
     use rustfs_utils::HashAlgorithm;
+    use std::io::Cursor;
     use std::pin::Pin;
     use std::sync::{Arc, Mutex};
     use std::task::{Context, Poll};
@@ -382,6 +384,27 @@ mod tests {
 
         assert_eq!(written, b"small payload".len());
         assert!(!committed.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn encode_returns_unexpected_eof_for_truncated_limited_reader() {
+        let committed = Arc::new(Mutex::new(Vec::new()));
+        let writer = DeferredCommitWriter::new(committed);
+        let mut writers = vec![Some(BitrotWriterWrapper::new(
+            CustomWriter::new_tokio_writer(writer),
+            16,
+            HashAlgorithm::HighwayHash256S,
+        ))];
+
+        let erasure = Arc::new(Erasure::new(1, 0, 16));
+        let truncated = HardLimitReader::new(Cursor::new(b"short".to_vec()), 10);
+
+        let err = match erasure.encode(truncated, &mut writers, 1).await {
+            Ok(_) => panic!("truncated input must fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
     }
 
     /// encode_inline_small: empty reader returns (reader, 0) without writing to any shard.

--- a/crates/ecstore/src/erasure_coding/erasure.rs
+++ b/crates/ecstore/src/erasure_coding/erasure.rs
@@ -583,8 +583,8 @@ impl Erasure {
         let mut total = 0;
         let mut buf = vec![0u8; block_size];
         loop {
-            match rustfs_utils::read_full(&mut *reader, &mut buf).await {
-                Ok(n) if n > 0 => {
+            match rustfs_utils::read_full_or_eof(&mut *reader, &mut buf).await {
+                Ok(Some(n)) if n > 0 => {
                     warn!("encode_stream_callback_async read n={}", n);
                     total += n;
                     let erasure = self.clone();
@@ -604,7 +604,7 @@ impl Erasure {
                     buf = returned_buf;
                     on_block(res).await?
                 }
-                Ok(_) => {
+                Ok(None) => {
                     warn!("encode_stream_callback_async read unexpected ok");
                     break;
                 }
@@ -612,6 +612,7 @@ impl Erasure {
                     warn!("encode_stream_callback_async read unexpected eof");
                     break;
                 }
+                Ok(Some(_)) => unreachable!("read_full_or_eof never returns Some(0)"),
                 Err(e) => {
                     warn!("encode_stream_callback_async read error={:?}", e);
                     on_block(Err(e)).await?;

--- a/crates/ecstore/src/erasure_coding/erasure.rs
+++ b/crates/ecstore/src/erasure_coding/erasure.rs
@@ -579,12 +579,22 @@ impl Erasure {
         F: FnMut(std::io::Result<Vec<Bytes>>) -> Fut + Send,
         Fut: std::future::Future<Output = Result<(), E>> + Send,
     {
+        if self.block_size == 0 {
+            on_block(Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "erasure block_size must be non-zero",
+            )))
+            .await?;
+            return Ok(0);
+        }
+
         let block_size = self.block_size;
         let mut total = 0;
         let mut buf = vec![0u8; block_size];
         loop {
             match rustfs_utils::read_full_or_eof(&mut *reader, &mut buf).await {
-                Ok(Some(n)) if n > 0 => {
+                Ok(Some(n)) => {
+                    debug_assert!(n > 0, "non-zero block_size prevents zero-length reads");
                     warn!("encode_stream_callback_async read n={}", n);
                     total += n;
                     let erasure = self.clone();
@@ -612,7 +622,6 @@ impl Erasure {
                     warn!("encode_stream_callback_async read unexpected eof");
                     break;
                 }
-                Ok(Some(_)) => unreachable!("read_full_or_eof never returns Some(0)"),
                 Err(e) => {
                     warn!("encode_stream_callback_async read error={:?}", e);
                     on_block(Err(e)).await?;
@@ -1031,6 +1040,35 @@ mod tests {
         }
         recovered.truncate(data_clone.len());
         assert_eq!(&recovered, &data_clone);
+    }
+
+    #[tokio::test]
+    async fn test_encode_stream_callback_async_reports_zero_block_size() {
+        use std::io::Cursor;
+        use std::sync::{Arc, Mutex};
+
+        let erasure = Arc::new(Erasure::new(1, 0, 0));
+        let mut reader = Cursor::new(b"payload".to_vec());
+        let observed = Arc::new(Mutex::new(None));
+        let observed_clone = observed.clone();
+
+        let total = erasure
+            .encode_stream_callback_async::<_, _, (), _>(&mut reader, move |res| {
+                let observed = observed_clone.clone();
+                async move {
+                    let err = res.expect_err("zero block size should report an error");
+                    *observed.lock().unwrap() = Some((err.kind(), err.to_string()));
+                    Ok(())
+                }
+            })
+            .await
+            .expect("callback should handle the zero block size error");
+
+        assert_eq!(total, 0);
+        let observed = observed.lock().unwrap();
+        let (kind, message) = observed.as_ref().expect("callback should be invoked once");
+        assert_eq!(*kind, std::io::ErrorKind::InvalidInput);
+        assert!(message.contains("block_size"));
     }
 
     // SIMD mode specific tests

--- a/crates/rio/src/errors.rs
+++ b/crates/rio/src/errors.rs
@@ -62,6 +62,13 @@ pub struct ChecksumMismatch {
     pub got: String,
 }
 
+/// Request body ended before the declared size was fully read.
+#[derive(Error, Debug, Clone, PartialEq)]
+#[error("Incomplete body: {remaining} bytes were still expected")]
+pub struct IncompleteBody {
+    pub remaining: i64,
+}
+
 /// Invalid checksum error
 #[derive(Error, Debug, Clone, PartialEq)]
 #[error("invalid checksum")]

--- a/crates/rio/src/hardlimit_reader.rs
+++ b/crates/rio/src/hardlimit_reader.rs
@@ -41,11 +41,25 @@ where
         if self.remaining < 0 {
             return Poll::Ready(Err(Error::other("input provided more bytes than specified")));
         }
+        let original_filled = buf.filled().len();
         if self.remaining == 0 {
-            return Poll::Ready(Ok(()));
+            let mut discard = [0u8; 8192];
+            let mut discard_buf = ReadBuf::new(&mut discard);
+            return match self.as_mut().project().inner.poll_read(cx, &mut discard_buf) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Ok(())) => {
+                    if discard_buf.filled().is_empty() {
+                        debug_assert_eq!(buf.filled().len(), original_filled);
+                        Poll::Ready(Ok(()))
+                    } else {
+                        Poll::Ready(Err(Error::other("input provided more bytes than specified")))
+                    }
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+            };
         }
         // Save the initial length
-        let before = buf.filled().len();
+        let before = original_filled;
 
         // Poll the inner reader
         let this = self.as_mut().project();
@@ -161,5 +175,24 @@ mod tests {
                 .is_some(),
             "error should retain the incomplete body marker"
         );
+    }
+
+    #[tokio::test]
+    async fn test_hardlimit_reader_rejects_extra_bytes_after_limit() {
+        let data = b"abcdef";
+        let reader = BufReader::new(&data[..]);
+        let mut r = HardLimitReader::new(reader, 3);
+
+        let mut first = [0u8; 3];
+        let n = read_full(&mut r, &mut first).await.expect("first read should consume limit");
+        assert_eq!(n, 3);
+        assert_eq!(&first, b"abc");
+
+        let mut second = [0u8; 1];
+        let err = read_full(&mut r, &mut second)
+            .await
+            .expect_err("bytes beyond the declared limit must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert!(err.to_string().contains("more bytes than specified"));
     }
 }

--- a/crates/rio/src/hardlimit_reader.rs
+++ b/crates/rio/src/hardlimit_reader.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::IncompleteBody;
 use pin_project_lite::pin_project;
 use std::io::{Error, Result};
 use std::pin::Pin;
@@ -40,6 +41,9 @@ where
         if self.remaining < 0 {
             return Poll::Ready(Err(Error::other("input provided more bytes than specified")));
         }
+        if self.remaining == 0 {
+            return Poll::Ready(Ok(()));
+        }
         // Save the initial length
         let before = buf.filled().len();
 
@@ -50,6 +54,14 @@ where
         if let Poll::Ready(Ok(())) = &poll {
             let after = buf.filled().len();
             let read = (after - before) as i64;
+            if read == 0 && *this.remaining > 0 {
+                return Poll::Ready(Err(Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    IncompleteBody {
+                        remaining: *this.remaining,
+                    },
+                )));
+            }
             *this.remaining -= read;
             if *this.remaining < 0 {
                 return Poll::Ready(Err(Error::other("input provided more bytes than specified")));
@@ -73,7 +85,7 @@ mod tests {
     async fn test_hardlimit_reader_normal() {
         let data = b"hello world";
         let reader = BufReader::new(&data[..]);
-        let hardlimit = HardLimitReader::new(reader, 20);
+        let hardlimit = HardLimitReader::new(reader, data.len() as i64);
         let mut r = hardlimit;
         let mut buf = Vec::new();
         let n = r.read_to_end(&mut buf).await.unwrap();
@@ -121,11 +133,33 @@ mod tests {
     async fn test_hardlimit_reader_empty() {
         let data = b"";
         let reader = BufReader::new(&data[..]);
-        let hardlimit = HardLimitReader::new(reader, 5);
+        let hardlimit = HardLimitReader::new(reader, 0);
         let mut r = hardlimit;
         let mut buf = Vec::new();
         let n = r.read_to_end(&mut buf).await.unwrap();
         assert_eq!(n, 0);
         assert_eq!(&buf, data);
+    }
+
+    #[tokio::test]
+    async fn test_hardlimit_reader_short_input_returns_unexpected_eof() {
+        let data = b"abc";
+        let reader = BufReader::new(&data[..]);
+        let mut r = HardLimitReader::new(reader, 5);
+        let mut buf = [0u8; 8];
+
+        let err = read_full(&mut r, &mut buf)
+            .await
+            .expect_err("short input must surface unexpected eof");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.get_ref()
+                .and_then(|inner| inner.downcast_ref::<std::io::Error>())
+                .and_then(|inner| inner.get_ref())
+                .and_then(|inner| inner.downcast_ref::<IncompleteBody>())
+                .is_some(),
+            "error should retain the incomplete body marker"
+        );
     }
 }

--- a/crates/utils/src/io.rs
+++ b/crates/utils/src/io.rs
@@ -29,10 +29,15 @@ pub async fn write_all<W: AsyncWrite + Send + Sync + Unpin>(writer: &mut W, buf:
     Ok(total)
 }
 
-/// Read up to buf.len() bytes into buf, returning 0 only when EOF is reached before any bytes are read.
-/// Returns an error if the reader fails after partially filling the buffer.
-#[allow(dead_code)]
-pub async fn read_full<R: AsyncRead + Send + Sync + Unpin>(mut reader: R, mut buf: &mut [u8]) -> std::io::Result<usize> {
+/// Read up to buf.len() bytes into buf and distinguish a clean EOF from a short read.
+///
+/// Returns `Ok(None)` when EOF is reached before any bytes are read, `Ok(Some(n))` when
+/// at least one byte is read, and preserves the underlying error chain when the reader
+/// fails after a partial fill.
+pub async fn read_full_or_eof<R: AsyncRead + Send + Sync + Unpin>(
+    mut reader: R,
+    mut buf: &mut [u8],
+) -> std::io::Result<Option<usize>> {
     let mut total = 0;
     while !buf.is_empty() {
         let n = match reader.read(buf).await {
@@ -51,14 +56,24 @@ pub async fn read_full<R: AsyncRead + Send + Sync + Unpin>(mut reader: R, mut bu
         };
         if n == 0 {
             if total > 0 {
-                return Ok(total);
+                return Ok(Some(total));
             }
-            return Ok(0);
+            return Ok(None);
         }
         buf = &mut buf[n..];
         total += n;
     }
-    Ok(total)
+    Ok(Some(total))
+}
+
+/// Read exactly buf.len() bytes into buf, or return an error if EOF is reached before any bytes are read.
+/// Like Go's io.ReadFull.
+#[allow(dead_code)]
+pub async fn read_full<R: AsyncRead + Send + Sync + Unpin>(reader: R, buf: &mut [u8]) -> std::io::Result<usize> {
+    match read_full_or_eof(reader, buf).await? {
+        Some(n) => Ok(n),
+        None => Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "early EOF")),
+    }
 }
 
 /// Encodes a u64 into buf and returns the number of bytes written.
@@ -158,6 +173,17 @@ mod tests {
         let mut buf = vec![0u8; size / 3];
         read_full(&mut reader, &mut buf).await.unwrap();
         assert_eq!(buf, data[..size / 3]);
+    }
+
+    #[tokio::test]
+    async fn test_read_full_or_eof_returns_none_for_empty_reader() {
+        let data = b"";
+        let mut reader = BufReader::new(&data[..]);
+        let mut buf = [0u8; 8];
+
+        let n = read_full_or_eof(&mut reader, &mut buf).await.unwrap();
+
+        assert_eq!(n, None);
     }
 
     #[test]

--- a/crates/utils/src/io.rs
+++ b/crates/utils/src/io.rs
@@ -29,8 +29,8 @@ pub async fn write_all<W: AsyncWrite + Send + Sync + Unpin>(writer: &mut W, buf:
     Ok(total)
 }
 
-/// Read exactly buf.len() bytes into buf, or return an error if EOF is reached before.
-/// Like Go's io.ReadFull.
+/// Read up to buf.len() bytes into buf, returning 0 only when EOF is reached before any bytes are read.
+/// Returns an error if the reader fails after partially filling the buffer.
 #[allow(dead_code)]
 pub async fn read_full<R: AsyncRead + Send + Sync + Unpin>(mut reader: R, mut buf: &mut [u8]) -> std::io::Result<usize> {
     let mut total = 0;
@@ -46,17 +46,14 @@ pub async fn read_full<R: AsyncRead + Send + Sync + Unpin>(mut reader: R, mut bu
                 if e.kind() == std::io::ErrorKind::InvalidData {
                     return Err(e);
                 }
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
-                    format!("read {total} bytes, error: {e}"),
-                ));
+                return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
             }
         };
         if n == 0 {
             if total > 0 {
                 return Ok(total);
             }
-            return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "early EOF"));
+            return Ok(0);
         }
         buf = &mut buf[n..];
         total += n;

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -141,10 +141,14 @@ fn decoded_content_length_from_headers(headers: &HeaderMap) -> S3Result<Option<i
 }
 
 fn request_uses_aws_chunked(headers: &HeaderMap) -> bool {
-    headers
-        .get("content-encoding")
-        .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.split(',').any(|part| part.trim().eq_ignore_ascii_case("aws-chunked")))
+    let has_aws_chunked = |header_name: &str| {
+        headers
+            .get(header_name)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.split(',').any(|part| part.trim().eq_ignore_ascii_case("aws-chunked")))
+    };
+
+    has_aws_chunked("content-encoding") || has_aws_chunked("transfer-encoding")
 }
 
 struct DeadlockRequestGuard {

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -129,6 +129,24 @@ const ACCEPT_RANGES_BYTES: &str = "bytes";
 const MAX_GET_OBJECT_MEMORY_BUFFER_BYTES: i64 = 64 * 1024 * 1024;
 static GET_OBJECT_BUFFER_THRESHOLD_WARNED: AtomicBool = AtomicBool::new(false);
 
+fn decoded_content_length_from_headers(headers: &HeaderMap) -> S3Result<Option<i64>> {
+    let Some(val) = headers.get(AMZ_DECODED_CONTENT_LENGTH) else {
+        return Ok(None);
+    };
+
+    match atoi::atoi::<i64>(val.as_bytes()) {
+        Some(x) => Ok(Some(x)),
+        None => Err(s3_error!(UnexpectedContent)),
+    }
+}
+
+fn request_uses_aws_chunked(headers: &HeaderMap) -> bool {
+    headers
+        .get("content-encoding")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.split(',').any(|part| part.trim().eq_ignore_ascii_case("aws-chunked")))
+}
+
 struct DeadlockRequestGuard {
     deadlock_detector: Arc<deadlock_detector::DeadlockDetector>,
     request_id: String,
@@ -1728,18 +1746,12 @@ impl DefaultObjectUsecase {
 
         let Some(body) = body else { return Err(s3_error!(IncompleteBody)) };
 
-        let mut size = match content_length {
-            Some(c) => c,
-            None => {
-                if let Some(val) = req.headers.get(AMZ_DECODED_CONTENT_LENGTH) {
-                    match atoi::atoi::<i64>(val.as_bytes()) {
-                        Some(x) => x,
-                        None => return Err(s3_error!(UnexpectedContent)),
-                    }
-                } else {
-                    return Err(s3_error!(UnexpectedContent));
-                }
-            }
+        let decoded_content_length = decoded_content_length_from_headers(&req.headers)?;
+        let mut size = match (request_uses_aws_chunked(&req.headers), decoded_content_length, content_length) {
+            (true, Some(decoded), _) => decoded,
+            (_, _, Some(c)) => c,
+            (_, Some(decoded), None) => decoded,
+            _ => return Err(s3_error!(UnexpectedContent)),
         };
 
         if size == -1 {
@@ -4631,6 +4643,26 @@ mod tests {
         headers.insert(AMZ_SERVER_SIDE_ENCRYPTION, HeaderValue::from_static("AES256"));
 
         assert!(!should_use_zero_copy(2 * 1024 * 1024, &headers));
+    }
+
+    #[test]
+    fn aws_chunked_put_prefers_decoded_content_length() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-encoding", HeaderValue::from_static("aws-chunked"));
+        headers.insert(AMZ_DECODED_CONTENT_LENGTH, HeaderValue::from_static("71680"));
+
+        let decoded = decoded_content_length_from_headers(&headers).expect("decoded content length should parse");
+        assert!(request_uses_aws_chunked(&headers));
+        assert_eq!(decoded, Some(71680));
+
+        let resolved = match (request_uses_aws_chunked(&headers), decoded, Some(99999)) {
+            (true, Some(decoded), _) => decoded,
+            (_, _, Some(c)) => c,
+            (_, Some(decoded), None) => decoded,
+            _ => unreachable!("test provides a valid size source"),
+        };
+
+        assert_eq!(resolved, 71680);
     }
 
     #[test]

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -181,6 +181,20 @@ impl ApiError {
     }
 }
 
+fn error_chain_has_type<T>(err: &(dyn std::error::Error + 'static)) -> bool
+where
+    T: std::error::Error + 'static,
+{
+    let mut current = Some(err);
+    while let Some(err) = current {
+        if err.downcast_ref::<T>().is_some() {
+            return true;
+        }
+        current = err.source();
+    }
+    false
+}
+
 impl From<ApiError> for S3Error {
     fn from(err: ApiError) -> Self {
         let mut s3e = S3Error::with_message(err.code, err.message);
@@ -260,17 +274,18 @@ impl From<std::io::Error> for ApiError {
     fn from(err: std::io::Error) -> Self {
         // Check if the error is a ChecksumMismatch (BadDigest)
         if let Some(inner) = err.get_ref() {
-            if inner.downcast_ref::<rustfs_rio::ChecksumMismatch>().is_some() {
+            if error_chain_has_type::<rustfs_rio::ChecksumMismatch>(inner) || error_chain_has_type::<rustfs_rio::BadDigest>(inner)
+            {
                 return ApiError {
                     code: S3ErrorCode::BadDigest,
                     message: ApiError::error_code_to_message(&S3ErrorCode::BadDigest),
                     source: Some(Box::new(err)),
                 };
             }
-            if inner.downcast_ref::<rustfs_rio::BadDigest>().is_some() {
+            if error_chain_has_type::<rustfs_rio::IncompleteBody>(inner) {
                 return ApiError {
-                    code: S3ErrorCode::BadDigest,
-                    message: ApiError::error_code_to_message(&S3ErrorCode::BadDigest),
+                    code: S3ErrorCode::IncompleteBody,
+                    message: ApiError::error_code_to_message(&S3ErrorCode::IncompleteBody),
                     source: Some(Box::new(err)),
                 };
             }
@@ -445,6 +460,16 @@ mod tests {
             assert_eq!(api_error.code, expected_code);
             assert!(api_error.source.is_some());
         }
+    }
+
+    #[test]
+    fn test_api_error_from_unexpected_eof_maps_to_incomplete_body() {
+        let io_error = IoError::new(ErrorKind::UnexpectedEof, rustfs_rio::IncompleteBody { remaining: 7 });
+        let api_error: ApiError = io_error.into();
+
+        assert_eq!(api_error.code, S3ErrorCode::IncompleteBody);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::IncompleteBody));
+        assert!(api_error.source.is_some());
     }
 
     #[test]

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -185,6 +185,17 @@ fn error_chain_has_type<T>(err: &(dyn std::error::Error + 'static)) -> bool
 where
     T: std::error::Error + 'static,
 {
+    if err.downcast_ref::<T>().is_some() {
+        return true;
+    }
+
+    if let Some(io_err) = err.downcast_ref::<std::io::Error>()
+        && let Some(inner) = io_err.get_ref()
+        && error_chain_has_type::<T>(inner)
+    {
+        return true;
+    }
+
     let mut current = Some(err);
     while let Some(err) = current {
         if err.downcast_ref::<T>().is_some() {
@@ -466,6 +477,19 @@ mod tests {
     fn test_api_error_from_unexpected_eof_maps_to_incomplete_body() {
         let io_error = IoError::new(ErrorKind::UnexpectedEof, rustfs_rio::IncompleteBody { remaining: 7 });
         let api_error: ApiError = io_error.into();
+
+        assert_eq!(api_error.code, S3ErrorCode::IncompleteBody);
+        assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::IncompleteBody));
+        assert!(api_error.source.is_some());
+    }
+
+    #[test]
+    fn test_api_error_from_nested_unexpected_eof_maps_to_incomplete_body() {
+        let nested = IoError::new(
+            ErrorKind::UnexpectedEof,
+            IoError::new(ErrorKind::UnexpectedEof, rustfs_rio::IncompleteBody { remaining: 7 }),
+        );
+        let api_error: ApiError = nested.into();
 
         assert_eq!(api_error.code, S3ErrorCode::IncompleteBody);
         assert_eq!(api_error.message, ApiError::error_code_to_message(&S3ErrorCode::IncompleteBody));


### PR DESCRIPTION
## Related Issues
Fixes rustfs/backlog#654

## Summary of Changes
- surface truncated fixed-size PUT request bodies as `IncompleteBody` instead of letting erasure encoding treat them as a normal EOF
- preserve incomplete body error chains through `read_full`/`read_full_or_eof` and map them to the S3 `IncompleteBody` response at the API layer
- use `x-amz-decoded-content-length` for `aws-chunked` PutObject requests so trailer-checksum uploads are sized against the decoded payload instead of the wire-encoded `Content-Length`
- add regression coverage for `HardLimitReader`, erasure encoding, aws-chunked size selection, and nested incomplete-body error mapping

## Verification
- `cargo test -p rustfs-rio hardlimit_reader`
- `cargo test -p rustfs-ecstore encode_returns_unexpected_eof_for_truncated_limited_reader`
- `cargo test -p rustfs --lib test_api_error_from_unexpected_eof_maps_to_incomplete_body`
- `cargo test -p rustfs --lib aws_chunked_put_prefers_decoded_content_length`
- `cargo test -p rustfs --lib nested_unexpected_eof_maps_to_incomplete_body`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
- fixed-size object uploads that terminate before the declared payload length is fully read now return `IncompleteBody` instead of bubbling up as `InternalError`
- SigV4 streaming uploads with checksum trailers now prefer the decoded payload length when both wire `Content-Length` and `x-amz-decoded-content-length` are present
- no configuration or API surface changes beyond the corrected error semantics

## Additional Notes
- addressed review feedback from `pullrequestreview-4407084974`
- branch rebases cleanly on `main`
