### PR TITLE
ci: restore ubicloud runners for heavy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     name: Test and Lint
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: rustfs
+    runs-on: ubicloud-standard-4
     timeout-minutes: 60
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -143,7 +143,7 @@ jobs:
     name: Build RustFS Debug Binary
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: rustfs
+    runs-on: ubicloud-standard-4
     timeout-minutes: 30
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -176,7 +176,7 @@ jobs:
     name: End-to-End Tests
     needs: [ skip-check, build-rustfs-debug-binary ]
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: rustfs
+    runs-on: ubicloud-standard-2
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -223,7 +223,7 @@ jobs:
     name: S3 Implemented Tests
     needs: [ skip-check, build-rustfs-debug-binary ]
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: rustfs
+    runs-on: ubicloud-standard-4
     timeout-minutes: 60
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -263,7 +263,7 @@ jobs:
     name: Build Docker Images
     needs: build-check
     if: needs.build-check.outputs.should_build == 'true'
-    runs-on: rustfs
+    runs-on: ubicloud-standard-2
     timeout-minutes: 60
     strategy:
           fail-fast: false

--- a/.github/workflows/e2e-s3tests.yml
+++ b/.github/workflows/e2e-s3tests.yml
@@ -63,7 +63,7 @@ defaults:
 jobs:
   s3tests-single:
     if: github.event.inputs['test-mode'] == 'single'
-    runs-on: rustfs
+    runs-on: ubicloud-standard-2
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
@@ -225,7 +225,7 @@ jobs:
 
   s3tests-multi:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs['test-mode'] == 'multi'
-    runs-on: rustfs
+    runs-on: ubicloud-standard-2
     timeout-minutes: 150
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   performance-profile:
     name: Performance Profiling
-    runs-on: rustfs
+    runs-on: ubicloud-standard-2
     timeout-minutes: 30
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -117,7 +117,7 @@ jobs:
 
   benchmark:
     name: Benchmark Tests
-    runs-on: rustfs
+    runs-on: ubicloud-standard-2
     timeout-minutes: 45
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Restore Ubicloud runners for the heavy CI, Docker build, S3 tests, and performance jobs that still used the `rustfs` self-hosted runner.
- Keep lightweight jobs that already moved to `ubuntu-latest` unchanged.

## Verification
- `git diff --check -- .github/workflows`
- `rg -n "runs-on:\\s*rustfs" .github/workflows` returned no matches
- `make pre-commit` was not run per maintainer request for this runner-only workflow change.

## Impact
CI scheduling changes for selected heavy workflow jobs only. No Rust code or runtime behavior changes.

## Additional Notes
N/A
