### PR TITLE
chore: add missing-shard first-scene diagnostics

### DIFF
--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -1204,12 +1204,46 @@ impl ObjectIO for SetDisks {
 
             fi.is_latest = true;
 
+            if issue3031_diag_enabled() {
+                let online_success_count = online_disks.iter().filter(|disk| disk.is_some()).count();
+                warn!(
+                    target: "rustfs_ecstore::set_disk",
+                    bucket = %bucket,
+                    object = %object,
+                    tmp_dir = %tmp_dir,
+                    data_dir = ?fi.data_dir,
+                    write_quorum,
+                    online_success_count,
+                    op_old_dir = ?op_old_dir,
+                    "issue3031_put_object_commit_succeeded"
+                );
+            }
+
             Ok(ObjectInfo::from_file_info(&fi, bucket, object, opts.versioned || opts.version_suspended))
         }
         .await;
 
+        if issue3031_diag_enabled() {
+            warn!(
+                target: "rustfs_ecstore::set_disk",
+                bucket = %bucket,
+                object = %object,
+                tmp_dir = %tmp_dir,
+                result = ?result.as_ref().map(|_| ()).map_err(|err| err.to_string()),
+                "issue3031_put_object_tmp_cleanup_start"
+            );
+        }
+
         if let Err(err) = self.delete_all(RUSTFS_META_TMP_BUCKET, &tmp_dir).await {
             warn!(tmp_dir = %tmp_dir, error = ?err, "failed to cleanup put_object temporary data");
+        } else if issue3031_diag_enabled() {
+            warn!(
+                target: "rustfs_ecstore::set_disk",
+                bucket = %bucket,
+                object = %object,
+                tmp_dir = %tmp_dir,
+                "issue3031_put_object_tmp_cleanup_done"
+            );
         }
 
         result

--- a/crates/ecstore/src/set_disk/write.rs
+++ b/crates/ecstore/src/set_disk/write.rs
@@ -92,6 +92,34 @@ impl SetDisks {
             }
         }
 
+        if issue3031_diag_enabled() {
+            let success_count = errs.iter().filter(|err| err.is_none()).count();
+            let failure_count = errs.len().saturating_sub(success_count);
+            let ignored_failure_count = errs
+                .iter()
+                .filter(|err| err.as_ref().is_some_and(|err| OBJECT_OP_IGNORED_ERRS.contains(err)))
+                .count();
+            let data_dir_vote_count = data_dirs.iter().filter(|data_dir| data_dir.is_some()).count();
+            let reduced_data_dir = Self::reduce_common_data_dir(&data_dirs, write_quorum);
+            warn!(
+                target: "rustfs_ecstore::set_disk",
+                src_bucket = %src_bucket,
+                src_object = %src_object,
+                dst_bucket = %dst_bucket,
+                dst_object = %dst_object,
+                write_quorum,
+                disk_count = errs.len(),
+                success_count,
+                failure_count,
+                ignored_failure_count,
+                data_dir_vote_count,
+                reduced_data_dir = ?reduced_data_dir,
+                errs = ?errs,
+                data_dirs = ?data_dirs,
+                "issue3031_rename_data_quorum_context"
+            );
+        }
+
         let mut futures = Vec::with_capacity(disks.len());
         if let Some(ret_err) = reduce_write_quorum_errs(&errs, OBJECT_OP_IGNORED_ERRS, write_quorum) {
             // TODO: add concurrency
@@ -126,6 +154,21 @@ impl SetDisks {
                             });
                     }));
                 }
+            }
+
+            if issue3031_diag_enabled() {
+                warn!(
+                    target: "rustfs_ecstore::set_disk",
+                    src_bucket = %src_bucket,
+                    src_object = %src_object,
+                    dst_bucket = %dst_bucket,
+                    dst_object = %dst_object,
+                    write_quorum,
+                    ret_err = %ret_err,
+                    errs = ?errs,
+                    data_dirs = ?data_dirs,
+                    "issue3031_rename_data_quorum_failed"
+                );
             }
 
             let _ = join_all(futures).await;


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add issue-scoped diagnostics around `rename_data()` quorum aggregation so partial-disk success can be correlated with later missing-shard reads.
- Log `put_object` commit success context and `.rustfs.sys/tmp` cleanup boundaries behind `RUSTFS_ISSUE3031_DIAG_ENABLE`.
- Keep the change diagnostic-only and reuse the existing issue3031 debug gate to avoid default log noise.

## Verification
- `cargo fmt --all`
- `cargo check -p rustfs-ecstore`

## Impact
- No behavior change when `RUSTFS_ISSUE3031_DIAG_ENABLE` is unset.
- When enabled, adds focused warnings that help reconstruct first-scene evidence for quorum-success-but-incomplete writes and subsequent tmp cleanup.

## Additional Notes
This PR is intended to support reproduction and root-cause analysis of missing-shard symptoms before proposing a behavioral fix.
