### PR TITLE
chore(scanner): enable pulsar telemetry feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8146,6 +8146,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "tracing",
  "url",
  "uuid",
  "webpki-roots 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ futures-core = "0.3.32"
 futures-lite = "2.6.1"
 futures-util = "0.3.32"
 pollster = "0.4.0"
-pulsar = { version = "6.8.0", default-features = false, features = ["tokio-rustls-runtime"] }
+pulsar = { version = "6.8.0", default-features = false, features = ["tokio-rustls-runtime","telemetry"] }
 lapin = { version = "4.10.0", default-features = false, features = ["tokio", "rustls", "rustls--aws_lc_rs"] }
 hyper = { version = "1.10.1", features = ["http2", "http1", "server"] }
 hyper-rustls = { version = "0.27.9", default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs", "webpki-roots"] }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Enable the `telemetry` feature on the workspace `pulsar` dependency in `Cargo.toml`, and update `Cargo.lock` accordingly.

## Verification
- `cargo check -p rustfs-scanner --all-targets`
- `cargo clippy -p rustfs-scanner --all-targets --all-features -- -D warnings`

## Impact
Dependency and lockfile update scoped to Pulsar integration; behavior impact is to enable telemetry instrumentation support.

## Additional Notes
N/A
