### PR TITLE
refactor: narrow storage compatibility exports

### DIFF
--- a/crates/e2e_test/src/storage_compat.rs
+++ b/crates/e2e_test/src/storage_compat.rs
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{bucket, disk, rpc};
+}

--- a/crates/heal/tests/common/storage_compat.rs
+++ b/crates/heal/tests/common/storage_compat.rs
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{bucket, disk, endpoints, store};
+}

--- a/crates/iam/src/storage_compat.rs
+++ b/crates/iam/src/storage_compat.rs
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{config, error, global, notification_sys, store};
+}

--- a/crates/notify/src/storage_compat.rs
+++ b/crates/notify/src/storage_compat.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{config, global, store_api};
+}
 
 pub type NotifyObjectInfo = ecstore::store_api::ObjectInfo;

--- a/crates/obs/src/storage_compat.rs
+++ b/crates/obs/src/storage_compat.rs
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{bucket, data_usage, global, pools, resolve_object_store_handle};
+}

--- a/crates/s3select-api/src/storage_compat.rs
+++ b/crates/s3select-api/src/storage_compat.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{error, resolve_object_store_handle, set_disk, store, store_api};
+}
 
 use ecstore::store_api::{
     GetObjectReader as EcstoreGetObjectReader, ObjectInfo as EcstoreObjectInfo, ObjectOptions as EcstoreObjectOptions,

--- a/crates/scanner/tests/common/storage_compat.rs
+++ b/crates/scanner/tests/common/storage_compat.rs
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{bucket, client, disk, endpoints, global, pools, store, tier};
+}

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,21 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-test-harness-fuzz-storage-boundaries`
-- Baseline: `origin/main` after `rustfs/rustfs#3572` merged as
-  `8313767f75f694cb8cf1fb47e5c0f44dfc5bf2b8`.
+- Branch: `overtrue/arch-narrow-storage-compat-exports`
+- Baseline: `origin/main` after `rustfs/rustfs#3573` merged as
+  `c098184c67a80ed9c8e31ac7fd2587fddfa1799e`.
 - PR type for this branch: `consumer-migration`
-- Runtime behavior changes: no migration behavior change expected; CI follow-up
-  preserves empty-object erasure recovery by avoiding zero-byte SIMD decode.
-- Rust code changes: add RustFS root, observability, IAM, test harness, and
-  fuzz ECStore compatibility boundaries; extend notify and S3 Select
-  boundaries; route runtime, server, startup, capacity, table catalog, obs,
-  notify, S3 Select, IAM, scanner/heal integration tests, e2e helpers, and
-  fuzz direct ECStore imports through local boundaries. ECStore-owned
-  definitions and runtime behavior stay in ECStore.
+- Runtime behavior changes: no migration behavior change expected.
+- Rust code changes: narrow RustFS, obs, notify, S3 Select, IAM, scanner/heal
+  test, e2e, and fuzz ECStore compatibility boundary modules from whole-crate
+  aliases to explicit re-export surfaces. ECStore-owned definitions and runtime
+  behavior stay in ECStore.
 - CI/script changes: none.
-- Docs changes: record the larger runtime/observability/select/IAM plus test
-  harness/fuzz boundary cleanup slice.
+- Docs changes: record the compatibility export surface cleanup slice.
 
 ## Phase 0 Tasks
 
@@ -923,6 +919,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Verification: focused scanner/heal/e2e compile, fuzz target compile,
     migration/layer guards, formatting check, diff hygiene, direct import scan,
     risk scan, full pre-commit, and required three-expert review passed.
+
+- [x] `API-033` Narrow ECStore compatibility export surfaces.
+  - Current branch: `overtrue/arch-narrow-storage-compat-exports`.
+  - Completed slice: replace local whole-crate ECStore compatibility aliases
+    with explicit re-export modules for RustFS runtime/app/admin/storage, obs,
+    notify, S3 Select, IAM, scanner/heal integration tests, e2e helpers, and
+    fuzz targets.
+  - Acceptance: local ECStore compatibility boundaries expose only the ECStore
+    modules/functions required by their consumers; direct `rustfs_ecstore`
+    references remain limited to compatibility boundary modules.
+  - Must preserve: all runtime, admin, storage, observability, notification, S3
+    Select, IAM, scanner/heal test, e2e helper, and fuzz behavior from
+    API-031/API-032.
+  - Risk defense: this slice changes compatibility re-export ownership only; it
+    does not move ECStore definitions, alter runtime control flow, mutate
+    metadata formats, change test setup semantics, or adjust fuzz inputs.
+  - Verification: focused compile, fuzz target compile, migration/layer guards,
+    formatting check, diff hygiene, direct import scan, risk scan, full
+    pre-commit, and required three-expert review passed.
 
 ## Phase 8 Background Controller Tasks
 

--- a/fuzz/fuzz_targets/storage_compat.rs
+++ b/fuzz/fuzz_targets/storage_compat.rs
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::bucket;
+}

--- a/rustfs/src/admin/storage_compat.rs
+++ b/rustfs/src/admin/storage_compat.rs
@@ -12,4 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{
+        bucket, client, config, data_usage, disk, endpoints, error, global, metrics_realtime, notification_sys, rebalance, rpc,
+        store, store_utils, tier,
+    };
+}

--- a/rustfs/src/app/storage_compat.rs
+++ b/rustfs/src/app/storage_compat.rs
@@ -12,4 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{
+        admin_server_info, bucket, client, compress, config, data_usage, disk, endpoints, error, global, new_object_layer_fn,
+        notification_sys, pools, rio, set_disk, set_object_store_resolver, store, tier,
+    };
+}

--- a/rustfs/src/storage/storage_compat.rs
+++ b/rustfs/src/storage/storage_compat.rs
@@ -12,4 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{
+        admin_server_info, bucket, client, config, disk, error, get_global_lock_client, global, metrics_realtime,
+        resolve_object_store_handle, rio, rpc, set_disk, store, store_api,
+    };
+}

--- a/rustfs/src/storage_compat.rs
+++ b/rustfs/src/storage_compat.rs
@@ -12,4 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore as ecstore;
+pub(crate) mod ecstore {
+    #![allow(unused_imports)]
+
+    pub(crate) use rustfs_ecstore::{
+        bucket, config, data_usage, disk, disks_layout, endpoints, error, event_notification, global, notification_sys, pools,
+        resolve_object_store_handle, rpc, set_disk, set_global_endpoints, store, update_erasure_type,
+    };
+}


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Narrow local ECStore `storage_compat` shims from whole-crate aliases to explicit re-export modules.
- Keep existing consumer import paths stable while reducing each compatibility boundary to the modules and functions it actually exposes.
- Update the architecture migration progress log for API-033.

## Verification
- `cargo check --tests -p rustfs -p rustfs-obs -p rustfs-notify -p rustfs-s3select-api -p rustfs-iam -p rustfs-scanner -p rustfs-heal -p e2e_test`
- `cargo check --manifest-path fuzz/Cargo.toml --bins`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `make pre-commit`

## Impact
No behavior change expected. This only narrows compatibility re-export surfaces; ECStore-owned definitions and runtime behavior stay in ECStore.

## Additional Notes
Required quality/architecture, migration-preservation, and testing/verification review completed before push.
