### PR TITLE
test(fuzz): add policy ingress fuzz target

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4188,7 +4188,10 @@ dependencies = [
  "libfuzzer-sys",
  "rustfs-ecstore",
  "rustfs-filemeta",
+ "rustfs-policy",
+ "rustfs-security-governance",
  "rustfs-utils",
+ "serde_json",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,10 @@ arbitrary = "1"
 libfuzzer-sys = "0.4"
 rustfs-ecstore = { path = "../crates/ecstore" }
 rustfs-filemeta = { path = "../crates/filemeta" }
+rustfs-policy = { path = "../crates/policy" }
+rustfs-security-governance = { path = "../crates/security-governance" }
 rustfs-utils = { path = "../crates/utils", features = ["compress", "path"] }
+serde_json = "1"
 
 [[bin]]
 name = "bucket_validation"
@@ -26,6 +29,13 @@ bench = false
 [[bin]]
 name = "local_metadata"
 path = "fuzz_targets/local_metadata.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "policy_ingress"
+path = "fuzz_targets/policy_ingress.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -37,6 +37,8 @@ fuzz/
   - Exercises object-path acceptance and containment invariants using public path helpers.
 - `local_metadata`
   - Exercises `rustfs-filemeta` metadata decoding and `rustfs-utils` block decompression.
+- `policy_ingress`
+  - Exercises RustFS-owned bucket policy and policy-doc JSON ingress behavior, including strict-vs-tolerant unknown-field expectations.
 
 ## Usage
 

--- a/fuzz/corpus/policy_ingress/legacy_policy_doc.json
+++ b/fuzz/corpus/policy_ingress/legacy_policy_doc.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "policy": {
+    "Version": "2012-10-17",
+    "Statement": []
+  },
+  "create_date": "2025-03-07T12:00:00Z",
+  "update_date": "2025-03-07T12:00:00Z"
+}

--- a/fuzz/corpus/policy_ingress/malformed_bucket_policy.json
+++ b/fuzz/corpus/policy_ingress/malformed_bucket_policy.json
@@ -1,0 +1,1 @@
+{"Version":"2012-10-17","Statement":[INVALID]}

--- a/fuzz/corpus/policy_ingress/valid_bucket_policy.json
+++ b/fuzz/corpus/policy_ingress/valid_bucket_policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::bucket/*"
+      ]
+    }
+  ]
+}

--- a/fuzz/corpus/policy_ingress/valid_policy_doc.json
+++ b/fuzz/corpus/policy_ingress/valid_policy_doc.json
@@ -1,0 +1,9 @@
+{
+  "Version": 1,
+  "Policy": {
+    "Version": "2012-10-17",
+    "Statement": []
+  },
+  "CreateDate": "2025-03-07T12:00:00Z",
+  "UpdateDate": "2025-03-07T12:00:00Z"
+}

--- a/fuzz/fuzz_targets/policy_ingress.rs
+++ b/fuzz/fuzz_targets/policy_ingress.rs
@@ -1,0 +1,84 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rustfs_policy::policy::{BucketPolicy, Policy, PolicyDoc};
+use rustfs_security_governance::{SerdePolicy, SerdePolicyKind, UnknownFieldPolicy, validate_serde_policies};
+use serde_json::{Map, Value, json};
+
+fn add_unknown_top_level_field(data: &[u8]) -> Option<Vec<u8>> {
+    let mut value: Value = serde_json::from_slice(data).ok()?;
+    let object = value.as_object_mut()?;
+    object.insert("UnexpectedField".to_string(), json!(true));
+    serde_json::to_vec(&value).ok()
+}
+
+fn looks_like_policy_doc(value: &Value) -> bool {
+    value
+        .as_object()
+        .is_some_and(|object| object.contains_key("Policy") || object.contains_key("policy"))
+}
+
+fn exercise_governance_contracts() {
+    let ok = [
+        SerdePolicy::new("BucketPolicy", SerdePolicyKind::StrictIngress, UnknownFieldPolicy::Deny),
+        SerdePolicy::new("PolicyDoc", SerdePolicyKind::TolerantCompat, UnknownFieldPolicy::Warn),
+    ];
+    assert!(validate_serde_policies(&ok).is_ok());
+
+    let bad = [SerdePolicy::new(
+        "BucketPolicy",
+        SerdePolicyKind::StrictIngress,
+        UnknownFieldPolicy::Warn,
+    )];
+    assert!(validate_serde_policies(&bad).is_err());
+}
+
+fn exercise_policy_doc(raw: &[u8]) {
+    let _ = serde_json::from_slice::<PolicyDoc>(raw);
+    let _ = serde_json::from_slice::<Policy>(raw);
+    let parsed = PolicyDoc::try_from(raw.to_vec());
+
+    if parsed.is_ok()
+        && let Ok(value) = serde_json::from_slice::<Value>(raw)
+        && looks_like_policy_doc(&value)
+    {
+        let mutated = add_unknown_top_level_field(raw).expect("policy doc mutation should stay serializable");
+        assert!(
+            PolicyDoc::try_from(mutated).is_ok(),
+            "policy doc ingress should tolerate unknown top-level fields for compat JSON"
+        );
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    exercise_governance_contracts();
+
+    let bucket_policy = serde_json::from_slice::<BucketPolicy>(data);
+    if bucket_policy.is_ok() {
+        if let Some(mutated) = add_unknown_top_level_field(data) {
+            assert!(
+                serde_json::from_slice::<BucketPolicy>(&mutated).is_err(),
+                "bucket policy strict ingress should reject unknown top-level fields"
+            );
+        }
+    }
+
+    exercise_policy_doc(data);
+
+    if let Ok(value) = serde_json::from_slice::<Value>(data)
+        && let Some(object) = value.as_object()
+    {
+        let mut legacy_doc = Map::new();
+        if let Some(policy) = object.get("Policy").or_else(|| object.get("policy")) {
+            legacy_doc.insert("version".to_string(), json!(1));
+            legacy_doc.insert("policy".to_string(), policy.clone());
+            legacy_doc.insert("create_date".to_string(), json!("2025-03-07T12:00:00Z"));
+            legacy_doc.insert("update_date".to_string(), json!("2025-03-07T12:00:00Z"));
+            let legacy_doc = serde_json::to_vec(&Value::Object(legacy_doc)).expect("legacy policy doc should serialize");
+            assert!(
+                PolicyDoc::try_from(legacy_doc).is_ok(),
+                "legacy policy doc aliases should remain parseable"
+            );
+        }
+    }
+});


### PR DESCRIPTION
## Related Issues
Refs #3519
Refs #3530

## Summary of Changes
- add a RustFS-owned `policy_ingress` fuzz target instead of touching upstream `s3s` XML parsing
- cover strict ingress behavior for `BucketPolicy` and tolerant compatibility behavior for `PolicyDoc`
- encode unknown-field governance expectations directly in fuzz assertions
- add a small corpus for valid bucket policy JSON, valid policy documents, legacy lowercase aliases, and malformed policy JSON

## Verification
- `cargo fmt --manifest-path /private/tmp/issue-3530/fuzz/Cargo.toml`
- `cargo check --manifest-path /private/tmp/issue-3530/fuzz/Cargo.toml --bin policy_ingress`

## Impact
- fuzz-only test coverage improvement on top of the standalone harness
- no production runtime behavior, API surface, deployment behavior, or CI workflow changes

## Additional Notes
- this PR is intentionally stacked on top of `houseme/issue-3526-fuzz-harness-smoke`
- the target stays within RustFS-owned JSON ingress paths and does not fuzz `s3s` XML body parsing

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
