### PR TITLE
fix(security): add authorization check to ListRemoteTargetHandler (GHSA-796f-j7xp-hwf4)

### DIFF
--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -318,11 +318,9 @@ pub struct ListRemoteTargetHandler {}
 #[async_trait::async_trait]
 impl Operation for ListRemoteTargetHandler {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+        validate_replication_admin_request(&req, AdminAction::GetBucketTargetAction).await?;
+
         let queries = extract_query_params(&req.uri);
-        let Some(_cred) = req.credentials else {
-            error!("credentials null");
-            return Err(s3_error!(InvalidRequest, "get cred failed"));
-        };
 
         if let Some(bucket) = queries.get("bucket") {
             if bucket.is_empty() {


### PR DESCRIPTION
## Security Fix: GHSA-796f-j7xp-hwf4 — ListRemoteTargetHandler authorization bypass

### Problem

`ListRemoteTargetHandler` only verified that request credentials existed but did not check whether the caller has replication or administrator permissions. This allowed any authenticated user to list remote replication target configuration for a bucket, potentially leaking remote target credentials (`accessKey`, `secretKey`, `sessionToken`).

Other replication admin handlers (`GetReplicationMetricsHandler`, `SetRemoteTargetHandler`, `RemoveRemoteTargetHandler`) all call `validate_replication_admin_request()` for proper authorization. `ListRemoteTargetHandler` was the only one missing this check.

### Fix

Replace the authentication-only check with a call to `validate_replication_admin_request(&req, AdminAction::GetBucketTargetAction)`, consistent with how the sibling handlers authorize the same operation.

### Verification

```bash
cargo check -p rustfs
cargo test -p rustfs
```

### Advisory

- Fixes: [GHSA-796f-j7xp-hwf4](https://github.com/rustfs/rustfs/security/advisories/GHSA-796f-j7xp-hwf4)
- CWE-862 (Missing Authorization), CWE-863 (Incorrect Authorization), CWE-200, CWE-522
- Severity: High (CVSS 3.1: 8.2)
