### PR TITLE
fix(docker): align TLS compose healthchecks

### DIFF
--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -31,7 +31,10 @@ services:
       - RUSTFS_ACCESS_KEY=rustfsadmin # CHANGEME
       - RUSTFS_SECRET_KEY=rustfsadmin # CHANGEME
       - RUSTFS_OBS_LOGGER_LEVEL=info
-      - RUSTFS_TLS_PATH=/opt/tls
+      # Optional TLS:
+      # - mount your cert directory to /opt/tls
+      # - set RUSTFS_TLS_PATH=/opt/tls
+      # - when TLS is enabled, health checks automatically switch to HTTPS
       # Keep strict disk topology checks enabled by default.
       # For local testing only, set `RUSTFS_UNSAFE_BYPASS_DISK_CHECK=true` explicitly.
       - RUSTFS_UNSAFE_BYPASS_DISK_CHECK=${RUSTFS_UNSAFE_BYPASS_DISK_CHECK:-false}

--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -46,14 +46,32 @@ services:
       - rustfs-network
     restart: unless-stopped
     healthcheck:
-      # Production strict TLS example (SAN/FQDN aligned, no `-k`):
-      # curl -f --cacert /opt/tls/ca.crt --resolve rustfs-a.example.com:9000:127.0.0.1 https://rustfs-a.example.com:9000/health
-      # curl -f --cacert /opt/tls/ca.crt --resolve rustfs-a.example.com:9001:127.0.0.1 https://rustfs-a.example.com:9001/rustfs/console/health
+      # Default behavior:
+      # - HTTP when RUSTFS_TLS_PATH is unset
+      # - HTTPS when RUSTFS_TLS_PATH is set
+      # - loopback TLS uses `-k` unless strict host+CA values are provided
+      #
+      # Strict TLS example:
+      # - set RUSTFS_HEALTHCHECK_HOST to a SAN-covered hostname
+      # - optionally set RUSTFS_HEALTHCHECK_CA (defaults to /opt/tls/ca.crt when present)
       test:
         [
           "CMD",
-          "sh", "-c",
-          "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/rustfs/console/health"
+          "sh", "-ec",
+          "host=\"$${RUSTFS_HEALTHCHECK_HOST:-127.0.0.1}\"; scheme=\"http\"; set -- -fsS; \
+          if [ -n \"$${RUSTFS_TLS_PATH:-}\" ]; then \
+            scheme=\"https\"; \
+            ca_path=\"$${RUSTFS_HEALTHCHECK_CA:-}\"; \
+            if [ -z \"$${ca_path}\" ] && [ -f /opt/tls/ca.crt ]; then ca_path=/opt/tls/ca.crt; fi; \
+            case \"$${host}\" in 127.0.0.1|localhost) strict_host=false ;; *) strict_host=true ;; esac; \
+            if [ \"$${strict_host}\" = true ] && [ -n \"$${ca_path}\" ]; then \
+              set -- \"$${@}\" --cacert \"$${ca_path}\" --resolve \"$${host}:9000:127.0.0.1\" --resolve \"$${host}:9001:127.0.0.1\"; \
+            else \
+              set -- \"$${@}\" -k; \
+            fi; \
+          fi; \
+          curl \"$${@}\" \"$${scheme}://$${host}:9000/health\" && \
+          curl \"$${@}\" \"$${scheme}://$${host}:9001/rustfs/console/health\""
         ]
       interval: 30s
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,14 +56,32 @@ services:
       - rustfs-network
     restart: unless-stopped
     healthcheck:
-      # Production strict TLS example (SAN/FQDN aligned, no `-k`):
-      # curl -f --cacert /opt/tls/ca.crt --resolve rustfs-a.example.com:9000:127.0.0.1 https://rustfs-a.example.com:9000/health
-      # curl -f --cacert /opt/tls/ca.crt --resolve rustfs-a.example.com:9001:127.0.0.1 https://rustfs-a.example.com:9001/rustfs/console/health
+      # Default behavior:
+      # - HTTP when RUSTFS_TLS_PATH is unset
+      # - HTTPS when RUSTFS_TLS_PATH is set
+      # - loopback TLS uses `-k` unless strict host+CA values are provided
+      #
+      # Strict TLS example:
+      # - set RUSTFS_HEALTHCHECK_HOST to a SAN-covered hostname
+      # - optionally set RUSTFS_HEALTHCHECK_CA (defaults to /opt/tls/ca.crt when present)
       test:
         [
           "CMD",
-          "sh", "-c",
-          "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/rustfs/console/health"
+          "sh", "-ec",
+          "host=\"$${RUSTFS_HEALTHCHECK_HOST:-127.0.0.1}\"; scheme=\"http\"; set -- -fsS; \
+          if [ -n \"$${RUSTFS_TLS_PATH:-}\" ]; then \
+            scheme=\"https\"; \
+            ca_path=\"$${RUSTFS_HEALTHCHECK_CA:-}\"; \
+            if [ -z \"$${ca_path}\" ] && [ -f /opt/tls/ca.crt ]; then ca_path=/opt/tls/ca.crt; fi; \
+            case \"$${host}\" in 127.0.0.1|localhost) strict_host=false ;; *) strict_host=true ;; esac; \
+            if [ \"$${strict_host}\" = true ] && [ -n \"$${ca_path}\" ]; then \
+              set -- \"$${@}\" --cacert \"$${ca_path}\" --resolve \"$${host}:9000:127.0.0.1\" --resolve \"$${host}:9001:127.0.0.1\"; \
+            else \
+              set -- \"$${@}\" -k; \
+            fi; \
+          fi; \
+          curl \"$${@}\" \"$${scheme}://$${host}:9000/health\" && \
+          curl \"$${@}\" \"$${scheme}://$${host}:9001/rustfs/console/health\""
         ]
       interval: 30s
       timeout: 10s
@@ -107,8 +125,21 @@ services:
       test:
         [
           "CMD",
-          "sh", "-c",
-          "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/rustfs/console/health"
+          "sh", "-ec",
+          "host=\"$${RUSTFS_HEALTHCHECK_HOST:-127.0.0.1}\"; scheme=\"http\"; set -- -fsS; \
+          if [ -n \"$${RUSTFS_TLS_PATH:-}\" ]; then \
+            scheme=\"https\"; \
+            ca_path=\"$${RUSTFS_HEALTHCHECK_CA:-}\"; \
+            if [ -z \"$${ca_path}\" ] && [ -f /opt/tls/ca.crt ]; then ca_path=/opt/tls/ca.crt; fi; \
+            case \"$${host}\" in 127.0.0.1|localhost) strict_host=false ;; *) strict_host=true ;; esac; \
+            if [ \"$${strict_host}\" = true ] && [ -n \"$${ca_path}\" ]; then \
+              set -- \"$${@}\" --cacert \"$${ca_path}\" --resolve \"$${host}:9000:127.0.0.1\" --resolve \"$${host}:9001:127.0.0.1\"; \
+            else \
+              set -- \"$${@}\" -k; \
+            fi; \
+          fi; \
+          curl \"$${@}\" \"$${scheme}://$${host}:9000/health\" && \
+          curl \"$${@}\" \"$${scheme}://$${host}:9001/rustfs/console/health\""
         ]
       interval: 30s
       timeout: 10s


### PR DESCRIPTION
## Related Issues
Fixes #2723.

## Summary of Changes
- update `docker-compose.yml` health checks to switch between HTTP and HTTPS based on `RUSTFS_TLS_PATH`
- update `docker-compose-simple.yml` health checks with the same TLS-aware behavior
- document how to enable stricter TLS probing with `RUSTFS_HEALTHCHECK_HOST` and `RUSTFS_HEALTHCHECK_CA`

## Verification
- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose-simple.yml config`
- `make pre-commit` was not run per user request

## Impact
- fixes TLS-enabled compose deployments being marked unhealthy by plain HTTP loopback probes
- adds optional environment variables for stricter SAN-aligned health checks in compose-based deployments
- no API or storage behavior changes

## Additional Notes
- this PR intentionally scopes only the compose health check issue from #2723
- site replication `9000`/`9001` endpoint drift remains a separate follow-up concern
