### PR TITLE
fix(helm): validate replicaCount is 4 or 16 in distributed mode

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -143,7 +143,7 @@ uer. `ClusterIssuer` or `Issuer`. |
 | readinessProbe.periodSeconds | int | `5` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `3` |  |
-| replicaCount | int | `4` | Number of cluster nodes. |
+| replicaCount | int | `4` | Number of cluster nodes in distributed mode. Only `4` or `16` are supported; other values fail rendering. Ignored in standalone mode. |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.8.0"
+version: "0.8.1"
 appVersion: "1.0.0-beta.8"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -2,6 +2,10 @@
 {{- $logDirEnabled := ne $logDir "" }}
 
 {{- if .Values.mode.distributed.enabled }}
+{{- $replicas := int .Values.replicaCount }}
+{{- if and (ne $replicas 4) (ne $replicas 16) }}
+{{- fail (printf "replicaCount must be 4 or 16 in distributed mode (got %d). See helm/README.md for supported topologies." $replicas) }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -2,7 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+# Number of cluster nodes in distributed mode. Only 4 (each pod gets 4 data PVCs)
+# or 16 (each pod gets 1 data PVC) are supported; any other value fails rendering.
+# Ignored in standalone mode (capped to 1). See https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 4
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

In distributed mode the chart only supports `replicaCount` of 4 (each pod gets 4 data PVCs) or 16 (each pod gets 1 data PVC). This is documented in `helm/README.md`, but nothing enforced it.

Setting any other value, for example 8, rendered a StatefulSet with no data volume mounts and no data volumeClaimTemplates, and `RUSTFS_VOLUMES` came out empty. `helm install`, `helm template` and `helm lint` all succeeded with no warning, so the misconfiguration was only visible at runtime: the pods crash looped because rustfs refuses to start without a volumes argument (`a value is required for '<VOLUMES>...'`).

This PR adds a `fail` guard at the top of the distributed StatefulSet template so rendering stops with a clear message when `replicaCount` is not 4 or 16. Standalone mode is not affected because the Deployment already caps replicas to 1. The constraint is also documented in `values.yaml` and the chart README, and the chart version is bumped to 0.8.1.

Behavior for the supported values (4 and 16) and for standalone mode is unchanged.

## Verification

Chart only change, so the Rust gates do not apply. Ran the following:

- `helm lint ./helm/rustfs` passes
- `helm template` with `replicaCount=4` renders
- `helm template` with `replicaCount=16` renders
- `helm template` with `replicaCount=8` fails with the new guard message
- `helm template` with standalone mode and `replicaCount=8` renders (guard skipped)
- Deployed `replicaCount=8` on a k3s cluster before the fix and confirmed CrashLoopBackOff with empty `RUSTFS_VOLUMES` and no data PVCs

## Impact

Users who set `replicaCount` to an unsupported value now get a clear error at install time instead of a broken deployment that crash loops. Existing installs using 4 or 16, and standalone installs, are not affected.

## Additional Notes

The guard keeps the current 4 or 16 limitation rather than generalizing the templates to arbitrary replica counts, since that would touch the erasure set storage topology and is better discussed separately.
