### PR TITLE
Update podman instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,11 @@ docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/log
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command
 
 ```bash
-podman run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
+# Create data and logs directories
+mkdir -p data logs
+
+# Run the container (podman will automatically set the folders ownership)
+podman run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data:Z,U -v $(pwd)/logs:/logs:Z,U rustfs/rustfs:latest
 ```
 
 If you enable TLS with a bind-mounted certificate directory, prepare that mount the same way:


### PR DESCRIPTION
## Related Issues
Fixes #3478 

## Summary of Changes
Fix instructions to run on rootless podman by adding correct volume mounting option.

## Verification
The container runs without any issue and the app is accessible

## Impact
Users are now able to use rootless podman to run RustFS

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
