### PR TITLE
refactor: move lifecycle helper storage contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9702,6 +9702,7 @@ dependencies = [
  "rustfs-ecstore",
  "rustfs-s3-ops",
  "rustfs-s3-types",
+ "rustfs-storage-api",
  "rustfs-targets",
  "rustfs-utils",
  "serde",

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -15,7 +15,7 @@
 use crate::bucket::lifecycle::bucket_lifecycle_audit::{LcAuditEvent, LcEventSrc};
 use crate::bucket::lifecycle::evaluator::Evaluator;
 use crate::bucket::lifecycle::lifecycle::{
-    self, ExpirationOptions, Lifecycle, ObjectOpts, TransitionOptions, abort_incomplete_multipart_upload_due,
+    self, Lifecycle, ObjectOpts, TransitionOptions, abort_incomplete_multipart_upload_due,
 };
 use crate::bucket::lifecycle::tier_delete_journal::{process_tier_delete_journal_entry, run_tier_delete_journal_recovery_loop};
 use crate::bucket::lifecycle::tier_free_version_recovery::{DEFAULT_FREE_VERSION_RECOVERY_LIMIT, recover_tier_free_versions};
@@ -59,7 +59,8 @@ use rustfs_filemeta::{
 };
 use rustfs_s3_types::EventName;
 use rustfs_storage_api::{
-    DeletedObject, HTTPRangeSpec, ListOperations as _, MultipartOperations as _, ObjectOperations as _, ObjectToDelete,
+    DeletedObject, ExpirationOptions, HTTPRangeSpec, ListOperations as _, MultipartOperations as _, ObjectOperations as _,
+    ObjectToDelete,
 };
 use rustfs_utils::{get_env_i64, get_env_usize, path::encode_dir_object, string::strings_has_prefix_fold};
 use s3s::dto::{
@@ -379,14 +380,7 @@ pub trait ExpiryOp: 'static {
     fn as_any(&self) -> &dyn Any;
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct TransitionedObject {
-    pub name: String,
-    pub version_id: String,
-    pub tier: String,
-    pub free_version: bool,
-    pub status: String,
-}
+pub use rustfs_storage_api::TransitionedObject;
 
 struct FreeVersionTask(ObjectInfo);
 
@@ -2862,7 +2856,6 @@ mod tests {
         transitioned_cleanup_tuple,
     };
     use crate::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
-    use crate::bucket::lifecycle::core::ExpirationOptions;
     use crate::bucket::lifecycle::tier_sweeper::Jentry;
     use crate::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
     use crate::bucket::metadata_sys;
@@ -2877,6 +2870,7 @@ mod tests {
     use rustfs_common::metrics::{IlmAction, global_metrics};
     use rustfs_config::ENV_TRANSITION_WORKERS_ABSOLUTE_MAX;
     use rustfs_filemeta::{ReplicateDecision, VersionPurgeStatusType};
+    use rustfs_storage_api::ExpirationOptions;
     use rustfs_storage_api::{BucketOperations, BucketOptions, MakeBucketOptions, MultipartOperations as _};
     use s3s::dto::{BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule, Timestamp};
     use serial_test::serial;

--- a/crates/ecstore/src/bucket/lifecycle/core.rs
+++ b/crates/ecstore/src/bucket/lifecycle/core.rs
@@ -934,10 +934,7 @@ impl Default for Event {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct ExpirationOptions {
-    pub expire: bool,
-}
+pub use rustfs_storage_api::ExpirationOptions;
 
 #[derive(Debug, Clone)]
 pub struct TransitionOptions {

--- a/crates/ecstore/src/bucket/lifecycle/tier_sweeper.rs
+++ b/crates/ecstore/src/bucket/lifecycle/tier_sweeper.rs
@@ -18,12 +18,13 @@
 #![allow(unused_must_use)]
 #![allow(clippy::all)]
 
-use crate::bucket::lifecycle::bucket_lifecycle_ops::{ExpiryOp, GLOBAL_ExpiryState, TransitionedObject};
+use crate::bucket::lifecycle::bucket_lifecycle_ops::{ExpiryOp, GLOBAL_ExpiryState};
 use crate::bucket::lifecycle::lifecycle::{self, ObjectOpts};
 use crate::bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry;
 use crate::client::signer_error::error_chain_contains_signer_header_marker;
 use crate::global::GLOBAL_TierConfigMgr;
 use crate::store::ECStore;
+use rustfs_storage_api::TransitionedObject;
 use rustfs_utils::get_env_usize;
 use sha2::{Digest, Sha256};
 use std::any::Any;

--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -5004,7 +5004,6 @@ pub fn is_infrequent_access_class(storage_class: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bucket::lifecycle::bucket_lifecycle_ops::TransitionedObject;
     use crate::disk::CHECK_PART_UNKNOWN;
     use crate::disk::CHECK_PART_VOLUME_NOT_FOUND;
     use crate::disk::RUSTFS_META_BUCKET;
@@ -5023,6 +5022,7 @@ mod tests {
     use rustfs_filemeta::ReplicationState;
     use rustfs_lock::client::local::LocalClient;
     use rustfs_lock::{LockError, LockInfo, LockResponse, LockStats};
+    use rustfs_storage_api::TransitionedObject;
     use rustfs_storage_api::{CompletePart, NamespaceLocking as _, ObjectOperations as _};
     use serial_test::serial;
     use std::collections::HashMap;

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1267,9 +1267,9 @@ impl ECStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bucket::lifecycle::bucket_lifecycle_ops::TransitionedObject;
     use crate::bucket::lifecycle::core::TRANSITION_COMPLETE;
     use bytes::Bytes;
+    use rustfs_storage_api::TransitionedObject;
     use std::io::Cursor;
     use tokio::io::AsyncReadExt;
 

--- a/crates/ecstore/src/store_api.rs
+++ b/crates/ecstore/src/store_api.rs
@@ -18,11 +18,7 @@ use crate::config::storageclass;
 use crate::error::{Error, Result};
 use crate::rio::{HashReader, LimitReader};
 use crate::store_utils::clean_metadata;
-use crate::{
-    bucket::lifecycle::bucket_lifecycle_audit::LcAuditEvent,
-    bucket::lifecycle::lifecycle::ExpirationOptions,
-    bucket::lifecycle::{bucket_lifecycle_ops::TransitionedObject, lifecycle::TransitionOptions},
-};
+use crate::{bucket::lifecycle::bucket_lifecycle_audit::LcAuditEvent, bucket::lifecycle::lifecycle::TransitionOptions};
 use bytes::Bytes;
 use http::{HeaderMap, HeaderValue};
 use rustfs_common::heal_channel::HealOpts;
@@ -34,7 +30,7 @@ use rustfs_filemeta::{
 use rustfs_lock::NamespaceLockWrapper;
 use rustfs_madmin::heal_commands::HealResultItem;
 use rustfs_rio::Checksum;
-use rustfs_storage_api::HTTPRangeSpec;
+use rustfs_storage_api::{ExpirationOptions, HTTPRangeSpec, TransitionedObject};
 use rustfs_utils::CompressionAlgorithm;
 use rustfs_utils::http::headers::AMZ_OBJECT_TAGGING;
 use rustfs_utils::http::{AMZ_BUCKET_REPLICATION_STATUS, AMZ_RESTORE, AMZ_STORAGE_CLASS};

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -60,6 +60,7 @@ quick-xml = { workspace = true, features = ["serialize", "serde-types", "encodin
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 axum = { workspace = true }
+rustfs-storage-api = { workspace = true }
 rustfs-utils = { workspace = true, features = ["path"] }
 serde_json = { workspace = true }
 time = { workspace = true }

--- a/crates/notify/src/storage_compat.rs
+++ b/crates/notify/src/storage_compat.rs
@@ -79,7 +79,7 @@ impl From<EcstoreObjectInfo> for NotifyObjectInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustfs_ecstore::bucket::lifecycle::bucket_lifecycle_ops::TransitionedObject;
+    use rustfs_storage_api::TransitionedObject;
     use std::{collections::HashMap, sync::Arc};
     use time::{Duration, OffsetDateTime};
 

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -25,6 +25,7 @@ pub use bucket::{BucketInfo, BucketOperations, BucketOptions, DeleteBucketOption
 pub use error::{StorageErrorCode, StorageResult};
 pub use multipart::{CompletePart, ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};
 pub use object::{DeletedObject, ObjectToDelete};
+pub use object::{ExpirationOptions, TransitionedObject};
 pub use object::{HTTPPreconditions, HTTPRangeError, HTTPRangeSpec, ObjectLockRetentionOptions};
 pub use object::{HealOperations, MultipartOperations, NamespaceLocking, ObjectIO, ObjectOperations};
 pub use object::{ListObjectVersionsInfo, ListObjectsInfo, ListObjectsV2Info, ListOperations, ObjectInfoOrErr};

--- a/crates/storage-api/src/object.rs
+++ b/crates/storage-api/src/object.rs
@@ -48,6 +48,20 @@ pub struct ObjectLockRetentionOptions {
     pub bypass_governance: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ExpirationOptions {
+    pub expire: bool,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct TransitionedObject {
+    pub name: String,
+    pub version_id: String,
+    pub tier: String,
+    pub free_version: bool,
+    pub status: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ObjectPreconditionPart {
     pub number: usize,
@@ -795,6 +809,19 @@ mod tests {
 
         assert_eq!(object.version_purge_status(), VersionPurgeStatusType::Empty);
         assert_eq!(object.delete_marker_replication_status(), ReplicationStatusType::Empty);
+    }
+
+    #[test]
+    fn lifecycle_helper_defaults_preserve_existing_contracts() {
+        let expiration = ExpirationOptions::default();
+        let transitioned = TransitionedObject::default();
+
+        assert!(!expiration.expire);
+        assert!(transitioned.name.is_empty());
+        assert!(transitioned.version_id.is_empty());
+        assert!(transitioned.tier.is_empty());
+        assert!(!transitioned.free_version);
+        assert!(transitioned.status.is_empty());
     }
 
     #[derive(Debug)]

--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -95,6 +95,7 @@ Required `rustfs-storage-api` public re-exports:
 - `pub use error::{StorageErrorCode, StorageResult};`
 - `pub use multipart::{CompletePart, ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};`
 - `pub use object::{HTTPPreconditions, HTTPRangeError, HTTPRangeSpec, ObjectLockRetentionOptions};`
+- `pub use object::{ExpirationOptions, TransitionedObject};`
 - `pub use object::{HealOperations, MultipartOperations, NamespaceLocking, ObjectIO, ObjectOperations};`
 - `pub use object::{ListObjectVersionsInfo, ListObjectsInfo, ListObjectsV2Info, ListOperations, ObjectInfoOrErr};`
 - `pub use object::{ObjectPreconditionError, ObjectPreconditionPart, ObjectPreconditionState};`
@@ -117,3 +118,7 @@ directly for `ObjectIO`, `ObjectOperations`, `ListOperations`,
 `MultipartOperations`, `HealOperations`, and `NamespaceLocking`; ECStore keeps
 the concrete compatibility traits only for internal implementation and
 downstream compatibility.
+
+ECStore internal consumers must use `rustfs-storage-api` lifecycle helper DTOs
+directly for `ExpirationOptions` and `TransitionedObject`; ECStore keeps the
+old lifecycle paths only as downstream compatibility re-exports.

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,18 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-delete-object-contracts`
-- Baseline: stacked on `rustfs/rustfs#3579` head
-  (`903aff047d2faffaec907637d64440c84053f62e`).
-- PR type for this branch: `consumer-migration`
+- Branch: `overtrue/arch-storage-api-lifecycle-contracts`
+- Baseline: stacked on `rustfs/rustfs#3594` head
+  (`6fc05b84e2cd22a0482adfbc042184b03f8fdfa6`).
+- PR type for this branch: `pure-move`
 - Runtime behavior changes: no migration behavior change expected.
-- Rust code changes: move delete-object DTO contracts from ECStore store_api to
-  rustfs-storage-api, keep ECStore old-path type aliases, and migrate RustFS,
-  scanner, and ECStore internal consumers to the storage-api contracts.
-- CI/script changes: add a migration guard rejecting reintroduced ECStore
-  delete DTO definitions, public re-exports, or internal old-path consumers.
-- Docs changes: record the delete-object contract move and consumer cleanup
-  slices.
+- Rust code changes: move lifecycle helper DTO contracts for expiration and
+  transitioned object metadata into rustfs-storage-api, switch ECStore internal
+  consumers to direct storage-api imports, and keep ECStore old-path re-exports.
+- CI/script changes: add migration guards rejecting reintroduced ECStore
+  lifecycle helper DTO definitions and old internal consumer imports.
+- Docs changes: record the lifecycle helper pure-move slice.
 
 ## Phase 0 Tasks
 
@@ -1276,6 +1275,27 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     formatting check, diff hygiene, risk scan, full pre-commit, and required
     three-expert review passed before push.
 
+- [x] `API-050` Move lifecycle helper DTO contracts.
+  - Current branch: `overtrue/arch-storage-api-lifecycle-contracts`.
+  - Current slice: move `ExpirationOptions` and `TransitionedObject` into
+    rustfs-storage-api, update ECStore internal consumers plus notify test
+    coverage to import them directly, and keep ECStore old-path re-exports for
+    downstream compatibility callers.
+  - Acceptance: rustfs-storage-api exports both lifecycle helper DTOs, ECStore
+    no longer owns their concrete struct definitions, ECStore internal
+    consumers and notify coverage use the storage-api contracts directly, old
+    ECStore lifecycle paths remain available as re-exports, and migration rules
+    reject restoring the ECStore definitions or old internal imports.
+  - Must preserve: lifecycle expiration flags, transitioned object journal
+    metadata, object info construction, notify event conversion, and all old
+    ECStore import paths used by existing callers.
+  - Risk defense: this is a pure DTO move; no lifecycle scheduling, object I/O,
+    transition journal, replication, or reader behavior is changed.
+  - Verification: storage-api lifecycle helper unit test, ECStore transitioned
+    lifecycle tests, notify event conversion test, focused compile checks,
+    migration and layer guards, formatting check, diff hygiene, risk scan, full
+    pre-commit, and required three-expert review passed before push.
+
 ## Phase 8 Background Controller Tasks
 
 - [x] `BGC-001` Inventory background services.
@@ -1552,13 +1572,31 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, and fuzz compatibility contracts without moving ECStore storage metadata ownership. |
-| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, unchanged no-op handling, and remove-event behavior are preserved. |
+| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049/API-050 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, fuzz, and lifecycle helper compatibility contracts without moving ECStore storage metadata ownership. |
+| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, lifecycle expiration/transition helper DTO field contracts, unchanged no-op handling, and remove-event behavior are preserved. |
 | Testing/verification | passed | Focused compiles/tests, guards, formatting, diff hygiene, risk scan, and full `make pre-commit` passed for the current slice. |
 
 ## Verification Notes
 
 Passed before push:
+
+- API-050 current slice:
+  - `cargo test -p rustfs-storage-api lifecycle_helper_defaults_preserve_existing_contracts --no-fail-fast`:
+    passed.
+  - `cargo check --tests -p rustfs-storage-api -p rustfs-ecstore -p rustfs-notify`:
+    passed.
+  - `cargo test -p rustfs-ecstore transitioned --no-fail-fast`: passed.
+  - `cargo test -p rustfs-notify ecstore_object_info_conversion_preserves_notify_event_fields --no-fail-fast`:
+    passed.
+  - `cargo check --tests -p rustfs`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - Rust risk scan: passed; no new unwrap/expect, panic/todo/unsafe, risky
+    casts, ad-hoc error construction, or sensitive-token handling in added
+    lines.
+  - `make pre-commit`: passed.
 
 - S-015 current slice:
   - `cargo test -p rustfs-policy test_legacy_kms_admin_actions_are_rejected --no-fail-fast`:

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -59,6 +59,8 @@ STORE_API_LIST_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_list_helper_reexports
 STORE_API_LIST_RESPONSE_REEXPORTS_FILE="${TMP_DIR}/store_api_list_response_reexports.txt"
 STORE_API_DELETE_DTO_REEXPORTS_FILE="${TMP_DIR}/store_api_delete_dto_reexports.txt"
 STORE_API_DELETE_DTO_INTERNAL_HITS_FILE="${TMP_DIR}/store_api_delete_dto_internal_hits.txt"
+STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_definition_hits.txt"
+STORE_API_LIFECYCLE_HELPER_OLD_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_old_consumer_hits.txt"
 STORE_API_EXTERNAL_LIST_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_list_consumer_hits.txt"
 STORE_API_EXTERNAL_OPERATION_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_operation_consumer_hits.txt"
 STORE_API_OBJECT_OPERATION_LOCAL_METHOD_HITS_FILE="${TMP_DIR}/store_api_object_operation_local_method_hits.txt"
@@ -216,6 +218,10 @@ require_source_line \
   "storage-api public delete object contract re-export"
 require_source_line \
   "crates/storage-api/src/lib.rs" \
+  "pub use object::{ExpirationOptions, TransitionedObject};" \
+  "storage-api public lifecycle helper contract re-export"
+require_source_line \
+  "crates/storage-api/src/lib.rs" \
   "pub use object::{ListObjectVersionsInfo, ListObjectsInfo, ListObjectsV2Info, ListOperations, ObjectInfoOrErr};" \
   "storage-api public list response contract re-export"
 require_source_line \
@@ -332,6 +338,36 @@ fi
 
 if [[ -s "$STORE_API_DELETE_DTO_INTERNAL_HITS_FILE" ]]; then
   report_failure "ecstore internal delete DTO old store_api path reintroduced: $(paste -sd '; ' "$STORE_API_DELETE_DTO_INTERNAL_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'pub struct (?:ExpirationOptions|TransitionedObject)\b' \
+    crates/ecstore/src/bucket/lifecycle/core.rs \
+    crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs || true
+) >"$STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE"
+
+if [[ -s "$STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE" ]]; then
+  report_failure "ECStore lifecycle helper DTO definitions must stay in rustfs-storage-api: $(paste -sd '; ' "$STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE")"
+fi
+
+require_source_line \
+  "crates/ecstore/src/bucket/lifecycle/core.rs" \
+  "pub use rustfs_storage_api::ExpirationOptions;" \
+  "ECStore ExpirationOptions compatibility re-export"
+require_source_line \
+  "crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs" \
+  "pub use rustfs_storage_api::TransitionedObject;" \
+  "ECStore TransitionedObject compatibility re-export"
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'crate::bucket::lifecycle::(?:bucket_lifecycle_ops::TransitionedObject|core::ExpirationOptions|lifecycle::ExpirationOptions)|use crate::bucket::lifecycle::(?:bucket_lifecycle_ops::TransitionedObject|core::ExpirationOptions|lifecycle::ExpirationOptions)|rustfs_ecstore::bucket::lifecycle::bucket_lifecycle_ops::TransitionedObject' \
+    crates/ecstore/src rustfs/src crates/scanner/src crates/scanner/tests crates/notify/src --glob '*.rs' || true
+) >"$STORE_API_LIFECYCLE_HELPER_OLD_CONSUMER_HITS_FILE"
+
+if [[ -s "$STORE_API_LIFECYCLE_HELPER_OLD_CONSUMER_HITS_FILE" ]]; then
+  report_failure "lifecycle helper DTO consumers must import rustfs-storage-api directly: $(paste -sd '; ' "$STORE_API_LIFECYCLE_HELPER_OLD_CONSUMER_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#660.

## Summary of Changes
- Move lifecycle helper DTO contracts into `rustfs-storage-api` and re-export them publicly.
- Keep the old ECStore lifecycle helper paths as compatibility re-exports while switching ECStore internal consumers and notify coverage to direct storage-api imports.
- Add architecture guardrails and migration progress notes for API-050.

## Verification
- `cargo test -p rustfs-storage-api lifecycle_helper_defaults_preserve_existing_contracts --no-fail-fast`
- `cargo check --tests -p rustfs-storage-api -p rustfs-ecstore -p rustfs-notify`
- `cargo test -p rustfs-ecstore transitioned --no-fail-fast`
- `cargo test -p rustfs-notify ecstore_object_info_conversion_preserves_notify_event_fields --no-fail-fast`
- `cargo check --tests -p rustfs`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
No runtime behavior change expected. Lifecycle expiration and transitioned-object metadata field contracts are preserved, and old ECStore import paths remain available for compatibility.

## Additional Notes
Stacked on `overtrue/arch-test-fuzz-compat-boundaries` while that branch finishes CI.
