### PR TITLE
fix(admin): format policy JSON and improve error messages in service account API

### DIFF
--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -124,8 +124,16 @@ fn parse_service_account_policy(policy: &serde_json::Value) -> S3Result<Policy> 
     let policy_bytes = serde_json::to_vec(policy).map_err(|e| s3_error!(InvalidArgument, "marshal policy failed: {:?}", e))?;
     Policy::parse_config(&policy_bytes).map_err(|e| {
         debug!("parse service account policy failed, e: {:?}", e);
-        let message = e.to_string().replace('\'', "");
-        s3_error!(InvalidArgument, "invalid service account policy: {}", message)
+        // Provide user-friendly error messages instead of exposing internal details
+        let error_msg = e.to_string();
+        let user_friendly_msg = if error_msg.contains("invalid type") || error_msg.contains("expected") {
+            "Policy format is invalid. Please check the JSON structure and ensure it follows the IAM policy format."
+        } else if error_msg.contains("missing field") {
+            "Policy is missing required fields. A valid policy must include Version and Statement."
+        } else {
+            "Policy format is invalid. Please check the JSON structure."
+        };
+        s3_error!(InvalidArgument, "{}", user_friendly_msg)
     })
 }
 
@@ -428,7 +436,7 @@ async fn build_info_service_account_resp<T: IamStore>(
 
     let policy = effective_policy
         .map(|policy| {
-            serde_json::to_string(&policy).map_err(|e| {
+            serde_json::to_string_pretty(&policy).map_err(|e| {
                 debug!("marshal policy failed, e: {:?}", e);
                 s3_error!(InternalError, "marshal policy failed")
             })


### PR DESCRIPTION
## Related Issues

Fixes #3233
Fixes #3232

## Summary of Changes

### Issue #3233 — Access keys policy edit field not showing formatted JSON

The `build_info_service_account_resp` function used `serde_json::to_string` which produces compact JSON. Changed to `serde_json::to_string_pretty` to match MinIO behavior (`json.MarshalIndent`), so the policy JSON is returned formatted with indentation.

### Issue #3232 — Error message not shown to user when changing access keys policy

The `parse_service_account_policy` function exposed raw serde deserialization errors to users (e.g. `io error: invalid type: string "invalid json", expected struct Policy`). Replaced with user-friendly messages:

- Invalid JSON structure → "Policy format is invalid. Please check the JSON structure and ensure it follows the IAM policy format."
- Missing required fields → "Policy is missing required fields. A valid policy must include Version and Statement."
- Other errors → "Policy format is invalid. Please check the JSON structure."

## Verification

- `cargo check` passes (syntax verified)
- Manual verification of error message output

## Impact

- **User-facing**: Policy JSON now displays formatted in Access Keys edit dialog; error messages are readable instead of raw internal errors.
- **Compatibility**: Aligns with MinIO behavior for policy serialization. No API contract changes.

## Additional Notes

The companion console PR adds frontend-side policy validation and uses `DOMParser` for proper XML error message decoding with automatic HTML entity handling.