### PR TITLE
test: guard table catalog ingress unknown fields

### DIFF
--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -1809,6 +1809,60 @@ mod tests {
     }
 
     #[test]
+    fn table_catalog_ingress_requests_reject_unknown_fields() {
+        assert_rejects_unknown_field::<CreateNamespaceRequest>(
+            "CreateNamespaceRequest",
+            serde_json::json!({
+                "namespace": ["analytics"],
+                "unexpected": true
+            }),
+        );
+        assert_rejects_unknown_field::<RegisterTableRequest>(
+            "RegisterTableRequest",
+            serde_json::json!({
+                "name": "events",
+                "metadata-location": ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json",
+                "unexpected": true
+            }),
+        );
+        assert_rejects_unknown_field::<CreateTableRequest>(
+            "CreateTableRequest",
+            serde_json::json!({
+                "name": "events",
+                "schema": {},
+                "unexpected": true
+            }),
+        );
+        assert_rejects_unknown_field::<RestCommitTableRequest>(
+            "RestCommitTableRequest",
+            serde_json::json!({
+                "unexpected": true
+            }),
+        );
+        assert_rejects_unknown_field::<TableMetadataMaintenanceRequest>(
+            "TableMetadataMaintenanceRequest",
+            serde_json::json!({
+                "delete": true,
+                "unexpected": true
+            }),
+        );
+    }
+
+    fn assert_rejects_unknown_field<T>(target: &str, value: serde_json::Value)
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let err = match serde_json::from_value::<T>(value) {
+            Ok(_) => panic!("{target} should reject unknown fields"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("unknown field"),
+            "{target} should reject unknown fields, got: {err}"
+        );
+    }
+
+    #[test]
     fn create_namespace_request_uses_rest_namespace_segments_and_properties() {
         let request: CreateNamespaceRequest = serde_json::from_value(serde_json::json!({
             "namespace": ["analytics", "daily_events"],


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#660.

## Summary of Changes
PR type: test-only.

Adds a focused regression test for table catalog JSON ingress DTOs so unknown fields are rejected for create namespace, register table, create table, commit table, and metadata maintenance requests.

No handler, authorization, storage, route registration, serde attribute, or runtime behavior is changed.

## Verification
- `cargo test -p rustfs admin::handlers::table_catalog::tests::table_catalog_ingress_requests_reject_unknown_fields -- --nocapture`
- `cargo test -p rustfs admin::handlers::table_catalog -- --nocapture`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_metrics_migration_refs.sh`
- `git diff --check`
- `make pre-commit`

## Impact
No user-facing, compatibility, API, deployment, configuration, or runtime behavior impact. This only adds test coverage for the existing strict ingress contract.

## Additional Notes
Three-expert pre-push review passed: quality/architecture, migration preservation, and testing/verification.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
