### PR TITLE
build(deps): bump s3s for header parsing fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8179,16 +8179,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -10332,7 +10322,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s3s"
 version = "0.14.0-dev"
-source = "git+https://github.com/rustfs/s3s?rev=507e1312b211c3ddc214b03875d6fabd15d22ed5#507e1312b211c3ddc214b03875d6fabd15d22ed5"
+source = "git+https://github.com/rustfs/s3s?rev=cf4c3346ed2554daa7fc6437f9969b076a5137ad#cf4c3346ed2554daa7fc6437f9969b076a5137ad"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -10359,7 +10349,7 @@ dependencies = [
  "nom 8.0.0",
  "numeric_cast",
  "pin-project-lite",
- "quick-xml 0.37.5",
+ "quick-xml 0.40.1",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ redis = { version = "1.2.2", features = ["connection-manager", "tokio-rustls-com
 rustix = { version = "1.1.4", features = ["fs"] }
 rust-embed = { version = "8.11.0" }
 rustc-hash = { version = "2.1.2" }
-s3s = { git = "https://github.com/rustfs/s3s", rev = "507e1312b211c3ddc214b03875d6fabd15d22ed5", features = ["minio"] }
+s3s = { git = "https://github.com/rustfs/s3s", rev = "cf4c3346ed2554daa7fc6437f9969b076a5137ad", features = ["minio"] }
 serial_test = "3.5.0"
 shadow-rs = { version = "2.0.0", default-features = false }
 siphasher = "1.0.3"


### PR DESCRIPTION
## Related Issues
Fixes #3124

## Summary of Changes
- bump the pinned `s3s` dependency to `cf4c3346ed2554daa7fc6437f9969b076a5137ad`
- pick up the upstream `s3s` fix for request preparation to avoid failing uploads on unrelated non-UTF-8 custom headers
- refresh the lockfile so `s3s` now resolves `quick-xml` through the updated upstream dependency graph

## Verification
- `make pre-commit`

## Impact
- addresses the upload failure reported in #3124 when reverse proxies or clients inject custom headers with non-ASCII/non-UTF-8 bytes
- updates only the pinned upstream `s3s` revision and dependent lockfile entries

## Additional Notes
- issue #3124 was previously confirmed as an upstream `s3s` request-header parsing problem, and this bump pulls in the merged upstream fix

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
