### PR TITLE
docs: complete config helper inventory

### DIFF
--- a/docs/architecture/ecstore-config-consumer-inventory.md
+++ b/docs/architecture/ecstore-config-consumer-inventory.md
@@ -19,9 +19,11 @@ In scope:
 - `rustfs_ecstore::config::com::{read_config_without_migrate, save_server_config}`
 - Consumers that persist, clone, inspect, mutate, or pass these types across
   runtime boundaries.
-- Adjacent users of `rustfs_ecstore::config::com::{read_config, save_config,
-  delete_config}` are listed separately because moving `com.rs` would affect
-  them even when they do not consume `Config`, `KV`, or `KVS`.
+- Selected adjacent users of `rustfs_ecstore::config::com::{read_config,
+  save_config, delete_config}` and related helper variants are listed separately
+  when they appear outside the core `Config`, `KV`, and `KVS` consumer map.
+  This is not a complete `com.rs` move inventory; any future `com.rs` move must
+  first inventory ECStore-internal persistence helper users too.
 
 Out of scope:
 
@@ -123,6 +125,8 @@ behind narrower contracts.
 | `rustfs/src/admin/handlers/kms_dynamic.rs` | Uses generic `read_config` and `save_config` for dynamic KMS config objects. |
 | `rustfs/src/admin/handlers/site_replication.rs` | Uses generic `read_config`, `save_config`, and `delete_config` for site-replication state objects. |
 | `rustfs/src/admin/service/site_replication.rs` | Uses generic `read_config` and `save_config` for site-replication state normalization. |
+| `rustfs/src/server/module_switch.rs` | Uses generic `read_config` and `save_config` for module-switch config objects. |
+| `crates/iam/src/store/object.rs` | Uses generic `read_config_no_lock`, `read_config_with_metadata`, `save_config`, `save_config_with_opts`, and `delete_config` helper variants for IAM object-store persistence paths. |
 | `crates/scanner/src/{scanner,data_usage_define}.rs` | Uses generic `read_config` and `save_config` for scanner metadata and cache persistence paths. |
 
 ### Runtime Target, Notify, And Audit Crates

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,13 +5,14 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-config-inventory`
-- Baseline: `upstream/main` at `241e45d3b040684e5d217d2dd95f84c72f1de316`
+- Branch: `overtrue/arch-config-helper-inventory-followup`
+- Baseline: `upstream/main` at `3c71d5ef1c63bec63780d48caa2a9fe880ea0c64`
 - PR type for this branch: `docs-only`
 - Runtime behavior changes: none
 - Rust code changes: none
-- Docs changes: add the ECStore config consumer inventory for later config-model
-  contract, pure-move, and global-state migration work.
+- Docs changes: add PR-review-raised adjacent config-object helper users for
+  module-switch and IAM persistence without claiming a complete `com.rs` move
+  inventory.
 
 ## Phase 0 Tasks
 
@@ -67,7 +68,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | Re-review confirmed dependency/call direction arrows, scanner global readers, adjacent scanner persistence helpers, notify config-manager persistence, narrowed test wording, and `Config model contract` wording are source-backed |
+| Quality/architecture | pass | Re-review confirmed dependency/call direction arrows, scanner global readers, selected adjacent scanner/module-switch/IAM persistence helpers, notify config-manager persistence, narrowed test wording, and `Config model contract` wording are source-backed |
 | Migration preservation | pass | Confirmed this branch is docs-only, aligned with `rustfs/backlog#660`, and does not touch runtime logic, storage hot paths, global state implementation, compatibility code, scripts, or crate boundaries |
 | Testing/verification | pass | Confirmed docs-only verification is sufficient after wording was narrowed and the final staged diff check covers all docs |
 
@@ -98,3 +99,5 @@ Final pre-push after staging all docs:
   `RUSTFS_COMPAT_TODO(<task-id>)` marker and cleanup-register entry.
 - The next config-model PR must preserve the current tuple-struct shapes and
   persistence behavior before introducing narrower provider contracts.
+- Do not move `config::com` until a dedicated helper-user inventory covers
+  ECStore-internal persistence paths as well as adjacent non-model users.


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#660

## Summary of Changes

- Add PR-review-raised adjacent `config::com` helper users for module switches and IAM object-store persistence.
- Narrow the inventory scope so it does not claim to be a complete `com.rs` move inventory.
- Update migration progress with the new branch context and a handoff note requiring a dedicated ECStore-internal helper inventory before moving `config::com`.

## Verification

- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_metrics_migration_refs.sh`
- `git diff --check upstream/main`
- `git diff --check upstream/main...HEAD`
- `git diff --cached --check`
- Three-expert review: quality/architecture, migration preservation, and testing/verification

## Impact

Documentation only. No runtime behavior, API, storage hot-path, deployment, or configuration changes.

## Additional Notes

`make pre-commit` was not run because repository guidance exempts documentation-only changes.
