### PR TITLE
docs: add scheduler placement profiling baselines

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,18 +5,15 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-runtime-compat-surface-prune`
-- Baseline: stacked on `rustfs/rustfs#3597` head
-  (`33920e8fff1c62666435be1bc04a4e0dc97b5165`).
-- PR type for this branch: `pure-move`
-- Runtime behavior changes: no migration behavior change expected.
-- Rust code changes: flatten RustFS root, app, admin, and storage runtime
-  scalar compatibility facades from secondary modules into direct aliases and
-  functions.
-- CI/script changes: add migration guards rejecting restored scalar
-  `storage_compat::*::*` paths in RustFS runtime source.
-- Docs changes: record the RustFS runtime scalar compatibility surface cleanup
-  slice.
+- Branch: `overtrue/arch-scheduler-profiling-baselines`
+- Baseline: stacked on `rustfs/rustfs#3599` head
+  (`91767c9b36c19d7bb6c8c5f85ab3b3570242cadb`).
+- PR type for this branch: `docs-only`
+- Runtime behavior changes: none.
+- Rust code changes: none.
+- CI/script changes: none.
+- Docs changes: add scheduler, placement/repair, and profiling/NUMA baseline
+  inventories for `G-011`, `G-012`, and `G-013`.
 
 ## Phase 0 Tasks
 
@@ -64,6 +61,28 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     [`ecstore-config-consumer-inventory.md`](ecstore-config-consumer-inventory.md)
     records the current model definitions, global accessors, persistence helpers,
     consumer groups, migration risks, and do-not-change contract.
+- [x] `G-011` Inventory scheduler baseline.
+  - Acceptance:
+    [`scheduler-baseline.md`](scheduler-baseline.md) records current owners for
+    request admission, reusable scheduler/backpressure facades, workers, scanner
+    budget, heal admission, and the Tokio runtime builder.
+  - Must preserve: no Rust source changes, no scheduler/controller contract
+    changes, and no runtime behavior changes.
+- [x] `G-012` Inventory placement and repair invariants.
+  - Acceptance:
+    [`placement-repair-invariants.md`](placement-repair-invariants.md) records
+    object-to-set hashing, pool/set/disk assignment boundaries, set-aware
+    readiness and lock quorum, scanner budget, and heal admission preservation
+    gates.
+  - Must preserve: no placement, repair, scanner, heal, readiness, lock, or
+    storage metadata behavior changes.
+- [x] `G-013` Inventory profiling and NUMA capabilities.
+  - Acceptance:
+    [`profiling-numa-capability-inventory.md`](profiling-numa-capability-inventory.md)
+    records current CPU/memory profiling, cgroup memory sampling, allocator
+    backend, eBPF, and NUMA capability support plus no-op fallback invariants.
+  - Must preserve: no startup, profiling, allocator, runtime, or platform-gate
+    behavior changes.
 - [x] `TEST-PRTYPE-001` Check PR type enum consistency.
   - Acceptance: `./scripts/check_architecture_migration_rules.sh` parses the
     allowed PR types from [`crate-boundaries.md`](crate-boundaries.md) and fails
@@ -1646,7 +1665,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 ## Next PRs
 
-1. `pure-move`/`consumer-migration`: continue larger cleanup slices with the
+1. `docs-only`/`contract`: use the scheduler, placement/repair, and
+   profiling/NUMA baseline inventories to size the next larger capability or
+   startup-runtime slice.
+2. `pure-move`/`consumer-migration`: continue larger cleanup slices with the
    loss-prevention guards active for remaining ECStore compatibility contracts
    now that broad compatibility passthroughs are fully closed.
 
@@ -1654,13 +1676,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049/API-050/API-051/API-052/API-053/API-054 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, fuzz, lifecycle helper, harness, and RustFS runtime compatibility contracts without moving ECStore storage metadata ownership. |
-| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, lifecycle expiration/transition helper DTO field contracts, flattened harness and RustFS runtime scalar/secondary alias behavior, unchanged no-op handling, and remove-event behavior are preserved. |
-| Testing/verification | passed | Focused compiles/tests, fuzz target compile, guards, formatting, diff hygiene, risk scan, and full `make pre-commit` passed for the current slice. |
+| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049/API-050/API-051/API-052/API-053/API-054 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, fuzz, lifecycle helper, harness, and RustFS runtime compatibility contracts without moving ECStore storage metadata ownership; G-011/G-012/G-013 add docs-only baselines for scheduler, placement/repair, and profiling/NUMA work. |
+| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, lifecycle expiration/transition helper DTO field contracts, flattened harness and RustFS runtime scalar/secondary alias behavior, unchanged no-op handling, remove-event behavior, scheduler/readiness/placement/profiling runtime behavior, and platform gates are preserved. |
+| Testing/verification | passed | Focused compiles/tests, fuzz target compile, guards, formatting, diff hygiene, risk scan, and full `make pre-commit` passed for prior code slices; docs-only G-011/G-012/G-013 uses architecture guard and diff hygiene verification. |
 
 ## Verification Notes
 
 Passed before push:
+
+- G-011/G-012/G-013 current slice:
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `git diff --check`: passed.
+  - Three-expert review: passed.
+  - Full `make pre-commit`: not run because this slice is documentation-only.
 
 - API-054 current slice:
   - `cargo check -p rustfs --lib`: passed.

--- a/docs/architecture/placement-repair-invariants.md
+++ b/docs/architecture/placement-repair-invariants.md
@@ -1,0 +1,97 @@
+# Placement And Repair Invariants
+
+This inventory covers `G-012` for `rustfs/backlog#666`. It records the current
+object placement, readiness, lock quorum, scanner, and repair boundaries that
+later scheduler or topology work must preserve.
+
+## Object To Set Hash Rule
+
+Objects reach a set through `Sets::get_disks_by_key`, which calls
+`get_hashed_set_index` on the object key:
+
+- `DistributionAlgoVersion::V1` uses `crc_hash(input, set_count)`.
+- `DistributionAlgoVersion::V2` and `V3` use
+  `sip_hash(input, set_count, format_id_bytes)`.
+- The format ID is part of the V2/V3 distribution seed, so changing the seed,
+  object key, set count, or algorithm changes placement.
+
+Preservation rule: every object read, write, list, heal, repair, and
+decommission path that resolves a set for an existing object must preserve the
+same object key and format distribution algorithm.
+
+## Pool, Set, And Disk Assignment Boundary
+
+Pool selection is separate from set hashing:
+
+- Existing objects are discovered across pools and resolved to the best current
+  pool candidate before reads or updates continue.
+- New object writes select an available pool from current per-pool free-space
+  inputs after suspended or rebalancing pools are skipped.
+- Set selection inside a pool still uses the object-to-set hash rule above.
+- Disk index assignment comes from endpoint and format metadata, not from a
+  scheduler decision.
+
+Boundary rule: schedulers may influence admission, worker concurrency, or
+buffer sizing, but they must not rewrite pool, set, or disk indexes.
+
+## Readiness And Lock Quorum Boundary
+
+Runtime readiness currently checks storage and lock health independently:
+
+- Storage readiness requires every observed set to meet write quorum based on
+  the set drive count and storage class data/parity shape.
+- Lock readiness aggregates per-set lock-client host quorum and fails fast if
+  any set loses quorum.
+- Object and bucket mutations acquire namespace locks through the existing
+  storage lock wrappers before changing object or bucket state.
+
+Boundary rule: readiness and lock quorum must stay set-aware. A global healthy
+disk count or global connected-host count is not sufficient when any individual
+set is below quorum.
+
+## Scanner Budget Preservation
+
+Scanner cycles are bounded by `ScannerCycleBudget`:
+
+- Runtime budget cancels the child token after the configured duration.
+- Object budget cancels after the configured object count.
+- Directory budget rejects additional directories and cancels with the
+  directories reason.
+- Partial-cycle metrics and checkpoints use the budget reason.
+
+Preservation rule: later scheduler work can change how scan cycles are admitted
+only if it preserves the budget reason, checkpoint reason, and child-token
+cancellation behavior.
+
+## Heal Admission Preservation
+
+Scanner and background repair work enter the heal manager through explicit
+admission:
+
+- Scanner object heal requests are low priority and may be accepted, merged,
+  rejected as full, or dropped.
+- Required/high-priority heal candidates escalate on non-admission instead of
+  silently disappearing.
+- Heal queue admission deduplicates queued and active work unless the request
+  explicitly forces admission.
+- Full queues can drop low-priority work or displace lower-priority work for a
+  higher-priority request according to current manager rules.
+
+Preservation rule: repair scheduling changes must keep admission outcomes
+observable and must not convert rejected or dropped repair work into silent
+success.
+
+## Behavior Change Gates
+
+Any later placement or repair PR must use the following gates:
+
+- Placement gate: prove object-to-set hashing is unchanged for existing object
+  keys and format algorithms.
+- Pool gate: prove pool selection does not choose suspended or rebalancing
+  pools unless the existing path already allows it.
+- Quorum gate: prove storage readiness and lock readiness remain per-set.
+- Scanner gate: prove scan budget reason and checkpoint mapping remain stable.
+- Heal gate: prove low-priority scanner heal, forced heal, duplicate merge, and
+  queue-full outcomes remain distinct.
+- Rollback gate: if a new scheduler sidecar is disabled, placement and repair
+  must fall back to the current direct ECStore/scanner/heal behavior.

--- a/docs/architecture/profiling-numa-capability-inventory.md
+++ b/docs/architecture/profiling-numa-capability-inventory.md
@@ -1,0 +1,81 @@
+# Profiling And NUMA Capability Inventory
+
+This inventory covers `G-013` for `rustfs/backlog#667`. It records the current
+profiling, memory sampling, allocator, and NUMA baseline before optional runtime
+sidecars are designed.
+
+## Platform Support Matrix
+
+| Capability | Current support | Current owner | Baseline recommendation |
+|---|---|---|---|
+| CPU pprof dump | Linux and macOS builds use `pprof`; other targets return an unsupported-platform error. | `rustfs/src/profiling.rs` | Keep CPU profiling opt-in through existing env flags and cancellation token. |
+| Continuous CPU profiling | Linux and macOS builds can hold a continuous `ProfilerGuard` when enabled. | `rustfs/src/profiling.rs` | Preserve single-guard ownership and avoid starting multiple continuous guards. |
+| Periodic CPU profiling | Linux and macOS builds can spawn a periodic sampling loop. | `rustfs/src/profiling.rs` | Keep the loop cancellation-driven and non-fatal. |
+| Jemalloc memory pprof | Only `linux` + `gnu` + `x86_64` exposes jemalloc pprof dumping. Other supported builds return an unsupported-target error. | `rustfs/src/profiling.rs` | Treat memory pprof as optional and target-gated. |
+| Periodic memory pprof | Only runs where jemalloc profiling control is available and active. | `rustfs/src/profiling.rs` | Keep inactive jemalloc as a skipped dump, not a startup failure. |
+| Process/system memory sampling | Uses `rustfs_io_metrics::snapshot_process_resource_and_system` plus `sysinfo` total memory. | `rustfs/src/memory_observability.rs` | Keep sampling portable and metric-gated. |
+| cgroup memory sampling | Reads Linux cgroup v2 or v1 memory files when present. Missing files produce no cgroup split. | `rustfs/src/memory_observability.rs` | Keep cgroup data opportunistic and absent-safe. |
+| Allocator reclaim | Uses jemalloc backend on `linux` + `gnu` + `x86_64`; otherwise mimalloc variants. | `rustfs/src/allocator_reclaim.rs` | Keep backend detection read-only and preserve effective-force behavior. |
+| eBPF | No runtime eBPF sidecar is currently wired into startup. | N/A | Treat eBPF as future optional Linux-only inventory, never as a required baseline. |
+| NUMA | No NUMA placement or topology controller is currently wired into startup. | N/A | Treat NUMA as future optional capability with no-op fallback. |
+
+## Cross-Platform Baseline
+
+The current safe baseline is:
+
+- Profiling is opt-in through env flags and must not make startup fatal.
+- Unsupported profiling targets return structured unsupported errors or skip
+  startup tasks.
+- Memory observability records process/system metrics and adds cgroup split
+  only when cgroup files exist.
+- Allocator reclaim observes active HTTP, delete-tail, scanner, heal, erasure,
+  and GET-buffer activity before reclaiming.
+- Runtime thread sizing remains owned by the Tokio runtime builder and sysinfo
+  core detection, not NUMA topology.
+
+## Optional Sidecar Invariants
+
+Future sidecars for profiling, eBPF, or NUMA must preserve these invariants:
+
+- Sidecars must be disabled by default or target-gated until explicitly enabled.
+- Unsupported targets must degrade to no-op status, not panic or fail startup.
+- Sidecars must use the runtime cancellation token or an equivalent explicit
+  shutdown handle.
+- Sidecars must not mutate Tokio worker counts after runtime creation.
+- Profiling output directory fallback must stay local to profiling and must not
+  affect object storage paths.
+- NUMA fallback must preserve current runtime thread defaults, storage set
+  placement, and request admission behavior.
+
+## First Implementation Candidates
+
+`API-013`:
+
+- Define a read-only capability contract for profiling, cgroup memory, eBPF,
+  allocator backend, and NUMA availability.
+- Keep the contract in a low-dependency crate and report unsupported states
+  explicitly.
+
+`R-016`:
+
+- Wire storage runtime startup to consume capability snapshots read-only.
+- Do not start sidecars or mutate runtime worker ownership in the same PR.
+
+`X-012`:
+
+- Add an optional profiling/eBPF extension point that can observe capability
+  status.
+- Keep unsupported targets and disabled sidecars as no-op.
+
+`X-013`:
+
+- Add extension tests for disabled, unsupported, and enabled capability
+  snapshots.
+- Verify no startup fatal boundary is added for optional profiling sidecars.
+
+`R-017`:
+
+- If a runtime service sidecar is added later, start it from the startup service
+  boundary with explicit shutdown ownership.
+- Preserve current service order, KMS/audit/notification fatal boundaries, and
+  scanner/heal startup semantics.

--- a/docs/architecture/scheduler-baseline.md
+++ b/docs/architecture/scheduler-baseline.md
@@ -1,0 +1,78 @@
+# Scheduler Baseline Inventory
+
+This inventory covers `G-011` for `rustfs/backlog#675`. It is a docs-only
+snapshot of the current scheduling, backpressure, worker, scanner, heal, and
+runtime-builder ownership. It does not define new behavior.
+
+## Current Owners
+
+| Surface | Current owner | Current responsibility | Migration boundary |
+|---|---|---|---|
+| `ConcurrencyManager` | `rustfs/src/storage/concurrency/manager.rs` | Owns the RustFS S3 read-path disk-read semaphore, I/O metrics, priority queue, storage media detection, access-pattern detection, and buffer strategy. | Keep request admission and I/O metrics behavior stable until a controller can consume the same state explicitly. |
+| `SchedulerManager` | `crates/concurrency/src/scheduler.rs` | Provides a reusable facade over `rustfs-io-core::IoScheduler` and derives buffer/priority decisions from `SchedulerPolicy`. | Treat it as reusable library surface; do not assume the RustFS S3 read path has already moved to this facade. |
+| `BackpressureManager` | `crates/concurrency/src/backpressure.rs` | Provides a reusable duplex-pipe backpressure facade over `rustfs-io-core::BackpressureMonitor`. | Keep pipe sizing and watermark policy separate from object-read disk semaphore admission. |
+| RustFS backpressure monitor | `rustfs/src/storage/backpressure.rs` | Tracks object-pipe watermark state used by RustFS storage backpressure tests and helpers. | Preserve current state labels and watermark semantics when consolidating with reusable facades. |
+| `Workers` | `crates/concurrency/src/workers.rs` | Provides cooperative worker-slot admission with `take`, `give`, and `wait`; current background workflows use it for bounded set workers. | Preserve blocking/wakeup semantics and over-release clamping. |
+| Scanner cycle budget | `crates/scanner/src/scanner_budget.rs` | Cancels a child token when runtime, object-count, or directory-count budget is reached. | Preserve partial-cycle reason mapping and checkpoint accounting. |
+| Heal admission | `crates/heal/src/heal/manager.rs`, `crates/heal/src/heal/channel.rs`, `rustfs_common::heal_channel` | Owns priority queue admission, duplicate merge/drop/full results, active-task tracking, retry admission, and channel responses. | Preserve low-priority scanner behavior and high-priority escalation gates. |
+| Tokio runtime builder | `rustfs/src/server/runtime.rs` | Builds the multi-thread runtime from env/defaults, sets thread counts, stack, queue/event intervals, I/O event cap, thread name, and optional dial9 tracing. | Keep runtime defaults and env names stable when later startup phases move ownership. |
+
+## Current Flow
+
+```mermaid
+flowchart TD
+    http["HTTP/S3 request"] --> app["app object usecase"]
+    app --> guard["ConcurrencyManager::track_request"]
+    app --> permit["disk-read semaphore permit"]
+    permit --> strategy["I/O queue status and buffer strategy"]
+    strategy --> ecstore["ECStore object/read path"]
+    ecstore --> setdisks["hashed set disks"]
+
+    scanner["scanner cycle"] --> budget["ScannerCycleBudget"]
+    budget --> folder["folder/object scan"]
+    folder --> healreq["heal channel request"]
+    healreq --> admission["HealManager admission queue"]
+    admission --> healworker["heal workers and retries"]
+
+    startup["startup entrypoint"] --> runtime["Tokio runtime builder"]
+    runtime --> services["background services"]
+```
+
+## Missing State For Later Work
+
+`R-015` storage foundation:
+
+- Needs a stable inventory of endpoint publication, local disk prewarm, lock
+  client setup, and per-set readiness state before any scheduler/controller
+  consumes storage topology.
+- Must not infer set availability only from request-path I/O metrics.
+
+`E-011` extension/runtime consumers:
+
+- Need explicit ownership for runtime admission snapshots before extensions can
+  observe scheduler or backpressure state.
+- Must not receive mutable handles to `ConcurrencyManager`, heal queues, or
+  scanner budget tokens.
+
+`C-011` controller work:
+
+- Needs desired/current/status snapshots for request admission, scanner budget,
+  and heal queue pressure before any controller can reconcile them.
+- Must keep worker mutation explicit. Read-only status should report `None` or
+  no-op mutation until a reviewed worker lifecycle PR exists.
+
+## Preservation Invariants
+
+- Request reads must keep the same disk-read semaphore admission and active GET
+  accounting.
+- I/O queue status and congestion metrics must remain derived from the same
+  permit counts.
+- Scanner budget cancellation must keep its reason as runtime, objects, or
+  directories.
+- Scanner inline-heal compatibility must continue to use asynchronous heal
+  admission.
+- Heal duplicate admission must prefer merge semantics before full-queue
+  rejection.
+- High-priority heal admission must still be able to displace lower-priority
+  queued work where the current manager allows it.
+- Tokio runtime env names and fallback defaults must remain unchanged.


### PR DESCRIPTION
## Related Issues

- rustfs/backlog#675
- rustfs/backlog#666
- rustfs/backlog#667

## Summary of Changes

- Add a scheduler baseline inventory for request admission, reusable scheduler/backpressure facades, workers, scanner budget, heal admission, and Tokio runtime builder ownership.
- Add placement and repair invariants for object-to-set hashing, pool/set/disk assignment, readiness, lock quorum, scanner budget, and heal admission.
- Add a profiling and NUMA capability inventory covering CPU/memory profiling, cgroup sampling, allocator backend, eBPF, NUMA, and no-op fallback rules.
- Update the migration progress tracker for the combined `G-011`, `G-012`, and `G-013` docs-only slice.

## Verification

- `./scripts/check_architecture_migration_rules.sh`
- `git diff --check`
- Three-expert review completed for the docs-only scope.
- Full `make pre-commit` was not run because this PR changes documentation only.

## Impact

Documentation only. No runtime, API, storage metadata, configuration, startup, placement, repair, profiling, allocator, or platform-gate behavior changes.

## Additional Notes

Stacked on #3599.
