### PR TITLE
fix: return 503 on lock contention instead of 500

### DIFF
--- a/crates/e2e_test/src/namespace_lock_quorum_test.rs
+++ b/crates/e2e_test/src/namespace_lock_quorum_test.rs
@@ -120,3 +120,96 @@ async fn test_concurrent_cluster_overwrites_do_not_fail_namespace_lock_quorum() 
     clients[0].delete_object().bucket(BUCKET).key(KEY).send().await?;
     Ok(())
 }
+
+/// Regression test: concurrent PUTs to the same key must return 503 (ServiceUnavailable)
+/// on lock contention, never 500 (InternalError).
+///
+/// Before the fix, `map_namespace_lock_error` wrapped lock timeout/conflict errors as
+/// `StorageError::other(...)` → `StorageError::Io(...)`, which fell through to
+/// `S3ErrorCode::InternalError` (500) in the error mapping.
+#[tokio::test]
+#[serial]
+async fn test_concurrent_put_same_key_never_returns_500() -> TestResult {
+    crate::common::init_logging();
+    info!("Starting concurrent PUT 500 regression test");
+
+    let mut cluster = RustFSTestClusterEnvironment::new(4).await?;
+    // Short lock timeout to trigger contention errors quickly
+    cluster.set_env("RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT", "3");
+    cluster.start().await?;
+    cluster.create_test_bucket(BUCKET).await?;
+
+    let clients = cluster.create_all_clients()?;
+    let writer_count = clients.len() * 4; // 16 writers for heavy contention
+    let barrier = Arc::new(Barrier::new(writer_count));
+
+    // Seed initial object
+    let first_payload = b"initial object for 500 regression".to_vec();
+    put_object(clients[0].clone(), first_payload, 0).await?;
+
+    let err_500_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let err_503_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let ok_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    let mut handles = Vec::with_capacity(writer_count);
+    for writer_id in 0..writer_count {
+        let client = clients[writer_id % clients.len()].clone();
+        let barrier = barrier.clone();
+        let payload = format!("payload from writer {writer_id:02}").into_bytes();
+        let err_500 = err_500_count.clone();
+        let err_503 = err_503_count.clone();
+        let ok = ok_count.clone();
+
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            match client
+                .put_object()
+                .bucket(BUCKET)
+                .key(KEY)
+                .body(Bytes::from(payload).into())
+                .send()
+                .await
+            {
+                Ok(_) => {
+                    ok.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+                Err(err) => match &err {
+                    SdkError::ServiceError(service_err) => {
+                        let code = service_err.err().meta().code().unwrap_or("<unknown>");
+                        if code == "500" || code == "InternalError" {
+                            err_500.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            warn!("writer {writer_id} returned 500: {code}");
+                        } else if code == "503" || code == "ServiceUnavailable" {
+                            err_503.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        } else {
+                            warn!("writer {writer_id} returned unexpected error: {code}");
+                        }
+                    }
+                    other => {
+                        warn!("writer {writer_id} returned SDK error: {other:?}");
+                    }
+                },
+            }
+        }));
+    }
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    let ok = ok_count.load(std::sync::atomic::Ordering::Relaxed);
+    let err_503 = err_503_count.load(std::sync::atomic::Ordering::Relaxed);
+    let err_500 = err_500_count.load(std::sync::atomic::Ordering::Relaxed);
+    let total = ok + err_503 + err_500;
+
+    info!("Concurrent PUT 500 regression: total={total}, ok={ok}, 503={err_503}, 500={err_500}");
+
+    assert_eq!(
+        err_500, 0,
+        "Concurrent PUTs to the same key must NEVER return 500 InternalError. \
+         Got {err_500} out of {total} requests. 503 count: {err_503}, ok: {ok}"
+    );
+
+    clients[0].delete_object().bucket(BUCKET).key(KEY).send().await?;
+    Ok(())
+}

--- a/crates/e2e_test/src/namespace_lock_quorum_test.rs
+++ b/crates/e2e_test/src/namespace_lock_quorum_test.rs
@@ -149,6 +149,7 @@ async fn test_concurrent_put_same_key_never_returns_500() -> TestResult {
 
     let err_500_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let err_503_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let unexpected_err_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
     let ok_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
     let mut handles = Vec::with_capacity(writer_count);
@@ -158,6 +159,7 @@ async fn test_concurrent_put_same_key_never_returns_500() -> TestResult {
         let payload = format!("payload from writer {writer_id:02}").into_bytes();
         let err_500 = err_500_count.clone();
         let err_503 = err_503_count.clone();
+        let unexpected_err = unexpected_err_count.clone();
         let ok = ok_count.clone();
 
         handles.push(tokio::spawn(async move {
@@ -182,10 +184,12 @@ async fn test_concurrent_put_same_key_never_returns_500() -> TestResult {
                         } else if code == "503" || code == "ServiceUnavailable" {
                             err_503.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         } else {
+                            unexpected_err.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             warn!("writer {writer_id} returned unexpected error: {code}");
                         }
                     }
                     other => {
+                        unexpected_err.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         warn!("writer {writer_id} returned SDK error: {other:?}");
                     }
                 },
@@ -194,15 +198,30 @@ async fn test_concurrent_put_same_key_never_returns_500() -> TestResult {
     }
 
     for handle in handles {
-        let _ = handle.await;
+        if let Err(err) = handle.await {
+            unexpected_err_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            warn!("writer task join failed: {err}");
+        }
     }
 
     let ok = ok_count.load(std::sync::atomic::Ordering::Relaxed);
     let err_503 = err_503_count.load(std::sync::atomic::Ordering::Relaxed);
     let err_500 = err_500_count.load(std::sync::atomic::Ordering::Relaxed);
-    let total = ok + err_503 + err_500;
+    let unexpected_err = unexpected_err_count.load(std::sync::atomic::Ordering::Relaxed);
+    let total = ok + err_503 + err_500 + unexpected_err;
 
-    info!("Concurrent PUT 500 regression: total={total}, ok={ok}, 503={err_503}, 500={err_500}");
+    info!("Concurrent PUT 500 regression: total={total}, ok={ok}, 503={err_503}, 500={err_500}, unexpected={unexpected_err}");
+
+    assert_eq!(
+        total, writer_count as u64,
+        "every concurrent PUT writer must be classified as success, 503, 500, or unexpected error"
+    );
+
+    assert_eq!(
+        unexpected_err, 0,
+        "Concurrent PUTs to the same key must only succeed or return 503. \
+         Got {unexpected_err} unexpected errors out of {total} requests. 503 count: {err_503}, ok: {ok}"
+    );
 
     assert_eq!(
         err_500, 0,

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1562,7 +1562,7 @@ impl LocalDisk {
                         None
                     };
 
-                    if opts.limit <= 0 || file_meta.as_ref().is_none_or(|meta| !meta.all_hidden(true)) {
+                    if opts.limit <= 0 || file_meta.as_ref().is_none_or(file_meta_counts_toward_limit) {
                         *objs_returned += 1;
                     }
 
@@ -1638,7 +1638,15 @@ fn is_root_path(path: impl AsRef<Path>) -> bool {
 }
 
 fn metadata_counts_toward_limit(metadata: &[u8]) -> bool {
-    FileMeta::load(metadata).map_or(true, |meta| !meta.all_hidden(true))
+    FileMeta::load(metadata).map_or(true, |meta| file_meta_counts_toward_limit(&meta))
+}
+
+fn file_meta_counts_toward_limit(meta: &FileMeta) -> bool {
+    meta.list_versions("", "", false).map_or(true, |versions| {
+        versions
+            .first()
+            .is_none_or(|latest| !latest.deleted && !latest.tier_free_version())
+    })
 }
 
 // Filter std::io::ErrorKind::NotFound
@@ -3663,6 +3671,25 @@ mod test {
             fm.marshal_msg().expect("delete marker metadata should encode")
         }
 
+        fn delete_marker_with_old_object_metadata(delete_version_id: &str, object_version_id: &str) -> Vec<u8> {
+            let mut fm = FileMeta::default();
+            fm.add_version({
+                let mut fi = FileInfo::new("hidden", 1, 1);
+                fi.version_id = Some(Uuid::parse_str(object_version_id).expect("test version id should parse"));
+                fi.mod_time = Some(OffsetDateTime::now_utc() - time::Duration::seconds(1));
+                fi
+            })
+            .expect("object metadata should be valid");
+            fm.add_version(FileInfo {
+                deleted: true,
+                version_id: Some(Uuid::parse_str(delete_version_id).expect("test version id should parse")),
+                mod_time: Some(OffsetDateTime::now_utc()),
+                ..Default::default()
+            })
+            .expect("delete marker metadata should be valid");
+            fm.marshal_msg().expect("delete marker metadata should encode")
+        }
+
         fn object_metadata(version_id: &str) -> Vec<u8> {
             let mut fm = FileMeta::default();
             let mut fi = FileInfo::new("visible", 1, 1);
@@ -3688,11 +3715,23 @@ mod test {
                 .unwrap();
         }
 
+        let hidden_versioned_dir = bucket_dir.join("shard/aaa-trash-0003");
+        fs::create_dir_all(&hidden_versioned_dir).await.unwrap();
+        fs::write(
+            hidden_versioned_dir.join(STORAGE_FORMAT_FILE),
+            delete_marker_with_old_object_metadata(
+                "44444444-4444-4444-4444-444444444444",
+                "55555555-5555-5555-5555-555555555555",
+            ),
+        )
+        .await
+        .unwrap();
+
         let visible_dir = bucket_dir.join("shard/bbb-visible-0000");
         fs::create_dir_all(&visible_dir).await.unwrap();
         fs::write(
             visible_dir.join(STORAGE_FORMAT_FILE),
-            object_metadata("44444444-4444-4444-4444-444444444444"),
+            object_metadata("66666666-6666-6666-6666-666666666666"),
         )
         .await
         .unwrap();

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1451,12 +1451,9 @@ impl LocalDisk {
                 let name = entry.trim_end_matches(SLASH_SEPARATOR);
                 let name = decode_dir_object(format!("{}/{}", &current, &name).as_str());
 
-                // if opts.limit > 0
-                //     && let Ok(meta) = FileMeta::load(&metadata)
-                //     && !meta.all_hidden(true)
-                // {
-                *objs_returned += 1;
-                // }
+                if opts.limit <= 0 || metadata_counts_toward_limit(&metadata) {
+                    *objs_returned += 1;
+                }
 
                 out.write_obj(&MetaCacheEntry {
                     name: name.clone(),
@@ -1559,15 +1556,19 @@ impl LocalDisk {
 
                     out.write_obj(&meta).await?;
 
-                    // if let Ok(meta) = FileMeta::load(&meta.metadata)
-                    //     && !meta.all_hidden(true)
-                    // {
-                    *objs_returned += 1;
-                    // }
+                    let file_meta = if opts.limit > 0 || opts.recursive {
+                        FileMeta::load(&res).ok()
+                    } else {
+                        None
+                    };
+
+                    if opts.limit <= 0 || file_meta.as_ref().is_none_or(|meta| !meta.all_hidden(true)) {
+                        *objs_returned += 1;
+                    }
 
                     if opts.recursive {
                         let mut dir_to_skip = HashSet::new();
-                        if let Ok(file_meta) = FileMeta::load(&res)
+                        if let Some(file_meta) = file_meta.as_ref()
                             && let Ok(data_dirs) = file_meta.get_data_dirs()
                         {
                             for data_dir in data_dirs.iter().flatten() {
@@ -1634,6 +1635,10 @@ impl Drop for ScanGuard {
 
 fn is_root_path(path: impl AsRef<Path>) -> bool {
     path.as_ref().components().count() == 1 && path.as_ref().has_root()
+}
+
+fn metadata_counts_toward_limit(metadata: &[u8]) -> bool {
+    FileMeta::load(metadata).map_or(true, |meta| !meta.all_hidden(true))
 }
 
 // Filter std::io::ErrorKind::NotFound
@@ -3639,6 +3644,90 @@ mod test {
             "forward_to must not skip a child directory whose name repeats the base prefix"
         );
         assert_eq!(double_count as usize, double_names.len());
+    }
+
+    #[tokio::test]
+    async fn test_scan_dir_hidden_delete_markers_do_not_exhaust_limit() {
+        use rustfs_filemeta::MetacacheReader;
+        use tempfile::tempdir;
+
+        fn delete_marker_metadata(version_id: &str) -> Vec<u8> {
+            let mut fm = FileMeta::default();
+            fm.add_version(FileInfo {
+                deleted: true,
+                version_id: Some(Uuid::parse_str(version_id).expect("test version id should parse")),
+                mod_time: Some(OffsetDateTime::now_utc()),
+                ..Default::default()
+            })
+            .expect("delete marker metadata should be valid");
+            fm.marshal_msg().expect("delete marker metadata should encode")
+        }
+
+        fn object_metadata(version_id: &str) -> Vec<u8> {
+            let mut fm = FileMeta::default();
+            let mut fi = FileInfo::new("visible", 1, 1);
+            fi.version_id = Some(Uuid::parse_str(version_id).expect("test version id should parse"));
+            fi.mod_time = Some(OffsetDateTime::now_utc());
+            fm.add_version(fi).expect("object metadata should be valid");
+            fm.marshal_msg().expect("object metadata should encode")
+        }
+
+        let dir = tempdir().unwrap();
+        let bucket = "test-bucket";
+        let bucket_dir = dir.path().join(bucket);
+
+        for (name, version_id) in [
+            ("shard/aaa-trash-0000", "11111111-1111-1111-1111-111111111111"),
+            ("shard/aaa-trash-0001", "22222222-2222-2222-2222-222222222222"),
+            ("shard/aaa-trash-0002", "33333333-3333-3333-3333-333333333333"),
+        ] {
+            let object_dir = bucket_dir.join(name);
+            fs::create_dir_all(&object_dir).await.unwrap();
+            fs::write(object_dir.join(STORAGE_FORMAT_FILE), delete_marker_metadata(version_id))
+                .await
+                .unwrap();
+        }
+
+        let visible_dir = bucket_dir.join("shard/bbb-visible-0000");
+        fs::create_dir_all(&visible_dir).await.unwrap();
+        fs::write(
+            visible_dir.join(STORAGE_FORMAT_FILE),
+            object_metadata("44444444-4444-4444-4444-444444444444"),
+        )
+        .await
+        .unwrap();
+
+        let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+        let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+
+        let (reader, mut writer) = tokio::io::duplex(4096);
+        let mut out = MetacacheWriter::new(&mut writer);
+        let opts = WalkDirOptions {
+            bucket: bucket.to_string(),
+            base_dir: "".to_string(),
+            recursive: true,
+            limit: 1,
+            ..Default::default()
+        };
+        let mut objs_returned = 0;
+
+        disk.scan_dir("".to_string(), "".to_string(), &opts, &mut out, &mut objs_returned, false, None)
+            .await
+            .unwrap();
+        out.close().await.unwrap();
+        drop(out);
+        drop(writer);
+
+        let mut reader = MetacacheReader::new(reader);
+        let has_visible_object = reader
+            .read_all()
+            .await
+            .unwrap()
+            .into_iter()
+            .any(|entry| !entry.metadata.is_empty() && entry.name == "shard/bbb-visible-0000");
+
+        assert!(has_visible_object);
+        assert_eq!(objs_returned, 1);
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1642,11 +1642,8 @@ fn metadata_counts_toward_limit(metadata: &[u8]) -> bool {
 }
 
 fn file_meta_counts_toward_limit(meta: &FileMeta) -> bool {
-    meta.list_versions("", "", false).map_or(true, |versions| {
-        versions
-            .first()
-            .is_none_or(|latest| !latest.deleted && !latest.tier_free_version())
-    })
+    meta.into_fileinfo("", "", "", false, true, false)
+        .map_or_else(|_| !meta.all_hidden(true), |latest| !latest.deleted && !latest.tier_free_version())
 }
 
 // Filter std::io::ErrorKind::NotFound

--- a/crates/ecstore/src/set_disk/lock.rs
+++ b/crates/ecstore/src/set_disk/lock.rs
@@ -67,10 +67,7 @@ impl SetDisks {
                     achieved,
                 }
             }
-            other => StorageError::other(format!(
-                "Failed to acquire {mode} lock: {}",
-                self.format_lock_error_from_error(bucket, object, mode, &other)
-            )),
+            other => StorageError::Lock(other),
         }
     }
 

--- a/crates/ecstore/src/store/bucket.rs
+++ b/crates/ecstore/src/store/bucket.rs
@@ -81,7 +81,7 @@ impl ECStore {
                                 achieved,
                             }
                         }
-                        other => StorageError::other(format!("make_bucket: failed to acquire write lock on {bucket}: {other}")),
+                        other => StorageError::Lock(other),
                     })?,
             )
         } else {
@@ -185,7 +185,7 @@ impl ECStore {
                                 achieved,
                             }
                         }
-                        other => StorageError::other(format!("delete_bucket: failed to acquire write lock on {bucket}: {other}")),
+                        other => StorageError::Lock(other),
                     })?,
             )
         } else {

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -243,7 +243,7 @@ impl ECStore {
                 required,
                 achieved,
             },
-            other => StorageError::other(format!("Failed to acquire {mode} lock on {bucket}/{object}: {other}")),
+            other => StorageError::Lock(other),
         }
     }
 

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -723,7 +723,7 @@ fn copy_namespace_lock_error(bucket: &str, object: &str, mode: &'static str, err
             required,
             achieved,
         },
-        other => StorageError::other(format!("Failed to acquire {mode} lock on {bucket}/{object}: {other}")),
+        other => StorageError::Lock(other),
     }
 }
 

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -243,6 +243,7 @@ impl From<StorageError> for ApiError {
             StorageError::StorageFull => S3ErrorCode::ServiceUnavailable,
             StorageError::SlowDown => S3ErrorCode::SlowDown,
             StorageError::NamespaceLockQuorumUnavailable { .. } => S3ErrorCode::ServiceUnavailable,
+            StorageError::Lock(_) => S3ErrorCode::ServiceUnavailable,
             StorageError::DecommissionNotStarted => S3ErrorCode::InvalidRequest,
             StorageError::DecommissionAlreadyRunning => S3ErrorCode::InvalidRequest,
             StorageError::RebalanceAlreadyRunning => S3ErrorCode::InvalidRequest,


### PR DESCRIPTION
## Problem

Concurrent PUTs to the same key return HTTP 500 (InternalError) when lock contention occurs (timeout or conflict). Expected: 503 (ServiceUnavailable), which clients can retry.

**Reported by:** French customer — "concurrent PUTs with the same key return a 500 after holding a lock"

## Root Cause

`map_namespace_lock_error` wrapped non-quorum lock errors as `StorageError::other(...)` → `StorageError::Io(...)`. In the `From<StorageError> for ApiError` mapping, `StorageError::Io(...)` falls through to the `_ => S3ErrorCode::InternalError` catch-all, producing HTTP 500.

Only `LockError::QuorumNotReached` was correctly mapped to `StorageError::NamespaceLockQuorumUnavailable` → `S3ErrorCode::ServiceUnavailable` (503). All other lock errors (Timeout, AlreadyLocked, etc.) became 500.

## Fix

- `map_namespace_lock_error` now returns `StorageError::Lock(err)` for non-quorum lock errors (instead of `StorageError::other(...)`)
- Added `StorageError::Lock(_) => S3ErrorCode::ServiceUnavailable` in the HTTP error mapping

### Files changed

| File | Change |
|------|--------|
| `crates/ecstore/src/set_disk/lock.rs` | `map_namespace_lock_error` → `StorageError::Lock(other)` |
| `crates/ecstore/src/store/object.rs` | Same (Store-level lock error mapping) |
| `crates/ecstore/src/store/bucket.rs` | `make_bucket` + `delete_bucket` lock error mapping |
| `rustfs/src/app/object_usecase.rs` | `copy_namespace_lock_error` |
| `rustfs/src/error.rs` | `StorageError::Lock(_) => S3ErrorCode::ServiceUnavailable` |
| `crates/e2e_test/src/namespace_lock_quorum_test.rs` | Regression test |

### All affected lock error paths (verified)

All production code paths that call `get_write_lock`/`get_read_lock` and surface errors to S3 API responses have been fixed:

- `SetDisks::acquire_write_lock_diag` (put_object, delete_object, put_object_metadata, complete_multipart_upload, etc.)
- `SetDisks::acquire_read_lock_diag` (get_object, get_object_info, etc.)
- `Store::acquire_object_write_lock_if_needed` / `acquire_object_read_lock_if_needed`
- `copy_namespace_lock_error` (copy_object self-copy)
- `store/bucket.rs` make_bucket / delete_bucket

Internal paths (heal, replication resyncer) handle lock errors separately and are unaffected.

## Regression Test

`test_concurrent_put_same_key_never_returns_500` — 4-node cluster, 16 concurrent writers to the same key, short lock timeout (3s). Asserts zero 500 responses; 503 and success are acceptable.

## Verification

```
cargo check -p rustfs-ecstore  # ✅
cargo check -p e2e_test        # ✅
cargo fmt --all --check        # ✅
```
