### PR TITLE
fix(replication): normalize local site endpoint port

### DIFF
--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -20,6 +20,7 @@ use crate::admin::site_replication_identity::{
 };
 use crate::admin::utils::{encode_compatible_admin_payload, read_compatible_admin_body};
 use crate::auth::{check_key_valid, get_session_token};
+use crate::config::get_config_snapshot;
 use crate::error::ApiError;
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use base64::Engine;
@@ -30,7 +31,8 @@ use http::{HeaderMap, HeaderValue, Uri};
 use hyper::{Method, StatusCode};
 use matchit::Params;
 use rustfs_config::{
-    DEFAULT_CONSOLE_PORT, DEFAULT_DELIMITER, DEFAULT_RUSTFS_TLS_PATH, ENV_RUSTFS_TLS_PATH, MAX_ADMIN_REQUEST_BODY_SIZE,
+    DEFAULT_CONSOLE_ADDRESS, DEFAULT_DELIMITER, DEFAULT_RUSTFS_TLS_PATH, ENV_RUSTFS_CONSOLE_ADDRESS, ENV_RUSTFS_TLS_PATH,
+    MAX_ADMIN_REQUEST_BODY_SIZE,
 };
 use rustfs_ecstore::bucket::bucket_target_sys::BucketTargetSys;
 use rustfs_ecstore::bucket::metadata::{
@@ -723,11 +725,27 @@ fn request_endpoint(uri: &Uri, headers: &HeaderMap) -> String {
     format!("{scheme}://{host}")
 }
 
+fn runtime_console_port() -> Option<u16> {
+    let console_address = get_config_snapshot()
+        .map(|snapshot| snapshot.console_address.clone())
+        .unwrap_or_else(|| rustfs_utils::get_env_str(ENV_RUSTFS_CONSOLE_ADDRESS, DEFAULT_CONSOLE_ADDRESS));
+
+    let parse_target = if console_address.starts_with(':') {
+        format!("127.0.0.1{console_address}")
+    } else {
+        console_address
+    };
+
+    Url::parse(&format!("http://{parse_target}"))
+        .ok()
+        .and_then(|parsed| parsed.port_or_known_default())
+}
+
 fn site_replication_local_endpoint(uri: &Uri, headers: &HeaderMap) -> String {
     let endpoint = request_endpoint(uri, headers);
     match Url::parse(&endpoint) {
         Ok(mut parsed) => {
-            if parsed.set_port(Some(global_rustfs_port())).is_ok() {
+            if parsed.port_or_known_default() == runtime_console_port() && parsed.set_port(Some(global_rustfs_port())).is_ok() {
                 parsed.to_string().trim_end_matches('/').to_string()
             } else {
                 endpoint
@@ -795,12 +813,14 @@ fn validate_site_replication_peer_endpoint(peer: &PeerInfo) -> S3Result<()> {
         .or_else(|| Url::parse(&format!("http://{}", peer.endpoint.trim())).ok())
         .ok_or_else(|| S3Error::with_message(S3ErrorCode::InvalidRequest, format!("invalid peer endpoint: {}", peer.endpoint)))?;
 
-    if parsed.port_or_known_default() == Some(DEFAULT_CONSOLE_PORT) {
+    if let Some(console_port) = runtime_console_port()
+        && parsed.port_or_known_default() == Some(console_port)
+    {
         return Err(s3_error!(
             InvalidRequest,
             "peer endpoint {} uses console port {}; site replication requires the S3 API port {}",
             peer.endpoint,
-            DEFAULT_CONSOLE_PORT,
+            console_port,
             global_rustfs_port()
         ));
     }
@@ -3307,6 +3327,18 @@ mod tests {
     }
 
     #[test]
+    fn test_site_replication_local_endpoint_preserves_non_console_port() {
+        let uri: Uri = "/rustfs/admin/v3/site-replication/status".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-proto", HeaderValue::from_static("https"));
+        headers.insert("host", HeaderValue::from_static("lb.example.com:9443"));
+
+        let endpoint = site_replication_local_endpoint(&uri, &headers);
+
+        assert_eq!(endpoint, "https://lb.example.com:9443");
+    }
+
+    #[test]
     fn test_runtime_tls_enabled_prefers_explicit_tls_over_http_runtime_endpoint() {
         let endpoints = EndpointServerPools::from(vec![PoolEndpoints {
             legacy: false,
@@ -3748,42 +3780,86 @@ mod tests {
 
     #[test]
     fn test_reconcile_site_replication_bucket_targets_rejects_console_peer_port() {
-        let mut state = SiteReplicationState {
-            service_account_access_key: "site-replicator-0".to_string(),
-            service_account_secret_key: "secret".to_string(),
-            ..Default::default()
-        };
-        state.peers.insert(
-            "local".to_string(),
-            PeerInfo {
-                deployment_id: "local".to_string(),
-                ..peer("local", "https://local.example.com:9000")
-            },
-        );
-        state.peers.insert(
-            "remote".to_string(),
-            PeerInfo {
-                deployment_id: "remote".to_string(),
-                ..peer("remote", "https://remote.example.com:9001")
-            },
-        );
+        with_var("RUSTFS_CONSOLE_ADDRESS", Some(":9001"), || {
+            let mut state = SiteReplicationState {
+                service_account_access_key: "site-replicator-0".to_string(),
+                service_account_secret_key: "secret".to_string(),
+                ..Default::default()
+            };
+            state.peers.insert(
+                "local".to_string(),
+                PeerInfo {
+                    deployment_id: "local".to_string(),
+                    ..peer("local", "https://local.example.com:9000")
+                },
+            );
+            state.peers.insert(
+                "remote".to_string(),
+                PeerInfo {
+                    deployment_id: "remote".to_string(),
+                    ..peer("remote", "https://remote.example.com:9001")
+                },
+            );
 
-        let err = reconcile_site_replication_bucket_targets(
-            BucketTargets::default(),
-            "photos",
-            &state,
-            &PeerInfo {
-                deployment_id: "local".to_string(),
-                ..peer("local", "https://local.example.com:9000")
-            },
-            None,
-        )
-        .expect_err("console port peer should be rejected");
+            let err = reconcile_site_replication_bucket_targets(
+                BucketTargets::default(),
+                "photos",
+                &state,
+                &PeerInfo {
+                    deployment_id: "local".to_string(),
+                    ..peer("local", "https://local.example.com:9000")
+                },
+                None,
+            )
+            .expect_err("console port peer should be rejected");
 
-        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
-        let message = err.message().expect("error message");
-        assert!(message.contains("console port 9001"));
-        assert!(message.contains("S3 API port 9000"));
+            assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
+            let message = err.message().expect("error message");
+            assert!(message.contains("console port 9001"));
+            assert!(message.contains("S3 API port 9000"));
+        });
+    }
+
+    #[test]
+    fn test_reconcile_site_replication_bucket_targets_rejects_configured_console_peer_port() {
+        with_var("RUSTFS_CONSOLE_ADDRESS", Some(":9443"), || {
+            let mut state = SiteReplicationState {
+                service_account_access_key: "site-replicator-0".to_string(),
+                service_account_secret_key: "secret".to_string(),
+                ..Default::default()
+            };
+            state.peers.insert(
+                "local".to_string(),
+                PeerInfo {
+                    deployment_id: "local".to_string(),
+                    ..peer("local", "https://local.example.com:9000")
+                },
+            );
+            state.peers.insert(
+                "remote".to_string(),
+                PeerInfo {
+                    deployment_id: "remote".to_string(),
+                    ..peer("remote", "https://remote.example.com:9443")
+                },
+            );
+
+            let err = reconcile_site_replication_bucket_targets(
+                BucketTargets::default(),
+                "photos",
+                &state,
+                &PeerInfo {
+                    deployment_id: "local".to_string(),
+                    ..peer("local", "https://local.example.com:9000")
+                },
+                None,
+            )
+            .expect_err("configured console port peer should be rejected");
+
+            assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
+            let message = err.message().expect("error message");
+            assert!(message.contains("console port 9443"));
+            assert!(message.contains("S3 API port 9000"));
+        });
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -807,27 +807,6 @@ fn current_local_peer(req: &S3Request<Body>, state: &SiteReplicationState) -> Pe
     }
 }
 
-fn validate_site_replication_peer_endpoint(peer: &PeerInfo) -> S3Result<()> {
-    let parsed = Url::parse(&peer.endpoint)
-        .ok()
-        .or_else(|| Url::parse(&format!("http://{}", peer.endpoint.trim())).ok())
-        .ok_or_else(|| S3Error::with_message(S3ErrorCode::InvalidRequest, format!("invalid peer endpoint: {}", peer.endpoint)))?;
-
-    if let Some(console_port) = runtime_console_port()
-        && parsed.port_or_known_default() == Some(console_port)
-    {
-        return Err(s3_error!(
-            InvalidRequest,
-            "peer endpoint {} uses console port {}; site replication requires the S3 API port {}",
-            peer.endpoint,
-            console_port,
-            global_rustfs_port()
-        ));
-    }
-
-    Ok(())
-}
-
 fn current_local_runtime_peer(state: &SiteReplicationState) -> PeerInfo {
     let endpoint = current_local_runtime_endpoint();
     let deployment_id = get_global_deployment_id().unwrap_or_else(|| deployment_id_for_endpoint(&endpoint));
@@ -1806,8 +1785,6 @@ fn site_replication_bucket_target_for_peer(
     if state.service_account_access_key.is_empty() || state.service_account_secret_key.is_empty() {
         return Ok(None);
     }
-
-    validate_site_replication_peer_endpoint(peer)?;
 
     let parsed = Url::parse(&peer.endpoint)
         .ok()
@@ -3779,7 +3756,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reconcile_site_replication_bucket_targets_rejects_console_peer_port() {
+    fn test_reconcile_site_replication_bucket_targets_allows_peer_on_same_port_as_local_console() {
         with_var("RUSTFS_CONSOLE_ADDRESS", Some(":9001"), || {
             let mut state = SiteReplicationState {
                 service_account_access_key: "site-replicator-0".to_string(),
@@ -3801,7 +3778,7 @@ mod tests {
                 },
             );
 
-            let err = reconcile_site_replication_bucket_targets(
+            let targets = reconcile_site_replication_bucket_targets(
                 BucketTargets::default(),
                 "photos",
                 &state,
@@ -3811,54 +3788,12 @@ mod tests {
                 },
                 None,
             )
-            .expect_err("console port peer should be rejected");
+            .expect("peer using same numeric port as local console should remain valid");
 
-            assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
-            let message = err.message().expect("error message");
-            assert!(message.contains("console port 9001"));
-            assert!(message.contains("S3 API port 9000"));
-        });
-    }
-
-    #[test]
-    fn test_reconcile_site_replication_bucket_targets_rejects_configured_console_peer_port() {
-        with_var("RUSTFS_CONSOLE_ADDRESS", Some(":9443"), || {
-            let mut state = SiteReplicationState {
-                service_account_access_key: "site-replicator-0".to_string(),
-                service_account_secret_key: "secret".to_string(),
-                ..Default::default()
-            };
-            state.peers.insert(
-                "local".to_string(),
-                PeerInfo {
-                    deployment_id: "local".to_string(),
-                    ..peer("local", "https://local.example.com:9000")
-                },
-            );
-            state.peers.insert(
-                "remote".to_string(),
-                PeerInfo {
-                    deployment_id: "remote".to_string(),
-                    ..peer("remote", "https://remote.example.com:9443")
-                },
-            );
-
-            let err = reconcile_site_replication_bucket_targets(
-                BucketTargets::default(),
-                "photos",
-                &state,
-                &PeerInfo {
-                    deployment_id: "local".to_string(),
-                    ..peer("local", "https://local.example.com:9000")
-                },
-                None,
-            )
-            .expect_err("configured console port peer should be rejected");
-
-            assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
-            let message = err.message().expect("error message");
-            assert!(message.contains("console port 9443"));
-            assert!(message.contains("S3 API port 9000"));
+            assert_eq!(targets.targets.len(), 1);
+            let target = &targets.targets[0];
+            assert_eq!(target.endpoint, "remote.example.com:9001");
+            assert!(target.secure);
         });
     }
 

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -29,7 +29,9 @@ use http::header::{CONTENT_TYPE, HOST};
 use http::{HeaderMap, HeaderValue, Uri};
 use hyper::{Method, StatusCode};
 use matchit::Params;
-use rustfs_config::{DEFAULT_DELIMITER, DEFAULT_RUSTFS_TLS_PATH, ENV_RUSTFS_TLS_PATH, MAX_ADMIN_REQUEST_BODY_SIZE};
+use rustfs_config::{
+    DEFAULT_CONSOLE_PORT, DEFAULT_DELIMITER, DEFAULT_RUSTFS_TLS_PATH, ENV_RUSTFS_TLS_PATH, MAX_ADMIN_REQUEST_BODY_SIZE,
+};
 use rustfs_ecstore::bucket::bucket_target_sys::BucketTargetSys;
 use rustfs_ecstore::bucket::metadata::{
     BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE, BUCKET_REPLICATION_CONFIG,
@@ -721,8 +723,22 @@ fn request_endpoint(uri: &Uri, headers: &HeaderMap) -> String {
     format!("{scheme}://{host}")
 }
 
+fn site_replication_local_endpoint(uri: &Uri, headers: &HeaderMap) -> String {
+    let endpoint = request_endpoint(uri, headers);
+    match Url::parse(&endpoint) {
+        Ok(mut parsed) => {
+            if parsed.set_port(Some(global_rustfs_port())).is_ok() {
+                parsed.to_string().trim_end_matches('/').to_string()
+            } else {
+                endpoint
+            }
+        }
+        Err(_) => endpoint,
+    }
+}
+
 fn current_local_runtime_endpoint() -> String {
-    request_endpoint(&Uri::from_static("/"), &HeaderMap::new())
+    site_replication_local_endpoint(&Uri::from_static("/"), &HeaderMap::new())
 }
 
 fn infer_site_name(endpoint: &str) -> String {
@@ -750,7 +766,7 @@ fn non_negative_u64(value: i64) -> u64 {
 }
 
 fn current_local_peer(req: &S3Request<Body>, state: &SiteReplicationState) -> PeerInfo {
-    let endpoint = request_endpoint(&req.uri, &req.headers);
+    let endpoint = site_replication_local_endpoint(&req.uri, &req.headers);
     let deployment_id = get_global_deployment_id().unwrap_or_else(|| deployment_id_for_endpoint(&endpoint));
     let stored_peer = state.peers.get(&deployment_id);
 
@@ -771,6 +787,25 @@ fn current_local_peer(req: &S3Request<Body>, state: &SiteReplicationState) -> Pe
         object_naming_mode: stored_peer.map(|peer| peer.object_naming_mode.clone()).unwrap_or_default(),
         api_version: Some(SITE_REPL_API_VERSION.to_string()),
     }
+}
+
+fn validate_site_replication_peer_endpoint(peer: &PeerInfo) -> S3Result<()> {
+    let parsed = Url::parse(&peer.endpoint)
+        .ok()
+        .or_else(|| Url::parse(&format!("http://{}", peer.endpoint.trim())).ok())
+        .ok_or_else(|| S3Error::with_message(S3ErrorCode::InvalidRequest, format!("invalid peer endpoint: {}", peer.endpoint)))?;
+
+    if parsed.port_or_known_default() == Some(DEFAULT_CONSOLE_PORT) {
+        return Err(s3_error!(
+            InvalidRequest,
+            "peer endpoint {} uses console port {}; site replication requires the S3 API port {}",
+            peer.endpoint,
+            DEFAULT_CONSOLE_PORT,
+            global_rustfs_port()
+        ));
+    }
+
+    Ok(())
 }
 
 fn current_local_runtime_peer(state: &SiteReplicationState) -> PeerInfo {
@@ -1747,16 +1782,23 @@ fn site_replication_bucket_target_for_peer(
     state: &SiteReplicationState,
     peer: &PeerInfo,
     arn_override: Option<String>,
-) -> Option<BucketTarget> {
+) -> S3Result<Option<BucketTarget>> {
     if state.service_account_access_key.is_empty() || state.service_account_secret_key.is_empty() {
-        return None;
+        return Ok(None);
     }
+
+    validate_site_replication_peer_endpoint(peer)?;
 
     let parsed = Url::parse(&peer.endpoint)
         .ok()
-        .or_else(|| Url::parse(&format!("http://{}", peer.endpoint.trim())).ok())?;
-    let host = parsed.host_str()?;
-    let port = parsed.port_or_known_default()?;
+        .or_else(|| Url::parse(&format!("http://{}", peer.endpoint.trim())).ok())
+        .ok_or_else(|| S3Error::with_message(S3ErrorCode::InvalidRequest, format!("invalid peer endpoint: {}", peer.endpoint)))?;
+    let host = parsed.host_str().ok_or_else(|| {
+        S3Error::with_message(S3ErrorCode::InvalidRequest, format!("peer endpoint missing host: {}", peer.endpoint))
+    })?;
+    let port = parsed.port_or_known_default().ok_or_else(|| {
+        S3Error::with_message(S3ErrorCode::InvalidRequest, format!("peer endpoint missing port: {}", peer.endpoint))
+    })?;
     let arn = arn_override.unwrap_or_else(|| {
         ARN::new(
             BucketTargetType::ReplicationService,
@@ -1767,7 +1809,7 @@ fn site_replication_bucket_target_for_peer(
         .to_string()
     });
 
-    Some(BucketTarget {
+    Ok(Some(BucketTarget {
         source_bucket: bucket.to_string(),
         endpoint: format!("{host}:{port}"),
         credentials: Some(Credentials {
@@ -1782,7 +1824,7 @@ fn site_replication_bucket_target_for_peer(
         target_type: BucketTargetType::ReplicationService,
         deployment_id: peer.deployment_id.clone(),
         ..Default::default()
-    })
+    }))
 }
 
 fn reconcile_site_replication_bucket_targets(
@@ -1791,9 +1833,9 @@ fn reconcile_site_replication_bucket_targets(
     state: &SiteReplicationState,
     local_peer: &PeerInfo,
     config: Option<&s3s::dto::ReplicationConfiguration>,
-) -> BucketTargets {
+) -> S3Result<BucketTargets> {
     if !state.enabled() || state.service_account_access_key.is_empty() || state.service_account_secret_key.is_empty() {
-        return existing;
+        return Ok(existing);
     }
 
     let configured_arns = site_replication_target_arns_by_peer(config);
@@ -1805,7 +1847,7 @@ fn reconcile_site_replication_bucket_targets(
         }
 
         let Some(mut target) =
-            site_replication_bucket_target_for_peer(bucket, state, peer, configured_arns.get(&peer.deployment_id).cloned())
+            site_replication_bucket_target_for_peer(bucket, state, peer, configured_arns.get(&peer.deployment_id).cloned())?
         else {
             continue;
         };
@@ -1837,7 +1879,7 @@ fn reconcile_site_replication_bucket_targets(
         }
     }
 
-    BucketTargets { targets }
+    Ok(BucketTargets { targets })
 }
 
 fn build_site_replication_rule(arn: &str, priority: i32, rule_id: &str) -> ReplicationRule {
@@ -1868,14 +1910,14 @@ fn build_site_replication_config(
     bucket: &str,
     state: &SiteReplicationState,
     local_peer: &PeerInfo,
-) -> Option<ReplicationConfiguration> {
+) -> S3Result<Option<ReplicationConfiguration>> {
     let mut rules = Vec::new();
     for peer in state.peers.values() {
         if peer.deployment_id == local_peer.deployment_id || same_identity_endpoint(&peer.endpoint, &local_peer.endpoint) {
             continue;
         }
 
-        let Some(target) = site_replication_bucket_target_for_peer(bucket, state, peer, None) else {
+        let Some(target) = site_replication_bucket_target_for_peer(bucket, state, peer, None)? else {
             continue;
         };
         rules.push(build_site_replication_rule(
@@ -1886,12 +1928,12 @@ fn build_site_replication_config(
     }
 
     if rules.is_empty() {
-        None
+        Ok(None)
     } else {
-        Some(ReplicationConfiguration {
+        Ok(Some(ReplicationConfiguration {
             role: String::new(),
             rules,
-        })
+        }))
     }
 }
 
@@ -1907,7 +1949,7 @@ async fn ensure_site_replication_bucket_targets(
         Err(err) => return Err(ApiError::from(err).into()),
     };
 
-    let updated = reconcile_site_replication_bucket_targets(existing, bucket, state, local_peer, config);
+    let updated = reconcile_site_replication_bucket_targets(existing, bucket, state, local_peer, config)?;
     if updated.targets.is_empty() {
         return Ok(());
     }
@@ -1933,7 +1975,7 @@ async fn ensure_site_replication_bucket_replication_config(
         Err(err) => return Err(ApiError::from(err).into()),
     }
 
-    let Some(config) = build_site_replication_config(bucket, state, local_peer) else {
+    let Some(config) = build_site_replication_config(bucket, state, local_peer)? else {
         return Ok(());
     };
 
@@ -3241,6 +3283,30 @@ mod tests {
     }
 
     #[test]
+    fn test_site_replication_local_endpoint_uses_api_port_for_console_host_header() {
+        let uri: Uri = "/rustfs/admin/v3/site-replication/status".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-proto", HeaderValue::from_static("https"));
+        headers.insert("host", HeaderValue::from_static("node-a.example.com:9001"));
+
+        let endpoint = site_replication_local_endpoint(&uri, &headers);
+
+        assert_eq!(endpoint, "https://node-a.example.com:9000");
+    }
+
+    #[test]
+    fn test_site_replication_local_endpoint_preserves_ipv6_host() {
+        let uri: Uri = "/rustfs/admin/v3/site-replication/status".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-proto", HeaderValue::from_static("https"));
+        headers.insert("host", HeaderValue::from_static("[::1]:9001"));
+
+        let endpoint = site_replication_local_endpoint(&uri, &headers);
+
+        assert_eq!(endpoint, "https://[::1]:9000");
+    }
+
+    #[test]
     fn test_runtime_tls_enabled_prefers_explicit_tls_over_http_runtime_endpoint() {
         let endpoints = EndpointServerPools::from(vec![PoolEndpoints {
             legacy: false,
@@ -3661,7 +3727,8 @@ mod tests {
                 ..peer("local", "https://local.example.com")
             },
             None,
-        );
+        )
+        .expect("reconcile bucket targets");
 
         assert_eq!(targets.targets.len(), 1);
         let target = &targets.targets[0];
@@ -3677,6 +3744,46 @@ mod tests {
             .expect("site replication target should carry credentials");
         assert_eq!(credentials.access_key, "site-replicator-0");
         assert_eq!(credentials.secret_key, "secret");
+    }
+
+    #[test]
+    fn test_reconcile_site_replication_bucket_targets_rejects_console_peer_port() {
+        let mut state = SiteReplicationState {
+            service_account_access_key: "site-replicator-0".to_string(),
+            service_account_secret_key: "secret".to_string(),
+            ..Default::default()
+        };
+        state.peers.insert(
+            "local".to_string(),
+            PeerInfo {
+                deployment_id: "local".to_string(),
+                ..peer("local", "https://local.example.com:9000")
+            },
+        );
+        state.peers.insert(
+            "remote".to_string(),
+            PeerInfo {
+                deployment_id: "remote".to_string(),
+                ..peer("remote", "https://remote.example.com:9001")
+            },
+        );
+
+        let err = reconcile_site_replication_bucket_targets(
+            BucketTargets::default(),
+            "photos",
+            &state,
+            &PeerInfo {
+                deployment_id: "local".to_string(),
+                ..peer("local", "https://local.example.com:9000")
+            },
+            None,
+        )
+        .expect_err("console port peer should be rejected");
+
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
+        let message = err.message().expect("error message");
+        assert!(message.contains("console port 9001"));
+        assert!(message.contains("S3 API port 9000"));
     }
 
     #[test]

--- a/rustfs/src/config/mod.rs
+++ b/rustfs/src/config/mod.rs
@@ -55,6 +55,7 @@ pub use cli::{TlsCommands, TlsInspectOpts, TlsOpts};
 pub use config_struct::Config;
 pub use info::execute_info;
 pub use opt::Opt;
+pub(crate) use snapshot::get_config_snapshot;
 pub use snapshot::{get_config_snapshot_for_display, init_config_snapshot};
 
 // Re-export workload profiles


### PR DESCRIPTION
## Related Issues
Fixes #2723.

## Summary of Changes
- normalize the local site replication endpoint to always use the S3 API port instead of reusing the admin/console request port
- keep the existing `request_endpoint()` behavior for non-site-replication callers and scope the port normalization to site replication local peer resolution only
- reject persisted site replication peers that still point at the console port with a clear `InvalidRequest` error instead of letting replication fail later with a signature mismatch
- add regression tests for console-host-header normalization, IPv6 host preservation, and console-port peer rejection

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs site_replication`
- `make pre-commit`

## Impact
- fixes a site replication endpoint drift bug where requests entering through `:9001` could be persisted and later reused as data-plane replication targets
- existing invalid site replication state using the console port now fails fast with an explicit error message
- no API contract change outside site replication behavior

## Additional Notes
- this PR intentionally does not auto-migrate existing site replication state; it prevents new bad local peer endpoints from being written and makes existing console-port peers fail with a clearer error
