### PR TITLE
ci(audit): wire cargo deny supply-chain gate

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,12 +20,14 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - 'deny.toml'
       - '.github/workflows/audit.yml'
   pull_request:
     branches: [ main ]
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - 'deny.toml'
       - '.github/workflows/audit.yml'
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
@@ -62,6 +64,27 @@ jobs:
           name: security-audit-results-${{ github.run_number }}
           path: audit-results.json
           retention-days: 30
+
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust environment
+        uses: ./.github/actions/setup
+        with:
+          cache-shared-key: rustfs-cargo-deny
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: Run cargo-deny
+        run: cargo deny check --hide-inclusion-graph advisories sources bans licenses
 
   dependency-review:
     name: Dependency Review

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,10 @@ ignore = [
     # in-process RSA decryption oracles are removed.
     # owner: rustfs-maintainers  review: 2026-07
     { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing sidechannel; no fixed upstream version; tracked separately" },
+    # `proc-macro-error2 2.0.1` — unmaintained. No direct dependency; pulled
+    # transitively through `mysql_async` via `mysql-common-derive`.
+    # owner: rustfs-maintainers  review: 2026-07
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive only via mysql_async; tracked for dependency refresh" },
 ]
 
 [sources]
@@ -43,12 +47,6 @@ allow-git = [
     # Custom S3 server library with minio compatibility patches not yet upstreamed.
     # Pinned to a specific commit in workspace Cargo.toml.
     "https://github.com/rustfs/s3s",
-    # Temporary git source for russh until required upstream fixes are released.
-    # owner: rustfs-maintainers  review: 2026-05
-    "https://github.com/Eugeny/russh",
-    # Temporary git source for mysql_async until required upstream fixes are released.
-    # owner: rustfs-maintainers  review: 2026-05
-    "https://github.com/blackbeam/mysql_async",
 ]
 
 [bans]


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Add an independent Cargo Deny job to the existing security audit workflow.
- Trigger the audit workflow when `deny.toml` changes.
- Add the current `RUSTSEC-2026-0173` transitive advisory baseline with owner/review metadata.
- Remove stale git source allowlist entries for dependencies that now resolve from the registry.

## Verification

- `cargo deny check --hide-inclusion-graph advisories sources bans licenses`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/audit.yml"); puts "audit workflow yaml ok"'`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_metrics_migration_refs.sh`

Focused workflow/config validation was used instead of `make pre-commit` for this workflow/config-only slice.

## Impact

No runtime behavior change. Security Audit now has a separate Cargo Deny job for advisories, sources, bans, and licenses.

## Additional Notes

Existing duplicate and wildcard dependency findings remain configured as warnings in `deny.toml`; the new gate passes advisories, bans, licenses, and sources.
