### PR TITLE
refactor(config): remove legacy model re-export

### DIFF
--- a/crates/ecstore/src/config/mod.rs
+++ b/crates/ecstore/src/config/mod.rs
@@ -34,12 +34,10 @@ use rustfs_config::notify::{
     NOTIFY_POSTGRES_SUB_SYS, NOTIFY_PULSAR_SUB_SYS, NOTIFY_REDIS_SUB_SYS, NOTIFY_WEBHOOK_SUB_SYS,
 };
 use rustfs_config::oidc::IDENTITY_OPENID_SUB_SYS;
+use rustfs_config::server_config::{Config, register_default_kvs};
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::sync::{Arc, RwLock};
-
-// RUSTFS_COMPAT_TODO(CFG-004): keep old rustfs_ecstore::config model import paths while server-config model consumers migrate. Remove after all consumers import Config, KV, KVS, DEFAULT_KVS, and register_default_kvs from rustfs_config::server_config.
-pub use rustfs_config::server_config::{Config, DEFAULT_KVS, KV, KVS, register_default_kvs};
 
 pub static GLOBAL_STORAGE_CLASS: LazyLock<RwLock<storageclass::Config>> =
     LazyLock::new(|| RwLock::new(storageclass::Config::default()));
@@ -134,6 +132,7 @@ pub fn init() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustfs_config::server_config::KVS;
     use rustfs_config::{
         DEFAULT_DELIMITER, DEFAULT_HEAL_BITROT_CYCLE_SECS, DEFAULT_SCANNER_SPEED, HEAL_BITROT_CYCLE, SCANNER_CYCLE_MAX_OBJECTS,
         SCANNER_DELAY, SCANNER_MAX_WAIT, SCANNER_SPEED, SCANNER_SUB_SYS,
@@ -174,24 +173,5 @@ mod tests {
             .expect("heal defaults should exist");
 
         assert_eq!(heal_kvs.get(HEAL_BITROT_CYCLE), DEFAULT_HEAL_BITROT_CYCLE_SECS.to_string());
-    }
-
-    #[test]
-    fn old_config_model_path_reexports_moved_types() {
-        let mut kvs = crate::config::KVS::new();
-        kvs.insert("key".to_string(), "value".to_string());
-        let cfg = crate::config::Config(HashMap::from([(
-            "subsys".to_string(),
-            HashMap::from([(DEFAULT_DELIMITER.to_string(), kvs)]),
-        )]));
-        let moved_cfg: rustfs_config::server_config::Config = cfg;
-
-        assert_eq!(
-            moved_cfg
-                .get_value("subsys", DEFAULT_DELIMITER)
-                .expect("subsys should exist")
-                .get("key"),
-            "value"
-        );
     }
 }

--- a/docs/architecture/compat-cleanup-register.md
+++ b/docs/architecture/compat-cleanup-register.md
@@ -30,12 +30,6 @@ for later deletion.
   - Why: old `StorageAPI::new_ns_lock` callers must keep compiling while namespace-lock-only consumers migrate to NamespaceLocking.
   - Removal condition: remove after all namespace-lock-only consumers depend on NamespaceLocking and StorageAPI no longer owns namespace lock capability.
   - Status: planned cleanup.
-- `RUSTFS_COMPAT_TODO(CFG-004)`
-  - Task: `CFG-004`
-  - File: `crates/ecstore/src/config/mod.rs`
-  - Why: old `rustfs_ecstore::config` model import paths must keep compiling while server-config model consumers migrate.
-  - Removal condition: remove after all consumers import Config, KV, KVS, DEFAULT_KVS, and register_default_kvs from rustfs_config::server_config.
-  - Status: planned cleanup.
 
 ## Review Checklist
 

--- a/docs/architecture/config-model-boundary-adr.md
+++ b/docs/architecture/config-model-boundary-adr.md
@@ -22,15 +22,17 @@ The exported path should be:
 rustfs_config::server_config::{Config, KV, KVS}
 ```
 
-The existing path must remain available through a temporary compatibility
-re-export:
+The extraction kept the existing path available through a temporary
+compatibility re-export:
 
 ```rust
 rustfs_ecstore::config::{Config, KV, KVS}
 ```
 
-That re-export must include `RUSTFS_COMPAT_TODO(CFG-004)` and a matching entry in
-[`compat-cleanup-register.md`](compat-cleanup-register.md).
+That re-export included `RUSTFS_COMPAT_TODO(CFG-004)` and a matching entry in
+[`compat-cleanup-register.md`](compat-cleanup-register.md) until the model
+consumers were migrated. The CFG-004 cleanup removed this old model path after
+code scans showed consumers import the model directly from `rustfs-config`.
 
 ## Why `rustfs-config`
 
@@ -129,8 +131,9 @@ The extraction PR must preserve:
 must not migrate consumers, change persistence helpers, or alter runtime
 behavior.
 
-`CFG-004` should keep the old `rustfs_ecstore::config::*` path as a temporary
-compatibility shim and register its removal condition.
+`CFG-004` kept the old `rustfs_ecstore::config::*` path as a temporary
+compatibility shim, registered its removal condition, and removed the shim after
+all in-repo consumers migrated.
 
 `CFG-005` should migrate external consumers one group at a time after the model
 and compatibility path are stable.
@@ -143,8 +146,9 @@ Before pushing an extraction PR, run:
 - tests for `hiddenIfEmpty` alias compatibility
 - tests for `KVS` insertion, lookup, extension, and keys behavior
 - tests for `Config::new`, `set_defaults`, `marshal`, `unmarshal`, and `merge`
-- a compile smoke test that the old `rustfs_ecstore::config::{Config, KV, KVS}`
-  path still works
+- a cleanup scan proving in-repo consumers no longer use the old
+  `rustfs_ecstore::config::{Config, KV, KVS}` model path before removing the
+  compatibility shim
 - `cargo tree -p rustfs-config --edges normal`
 - `cargo tree -p rustfs-ecstore --edges normal`
 - `./scripts/check_layer_dependencies.sh`

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-config-scanner-consumer`
-- Baseline: `origin/main` at `704c95a22d9106b75cde26bf6fcc3988a175a19b`
-- PR type for this branch: `consumer-migration`
+- Branch: `overtrue/arch-config-compat-cleanup`
+- Baseline: `origin/main` at `69549634ea9524724dafd6bd90c8639880a2dbc6`
+- PR type for this branch: `api-extraction`
 - Runtime behavior changes: none.
-- Rust code changes: migrate the scanner runtime-config model consumer from
-  the temporary `rustfs_ecstore::config` model path to
-  `rustfs_config::server_config`, and enable the `server-config-model` feature
-  in `rustfs-scanner`.
+- Rust code changes: remove the temporary CFG-004
+  `rustfs_ecstore::config` server-config model compatibility re-export and its
+  smoke test after all in-repo consumers migrated to
+  `rustfs_config::server_config`.
 - CI/script changes: none.
-- Docs changes: record CFG-007 consumer-migration context, verification
-  evidence, and the preserved ECStore global server-config boundary.
+- Docs changes: record CFG-004 cleanup context, update the compatibility
+  cleanup register, and mark the model-boundary ADR cleanup status.
 
 ## Phase 0 Tasks
 
@@ -84,10 +84,13 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     and global server-config state remain in `ecstore`.
   - Must preserve: tuple struct shapes, serde alias behavior, default
     application, internal JSON shape, and existing persisted config semantics.
-- [x] `CFG-004` Keep old `ecstore::config::*` compatibility path.
+- [x] `CFG-004` Keep and clean up old `ecstore::config::*` compatibility path.
   - Completed slice: `rustfs/rustfs#3351` re-exported moved model types and
     default-registration surface from `rustfs_ecstore::config` with
     `RUSTFS_COMPAT_TODO(CFG-004)` and cleanup-register coverage.
+  - Cleanup slice: remove the temporary model re-export and smoke test after
+    CFG-005/CFG-006/CFG-007 migrated all in-repo consumers to
+    `rustfs_config::server_config`.
 - [x] `CFG-005` Migrate external server-config model consumers.
   - Current branch: migrate admin handlers, admin services, runtime context,
     server audit/event setup, and the audit/notify/targets/iam crates from the
@@ -337,36 +340,34 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 ## Next PRs
 
-1. `api-extraction`: remove the temporary `rustfs_ecstore::config` model
-   re-export after code scans prove only the deliberate CFG-004 compatibility
-   marker and smoke test still use the old model path.
-2. `security-change`: make Local KMS unsafe defaults explicit development
+1. `security-change`: make Local KMS unsafe defaults explicit development
    opt-ins or production failures in KMSD-002.
-3. `security-change`: make Vault unsafe defaults explicit development opt-ins
+2. `security-change`: make Vault unsafe defaults explicit development opt-ins
    or production failures in KMSD-003.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | Confirmed the diff only moves scanner pure model imports to `rustfs_config::server_config`, enables the required feature, and keeps ECStore global-state access through ECStore. |
-| Migration preservation | pass | Confirmed scanner defaults, env/config precedence, validation, cycle scheduling, bitrot compatibility, cache timeout, alert thresholds, and active global-config access are unchanged. |
-| Testing/verification | pass | Confirmed focused scanner runtime-config tests, scanner/ECStore/server compile check, migration guards, old-path scan, and added-line risk scan are sufficient; full pre-commit is skipped under the current larger-granularity instruction. |
+| Quality/architecture | pass | Confirmed the diff only removes the temporary model re-export and smoke test; ECStore persistence helpers, global state, startup wiring, and default registration remain unchanged. |
+| Migration preservation | pass | Confirmed `ConfigSys`, `GLOBAL_SERVER_CONFIG`, storage-class globals/accessors, read/save/serde paths, scanner/admin consumers, and in-repo model imports remain correct after old-path removal. |
+| Testing/verification | pass | Confirmed ECStore config tests, rustfs-config/ECStore/server compile check, migration guards, old-path scan, and added-line risk scan are sufficient; full pre-commit is skipped under the current larger-granularity instruction. |
 
 ## Verification Notes
 
 Passed:
+- `cargo test -p rustfs-ecstore config --lib`; 59 passed.
+- `cargo check -p rustfs-config -p rustfs-ecstore -p rustfs --lib`.
 - `cargo fmt --all --check`.
-- `cargo test -p rustfs-scanner runtime_config --lib`; 16 passed.
-- `cargo check -p rustfs-scanner -p rustfs-ecstore -p rustfs --lib`.
 - `./scripts/check_architecture_migration_rules.sh`.
 - `./scripts/check_layer_dependencies.sh`.
 - `./scripts/check_metrics_migration_refs.sh`.
 - `./scripts/check_unsafe_code_allowances.sh`.
 - `git diff --check`.
-- Old model code-path scan:
+- CFG-004 old model code-path scan found no
   `rustfs_ecstore::config::{Config, KV, KVS, DEFAULT_KVS,
-  register_default_kvs}` is absent from `crates/**/*.rs` and `rustfs/src`.
+  register_default_kvs}` imports and no `RUSTFS_COMPAT_TODO(CFG-004)` markers
+  in `crates/**/*.rs` or `rustfs/src`.
 - Added-line risk scan found no production `unwrap`/`expect`, lossy numeric
   casts, stringly public errors, boxed dynamic errors, stdout/stderr printing,
   or relaxed atomic ordering.
@@ -374,20 +375,17 @@ Passed:
 Notes:
 - Full pre-commit may be skipped if focused tests, compile checks, and guards
   pass, per the current instruction to increase PR granularity.
-- This slice migrates the scanner model consumer only. ECStore retains
-  persistence helpers, ConfigSys, global server-config state, storage-class
-  global state, startup wiring, and all storage/config persistence logic.
-- The old rustfs_ecstore::config model path intentionally remains as a
-  temporary compatibility re-export with `RUSTFS_COMPAT_TODO(CFG-004)` and a
-  matching cleanup-register entry.
-- The remaining old-path references are limited to architecture documentation;
-  the deliberate CFG-004 compatibility re-export remains available but is no
-  longer imported by Rust code in `crates` or `rustfs/src`.
+- This slice removes only the old pure model compatibility path. ECStore
+  retains persistence helpers, ConfigSys, global server-config state,
+  storage-class global state, startup wiring, and all storage/config persistence
+  logic.
+- The old `rustfs_ecstore::config` model path is no longer available after this
+  cleanup. Consumers must use `rustfs_config::server_config`.
 
 ## Handoff Notes
 
-- Keep this CFG-007 slice as a `consumer-migration` PR that only updates the
-  scanner model type import and affected crate feature gate.
+- Keep this CFG-004 cleanup slice as an `api-extraction` PR that only removes
+  the temporary model compatibility re-export and its cleanup-register entry.
 - Do not move `ConfigSys`, `GLOBAL_SERVER_CONFIG`, storage-class global state,
   `read_config_without_migrate`, `save_server_config`, config-object helpers,
   startup wiring, storage-class helpers, ECStore persistence helpers, or storage


### PR DESCRIPTION
## Related Issues
- rustfs/backlog#660

## Summary of Changes
- Remove the temporary CFG-004 `rustfs_ecstore::config` server-config model compatibility re-export after all in-repo consumers migrated to `rustfs_config::server_config`.
- Remove the old-path smoke test and the completed CFG-004 cleanup-register entry.
- Update architecture migration notes and the config model boundary ADR to record that the legacy model path cleanup is complete.

## Verification
- `cargo test -p rustfs-ecstore config --lib`
- `cargo check -p rustfs-config -p rustfs-ecstore -p rustfs --lib`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_metrics_migration_refs.sh`
- `./scripts/check_unsafe_code_allowances.sh`
- `git diff --check`
- CFG-004 old model code-path scan for `rustfs_ecstore::config::{Config, KV, KVS, DEFAULT_KVS, register_default_kvs}` and `RUSTFS_COMPAT_TODO(CFG-004)` in Rust code
- Added-line Rust risk scan

## Impact
The old `rustfs_ecstore::config` pure model import path is removed. In-repo consumers already use `rustfs_config::server_config`; ECStore persistence helpers, global server-config state, storage-class state, startup wiring, default registration, and persisted config semantics remain unchanged.

## Additional Notes
Full pre-commit was skipped per the current larger-granularity instruction after focused tests, compile checks, migration guards, old-path scans, added-line risk scan, and the required three-expert review passed.
