### PR TITLE
fix(helm): add apiVersion and kind to PersistentVolumeClaim metadata

### DIFF
--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -185,7 +185,9 @@ spec:
         {{- end }}
       {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: logs
         labels:
           {{- toYaml .Values.commonLabels | nindent 10 }}
@@ -199,7 +201,9 @@ spec:
             storage: {{ .Values.storageclass.logStorageSize }}
     {{- if eq (int .Values.replicaCount) 4 }}
     {{- range $i := until (int .Values.replicaCount) }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data-rustfs-{{ $i }}
         labels:
           {{- toYaml $.Values.commonLabels | nindent 10 }}
@@ -213,7 +217,9 @@ spec:
             storage: {{ $.Values.storageclass.dataStorageSize }}
     {{- end }}
     {{- else if eq (int .Values.replicaCount) 16 }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         labels:
           {{- toYaml .Values.commonLabels | nindent 10 }}


### PR DESCRIPTION
the missing apiVersion and kind are causing argocd to always detect a diff

<!--
Pull Request Template for RustFS
-->

## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->
N/A

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->

- Adding apiVersion and kind to volumeClaimTemplates of the rustfs StatefulSet, these are infered by kubernetes but are causing argocd to detect a config drift.

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->

N/A

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->

N/A

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->

Example argocd diff of the issue

<img width="1841" height="1181" alt="image" src="https://github.com/user-attachments/assets/5a0aab85-199f-40cf-b4ee-885a0807406b" />


---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
