### PR TITLE
fix: update s3s raw URI signature handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8179,6 +8179,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -10326,7 +10336,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s3s"
 version = "0.14.0-dev"
-source = "git+https://github.com/rustfs/s3s?rev=cf4c3346ed2554daa7fc6437f9969b076a5137ad#cf4c3346ed2554daa7fc6437f9969b076a5137ad"
+source = "git+https://github.com/rustfs/s3s?rev=a3b16608df35aaeed8fff08b4988d03f4ca9445b#a3b16608df35aaeed8fff08b4988d03f4ca9445b"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -10353,7 +10363,7 @@ dependencies = [
  "nom 8.0.0",
  "numeric_cast",
  "pin-project-lite",
- "quick-xml 0.40.1",
+ "quick-xml 0.37.5",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ redis = { version = "1.2.2", features = ["connection-manager", "tokio-rustls-com
 rustix = { version = "1.1.4", features = ["fs"] }
 rust-embed = { version = "8.11.0" }
 rustc-hash = { version = "2.1.2" }
-s3s = { git = "https://github.com/rustfs/s3s", rev = "cf4c3346ed2554daa7fc6437f9969b076a5137ad", features = ["minio"] }
+s3s = { git = "https://github.com/rustfs/s3s", rev = "a3b16608df35aaeed8fff08b4988d03f4ca9445b", features = ["minio"] }
 serial_test = "3.5.0"
 shadow-rs = { version = "2.0.0", default-features = false }
 siphasher = "1.0.3"


### PR DESCRIPTION
## Related Issues
Fixes #3299.

## Summary of Changes
Updates the pinned `rustfs/s3s` revision to include the upstream raw URI path SigV4 fallback fix. This addresses clients that sign object keys containing raw reserved characters such as `*`, where the request can otherwise fail with `SignatureDoesNotMatch`.

## Verification
- `cargo test -p rustfs-signer request_signature_v4::tests:: --lib`
- `cargo test -p rustfs --lib auth::tests::test_get_request_auth_type_signature_v4`
- `cargo test -p rustfs --lib server::layer::tests::test_insert_missing_signature_error_message`
- `cargo test -p rustfs-signer request_signature_v4::tests::example_signature --lib --locked`
- `cargo test -p rustfs --lib auth::tests::test_get_request_auth_type_signature_v4 --locked`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
S3 clients can store object keys containing `*` when their SigV4 canonical URI uses the raw path form accepted by the upstream fallback. No RustFS API or configuration changes.

## Additional Notes
`cargo test -p s3s sig_v4::methods::tests::special_20230204 --locked` was not runnable from this workspace because `s3s` is a git dependency, not a workspace member.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
