### PR TITLE
fix(bucket-encryption): populate default KMS key for SSE-KMS without key ID

### DIFF
--- a/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
+++ b/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
@@ -520,3 +520,74 @@ async fn test_explicit_encryption_overrides_bucket_default() -> Result<(), Box<d
 
     Ok(())
 }
+
+/// Test 5: Setting SSE-KMS without a specific key ID should auto-populate the
+/// default KMS key ID so that GetBucketEncryption returns it (issue #3039).
+#[tokio::test]
+#[serial]
+async fn test_sse_kms_without_key_id_populates_default() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    init_logging();
+    info!("Testing SSE-KMS without explicit key ID populates default key");
+
+    let mut kms_env = LocalKMSTestEnvironment::new().await?;
+    let default_key_id = kms_env.start_rustfs_for_local_kms().await?;
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+    let s3_client = kms_env.base_env.create_s3_client();
+    kms_env.base_env.create_test_bucket(TEST_BUCKET).await?;
+
+    // Set bucket encryption to SSE-KMS WITHOUT specifying a key ID
+    info!("Setting bucket default encryption to SSE-KMS without key ID");
+    let encryption_config = ServerSideEncryptionConfiguration::builder()
+        .rules(
+            ServerSideEncryptionRule::builder()
+                .apply_server_side_encryption_by_default(
+                    ServerSideEncryptionByDefault::builder()
+                        .sse_algorithm(ServerSideEncryption::AwsKms)
+                        .build()
+                        .unwrap(),
+                )
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    s3_client
+        .put_bucket_encryption()
+        .bucket(TEST_BUCKET)
+        .server_side_encryption_configuration(encryption_config)
+        .send()
+        .await
+        .expect("Failed to set bucket SSE-KMS encryption without key ID");
+
+    // GetBucketEncryption should return the default KMS key ID
+    info!("Verifying GetBucketEncryption returns default KMS key ID");
+    let get_response = s3_client
+        .get_bucket_encryption()
+        .bucket(TEST_BUCKET)
+        .send()
+        .await
+        .expect("Failed to get bucket encryption");
+
+    let config = get_response.server_side_encryption_configuration();
+    let rule = config
+        .and_then(|c| c.rules.first())
+        .expect("Should have at least one encryption rule");
+    let by_default = rule
+        .apply_server_side_encryption_by_default()
+        .expect("Should have ApplyServerSideEncryptionByDefault");
+
+    assert_eq!(by_default.sse_algorithm(), &ServerSideEncryption::AwsKms, "Algorithm should be aws:kms");
+    assert!(
+        by_default.kms_master_key_id().is_some(),
+        "KMS key ID should be populated with the default key (was None)"
+    );
+    assert_eq!(
+        by_default.kms_master_key_id().unwrap(),
+        &default_key_id,
+        "KMS key ID should match the configured default key"
+    );
+
+    info!("Test passed: SSE-KMS without key ID correctly populates default key '{}'", default_key_id);
+    Ok(())
+}

--- a/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
+++ b/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
@@ -572,7 +572,7 @@ async fn test_sse_kms_without_key_id_populates_default() -> Result<(), Box<dyn s
 
     let config = get_response.server_side_encryption_configuration();
     let rule = config
-        .and_then(|c| c.rules.first())
+        .and_then(|c| c.rules().first())
         .expect("Should have at least one encryption rule");
     let by_default = rule
         .apply_server_side_encryption_by_default()

--- a/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
+++ b/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
@@ -544,6 +544,7 @@ async fn test_sse_kms_without_key_id_populates_default() -> Result<(), Box<dyn s
                 .apply_server_side_encryption_by_default(
                     ServerSideEncryptionByDefault::builder()
                         .sse_algorithm(ServerSideEncryption::AwsKms)
+                        .kms_master_key_id("")
                         .build()
                         .unwrap(),
                 )

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -1512,10 +1512,15 @@ impl DefaultBucketUsecase {
         if let Some(rule) = server_side_encryption_configuration.rules.first_mut()
             && let Some(ref mut by_default) = rule.apply_server_side_encryption_by_default
             && by_default.sse_algorithm.as_str() == ServerSideEncryption::AWS_KMS
-            && (by_default.kms_master_key_id.is_none() || by_default.kms_master_key_id.as_deref() == Some(""))
-            && let Some(service) = rustfs_kms::service_manager::get_global_encryption_service().await
-            && let Some(default_key) = service.get_default_key_id()
+            && by_default.kms_master_key_id.as_deref().is_none_or(str::is_empty)
         {
+            let service = rustfs_kms::service_manager::get_global_encryption_service()
+                .await
+                .ok_or_else(|| S3Error::with_message(S3ErrorCode::InternalError, "KMS service not initialized".to_string()))?;
+            let default_key = service
+                .get_default_key_id()
+                .filter(|key| !key.is_empty())
+                .ok_or_else(|| S3Error::with_message(S3ErrorCode::InternalError, "KMS default key not configured".to_string()))?;
             by_default.kms_master_key_id = Some(default_key.clone());
         }
 

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -1501,9 +1501,23 @@ impl DefaultBucketUsecase {
     ) -> S3Result<S3Response<PutBucketEncryptionOutput>> {
         let PutBucketEncryptionInput {
             bucket,
-            server_side_encryption_configuration,
+            mut server_side_encryption_configuration,
             ..
         } = req.input;
+
+        // When SSE-KMS is set without a specific key ID, populate the default
+        // KMS key so that GetBucketEncryption responses include it. Clients like
+        // mc rely on the presence of KMSMasterKeyID to distinguish SSE-KMS from
+        // SSE-S3 in their display logic.
+        if let Some(rule) = server_side_encryption_configuration.rules.first_mut()
+            && let Some(ref mut by_default) = rule.apply_server_side_encryption_by_default
+            && by_default.sse_algorithm.as_str() == ServerSideEncryption::AWS_KMS
+            && (by_default.kms_master_key_id.is_none() || by_default.kms_master_key_id.as_deref() == Some(""))
+            && let Some(service) = rustfs_kms::service_manager::get_global_encryption_service().await
+            && let Some(default_key) = service.get_default_key_id()
+        {
+            by_default.kms_master_key_id = Some(default_key.clone());
+        }
 
         info!("sse_config {:?}", &server_side_encryption_configuration);
 


### PR DESCRIPTION
## Description

When `PutBucketEncryption` receives SSE-KMS configuration without a specific KMS key ID, the handler now queries the KMS service for the default key and populates `KMSMasterKeyID` before storing. This ensures `GetBucketEncryption` responses always include the key ID for SSE-KMS configs.

## Motivation

`mc encrypt set sse-kms <bucket>` (without a key ID) sends `SSEAlgorithm=aws:kms` with an empty `KMSMasterKeyID`. Previously RustFS stored this as-is. When `mc encrypt info` called `GetBucketEncryption`, the response contained the algorithm but no key ID. The mc client determines SSE-KMS vs SSE-S3 by checking whether `KMSMasterKeyID` is present, so it displayed "Auto encryption 'sse-s3' is enabled" despite the bucket being configured for SSE-KMS.

## Changes

- `rustfs/src/app/bucket_usecase.rs`: In `execute_put_bucket_encryption`, when SSE-KMS is set without a key ID, look up the default KMS key from the encryption service and fill it in.
- `crates/e2e_test/src/kms/bucket_default_encryption_test.rs`: Added regression test `test_sse_kms_without_key_id_populates_default`.

## Verification

```bash
cargo check --package rustfs
cargo check --package e2e_test
cargo fmt --all --check
```

Fixes #3039
