### PR TITLE
fix(admin): reject access keys and names containing any whitespace

### DIFF
--- a/rustfs/src/admin/utils.rs
+++ b/rustfs/src/admin/utils.rs
@@ -16,8 +16,13 @@ use crate::server::{MINIO_ADMIN_PREFIX, has_path_prefix};
 use rustfs_crypto::{decrypt_data, decrypt_stream_io, encrypt_stream_io};
 use s3s::{Body, S3Result, s3_error};
 
+/// Returns `true` if `s` contains any whitespace character.
+///
+/// Used to reject identifiers (access keys, user/group/policy names) that
+/// contain spaces. Detects whitespace anywhere in the string — leading,
+/// trailing, or internal — so values like `"my key"` are correctly rejected.
 pub(crate) fn has_space_be(s: &str) -> bool {
-    s.trim().len() != s.len()
+    s.chars().any(char::is_whitespace)
 }
 
 pub(crate) fn is_compat_admin_request(path: &str) -> bool {
@@ -59,6 +64,21 @@ mod tests {
     use super::*;
     use rustfs_crypto::encrypt_data;
     use s3s::Body;
+
+    #[test]
+    fn has_space_be_detects_any_whitespace() {
+        // Internal space — the original bug: access keys like "my key" slipped
+        // past validation because only leading/trailing space was detected.
+        assert!(has_space_be("my key"));
+        assert!(has_space_be("ab\tcd"));
+        // Leading / trailing whitespace (already caught before the fix).
+        assert!(has_space_be(" abcd"));
+        assert!(has_space_be("abcd "));
+        // Clean identifiers must pass.
+        assert!(!has_space_be("abcd"));
+        assert!(!has_space_be("my-key_01"));
+        assert!(!has_space_be(""));
+    }
 
     #[test]
     fn detects_compat_admin_paths_only_for_external_prefix() {


### PR DESCRIPTION
## Summary
`has_space_be` only stripped leading/trailing whitespace (`s.trim().len() != s.len()`), so an access key or name with an **internal** space (e.g. `my key`) passed the check, then failed deeper with a generic error instead of the intended message. Creating an access key named `my key` in the console therefore returned a generic failure rather than "access key has spaces".

## Fix
Detect **any** whitespace character (`s.chars().any(char::is_whitespace)`), so the existing specific messages fire correctly. The helper guards access keys plus user, group, and policy names, so all of them now reject internal whitespace consistently.

## Tests
Adds regression tests covering internal, leading, trailing, tab, and clean-identifier cases.

## Verification
- `cargo test -p rustfs --lib admin::utils` — green
- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Manually: creating an access key with a space now returns `InvalidRequest: access key has spaces` (HTTP 400).

## Agreement
I have read and agree to the CLA.

<img width="735" height="840" alt="image" src="https://github.com/user-attachments/assets/92e934e6-44d6-4089-b56a-c93cf3acca81" />

