### PR TITLE
refactor: remove legacy KMS admin action fallback

### DIFF
--- a/docs/architecture/compat-cleanup-register.md
+++ b/docs/architecture/compat-cleanup-register.md
@@ -12,12 +12,7 @@ for later deletion.
 
 ## Open Items
 
-- `RUSTFS_COMPAT_TODO(S-012)`
-  - Task: `S-012`
-  - File: `rustfs/src/admin/handlers/kms_keys.rs`
-  - Why: legacy KMS create-key and key-status admin grants must keep working during the dedicated KMS policy migration.
-  - Removal condition: remove after KMS admin clients and built-in policies use `kms:Configure`, `kms:DescribeKey`, and `kms:ListKeys`.
-  - Status: planned cleanup.
+No compatibility code is currently registered.
 
 ## Review Checklist
 

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -304,6 +304,14 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     and persisted config serialization still writes the original secret values.
   - Verification: focused KMS redaction/status tests, full KMS tests, migration
     guards, Rust quality scan, clippy, and `make pre-commit` passed.
+- [x] `S-014` Remove legacy KMS admin action fallbacks.
+  - Acceptance: KMS create, describe, and list-key handlers authorize only the
+    dedicated `kms:*` actions and no longer retain legacy admin grant fallbacks.
+  - Must preserve: legacy KMS endpoint URLs, query aliases, request bodies, and
+    response contracts remain unchanged.
+  - Verification: focused KMS auth and route-policy tests, migration guards,
+    formatting, diff hygiene, risk scan, full pre-commit, and required
+    three-expert review passed before push.
 - [x] `KMSD-001` Inventory KMS development defaults.
   - Acceptance:
     [`kms-development-defaults-inventory.md`](kms-development-defaults-inventory.md)
@@ -1536,13 +1544,31 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, and fuzz compatibility contracts without moving ECStore storage metadata ownership. |
-| Migration preservation | passed | Event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, unchanged no-op handling, and remove-event behavior are preserved. |
+| Quality/architecture | passed | S-014 removes the registered KMS legacy admin action fallback; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, and fuzz compatibility contracts without moving ECStore storage metadata ownership. |
+| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, and response contracts are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, unchanged no-op handling, and remove-event behavior are preserved. |
 | Testing/verification | passed | Focused compiles/tests, guards, formatting, diff hygiene, risk scan, and full `make pre-commit` passed for the current slice. |
 
 ## Verification Notes
 
 Passed before push:
+
+- S-014 current slice:
+  - `cargo test -p rustfs kms_key_auth_actions_use_dedicated_kms_actions --no-fail-fast`:
+    passed.
+  - `cargo test -p rustfs route_policy_records_dedicated_kms_actions --no-fail-fast`:
+    passed.
+  - `cargo test -p rustfs route_policy_rejects_server_info_for_sensitive_kms_actions --no-fail-fast`:
+    passed.
+  - `cargo check --tests -p rustfs`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - Source marker scan: passed; no non-doc `RUSTFS_COMPAT_TODO` markers remain.
+  - Rust risk scan: passed; no new unwrap/expect, panic/todo/unsafe, risky
+    casts, ad-hoc error construction, or sensitive-token handling in added
+    lines.
+  - `make pre-commit`: passed.
 
 - API-049 current slice:
   - `cargo check --tests -p rustfs-heal -p rustfs-scanner -p e2e_test`:

--- a/rustfs/src/admin/handlers/kms_keys.rs
+++ b/rustfs/src/admin/handlers/kms_keys.rs
@@ -24,7 +24,7 @@ use hyper::{HeaderMap, Method, StatusCode};
 use matchit::Params;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
 use rustfs_kms::{KmsError, init_global_kms_service_manager, types::*};
-use rustfs_policy::policy::action::{Action, AdminAction, KmsAction};
+use rustfs_policy::policy::action::{Action, KmsAction};
 use s3s::header::CONTENT_TYPE;
 use s3s::{Body, S3Request, S3Response, S3Result, s3_error};
 use serde::{Deserialize, Serialize};
@@ -126,27 +126,15 @@ async fn kms_encryption_service_from_context() -> Option<std::sync::Arc<rustfs_k
 }
 
 fn kms_create_key_actions() -> Vec<Action> {
-    // RUSTFS_COMPAT_TODO(S-012): keep legacy KMS create-key grants during KMS policy migration. Remove after KMS admin clients and built-in policies use kms:Configure.
-    vec![
-        Action::KmsAction(KmsAction::ConfigureAction),
-        Action::AdminAction(AdminAction::KMSCreateKeyAdminAction),
-    ]
+    vec![Action::KmsAction(KmsAction::ConfigureAction)]
 }
 
 fn kms_describe_key_actions() -> Vec<Action> {
-    // RUSTFS_COMPAT_TODO(S-012): keep legacy KMS key-status grants during KMS policy migration. Remove after KMS admin clients and built-in policies use kms:DescribeKey.
-    vec![
-        Action::KmsAction(KmsAction::DescribeKeyAction),
-        Action::AdminAction(AdminAction::KMSKeyStatusAdminAction),
-    ]
+    vec![Action::KmsAction(KmsAction::DescribeKeyAction)]
 }
 
 fn kms_list_keys_actions() -> Vec<Action> {
-    // RUSTFS_COMPAT_TODO(S-012): keep legacy KMS key-status grants during KMS policy migration. Remove after KMS admin clients and built-in policies use kms:ListKeys.
-    vec![
-        Action::KmsAction(KmsAction::ListKeysAction),
-        Action::AdminAction(AdminAction::KMSKeyStatusAdminAction),
-    ]
+    vec![Action::KmsAction(KmsAction::ListKeysAction)]
 }
 
 fn kms_generate_data_key_actions() -> Vec<Action> {
@@ -405,15 +393,15 @@ mod tests {
     fn kms_key_auth_actions_use_dedicated_kms_actions() {
         let create_actions = kms_create_key_actions();
         assert_has_action(&create_actions, Action::KmsAction(KmsAction::ConfigureAction));
-        assert_has_action(&create_actions, Action::AdminAction(AdminAction::KMSCreateKeyAdminAction));
+        assert_lacks_action(&create_actions, Action::AdminAction(AdminAction::KMSCreateKeyAdminAction));
 
         let describe_actions = kms_describe_key_actions();
         assert_has_action(&describe_actions, Action::KmsAction(KmsAction::DescribeKeyAction));
-        assert_has_action(&describe_actions, Action::AdminAction(AdminAction::KMSKeyStatusAdminAction));
+        assert_lacks_action(&describe_actions, Action::AdminAction(AdminAction::KMSKeyStatusAdminAction));
 
         let list_actions = kms_list_keys_actions();
         assert_has_action(&list_actions, Action::KmsAction(KmsAction::ListKeysAction));
-        assert_has_action(&list_actions, Action::AdminAction(AdminAction::KMSKeyStatusAdminAction));
+        assert_lacks_action(&list_actions, Action::AdminAction(AdminAction::KMSKeyStatusAdminAction));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Remove the temporary legacy admin action fallback from KMS create, describe, and list-key authorization helpers.
- Clear the completed S-012 compatibility cleanup register entry.
- Record S-014 progress and verification notes in `docs/architecture/migration-progress.md`.

## Verification
- `cargo test -p rustfs kms_key_auth_actions_use_dedicated_kms_actions --no-fail-fast`
- `cargo test -p rustfs route_policy_records_dedicated_kms_actions --no-fail-fast`
- `cargo test -p rustfs route_policy_rejects_server_info_for_sensitive_kms_actions --no-fail-fast`
- `cargo check --tests -p rustfs`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
KMS create, describe, and list-key admin endpoints now require the dedicated `kms:*` policy actions. Endpoint URLs, query aliases, request bodies, and response contracts are unchanged.

## Additional Notes
Stacked on `overtrue/arch-test-fuzz-compat-boundaries`.
