### PR TITLE
refactor: prune runtime storage compat surface

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-rustfs-storage-compat-aliases`
-- Baseline: stacked on `rustfs/rustfs#3596` head
-  (`55b8bca6de60ed435a3c7e18119e3dff0a7fb1f7`).
+- Branch: `overtrue/arch-runtime-compat-surface-prune`
+- Baseline: stacked on `rustfs/rustfs#3597` head
+  (`33920e8fff1c62666435be1bc04a4e0dc97b5165`).
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: no migration behavior change expected.
 - Rust code changes: flatten RustFS root, app, admin, and storage runtime
-  compatibility facades from nested ECStore modules into direct aliases and
+  scalar compatibility facades from secondary modules into direct aliases and
   functions.
-- CI/script changes: add migration guards rejecting nested
-  `storage_compat::ecstore` paths in RustFS runtime source.
-- Docs changes: record the RustFS runtime compatibility alias cleanup slice.
+- CI/script changes: add migration guards rejecting restored scalar
+  `storage_compat::*::*` paths in RustFS runtime source.
+- Docs changes: record the RustFS runtime scalar compatibility surface cleanup
+  slice.
 
 ## Phase 0 Tasks
 
@@ -1333,6 +1334,27 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     formatting check, diff hygiene, risk scan, full pre-commit, and required
     three-expert review passed before push.
 
+- [x] `API-053` Flatten RustFS runtime scalar storage compatibility aliases.
+  - Current branch: `overtrue/arch-runtime-compat-surface-prune`.
+  - Current slice: flatten RustFS root, app, admin, and storage runtime scalar
+    compatibility facades such as store, error, global, endpoints, RPC,
+    metrics, notification, set-disk, and data-usage paths into direct
+    crate-local aliases and functions.
+  - Acceptance: RustFS runtime source no longer consumes those scalar
+    compatibility surfaces through secondary modules, while higher-coupling
+    bucket/config/rio compatibility modules remain unchanged; migration rules
+    reject restoring the flattened scalar paths.
+  - Must preserve: startup config/bootstrap behavior, server readiness checks,
+    admin replication/rebalance/tier/config handlers, app object/bucket/
+    multipart usecases, storage RPC/SSE/access paths, table catalog storage
+    access, and existing ECStore concrete type ownership.
+  - Risk defense: this is import ownership and facade-shape cleanup only; no
+    production runtime behavior, ECStore ownership, storage metadata format,
+    object I/O, admin authorization, or readiness semantics are changed.
+  - Verification: focused RustFS compile, migration and layer guards,
+    formatting check, diff hygiene, risk scan, full pre-commit, and required
+    three-expert review passed before push.
+
 ## Phase 8 Background Controller Tasks
 
 - [x] `BGC-001` Inventory background services.
@@ -1609,13 +1631,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049/API-050/API-051/API-052 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, fuzz, lifecycle helper, harness, and RustFS runtime compatibility contracts without moving ECStore storage metadata ownership. |
-| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, lifecycle expiration/transition helper DTO field contracts, flattened harness and RustFS runtime alias behavior, unchanged no-op handling, and remove-event behavior are preserved. |
+| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049/API-050/API-051/API-052/API-053 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, fuzz, lifecycle helper, harness, and RustFS runtime compatibility contracts without moving ECStore storage metadata ownership. |
+| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, lifecycle expiration/transition helper DTO field contracts, flattened harness and RustFS runtime scalar alias behavior, unchanged no-op handling, and remove-event behavior are preserved. |
 | Testing/verification | passed | Focused compiles/tests, fuzz target compile, guards, formatting, diff hygiene, risk scan, and full `make pre-commit` passed for the current slice. |
 
 ## Verification Notes
 
 Passed before push:
+
+- API-053 current slice:
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo check --tests -p rustfs`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - Rust risk scan: passed; only existing import and path rewrites were
+    reviewed, with no new unwrap/expect, panic/todo/unsafe, risky casts,
+    ad-hoc error construction, or sensitive-token handling semantics.
+  - `make pre-commit`: passed.
 
 - API-052 current slice:
   - `cargo check -p rustfs --lib`: passed.

--- a/rustfs/src/admin/handlers/bucket_meta.rs
+++ b/rustfs/src/admin/handlers/bucket_meta.rs
@@ -14,6 +14,7 @@
 
 use crate::admin::storage_compat::bucket::utils::{deserialize, serialize};
 use crate::admin::storage_compat::{
+    StorageError,
     bucket::{
         metadata::{
             BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE,
@@ -24,7 +25,6 @@ use crate::admin::storage_compat::{
         quota::BucketQuota,
         target::BucketTargets,
     },
-    error::StorageError,
 };
 use crate::{
     admin::{

--- a/rustfs/src/admin/handlers/config_admin.rs
+++ b/rustfs/src/admin/handlers/config_admin.rs
@@ -18,12 +18,12 @@ use crate::admin::service::config::{
     apply_dynamic_config_for_subsystem, is_dynamic_config_subsystem, signal_config_snapshot_reload, signal_dynamic_config_reload,
     validate_server_config,
 };
+use crate::admin::storage_compat::RUSTFS_META_BUCKET;
 use crate::admin::storage_compat::config::com::STORAGE_CLASS_SUB_SYS;
 use crate::admin::storage_compat::config::com::{
     delete_config, read_config, read_config_without_migrate, save_config, save_server_config,
 };
 use crate::admin::storage_compat::config::storageclass::{INLINE_BLOCK_ENV, OPTIMIZE_ENV, RRS_ENV, STANDARD_ENV};
-use crate::admin::storage_compat::disk::RUSTFS_META_BUCKET;
 use crate::admin::utils::{encode_compatible_admin_payload, is_compat_admin_request, read_compatible_admin_body};
 use crate::app::context::resolve_object_store_handle;
 use crate::auth::{check_key_valid, get_session_token};
@@ -711,7 +711,7 @@ fn success_response(config_applied: bool) -> S3Result<S3Response<(StatusCode, Bo
     Ok(S3Response::with_headers((StatusCode::OK, Body::default()), headers))
 }
 
-fn object_store() -> S3Result<std::sync::Arc<crate::admin::storage_compat::store::ECStore>> {
+fn object_store() -> S3Result<std::sync::Arc<crate::admin::storage_compat::ECStore>> {
     resolve_object_store_handle().ok_or_else(|| s3_error!(InternalError, "server storage not initialized"))
 }
 

--- a/rustfs/src/admin/handlers/heal.rs
+++ b/rustfs/src/admin/handlers/heal.rs
@@ -15,7 +15,7 @@
 use crate::admin::auth::{authenticate_request, validate_admin_request};
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::storage_compat::bucket::utils::is_valid_object_prefix;
-use crate::admin::storage_compat::store_utils::is_reserved_or_invalid_bucket;
+use crate::admin::storage_compat::is_reserved_or_invalid_bucket;
 use crate::app::context::resolve_object_store_handle;
 use crate::server::ADMIN_PREFIX;
 use crate::server::RemoteAddr;
@@ -345,10 +345,10 @@ fn should_handle_root_heal_directly(hip: &HealInitParams) -> bool {
     hip.bucket.is_empty() && hip.obj_prefix.is_empty() && hip.client_token.is_empty() && !hip.force_stop
 }
 
-fn map_root_heal_status(heal_err: Option<crate::admin::storage_compat::error::Error>) -> S3Result<()> {
+fn map_root_heal_status(heal_err: Option<crate::admin::storage_compat::Error>) -> S3Result<()> {
     match heal_err {
         None => Ok(()),
-        Some(crate::admin::storage_compat::error::StorageError::NoHealRequired) => {
+        Some(crate::admin::storage_compat::StorageError::NoHealRequired) => {
             info!(
                 event = EVENT_ADMIN_RESPONSE_EMITTED,
                 component = LOG_COMPONENT_ADMIN_API,
@@ -703,7 +703,7 @@ mod tests {
         encode_heal_task_status, heal_channel_response_items, heal_channel_response_summary, json_response, map_heal_response,
         map_root_heal_status, should_handle_root_heal_directly, validate_heal_request_mode, validate_heal_target,
     };
-    use crate::admin::storage_compat::error::StorageError;
+    use crate::admin::storage_compat::StorageError;
     use bytes::Bytes;
     use http::StatusCode;
     use http::Uri;

--- a/rustfs/src/admin/handlers/metrics.rs
+++ b/rustfs/src/admin/handlers/metrics.rs
@@ -20,7 +20,7 @@
 
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::Operation;
-use crate::admin::storage_compat::metrics_realtime::{CollectMetricsOpts, MetricType, collect_local_metrics};
+use crate::admin::storage_compat::{CollectMetricsOpts, MetricType, collect_local_metrics};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::RemoteAddr;
 use crate::storage::request_context::spawn_traced;

--- a/rustfs/src/admin/handlers/object_zip_download.rs
+++ b/rustfs/src/admin/handlers/object_zip_download.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::router::{ADMIN_OBJECT_ZIP_DOWNLOADS_PATH, AdminOperation, Operation, S3Router};
-use crate::admin::storage_compat::global::get_global_region;
+use crate::admin::storage_compat::get_global_region;
 use crate::app::context::resolve_object_store_handle;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::error::ApiError;
@@ -649,7 +649,7 @@ async fn preflight_zip_items(request: &CreateObjectZipDownloadRequest, items: &[
     Ok(())
 }
 
-fn storage_error_to_s3(err: crate::admin::storage_compat::error::Error) -> s3s::S3Error {
+fn storage_error_to_s3(err: crate::admin::storage_compat::Error) -> s3s::S3Error {
     ApiError::from(err).into()
 }
 

--- a/rustfs/src/admin/handlers/pools.rs
+++ b/rustfs/src/admin/handlers/pools.rs
@@ -99,7 +99,7 @@ macro_rules! log_pool_response_emitted {
     };
 }
 
-fn endpoints_from_context() -> Option<crate::admin::storage_compat::endpoints::EndpointServerPools> {
+fn endpoints_from_context() -> Option<crate::admin::storage_compat::EndpointServerPools> {
     resolve_endpoints_handle()
 }
 

--- a/rustfs/src/admin/handlers/quota.rs
+++ b/rustfs/src/admin/handlers/quota.rs
@@ -175,7 +175,7 @@ async fn current_usage_from_context(bucket: &str) -> u64 {
         return 0;
     };
 
-    match crate::admin::storage_compat::data_usage::load_data_usage_from_backend(store).await {
+    match crate::admin::storage_compat::load_data_usage_from_backend(store).await {
         Ok(data_usage_info) => data_usage_info
             .buckets_usage
             .get(bucket)

--- a/rustfs/src/admin/handlers/rebalance.rs
+++ b/rustfs/src/admin/handlers/rebalance.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use crate::admin::storage_compat::{
-    error::StorageError,
-    notification_sys::get_global_notification_sys,
+    StorageError, get_global_notification_sys,
     rebalance::{DiskStat, RebalSaveOpt, RebalanceCleanupWarnings, RebalanceMeta},
 };
 use crate::{

--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -15,6 +15,7 @@
 use crate::admin::auth::validate_admin_request;
 use crate::admin::handlers::site_replication::site_replication_peer_deployment_id_for_endpoint;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
+use crate::admin::storage_compat::StorageError;
 use crate::admin::storage_compat::bucket::bucket_target_sys::{BucketTargetError, BucketTargetSys};
 use crate::admin::storage_compat::bucket::metadata::BUCKET_TARGETS_FILE;
 use crate::admin::storage_compat::bucket::metadata_sys;
@@ -22,8 +23,7 @@ use crate::admin::storage_compat::bucket::metadata_sys::get_replication_config;
 use crate::admin::storage_compat::bucket::replication::BucketStats;
 use crate::admin::storage_compat::bucket::replication::GLOBAL_REPLICATION_STATS;
 use crate::admin::storage_compat::bucket::target::BucketTarget;
-use crate::admin::storage_compat::error::StorageError;
-use crate::admin::storage_compat::global::global_rustfs_port;
+use crate::admin::storage_compat::global_rustfs_port;
 use crate::admin::utils::read_compatible_admin_body;
 use crate::app::context::resolve_object_store_handle;
 use crate::auth::{check_key_valid, get_session_token};

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -18,6 +18,7 @@ use crate::admin::site_replication_identity::{
     canonical_endpoint, deployment_id_for_endpoint, normalize_peer_map_by_identity_with, same_identity_endpoint,
     site_identity_key,
 };
+use crate::admin::storage_compat::Error as StorageError;
 use crate::admin::storage_compat::bucket::bucket_target_sys::BucketTargetSys;
 use crate::admin::storage_compat::bucket::metadata::{
     BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE, BUCKET_REPLICATION_CONFIG,
@@ -30,10 +31,7 @@ use crate::admin::storage_compat::bucket::target::{ARN, BucketTarget, BucketTarg
 use crate::admin::storage_compat::bucket::utils::{deserialize, serialize};
 use crate::admin::storage_compat::bucket::versioning::VersioningApi;
 use crate::admin::storage_compat::config::com::{delete_config, read_config, save_config};
-use crate::admin::storage_compat::error::Error as StorageError;
-use crate::admin::storage_compat::global::{
-    get_global_deployment_id, get_global_endpoints_opt, get_global_region, global_rustfs_port,
-};
+use crate::admin::storage_compat::{get_global_deployment_id, get_global_endpoints_opt, get_global_region, global_rustfs_port};
 use crate::admin::utils::{encode_compatible_admin_payload, read_compatible_admin_body};
 use crate::app::context::resolve_object_store_handle;
 use crate::auth::{check_key_valid, get_session_token};
@@ -654,7 +652,7 @@ async fn site_replication_peer_client() -> S3Result<reqwest::Client> {
     built
 }
 
-fn runtime_tls_enabled_with(endpoints: Option<&crate::admin::storage_compat::endpoints::EndpointServerPools>) -> bool {
+fn runtime_tls_enabled_with(endpoints: Option<&crate::admin::storage_compat::EndpointServerPools>) -> bool {
     if !rustfs_utils::get_env_str(ENV_RUSTFS_TLS_PATH, DEFAULT_RUSTFS_TLS_PATH).is_empty() {
         return true;
     }
@@ -4576,8 +4574,8 @@ impl Operation for SRRotateServiceAccountHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::admin::storage_compat::disk::endpoint::Endpoint;
-    use crate::admin::storage_compat::endpoints::{EndpointServerPools, Endpoints, PoolEndpoints};
+    use crate::admin::storage_compat::Endpoint;
+    use crate::admin::storage_compat::{EndpointServerPools, Endpoints, PoolEndpoints};
     use http::{HeaderMap, HeaderValue, Uri};
     use rustfs_common::{get_global_outbound_tls_generation, set_global_outbound_tls_generation};
     use rustfs_policy::policy::action::S3Action;

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::admin::storage_compat::{
+    ECStore,
     bucket::{metadata::table_catalog_path_hash, metadata_sys},
-    store::ECStore,
 };
 use crate::admin::{
     auth::{AdminResourceScope, validate_admin_request, validate_admin_request_with_bucket_object},

--- a/rustfs/src/admin/handlers/tier.rs
+++ b/rustfs/src/admin/handlers/tier.rs
@@ -18,7 +18,7 @@ use crate::admin::storage_compat::{
     bucket::lifecycle::tier_last_day_stats::DailyAllTierStats,
     client::admin_handler_utils::AdminError,
     config::storageclass,
-    notification_sys::get_global_notification_sys,
+    get_global_notification_sys,
     tier::{
         tier::{ERR_TIER_BACKEND_IN_USE, ERR_TIER_BACKEND_NOT_EMPTY, ERR_TIER_MISSING_CREDENTIALS},
         tier_admin::TierCreds,

--- a/rustfs/src/admin/handlers/trace.rs
+++ b/rustfs/src/admin/handlers/trace.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::router::Operation;
-use crate::admin::storage_compat::rpc::PeerRestClient;
+use crate::admin::storage_compat::PeerRestClient;
 use crate::app::context::resolve_endpoints_handle;
 use http::StatusCode;
 use hyper::Uri;

--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -14,6 +14,8 @@
 
 use crate::admin::console::{is_console_path, make_console_server};
 use crate::admin::handlers::oidc::is_oidc_path;
+use crate::admin::storage_compat::GLOBAL_BOOT_TIME;
+use crate::admin::storage_compat::PeerRestClient;
 use crate::admin::storage_compat::bucket::bandwidth::monitor::BandwidthDetails;
 use crate::admin::storage_compat::bucket::bucket_target_sys::{
     BucketTargetSys, PutObjectOptions, RemoveObjectOptions, S3ClientError, TargetClient,
@@ -28,10 +30,8 @@ use crate::admin::storage_compat::bucket::target::{BucketTarget, BucketTargetTyp
 use crate::admin::storage_compat::bucket::versioning::VersioningApi;
 use crate::admin::storage_compat::bucket::versioning_sys::BucketVersioningSys;
 use crate::admin::storage_compat::config::com::read_config_without_migrate;
-use crate::admin::storage_compat::global::GLOBAL_BOOT_TIME;
-use crate::admin::storage_compat::global::{get_global_bucket_monitor, get_global_deployment_id, get_global_region};
-use crate::admin::storage_compat::notification_sys::get_global_notification_sys;
-use crate::admin::storage_compat::rpc::PeerRestClient;
+use crate::admin::storage_compat::get_global_notification_sys;
+use crate::admin::storage_compat::{get_global_bucket_monitor, get_global_deployment_id, get_global_region};
 use crate::app::context::resolve_object_store_handle;
 use crate::app::object_usecase::DefaultObjectUsecase;
 use crate::auth::{check_key_valid, get_session_token};
@@ -1420,9 +1420,7 @@ async fn ensure_replication_bucket_exists(bucket: &str) -> S3Result<()> {
 async fn ensure_replication_config_exists(bucket: &str) -> S3Result<()> {
     match metadata_sys::get_replication_config(bucket).await {
         Ok(_) => Ok(()),
-        Err(crate::admin::storage_compat::error::StorageError::ConfigNotFound) => {
-            Err(s3_error!(ReplicationConfigurationNotFoundError))
-        }
+        Err(crate::admin::storage_compat::StorageError::ConfigNotFound) => Err(s3_error!(ReplicationConfigurationNotFoundError)),
         Err(err) => Err(ApiError::from(err).into()),
     }
 }
@@ -2062,7 +2060,7 @@ async fn source_bucket_requires_object_lock(bucket: &str) -> S3Result<bool> {
             .object_lock_enabled
             .as_ref()
             .is_some_and(|state| state.as_str() == s3s::dto::ObjectLockEnabled::ENABLED)),
-        Err(crate::admin::storage_compat::error::StorageError::ConfigNotFound) => Ok(false),
+        Err(crate::admin::storage_compat::StorageError::ConfigNotFound) => Ok(false),
         Err(err) => Err(ApiError::from(err).into()),
     }
 }

--- a/rustfs/src/admin/service/config.rs
+++ b/rustfs/src/admin/service/config.rs
@@ -15,7 +15,7 @@
 use crate::admin::storage_compat::config::com::{STORAGE_CLASS_SUB_SYS, read_config_without_migrate};
 use crate::admin::storage_compat::config::set_global_storage_class;
 use crate::admin::storage_compat::config::storageclass;
-use crate::admin::storage_compat::notification_sys::get_global_notification_sys;
+use crate::admin::storage_compat::get_global_notification_sys;
 use crate::app::context::resolve_object_store_handle;
 use rustfs_audit::reload_audit_config;
 use rustfs_config::audit::{AUDIT_MQTT_SUB_SYS, AUDIT_REDIS_DEFAULT_CHANNEL, AUDIT_WEBHOOK_SUB_SYS};

--- a/rustfs/src/admin/service/site_replication.rs
+++ b/rustfs/src/admin/service/site_replication.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::admin::site_replication_identity::{deployment_id_for_endpoint, normalize_peer_map_by_identity_with};
+use crate::admin::storage_compat::Error as StorageError;
 use crate::admin::storage_compat::config::com::{read_config, save_config};
-use crate::admin::storage_compat::error::Error as StorageError;
 use crate::app::context::resolve_object_store_handle;
 use rustfs_madmin::PeerInfo;
 use s3s::{S3Error, S3ErrorCode, S3Result};

--- a/rustfs/src/admin/storage_compat.rs
+++ b/rustfs/src/admin/storage_compat.rs
@@ -27,57 +27,28 @@ pub(crate) mod config {
     pub(crate) use rustfs_ecstore::config::{com, init, set_global_storage_class, storageclass};
 }
 
-pub(crate) mod data_usage {
-    pub(crate) use rustfs_ecstore::data_usage::load_data_usage_from_backend;
-}
-
-pub(crate) mod disk {
-    pub(crate) use rustfs_ecstore::disk::RUSTFS_META_BUCKET;
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::disk::endpoint;
-}
-
-pub(crate) mod endpoints {
-    pub(crate) use rustfs_ecstore::endpoints::EndpointServerPools;
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::endpoints::{Endpoints, PoolEndpoints};
-}
-
-pub(crate) mod error {
-    pub(crate) use rustfs_ecstore::error::{Error, StorageError};
-}
-
-pub(crate) mod global {
-    pub(crate) use rustfs_ecstore::global::{
-        GLOBAL_BOOT_TIME, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints_opt, get_global_region,
-        global_rustfs_port,
-    };
-}
-
-pub(crate) mod metrics_realtime {
-    pub(crate) use rustfs_ecstore::metrics_realtime::{CollectMetricsOpts, MetricType, collect_local_metrics};
-}
-
-pub(crate) mod notification_sys {
-    pub(crate) use rustfs_ecstore::notification_sys::get_global_notification_sys;
-}
+pub(crate) use rustfs_ecstore::data_usage::load_data_usage_from_backend;
+pub(crate) use rustfs_ecstore::disk::RUSTFS_META_BUCKET;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::disk::endpoint::Endpoint;
+pub(crate) use rustfs_ecstore::endpoints::EndpointServerPools;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::endpoints::{Endpoints, PoolEndpoints};
+pub(crate) use rustfs_ecstore::error::{Error, StorageError};
+pub(crate) use rustfs_ecstore::global::{
+    GLOBAL_BOOT_TIME, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints_opt, get_global_region,
+    global_rustfs_port,
+};
+pub(crate) use rustfs_ecstore::metrics_realtime::{CollectMetricsOpts, MetricType, collect_local_metrics};
+pub(crate) use rustfs_ecstore::notification_sys::get_global_notification_sys;
+pub(crate) use rustfs_ecstore::rpc::PeerRestClient;
+pub(crate) use rustfs_ecstore::store::ECStore;
+pub(crate) use rustfs_ecstore::store_utils::is_reserved_or_invalid_bucket;
 
 pub(crate) mod rebalance {
     pub(crate) use rustfs_ecstore::rebalance::{DiskStat, RebalSaveOpt, RebalanceCleanupWarnings, RebalanceMeta, RebalanceStats};
     #[cfg(test)]
     pub(crate) use rustfs_ecstore::rebalance::{RebalStatus, RebalanceInfo};
-}
-
-pub(crate) mod rpc {
-    pub(crate) use rustfs_ecstore::rpc::PeerRestClient;
-}
-
-pub(crate) mod store {
-    pub(crate) use rustfs_ecstore::store::ECStore;
-}
-
-pub(crate) mod store_utils {
-    pub(crate) use rustfs_ecstore::store_utils::is_reserved_or_invalid_bucket;
 }
 
 pub(crate) mod tier {

--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -15,13 +15,11 @@
 //! Admin application use-case contracts.
 
 use crate::app::context::{AppContext, get_global_app_context, resolve_object_store_handle_for_context};
-use crate::app::storage_compat::admin_server_info::get_server_info;
-use crate::app::storage_compat::data_usage::{apply_bucket_usage_memory_overlay, load_data_usage_from_backend};
-use crate::app::storage_compat::endpoints::EndpointServerPools;
-use crate::app::storage_compat::pools::{
-    PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
-};
-use crate::app::storage_compat::store::ECStore;
+use crate::app::storage_compat::ECStore;
+use crate::app::storage_compat::EndpointServerPools;
+use crate::app::storage_compat::get_server_info;
+use crate::app::storage_compat::{PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free};
+use crate::app::storage_compat::{apply_bucket_usage_memory_overlay, load_data_usage_from_backend};
 use crate::capacity::resolve_admin_used_capacity;
 use crate::error::ApiError;
 use crate::server::{DependencyReadiness, collect_dependency_readiness as collect_runtime_dependency_readiness};
@@ -318,7 +316,7 @@ impl DefaultAdminUsecase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::storage_compat::pools::{PoolDecommissionInfo, PoolStatus};
+    use crate::app::storage_compat::{PoolDecommissionInfo, PoolStatus};
     use time::OffsetDateTime;
 
     #[tokio::test]

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -20,6 +20,8 @@ use crate::admin::handlers::site_replication::{
 use crate::app::context::{
     AppContext, default_notify_interface, get_global_app_context, resolve_object_store_handle_for_context,
 };
+use crate::app::storage_compat::ECStore;
+use crate::app::storage_compat::StorageError;
 use crate::app::storage_compat::bucket::{
     bucket_target_sys::BucketTargetSys,
     lifecycle::bucket_lifecycle_ops::{
@@ -39,9 +41,7 @@ use crate::app::storage_compat::bucket::{
     versioning_sys::BucketVersioningSys,
 };
 use crate::app::storage_compat::client::object_api_utils::to_s3s_etag;
-use crate::app::storage_compat::error::StorageError;
-use crate::app::storage_compat::notification_sys::get_global_notification_sys;
-use crate::app::storage_compat::store::ECStore;
+use crate::app::storage_compat::get_global_notification_sys;
 use crate::auth::get_condition_values_with_client_info;
 use crate::error::ApiError;
 use crate::server::RemoteAddr;

--- a/rustfs/src/app/capacity_dirty_scope_test.rs
+++ b/rustfs/src/app/capacity_dirty_scope_test.rs
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::app::storage_compat::{
-    bucket::metadata_sys,
-    disk::endpoint::Endpoint,
-    endpoints::{EndpointServerPools, Endpoints, PoolEndpoints},
-    store::ECStore,
-};
+use crate::app::storage_compat::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, bucket::metadata_sys};
 use rustfs_common::heal_channel::{HealOpts, HealScanMode};
 use rustfs_object_capacity::capacity_manager::{HybridStrategyConfig, create_isolated_manager};
 use rustfs_storage_api::{BucketOperations, BucketOptions, HealOperations as _, MakeBucketOptions, ObjectIO as _};
@@ -82,7 +77,7 @@ async fn setup_capacity_dirty_scope_env() -> (Vec<PathBuf>, Arc<ECStore>) {
     };
 
     let endpoint_pools = EndpointServerPools(vec![pool_endpoints]);
-    crate::app::storage_compat::store::init_local_disks(endpoint_pools.clone())
+    crate::app::storage_compat::init_local_disks(endpoint_pools.clone())
         .await
         .unwrap();
 

--- a/rustfs/src/app/context/compat.rs
+++ b/rustfs/src/app/context/compat.rs
@@ -17,10 +17,10 @@ use super::handles::{
     default_bucket_metadata_interface, default_endpoints_interface, default_kms_runtime_interface,
     default_server_config_interface, default_tier_config_interface,
 };
+use crate::app::storage_compat::ECStore;
+use crate::app::storage_compat::EndpointServerPools;
 use crate::app::storage_compat::bucket::metadata_sys::BucketMetadataSys;
-use crate::app::storage_compat::endpoints::EndpointServerPools;
 use crate::app::storage_compat::new_object_layer_fn;
-use crate::app::storage_compat::store::ECStore;
 use crate::app::storage_compat::tier::tier::TierConfigMgr;
 #[cfg(test)]
 use crate::config::RustFSBufferConfig;
@@ -126,10 +126,10 @@ mod tests {
         BucketMetadataInterface, BufferConfigInterface, EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface,
         ServerConfigInterface, TierConfigInterface,
     };
-    use crate::app::storage_compat::disk::endpoint::Endpoint;
-    use crate::app::storage_compat::endpoints::{Endpoints, PoolEndpoints};
+    use crate::app::storage_compat::Endpoint;
+    use crate::app::storage_compat::init_local_disks;
     use crate::app::storage_compat::new_object_layer_fn;
-    use crate::app::storage_compat::store::init_local_disks;
+    use crate::app::storage_compat::{Endpoints, PoolEndpoints};
     use crate::config::{RustFSBufferConfig, WorkloadProfile};
     use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
     use std::path::PathBuf;

--- a/rustfs/src/app/context/global.rs
+++ b/rustfs/src/app/context/global.rs
@@ -21,7 +21,7 @@ use super::interfaces::{
     BucketMetadataInterface, BufferConfigInterface, EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface,
     NotifyInterface, RegionInterface, ServerConfigInterface, TierConfigInterface,
 };
-use crate::app::storage_compat::{set_object_store_resolver, store::ECStore};
+use crate::app::storage_compat::{ECStore, set_object_store_resolver};
 use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
 use rustfs_kms::KmsServiceManager;
 use std::sync::{Arc, OnceLock};

--- a/rustfs/src/app/context/handles.rs
+++ b/rustfs/src/app/context/handles.rs
@@ -16,10 +16,10 @@ use super::interfaces::{
     BucketMetadataInterface, BufferConfigInterface, EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface,
     NotifyInterface, RegionInterface, ServerConfigInterface, TierConfigInterface,
 };
+use crate::app::storage_compat::EndpointServerPools;
 use crate::app::storage_compat::bucket::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys};
-use crate::app::storage_compat::endpoints::EndpointServerPools;
-use crate::app::storage_compat::global::{get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr};
 use crate::app::storage_compat::tier::tier::TierConfigMgr;
+use crate::app::storage_compat::{get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr};
 use crate::config::{RustFSBufferConfig, get_global_buffer_config};
 use async_trait::async_trait;
 use rustfs_config::server_config::Config;

--- a/rustfs/src/app/context/interfaces.rs
+++ b/rustfs/src/app/context/interfaces.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::app::storage_compat::EndpointServerPools;
 use crate::app::storage_compat::bucket::metadata_sys::BucketMetadataSys;
-use crate::app::storage_compat::endpoints::EndpointServerPools;
 use crate::app::storage_compat::tier::tier::TierConfigMgr;
 use crate::config::RustFSBufferConfig;
 use async_trait::async_trait;

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -15,14 +15,11 @@
 use super::{multipart_usecase::DefaultMultipartUsecase, object_usecase::DefaultObjectUsecase};
 use crate::app::bucket_usecase::DefaultBucketUsecase;
 use crate::app::storage_compat::{
+    ECStore, Endpoint, EndpointServerPools, Endpoints, GLOBAL_TierConfigMgr, PoolEndpoints,
     bucket::metadata::{BUCKET_LIFECYCLE_CONFIG, OBJECT_LOCK_CONFIG},
     bucket::metadata_sys,
     client::object_api_utils::to_s3s_etag,
     client::transition_api::{ReadCloser, ReaderImpl},
-    disk::endpoint::Endpoint,
-    endpoints::{EndpointServerPools, Endpoints, PoolEndpoints},
-    global::GLOBAL_TierConfigMgr,
-    store::ECStore,
     tier::{
         tier_config::{TierConfig, TierType},
         warm_backend::{WarmBackend, WarmBackendGetOpts},
@@ -113,7 +110,7 @@ async fn setup_test_env() -> (Vec<PathBuf>, Arc<ECStore>) {
 
     let endpoint_pools = EndpointServerPools(vec![pool_endpoints]);
 
-    crate::app::storage_compat::store::init_local_disks(endpoint_pools.clone())
+    crate::app::storage_compat::init_local_disks(endpoint_pools.clone())
         .await
         .unwrap();
 

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -16,6 +16,7 @@
 
 use crate::app::context::{AppContext, get_global_app_context, resolve_object_store_handle_for_context};
 use crate::app::object_usecase::{build_put_like_object_lock_metadata, validate_existing_object_lock_for_write};
+use crate::app::storage_compat::ECStore;
 use crate::app::storage_compat::bucket::quota::checker::QuotaChecker;
 use crate::app::storage_compat::bucket::{
     lifecycle::{bucket_lifecycle_audit::LcEventSrc, bucket_lifecycle_ops::enqueue_transition_immediate},
@@ -26,12 +27,11 @@ use crate::app::storage_compat::bucket::{
 };
 use crate::app::storage_compat::client::object_api_utils::to_s3s_etag;
 use crate::app::storage_compat::compress::is_disk_compressible;
-use crate::app::storage_compat::error::{StorageError, is_err_object_not_found, is_err_version_not_found};
+use crate::app::storage_compat::is_valid_storage_class;
 #[cfg(test)]
 use crate::app::storage_compat::rio::{DecryptReader, EncryptReader, HardLimitReader, boxed_reader, wrap_reader};
 use crate::app::storage_compat::rio::{HashReader, WritePlan};
-use crate::app::storage_compat::set_disk::is_valid_storage_class;
-use crate::app::storage_compat::store::ECStore;
+use crate::app::storage_compat::{StorageError, is_err_object_not_found, is_err_version_not_found};
 use crate::capacity::record_capacity_write;
 use crate::error::ApiError;
 use crate::storage::access::has_bypass_governance_header;
@@ -479,7 +479,7 @@ impl DefaultMultipartUsecase {
                         ));
                     }
                     // Update quota tracking after successful multipart upload
-                    crate::app::storage_compat::data_usage::record_bucket_object_write_memory(
+                    crate::app::storage_compat::record_bucket_object_write_memory(
                         &bucket,
                         previous_current_size,
                         obj_info.size.max(0) as u64,

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -48,6 +48,7 @@ use metrics::{counter, histogram};
 use pin_project_lite::pin_project;
 use rustfs_object_capacity::capacity_manager::get_capacity_manager;
 // Performance metrics recording (with zero-copy-metrics integration)
+use crate::app::storage_compat::ECStore;
 use crate::app::storage_compat::bucket::quota::checker::QuotaChecker;
 use crate::app::storage_compat::bucket::{
     lifecycle::{
@@ -73,12 +74,11 @@ use crate::app::storage_compat::client::object_api_utils::to_s3s_etag;
 use crate::app::storage_compat::compress::{MIN_DISK_COMPRESSIBLE_SIZE, is_disk_compressible};
 use crate::app::storage_compat::config::storageclass;
 use crate::app::storage_compat::disk::{error::DiskError, error_reduce::is_all_buckets_not_found};
-use crate::app::storage_compat::error::{
+use crate::app::storage_compat::rio::{DynReader, HashReader, WritePlan, wrap_reader};
+use crate::app::storage_compat::{
     Error as EcstoreError, StorageError, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
 };
-use crate::app::storage_compat::rio::{DynReader, HashReader, WritePlan, wrap_reader};
-use crate::app::storage_compat::set_disk::{get_lock_acquire_timeout, is_valid_storage_class};
-use crate::app::storage_compat::store::ECStore;
+use crate::app::storage_compat::{get_lock_acquire_timeout, is_valid_storage_class};
 use rustfs_concurrency::GetObjectQueueSnapshot;
 use rustfs_filemeta::{
     REPLICATE_INCOMING_DELETE, ReplicateDecision, ReplicateTargetDecision, ReplicationState, ReplicationStatusType,
@@ -1539,7 +1539,7 @@ impl DefaultObjectUsecase {
     #[allow(clippy::too_many_arguments)]
     async fn prepare_get_object_read(
         req: &S3Request<GetObjectInput>,
-        store: &crate::app::storage_compat::store::ECStore,
+        store: &crate::app::storage_compat::ECStore,
         manager: &ConcurrencyManager,
         bucket: &str,
         key: &str,
@@ -2340,7 +2340,7 @@ impl DefaultObjectUsecase {
         maybe_enqueue_transition_immediate(&obj_info, LcEventSrc::S3PutObject).await;
 
         // Fast in-memory update for immediate quota and admin usage consistency
-        crate::app::storage_compat::data_usage::record_bucket_object_write_memory(
+        crate::app::storage_compat::record_bucket_object_write_memory(
             &bucket,
             previous_current_size,
             obj_info.size.max(0) as u64,
@@ -3303,12 +3303,8 @@ impl DefaultObjectUsecase {
 
         // Update quota tracking after successful copy
         if has_bucket_metadata {
-            crate::app::storage_compat::data_usage::record_bucket_object_write_memory(
-                &bucket,
-                previous_current_size,
-                oi.size.max(0) as u64,
-            )
-            .await;
+            crate::app::storage_compat::record_bucket_object_write_memory(&bucket, previous_current_size, oi.size.max(0) as u64)
+                .await;
         }
 
         let raw_dest_version = oi.version_id.map(|v| v.to_string());
@@ -3585,7 +3581,7 @@ impl DefaultObjectUsecase {
                     );
                 }
                 let size = object_sizes[i].max(0) as u64;
-                crate::app::storage_compat::data_usage::record_bucket_object_delete_memory(
+                crate::app::storage_compat::record_bucket_object_delete_memory(
                     &bucket,
                     size,
                     existing_object_infos[i].is_some() && object_to_delete[i].version_id.is_none(),
@@ -3823,7 +3819,7 @@ impl DefaultObjectUsecase {
         }
 
         // Fast in-memory update for immediate quota and admin usage consistency
-        crate::app::storage_compat::data_usage::record_bucket_object_delete_memory(
+        crate::app::storage_compat::record_bucket_object_delete_memory(
             &bucket,
             obj_info.size.max(0) as u64,
             opts.version_id.is_none(),

--- a/rustfs/src/app/storage_compat.rs
+++ b/rustfs/src/app/storage_compat.rs
@@ -12,11 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore::global::{new_object_layer_fn, set_object_store_resolver};
-
-pub(crate) mod admin_server_info {
-    pub(crate) use rustfs_ecstore::admin_server_info::get_server_info;
-}
+pub(crate) use rustfs_ecstore::admin_server_info::get_server_info;
+pub(crate) use rustfs_ecstore::data_usage::{
+    apply_bucket_usage_memory_overlay, load_data_usage_from_backend, record_bucket_object_delete_memory,
+    record_bucket_object_write_memory,
+};
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::disk::endpoint::Endpoint;
+pub(crate) use rustfs_ecstore::endpoints::EndpointServerPools;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::endpoints::{Endpoints, PoolEndpoints};
+pub(crate) use rustfs_ecstore::error::{
+    Error, StorageError, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
+};
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::global::GLOBAL_TierConfigMgr;
+pub(crate) use rustfs_ecstore::global::{
+    get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr, new_object_layer_fn, set_object_store_resolver,
+};
+pub(crate) use rustfs_ecstore::notification_sys::get_global_notification_sys;
+pub(crate) use rustfs_ecstore::pools::{
+    PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
+};
+pub(crate) use rustfs_ecstore::set_disk::{get_lock_acquire_timeout, is_valid_storage_class};
+pub(crate) use rustfs_ecstore::store::ECStore;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::store::init_local_disks;
 
 pub(crate) mod bucket {
     pub(crate) use rustfs_ecstore::bucket::{
@@ -39,45 +60,8 @@ pub(crate) mod config {
     pub(crate) use rustfs_ecstore::config::storageclass;
 }
 
-pub(crate) mod data_usage {
-    pub(crate) use rustfs_ecstore::data_usage::{
-        apply_bucket_usage_memory_overlay, load_data_usage_from_backend, record_bucket_object_delete_memory,
-        record_bucket_object_write_memory,
-    };
-}
-
 pub(crate) mod disk {
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::disk::endpoint;
     pub(crate) use rustfs_ecstore::disk::{error, error_reduce};
-}
-
-pub(crate) mod endpoints {
-    pub(crate) use rustfs_ecstore::endpoints::EndpointServerPools;
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::endpoints::{Endpoints, PoolEndpoints};
-}
-
-pub(crate) mod error {
-    pub(crate) use rustfs_ecstore::error::{
-        Error, StorageError, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
-    };
-}
-
-pub(crate) mod global {
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::global::GLOBAL_TierConfigMgr;
-    pub(crate) use rustfs_ecstore::global::{get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr};
-}
-
-pub(crate) mod notification_sys {
-    pub(crate) use rustfs_ecstore::notification_sys::get_global_notification_sys;
-}
-
-pub(crate) mod pools {
-    pub(crate) use rustfs_ecstore::pools::{
-        PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
-    };
 }
 
 pub(crate) mod rio {
@@ -86,16 +70,6 @@ pub(crate) mod rio {
     pub(crate) use rustfs_ecstore::rio::{
         DynReader, HashReader, WriteEncryption, WritePlan, compression_metadata_value, wrap_reader,
     };
-}
-
-pub(crate) mod set_disk {
-    pub(crate) use rustfs_ecstore::set_disk::{get_lock_acquire_timeout, is_valid_storage_class};
-}
-
-pub(crate) mod store {
-    pub(crate) use rustfs_ecstore::store::ECStore;
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::store::init_local_disks;
 }
 
 pub(crate) mod tier {

--- a/rustfs/src/capacity/service.rs
+++ b/rustfs/src/capacity/service.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage_compat::disk::DiskAPI;
+use crate::storage_compat::DiskAPI;
 use rustfs_io_metrics::capacity_metrics::{
     record_capacity_cache_hit, record_capacity_cache_miss, record_capacity_cache_served, record_capacity_refresh_request,
     record_capacity_scan_mode,
@@ -263,7 +263,7 @@ pub async fn init_capacity_management_for_local_disks() {
         "Capacity manager state changed"
     );
 
-    let disks = crate::storage_compat::store::all_local_disk().await;
+    let disks = crate::storage_compat::all_local_disk().await;
     if disks.is_empty() {
         warn!(
             component = LOG_COMPONENT_CAPACITY,

--- a/rustfs/src/config/config_test.rs
+++ b/rustfs/src/config/config_test.rs
@@ -16,7 +16,7 @@
 #[allow(unsafe_op_in_unsafe_fn)]
 mod tests {
     use crate::config::{CommandResult, Config, Opt, TlsCommands};
-    use crate::storage_compat::disks_layout::DisksLayout;
+    use crate::storage_compat::DisksLayout;
     use rustfs_config::{DEFAULT_CONSOLE_ADDRESS, DEFAULT_CONSOLE_ENABLE, DEFAULT_OBS_ENDPOINT, RUSTFS_REGION};
     use rustfs_credentials::{DEFAULT_ACCESS_KEY, DEFAULT_SECRET_KEY};
     use serial_test::serial;
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_volumes_and_disk_layout_parsing() {
-        use crate::storage_compat::disks_layout::DisksLayout;
+        use crate::storage_compat::DisksLayout;
 
         // Test case 1: Single volume path
         let args = vec!["rustfs", "/data/vol1"];

--- a/rustfs/src/embedded.rs
+++ b/rustfs/src/embedded.rs
@@ -51,20 +51,15 @@ use crate::init::{add_bucket_notification_configuration, init_buffer_profile_sys
 use crate::server::{ShutdownHandle, shutdown_event_notifier, start_http_server, stop_audit_system};
 use crate::startup_fs_guard::enforce_unsupported_fs_policy;
 use crate::startup_iam::{bootstrap_or_defer_iam_init, publish_ready_for_iam_bootstrap};
-use crate::storage_compat::store::init_lock_clients;
+use crate::storage_compat::init_lock_clients;
 use crate::storage_compat::{
+    ECStore, EndpointServerPools,
     bucket::replication::init_background_replication,
     bucket::{
         metadata_sys::init_bucket_metadata_sys,
         migration::{try_migrate_bucket_metadata, try_migrate_iam_config},
     },
-    config as ecconfig,
-    endpoints::EndpointServerPools,
-    global::set_global_rustfs_port,
-    set_global_endpoints,
-    store::ECStore,
-    store::init_local_disks,
-    update_erasure_type,
+    config as ecconfig, init_local_disks, set_global_endpoints, set_global_rustfs_port, update_erasure_type,
 };
 use rustfs_common::{GlobalReadiness, SystemStage, set_global_addr};
 use rustfs_credentials::init_global_action_credentials;
@@ -333,7 +328,7 @@ impl RustFSServerBuilder {
             let region = region_str
                 .parse()
                 .map_err(|e| ServerError::Init(format!("invalid region '{region_str}': {e}")))?;
-            crate::storage_compat::global::set_global_region(region);
+            crate::storage_compat::set_global_region(region);
         }
 
         let server_port = server_addr.port();

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::storage_compat::StorageError;
 use crate::storage_compat::bucket::quota::QuotaError;
-use crate::storage_compat::error::StorageError;
 use rustfs_storage_api::HTTPRangeError;
 use s3s::{S3Error, S3ErrorCode};
 

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -157,7 +157,7 @@ fn arn_to_target_id(arn_str: &str) -> Result<rustfs_targets::arn::TargetID, Targ
 /// * `buckets` - A vector of bucket names to process
 #[instrument(skip_all)]
 pub async fn add_bucket_notification_configuration(buckets: Vec<String>) {
-    let global_region = crate::storage_compat::global::get_global_region();
+    let global_region = crate::storage_compat::get_global_region();
     let region = global_region
         .as_ref()
         .filter(|r| !r.as_str().is_empty())

--- a/rustfs/src/server/event.rs
+++ b/rustfs/src/server/event.rs
@@ -14,7 +14,7 @@
 
 use super::{module_switch::resolve_notify_module_state, refresh_persisted_module_switches_from_store};
 use crate::app::context::resolve_server_config;
-use crate::storage_compat::event_notification::{EventArgs as EcstoreEventArgs, register_event_dispatch_hook};
+use crate::storage_compat::{EcstoreEventArgs, register_event_dispatch_hook};
 use rustfs_notify::EventArgs as NotifyEventArgs;
 use rustfs_s3_types::EventName;
 use std::net::SocketAddr;

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -33,7 +33,7 @@ use crate::server::{
 use crate::storage;
 use crate::storage::rpc::InternodeRpcService;
 use crate::storage::tonic_service::make_server;
-use crate::storage_compat::rpc::{TONIC_RPC_PREFIX, verify_rpc_signature};
+use crate::storage_compat::{TONIC_RPC_PREFIX, verify_rpc_signature};
 use bytes::Bytes;
 use http::{HeaderMap, Method, Request as HttpRequest, Response};
 use hyper_util::{

--- a/rustfs/src/server/module_switch.rs
+++ b/rustfs/src/server/module_switch.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::storage_compat::{
+    EcstoreError as StorageError,
     config::com::{read_config, save_config},
-    error::Error as StorageError,
     resolve_object_store_handle,
 };
 use serde::{Deserialize, Serialize};

--- a/rustfs/src/server/readiness.rs
+++ b/rustfs/src/server/readiness.rs
@@ -14,9 +14,9 @@
 
 use crate::server::{ServiceState, ServiceStateManager};
 use crate::server::{has_path_prefix, is_table_catalog_path};
-use crate::storage_compat::global::is_dist_erasure;
-use crate::storage_compat::global::{get_global_endpoints_opt, get_global_lock_clients};
+use crate::storage_compat::is_dist_erasure;
 use crate::storage_compat::resolve_object_store_handle;
+use crate::storage_compat::{get_global_endpoints_opt, get_global_lock_clients};
 use bytes::Bytes;
 use http::{Request as HttpRequest, Response, StatusCode};
 use http_body::Body;
@@ -496,13 +496,10 @@ async fn collect_storage_readiness_uncached() -> bool {
     }
 }
 
-fn set_lock_quorum_status(
-    online_hosts: &HashSet<String>,
-    set_endpoints: &[crate::storage_compat::disk::endpoint::Endpoint],
-) -> LockQuorumStatus {
+fn set_lock_quorum_status(online_hosts: &HashSet<String>, set_endpoints: &[crate::storage_compat::Endpoint]) -> LockQuorumStatus {
     let total_clients = set_endpoints
         .iter()
-        .map(crate::storage_compat::disk::endpoint::Endpoint::host_port)
+        .map(crate::storage_compat::Endpoint::host_port)
         .filter(|host| !host.is_empty())
         .collect::<HashSet<_>>();
     let total_clients_len = total_clients.len();
@@ -526,7 +523,7 @@ fn set_lock_quorum_status(
 }
 
 fn aggregate_lock_quorum_status(
-    pool_endpoints: &crate::storage_compat::endpoints::EndpointServerPools,
+    pool_endpoints: &crate::storage_compat::EndpointServerPools,
     online_hosts: &HashSet<String>,
 ) -> LockQuorumStatus {
     let mut connected_clients = 0usize;
@@ -842,8 +839,8 @@ mod tests {
 
     #[test]
     fn aggregate_lock_quorum_status_requires_each_set_to_meet_quorum() {
-        use crate::storage_compat::disk::endpoint::Endpoint;
-        use crate::storage_compat::endpoints::{EndpointServerPools, Endpoints, PoolEndpoints};
+        use crate::storage_compat::Endpoint;
+        use crate::storage_compat::{EndpointServerPools, Endpoints, PoolEndpoints};
 
         let endpoints = vec![
             Endpoint {
@@ -900,8 +897,8 @@ mod tests {
 
     #[test]
     fn aggregate_lock_quorum_status_fails_when_any_set_loses_quorum() {
-        use crate::storage_compat::disk::endpoint::Endpoint;
-        use crate::storage_compat::endpoints::{EndpointServerPools, Endpoints, PoolEndpoints};
+        use crate::storage_compat::Endpoint;
+        use crate::storage_compat::{EndpointServerPools, Endpoints, PoolEndpoints};
 
         let endpoints = vec![
             Endpoint {

--- a/rustfs/src/startup_fs_guard.rs
+++ b/rustfs/src/startup_fs_guard.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage_compat::endpoints::EndpointServerPools;
+use crate::storage_compat::EndpointServerPools;
 use rustfs_config::{
     DEFAULT_RUSTFS_UNSUPPORTED_FS_POLICY, ENV_RUSTFS_UNSUPPORTED_FS_POLICY, RUSTFS_UNSUPPORTED_FS_POLICY_FAIL,
     RUSTFS_UNSUPPORTED_FS_POLICY_WARN,

--- a/rustfs/src/startup_iam.rs
+++ b/rustfs/src/startup_iam.rs
@@ -14,7 +14,7 @@
 
 use crate::app::context::{AppContext, get_global_app_context, init_global_app_context};
 use crate::server::{ServiceStateManager, publish_ready_when_runtime_ready};
-use crate::storage_compat::store::ECStore;
+use crate::storage_compat::ECStore;
 use rustfs_common::{GlobalReadiness, SystemStage};
 use rustfs_iam::init_iam_sys;
 use rustfs_kms::KmsServiceManager;

--- a/rustfs/src/startup_server.rs
+++ b/rustfs/src/startup_server.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage_compat::global::set_global_rustfs_port;
+use crate::storage_compat::set_global_rustfs_port;
 use crate::{
     capacity::capacity_integration::init_capacity_management,
     config::Config,
@@ -57,7 +57,7 @@ pub async fn init_startup_listen_context(config: &Config) -> Result<StartupListe
     if let Some(region_str) = &config.region {
         region_str
             .parse::<s3s::region::Region>()
-            .map(crate::storage_compat::global::set_global_region)
+            .map(crate::storage_compat::set_global_region)
             .map_err(|err| Error::other(format!("invalid region '{}': {}", region_str, err)))?;
     }
 

--- a/rustfs/src/startup_services.rs
+++ b/rustfs/src/startup_services.rs
@@ -13,15 +13,13 @@
 // limitations under the License.
 
 use crate::storage_compat::{
+    ECStore, EndpointServerPools,
     bucket::{
         metadata_sys::init_bucket_metadata_sys,
         migration::{try_migrate_bucket_metadata, try_migrate_iam_config},
         replication::get_global_replication_pool,
     },
-    endpoints::EndpointServerPools,
-    global::shutdown_background_services,
-    notification_sys::new_global_notification_sys,
-    store::ECStore,
+    new_global_notification_sys, shutdown_background_services,
 };
 use crate::{
     config::Config,
@@ -597,14 +595,14 @@ where
     start_audit().await
 }
 
-pub async fn init_notification_system(endpoint_pools: EndpointServerPools) -> crate::storage_compat::error::Result<()> {
+pub async fn init_notification_system(endpoint_pools: EndpointServerPools) -> crate::storage_compat::EcstoreResult<()> {
     init_notification_system_with(|| new_global_notification_sys(endpoint_pools)).await
 }
 
-async fn init_notification_system_with<InitFn, InitFuture>(init_notification: InitFn) -> crate::storage_compat::error::Result<()>
+async fn init_notification_system_with<InitFn, InitFuture>(init_notification: InitFn) -> crate::storage_compat::EcstoreResult<()>
 where
     InitFn: FnOnce() -> InitFuture,
-    InitFuture: Future<Output = crate::storage_compat::error::Result<()>>,
+    InitFuture: Future<Output = crate::storage_compat::EcstoreResult<()>>,
 {
     init_notification().await
 }
@@ -662,7 +660,7 @@ mod tests {
 
     #[tokio::test]
     async fn notification_system_returns_source_error() {
-        let result = init_notification_system_with(|| async { Err(crate::storage_compat::error::Error::FaultyDisk) }).await;
+        let result = init_notification_system_with(|| async { Err(crate::storage_compat::EcstoreError::FaultyDisk) }).await;
 
         assert!(result.is_err());
     }

--- a/rustfs/src/startup_storage.rs
+++ b/rustfs/src/startup_storage.rs
@@ -14,12 +14,8 @@
 
 use crate::startup_fs_guard::enforce_unsupported_fs_policy;
 use crate::storage_compat::{
-    bucket::replication::init_background_replication,
-    config as ecconfig,
-    endpoints::EndpointServerPools,
-    set_global_endpoints,
-    store::{ECStore, init_local_disks, init_lock_clients, prewarm_local_disk_id_map},
-    update_erasure_type,
+    ECStore, EndpointServerPools, bucket::replication::init_background_replication, config as ecconfig, init_local_disks,
+    init_lock_clients, prewarm_local_disk_id_map, set_global_endpoints, update_erasure_type,
 };
 use rustfs_common::{GlobalReadiness, SystemStage};
 use std::{

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -18,11 +18,11 @@ use crate::error::ApiError;
 use crate::license::license_check;
 use crate::server::RemoteAddr;
 use crate::storage::request_context::RequestContext;
+use crate::storage::storage_compat::ECStore;
 use crate::storage::storage_compat::bucket::metadata_sys;
 use crate::storage::storage_compat::bucket::policy_sys::PolicySys;
-use crate::storage::storage_compat::error::{StorageError, is_err_bucket_not_found};
 use crate::storage::storage_compat::resolve_object_store_handle;
-use crate::storage::storage_compat::store::ECStore;
+use crate::storage::storage_compat::{StorageError, is_err_bucket_not_found};
 use metrics::counter;
 use rustfs_iam::error::Error as IamError;
 use rustfs_policy::policy::action::{Action, AdminAction, S3Action};
@@ -930,7 +930,7 @@ impl S3Access for FS {
         let req_info = ReqInfo {
             cred,
             is_owner,
-            region: crate::storage::storage_compat::global::get_global_region(),
+            region: crate::storage::storage_compat::get_global_region(),
             request_context,
             ..Default::default()
         };

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -22,6 +22,7 @@ use crate::storage::helper::OperationHelper;
 use crate::storage::options::get_opts;
 use crate::storage::s3_api::acl;
 use crate::storage::storage_compat::{
+    StorageError,
     bucket::{
         metadata::{
             BUCKET_ACCELERATE_CONFIG, BUCKET_LOGGING_CONFIG, BUCKET_REQUEST_PAYMENT_CONFIG, BUCKET_VERSIONING_CONFIG,
@@ -35,7 +36,7 @@ use crate::storage::storage_compat::{
         versioning::VersioningApi,
         versioning_sys::BucketVersioningSys,
     },
-    error::{StorageError, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found},
+    is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
 };
 use crate::storage::{parse_object_lock_legal_hold, parse_object_lock_retention, validate_bucket_object_lock_enabled};
 use crate::table_catalog;

--- a/rustfs/src/storage/ecfs_extend.rs
+++ b/rustfs/src/storage/ecfs_extend.rs
@@ -16,11 +16,11 @@ use crate::config::{RustFSBufferConfig, WorkloadProfile, get_global_buffer_confi
 use crate::error::ApiError;
 use crate::server::cors;
 use crate::storage::ecfs::ListObjectUnorderedQuery;
+use crate::storage::storage_compat::StorageError;
 use crate::storage::storage_compat::bucket::metadata_sys;
 use crate::storage::storage_compat::bucket::metadata_sys::get_replication_config;
 use crate::storage::storage_compat::bucket::object_lock::objectlock_sys;
 use crate::storage::storage_compat::bucket::replication::ReplicationConfigurationExt;
-use crate::storage::storage_compat::error::StorageError;
 use crate::storage::storage_compat::resolve_object_store_handle;
 use http::header::{IF_MATCH, IF_MODIFIED_SINCE, IF_NONE_MATCH, IF_UNMODIFIED_SINCE};
 use http::{HeaderMap, HeaderValue, StatusCode};
@@ -739,7 +739,7 @@ pub(crate) async fn has_replication_rules(bucket: &str, objects: &[ObjectToDelet
 }
 
 /// Helper function to get store and validate bucket exists
-pub(crate) async fn get_validated_store(bucket: &str) -> S3Result<Arc<crate::storage::storage_compat::store::ECStore>> {
+pub(crate) async fn get_validated_store(bucket: &str) -> S3Result<Arc<crate::storage::storage_compat::ECStore>> {
     let Some(store) = resolve_object_store_handle() else {
         return Err(S3Error::with_message(S3ErrorCode::InternalError, "Not init".to_string()));
     };

--- a/rustfs/src/storage/ecfs_test.rs
+++ b/rustfs/src/storage/ecfs_test.rs
@@ -18,8 +18,8 @@ mod tests {
     use crate::server::cors;
     use crate::storage::ecfs::{FS, validate_object_lock_configuration_input};
     use crate::storage::s3_api::common::{rustfs_initiator, rustfs_owner};
+    use crate::storage::storage_compat::DEFAULT_READ_BUFFER_SIZE;
     use crate::storage::storage_compat::bucket::{metadata::BucketMetadata, metadata_sys};
-    use crate::storage::storage_compat::set_disk::DEFAULT_READ_BUFFER_SIZE;
     use crate::storage::{
         StorageObjectInfo as ObjectInfo, apply_cors_headers, apply_default_lock_retention_metadata, check_preconditions,
         get_adaptive_buffer_size_with_profile, get_buffer_size_opt_in, is_etag_equal, matches_origin_pattern, parse_etag,

--- a/rustfs/src/storage/head_prefix.rs
+++ b/rustfs/src/storage/head_prefix.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage::storage_compat::store::ECStore;
+use crate::storage::storage_compat::ECStore;
 use rustfs_storage_api::ListOperations as _;
 use std::sync::Arc;
 

--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::storage::storage_compat::Result;
+use crate::storage::storage_compat::StorageError;
 use crate::storage::storage_compat::bucket::versioning_sys::BucketVersioningSys;
-use crate::storage::storage_compat::error::Result;
-use crate::storage::storage_compat::error::StorageError;
 use http::header::{IF_MATCH, IF_NONE_MATCH};
 use http::{HeaderMap, HeaderValue};
 use rustfs_utils::http::{

--- a/rustfs/src/storage/rpc/http_service.rs
+++ b/rustfs/src/storage/rpc/http_service.rs
@@ -14,10 +14,10 @@
 
 use crate::server::RPC_PREFIX;
 use crate::storage::request_context::spawn_traced;
-use crate::storage::storage_compat::disk::{DiskAPI, WalkDirOptions};
-use crate::storage::storage_compat::rpc::verify_rpc_signature;
-use crate::storage::storage_compat::set_disk::DEFAULT_READ_BUFFER_SIZE;
-use crate::storage::storage_compat::store::find_local_disk_by_ref;
+use crate::storage::storage_compat::DEFAULT_READ_BUFFER_SIZE;
+use crate::storage::storage_compat::find_local_disk_by_ref;
+use crate::storage::storage_compat::verify_rpc_signature;
+use crate::storage::storage_compat::{DiskAPI, WalkDirOptions};
 use bytes::{Bytes, BytesMut};
 use futures_util::TryStreamExt;
 use http::{HeaderMap, Method, Request, Response, StatusCode, Uri};

--- a/rustfs/src/storage/rpc/node_service.rs
+++ b/rustfs/src/storage/rpc/node_service.rs
@@ -17,21 +17,12 @@ use crate::admin::service::{
     site_replication::reload_site_replication_runtime_state,
 };
 use crate::storage::storage_compat::{
-    admin_server_info::get_local_server_property,
+    CollectMetricsOpts, DeleteOptions, DiskAPI, DiskError, DiskInfoOptions, DiskStore, FileInfoVersions, GLOBAL_TierConfigMgr,
+    LocalPeerS3Client, MetricType, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerS3Client, ReadMultipleReq, ReadMultipleResp,
+    ReadOptions, SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC, UpdateMetadataOpts, all_local_disk_path,
     bucket::{metadata::load_bucket_metadata, metadata_sys},
-    disk::{
-        DeleteOptions, DiskAPI, DiskInfoOptions, DiskStore, FileInfoVersions, ReadMultipleReq, ReadMultipleResp, ReadOptions,
-        UpdateMetadataOpts, error::DiskError,
-    },
-    get_global_lock_client,
-    global::GLOBAL_TierConfigMgr,
-    metrics_realtime::{CollectMetricsOpts, MetricType, collect_local_metrics},
+    collect_local_metrics, find_local_disk_by_ref, get_global_lock_client, get_local_server_property,
     resolve_object_store_handle,
-    rpc::{
-        LocalPeerS3Client, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerS3Client, SERVICE_SIGNAL_REFRESH_CONFIG,
-        SERVICE_SIGNAL_RELOAD_DYNAMIC,
-    },
-    store::{all_local_disk_path, find_local_disk_by_ref},
 };
 use bytes::Bytes;
 use futures::Stream;
@@ -132,7 +123,7 @@ fn unimplemented_rpc(method: &str) -> Status {
     Status::unimplemented(format!("{method} is not implemented"))
 }
 
-fn background_rebalance_start_error_message(result: crate::storage::storage_compat::error::Result<()>) -> Option<String> {
+fn background_rebalance_start_error_message(result: crate::storage::storage_compat::Result<()>) -> Option<String> {
     result.err().map(|err| format!("start_rebalance failed: {err}"))
 }
 
@@ -2376,7 +2367,7 @@ mod tests {
 
     #[test]
     fn test_background_rebalance_start_error_message_formats_error() {
-        let message = background_rebalance_start_error_message(Err(crate::storage::storage_compat::error::Error::other("boom")))
+        let message = background_rebalance_start_error_message(Err(crate::storage::storage_compat::Error::other("boom")))
             .expect("background rebalance start failure should be formatted");
 
         assert!(message.contains("start_rebalance failed"));

--- a/rustfs/src/storage/sse.rs
+++ b/rustfs/src/storage/sse.rs
@@ -69,7 +69,7 @@
 //! }
 //! ```
 
-use crate::storage::storage_compat::error::StorageError;
+use crate::storage::storage_compat::StorageError;
 use aes_gcm::{
     Aes256Gcm, Key, Nonce,
     aead::{Aead, KeyInit},
@@ -128,8 +128,8 @@ const SEALED_KEY_SIZE: usize = DARE_HEADER_SIZE + 32 + DARE_TAG_SIZE;
 const OBJECT_KEY_DERIVATION_CONTEXT: &[u8] = b"object-encryption-key generation";
 
 use crate::error::ApiError;
+use crate::storage::storage_compat::Error;
 use crate::storage::storage_compat::bucket::metadata_sys;
-use crate::storage::storage_compat::error::Error;
 use rustfs_utils::http::headers::{
     AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM, AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY,
     AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5, AMZ_SERVER_SIDE_ENCRYPTION_KMS_CONTEXT,
@@ -745,19 +745,19 @@ pub struct ManagedSealedKey {
 }
 
 impl EncryptionMaterial {
-    pub fn write_encryption(&self, multipart_part_number: Option<usize>) -> crate::storage::storage_compat::rio::WriteEncryption {
+    pub fn write_encryption(&self, multipart_part_number: Option<usize>) -> crate::storage::storage_compat::WriteEncryption {
         match (self.key_kind, multipart_part_number) {
             (EncryptionKeyKind::Object, Some(part_number)) => {
-                crate::storage::storage_compat::rio::WriteEncryption::multipart_object_key(self.key_bytes, part_number as u32)
+                crate::storage::storage_compat::WriteEncryption::multipart_object_key(self.key_bytes, part_number as u32)
             }
             (EncryptionKeyKind::Object, None) => {
-                crate::storage::storage_compat::rio::WriteEncryption::singlepart_object_key(self.key_bytes)
+                crate::storage::storage_compat::WriteEncryption::singlepart_object_key(self.key_bytes)
             }
             (EncryptionKeyKind::Direct, Some(part_number)) => {
-                crate::storage::storage_compat::rio::WriteEncryption::multipart(self.key_bytes, self.base_nonce, part_number)
+                crate::storage::storage_compat::WriteEncryption::multipart(self.key_bytes, self.base_nonce, part_number)
             }
             (EncryptionKeyKind::Direct, None) => {
-                crate::storage::storage_compat::rio::WriteEncryption::singlepart(self.key_bytes, self.base_nonce)
+                crate::storage::storage_compat::WriteEncryption::singlepart(self.key_bytes, self.base_nonce)
             }
         }
     }

--- a/rustfs/src/storage/storage_compat.rs
+++ b/rustfs/src/storage/storage_compat.rs
@@ -12,11 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore::global::{get_global_lock_client, resolve_object_store_handle};
-
-pub(crate) mod admin_server_info {
-    pub(crate) use rustfs_ecstore::admin_server_info::get_local_server_property;
-}
+pub(crate) use rustfs_ecstore::admin_server_info::get_local_server_property;
+pub(crate) use rustfs_ecstore::disk::error::DiskError;
+pub(crate) use rustfs_ecstore::disk::{
+    DeleteOptions, DiskAPI, DiskInfoOptions, DiskStore, FileInfoVersions, ReadMultipleReq, ReadMultipleResp, ReadOptions,
+    UpdateMetadataOpts, WalkDirOptions,
+};
+pub(crate) use rustfs_ecstore::error::{
+    Error, Result, StorageError, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
+};
+pub(crate) use rustfs_ecstore::global::{
+    GLOBAL_TierConfigMgr, get_global_lock_client, get_global_region, resolve_object_store_handle,
+};
+pub(crate) use rustfs_ecstore::metrics_realtime::{CollectMetricsOpts, MetricType, collect_local_metrics};
+pub(crate) use rustfs_ecstore::rio::WriteEncryption;
+pub(crate) use rustfs_ecstore::rpc::{
+    LocalPeerS3Client, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerS3Client, SERVICE_SIGNAL_REFRESH_CONFIG,
+    SERVICE_SIGNAL_RELOAD_DYNAMIC, verify_rpc_signature,
+};
+pub(crate) use rustfs_ecstore::set_disk::DEFAULT_READ_BUFFER_SIZE;
+pub(crate) use rustfs_ecstore::store::{ECStore, all_local_disk_path, find_local_disk_by_ref};
 
 pub(crate) mod bucket {
     pub(crate) use rustfs_ecstore::bucket::{
@@ -28,52 +43,12 @@ pub(crate) mod client {
     pub(crate) use rustfs_ecstore::client::object_api_utils;
 }
 
-#[cfg(test)]
-pub(crate) mod config {
-    pub(crate) use rustfs_ecstore::config::com;
-}
-
-pub(crate) mod disk {
-    pub(crate) use rustfs_ecstore::disk::{
-        DeleteOptions, DiskAPI, DiskInfoOptions, DiskStore, FileInfoVersions, ReadMultipleReq, ReadMultipleResp, ReadOptions,
-        UpdateMetadataOpts, WalkDirOptions, error,
-    };
-}
-
-pub(crate) mod error {
-    pub(crate) use rustfs_ecstore::error::{
-        Error, Result, StorageError, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
-    };
-}
-
-pub(crate) mod global {
-    pub(crate) use rustfs_ecstore::global::{GLOBAL_TierConfigMgr, get_global_region};
-}
-
-pub(crate) mod metrics_realtime {
-    pub(crate) use rustfs_ecstore::metrics_realtime::{CollectMetricsOpts, MetricType, collect_local_metrics};
-}
-
-pub(crate) mod rio {
-    pub(crate) use rustfs_ecstore::rio::WriteEncryption;
-}
-
-pub(crate) mod rpc {
-    pub(crate) use rustfs_ecstore::rpc::{
-        LocalPeerS3Client, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerS3Client, SERVICE_SIGNAL_REFRESH_CONFIG,
-        SERVICE_SIGNAL_RELOAD_DYNAMIC, verify_rpc_signature,
-    };
-}
-
-pub(crate) mod set_disk {
-    pub(crate) use rustfs_ecstore::set_disk::DEFAULT_READ_BUFFER_SIZE;
-}
-
-pub(crate) mod store {
-    pub(crate) use rustfs_ecstore::store::{ECStore, all_local_disk_path, find_local_disk_by_ref};
-}
-
 pub(crate) type GetObjectReader = rustfs_ecstore::store_api::GetObjectReader;
 pub(crate) type ObjectInfo = rustfs_ecstore::store_api::ObjectInfo;
 pub(crate) type ObjectOptions = rustfs_ecstore::store_api::ObjectOptions;
 pub(crate) type PutObjReader = rustfs_ecstore::store_api::PutObjReader;
+
+#[cfg(test)]
+pub(crate) mod config {
+    pub(crate) use rustfs_ecstore::config::com;
+}

--- a/rustfs/src/storage_compat.rs
+++ b/rustfs/src/storage_compat.rs
@@ -12,7 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore::global::{resolve_object_store_handle, set_global_endpoints, update_erasure_type};
+pub(crate) use rustfs_ecstore::disk::{DiskAPI, RUSTFS_META_BUCKET, endpoint::Endpoint};
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::disks_layout::DisksLayout;
+pub(crate) use rustfs_ecstore::endpoints::EndpointServerPools;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::endpoints::{Endpoints, PoolEndpoints};
+pub(crate) use rustfs_ecstore::error::{Error as EcstoreError, Result as EcstoreResult, StorageError};
+pub(crate) use rustfs_ecstore::event_notification::{EventArgs as EcstoreEventArgs, register_event_dispatch_hook};
+pub(crate) use rustfs_ecstore::global::{
+    get_global_endpoints_opt, get_global_lock_clients, get_global_region, is_dist_erasure, resolve_object_store_handle,
+    set_global_endpoints, set_global_region, set_global_rustfs_port, shutdown_background_services, update_erasure_type,
+};
+pub(crate) use rustfs_ecstore::notification_sys::new_global_notification_sys;
+pub(crate) use rustfs_ecstore::rpc::{TONIC_RPC_PREFIX, verify_rpc_signature};
+pub(crate) use rustfs_ecstore::set_disk::get_lock_acquire_timeout;
+pub(crate) use rustfs_ecstore::store::{ECStore, all_local_disk, init_local_disks, init_lock_clients, prewarm_local_disk_id_map};
 
 pub(crate) mod bucket {
     pub(crate) use rustfs_ecstore::bucket::{metadata, metadata_sys, migration, quota, replication};
@@ -20,52 +35,4 @@ pub(crate) mod bucket {
 
 pub(crate) mod config {
     pub(crate) use rustfs_ecstore::config::{com, init, init_global_config_sys, try_migrate_server_config};
-}
-
-pub(crate) mod disk {
-    pub(crate) use rustfs_ecstore::disk::{DiskAPI, RUSTFS_META_BUCKET, endpoint};
-}
-
-#[cfg(test)]
-pub(crate) mod disks_layout {
-    pub(crate) use rustfs_ecstore::disks_layout::DisksLayout;
-}
-
-pub(crate) mod endpoints {
-    pub(crate) use rustfs_ecstore::endpoints::EndpointServerPools;
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::endpoints::{Endpoints, PoolEndpoints};
-}
-
-pub(crate) mod error {
-    pub(crate) use rustfs_ecstore::error::{Error, Result, StorageError};
-}
-
-pub(crate) mod event_notification {
-    pub(crate) use rustfs_ecstore::event_notification::{EventArgs, register_event_dispatch_hook};
-}
-
-pub(crate) mod global {
-    pub(crate) use rustfs_ecstore::global::{
-        get_global_endpoints_opt, get_global_lock_clients, get_global_region, is_dist_erasure, set_global_region,
-        set_global_rustfs_port, shutdown_background_services,
-    };
-}
-
-pub(crate) mod notification_sys {
-    pub(crate) use rustfs_ecstore::notification_sys::new_global_notification_sys;
-}
-
-pub(crate) mod rpc {
-    pub(crate) use rustfs_ecstore::rpc::{TONIC_RPC_PREFIX, verify_rpc_signature};
-}
-
-pub(crate) mod set_disk {
-    pub(crate) use rustfs_ecstore::set_disk::get_lock_acquire_timeout;
-}
-
-pub(crate) mod store {
-    pub(crate) use rustfs_ecstore::store::{
-        ECStore, all_local_disk, init_local_disks, init_lock_clients, prewarm_local_disk_id_map,
-    };
 }

--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -27,6 +27,7 @@ use std::{
     time::{Duration as StdDuration, Instant},
 };
 
+use crate::storage_compat::RUSTFS_META_BUCKET;
 use crate::storage_compat::bucket::{
     metadata::{
         BUCKET_TABLE_CATALOG_META_PREFIX, BUCKET_TABLE_CATALOG_TABLE_BUCKETS_PREFIX, BUCKET_TABLE_CONFIG,
@@ -34,9 +35,8 @@ use crate::storage_compat::bucket::{
     },
     metadata_sys,
 };
-use crate::storage_compat::disk::RUSTFS_META_BUCKET;
-use crate::storage_compat::error::{Error as EcstoreError, StorageError};
-use crate::storage_compat::set_disk::get_lock_acquire_timeout;
+use crate::storage_compat::get_lock_acquire_timeout;
+use crate::storage_compat::{EcstoreError, StorageError};
 use bytes::Bytes;
 use datafusion::{
     arrow::datatypes::SchemaRef,
@@ -7813,7 +7813,7 @@ mod tests {
             .map(|(bucket, _)| bucket.as_str())
             .collect::<BTreeSet<_>>();
 
-        assert_eq!(object_buckets, BTreeSet::from([crate::storage_compat::disk::RUSTFS_META_BUCKET]));
+        assert_eq!(object_buckets, BTreeSet::from([crate::storage_compat::RUSTFS_META_BUCKET]));
     }
 
     #[tokio::test]
@@ -10777,7 +10777,7 @@ mod tests {
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         backend
-            .fail_put_attempt(crate::storage_compat::disk::RUSTFS_META_BUCKET, &idempotency_path, 1)
+            .fail_put_attempt(crate::storage_compat::RUSTFS_META_BUCKET, &idempotency_path, 1)
             .await;
 
         let err = store
@@ -10827,7 +10827,7 @@ mod tests {
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         backend
-            .fail_put_attempt(crate::storage_compat::disk::RUSTFS_META_BUCKET, &commit_path, 2)
+            .fail_put_attempt(crate::storage_compat::RUSTFS_META_BUCKET, &commit_path, 2)
             .await;
 
         let request = TableCommitRequest {
@@ -10882,7 +10882,7 @@ mod tests {
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         backend
-            .fail_put_attempt(crate::storage_compat::disk::RUSTFS_META_BUCKET, &commit_path, 2)
+            .fail_put_attempt(crate::storage_compat::RUSTFS_META_BUCKET, &commit_path, 2)
             .await;
 
         let result = store
@@ -10936,7 +10936,7 @@ mod tests {
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         backend
-            .fail_put_attempt(crate::storage_compat::disk::RUSTFS_META_BUCKET, &commit_path, 2)
+            .fail_put_attempt(crate::storage_compat::RUSTFS_META_BUCKET, &commit_path, 2)
             .await;
 
         store
@@ -10990,7 +10990,7 @@ mod tests {
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         backend
-            .fail_put_attempt(crate::storage_compat::disk::RUSTFS_META_BUCKET, &commit_path, 2)
+            .fail_put_attempt(crate::storage_compat::RUSTFS_META_BUCKET, &commit_path, 2)
             .await;
 
         store
@@ -11041,7 +11041,7 @@ mod tests {
         backend.seed_object(bucket, &current_metadata, b"{}".to_vec()).await;
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         backend
-            .fail_put_attempt(crate::storage_compat::disk::RUSTFS_META_BUCKET, &table_path, 2)
+            .fail_put_attempt(crate::storage_compat::RUSTFS_META_BUCKET, &table_path, 2)
             .await;
 
         let err = store
@@ -11098,7 +11098,7 @@ mod tests {
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         backend
-            .fail_put_attempt(crate::storage_compat::disk::RUSTFS_META_BUCKET, &idempotency_path, 2)
+            .fail_put_attempt(crate::storage_compat::RUSTFS_META_BUCKET, &idempotency_path, 2)
             .await;
 
         let result = store

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -67,6 +67,7 @@ STORE_API_OBJECT_OPERATION_LOCAL_METHOD_HITS_FILE="${TMP_DIR}/store_api_object_o
 DIRECT_ECSTORE_IMPORT_HITS_FILE="${TMP_DIR}/direct_ecstore_import_hits.txt"
 TEST_HARNESS_NESTED_STORAGE_COMPAT_HITS_FILE="${TMP_DIR}/test_harness_nested_storage_compat_hits.txt"
 RUSTFS_NESTED_STORAGE_COMPAT_HITS_FILE="${TMP_DIR}/rustfs_nested_storage_compat_hits.txt"
+RUSTFS_RUNTIME_SCALAR_STORAGE_COMPAT_HITS_FILE="${TMP_DIR}/rustfs_runtime_scalar_storage_compat_hits.txt"
 PRODUCTION_UNUSED_COMPAT_ALLOW_HITS_FILE="${TMP_DIR}/production_unused_compat_allow_hits.txt"
 BROAD_STORE_API_COMPAT_REEXPORT_HITS_FILE="${TMP_DIR}/broad_store_api_compat_reexport_hits.txt"
 NESTED_STORE_API_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/nested_store_api_compat_module_hits.txt"
@@ -427,6 +428,18 @@ fi
 
 if [[ -s "$RUSTFS_NESTED_STORAGE_COMPAT_HITS_FILE" ]]; then
   report_failure "RustFS runtime storage compatibility paths must use direct aliases instead of nested ecstore modules: $(paste -sd '; ' "$RUSTFS_NESTED_STORAGE_COMPAT_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading '\bstorage_compat::(?:store|error|global|endpoints|set_disk|rpc|metrics_realtime|notification_sys|admin_server_info|store_utils|data_usage|disks_layout|event_notification)::|\bstorage_compat::disk::(?:RUSTFS_META_BUCKET|DiskAPI|endpoint::Endpoint)\b|\bstorage_compat::\{[^}\n]*(?:store|error|global|endpoints|set_disk|rpc|metrics_realtime|notification_sys|admin_server_info|store_utils|data_usage|disks_layout|event_notification|disk)::' \
+    rustfs/src \
+    --glob '*.rs' \
+    --glob '!target/**' || true
+) >"$RUSTFS_RUNTIME_SCALAR_STORAGE_COMPAT_HITS_FILE"
+
+if [[ -s "$RUSTFS_RUNTIME_SCALAR_STORAGE_COMPAT_HITS_FILE" ]]; then
+  report_failure "RustFS runtime scalar storage compatibility paths must use direct aliases instead of secondary modules: $(paste -sd '; ' "$RUSTFS_RUNTIME_SCALAR_STORAGE_COMPAT_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

- Part of rustfs/backlog#660

## Summary of Changes

- Flatten RustFS runtime scalar storage compatibility facades in `rustfs/src` into direct crate-local aliases and functions.
- Keep higher-coupling bucket, config, and rio compatibility modules unchanged.
- Extend `scripts/check_architecture_migration_rules.sh` to reject restored scalar `storage_compat::*::*` runtime paths.
- Update `docs/architecture/migration-progress.md` for the API-053 slice.

## Verification

- `cargo check -p rustfs --lib`
- `cargo check --tests -p rustfs`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`
- Post-rebase focused compile and guard checks after rebasing onto latest `overtrue/arch-test-harness-compat-aliases`

## Impact

- No runtime behavior change expected.
- Internal facade and import ownership cleanup only.

## Additional Notes

- Stacked on rustfs/rustfs#3596.
