### PR TITLE
feat(scanner): expose pacing pressure status

### DIFF
--- a/crates/common/src/metrics.rs
+++ b/crates/common/src/metrics.rs
@@ -748,6 +748,31 @@ pub struct ScannerSourceCycleSnapshot {
     pub cycles: u64,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ScannerPacingPressureSnapshot {
+    pub primary_pressure: String,
+    pub current_queued_scans: u64,
+    pub current_active_scans: u64,
+    pub last_cycle_budget_limited: bool,
+    pub last_cycle_throttle_sleep_ratio: f64,
+    pub last_cycle_yield_ratio: f64,
+    pub last_cycle_total_pause_ratio: f64,
+}
+
+impl Default for ScannerPacingPressureSnapshot {
+    fn default() -> Self {
+        Self {
+            primary_pressure: "none".to_string(),
+            current_queued_scans: 0,
+            current_active_scans: 0,
+            last_cycle_budget_limited: false,
+            last_cycle_throttle_sleep_ratio: 0.0,
+            last_cycle_yield_ratio: 0.0,
+            last_cycle_total_pause_ratio: 0.0,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ScannerLastMinute {
     pub actions: HashMap<String, ScannerTimedAction>,
@@ -853,6 +878,8 @@ pub struct ScannerMetricsReport {
     #[serde(default)]
     pub partial_cycles_by_source: Vec<ScannerSourceCycleSnapshot>,
     #[serde(default)]
+    pub pacing_pressure: ScannerPacingPressureSnapshot,
+    #[serde(default)]
     pub throttle_idle_mode_enabled: bool,
     #[serde(default)]
     pub throttle_sleep_factor: f64,
@@ -930,6 +957,74 @@ fn scan_cycle_result_label(result: u8) -> &'static str {
         SCAN_CYCLE_RESULT_ERROR => SCAN_CYCLE_RESULT_ERROR_LABEL,
         SCAN_CYCLE_RESULT_PARTIAL => SCAN_CYCLE_RESULT_PARTIAL_LABEL,
         _ => SCAN_CYCLE_RESULT_UNKNOWN_LABEL,
+    }
+}
+
+fn scanner_ratio(numerator: f64, denominator: f64) -> f64 {
+    if denominator <= 0.0 {
+        0.0
+    } else {
+        (numerator / denominator).clamp(0.0, 1.0)
+    }
+}
+
+fn scanner_last_cycle_budget_limited(result_code: u64, partial_reason: &str) -> bool {
+    result_code == u64::from(SCAN_CYCLE_RESULT_PARTIAL) && matches!(partial_reason, "runtime" | "objects" | "directories")
+}
+
+fn scanner_primary_pressure(
+    current_queued_scans: u64,
+    current_active_scans: u64,
+    last_cycle_budget_limited: bool,
+    last_cycle_throttle_sleep_events: u64,
+    last_cycle_yield_events: u64,
+) -> &'static str {
+    if current_queued_scans > 0 {
+        "queued_scans"
+    } else if last_cycle_budget_limited {
+        "cycle_budget"
+    } else if last_cycle_throttle_sleep_events > 0 || last_cycle_yield_events > 0 {
+        "throttle_pause"
+    } else if current_active_scans > 0 {
+        "active_scans"
+    } else {
+        "none"
+    }
+}
+
+fn scanner_pacing_pressure(metrics: &ScannerMetricsReport) -> ScannerPacingPressureSnapshot {
+    let current_queued_scans = metrics
+        .current_set_scans_queued
+        .saturating_add(metrics.current_disk_bucket_scans_queued);
+    let current_active_scans = metrics
+        .current_set_scans_active
+        .saturating_add(metrics.current_disk_bucket_scans_active)
+        .max(usize_to_u64_saturated(metrics.active_scan_paths));
+    let last_cycle_budget_limited =
+        scanner_last_cycle_budget_limited(metrics.last_cycle_result_code, metrics.last_cycle_partial_reason.as_str());
+    let last_cycle_throttle_sleep_ratio =
+        scanner_ratio(metrics.last_cycle_throttle_sleep_duration_seconds, metrics.last_cycle_duration_seconds);
+    let last_cycle_yield_ratio = scanner_ratio(metrics.last_cycle_yield_duration_seconds, metrics.last_cycle_duration_seconds);
+    let last_cycle_total_pause_ratio = scanner_ratio(
+        metrics.last_cycle_throttle_sleep_duration_seconds.max(0.0) + metrics.last_cycle_yield_duration_seconds.max(0.0),
+        metrics.last_cycle_duration_seconds,
+    );
+
+    ScannerPacingPressureSnapshot {
+        primary_pressure: scanner_primary_pressure(
+            current_queued_scans,
+            current_active_scans,
+            last_cycle_budget_limited,
+            metrics.last_cycle_throttle_sleep_events,
+            metrics.last_cycle_yield_events,
+        )
+        .to_string(),
+        current_queued_scans,
+        current_active_scans,
+        last_cycle_budget_limited,
+        last_cycle_throttle_sleep_ratio,
+        last_cycle_yield_ratio,
+        last_cycle_total_pause_ratio,
     }
 }
 
@@ -1904,6 +1999,8 @@ impl Metrics {
             }
         }
 
+        m.pacing_pressure = scanner_pacing_pressure(&m);
+
         m
     }
 }
@@ -2058,6 +2155,35 @@ mod tests {
         assert_eq!(report.current_disk_scan_concurrency_limit, 0);
         assert_eq!(report.current_disk_bucket_scans_queued, 0);
         assert_eq!(report.current_disk_bucket_scans_active, 0);
+    }
+
+    #[tokio::test]
+    async fn report_derives_scanner_pacing_pressure() {
+        let metrics = Metrics::new();
+        metrics.record_scanner_set_scan_state(Some(2), Some(3), Some(1));
+        metrics.record_scanner_disk_bucket_scan_state("0", "0", Some(1), Some(4), Some(1));
+        metrics.record_scan_cycle_partial_with_source(
+            Duration::from_secs(10),
+            ScanCyclePartialReason::Runtime,
+            Some(ScannerWorkSource::Usage),
+        );
+        metrics.record_scan_cycle_work(ScanCycleWorkSnapshot {
+            yield_events: 2,
+            yield_duration_millis: 500,
+            throttle_sleep_events: 4,
+            throttle_sleep_duration_millis: 2500,
+            ..Default::default()
+        });
+
+        let report = metrics.report().await;
+
+        assert_eq!(report.pacing_pressure.primary_pressure, "queued_scans");
+        assert_eq!(report.pacing_pressure.current_queued_scans, 7);
+        assert_eq!(report.pacing_pressure.current_active_scans, 2);
+        assert!(report.pacing_pressure.last_cycle_budget_limited);
+        assert_eq!(report.pacing_pressure.last_cycle_throttle_sleep_ratio, 0.25);
+        assert_eq!(report.pacing_pressure.last_cycle_yield_ratio, 0.05);
+        assert_eq!(report.pacing_pressure.last_cycle_total_pause_ratio, 0.3);
     }
 
     #[tokio::test]

--- a/crates/common/src/metrics.rs
+++ b/crates/common/src/metrics.rs
@@ -754,6 +754,7 @@ pub struct ScannerPacingPressureSnapshot {
     pub current_queued_scans: u64,
     pub current_active_scans: u64,
     pub last_cycle_budget_limited: bool,
+    pub last_cycle_pause_observed: bool,
     pub last_cycle_throttle_sleep_ratio: f64,
     pub last_cycle_yield_ratio: f64,
     pub last_cycle_total_pause_ratio: f64,
@@ -766,6 +767,7 @@ impl Default for ScannerPacingPressureSnapshot {
             current_queued_scans: 0,
             current_active_scans: 0,
             last_cycle_budget_limited: false,
+            last_cycle_pause_observed: false,
             last_cycle_throttle_sleep_ratio: 0.0,
             last_cycle_yield_ratio: 0.0,
             last_cycle_total_pause_ratio: 0.0,
@@ -1002,6 +1004,7 @@ fn scanner_pacing_pressure(metrics: &ScannerMetricsReport) -> ScannerPacingPress
         .max(usize_to_u64_saturated(metrics.active_scan_paths));
     let last_cycle_budget_limited =
         scanner_last_cycle_budget_limited(metrics.last_cycle_result_code, metrics.last_cycle_partial_reason.as_str());
+    let last_cycle_pause_observed = metrics.last_cycle_throttle_sleep_events > 0 || metrics.last_cycle_yield_events > 0;
     let last_cycle_throttle_sleep_ratio =
         scanner_ratio(metrics.last_cycle_throttle_sleep_duration_seconds, metrics.last_cycle_duration_seconds);
     let last_cycle_yield_ratio = scanner_ratio(metrics.last_cycle_yield_duration_seconds, metrics.last_cycle_duration_seconds);
@@ -1022,6 +1025,7 @@ fn scanner_pacing_pressure(metrics: &ScannerMetricsReport) -> ScannerPacingPress
         current_queued_scans,
         current_active_scans,
         last_cycle_budget_limited,
+        last_cycle_pause_observed,
         last_cycle_throttle_sleep_ratio,
         last_cycle_yield_ratio,
         last_cycle_total_pause_ratio,
@@ -2181,6 +2185,7 @@ mod tests {
         assert_eq!(report.pacing_pressure.current_queued_scans, 7);
         assert_eq!(report.pacing_pressure.current_active_scans, 2);
         assert!(report.pacing_pressure.last_cycle_budget_limited);
+        assert!(report.pacing_pressure.last_cycle_pause_observed);
         assert_eq!(report.pacing_pressure.last_cycle_throttle_sleep_ratio, 0.25);
         assert_eq!(report.pacing_pressure.last_cycle_yield_ratio, 0.05);
         assert_eq!(report.pacing_pressure.last_cycle_total_pause_ratio, 0.3);

--- a/crates/ecstore/src/metrics_realtime.rs
+++ b/crates/ecstore/src/metrics_realtime.rs
@@ -107,6 +107,7 @@ fn to_madmin_scanner_metrics(metrics: rustfs_common::metrics::ScannerMetricsRepo
             current_queued_scans: metrics.pacing_pressure.current_queued_scans,
             current_active_scans: metrics.pacing_pressure.current_active_scans,
             last_cycle_budget_limited: metrics.pacing_pressure.last_cycle_budget_limited,
+            last_cycle_pause_observed: metrics.pacing_pressure.last_cycle_pause_observed,
             last_cycle_throttle_sleep_ratio: metrics.pacing_pressure.last_cycle_throttle_sleep_ratio,
             last_cycle_yield_ratio: metrics.pacing_pressure.last_cycle_yield_ratio,
             last_cycle_total_pause_ratio: metrics.pacing_pressure.last_cycle_total_pause_ratio,
@@ -394,6 +395,7 @@ mod test {
                 current_queued_scans: 4,
                 current_active_scans: 2,
                 last_cycle_budget_limited: true,
+                last_cycle_pause_observed: true,
                 last_cycle_throttle_sleep_ratio: 0.25,
                 last_cycle_yield_ratio: 0.05,
                 last_cycle_total_pause_ratio: 0.3,
@@ -405,6 +407,7 @@ mod test {
         assert_eq!(scanner.pacing_pressure.current_queued_scans, 4);
         assert_eq!(scanner.pacing_pressure.current_active_scans, 2);
         assert!(scanner.pacing_pressure.last_cycle_budget_limited);
+        assert!(scanner.pacing_pressure.last_cycle_pause_observed);
         assert_eq!(scanner.pacing_pressure.last_cycle_throttle_sleep_ratio, 0.25);
         assert_eq!(scanner.pacing_pressure.last_cycle_yield_ratio, 0.05);
         assert_eq!(scanner.pacing_pressure.last_cycle_total_pause_ratio, 0.3);

--- a/crates/ecstore/src/metrics_realtime.rs
+++ b/crates/ecstore/src/metrics_realtime.rs
@@ -18,8 +18,8 @@ use rustfs_common::{GLOBAL_LOCAL_NODE_NAME, GLOBAL_RUSTFS_ADDR, heal_channel::Dr
 use rustfs_io_metrics::internode_metrics::global_internode_metrics;
 use rustfs_madmin::metrics::{
     DiskIOStats, DiskMetric, LastMinute as MadminLastMinute, NetDevLine, NetMetrics, RPCMetrics, RealtimeMetrics,
-    ScannerMetrics as MadminScannerMetrics, ScannerSourceCycleSnapshot as MadminScannerSourceCycleSnapshot,
-    TimedAction as MadminTimedAction,
+    ScannerMetrics as MadminScannerMetrics, ScannerPacingPressureSnapshot as MadminScannerPacingPressureSnapshot,
+    ScannerSourceCycleSnapshot as MadminScannerSourceCycleSnapshot, TimedAction as MadminTimedAction,
 };
 use rustfs_utils::os::get_drive_stats;
 use serde::{Deserialize, Serialize};
@@ -102,6 +102,15 @@ fn to_madmin_scanner_metrics(metrics: rustfs_common::metrics::ScannerMetricsRepo
         active_paths: metrics.active_paths,
         last_cycle_partial_source: metrics.last_cycle_partial_source,
         last_cycle_partial_source_code: metrics.last_cycle_partial_source_code,
+        pacing_pressure: MadminScannerPacingPressureSnapshot {
+            primary_pressure: metrics.pacing_pressure.primary_pressure,
+            current_queued_scans: metrics.pacing_pressure.current_queued_scans,
+            current_active_scans: metrics.pacing_pressure.current_active_scans,
+            last_cycle_budget_limited: metrics.pacing_pressure.last_cycle_budget_limited,
+            last_cycle_throttle_sleep_ratio: metrics.pacing_pressure.last_cycle_throttle_sleep_ratio,
+            last_cycle_yield_ratio: metrics.pacing_pressure.last_cycle_yield_ratio,
+            last_cycle_total_pause_ratio: metrics.pacing_pressure.last_cycle_total_pause_ratio,
+        },
         partial_cycles_by_source: metrics
             .partial_cycles_by_source
             .into_iter()
@@ -375,5 +384,29 @@ mod test {
             .find(|source| source.source == "usage")
             .expect("usage partial source should be mapped");
         assert_eq!(usage.cycles, 2);
+    }
+
+    #[test]
+    fn scanner_metrics_mapping_preserves_pacing_pressure() {
+        let scanner = to_madmin_scanner_metrics(rustfs_common::metrics::ScannerMetricsReport {
+            pacing_pressure: rustfs_common::metrics::ScannerPacingPressureSnapshot {
+                primary_pressure: "cycle_budget".to_string(),
+                current_queued_scans: 4,
+                current_active_scans: 2,
+                last_cycle_budget_limited: true,
+                last_cycle_throttle_sleep_ratio: 0.25,
+                last_cycle_yield_ratio: 0.05,
+                last_cycle_total_pause_ratio: 0.3,
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(scanner.pacing_pressure.primary_pressure, "cycle_budget");
+        assert_eq!(scanner.pacing_pressure.current_queued_scans, 4);
+        assert_eq!(scanner.pacing_pressure.current_active_scans, 2);
+        assert!(scanner.pacing_pressure.last_cycle_budget_limited);
+        assert_eq!(scanner.pacing_pressure.last_cycle_throttle_sleep_ratio, 0.25);
+        assert_eq!(scanner.pacing_pressure.last_cycle_yield_ratio, 0.05);
+        assert_eq!(scanner.pacing_pressure.last_cycle_total_pause_ratio, 0.3);
     }
 }

--- a/crates/madmin/src/metrics.rs
+++ b/crates/madmin/src/metrics.rs
@@ -138,6 +138,8 @@ pub struct ScannerPacingPressureSnapshot {
     pub current_active_scans: u64,
     #[serde(rename = "last_cycle_budget_limited", default)]
     pub last_cycle_budget_limited: bool,
+    #[serde(rename = "last_cycle_pause_observed", default)]
+    pub last_cycle_pause_observed: bool,
     #[serde(rename = "last_cycle_throttle_sleep_ratio", default)]
     pub last_cycle_throttle_sleep_ratio: f64,
     #[serde(rename = "last_cycle_yield_ratio", default)]
@@ -153,6 +155,7 @@ impl Default for ScannerPacingPressureSnapshot {
             current_queued_scans: 0,
             current_active_scans: 0,
             last_cycle_budget_limited: false,
+            last_cycle_pause_observed: false,
             last_cycle_throttle_sleep_ratio: 0.0,
             last_cycle_yield_ratio: 0.0,
             last_cycle_total_pause_ratio: 0.0,
@@ -166,7 +169,7 @@ impl ScannerPacingPressureSnapshot {
             "queued_scans"
         } else if self.last_cycle_budget_limited {
             "cycle_budget"
-        } else if self.last_cycle_total_pause_ratio > 0.0 {
+        } else if self.last_cycle_pause_observed {
             "throttle_pause"
         } else if self.current_active_scans > 0 {
             "active_scans"
@@ -177,9 +180,14 @@ impl ScannerPacingPressureSnapshot {
     }
 
     fn merge(&mut self, other: &Self) {
+        let pause_observed = self.last_cycle_pause_observed
+            || self.primary_pressure == "throttle_pause"
+            || other.last_cycle_pause_observed
+            || other.primary_pressure == "throttle_pause";
         self.current_queued_scans = self.current_queued_scans.saturating_add(other.current_queued_scans);
         self.current_active_scans = self.current_active_scans.saturating_add(other.current_active_scans);
         self.last_cycle_budget_limited |= other.last_cycle_budget_limited;
+        self.last_cycle_pause_observed = pause_observed;
         self.last_cycle_throttle_sleep_ratio = self
             .last_cycle_throttle_sleep_ratio
             .max(other.last_cycle_throttle_sleep_ratio);
@@ -780,6 +788,7 @@ mod tests {
                 primary_pressure: "cycle_budget".to_string(),
                 current_active_scans: 1,
                 last_cycle_budget_limited: true,
+                last_cycle_pause_observed: true,
                 last_cycle_throttle_sleep_ratio: 0.1,
                 last_cycle_yield_ratio: 0.2,
                 last_cycle_total_pause_ratio: 0.3,
@@ -824,6 +833,7 @@ mod tests {
         assert_eq!(scanner.pacing_pressure.current_queued_scans, 4);
         assert_eq!(scanner.pacing_pressure.current_active_scans, 3);
         assert!(scanner.pacing_pressure.last_cycle_budget_limited);
+        assert!(scanner.pacing_pressure.last_cycle_pause_observed);
         assert_eq!(scanner.pacing_pressure.last_cycle_throttle_sleep_ratio, 0.4);
         assert_eq!(scanner.pacing_pressure.last_cycle_yield_ratio, 0.2);
         assert_eq!(scanner.pacing_pressure.last_cycle_total_pause_ratio, 0.5);
@@ -840,5 +850,28 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn scanner_metrics_merge_preserves_pause_pressure_without_duration() {
+        let collected_at = Utc::now();
+        let mut scanner = ScannerMetrics {
+            collected_at,
+            pacing_pressure: ScannerPacingPressureSnapshot {
+                primary_pressure: "throttle_pause".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        scanner.merge(&ScannerMetrics {
+            collected_at: collected_at + chrono::Duration::seconds(1),
+            pacing_pressure: ScannerPacingPressureSnapshot::default(),
+            ..Default::default()
+        });
+
+        assert_eq!(scanner.pacing_pressure.primary_pressure, "throttle_pause");
+        assert!(scanner.pacing_pressure.last_cycle_pause_observed);
+        assert_eq!(scanner.pacing_pressure.last_cycle_total_pause_ratio, 0.0);
     }
 }

--- a/crates/madmin/src/metrics.rs
+++ b/crates/madmin/src/metrics.rs
@@ -128,6 +128,67 @@ pub struct ScannerSourceCycleSnapshot {
     pub cycles: u64,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ScannerPacingPressureSnapshot {
+    #[serde(rename = "primary_pressure", default)]
+    pub primary_pressure: String,
+    #[serde(rename = "current_queued_scans", default)]
+    pub current_queued_scans: u64,
+    #[serde(rename = "current_active_scans", default)]
+    pub current_active_scans: u64,
+    #[serde(rename = "last_cycle_budget_limited", default)]
+    pub last_cycle_budget_limited: bool,
+    #[serde(rename = "last_cycle_throttle_sleep_ratio", default)]
+    pub last_cycle_throttle_sleep_ratio: f64,
+    #[serde(rename = "last_cycle_yield_ratio", default)]
+    pub last_cycle_yield_ratio: f64,
+    #[serde(rename = "last_cycle_total_pause_ratio", default)]
+    pub last_cycle_total_pause_ratio: f64,
+}
+
+impl Default for ScannerPacingPressureSnapshot {
+    fn default() -> Self {
+        Self {
+            primary_pressure: "none".to_string(),
+            current_queued_scans: 0,
+            current_active_scans: 0,
+            last_cycle_budget_limited: false,
+            last_cycle_throttle_sleep_ratio: 0.0,
+            last_cycle_yield_ratio: 0.0,
+            last_cycle_total_pause_ratio: 0.0,
+        }
+    }
+}
+
+impl ScannerPacingPressureSnapshot {
+    fn refresh_primary_pressure(&mut self) {
+        self.primary_pressure = if self.current_queued_scans > 0 {
+            "queued_scans"
+        } else if self.last_cycle_budget_limited {
+            "cycle_budget"
+        } else if self.last_cycle_total_pause_ratio > 0.0 {
+            "throttle_pause"
+        } else if self.current_active_scans > 0 {
+            "active_scans"
+        } else {
+            "none"
+        }
+        .to_string();
+    }
+
+    fn merge(&mut self, other: &Self) {
+        self.current_queued_scans = self.current_queued_scans.saturating_add(other.current_queued_scans);
+        self.current_active_scans = self.current_active_scans.saturating_add(other.current_active_scans);
+        self.last_cycle_budget_limited |= other.last_cycle_budget_limited;
+        self.last_cycle_throttle_sleep_ratio = self
+            .last_cycle_throttle_sleep_ratio
+            .max(other.last_cycle_throttle_sleep_ratio);
+        self.last_cycle_yield_ratio = self.last_cycle_yield_ratio.max(other.last_cycle_yield_ratio);
+        self.last_cycle_total_pause_ratio = self.last_cycle_total_pause_ratio.max(other.last_cycle_total_pause_ratio);
+        self.refresh_primary_pressure();
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ScannerMetrics {
     #[serde(rename = "collected")]
@@ -154,6 +215,8 @@ pub struct ScannerMetrics {
     pub last_cycle_partial_source_code: u64,
     #[serde(rename = "partial_cycles_by_source", default)]
     pub partial_cycles_by_source: Vec<ScannerSourceCycleSnapshot>,
+    #[serde(rename = "pacing_pressure", default)]
+    pub pacing_pressure: ScannerPacingPressureSnapshot,
 }
 
 impl ScannerMetrics {
@@ -164,6 +227,8 @@ impl ScannerMetrics {
             self.last_cycle_partial_source = other.last_cycle_partial_source.clone();
             self.last_cycle_partial_source_code = other.last_cycle_partial_source_code;
         }
+
+        self.pacing_pressure.merge(&other.pacing_pressure);
 
         if self.ongoing_buckets < other.ongoing_buckets {
             self.ongoing_buckets = other.ongoing_buckets;
@@ -711,6 +776,15 @@ mod tests {
             collected_at,
             last_cycle_partial_source: "usage".to_string(),
             last_cycle_partial_source_code: 1,
+            pacing_pressure: ScannerPacingPressureSnapshot {
+                primary_pressure: "cycle_budget".to_string(),
+                current_active_scans: 1,
+                last_cycle_budget_limited: true,
+                last_cycle_throttle_sleep_ratio: 0.1,
+                last_cycle_yield_ratio: 0.2,
+                last_cycle_total_pause_ratio: 0.3,
+                ..Default::default()
+            },
             partial_cycles_by_source: vec![ScannerSourceCycleSnapshot {
                 source: "usage".to_string(),
                 cycles: 1,
@@ -722,6 +796,15 @@ mod tests {
             collected_at: collected_at + chrono::Duration::seconds(1),
             last_cycle_partial_source: "lifecycle".to_string(),
             last_cycle_partial_source_code: 2,
+            pacing_pressure: ScannerPacingPressureSnapshot {
+                primary_pressure: "queued_scans".to_string(),
+                current_queued_scans: 4,
+                current_active_scans: 2,
+                last_cycle_throttle_sleep_ratio: 0.4,
+                last_cycle_yield_ratio: 0.1,
+                last_cycle_total_pause_ratio: 0.5,
+                ..Default::default()
+            },
             partial_cycles_by_source: vec![
                 ScannerSourceCycleSnapshot {
                     source: "usage".to_string(),
@@ -737,6 +820,13 @@ mod tests {
 
         assert_eq!(scanner.last_cycle_partial_source, "lifecycle");
         assert_eq!(scanner.last_cycle_partial_source_code, 2);
+        assert_eq!(scanner.pacing_pressure.primary_pressure, "queued_scans");
+        assert_eq!(scanner.pacing_pressure.current_queued_scans, 4);
+        assert_eq!(scanner.pacing_pressure.current_active_scans, 3);
+        assert!(scanner.pacing_pressure.last_cycle_budget_limited);
+        assert_eq!(scanner.pacing_pressure.last_cycle_throttle_sleep_ratio, 0.4);
+        assert_eq!(scanner.pacing_pressure.last_cycle_yield_ratio, 0.2);
+        assert_eq!(scanner.pacing_pressure.last_cycle_total_pause_ratio, 0.5);
         assert_eq!(
             scanner.partial_cycles_by_source,
             vec![

--- a/crates/madmin/src/metrics.rs
+++ b/crates/madmin/src/metrics.rs
@@ -128,9 +128,15 @@ pub struct ScannerSourceCycleSnapshot {
     pub cycles: u64,
 }
 
+const SCANNER_PRIMARY_PRESSURE_NONE: &str = "none";
+
+fn default_scanner_primary_pressure() -> String {
+    SCANNER_PRIMARY_PRESSURE_NONE.to_string()
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ScannerPacingPressureSnapshot {
-    #[serde(rename = "primary_pressure", default)]
+    #[serde(rename = "primary_pressure", default = "default_scanner_primary_pressure")]
     pub primary_pressure: String,
     #[serde(rename = "current_queued_scans", default)]
     pub current_queued_scans: u64,
@@ -151,7 +157,7 @@ pub struct ScannerPacingPressureSnapshot {
 impl Default for ScannerPacingPressureSnapshot {
     fn default() -> Self {
         Self {
-            primary_pressure: "none".to_string(),
+            primary_pressure: default_scanner_primary_pressure(),
             current_queued_scans: 0,
             current_active_scans: 0,
             last_cycle_budget_limited: false,
@@ -174,7 +180,7 @@ impl ScannerPacingPressureSnapshot {
         } else if self.current_active_scans > 0 {
             "active_scans"
         } else {
-            "none"
+            SCANNER_PRIMARY_PRESSURE_NONE
         }
         .to_string();
     }
@@ -873,5 +879,18 @@ mod tests {
         assert_eq!(scanner.pacing_pressure.primary_pressure, "throttle_pause");
         assert!(scanner.pacing_pressure.last_cycle_pause_observed);
         assert_eq!(scanner.pacing_pressure.last_cycle_total_pause_ratio, 0.0);
+    }
+
+    #[test]
+    fn scanner_metrics_deserializes_missing_primary_pressure_as_none() {
+        let pacing_pressure: ScannerPacingPressureSnapshot = serde_json::from_str(
+            r#"{
+                "current_active_scans": 1
+            }"#,
+        )
+        .expect("deserialize partial scanner pacing pressure");
+
+        assert_eq!(pacing_pressure.primary_pressure, "none");
+        assert_eq!(pacing_pressure.current_active_scans, 1);
     }
 }


### PR DESCRIPTION
  ## Related Issues

  N/A

  ## Summary of Changes

  Adds a read-only scanner pacing pressure snapshot to the scanner metrics report.

  - Adds `pacing_pressure` to `ScannerMetricsReport`.
  - Derives `primary_pressure` from queued scans, cycle budget limits, throttle/yield pause, and active scans.
  - Exposes current queued/active scan pressure and last-cycle pause ratios.
  - Maps the new snapshot through `collect_local_metrics` into madmin scanner metrics.
  - Adds focused tests for report derivation, madmin mapping, and madmin merge behavior.

  ## Verification

  - `cargo fmt --all --check`
  - `CARGO_TARGET_DIR=/data/rustfs-target cargo test -p rustfs-common report_derives_scanner_pacing_pressure --lib`
  - `CARGO_TARGET_DIR=/data/rustfs-target cargo test -p rustfs-ecstore scanner_metrics_mapping_preserves_pacing_pressure --lib`
  - `CARGO_TARGET_DIR=/data/rustfs-target cargo test -p rustfs-madmin scanner_metrics_merge_aggregates_partial_cycles_by_source --lib`
  - `git diff --check`
  - `CARGO_TARGET_DIR=/data/rustfs-target cargo check -p rustfs --lib`

  ## Impact

  Adds a new read-only scanner metrics field. No scanner scheduling, pacing, budget, lifecycle, replication, heal, bitrot, or configuration behavior changes.

  ## Additional Notes

  `pacing_pressure.primary_pressure` is derived in priority order: `queued_scans`, `cycle_budget`, `throttle_pause`, `active_scans`, then `none`.