### PR TITLE
feat(storage-api): add contract crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9987,6 +9987,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfs-storage-api"
+version = "1.0.0-beta.7"
+
+[[package]]
 name = "rustfs-targets"
 version = "1.0.0-beta.7"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "crates/scanner", # Scanner for data integrity checks and health monitoring
     "crates/security-governance", # Security governance contracts
     "crates/signer", # client signer
+    "crates/storage-api", # Storage API contracts
     "crates/targets", # Target-specific configurations and utilities
     "crates/trusted-proxies", # Trusted proxies management
     "crates/tls-runtime", # Project-wide TLS runtime foundation
@@ -113,6 +114,7 @@ rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.
 rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.7" }
 rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.7" }
 rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.7" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.7" }
 rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.7" }
 rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.7" }
 rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.7" }

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -1,0 +1,31 @@
+# Copyright 2024 RustFS Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "rustfs-storage-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+description = "Storage API contracts for RustFS."
+keywords = ["storage", "api", "contract", "rustfs"]
+categories = ["web-programming", "development-tools", "filesystem"]
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Storage API contracts for RustFS.


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Add the `rustfs-storage-api` workspace crate as the Phase 2 `API-001` contract boundary.
- Register the crate in workspace members and workspace dependencies.
- Keep the crate dependency-free and avoid consumer, ECStore, storage hot path, runtime, or behavior changes.

## Verification

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check -p rustfs-storage-api`
- `cargo tree -p rustfs-storage-api --edges normal`
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_metrics_migration_refs.sh`
- `git diff --check`
- `make pre-commit`

## Impact

No runtime, deployment, configuration, storage behavior, or API consumer impact. This PR only introduces an empty contract crate for later storage boundary extraction.

## Additional Notes

PR type: contract. Migration task: API-001. No compatibility path is introduced, so no `RUSTFS_COMPAT_TODO` marker is required.
