### PR TITLE
fix(ci): install ripgrep for script checks

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -54,6 +54,7 @@ runs:
           build-essential \
           pkg-config \
           libssl-dev \
+          ripgrep \
           unzip \
           protobuf-compiler
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Install `ripgrep` in the shared Ubuntu setup action.
- Ensure CI scripts that call `rg`, including layer dependency and unsafe code checks, can run on GitHub runners.

## Verification
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_unsafe_code_allowances.sh`
- `git diff --check`

## Impact
CI setup only. No runtime, API, compatibility, or deployment impact.

## Additional Notes
Full `make pre-commit` was started but not completed after direct submission was requested.
