### PR TITLE
refactor: move multipart DTO contracts

### DIFF
--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -34,8 +34,8 @@ use crate::error::{Error, Result, is_err_version_not_found};
 use crate::error::{GenericError, ObjectApiError, is_err_object_not_found};
 use crate::global::{GLOBAL_LocalNodeName, GLOBAL_TierConfigMgr};
 use crate::store_api::ListObjectVersionsInfo;
-use crate::store_api::{ListPartsInfo, ObjectOptions, ObjectToDelete};
 use crate::store_api::{ObjectInfoOrErr, WalkOptions};
+use crate::store_api::{ObjectOptions, ObjectToDelete};
 use crate::{
     bucket::lifecycle::bucket_lifecycle_ops::{
         LifecycleOps, gen_transition_objname, get_transitioned_object_reader, put_restore_opts,
@@ -52,9 +52,8 @@ use crate::{
     event_notification::{EventArgs, send_event},
     global::{GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES, get_global_deployment_id, is_dist_erasure},
     store_api::{
-        BucketOperations, CompletePart, DeletedObject, GetObjectReader, HTTPRangeSpec, HealOperations, ListMultipartsInfo,
-        ListObjectsV2Info, ListOperations, MultipartInfo, MultipartOperations, MultipartUploadResult, NamespaceLocking, ObjectIO,
-        ObjectInfo, ObjectOperations, PartInfo, PutObjReader,
+        BucketOperations, CompletePart, DeletedObject, GetObjectReader, HTTPRangeSpec, HealOperations, ListObjectsV2Info,
+        ListOperations, MultipartOperations, NamespaceLocking, ObjectIO, ObjectInfo, ObjectOperations, PutObjReader,
     },
     store_init::load_format_erasure,
 };
@@ -86,7 +85,10 @@ use rustfs_object_capacity::capacity_scope::{
     CapacityScope, CapacityScopeDisk, record_capacity_scope, record_global_dirty_scope,
 };
 use rustfs_s3_types::EventName;
-use rustfs_storage_api::{BucketInfo, BucketOptions, DeleteBucketOptions, MakeBucketOptions};
+use rustfs_storage_api::{
+    BucketInfo, BucketOptions, DeleteBucketOptions, ListMultipartsInfo, ListPartsInfo, MakeBucketOptions, MultipartInfo,
+    MultipartUploadResult, PartInfo,
+};
 use rustfs_utils::http::headers::AMZ_OBJECT_TAGGING;
 use rustfs_utils::http::headers::AMZ_STORAGE_CLASS;
 use rustfs_utils::http::headers::{

--- a/crates/ecstore/src/sets.rs
+++ b/crates/ecstore/src/sets.rs
@@ -15,7 +15,7 @@
 
 use crate::disk::error_reduce::count_errs;
 use crate::error::{Error, Result};
-use crate::store_api::{ListPartsInfo, ObjectInfoOrErr, WalkOptions};
+use crate::store_api::{ObjectInfoOrErr, WalkOptions};
 use crate::{
     disk::{
         DiskAPI, DiskInfo, DiskOption, DiskStore,
@@ -28,9 +28,9 @@ use crate::{
     global::{GLOBAL_LOCAL_DISK_SET_DRIVES, get_global_lock_clients, is_dist_erasure},
     set_disk::SetDisks,
     store_api::{
-        BucketOperations, CompletePart, DeletedObject, GetObjectReader, HTTPRangeSpec, HealOperations, ListMultipartsInfo,
-        ListObjectVersionsInfo, ListObjectsV2Info, ListOperations, MultipartInfo, MultipartOperations, MultipartUploadResult,
-        NamespaceLocking, ObjectIO, ObjectInfo, ObjectOperations, ObjectOptions, ObjectToDelete, PartInfo, PutObjReader,
+        BucketOperations, CompletePart, DeletedObject, GetObjectReader, HTTPRangeSpec, HealOperations, ListObjectVersionsInfo,
+        ListObjectsV2Info, ListOperations, MultipartOperations, NamespaceLocking, ObjectIO, ObjectInfo, ObjectOperations,
+        ObjectOptions, ObjectToDelete, PutObjReader,
     },
     store_init::{check_format_erasure_values, get_format_erasure_in_quorum, load_format_erasure_all, save_format_file},
 };
@@ -48,7 +48,10 @@ use rustfs_filemeta::FileInfo;
 use rustfs_lock::NamespaceLockWrapper;
 use rustfs_lock::client::LockClient;
 use rustfs_madmin::heal_commands::{HealDriveInfo, HealResultItem};
-use rustfs_storage_api::{BucketInfo, BucketOptions, DeleteBucketOptions, MakeBucketOptions};
+use rustfs_storage_api::{
+    BucketInfo, BucketOptions, DeleteBucketOptions, ListMultipartsInfo, ListPartsInfo, MakeBucketOptions, MultipartInfo,
+    MultipartUploadResult, PartInfo,
+};
 use rustfs_utils::{crc_hash, path::path_join_buf, sip_hash};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;

--- a/crates/ecstore/src/store.rs
+++ b/crates/ecstore/src/store.rs
@@ -53,9 +53,7 @@ use crate::notification_sys::get_global_notification_sys;
 use crate::pools::PoolMeta;
 use crate::rebalance::RebalanceMeta;
 use crate::rpc::RemoteClient;
-use crate::store_api::{
-    ListMultipartsInfo, ListObjectVersionsInfo, ListPartsInfo, MultipartInfo, ObjectIO, ObjectInfoOrErr, WalkOptions,
-};
+use crate::store_api::{ListObjectVersionsInfo, ObjectIO, ObjectInfoOrErr, WalkOptions};
 use crate::store_init::{check_disk_fatal_errs, ec_drives_no_config};
 use crate::tier::tier::TierConfigMgr;
 use crate::{
@@ -66,8 +64,8 @@ use crate::{
     sets::Sets,
     store_api::{
         BucketOperations, CompletePart, DeletedObject, GetObjectReader, HTTPRangeSpec, HealOperations, ListObjectsV2Info,
-        ListOperations, MultipartOperations, MultipartUploadResult, NamespaceLocking, ObjectInfo, ObjectOperations,
-        ObjectOptions, ObjectToDelete, PartInfo, PutObjReader,
+        ListOperations, MultipartOperations, NamespaceLocking, ObjectInfo, ObjectOperations, ObjectOptions, ObjectToDelete,
+        PutObjReader,
     },
     store_init,
 };
@@ -81,7 +79,10 @@ use rustfs_config::server_config::{Config, get_global_server_config, set_global_
 use rustfs_filemeta::FileInfo;
 use rustfs_lock::{LocalClient, LockClient, NamespaceLockWrapper};
 use rustfs_madmin::heal_commands::HealResultItem;
-use rustfs_storage_api::{BucketInfo, BucketOptions, DeleteBucketOptions, MakeBucketOptions};
+use rustfs_storage_api::{
+    BucketInfo, BucketOptions, DeleteBucketOptions, ListMultipartsInfo, ListPartsInfo, MakeBucketOptions, MultipartInfo,
+    MultipartUploadResult, PartInfo,
+};
 use rustfs_utils::path::{decode_dir_object, encode_dir_object, path_join_buf};
 use s3s::dto::{BucketVersioningStatus, ObjectLockConfiguration, ObjectLockEnabled, VersioningConfiguration};
 use std::cmp::Ordering;

--- a/crates/ecstore/src/store_api/traits.rs
+++ b/crates/ecstore/src/store_api/traits.rs
@@ -1,5 +1,8 @@
 use super::*;
-use rustfs_storage_api::{BucketInfo, BucketOptions, DeleteBucketOptions, MakeBucketOptions};
+use rustfs_storage_api::{
+    BucketInfo, BucketOptions, DeleteBucketOptions, ListMultipartsInfo, ListPartsInfo, MakeBucketOptions, MultipartInfo,
+    MultipartUploadResult, PartInfo,
+};
 
 #[async_trait::async_trait]
 pub trait ObjectIO: Send + Sync + Debug + 'static {

--- a/crates/ecstore/src/store_api/types.rs
+++ b/crates/ecstore/src/store_api/types.rs
@@ -200,22 +200,6 @@ fn is_modified_since(mod_time: &OffsetDateTime, given_time: &OffsetDateTime) -> 
     mod_secs > given_secs
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct MultipartUploadResult {
-    pub upload_id: String,
-    pub checksum_algo: Option<String>,
-    pub checksum_type: Option<String>,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct PartInfo {
-    pub part_num: usize,
-    pub last_mod: Option<OffsetDateTime>,
-    pub size: usize,
-    pub etag: Option<String>,
-    pub actual_size: i64,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct CompletePart {
     pub part_num: usize,
@@ -869,113 +853,6 @@ pub struct ListObjectsV2Info {
 
     // List of prefixes for this request.
     pub prefixes: Vec<String>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct MultipartInfo {
-    // Name of the bucket.
-    pub bucket: String,
-
-    // Name of the object.
-    pub object: String,
-
-    // Upload ID identifying the multipart upload whose parts are being listed.
-    pub upload_id: String,
-
-    // Date and time at which the multipart upload was initiated.
-    pub initiated: Option<OffsetDateTime>,
-
-    // Any metadata set during InitMultipartUpload, including encryption headers.
-    pub user_defined: HashMap<String, String>,
-}
-
-// ListMultipartsInfo - represents bucket resources for incomplete multipart uploads.
-#[derive(Debug, Clone, Default)]
-pub struct ListMultipartsInfo {
-    // Together with upload-id-marker, this parameter specifies the multipart upload
-    // after which listing should begin.
-    pub key_marker: Option<String>,
-
-    // Together with key-marker, specifies the multipart upload after which listing
-    // should begin. If key-marker is not specified, the upload-id-marker parameter
-    // is ignored.
-    pub upload_id_marker: Option<String>,
-
-    // When a list is truncated, this element specifies the value that should be
-    // used for the key-marker request parameter in a subsequent request.
-    pub next_key_marker: Option<String>,
-
-    // When a list is truncated, this element specifies the value that should be
-    // used for the upload-id-marker request parameter in a subsequent request.
-    pub next_upload_id_marker: Option<String>,
-
-    // Maximum number of multipart uploads that could have been included in the
-    // response.
-    pub max_uploads: usize,
-
-    // Indicates whether the returned list of multipart uploads is truncated. A
-    // value of true indicates that the list was truncated. The list can be truncated
-    // if the number of multipart uploads exceeds the limit allowed or specified
-    // by max uploads.
-    pub is_truncated: bool,
-
-    // List of all pending uploads.
-    pub uploads: Vec<MultipartInfo>,
-
-    // When a prefix is provided in the request, The result contains only keys
-    // starting with the specified prefix.
-    pub prefix: String,
-
-    // A character used to truncate the object prefixes.
-    // NOTE: only supported delimiter is '/'.
-    pub delimiter: Option<String>,
-
-    // CommonPrefixes contains all (if there are any) keys between Prefix and the
-    // next occurrence of the string specified by delimiter.
-    pub common_prefixes: Vec<String>,
-    // encoding_type: String, // Not supported yet.
-}
-
-/// ListPartsInfo - represents list of all parts.
-#[derive(Debug, Clone, Default)]
-pub struct ListPartsInfo {
-    /// Name of the bucket.
-    pub bucket: String,
-
-    /// Name of the object.
-    pub object: String,
-
-    /// Upload ID identifying the multipart upload whose parts are being listed.
-    pub upload_id: String,
-
-    /// The class of storage used to store the object.
-    pub storage_class: String,
-
-    /// Part number after which listing begins.
-    pub part_number_marker: usize,
-
-    /// When a list is truncated, this element specifies the last part in the list,
-    /// as well as the value to use for the part-number-marker request parameter
-    /// in a subsequent request.
-    pub next_part_number_marker: usize,
-
-    /// Maximum number of parts that were allowed in the response.
-    pub max_parts: usize,
-
-    /// Indicates whether the returned list of parts is truncated.
-    pub is_truncated: bool,
-
-    /// List of all parts.
-    pub parts: Vec<PartInfo>,
-
-    /// Any metadata set during InitMultipartUpload, including encryption headers.
-    pub user_defined: HashMap<String, String>,
-
-    /// ChecksumAlgorithm if set
-    pub checksum_algorithm: String,
-
-    /// ChecksumType if set
-    pub checksum_type: String,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -17,7 +17,9 @@
 pub mod admin;
 pub mod bucket;
 pub mod error;
+pub mod multipart;
 
 pub use admin::{DiskSetSelector, StorageAdminApi};
 pub use bucket::{BucketInfo, BucketOptions, DeleteBucketOptions, MakeBucketOptions, SRBucketDeleteOp};
 pub use error::{StorageErrorCode, StorageResult};
+pub use multipart::{ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};

--- a/crates/storage-api/src/multipart.rs
+++ b/crates/storage-api/src/multipart.rs
@@ -1,0 +1,71 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+#[derive(Debug, Default, Clone)]
+pub struct MultipartUploadResult {
+    pub upload_id: String,
+    pub checksum_algo: Option<String>,
+    pub checksum_type: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PartInfo {
+    pub part_num: usize,
+    pub last_mod: Option<OffsetDateTime>,
+    pub size: usize,
+    pub etag: Option<String>,
+    pub actual_size: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MultipartInfo {
+    pub bucket: String,
+    pub object: String,
+    pub upload_id: String,
+    pub initiated: Option<OffsetDateTime>,
+    pub user_defined: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ListMultipartsInfo {
+    pub key_marker: Option<String>,
+    pub upload_id_marker: Option<String>,
+    pub next_key_marker: Option<String>,
+    pub next_upload_id_marker: Option<String>,
+    pub max_uploads: usize,
+    pub is_truncated: bool,
+    pub uploads: Vec<MultipartInfo>,
+    pub prefix: String,
+    pub delimiter: Option<String>,
+    pub common_prefixes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ListPartsInfo {
+    pub bucket: String,
+    pub object: String,
+    pub upload_id: String,
+    pub storage_class: String,
+    pub part_number_marker: usize,
+    pub next_part_number_marker: usize,
+    pub max_parts: usize,
+    pub is_truncated: bool,
+    pub parts: Vec<PartInfo>,
+    pub user_defined: HashMap<String, String>,
+    pub checksum_algorithm: String,
+    pub checksum_type: String,
+}

--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -93,6 +93,7 @@ Required `rustfs-storage-api` public re-exports:
 - `pub use admin::{DiskSetSelector, StorageAdminApi};`
 - `pub use bucket::{BucketInfo, BucketOptions, DeleteBucketOptions, MakeBucketOptions, SRBucketDeleteOp};`
 - `pub use error::{StorageErrorCode, StorageResult};`
+- `pub use multipart::{ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};`
 
 ECStore must keep compile-time coverage for both `StorageAdminApi` and the
 separate `NamespaceLocking` operation group.

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-storage-dto-path-cleanup`
-- Baseline: `origin/main` at `d094d919257861bb543eb4747412b90b617a6213`
-- PR type for this branch: `consumer-migration`
+- Branch: `overtrue/arch-storage-object-contracts-cleanup`
+- Baseline: `origin/main` at `2ff69ae21cad69eaf7d5969eb5267e6e974ef8c6`
+- PR type for this branch: `api-extraction`
 - Runtime behavior changes: no external behavior change expected.
-- Rust code changes: remove the remaining ECStore-internal bucket DTO aliases
-  from `store_api` and import the shared bucket DTO contracts directly from
-  `rustfs_storage_api`.
-- CI/script changes: add a migration guard that rejects reintroducing old
-  `ecstore::store_api` bucket DTO re-exports.
-- Docs changes: record the post-facade bucket DTO path cleanup slice.
+- Rust code changes: move multipart list/result DTO contracts from ECStore
+  `store_api` into `rustfs-storage-api` and migrate in-repo consumers to the
+  shared contract path.
+- CI/script changes: extend migration guards for the multipart DTO public
+  re-export and reject restoring the old ECStore-owned multipart DTO path.
+- Docs changes: record the multipart DTO contract extraction slice.
 
 ## Phase 0 Tasks
 
@@ -499,6 +499,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     required quality/architecture, migration-preservation, and
     testing/verification review passed.
 
+- [x] `API-013` Move multipart list/result DTO contracts.
+  - Completed slice: move `MultipartUploadResult`, `PartInfo`,
+    `MultipartInfo`, `ListMultipartsInfo`, and `ListPartsInfo` from ECStore
+    `store_api` into `rustfs-storage-api`; update ECStore traits and RustFS S3
+    multipart response builders to import these shared contracts directly.
+  - Acceptance: `rustfs-storage-api` exports the multipart DTO contracts,
+    in-repo consumers no longer use the old `rustfs_ecstore::store_api` path
+    for these DTOs, and migration guards reject restoring the old ECStore-owned
+    definitions or re-exports.
+  - Must preserve: multipart upload creation, part listing, multipart upload
+    listing, part metadata, checksum fields, S3 response mapping, and storage
+    operation trait behavior.
+  - Risk defense: keep `CompletePart`, `ObjectInfo`, `ObjectOptions`, readers,
+    filemeta conversions, replication state, encryption, compression, and range
+    semantics in ECStore for this slice.
+  - Verification: focused storage-api/ECStore/RustFS compile checks, multipart
+    response tests, migration/layer guards, formatting, diff hygiene, Rust risk
+    scan, and required three-expert review passed.
+
 ## Phase 8 Background Controller Tasks
 
 - [x] `BGC-001` Inventory background services.
@@ -775,16 +794,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | Direct bucket DTO imports leave ECStore `store_api` focused on operation traits and object/listing types; the guard prevents the old DTO alias from returning. |
-| Migration preservation | passed | The slice changes type import paths and migration checks only; storage/listing behavior and operation trait contracts are unchanged. |
-| Testing/verification | passed | Focused ECStore compile/test checks, migration/layer guards, formatting, diff hygiene, Rust risk scan, and full `make pre-commit` passed. |
+| Quality/architecture | passed | Multipart list/result DTOs now live in the storage contract crate, while ECStore keeps implementation-heavy object, reader, range, and complete-part types. |
+| Migration preservation | passed | The slice moves DTO ownership and import paths only; multipart operation bodies, S3 response mapping logic, and storage hot paths are unchanged. |
+| Testing/verification | passed | Focused storage-api/ECStore/RustFS compile checks, multipart response tests, migration/layer guards, formatting, diff hygiene, Rust risk scan, and full `make pre-commit` passed. |
 
 ## Verification Notes
 
-Passed on `d094d919257861bb543eb4747412b90b617a6213`:
+Passed on `2ff69ae21cad69eaf7d5969eb5267e6e974ef8c6`:
 
-- `cargo check -p rustfs-ecstore`: passed.
-- `cargo test -p rustfs-ecstore --test ecstore_contract_compat_test --no-fail-fast`:
+- `cargo check -p rustfs-storage-api -p rustfs-ecstore`: passed.
+- `cargo check -p rustfs`: passed.
+- `cargo test -p rustfs --lib storage::s3_api::multipart --no-fail-fast`:
   passed.
 - `./scripts/check_architecture_migration_rules.sh`: passed.
 - `./scripts/check_layer_dependencies.sh`: passed.
@@ -796,16 +816,17 @@ Passed on `d094d919257861bb543eb4747412b90b617a6213`:
 
 Notes:
 
-- This slice follows `rustfs/rustfs#3501` and keeps the old aggregate facade
-  guard active.
-- The shared bucket DTOs remain owned by `rustfs-storage-api`; ECStore
-  `store_api` keeps only ECStore operation traits and object/listing types.
+- This slice follows `rustfs/rustfs#3503` and keeps the old aggregate facade and
+  bucket DTO guards active.
+- The shared multipart list/result DTOs are now owned by `rustfs-storage-api`;
+  ECStore keeps implementation-heavy object, reader, range, and complete-part
+  types.
 - The slice does not move storage operation traits across crate boundaries or
-  alter runtime storage behavior.
+  alter multipart runtime behavior.
 
 ## Handoff Notes
 
-- Storage DTO path cleanup is in progress on a branch current with
+- Storage multipart DTO contract cleanup is in progress on a branch current with
   `origin/main`.
-- After this lands, remaining storage work can continue from concrete operation
-  contracts and direct shared DTO imports.
+- After this lands, remaining storage work can continue by extracting only DTOs
+  that have proven low implementation coupling.

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -53,10 +53,11 @@ use rustfs_ecstore::rio::{DecryptReader, EncryptReader, HardLimitReader, boxed_r
 use rustfs_ecstore::rio::{HashReader, WritePlan};
 use rustfs_ecstore::set_disk::is_valid_storage_class;
 use rustfs_ecstore::store::ECStore;
-use rustfs_ecstore::store_api::{CompletePart, HTTPRangeSpec, MultipartUploadResult, ObjectIO, ObjectOptions, PutObjReader};
+use rustfs_ecstore::store_api::{CompletePart, HTTPRangeSpec, ObjectIO, ObjectOptions, PutObjReader};
 use rustfs_ecstore::store_api::{MultipartOperations, ObjectOperations};
 use rustfs_filemeta::{ReplicationStatusType, ReplicationType};
 use rustfs_s3_ops::S3Operation;
+use rustfs_storage_api::MultipartUploadResult;
 use rustfs_targets::EventName;
 use rustfs_utils::CompressionAlgorithm;
 use rustfs_utils::http::{

--- a/rustfs/src/storage/s3_api/multipart.rs
+++ b/rustfs/src/storage/s3_api/multipart.rs
@@ -14,7 +14,7 @@
 
 use crate::storage::s3_api::common::{rustfs_initiator, rustfs_owner};
 use rustfs_ecstore::client::object_api_utils::to_s3s_etag;
-use rustfs_ecstore::store_api::{ListMultipartsInfo, ListPartsInfo};
+use rustfs_storage_api::{ListMultipartsInfo, ListPartsInfo};
 use s3s::dto::{CommonPrefix, ListMultipartUploadsOutput, ListPartsOutput, MultipartUpload, Part, Timestamp};
 use s3s::{S3Error, S3ErrorCode};
 
@@ -192,7 +192,7 @@ mod tests {
     };
     use crate::storage::s3_api::common::{rustfs_initiator, rustfs_owner};
     use rustfs_ecstore::client::object_api_utils::to_s3s_etag;
-    use rustfs_ecstore::store_api::{ListMultipartsInfo, ListPartsInfo, MultipartInfo, PartInfo};
+    use rustfs_storage_api::{ListMultipartsInfo, ListPartsInfo, MultipartInfo, PartInfo};
     use s3s::S3ErrorCode;
     use s3s::dto::Timestamp;
     use time::OffsetDateTime;

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -51,6 +51,7 @@ SOURCE_IDS_FILE="${TMP_DIR}/source_ids.txt"
 REGISTER_IDS_FILE="${TMP_DIR}/register_ids.txt"
 LEGACY_STORAGE_API_HITS_FILE="${TMP_DIR}/legacy_storage_api_hits.txt"
 STORE_API_BUCKET_DTO_REEXPORTS_FILE="${TMP_DIR}/store_api_bucket_dto_reexports.txt"
+STORE_API_MULTIPART_DTO_REEXPORTS_FILE="${TMP_DIR}/store_api_multipart_dto_reexports.txt"
 
 awk '
   /^## PR Types$/ {
@@ -185,6 +186,10 @@ require_source_line \
   "storage-api public bucket DTO re-export"
 require_source_line \
   "crates/storage-api/src/lib.rs" \
+  "pub use multipart::{ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};" \
+  "storage-api public multipart DTO re-export"
+require_source_line \
+  "crates/storage-api/src/lib.rs" \
   "pub use error::{StorageErrorCode, StorageResult};" \
   "storage-api public error contract re-export"
 
@@ -205,6 +210,16 @@ fi
 
 if [[ -s "$STORE_API_BUCKET_DTO_REEXPORTS_FILE" ]]; then
   report_failure "old ecstore store_api bucket DTO re-export reintroduced: $(paste -sd '; ' "$STORE_API_BUCKET_DTO_REEXPORTS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'pub(?:\(crate\))? use rustfs_storage_api::\{[^}]*\b(?:ListMultipartsInfo|ListPartsInfo|MultipartInfo|MultipartUploadResult|PartInfo)\b|pub struct (?:ListMultipartsInfo|ListPartsInfo|MultipartInfo|MultipartUploadResult|PartInfo)\b' \
+    crates/ecstore/src/store_api.rs crates/ecstore/src/store_api/types.rs || true
+) >"$STORE_API_MULTIPART_DTO_REEXPORTS_FILE"
+
+if [[ -s "$STORE_API_MULTIPART_DTO_REEXPORTS_FILE" ]]; then
+  report_failure "old ecstore store_api multipart DTO path reintroduced: $(paste -sd '; ' "$STORE_API_MULTIPART_DTO_REEXPORTS_FILE")"
 fi
 
 require_source_contains \


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Move multipart list/result DTO contracts into `rustfs-storage-api`.
- Update ECStore and RustFS multipart consumers to import shared multipart DTO contracts from `rustfs_storage_api`.
- Extend migration guardrails to require the storage-api multipart re-export and reject restoring the old ECStore-owned multipart DTO path.
- Update architecture boundary and migration progress docs for this slice.

## Verification

- `cargo check -p rustfs-storage-api -p rustfs-ecstore`
- `cargo check -p rustfs`
- `cargo test -p rustfs --lib storage::s3_api::multipart --no-fail-fast`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `git diff --check`
- Rust risk scan on added Rust lines
- `make pre-commit`

## Impact

No expected runtime behavior change. This is a DTO ownership and import-path cleanup for multipart list/result contracts.

## Additional Notes

`CompletePart`, `ObjectInfo`, `ObjectOptions`, readers, range handling, filemeta conversions, replication state, encryption, and compression remain ECStore-owned because they are implementation-coupled.
