### PR TITLE
fix(server): normalize empty request content length

### DIFF
--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -18,7 +18,7 @@ use crate::error::ApiError;
 use crate::server::cors;
 use crate::server::hybrid::HybridBody;
 use crate::server::{
-    ADMIN_PREFIX, CONSOLE_PREFIX, HEALTH_COMPAT_LIVE_PATH, HEALTH_PREFIX, HEALTH_READY_PATH, MINIO_ADMIN_PREFIX,
+    ADMIN_PREFIX, CONSOLE_PREFIX, FAVICON_PATH, HEALTH_COMPAT_LIVE_PATH, HEALTH_PREFIX, HEALTH_READY_PATH, MINIO_ADMIN_PREFIX,
     MINIO_ADMIN_V3_PREFIX, RPC_PREFIX, RUSTFS_ADMIN_PREFIX, VERSION, active_http_requests, collect_dependency_readiness_report,
     has_path_prefix, is_admin_path,
 };
@@ -343,7 +343,7 @@ fn is_empty_body_s3_path(method: &Method, uri: &http::Uri) -> bool {
 }
 
 fn is_empty_body_console_path(method: &Method, uri: &http::Uri) -> bool {
-    *method == Method::GET && uri.path().strip_prefix(CONSOLE_PREFIX) == Some(VERSION)
+    matches!(*method, Method::GET | Method::HEAD) && is_console_path(uri.path())
 }
 
 #[derive(Clone)]
@@ -1471,7 +1471,6 @@ mod tests {
             "/rustfs/adminx/object",
             "/minio/adminx/object",
             "/rustfs/rpc/read_file_stream",
-            "/rustfs/console/index.html",
             "/health",
             "/profile/cpu",
         ];
@@ -1529,19 +1528,58 @@ mod tests {
     }
 
     #[test]
-    fn console_version_get_without_content_length_is_normalized() {
-        let request = Request::builder()
-            .method(Method::GET)
-            .uri(format!("{CONSOLE_PREFIX}{VERSION}"))
-            .body(())
-            .expect("request");
+    fn console_empty_body_get_without_content_length_is_normalized() {
+        let paths = [
+            FAVICON_PATH.to_string(),
+            format!("{CONSOLE_PREFIX}{LICENSE}"),
+            format!("{CONSOLE_PREFIX}{VERSION}"),
+            format!("{CONSOLE_PREFIX}{HEALTH_PREFIX}"),
+            format!("{CONSOLE_PREFIX}{HEALTH_COMPAT_LIVE_PATH}"),
+            format!("{CONSOLE_PREFIX}{HEALTH_READY_PATH}"),
+            format!("{CONSOLE_PREFIX}/index.html"),
+            format!("{CONSOLE_PREFIX}/assets/app.js"),
+        ];
 
-        assert!(should_force_zero_content_length_for_empty_body_route(&request));
+        for path in paths {
+            let request = Request::builder()
+                .method(Method::GET)
+                .uri(path.as_str())
+                .body(())
+                .expect("request");
+
+            assert!(
+                should_force_zero_content_length_for_empty_body_route(&request),
+                "{path} should force Content-Length: 0"
+            );
+        }
+    }
+
+    #[test]
+    fn console_empty_body_head_without_content_length_is_normalized() {
+        let paths = [
+            format!("{CONSOLE_PREFIX}{HEALTH_PREFIX}"),
+            format!("{CONSOLE_PREFIX}{HEALTH_COMPAT_LIVE_PATH}"),
+            format!("{CONSOLE_PREFIX}{HEALTH_READY_PATH}"),
+            format!("{CONSOLE_PREFIX}/index.html"),
+        ];
+
+        for path in paths {
+            let request = Request::builder()
+                .method(Method::HEAD)
+                .uri(path.as_str())
+                .body(())
+                .expect("request");
+
+            assert!(
+                should_force_zero_content_length_for_empty_body_route(&request),
+                "{path} should force Content-Length: 0"
+            );
+        }
     }
 
     #[tokio::test]
     async fn empty_body_layer_inserts_zero_content_length_for_s3_and_console_get() {
-        for path in ["/?x-id=ListBuckets".to_string(), format!("{CONSOLE_PREFIX}{VERSION}")] {
+        for path in ["/?x-id=ListBuckets".to_string(), format!("{CONSOLE_PREFIX}/index.html")] {
             let capture = HeaderCaptureService::default();
             let headers = capture.headers();
             let mut service = EmptyBodyContentLengthCompatLayer.layer(capture);
@@ -1765,6 +1803,29 @@ mod tests {
             .method(Method::GET)
             .uri("/?x-id=ListBuckets")
             .header(http::header::TRANSFER_ENCODING, "chunked")
+            .body(())
+            .expect("request");
+
+        assert!(!should_force_zero_content_length_for_empty_body_route(&request));
+    }
+
+    #[test]
+    fn console_get_with_transfer_encoding_is_not_normalized() {
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(format!("{CONSOLE_PREFIX}/index.html"))
+            .header(http::header::TRANSFER_ENCODING, "chunked")
+            .body(())
+            .expect("request");
+
+        assert!(!should_force_zero_content_length_for_empty_body_route(&request));
+    }
+
+    #[test]
+    fn console_post_without_content_length_is_not_normalized() {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(format!("{CONSOLE_PREFIX}/upload"))
             .body(())
             .expect("request");
 

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -1466,15 +1466,7 @@ mod tests {
 
     #[test]
     fn non_s3_non_admin_get_without_content_length_is_not_normalized() {
-        let paths = [
-            "/rustfs/administrator/object",
-            "/minio/administrator/object",
-            "/rustfs/adminx/object",
-            "/minio/adminx/object",
-            "/rustfs/rpc/read_file_stream",
-            "/health",
-            "/profile/cpu",
-        ];
+        let paths = ["/rustfs/rpc/read_file_stream", "/health", "/profile/cpu"];
 
         for path in paths {
             let request = Request::builder().method(Method::GET).uri(path).body(()).expect("request");
@@ -1505,7 +1497,14 @@ mod tests {
 
     #[test]
     fn s3_empty_body_get_without_content_length_is_normalized() {
-        let paths = ["/?x-id=ListBuckets", "/", "/bucket?list-type=2", "/bucket/object.txt"];
+        let paths = [
+            "/?x-id=ListBuckets",
+            "/",
+            "/bucket?list-type=2",
+            "/bucket/object.txt",
+            "/rustfs/administrator/object",
+            "/minio/adminx/object",
+        ];
 
         for path in paths {
             let request = Request::builder().method(Method::GET).uri(path).body(()).expect("request");

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -18,8 +18,8 @@ use crate::error::ApiError;
 use crate::server::cors;
 use crate::server::hybrid::HybridBody;
 use crate::server::{
-    ADMIN_PREFIX, CONSOLE_PREFIX, FAVICON_PATH, HEALTH_COMPAT_LIVE_PATH, HEALTH_PREFIX, HEALTH_READY_PATH, MINIO_ADMIN_PREFIX,
-    MINIO_ADMIN_V3_PREFIX, RPC_PREFIX, RUSTFS_ADMIN_PREFIX, VERSION, active_http_requests, collect_dependency_readiness_report,
+    ADMIN_PREFIX, CONSOLE_PREFIX, HEALTH_COMPAT_LIVE_PATH, HEALTH_PREFIX, HEALTH_READY_PATH, MINIO_ADMIN_PREFIX,
+    MINIO_ADMIN_V3_PREFIX, RPC_PREFIX, RUSTFS_ADMIN_PREFIX, active_http_requests, collect_dependency_readiness_report,
     has_path_prefix, is_admin_path,
 };
 use crate::storage::apply_cors_headers;
@@ -1143,6 +1143,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::{FAVICON_PATH, LICENSE, VERSION};
     use futures::future::{Ready, ready};
     use http::Request;
     use http_body_util::BodyExt;

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -19,7 +19,7 @@ use crate::server::cors;
 use crate::server::hybrid::HybridBody;
 use crate::server::{
     ADMIN_PREFIX, CONSOLE_PREFIX, HEALTH_COMPAT_LIVE_PATH, HEALTH_PREFIX, HEALTH_READY_PATH, MINIO_ADMIN_PREFIX,
-    MINIO_ADMIN_V3_PREFIX, RPC_PREFIX, RUSTFS_ADMIN_PREFIX, active_http_requests, collect_dependency_readiness_report,
+    MINIO_ADMIN_V3_PREFIX, RPC_PREFIX, RUSTFS_ADMIN_PREFIX, VERSION, active_http_requests, collect_dependency_readiness_report,
     has_path_prefix, is_admin_path,
 };
 use crate::storage::apply_cors_headers;
@@ -284,6 +284,10 @@ fn should_force_zero_content_length_for_empty_body_route<B>(req: &HttpRequest<B>
         return false;
     }
 
+    if is_empty_body_console_path(req.method(), req.uri()) {
+        return true;
+    }
+
     is_empty_body_s3_path(req.method(), req.uri())
 }
 
@@ -335,7 +339,11 @@ fn is_heal_status_query(path: &str, query: Option<&str>) -> bool {
 }
 
 fn is_empty_body_s3_path(method: &Method, uri: &http::Uri) -> bool {
-    *method == Method::DELETE && ConditionalCorsLayer::is_s3_path(uri.path())
+    matches!(*method, Method::GET | Method::HEAD | Method::DELETE) && ConditionalCorsLayer::is_s3_path(uri.path())
+}
+
+fn is_empty_body_console_path(method: &Method, uri: &http::Uri) -> bool {
+    *method == Method::GET && uri.path().strip_prefix(CONSOLE_PREFIX) == Some(VERSION)
 }
 
 #[derive(Clone)]
@@ -1456,13 +1464,16 @@ mod tests {
     }
 
     #[test]
-    fn non_admin_get_without_content_length_is_not_normalized() {
+    fn non_s3_non_admin_get_without_content_length_is_not_normalized() {
         let paths = [
-            "/bucket/object",
             "/rustfs/administrator/object",
             "/minio/administrator/object",
             "/rustfs/adminx/object",
             "/minio/adminx/object",
+            "/rustfs/rpc/read_file_stream",
+            "/rustfs/console/index.html",
+            "/health",
+            "/profile/cpu",
         ];
 
         for path in paths {
@@ -1490,6 +1501,61 @@ mod tests {
 
         let headers = headers.lock().expect("captured headers").take().expect("captured headers");
         assert_eq!(headers.get(http::header::CONTENT_LENGTH).unwrap(), "0");
+    }
+
+    #[test]
+    fn s3_empty_body_get_without_content_length_is_normalized() {
+        let paths = ["/?x-id=ListBuckets", "/", "/bucket?list-type=2", "/bucket/object.txt"];
+
+        for path in paths {
+            let request = Request::builder().method(Method::GET).uri(path).body(()).expect("request");
+
+            assert!(
+                should_force_zero_content_length_for_empty_body_route(&request),
+                "{path} should force Content-Length: 0"
+            );
+        }
+    }
+
+    #[test]
+    fn s3_empty_body_head_without_content_length_is_normalized() {
+        let request = Request::builder()
+            .method(Method::HEAD)
+            .uri("/bucket/object.txt")
+            .body(())
+            .expect("request");
+
+        assert!(should_force_zero_content_length_for_empty_body_route(&request));
+    }
+
+    #[test]
+    fn console_version_get_without_content_length_is_normalized() {
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(format!("{CONSOLE_PREFIX}{VERSION}"))
+            .body(())
+            .expect("request");
+
+        assert!(should_force_zero_content_length_for_empty_body_route(&request));
+    }
+
+    #[tokio::test]
+    async fn empty_body_layer_inserts_zero_content_length_for_s3_and_console_get() {
+        for path in ["/?x-id=ListBuckets".to_string(), format!("{CONSOLE_PREFIX}{VERSION}")] {
+            let capture = HeaderCaptureService::default();
+            let headers = capture.headers();
+            let mut service = EmptyBodyContentLengthCompatLayer.layer(capture);
+            let request = Request::builder()
+                .method(Method::GET)
+                .uri(path.as_str())
+                .body(())
+                .expect("request");
+
+            let _ = service.call(request).await.expect("service call");
+
+            let headers = headers.lock().expect("captured headers").take().expect("captured headers");
+            assert_eq!(headers.get(http::header::CONTENT_LENGTH).unwrap(), "0");
+        }
     }
 
     #[tokio::test]
@@ -1686,6 +1752,18 @@ mod tests {
         let request = Request::builder()
             .method(Method::DELETE)
             .uri("/bucket/object?versionId=3HL4kqtJlcpXrof3Gj0OmxJnVBH40Nrjfkd")
+            .header(http::header::TRANSFER_ENCODING, "chunked")
+            .body(())
+            .expect("request");
+
+        assert!(!should_force_zero_content_length_for_empty_body_route(&request));
+    }
+
+    #[test]
+    fn s3_get_with_transfer_encoding_is_not_normalized() {
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/?x-id=ListBuckets")
             .header(http::header::TRANSFER_ENCODING, "chunked")
             .body(())
             .expect("request");


### PR DESCRIPTION
## Related Issues
Fixes #3075.

## Summary of Changes
- Normalize missing `Content-Length` for empty-body S3 `GET`, `HEAD`, and `DELETE` requests before s3s request preparation.
- Normalize missing `Content-Length` for console `GET` and `HEAD` paths, including favicon, license, version, health probes, and static/fallback console assets.
- Preserve fail-closed behavior for requests with explicit `Content-Length`, `Transfer-Encoding`, upload methods, RPC, health/profile paths outside console, and non-bodyless console methods.
- Add regression coverage for ListBuckets, S3 HEAD, console GET/HEAD paths, actual header insertion, and negative route boundaries.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `make pre-commit` (run by requester)

## Impact
Chromium-based clients that omit `Content-Length` on signed empty-body S3 and console requests can complete bucket listing, console metadata fetches, health probes, and static asset requests without 411 `MissingContentLength` responses. Upload and streaming request semantics remain unchanged.

## Additional Notes
N/A