### PR TITLE
refactor(config): remove legacy accessor re-export

### DIFF
--- a/crates/ecstore/src/config/mod.rs
+++ b/crates/ecstore/src/config/mod.rs
@@ -34,13 +34,10 @@ use rustfs_config::notify::{
     NOTIFY_POSTGRES_SUB_SYS, NOTIFY_PULSAR_SUB_SYS, NOTIFY_REDIS_SUB_SYS, NOTIFY_WEBHOOK_SUB_SYS,
 };
 use rustfs_config::oidc::IDENTITY_OPENID_SUB_SYS;
-use rustfs_config::server_config::register_default_kvs;
+use rustfs_config::server_config::{register_default_kvs, set_global_server_config};
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::sync::{Arc, RwLock};
-
-// RUSTFS_COMPAT_TODO(CFG-008): keep old ecstore global server-config accessor path while runtime consumers migrate. Remove after all consumers import these accessors from rustfs_config::server_config.
-pub use rustfs_config::server_config::{get_global_server_config, set_global_server_config};
 
 pub static GLOBAL_STORAGE_CLASS: LazyLock<RwLock<storageclass::Config>> =
     LazyLock::new(|| RwLock::new(storageclass::Config::default()));
@@ -124,7 +121,7 @@ pub fn init() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustfs_config::server_config::{Config, KVS};
+    use rustfs_config::server_config::{Config, KVS, get_global_server_config, set_global_server_config};
     use rustfs_config::{
         DEFAULT_DELIMITER, DEFAULT_HEAL_BITROT_CYCLE_SECS, DEFAULT_SCANNER_SPEED, HEAL_BITROT_CYCLE, SCANNER_CYCLE_MAX_OBJECTS,
         SCANNER_DELAY, SCANNER_MAX_WAIT, SCANNER_SPEED, SCANNER_SUB_SYS,

--- a/docs/architecture/compat-cleanup-register.md
+++ b/docs/architecture/compat-cleanup-register.md
@@ -30,12 +30,6 @@ for later deletion.
   - Why: old `StorageAPI::new_ns_lock` callers must keep compiling while namespace-lock-only consumers migrate to NamespaceLocking.
   - Removal condition: remove after all namespace-lock-only consumers depend on NamespaceLocking and StorageAPI no longer owns namespace lock capability.
   - Status: planned cleanup.
-- `RUSTFS_COMPAT_TODO(CFG-008)`
-  - Task: `CFG-008`
-  - File: `crates/ecstore/src/config/mod.rs`
-  - Why: old `rustfs_ecstore::config` global server-config accessor paths must keep compiling while runtime consumers migrate.
-  - Removal condition: remove after all consumers import global server-config accessors from `rustfs_config::server_config`.
-  - Status: planned cleanup.
 
 ## Review Checklist
 

--- a/docs/architecture/config-model-boundary-adr.md
+++ b/docs/architecture/config-model-boundary-adr.md
@@ -35,10 +35,10 @@ consumers were migrated. The CFG-004 cleanup removed this old model path after
 code scans showed consumers import the model directly from `rustfs-config`.
 
 Follow-up `CFG-008` moved the process-global server-config snapshot accessors
-to `rustfs_config::server_config` after the model path stabilized. ECStore keeps
-only a temporary `rustfs_ecstore::config::{get_global_server_config,
-set_global_server_config}` compatibility re-export while in-repo runtime
-consumers migrate.
+to `rustfs_config::server_config` after the model path stabilized. Its temporary
+`rustfs_ecstore::config::{get_global_server_config, set_global_server_config}`
+compatibility re-export was removed after in-repo runtime consumers migrated to
+the `rustfs-config` owner.
 
 ## Why `rustfs-config`
 
@@ -120,8 +120,9 @@ Move in `CFG-008`:
 - `get_global_server_config`
 - `set_global_server_config`
 
-Keep a temporary ECStore compatibility re-export for these accessors until all
-consumers use `rustfs_config::server_config` directly.
+The temporary ECStore compatibility re-export for these accessors was removed
+after code scans showed in-repo consumers use `rustfs_config::server_config`
+directly.
 
 ## Required Shape Preservation
 

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-config-global-state`
-- Baseline: `origin/main` at `ed3851782c48131e6102735d44d80fb6014a0699`
+- Branch: `overtrue/arch-config-compat-accessor-cleanup`
+- Baseline: `origin/main` at `2e3c777309a68c0a21f267d7646a9798f6052277`
 - PR type for this branch: `api-extraction`
 - Runtime behavior changes: none intended.
-- Rust code changes: move the process-global server-config snapshot accessors
-  to `rustfs_config::server_config`, migrate in-repo direct consumers to the
-  new owner, and keep a temporary ECStore compatibility re-export for the old
-  accessor path.
+- Rust code changes: remove the temporary CFG-008
+  `rustfs_ecstore::config` global server-config accessor compatibility
+  re-export after in-repo consumers moved to `rustfs_config::server_config`.
 - CI/script changes: none.
-- Docs changes: record CFG-008 global accessor ownership, update the
-  compatibility cleanup register, and mark the model-boundary ADR follow-up.
+- Docs changes: remove the CFG-008 cleanup-register entry and record the
+  completed compatibility cleanup in the model-boundary ADR and progress notes.
 
 ## Phase 0 Tasks
 
@@ -125,6 +124,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     `rustfs_ecstore::config::{get_global_server_config,
     set_global_server_config}` as a temporary re-export with
     `RUSTFS_COMPAT_TODO(CFG-008)`.
+  - Cleanup slice: remove the temporary accessor re-export after code scans
+    showed in-repo consumers import accessors from
+    `rustfs_config::server_config`.
   - Acceptance: ECStore still owns `ConfigSys`, config persistence helpers,
     storage-class global state, default registration wiring, and startup
     initialization; global server-config reads and writes keep the same
@@ -362,57 +364,49 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | Confirmed the diff only moves the process-global server-config snapshot accessors to `rustfs-config`, keeps ECStore persistence and storage-class ownership unchanged, and keeps the old accessor path as a temporary compatibility re-export. |
-| Migration preservation | pass | Confirmed scanner, IAM, admin, app context, and ECStore store consumers read and write the same global server-config snapshot through the new owner without changing startup, persistence, or storage behavior. |
-| Testing/verification | pass | Confirmed focused compile/tests, migration guards, old-path scan, dependency check, and Rust risk scan cover the changed accessor ownership; full pre-commit is skipped under the current larger-granularity instruction. |
+| Quality/architecture | pass | Confirmed the diff only removes the temporary CFG-008 ECStore accessor re-export while keeping ECStore persistence, storage-class ownership, and config initialization unchanged. |
+| Migration preservation | pass | Confirmed all in-repo runtime readers and writers already use `rustfs_config::server_config`, and ECStore initialization still writes the same global snapshot through a private import. |
+| Testing/verification | pass | Confirmed focused ECStore/config compile and tests, migration guards, old-path scan, and Rust risk scan cover this compatibility cleanup; full pre-commit is skipped under the current larger-granularity instruction. |
 
 ## Verification Notes
 
 Passed:
-- `cargo check -p rustfs-config -p rustfs-ecstore -p rustfs-iam -p rustfs-scanner -p rustfs --lib`.
-- `cargo test -p rustfs-config --lib`; 26 passed.
+- `cargo check -p rustfs-config -p rustfs-ecstore --lib`.
 - `cargo test -p rustfs-ecstore config --lib`; 59 passed.
-- `cargo test -p rustfs-scanner runtime_config --lib`; 16 passed.
-- `cargo test -p rustfs admin::handlers::config_admin --lib`; 29 passed.
-- `cargo test -p rustfs admin::handlers::oidc --lib`; 20 passed.
-- `cargo test -p rustfs-iam oidc --lib`; 53 passed.
 - `cargo fmt --all --check`.
 - `./scripts/check_architecture_migration_rules.sh`.
 - `./scripts/check_layer_dependencies.sh`.
 - `./scripts/check_metrics_migration_refs.sh`.
 - `git diff --check`.
-- `cargo tree -p rustfs-config --edges normal` found no dependency on
-  `rustfs-ecstore`, `rustfs-scanner`, `rustfs-iam`, or `rustfs`.
-- CFG-008 old accessor code-path scan found no direct in-repo runtime imports
-  from `rustfs_ecstore::config::{get_global_server_config,
-  set_global_server_config}` or `crate::config::{get_global_server_config,
-  set_global_server_config}` in `crates/**/*.rs` or `rustfs/src`.
+- CFG-008 source old-path and marker scan found no
+  `RUSTFS_COMPAT_TODO(CFG-008)`,
+  `rustfs_ecstore::config::{get_global_server_config,
+  set_global_server_config}`, or `crate::config::{get_global_server_config,
+  set_global_server_config}` matches in `crates/**/*.rs` or `rustfs/src`.
 - Added-line risk scan found no production `unwrap`/`expect`, lossy numeric
   casts, stringly public errors, boxed dynamic errors, stdout/stderr printing,
   or relaxed atomic ordering.
+- `cargo tree -p rustfs-config --edges normal` found no dependency on
+  `rustfs-ecstore`, `rustfs-scanner`, `rustfs-iam`, or `rustfs`.
 
 Notes:
 - Full pre-commit may be skipped if focused tests, compile checks, and guards
   pass, per the current instruction to increase PR granularity.
-- `./scripts/check_unsafe_code_allowances.sh` is not counted for this PR; it
-  currently reports unrelated existing unsafe allowance locations whose nearby
-  `SAFETY:` comments are present.
-- This slice moves only `GLOBAL_SERVER_CONFIG`, `get_global_server_config`, and
-  `set_global_server_config` to `rustfs_config::server_config`.
-- ECStore retains `ConfigSys`, config persistence helpers, storage-class global
-  state, default registration wiring, startup initialization, and storage
-  behavior.
-- The old `rustfs_ecstore::config` accessor path remains available through a
-  temporary `RUSTFS_COMPAT_TODO(CFG-008)` re-export for downstream callers.
+- This slice removes only the old CFG-008 global server-config accessor
+  compatibility path. ECStore retains `ConfigSys`, config persistence helpers,
+  storage-class global state, default registration wiring, startup
+  initialization, and storage behavior.
+- The old `rustfs_ecstore::config` accessor path is no longer available after
+  this cleanup. Consumers must use `rustfs_config::server_config`.
 
 ## Handoff Notes
 
-- Keep this CFG-008 slice as an `api-extraction` PR that only moves the global
-  server-config snapshot accessors and migrates direct in-repo runtime
-  consumers to `rustfs_config::server_config`.
+- Keep this CFG-008 cleanup slice as an `api-extraction` PR that only removes
+  the temporary global server-config accessor compatibility re-export and its
+  cleanup-register entry.
 - Do not move `ConfigSys`, storage-class global state,
   `read_config_without_migrate`, `save_server_config`, config-object helpers,
   default registration wiring, startup wiring, storage-class helpers, ECStore
   persistence helpers, or storage persistence logic in this PR.
-- Remove the CFG-008 compatibility re-export only after downstream and in-repo
-  consumers no longer need `rustfs_ecstore::config` accessor imports.
+- Do not add temporary compatibility code unless a matching
+  `RUSTFS_COMPAT_TODO(<task-id>)` marker and cleanup-register entry are added.


### PR DESCRIPTION
## Related Issues

- Relates to rustfs/backlog#660

## Summary of Changes

- Remove the temporary CFG-008 `rustfs_ecstore::config` global server-config accessor compatibility re-export.
- Keep ECStore initialization writing the global server-config snapshot through the `rustfs_config::server_config` owner.
- Remove the CFG-008 cleanup-register entry and update architecture migration notes.

## Verification

- `cargo check -p rustfs-config -p rustfs-ecstore --lib`
- `cargo test -p rustfs-ecstore config --lib`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_metrics_migration_refs.sh`
- `git diff --check`
- CFG-008 source old-path and marker scan found no Rust-code consumers or source markers.
- Added-line risk scan found no new production `unwrap`/`expect`, lossy numeric casts, stringly public errors, boxed dynamic errors, stdout/stderr printing, relaxed atomic ordering, or old accessor imports.
- `cargo tree -p rustfs-config --edges normal` found no dependency on `rustfs-ecstore`, `rustfs-scanner`, `rustfs-iam`, or `rustfs`.
- Full `make pre-commit` was skipped per maintainer instruction because focused tests and migration guards passed for this migration cleanup.

## Impact

- No intended runtime behavior change.
- The old `rustfs_ecstore::config` accessor path is removed; callers should use `rustfs_config::server_config`.
- ECStore continues to own config persistence helpers, `ConfigSys`, storage-class global state, default registration wiring, startup initialization, and storage behavior.

## Additional Notes

N/A
