### PR TITLE
refactor(ecstore): add accessor methods for service globals

### DIFF
--- a/crates/ecstore/src/store.rs
+++ b/crates/ecstore/src/store.rs
@@ -19,6 +19,7 @@ use crate::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
 use crate::bucket::lifecycle::bucket_lifecycle_ops::{
     enqueue_immediate_expiry, enqueue_transition_immediate, init_background_expiry,
 };
+use crate::bucket::metadata_sys::get_global_bucket_metadata_sys;
 use crate::bucket::metadata_sys::{self, set_bucket_metadata};
 use crate::bucket::utils::check_abort_multipart_args;
 use crate::bucket::utils::check_complete_multipart_args;
@@ -33,6 +34,7 @@ use crate::bucket::utils::check_put_object_args;
 use crate::bucket::utils::check_put_object_part_args;
 use crate::bucket::utils::{check_valid_bucket_name, check_valid_bucket_name_strict, is_meta_bucketname};
 use crate::config::storageclass;
+use crate::config::{get_global_server_config, get_global_storage_class};
 use crate::disk::endpoint::{Endpoint, EndpointType};
 use crate::disk::{DiskAPI, DiskInfo, DiskInfoOptions};
 use crate::error::{Error, Result};
@@ -43,8 +45,10 @@ use crate::error::{
 use crate::event_notification::EventNotifier;
 use crate::global::{
     DISK_ASSUME_UNKNOWN_SIZE, DISK_FILL_FRACTION, DISK_MIN_INODES, DISK_RESERVE_FRACTION, GLOBAL_BOOT_TIME,
-    GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES, TypeLocalDiskSetDrives, get_global_deployment_id, get_global_endpoints,
-    init_global_bucket_monitor, is_erasure_sd, set_global_deployment_id, set_object_layer,
+    GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_TierConfigMgr, TypeLocalDiskSetDrives,
+    get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints, get_global_region,
+    get_global_tier_config_mgr, init_global_bucket_monitor, is_dist_erasure, is_erasure_sd,
+    set_global_deployment_id, set_object_layer,
 };
 use crate::notification_sys::get_global_notification_sys;
 use crate::pools::PoolMeta;
@@ -237,37 +241,37 @@ impl ECStore {
 impl ECStore {
     /// Get the notification system
     pub fn notification_system(&self) -> Option<&'static crate::notification_sys::NotificationSys> {
-        crate::notification_sys::get_global_notification_sys()
+        get_global_notification_sys()
     }
 
     /// Get the bucket metadata system
     pub fn bucket_metadata_sys(&self) -> Option<Arc<tokio::sync::RwLock<crate::bucket::metadata_sys::BucketMetadataSys>>> {
-        crate::bucket::metadata_sys::get_global_bucket_metadata_sys()
+        get_global_bucket_metadata_sys()
     }
 
     /// Get the global endpoints
     pub fn endpoints(&self) -> EndpointServerPools {
-        crate::global::get_global_endpoints()
+        get_global_endpoints()
     }
 
     /// Get the global region
     pub fn region(&self) -> Option<s3s::region::Region> {
-        crate::global::get_global_region()
+        get_global_region()
     }
 
     /// Get the tier config manager
     pub fn tier_config_mgr(&self) -> Arc<tokio::sync::RwLock<crate::tier::tier::TierConfigMgr>> {
-        crate::global::get_global_tier_config_mgr()
+        get_global_tier_config_mgr()
     }
 
     /// Get the server configuration
     pub fn server_config(&self) -> Option<crate::config::Config> {
-        crate::config::get_global_server_config()
+        get_global_server_config()
     }
 
     /// Get the storage class configuration
     pub fn storage_class(&self) -> Option<crate::config::storageclass::Config> {
-        crate::config::get_global_storage_class()
+        get_global_storage_class()
     }
 }
 

--- a/crates/ecstore/src/store.rs
+++ b/crates/ecstore/src/store.rs
@@ -45,10 +45,9 @@ use crate::error::{
 use crate::event_notification::EventNotifier;
 use crate::global::{
     DISK_ASSUME_UNKNOWN_SIZE, DISK_FILL_FRACTION, DISK_MIN_INODES, DISK_RESERVE_FRACTION, GLOBAL_BOOT_TIME,
-    GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_TierConfigMgr, TypeLocalDiskSetDrives,
-    get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints, get_global_region,
-    get_global_tier_config_mgr, init_global_bucket_monitor, is_dist_erasure, is_erasure_sd,
-    set_global_deployment_id, set_object_layer,
+    GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES, TypeLocalDiskSetDrives, get_global_deployment_id, get_global_endpoints,
+    get_global_region, get_global_tier_config_mgr, init_global_bucket_monitor, is_erasure_sd, set_global_deployment_id,
+    set_object_layer,
 };
 use crate::notification_sys::get_global_notification_sys;
 use crate::pools::PoolMeta;

--- a/crates/ecstore/src/store.rs
+++ b/crates/ecstore/src/store.rs
@@ -231,6 +231,46 @@ impl ECStore {
     }
 }
 
+/// Phase 3: Accessor methods for service globals
+/// These provide a unified API through ECStore for accessing cross-cutting
+/// service singletons. The globals remain the source of truth.
+impl ECStore {
+    /// Get the notification system
+    pub fn notification_system(&self) -> Option<&'static crate::notification_sys::NotificationSys> {
+        crate::notification_sys::get_global_notification_sys()
+    }
+
+    /// Get the bucket metadata system
+    pub fn bucket_metadata_sys(&self) -> Option<Arc<tokio::sync::RwLock<crate::bucket::metadata_sys::BucketMetadataSys>>> {
+        crate::bucket::metadata_sys::get_global_bucket_metadata_sys()
+    }
+
+    /// Get the global endpoints
+    pub fn endpoints(&self) -> EndpointServerPools {
+        crate::global::get_global_endpoints()
+    }
+
+    /// Get the global region
+    pub fn region(&self) -> Option<s3s::region::Region> {
+        crate::global::get_global_region()
+    }
+
+    /// Get the tier config manager
+    pub fn tier_config_mgr(&self) -> Arc<tokio::sync::RwLock<crate::tier::tier::TierConfigMgr>> {
+        crate::global::get_global_tier_config_mgr()
+    }
+
+    /// Get the server configuration
+    pub fn server_config(&self) -> Option<crate::config::Config> {
+        crate::config::get_global_server_config()
+    }
+
+    /// Get the storage class configuration
+    pub fn storage_class(&self) -> Option<crate::config::storageclass::Config> {
+        crate::config::get_global_storage_class()
+    }
+}
+
 // impl Clone for ECStore {
 //     fn clone(&self) -> Self {
 //         let pool_meta = match self.pool_meta.read() {


### PR DESCRIPTION
## Related Issues
Relates to https://github.com/rustfs/backlog/issues/653 (item 8, Phase 3)

## Summary of Changes
Phase 3 of global singleton consolidation. Add ECStore accessor methods that delegate to process-global service singletons, providing a unified API through ECStore for accessing cross-cutting services.

### New ECStore methods:
- notification_system() — delegates to notification_sys global
- bucket_metadata_sys() — delegates to bucket metadata global
- endpoints() — delegates to endpoints global
- region() — delegates to region global
- tier_config_mgr() — delegates to tier config global
- server_config() — delegates to server config global
- storage_class() — delegates to storage class global

### Design:
- No local state — globals remain the single source of truth
- Pure delegation — methods provide a unified entry point through ECStore
- Once all callers migrate, globals can be removed

## Verification
```bash
cargo test -p rustfs-ecstore --lib
cargo clippy -p rustfs-ecstore -- -D warnings
cargo fmt --all --check
```
- 1161 tests pass
- Clippy clean
- Formatting clean

## Impact
No behavioral changes. Pure API addition.

## Additional Notes
N/A
