### PR TITLE
fix(security): add IAM authorization to FTP read/metadata/cwd handlers (GHSA-3g29-xff2-92vp)

### DIFF
--- a/crates/protocols/src/ftps/driver.rs
+++ b/crates/protocols/src/ftps/driver.rs
@@ -233,6 +233,11 @@ where
             .map_err(|e| Error::new(ErrorKind::PermanentFileNotAvailable, format!("{}: {}", "Invalid path", e)))?;
 
         if let Some(key) = key {
+            // Authorize HeadObject
+            authorize_operation(session_context, &S3Action::HeadObject, &bucket, Some(&key))
+                .await
+                .map_err(|_| Error::new(ErrorKind::PermanentFileNotAvailable, "Access denied"))?;
+
             match self
                 .storage
                 .head_object(
@@ -264,6 +269,11 @@ where
             }
         } else {
             // Directory metadata - use HeadBucket
+            // Authorize HeadBucket
+            authorize_operation(session_context, &S3Action::HeadBucket, &bucket, None)
+                .await
+                .map_err(|_| Error::new(ErrorKind::PermanentFileNotAvailable, "Access denied"))?;
+
             let bucket_clone = bucket.clone();
             match self
                 .storage
@@ -433,6 +443,11 @@ where
             .map_err(|e| Error::new(ErrorKind::PermanentFileNotAvailable, format!("{}: {}", "Invalid path", e)))?;
 
         let key = key.ok_or_else(|| Error::new(ErrorKind::PermanentFileNotAvailable, "Cannot get directory"))?;
+
+        // Authorize GetObject
+        authorize_operation(session_context, &S3Action::GetObject, &bucket, Some(&key))
+            .await
+            .map_err(|_| Error::new(ErrorKind::PermanentFileNotAvailable, "Access denied"))?;
 
         match self
             .storage
@@ -667,6 +682,11 @@ where
         let (bucket, _key) = self
             .parse_s3_path(&path_str)
             .map_err(|e| Error::new(ErrorKind::PermanentFileNotAvailable, format!("{}: {}", "Invalid path", e)))?;
+
+        // Authorize HeadBucket (CWD probes bucket existence)
+        authorize_operation(session_context, &S3Action::HeadBucket, &bucket, None)
+            .await
+            .map_err(|_| Error::new(ErrorKind::PermanentFileNotAvailable, "Access denied"))?;
 
         // Check if bucket exists
         match self

--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -318,11 +318,9 @@ pub struct ListRemoteTargetHandler {}
 #[async_trait::async_trait]
 impl Operation for ListRemoteTargetHandler {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+        validate_replication_admin_request(&req, AdminAction::GetBucketTargetAction).await?;
+
         let queries = extract_query_params(&req.uri);
-        let Some(_cred) = req.credentials else {
-            error!("credentials null");
-            return Err(s3_error!(InvalidRequest, "get cred failed"));
-        };
 
         if let Some(bucket) = queries.get("bucket") {
             if bucket.is_empty() {


### PR DESCRIPTION
## Security Fix: GHSA-3g29-xff2-92vp — FTP frontend skips IAM authorization on object reads

### Problem

The FTP frontend's `get()` (RETR/GetObject), `metadata()` (SIZE/MDTM/HeadObject), and `cwd()` (CWD/HeadBucket) handlers dispatched directly to the storage backend without calling `authorize_operation()`. This allowed any authenticated FTP user — including those with explicit `Deny` policies — to read arbitrary objects and probe bucket existence regardless of IAM policy.

The write-path handlers (`put`, `del`, `list`, `rmd`) and the WebDAV driver all correctly call `authorize_operation()`. Only the FTP read-path handlers were missing authorization.

### Fix

Add `authorize_operation()` calls to the three unprotected handlers:

| Handler | FTP command | S3Action |
|---------|-------------|----------|
| `get()` | RETR | `S3Action::GetObject` |
| `metadata()` (file) | SIZE/MDTM | `S3Action::HeadObject` |
| `metadata()` (dir) | SIZE/MDTM | `S3Action::HeadBucket` |
| `cwd()` | CWD | `S3Action::HeadBucket` |

This matches the authorization pattern used by the WebDAV driver (`crates/protocols/src/webdav/driver.rs`) for the same operations.

### Verification

```bash
cargo check -p rustfs-protocols
cargo test -p rustfs-protocols
```

### Advisory

- Fixes: [GHSA-3g29-xff2-92vp](https://github.com/rustfs/rustfs/security/advisories/GHSA-3g29-xff2-92vp)
- CWE-862 (Missing Authorization), CWE-863 (Incorrect Authorization)
- Severity: High (CVSS 4.0: 7.1)
