### PR TITLE
docs: decide config model boundary

### DIFF
--- a/docs/architecture/config-model-boundary-adr.md
+++ b/docs/architecture/config-model-boundary-adr.md
@@ -1,0 +1,162 @@
+# Config Model Boundary ADR
+
+Related issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
+
+Task: `CFG-002`
+
+## Decision
+
+Use the existing `crates/config` package (`rustfs-config`) as the target owner
+for the pure server-config model. Do not create a new config-model crate for
+the first extraction.
+
+The next model extraction PR should introduce the model under:
+
+```text
+crates/config/src/server_config.rs
+```
+
+The exported path should be:
+
+```rust
+rustfs_config::server_config::{Config, KV, KVS}
+```
+
+The existing path must remain available through a temporary compatibility
+re-export:
+
+```rust
+rustfs_ecstore::config::{Config, KV, KVS}
+```
+
+That re-export must include `RUSTFS_COMPAT_TODO(CFG-004)` and a matching entry in
+[`compat-cleanup-register.md`](compat-cleanup-register.md).
+
+## Why `rustfs-config`
+
+`rustfs-config` is already the lowest RustFS crate for configuration constants
+and subsystem identifiers used by ECStore, notify, audit, targets, scanner, IAM,
+and admin code. The current `ecstore::config::{Config, KV, KVS}` model already
+uses `rustfs-config` constants, so moving the pure model upward to
+`rustfs-config` cuts the wrong dependency direction without adding another crate.
+
+Creating a new crate now would add a second config namespace before consumers
+are migrated. That would increase re-export and compatibility surface while not
+removing any storage or runtime dependency by itself.
+
+## Allowed Dependencies
+
+The server-config model module may use only:
+
+- `std::collections::HashMap`
+- `std::sync::{LazyLock, OnceLock}` for the default `KVS` registration surface
+- `serde` for `KV` and `KVS` serialization compatibility
+- `serde_json` for `Config::marshal` and `Config::unmarshal`
+- existing `rustfs-config` constants and subsystem modules
+
+If `serde` and `serde_json` are added to `rustfs-config`, they should be attached
+only to a model feature such as `server-config-model` unless the implementation
+PR proves that making them non-optional is simpler and harmless for downstream
+builds.
+
+## Forbidden Dependencies
+
+The model module must not depend on:
+
+- `rustfs-ecstore`
+- `rustfs`
+- `StorageAPI` or object persistence helpers
+- notify, audit, targets, IAM, scanner, KMS, or admin handler crates
+- async runtimes, HTTP/router crates, object-store crates, or runtime lifecycle
+  state
+- global server-config snapshot state such as `GLOBAL_SERVER_CONFIG`
+- `ConfigSys`, `read_config_without_migrate`, `save_server_config`, or any
+  `com.rs` persistence helper
+
+## Boundary Split
+
+Move in the first extraction:
+
+- `KV`
+- `KVS`
+- `Config`
+- `DEFAULT_KVS`
+- `register_default_kvs`
+- `Config::new`
+- `Config::get_value`
+- `Config::set_defaults`
+- `Config::marshal`
+- `Config::unmarshal`
+- `Config::merge`
+
+Keep in `ecstore`:
+
+- `ConfigSys`
+- `GLOBAL_SERVER_CONFIG`
+- `get_global_server_config`
+- `set_global_server_config`
+- `init_global_config_sys`
+- `try_migrate_server_config`
+- `read_config_without_migrate`
+- `save_server_config`
+- generic `com.rs` config-object helpers
+- storage-class runtime global state
+
+Keep default registration wiring in `ecstore::config::init` until a later PR
+extracts a dedicated default-registration contract. The values may be registered
+through the moved `rustfs_config::server_config::register_default_kvs`, but the
+startup order and caller remain unchanged.
+
+## Required Shape Preservation
+
+The extraction PR must preserve:
+
+- `KV { key, value, hidden_if_empty }`
+- `#[serde(default, alias = "hiddenIfEmpty")]` on `KV::hidden_if_empty`
+- `KVS(pub Vec<KV>)`
+- `Config(pub HashMap<String, HashMap<String, KVS>>)`
+- `KVS::new`, `get`, `lookup`, `is_empty`, `keys`, `insert`, and `extend`
+- `Config::new`, `get_value`, `set_defaults`, `marshal`, `unmarshal`, and
+  `merge`
+- `Config::new()` default application after `ecstore::config::init()`
+- existing persisted server-config JSON shape
+- existing target, notify, audit, scanner, OIDC, and admin interpretation of
+  `Config` and `KVS`
+
+## Next PR Requirements
+
+`CFG-003` should be a pure model extraction or narrow `api-extraction` PR. It
+must not migrate consumers, change persistence helpers, or alter runtime
+behavior.
+
+`CFG-004` should keep the old `rustfs_ecstore::config::*` path as a temporary
+compatibility shim and register its removal condition.
+
+`CFG-005` should migrate external consumers one group at a time after the model
+and compatibility path are stable.
+
+## Verification Gate
+
+Before pushing an extraction PR, run:
+
+- serde roundtrip tests for old and new paths
+- tests for `hiddenIfEmpty` alias compatibility
+- tests for `KVS` insertion, lookup, extension, and keys behavior
+- tests for `Config::new`, `set_defaults`, `marshal`, `unmarshal`, and `merge`
+- a compile smoke test that the old `rustfs_ecstore::config::{Config, KV, KVS}`
+  path still works
+- `cargo tree -p rustfs-config --edges normal`
+- `cargo tree -p rustfs-ecstore --edges normal`
+- `./scripts/check_layer_dependencies.sh`
+- `./scripts/check_architecture_migration_rules.sh`
+- `./scripts/check_metrics_migration_refs.sh`
+- `cargo fmt --all --check`
+- `make pre-commit`
+
+## Non-Goals
+
+- No consumer migration in `CFG-002`.
+- No code movement in `CFG-002`.
+- No new crate in `CFG-002`.
+- No `com.rs` or `StorageAPI` movement in the first model extraction.
+- No global server-config state migration until the model path is stable.

--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -75,3 +75,10 @@ Rules:
 `ecstore::config::{Config, KV, KVS}` should move before extension config adapters
 or config-schema work. First inventory consumers, then decide whether existing
 `crates/config` is enough or whether a smaller model crate is required.
+
+The current decision is recorded in
+[`config-model-boundary-adr.md`](config-model-boundary-adr.md): use the existing
+`rustfs-config` package for the pure server-config model, keep persistence and
+global server-config state in `ecstore`, and preserve the old
+`rustfs_ecstore::config::*` path with a temporary compatibility marker during
+the first extraction.

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,14 +5,14 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-background-services-inventory`
-- Baseline: `upstream/main` at `03eb10b07f5f968c531151ae667dfe218050493d`
+- Branch: `overtrue/arch-config-consumer-inventory`
+- Baseline: `upstream/main` at `f9a5e6d7e67322ac6f626b6f437a5e722fbe22e2`
 - PR type for this branch: `docs-only`
 - Runtime behavior changes: none.
 - Rust code changes: none.
 - CI/script changes: none
-- Docs changes: add BGC-001 background service inventory and index it from the
-  architecture overview.
+- Docs changes: add the CFG-002 config model boundary ADR and link it from the
+  architecture overview, crate-boundary guardrails, and this progress handoff.
 
 ## Phase 0 Tasks
 
@@ -61,6 +61,27 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     source `RUSTFS_COMPAT_TODO(<task-id>)` marker lacks a cleanup-register entry,
     when a register entry lacks a source marker, or when a source marker omits a
     removal condition.
+
+## Phase 1a Config Model Tasks
+
+- [x] `CFG-001` Inventory `ecstore::config::{Config, KV, KVS}` consumers.
+  - Acceptance:
+    [`ecstore-config-consumer-inventory.md`](ecstore-config-consumer-inventory.md)
+    records the current definitions, persistence helpers, global accessors,
+    consumer groups, migration risks, and do-not-change contract.
+- [x] `CFG-002` Decide model boundary.
+  - Acceptance:
+    [`config-model-boundary-adr.md`](config-model-boundary-adr.md) records
+    `rustfs-config` as the target package, `server_config` as the future model
+    module, allowed dependencies, forbidden dependencies, preserved shape, and
+    extraction verification gates.
+- [ ] `CFG-003` Move pure model definitions.
+  - Next boundary: move only `Config`, `KV`, `KVS`, and default-registration
+    surface into `rustfs-config`; keep persistence helpers and global
+    server-config state in `ecstore`.
+- [ ] `CFG-004` Keep old `ecstore::config::*` compatibility path.
+  - Required compatibility: source must contain `RUSTFS_COMPAT_TODO(CFG-004)`
+    and a matching cleanup-register entry.
 
 ## Phase 1 Security Governance Tasks
 
@@ -128,17 +149,23 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Next PRs
 
 1. `contract`: define the minimal BackgroundController status vocabulary after
-   this inventory is reviewed.
+   the BGC-001 inventory is reviewed.
 2. `test-only`: add focused preservation tests before moving scanner, heal,
    replication, lifecycle, or disk health workers.
+3. `api-extraction`: move only the pure server-config model into
+   rustfs-config as CFG-003.
+4. `api-extraction`: keep the old rustfs_ecstore::config::* path with
+   RUSTFS_COMPAT_TODO(CFG-004) and cleanup-register coverage.
+5. `consumer-migration`: migrate external consumers one group at a time only
+   after the model path and compatibility shim are stable.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | Single `docs-only` BGC-001 inventory; it records current owners, cancellation, side effects, and follow-up inputs without adding a controller abstraction. |
-| Migration preservation | pass | No Rust source, Cargo manifest, workflow, script, or runtime config diff; storage hot path and shutdown behavior are untouched. |
-| Testing/verification | pass | Architecture migration rules, layer dependency guard, metrics reference guard, docs diff hygiene, and no-code-diff check passed. |
+| Quality/architecture | pass | Single `docs-only` PR; ADR chooses existing rustfs-config, records module path and dependency boundaries, and avoids a speculative new crate. |
+| Migration preservation | pass | No code movement; ADR explicitly keeps persistence helpers, global server-config state, startup order, and old-path compatibility requirements out of CFG-002. |
+| Testing/verification | pass | Docs-only verification uses migration guard scripts, metrics reference guard, layer dependency guard, and whitespace checks. |
 
 ## Verification Notes
 
@@ -157,10 +184,14 @@ Notes:
 
 ## Handoff Notes
 
-- Keep this BGC-001 branch as a focused `docs-only` PR.
-- Do not add controller traits, status structs, service registry code, shutdown
-  wiring, worker tests, or runtime behavior changes in this PR.
-- Follow-up BGC-002 may define a minimal read-only controller status vocabulary
-  after this inventory is reviewed.
+- Keep this CFG-002 branch as a focused `docs-only` PR. Do not move
+  `Config`, `KV`, `KVS`, persistence helpers, global server-config state,
+  Storage API code, startup code, or target/notify/audit/IAM consumers in this
+  branch.
+- The next extraction PR must preserve the tuple-struct shape, serde fields,
+  `hiddenIfEmpty` alias, `Config::new` default behavior, marshal/unmarshal
+  behavior, and old `rustfs_ecstore::config::*` path.
 - Do not add temporary compatibility code without a matching
   `RUSTFS_COMPAT_TODO(<task-id>)` marker and cleanup-register entry.
+- Do not create a new config-model crate unless a later implementation attempt
+  proves `rustfs-config` cannot hold the pure model boundary.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -30,6 +30,9 @@ hot-path behavior must not drift during this migration.
 - [`ecstore-config-consumer-inventory.md`](ecstore-config-consumer-inventory.md):
   current `ecstore::config::{Config, KV, KVS}` definitions, consumers,
   migration risks, and do-not-change contract.
+- [`config-model-boundary-adr.md`](config-model-boundary-adr.md): target crate,
+  module path, dependency rules, and verification gates for moving the pure
+  server-config model.
 - [`migration-progress.md`](migration-progress.md): current task state and context
   handoff.
 - [`compat-cleanup-register.md`](compat-cleanup-register.md): temporary
@@ -68,3 +71,4 @@ The first implementation sequence is conservative:
 2. Establish PR and compatibility rules.
 3. Add dependency and loss-prevention checks in a separate `ci-gate` PR.
 4. Inventory `ecstore::config::{Config, KV, KVS}` before moving any code.
+5. Decide the config model boundary before extracting or migrating consumers.


### PR DESCRIPTION
## Related Issues
Part of rustfs/backlog#660.

## Summary of Changes
- Add a CFG-002 ADR that selects `rustfs-config` as the target owner for the pure server-config model.
- Record the future `server_config` module path, allowed dependencies, forbidden dependencies, preserved shape, and extraction verification gates.
- Link the ADR from the architecture overview, crate-boundary guardrails, and migration progress handoff.

## Verification
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_metrics_migration_refs.sh`
- `git diff --check`

## Impact
Documentation only. No runtime behavior, Rust source, Cargo metadata, config serialization, startup order, global state, storage path, or crate-boundary behavior changes.

## Additional Notes
3-expert pre-push review completed for architecture scope, migration preservation, and docs-only verification.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
