### PR TITLE
feat: add observability topology capability contracts

### DIFF
--- a/crates/storage-api/src/capability.rs
+++ b/crates/storage-api/src/capability.rs
@@ -1,0 +1,113 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityState {
+    Supported,
+    Unsupported,
+    Disabled,
+    #[default]
+    Unknown,
+}
+
+impl CapabilityState {
+    pub const fn is_supported(self) -> bool {
+        matches!(self, Self::Supported)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CapabilityStatus {
+    pub state: CapabilityState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl CapabilityStatus {
+    pub const fn new(state: CapabilityState) -> Self {
+        Self { state, reason: None }
+    }
+
+    pub const fn supported() -> Self {
+        Self::new(CapabilityState::Supported)
+    }
+
+    pub const fn unsupported() -> Self {
+        Self::new(CapabilityState::Unsupported)
+    }
+
+    pub const fn disabled() -> Self {
+        Self::new(CapabilityState::Disabled)
+    }
+
+    pub const fn unknown() -> Self {
+        Self::new(CapabilityState::Unknown)
+    }
+
+    pub fn with_reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason = Some(reason.into());
+        self
+    }
+}
+
+impl Default for CapabilityStatus {
+    fn default() -> Self {
+        Self::unknown()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilitySnapshotError {
+    Unavailable,
+    Unsupported,
+    InvalidSnapshot(String),
+}
+
+impl fmt::Display for CapabilitySnapshotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable => f.write_str("capability snapshot unavailable"),
+            Self::Unsupported => f.write_str("capability snapshot unsupported"),
+            Self::InvalidSnapshot(reason) => write!(f, "invalid capability snapshot: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for CapabilitySnapshotError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_status_serializes_unknown_and_unsupported_states() {
+        let unknown = CapabilityStatus::unknown();
+        let unsupported = CapabilityStatus::unsupported().with_reason("target does not expose profiler");
+
+        let encoded = serde_json::to_string(&(unknown, unsupported)).expect("serialize capability statuses");
+        let decoded: (CapabilityStatus, CapabilityStatus) =
+            serde_json::from_str(&encoded).expect("deserialize capability statuses");
+
+        assert_eq!(decoded.0.state, CapabilityState::Unknown);
+        assert_eq!(decoded.1.state, CapabilityState::Unsupported);
+        assert_eq!(decoded.1.reason.as_deref(), Some("target does not expose profiler"));
+        assert!(!decoded.1.state.is_supported());
+    }
+}

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -16,12 +16,16 @@
 
 pub mod admin;
 pub mod bucket;
+pub mod capability;
 pub mod error;
 pub mod multipart;
 pub mod object;
+pub mod observability;
+pub mod topology;
 
 pub use admin::{DiskSetSelector, StorageAdminApi};
 pub use bucket::{BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, MakeBucketOptions, SRBucketDeleteOp};
+pub use capability::{CapabilitySnapshotError, CapabilityState, CapabilityStatus};
 pub use error::{StorageErrorCode, StorageResult};
 pub use multipart::{CompletePart, ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};
 pub use object::{DeletedObject, ObjectToDelete};
@@ -31,3 +35,10 @@ pub use object::{HealOperations, MultipartOperations, NamespaceLocking, ObjectIO
 pub use object::{ListObjectVersionsInfo, ListObjectsInfo, ListObjectsV2Info, ListOperations, ObjectInfoOrErr};
 pub use object::{ObjectPreconditionError, ObjectPreconditionPart, ObjectPreconditionState};
 pub use object::{VersionMarker, WalkOptions, WalkVersionsSortOrder};
+pub use observability::{
+    MemorySamplingState, ObservabilitySnapshot, ObservabilitySnapshotProvider, PlatformSupport, UserspaceProfilingCapability,
+};
+pub use topology::{
+    DiskCapabilities, TopologyCapabilities, TopologyDisk, TopologyLabels, TopologyPool, TopologySet, TopologySnapshot,
+    TopologySnapshotProvider,
+};

--- a/crates/storage-api/src/observability.rs
+++ b/crates/storage-api/src/observability.rs
@@ -1,0 +1,102 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{CapabilitySnapshotError, CapabilityStatus};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObservabilitySnapshot {
+    pub runtime_telemetry: CapabilityStatus,
+    pub userspace_profiling: UserspaceProfilingCapability,
+    pub memory_sampling: MemorySamplingState,
+    pub platform: PlatformSupport,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserspaceProfilingCapability {
+    pub cpu: CapabilityStatus,
+    pub memory: CapabilityStatus,
+    pub continuous_cpu: CapabilityStatus,
+    pub periodic_cpu: CapabilityStatus,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemorySamplingState {
+    pub process: CapabilityStatus,
+    pub system: CapabilityStatus,
+    pub cgroup: CapabilityStatus,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlatformSupport {
+    pub target_triple: Option<String>,
+    pub os: Option<String>,
+    pub arch: Option<String>,
+    pub allocator: CapabilityStatus,
+    pub ebpf: CapabilityStatus,
+    pub numa: CapabilityStatus,
+}
+
+#[async_trait::async_trait]
+pub trait ObservabilitySnapshotProvider: Send + Sync + Debug {
+    async fn observability_snapshot(&self) -> Result<ObservabilitySnapshot, CapabilitySnapshotError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CapabilityState;
+
+    #[test]
+    fn observability_snapshot_preserves_unknown_and_unsupported_states() {
+        let snapshot = ObservabilitySnapshot {
+            runtime_telemetry: CapabilityStatus::unknown(),
+            userspace_profiling: UserspaceProfilingCapability {
+                cpu: CapabilityStatus::unsupported().with_reason("unsupported target"),
+                memory: CapabilityStatus::disabled(),
+                continuous_cpu: CapabilityStatus::unknown(),
+                periodic_cpu: CapabilityStatus::supported(),
+            },
+            memory_sampling: MemorySamplingState {
+                process: CapabilityStatus::supported(),
+                system: CapabilityStatus::supported(),
+                cgroup: CapabilityStatus::unknown(),
+            },
+            platform: PlatformSupport {
+                target_triple: Some("x86_64-unknown-linux-gnu".to_owned()),
+                os: Some("linux".to_owned()),
+                arch: Some("x86_64".to_owned()),
+                allocator: CapabilityStatus::supported(),
+                ebpf: CapabilityStatus::unknown(),
+                numa: CapabilityStatus::unsupported(),
+            },
+        };
+
+        let encoded = serde_json::to_string(&snapshot).expect("serialize observability snapshot");
+        let decoded: ObservabilitySnapshot = serde_json::from_str(&encoded).expect("deserialize observability snapshot");
+
+        assert_eq!(decoded.runtime_telemetry.state, CapabilityState::Unknown);
+        assert_eq!(decoded.userspace_profiling.cpu.state, CapabilityState::Unsupported);
+        assert_eq!(decoded.userspace_profiling.memory.state, CapabilityState::Disabled);
+        assert_eq!(decoded.platform.numa.state, CapabilityState::Unsupported);
+        assert_eq!(decoded.platform.ebpf.state, CapabilityState::Unknown);
+    }
+}

--- a/crates/storage-api/src/topology.rs
+++ b/crates/storage-api/src/topology.rs
@@ -1,0 +1,153 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{CapabilitySnapshotError, CapabilityStatus};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TopologySnapshot {
+    pub pools: Vec<TopologyPool>,
+    pub capabilities: TopologyCapabilities,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TopologyCapabilities {
+    pub profiling: CapabilityStatus,
+    pub numa: CapabilityStatus,
+    pub failure_domain_labels: CapabilityStatus,
+    pub media_labels: CapabilityStatus,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TopologyPool {
+    pub pool_index: usize,
+    pub pool_id: Option<String>,
+    pub labels: TopologyLabels,
+    pub sets: Vec<TopologySet>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TopologySet {
+    pub pool_index: usize,
+    pub set_index: usize,
+    pub set_id: Option<String>,
+    pub labels: TopologyLabels,
+    pub disks: Vec<TopologyDisk>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TopologyDisk {
+    pub pool_index: usize,
+    pub set_index: usize,
+    pub disk_index: usize,
+    pub disk_id: Option<String>,
+    pub labels: TopologyLabels,
+    pub capabilities: DiskCapabilities,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TopologyLabels {
+    pub zone: Option<String>,
+    pub rack: Option<String>,
+    pub node: Option<String>,
+    pub media: Option<String>,
+    pub numa_node: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub additional: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiskCapabilities {
+    pub media_type: CapabilityStatus,
+    pub failure_domain: CapabilityStatus,
+    pub numa: CapabilityStatus,
+    pub profiling: CapabilityStatus,
+}
+
+#[async_trait::async_trait]
+pub trait TopologySnapshotProvider: Send + Sync + Debug {
+    async fn topology_snapshot(&self) -> Result<TopologySnapshot, CapabilitySnapshotError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CapabilityState;
+
+    #[test]
+    fn topology_snapshot_allows_missing_and_extra_labels() {
+        let raw = r#"{
+            "pools": [{
+                "pool_index": 0,
+                "pool_id": null,
+                "labels": {
+                    "additional": {
+                        "room": "a"
+                    }
+                },
+                "sets": [{
+                    "pool_index": 0,
+                    "set_index": 1,
+                    "set_id": null,
+                    "labels": {},
+                    "disks": [{
+                        "pool_index": 0,
+                        "set_index": 1,
+                        "disk_index": 2,
+                        "disk_id": "disk-2",
+                        "labels": {
+                            "media": "ssd",
+                            "additional": {
+                                "slot": "nvme0"
+                            }
+                        },
+                        "capabilities": {
+                            "media_type": { "state": "supported" },
+                            "failure_domain": { "state": "unknown" },
+                            "numa": { "state": "unsupported", "reason": "not reported" },
+                            "profiling": { "state": "disabled" }
+                        }
+                    }]
+                }]
+            }],
+            "capabilities": {
+                "profiling": { "state": "supported" },
+                "numa": { "state": "unknown" },
+                "failure_domain_labels": { "state": "supported" },
+                "media_labels": { "state": "supported" }
+            }
+        }"#;
+
+        let snapshot: TopologySnapshot = serde_json::from_str(raw).expect("deserialize topology snapshot");
+        let disk = &snapshot.pools[0].sets[0].disks[0];
+
+        assert_eq!(snapshot.pools[0].labels.zone, None);
+        assert_eq!(snapshot.pools[0].labels.additional.get("room").map(String::as_str), Some("a"));
+        assert_eq!(disk.labels.media.as_deref(), Some("ssd"));
+        assert_eq!(disk.labels.additional.get("slot").map(String::as_str), Some("nvme0"));
+        assert_eq!(disk.capabilities.numa.state, CapabilityState::Unsupported);
+        assert_eq!(disk.capabilities.profiling.state, CapabilityState::Disabled);
+    }
+}

--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -92,14 +92,17 @@ Required `rustfs-storage-api` public re-exports:
 
 - `pub use admin::{DiskSetSelector, StorageAdminApi};`
 - `pub use bucket::{BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, MakeBucketOptions, SRBucketDeleteOp};`
+- `pub use capability::{CapabilitySnapshotError, CapabilityState, CapabilityStatus};`
 - `pub use error::{StorageErrorCode, StorageResult};`
 - `pub use multipart::{CompletePart, ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};`
+- `pub use observability::{MemorySamplingState, ObservabilitySnapshot, ObservabilitySnapshotProvider, PlatformSupport, UserspaceProfilingCapability};`
 - `pub use object::{HTTPPreconditions, HTTPRangeError, HTTPRangeSpec, ObjectLockRetentionOptions};`
 - `pub use object::{ExpirationOptions, TransitionedObject};`
 - `pub use object::{HealOperations, MultipartOperations, NamespaceLocking, ObjectIO, ObjectOperations};`
 - `pub use object::{ListObjectVersionsInfo, ListObjectsInfo, ListObjectsV2Info, ListOperations, ObjectInfoOrErr};`
 - `pub use object::{ObjectPreconditionError, ObjectPreconditionPart, ObjectPreconditionState};`
 - `pub use object::{VersionMarker, WalkOptions, WalkVersionsSortOrder};`
+- `pub use topology::{DiskCapabilities, TopologyCapabilities, TopologyDisk, TopologyLabels, TopologyPool, TopologySet, TopologySnapshot, TopologySnapshotProvider};`
 
 ECStore must keep compile-time coverage for `StorageAdminApi`, `HealOperations`,
 and the separate `NamespaceLocking` operation group.

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,15 +5,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-scheduler-profiling-baselines`
-- Baseline: stacked on `rustfs/rustfs#3599` head
-  (`91767c9b36c19d7bb6c8c5f85ab3b3570242cadb`).
-- PR type for this branch: `docs-only`
+- Branch: `overtrue/arch-observability-topology-contracts`
+- Baseline: stacked on `origin/overtrue/arch-test-harness-compat-aliases`
+  after `rustfs/rustfs#3600`
+  (`ae6a5befcf60f2f2ebce9799ba93649032234273`).
+- PR type for this branch: `contract`
 - Runtime behavior changes: none.
-- Rust code changes: none.
-- CI/script changes: none.
-- Docs changes: add scheduler, placement/repair, and profiling/NUMA baseline
-  inventories for `G-011`, `G-012`, and `G-013`.
+- Rust code changes: add observability and topology capability DTO/trait
+  contracts to `rustfs-storage-api`.
+- CI/script changes: extend migration re-export guard coverage for the new
+  contract exports.
+- Docs changes: add
+  [`runtime-capability-contracts.md`](runtime-capability-contracts.md) and
+  record the combined PR-08/API-013 plus PR-09/API-014 contract slice.
 
 ## Phase 0 Tasks
 
@@ -83,6 +87,38 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     backend, eBPF, and NUMA capability support plus no-op fallback invariants.
   - Must preserve: no startup, profiling, allocator, runtime, or platform-gate
     behavior changes.
+
+## Issue #660 Capability Contract Tasks
+
+- [x] `PR-08/API-013` Add observability snapshot contract.
+  - Completed slice: add `CapabilityState`, `CapabilityStatus`,
+    `CapabilitySnapshotError`, `ObservabilitySnapshot`,
+    `UserspaceProfilingCapability`, `MemorySamplingState`,
+    `PlatformSupport`, and `ObservabilitySnapshotProvider` to
+    `rustfs-storage-api`.
+  - Acceptance: runtime telemetry, userspace profiling, memory sampling, and
+    platform support states are representable without runtime, ECStore, admin,
+    profiling, exporter, sidecar, eBPF, or OTEL implementation dependencies.
+  - Must preserve: no profiling, startup, admin route, exporter, sidecar, eBPF,
+    OTEL, or runtime behavior changes.
+  - Verification: storage-api contract tests for unknown, unsupported,
+    disabled, and supported capability states; focused storage-api check;
+    migration guard; formatting; diff hygiene; and three-expert review.
+
+- [x] `PR-09/API-014` Add topology capability contract.
+  - Completed slice: add `TopologySnapshot`, `TopologyCapabilities`,
+    `TopologyPool`, `TopologySet`, `TopologyDisk`, `TopologyLabels`,
+    `DiskCapabilities`, and `TopologySnapshotProvider` to
+    `rustfs-storage-api`.
+  - Acceptance: pool, set, and disk identity fields plus optional zone, rack,
+    node, media, NUMA, and additional labels are representable without
+    `rustfs-ecstore`.
+  - Must preserve: no ECStore endpoint/set implementation, placement,
+    membership, NUMA pinning, or runtime behavior changes.
+  - Verification: storage-api contract tests for missing and additional labels
+    plus supported, unsupported, unknown, and disabled capability states;
+    focused storage-api check; migration guard; formatting; diff hygiene; and
+    three-expert review.
 - [x] `TEST-PRTYPE-001` Check PR type enum consistency.
   - Acceptance: `./scripts/check_architecture_migration_rules.sh` parses the
     allowed PR types from [`crate-boundaries.md`](crate-boundaries.md) and fails
@@ -1665,9 +1701,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 ## Next PRs
 
-1. `docs-only`/`contract`: use the scheduler, placement/repair, and
-   profiling/NUMA baseline inventories to size the next larger capability or
-   startup-runtime slice.
+1. `contract`/`consumer-migration`: wire read-only observability and topology
+   snapshots to implementation owners without changing runtime, profiling,
+   placement, or admin route behavior.
 2. `pure-move`/`consumer-migration`: continue larger cleanup slices with the
    loss-prevention guards active for remaining ECStore compatibility contracts
    now that broad compatibility passthroughs are fully closed.
@@ -1676,13 +1712,23 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049/API-050/API-051/API-052/API-053/API-054 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, fuzz, lifecycle helper, harness, and RustFS runtime compatibility contracts without moving ECStore storage metadata ownership; G-011/G-012/G-013 add docs-only baselines for scheduler, placement/repair, and profiling/NUMA work. |
-| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, lifecycle expiration/transition helper DTO field contracts, flattened harness and RustFS runtime scalar/secondary alias behavior, unchanged no-op handling, remove-event behavior, scheduler/readiness/placement/profiling runtime behavior, and platform gates are preserved. |
-| Testing/verification | passed | Focused compiles/tests, fuzz target compile, guards, formatting, diff hygiene, risk scan, and full `make pre-commit` passed for prior code slices; docs-only G-011/G-012/G-013 uses architecture guard and diff hygiene verification. |
+| Quality/architecture | passed | S-015 removes obsolete KMS admin policy action variants after the handler fallback cleanup; API-042/API-043/API-044/API-045/API-046/API-047/API-048/API-049/API-050/API-051/API-052/API-053/API-054 narrow notify, S3 Select, OBS, IAM, Swift, heal, scanner, RustFS runtime, test, fuzz, lifecycle helper, harness, and RustFS runtime compatibility contracts without moving ECStore storage metadata ownership; G-011/G-012/G-013 add docs-only baselines for scheduler, placement/repair, and profiling/NUMA work; Issue #660 PR-08/PR-09 add read-only observability and topology contracts in rustfs-storage-api only. |
+| Migration preservation | passed | KMS endpoint URLs, query aliases, request bodies, response contracts, and dedicated `kms:*` authorization behavior are preserved; event builder call sites, ECStore event bridge conversion, restore event data, version IDs, metadata filtering, config read/save semantics, S3 Select store/error/buffer semantics, OBS metrics state reads, IAM config/notification/error semantics, Swift bucket metadata access, heal disk/resume/task behavior, scanner lifecycle/replication/data-usage behavior, RustFS startup/admin/app/storage runtime access, e2e/test/fuzz import behavior, lifecycle expiration/transition helper DTO field contracts, flattened harness and RustFS runtime scalar/secondary alias behavior, unchanged no-op handling, remove-event behavior, scheduler/readiness/placement/profiling runtime behavior, platform gates, missing/unknown capability states, and placement/topology labels are preserved. |
+| Testing/verification | passed | Focused compiles/tests, fuzz target compile, guards, formatting, diff hygiene, risk scan, and full `make pre-commit` passed for prior code slices; current Issue #660 PR-08/PR-09 contract slice uses storage-api tests/checks, migration guard, formatting, diff hygiene, and three-expert review. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 PR-08/PR-09 current slice:
+  - `cargo test -p rustfs-storage-api`: passed.
+  - `cargo check -p rustfs-storage-api`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `make pre-commit`: passed.
+  - Three-expert review: passed.
 
 - G-011/G-012/G-013 current slice:
   - `./scripts/check_architecture_migration_rules.sh`: passed.

--- a/docs/architecture/runtime-capability-contracts.md
+++ b/docs/architecture/runtime-capability-contracts.md
@@ -1,0 +1,44 @@
+# Runtime Capability Contracts
+
+This document records the `rustfs/backlog#660` PR-08 and PR-09 contract slice.
+It adds read-only observability and topology snapshot shapes to
+`rustfs-storage-api` without coupling the contract crate to runtime, ECStore,
+admin routes, profiling, or observability implementation crates.
+
+## Observability Snapshot Contract
+
+`ObservabilitySnapshot` records:
+
+- Runtime telemetry capability state.
+- Userspace CPU and memory profiling capability state.
+- Process, system, and cgroup memory sampling state.
+- Platform support for target triple, OS, architecture, allocator, eBPF, and
+  NUMA capability.
+
+Unsupported, disabled, and unknown states are represented by `CapabilityState`
+instead of failing snapshot construction. The contract is intentionally read
+only and does not replace existing profiling routes, telemetry APIs, exporter
+pipelines, or startup behavior.
+
+## Topology Snapshot Contract
+
+`TopologySnapshot` records:
+
+- Pool, set, and disk identity indexes plus optional stable IDs.
+- Optional zone, rack, node, media, NUMA, and additional labels.
+- Topology-wide profiling, NUMA, failure-domain label, and media-label
+  capability states.
+- Per-disk media, failure-domain, NUMA, and profiling capability states.
+
+Missing labels are represented as absent `Option` values. Extra topology labels
+belong in the `additional` label map, so future inventory labels do not require
+ECStore type leakage.
+
+## Boundary Rules
+
+- No `rustfs-ecstore`, `rustfs-obs`, Axum, KMS, admin route, OTEL, eBPF, or
+  profiling implementation dependency is added to `rustfs-storage-api`.
+- No placement, membership, NUMA pinning, profiling, startup, admin route, or
+  exporter behavior changes are part of this contract slice.
+- Providers must map implementation failures into `CapabilitySnapshotError`
+  before crossing the contract boundary.

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -210,8 +210,16 @@ require_source_line \
   "storage-api public bucket contract re-export"
 require_source_line \
   "crates/storage-api/src/lib.rs" \
+  "pub use capability::{CapabilitySnapshotError, CapabilityState, CapabilityStatus};" \
+  "storage-api public capability contract re-export"
+require_source_line \
+  "crates/storage-api/src/lib.rs" \
   "pub use multipart::{CompletePart, ListMultipartsInfo, ListPartsInfo, MultipartInfo, MultipartUploadResult, PartInfo};" \
   "storage-api public multipart DTO re-export"
+require_source_line \
+  "crates/storage-api/src/lib.rs" \
+  "pub use observability::{" \
+  "storage-api public observability contract re-export"
 require_source_line \
   "crates/storage-api/src/lib.rs" \
   "pub use object::{HTTPPreconditions, HTTPRangeError, HTTPRangeSpec, ObjectLockRetentionOptions};" \
@@ -244,6 +252,10 @@ require_source_line \
   "crates/storage-api/src/lib.rs" \
   "pub use error::{StorageErrorCode, StorageResult};" \
   "storage-api public error contract re-export"
+require_source_line \
+  "crates/storage-api/src/lib.rs" \
+  "pub use topology::{" \
+  "storage-api public topology contract re-export"
 
 (
   cd "$ROOT_DIR"


### PR DESCRIPTION
## Related Issues
- rustfs/backlog#660
- rustfs/backlog#676
- rustfs/backlog#680

## Summary of Changes
- Add shared capability state/status and snapshot error contracts to `rustfs-storage-api`.
- Add read-only observability snapshot DTOs and provider trait for runtime telemetry, userspace profiling, memory sampling, and platform support.
- Add topology snapshot DTOs and provider trait for pool/set/disk identity, optional labels, and capability states.
- Extend migration guard coverage and document the contract boundary.

## Verification
- `cargo test -p rustfs-storage-api`
- `cargo check -p rustfs-storage-api`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `make pre-commit`
- Three-expert review completed for quality/architecture, migration preservation, and verification coverage.

## Impact
Adds public contract types only. No runtime, ECStore, profiling, admin route, exporter, eBPF, OTEL, placement, membership, or NUMA behavior changes.

## Additional Notes
Stacked on `overtrue/arch-test-harness-compat-aliases`.
