### PR TITLE
test(fuzz): deepen path containment corpus and invariants

### DIFF
--- a/fuzz/corpus/path_containment/append-extra-valid.txt
+++ b/fuzz/corpus/path_containment/append-extra-valid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+prefix
+leaf
+append_extra

--- a/fuzz/corpus/path_containment/backslash-valid.txt
+++ b/fuzz/corpus/path_containment/backslash-valid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+folder/path/file.txt
+
+backslash

--- a/fuzz/corpus/path_containment/current-segment-invalid.txt
+++ b/fuzz/corpus/path_containment/current-segment-invalid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+safe/path
+child
+current_segment

--- a/fuzz/corpus/path_containment/double-separator-invalid.txt
+++ b/fuzz/corpus/path_containment/double-separator-invalid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+prefix/with/slashes
+
+double_sep

--- a/fuzz/corpus/path_containment/empty-segment-invalid.txt
+++ b/fuzz/corpus/path_containment/empty-segment-invalid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+a/b/c
+
+empty_segment

--- a/fuzz/corpus/path_containment/leading-slash-invalid.txt
+++ b/fuzz/corpus/path_containment/leading-slash-invalid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+nested/path.txt
+
+leading_slash

--- a/fuzz/corpus/path_containment/long-valid.txt
+++ b/fuzz/corpus/path_containment/long-valid.txt
@@ -1,0 +1,3 @@
+valid-bucket
+segment-000/segment-001/segment-002/segment-003/segment-004/segment-005/segment-006/segment-007/segment-008/segment-009/segment-010/segment-011/segment-012/segment-013/segment-014/segment-015/segment-016/segment-017/segment-018/segment-019
+

--- a/fuzz/corpus/path_containment/parent-segment-invalid.txt
+++ b/fuzz/corpus/path_containment/parent-segment-invalid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+safe/path
+escape
+parent_segment

--- a/fuzz/corpus/path_containment/whitespace-parent-invalid.txt
+++ b/fuzz/corpus/path_containment/whitespace-parent-invalid.txt
@@ -1,0 +1,4 @@
+valid-bucket
+safe/path
+escape
+leading_ws,parent_segment,trailing_ws

--- a/fuzz/fuzz_targets/path_containment.rs
+++ b/fuzz/fuzz_targets/path_containment.rs
@@ -7,26 +7,81 @@ use std::path::{Path, PathBuf};
 
 const ROOT: &str = "/srv/rustfs";
 
-fn parse_case(data: &[u8]) -> (String, String) {
+fn parse_case(data: &[u8]) -> (String, String, String, Vec<String>) {
     let text = String::from_utf8_lossy(data);
-    let mut parts = text.splitn(2, '\n');
+    let mut parts = text.splitn(4, '\n');
     let bucket = parts.next().unwrap_or_default().to_string();
     let object = parts.next().unwrap_or_default().to_string();
-    (bucket, object)
+    let extra = parts.next().unwrap_or_default().to_string();
+    let flags = parts
+        .next()
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|flag| !flag.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+
+    (bucket, object, extra, flags)
 }
 
 fn stays_within_root(root: &Path, candidate: &Path) -> bool {
     candidate == root || candidate.starts_with(root)
 }
 
+fn apply_flag(mut object: String, extra: &str, flag: &str) -> String {
+    let extra_segment = if extra.is_empty() { "tail" } else { extra };
+
+    match flag {
+        "leading_ws" => format!(" {object}"),
+        "trailing_ws" => {
+            object.push(' ');
+            object
+        }
+        "leading_slash" => format!("/{object}"),
+        "trailing_slash" => format!("{object}/"),
+        "double_sep" => {
+            if object.contains('/') {
+                object.replacen('/', "//", 1)
+            } else {
+                format!("{object}//{extra_segment}")
+            }
+        }
+        "backslash" => object.replace('/', "\\"),
+        "append_extra" => format!("{object}/{extra_segment}"),
+        "empty_segment" => {
+            if let Some((left, right)) = object.split_once('/') {
+                format!("{left}//{right}")
+            } else {
+                format!("{object}//{extra_segment}")
+            }
+        }
+        "parent_segment" => format!("{object}/../{extra_segment}"),
+        "current_segment" => format!("{object}/./{extra_segment}"),
+        _ => object,
+    }
+}
+
+fn materialize_object(base: String, extra: &str, flags: &[String]) -> String {
+    flags.iter().fold(base, |object, flag| apply_flag(object, extra, flag))
+}
+
+fn has_dot_segments(path: &str) -> bool {
+    path.split(['/', '\\']).any(|segment| {
+        let trimmed = segment.trim();
+        trimmed == "." || trimmed == ".."
+    })
+}
+
 fuzz_target!(|data: &[u8]| {
-    let (bucket, object) = parse_case(data);
+    let (bucket, base_object, extra, flags) = parse_case(data);
+    let object = materialize_object(base_object, &extra, &flags);
 
     let has_bad_component = has_bad_path_component(&object);
     let is_valid_prefix = is_valid_object_prefix(&object);
     let length_and_slash_ok = check_object_name_for_length_and_slash(&bucket, &object).is_ok();
 
-    if !(is_valid_prefix && length_and_slash_ok) {
+    if object.is_empty() || !(is_valid_prefix && length_and_slash_ok) {
         return;
     }
 
@@ -35,14 +90,26 @@ fuzz_target!(|data: &[u8]| {
         "accepted object unexpectedly retained a bad path component: {:?}",
         object
     );
+    assert!(
+        !has_dot_segments(&object),
+        "accepted object unexpectedly retained dot segments: {:?}",
+        object
+    );
 
     let root = PathBuf::from(ROOT);
     let joined = path_join(&[root.clone(), PathBuf::from(&object)]);
     let cleaned = PathBuf::from(clean(joined.to_string_lossy().as_ref()));
+    let cleaned_text = cleaned.to_string_lossy();
 
     assert!(
         stays_within_root(&root, &cleaned),
         "accepted object escaped root containment: object={:?} cleaned={:?}",
+        object,
+        cleaned
+    );
+    assert!(
+        !has_dot_segments(cleaned_text.as_ref()),
+        "cleaned accepted object unexpectedly retained dot segments: object={:?} cleaned={:?}",
         object,
         cleaned
     );


### PR DESCRIPTION
## Related Issues
Refs #3519
Refs #3527

## Summary of Changes
- deepen the existing `path_containment` fuzz target instead of introducing a second overlapping target
- switch the target input model from a single bucket/object pair to a base path plus composable mutation flags so path variants can be exercised systematically
- expand the path containment corpus with representative valid and invalid samples derived from the existing path validation tests
- assert both root containment and the absence of surviving `.` / `..` path-segment semantics for accepted object paths

## Verification
- `cargo fmt --manifest-path fuzz/Cargo.toml`
- `cargo check --manifest-path fuzz/Cargo.toml --bin path_containment`

## Impact
- fuzz-only test coverage improvement on top of the standalone harness
- no production runtime behavior, API surface, or deployment behavior changes
- no CI workflow changes in this PR

## Additional Notes
- this PR is intentionally stacked on top of `houseme/issue-3526-fuzz-harness-smoke` so reviewers can focus on the incremental path-containment changes
- the bounded `cargo-fuzz` smoke path now clears the earlier `tokio_unstable` harness blocker, but full sanitizer builds remain expensive on first run

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
