### PR TITLE
refactor: use storage list contracts in ecstore

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/tier_free_version_recovery.rs
+++ b/crates/ecstore/src/bucket/lifecycle/tier_free_version_recovery.rs
@@ -19,12 +19,19 @@ use tokio_util::sync::CancellationToken;
 
 use crate::disk::RUSTFS_META_BUCKET;
 use crate::error::Result;
-use crate::object_api::{ObjectInfo, ObjectInfoOrErr, WalkOptions};
+use crate::object_api::ObjectInfo;
 use crate::store::ECStore;
-use rustfs_storage_api::{BucketOperations, BucketOptions, ListOperations as _};
+use rustfs_filemeta::FileInfo;
+use rustfs_storage_api::{
+    BucketOperations, BucketOptions, ListOperations as _, ObjectInfoOrErr as StorageObjectInfoOrErr,
+    WalkOptions as StorageWalkOptions,
+};
 
 pub const DEFAULT_FREE_VERSION_RECOVERY_LIMIT: usize = 1_000;
 const DEFAULT_FREE_VERSION_RECOVERY_SCAN_LIMIT: usize = 10_000;
+
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, crate::error::Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FreeVersionRecoveryStats {

--- a/crates/ecstore/src/bucket/migration.rs
+++ b/crates/ecstore/src/bucket/migration.rs
@@ -17,17 +17,17 @@
 use crate::bucket::metadata::BUCKET_METADATA_FILE;
 use crate::bucket::replication::{decode_resync_file, encode_resync_file};
 use crate::disk::{BUCKET_META_PREFIX, MIGRATING_META_BUCKET, RUSTFS_META_BUCKET};
-use crate::object_api::{
-    GetObjectReader, ListObjectVersionsInfo, ListObjectsV2Info, ObjectInfo, ObjectInfoOrErr, ObjectOptions, PutObjReader,
-    WalkOptions,
-};
+use crate::error::Error;
+use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
 use crate::storage_api_contracts::{EcstoreObjectIO, EcstoreObjectOperations};
 use http::HeaderMap;
 use rustfs_filemeta::FileInfo;
 use rustfs_policy::auth::UserIdentity;
 use rustfs_policy::policy::PolicyDoc;
 use rustfs_storage_api::{
-    BucketOperations, BucketOptions, DeletedObject, HTTPRangeSpec, ListOperations, ObjectIO, ObjectOperations, ObjectToDelete,
+    BucketOperations, BucketOptions, DeletedObject, HTTPRangeSpec, ListObjectVersionsInfo as StorageListObjectVersionsInfo,
+    ListObjectsV2Info as StorageListObjectsV2Info, ListOperations, ObjectIO, ObjectInfoOrErr as StorageObjectInfoOrErr,
+    ObjectOperations, ObjectToDelete, WalkOptions as StorageWalkOptions,
 };
 use rustfs_utils::path::SLASH_SEPARATOR;
 use serde::{Deserialize, Serialize};
@@ -46,6 +46,11 @@ const IAM_POLICIES_PREFIX: &str = "config/iam/policies/";
 const IAM_POLICY_DB_PREFIX: &str = "config/iam/policydb/";
 const REPLICATION_META_DIR: &str = ".replication";
 const RESYNC_META_FILE: &str = "resync.bin";
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct CompatIamFormat {

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -31,10 +31,7 @@ use crate::error::{Error, Result, is_err_object_not_found, is_err_version_not_fo
 use crate::event_notification::{EventArgs, send_event};
 use crate::global::GLOBAL_LocalNodeName;
 use crate::global::get_global_bucket_monitor;
-use crate::object_api::{
-    GetObjectReader, ListObjectVersionsInfo, ListObjectsV2Info, ObjectInfo, ObjectInfoOrErr, ObjectOptions, PutObjReader,
-    WalkOptions,
-};
+use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
 use crate::resolve_object_store_handle;
 use crate::set_disk::get_lock_acquire_timeout;
 use crate::storage_api_contracts::{EcstoreObjectIO, EcstoreObjectOperations};
@@ -63,8 +60,9 @@ use rustfs_filemeta::{
 };
 use rustfs_s3_types::EventName;
 use rustfs_storage_api::{
-    DeletedObject, HTTPRangeSpec, ListOperations, NamespaceLocking as StorageNamespaceLocking, ObjectIO, ObjectOperations,
-    ObjectToDelete,
+    DeletedObject, HTTPRangeSpec, ListObjectVersionsInfo as StorageListObjectVersionsInfo,
+    ListObjectsV2Info as StorageListObjectsV2Info, ListOperations, NamespaceLocking as StorageNamespaceLocking, ObjectIO,
+    ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations, ObjectToDelete, WalkOptions as StorageWalkOptions,
 };
 use rustfs_utils::http::{
     AMZ_BUCKET_REPLICATION_STATUS, AMZ_OBJECT_TAGGING, AMZ_TAGGING_DIRECTIVE, CONTENT_ENCODING, HeaderExt as _,
@@ -108,6 +106,11 @@ const EVENT_REPLICATION_FORCE_DELETE_SKIPPED: &str = "replication_force_delete_s
 const EVENT_RESYNC_TASK_FAILED: &str = "replication_resync_task_failed";
 const EVENT_RESYNC_TARGET_OPERATION_FAILED: &str = "replication_resync_target_operation_failed";
 const EVENT_RESYNC_RUNTIME_CHANNEL_FAILED: &str = "replication_resync_runtime_channel_failed";
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 /// Storage capabilities required by bucket replication workers.
 pub trait ReplicationStorage:

--- a/crates/ecstore/src/object_api/types.rs
+++ b/crates/ecstore/src/object_api/types.rs
@@ -4,14 +4,6 @@ use rustfs_storage_api::{
     VersionMarker,
 };
 
-pub type ListObjectsInfo = rustfs_storage_api::ListObjectsInfo<ObjectInfo>;
-pub type ListObjectsV2Info = rustfs_storage_api::ListObjectsV2Info<ObjectInfo>;
-pub type ListObjectVersionsInfo = rustfs_storage_api::ListObjectVersionsInfo<ObjectInfo>;
-pub type ObjectInfoOrErr = rustfs_storage_api::ObjectInfoOrErr<ObjectInfo, Error>;
-pub type WalkOptions = rustfs_storage_api::WalkOptions<WalkFilter>;
-pub type ObjectToDelete = rustfs_storage_api::ObjectToDelete;
-pub type DeletedObject = rustfs_storage_api::DeletedObject;
-
 #[derive(Debug, Default, Clone)]
 pub struct ObjectOptions {
     // Use the maximum parity (N/2), used when saving server configuration files
@@ -715,9 +707,6 @@ fn versions_after_marker(file_infos: &rustfs_filemeta::FileInfoVersions, marker:
         .map(|idx| &file_infos.versions[idx + 1..])
         .unwrap_or(&file_infos.versions)
 }
-
-type WalkFilter = fn(&FileInfo) -> bool;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ecstore/src/set_disk.rs
+++ b/crates/ecstore/src/set_disk.rs
@@ -33,9 +33,7 @@ use crate::erasure_coding;
 use crate::error::{Error, Result, is_err_version_not_found};
 use crate::error::{GenericError, ObjectApiError, is_err_object_not_found};
 use crate::global::{GLOBAL_LocalNodeName, GLOBAL_TierConfigMgr};
-use crate::object_api::ListObjectVersionsInfo;
 use crate::object_api::ObjectOptions;
-use crate::object_api::{ObjectInfoOrErr, WalkOptions};
 use crate::{
     bucket::lifecycle::bucket_lifecycle_ops::{
         LifecycleOps, gen_transition_objname, get_transitioned_object_reader, put_restore_opts,
@@ -51,7 +49,7 @@ use crate::{
     // event::name::EventName,
     event_notification::{EventArgs, send_event},
     global::{GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES, get_global_deployment_id, is_dist_erasure},
-    object_api::{GetObjectReader, ListObjectsV2Info, ObjectInfo, PutObjReader},
+    object_api::{GetObjectReader, ObjectInfo, PutObjReader},
     store_init::load_format_erasure,
 };
 use bytes::Bytes;
@@ -82,10 +80,13 @@ use rustfs_object_capacity::capacity_scope::{
     CapacityScope, CapacityScopeDisk, record_capacity_scope, record_global_dirty_scope,
 };
 use rustfs_s3_types::EventName;
-use rustfs_storage_api::HTTPRangeSpec;
 use rustfs_storage_api::{
     BucketInfo, BucketOperations, BucketOptions, CompletePart, DeleteBucketOptions, DeletedObject, ListMultipartsInfo,
     ListPartsInfo, MakeBucketOptions, MultipartInfo, MultipartUploadResult, ObjectToDelete, PartInfo,
+};
+use rustfs_storage_api::{
+    HTTPRangeSpec, ListObjectVersionsInfo as StorageListObjectVersionsInfo, ListObjectsV2Info as StorageListObjectsV2Info,
+    ObjectInfoOrErr as StorageObjectInfoOrErr, WalkOptions as StorageWalkOptions,
 };
 use rustfs_storage_api::{MultipartOperations as _, NamespaceLocking as _, ObjectIO as _, ObjectOperations as _};
 use rustfs_utils::http::headers::AMZ_OBJECT_TAGGING;
@@ -130,6 +131,11 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::{Instrument, debug, info, warn};
 use uuid::Uuid;
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 const LOG_COMPONENT_ECSTORE: &str = "ecstore";
 const LOG_SUBSYSTEM_SET_DISK: &str = "set_disk";

--- a/crates/ecstore/src/sets.rs
+++ b/crates/ecstore/src/sets.rs
@@ -15,7 +15,6 @@
 
 use crate::disk::error_reduce::count_errs;
 use crate::error::{Error, Result};
-use crate::object_api::{ObjectInfoOrErr, WalkOptions};
 use crate::{
     disk::{
         DiskAPI, DiskInfo, DiskOption, DiskStore,
@@ -26,7 +25,7 @@ use crate::{
     endpoints::{Endpoints, PoolEndpoints},
     error::StorageError,
     global::{GLOBAL_LOCAL_DISK_SET_DRIVES, get_global_lock_clients, is_dist_erasure},
-    object_api::{GetObjectReader, ListObjectVersionsInfo, ListObjectsV2Info, ObjectInfo, ObjectOptions, PutObjReader},
+    object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
     set_disk::SetDisks,
     store_init::{check_format_erasure_values, get_format_erasure_in_quorum, load_format_erasure_all, save_format_file},
 };
@@ -47,8 +46,10 @@ use rustfs_madmin::heal_commands::{HealDriveInfo, HealResultItem};
 use rustfs_storage_api::CompletePart;
 use rustfs_storage_api::HTTPRangeSpec;
 use rustfs_storage_api::{
-    BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, DeletedObject, ListMultipartsInfo, ListPartsInfo,
-    MakeBucketOptions, MultipartInfo, MultipartUploadResult, ObjectToDelete, PartInfo,
+    BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, DeletedObject, ListMultipartsInfo,
+    ListObjectVersionsInfo as StorageListObjectVersionsInfo, ListObjectsV2Info as StorageListObjectsV2Info, ListPartsInfo,
+    MakeBucketOptions, MultipartInfo, MultipartUploadResult, ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectToDelete, PartInfo,
+    WalkOptions as StorageWalkOptions,
 };
 use rustfs_storage_api::{ObjectIO as _, ObjectOperations as _};
 use rustfs_utils::{crc_hash, path::path_join_buf, sip_hash};
@@ -60,6 +61,11 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use tracing::{error, info};
 use uuid::Uuid;
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 #[derive(Debug, Clone)]
 pub struct Sets {

--- a/crates/ecstore/src/storage_api_contracts.rs
+++ b/crates/ecstore/src/storage_api_contracts.rs
@@ -1,12 +1,18 @@
 use crate::error::Error;
-use crate::object_api::{
-    GetObjectReader, ListObjectVersionsInfo, ListObjectsV2Info, ObjectInfo, ObjectInfoOrErr, ObjectOptions, PutObjReader,
-    WalkOptions,
-};
+use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
 use rustfs_filemeta::FileInfo;
-use rustfs_storage_api::{DeletedObject, HTTPRangeSpec, ObjectToDelete};
+use rustfs_storage_api::{
+    DeletedObject, HTTPRangeSpec, ListObjectVersionsInfo as StorageListObjectVersionsInfo,
+    ListObjectsV2Info as StorageListObjectsV2Info, ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectToDelete,
+    WalkOptions as StorageWalkOptions,
+};
 use std::fmt::Debug;
 use tokio_util::sync::CancellationToken;
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 pub(crate) trait EcstoreObjectIO:
     rustfs_storage_api::ObjectIO<

--- a/crates/ecstore/src/store.rs
+++ b/crates/ecstore/src/store.rs
@@ -50,7 +50,6 @@ use crate::global::{
     set_object_layer,
 };
 use crate::notification_sys::get_global_notification_sys;
-use crate::object_api::{ListObjectVersionsInfo, ObjectInfoOrErr, WalkOptions};
 use crate::pools::PoolMeta;
 use crate::rebalance::RebalanceMeta;
 use crate::rpc::RemoteClient;
@@ -60,7 +59,7 @@ use crate::{
     bucket::{lifecycle::bucket_lifecycle_ops::TransitionState, metadata::BucketMetadata},
     disk::{BUCKET_META_PREFIX, DiskOption, DiskStore, RUSTFS_META_BUCKET, new_disk},
     endpoints::EndpointServerPools,
-    object_api::{GetObjectReader, ListObjectsV2Info, ObjectInfo, ObjectOptions, PutObjReader},
+    object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
     rpc::S3PeerSys,
     sets::Sets,
     store_init,
@@ -75,10 +74,13 @@ use rustfs_config::server_config::{Config, get_global_server_config, set_global_
 use rustfs_filemeta::FileInfo;
 use rustfs_lock::{LocalClient, LockClient, NamespaceLockWrapper};
 use rustfs_madmin::heal_commands::HealResultItem;
-use rustfs_storage_api::HTTPRangeSpec;
 use rustfs_storage_api::{
     BucketInfo, BucketOperations, BucketOptions, CompletePart, DeleteBucketOptions, DeletedObject, ListMultipartsInfo,
     ListPartsInfo, MakeBucketOptions, MultipartInfo, MultipartUploadResult, ObjectToDelete, PartInfo,
+};
+use rustfs_storage_api::{
+    HTTPRangeSpec, ListObjectVersionsInfo as StorageListObjectVersionsInfo, ListObjectsV2Info as StorageListObjectsV2Info,
+    ObjectInfoOrErr as StorageObjectInfoOrErr, WalkOptions as StorageWalkOptions,
 };
 use rustfs_utils::path::{decode_dir_object, encode_dir_object, path_join_buf};
 use s3s::dto::{BucketVersioningStatus, ObjectLockConfiguration, ObjectLockEnabled, VersioningConfiguration};
@@ -99,6 +101,11 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 use uuid::Uuid;
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 /// Check if a directory contains any xl.meta files (indicating actual S3 objects)
 /// This is used to determine if a bucket is empty for deletion purposes.

--- a/crates/ecstore/src/store_list_objects.rs
+++ b/crates/ecstore/src/store_list_objects.rs
@@ -21,17 +21,21 @@ use crate::disk::{DiskInfo, DiskStore};
 use crate::error::{
     Error, Result, StorageError, is_all_not_found, is_all_volume_not_found, is_err_bucket_not_found, to_object_err,
 };
-use crate::object_api::{ListObjectVersionsInfo, ListObjectsInfo, ObjectInfo, ObjectInfoOrErr, ObjectOptions, WalkOptions};
+use crate::object_api::{ObjectInfo, ObjectOptions};
 use crate::set_disk::SetDisks;
+use crate::store::ECStore;
 use crate::store_utils::is_reserved_or_invalid_bucket;
-use crate::{object_api::ListObjectsV2Info, store::ECStore};
 use futures::future::join_all;
 use rand::seq::SliceRandom;
 use rustfs_filemeta::{
     MetaCacheEntries, MetaCacheEntriesSorted, MetaCacheEntriesSortedResult, MetaCacheEntry, MetadataResolutionParams,
     merge_file_meta_versions,
 };
-use rustfs_storage_api::{ObjectOperations as _, VersionMarker, WalkVersionsSortOrder};
+use rustfs_storage_api::{
+    ListObjectVersionsInfo as StorageListObjectVersionsInfo, ListObjectsInfo as StorageListObjectsInfo,
+    ListObjectsV2Info as StorageListObjectsV2Info, ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations as _,
+    VersionMarker, WalkOptions as StorageWalkOptions, WalkVersionsSortOrder,
+};
 use rustfs_utils::path::{self, SLASH_SEPARATOR, base_dir_from_prefix};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -47,6 +51,12 @@ const MAX_OBJECT_LIST: i32 = 1000;
 // const MAX_PARTS_LIST: i32 = 10000;
 
 const METACACHE_SHARE_PREFIX: bool = false;
+
+type ListObjectsInfo = StorageListObjectsInfo<ObjectInfo>;
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&rustfs_filemeta::FileInfo) -> bool>;
 
 fn normalize_max_keys(max_keys: i32) -> i32 {
     max_keys.min(MAX_OBJECT_LIST)

--- a/crates/ecstore/tests/ecstore_contract_compat_test.rs
+++ b/crates/ecstore/tests/ecstore_contract_compat_test.rs
@@ -16,22 +16,25 @@ use rustfs_common::heal_channel::HealOpts;
 use rustfs_ecstore::{
     disk::DiskStore,
     error::Error,
-    object_api::{
-        GetObjectReader, ListObjectVersionsInfo, ListObjectsV2Info, ObjectInfo, ObjectInfoOrErr, ObjectOptions, PutObjReader,
-        WalkOptions,
-    },
+    object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
     store::ECStore,
 };
 use rustfs_filemeta::FileInfo;
 use rustfs_lock::NamespaceLockWrapper;
 use rustfs_madmin::heal_commands::HealResultItem;
 use rustfs_storage_api::{
-    CompletePart, DeletedObject, HTTPRangeSpec, HealOperations as StorageHealOperations, ListMultipartsInfo, ListPartsInfo,
+    CompletePart, DeletedObject, HTTPRangeSpec, HealOperations as StorageHealOperations, ListMultipartsInfo,
+    ListObjectVersionsInfo as StorageListObjectVersionsInfo, ListObjectsV2Info as StorageListObjectsV2Info, ListPartsInfo,
     MultipartInfo, MultipartOperations as StorageMultipartOperations, MultipartUploadResult,
-    NamespaceLocking as StorageNamespaceLocking, ObjectIO as StorageObjectIO, ObjectOperations as StorageObjectOperations,
-    ObjectToDelete, PartInfo, StorageAdminApi,
+    NamespaceLocking as StorageNamespaceLocking, ObjectIO as StorageObjectIO, ObjectInfoOrErr as StorageObjectInfoOrErr,
+    ObjectOperations as StorageObjectOperations, ObjectToDelete, PartInfo, StorageAdminApi, WalkOptions as StorageWalkOptions,
 };
 use tokio_util::sync::CancellationToken;
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 fn storage_admin_api_type_name<T>() -> &'static str
 where

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-object-api-module`
-- Baseline: stacked after `rustfs/rustfs#3611`
-  (`b3af0d584ea29acc4273cee57fbdbaf35870ca67`).
+- Branch: `overtrue/arch-ecstore-list-contracts-direct`
+- Baseline: stacked after `rustfs/rustfs#3613`
+  (`28fce7b377c38b286b69c62f1ab15711d0f59589`).
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: move the ECStore object DTO and reader implementation
-  module from the retired private `store_api` name into `object_api`.
-- CI/script changes: make the migration guard reject restoring ECStore
-  `store_api` module files or directories.
-- Docs changes: record the API-064 ECStore object API module cleanup slice.
+- Rust code changes: migrate ECStore internal list/walk consumers to direct
+  aliases over the generic `rustfs-storage-api` list contracts, including
+  replication worker trait bounds.
+- CI/script changes: make the migration guard reject ECStore internal
+  `crate::object_api` imports of list/walk compatibility aliases, including
+  multi-line import forms.
+- Docs changes: record the API-065 ECStore list contract cleanup slice.
 
 ## Phase 0 Tasks
 
@@ -284,6 +286,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Must preserve: object metadata shape, reader/writer behavior, storage-api
     contract bindings, object/list/multipart behavior, and downstream public
     object API compatibility.
+  - Verification: focused ECStore compile checks, migration guard, formatting,
+    diff hygiene, risk scan, and three-expert review.
+
+- [x] `API-065` Use storage-api list contracts inside ECStore.
+  - Completed slice: migrate ECStore internal list response, walk options, and
+    walk result bindings to local aliases over the generic `rustfs-storage-api`
+    contracts, including replication worker trait bounds, while retaining
+    public `rustfs_ecstore::object_api` aliases for downstream compatibility.
+  - Acceptance: ECStore implementation modules no longer import list/walk
+    compatibility aliases from `crate::object_api`, and migration rules reject
+    reintroducing those internal imports.
+  - Must preserve: list response shape, walk result item shape, object metadata
+    shape, storage-api trait bindings, and downstream public object API
+    compatibility.
   - Verification: focused ECStore compile checks, migration guard, formatting,
     diff hygiene, risk scan, and three-expert review.
 

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,18 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-list-contracts-direct`
-- Baseline: stacked after `rustfs/rustfs#3613`
-  (`28fce7b377c38b286b69c62f1ab15711d0f59589`).
+- Branch: `overtrue/arch-ecstore-object-api-alias-prune`
+- Baseline: stacked after `rustfs/rustfs#3614`
+  (`3740e65246aed8c8ee9685ed0234997c7d54e1b5`).
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: migrate ECStore internal list/walk consumers to direct
-  aliases over the generic `rustfs-storage-api` list contracts, including
-  replication worker trait bounds.
-- CI/script changes: make the migration guard reject ECStore internal
-  `crate::object_api` imports of list/walk compatibility aliases, including
-  multi-line import forms.
-- Docs changes: record the API-065 ECStore list contract cleanup slice.
+- Rust code changes: remove unused public `rustfs-storage-api` passthrough
+  aliases from ECStore `object_api` and bind the ECStore contract test directly
+  to the storage-api generic list/delete/walk contracts.
+- CI/script changes: make the migration guard reject restoring ECStore
+  `object_api` storage-api passthrough aliases.
+- Docs changes: record the API-066 ECStore object API alias prune slice.
 
 ## Phase 0 Tasks
 
@@ -302,6 +301,22 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     compatibility.
   - Verification: focused ECStore compile checks, migration guard, formatting,
     diff hygiene, risk scan, and three-expert review.
+
+- [x] `API-066` Prune ECStore object API storage aliases.
+  - Completed slice: remove unused public storage-api passthrough aliases from
+    ECStore `object_api` for list responses, walk options, walk result items,
+    and delete-object DTOs, then bind the ECStore contract test directly to the
+    generic `rustfs-storage-api` contracts.
+  - Acceptance: ECStore `object_api` no longer exposes storage-api passthrough
+    aliases, the storage contract test still proves ECStore implements the
+    storage-api traits with the same associated concrete types, and migration
+    rules reject restoring the object_api passthrough aliases.
+  - Must preserve: ECStore-owned object metadata, object options, reader/writer
+    types, storage-api trait associated type bindings, list/delete/walk response
+    shapes, and runtime behavior.
+  - Verification: focused ECStore compile checks, storage contract test,
+    downstream compile checks, migration and layer guards, formatting, diff
+    hygiene, risk scan, full pre-commit, and three-expert review.
 
 - [x] `TEST-PRTYPE-001` Check PR type enum consistency.
   - Acceptance: `./scripts/check_architecture_migration_rules.sh` parses the

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -58,6 +58,7 @@ STORE_API_RANGE_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_range_helper_reexpor
 STORE_API_LIST_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_list_helper_reexports.txt"
 STORE_API_LIST_RESPONSE_REEXPORTS_FILE="${TMP_DIR}/store_api_list_response_reexports.txt"
 ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE="${TMP_DIR}/ecstore_object_api_list_alias_internal_hits.txt"
+ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE="${TMP_DIR}/ecstore_object_api_storage_alias_hits.txt"
 STORE_API_DELETE_DTO_REEXPORTS_FILE="${TMP_DIR}/store_api_delete_dto_reexports.txt"
 STORE_API_DELETE_DTO_INTERNAL_HITS_FILE="${TMP_DIR}/store_api_delete_dto_internal_hits.txt"
 STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_definition_hits.txt"
@@ -512,6 +513,16 @@ fi
 
 if [[ -s "$ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE" ]]; then
   report_failure "ECStore internal list/walk consumers must bind rustfs-storage-api generic contracts directly: $(paste -sd '; ' "$ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'pub type (?:ListObjectsInfo|ListObjectsV2Info|ListObjectVersionsInfo|ObjectInfoOrErr|WalkOptions|ObjectToDelete|DeletedObject)\b' \
+    crates/ecstore/src/object_api/types.rs || true
+) >"$ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE"
+
+if [[ -s "$ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE" ]]; then
+  report_failure "ECStore object_api must not re-export storage-api passthrough aliases: $(paste -sd '; ' "$ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE")"
 fi
 
 (

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -57,6 +57,7 @@ STORE_API_OBJECT_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_object_helper_reexp
 STORE_API_RANGE_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_range_helper_reexports.txt"
 STORE_API_LIST_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_list_helper_reexports.txt"
 STORE_API_LIST_RESPONSE_REEXPORTS_FILE="${TMP_DIR}/store_api_list_response_reexports.txt"
+ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE="${TMP_DIR}/ecstore_object_api_list_alias_internal_hits.txt"
 STORE_API_DELETE_DTO_REEXPORTS_FILE="${TMP_DIR}/store_api_delete_dto_reexports.txt"
 STORE_API_DELETE_DTO_INTERNAL_HITS_FILE="${TMP_DIR}/store_api_delete_dto_internal_hits.txt"
 STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_definition_hits.txt"
@@ -493,6 +494,24 @@ fi
 
 if [[ -s "$STORE_API_EXTERNAL_LIST_CONSUMER_HITS_FILE" ]]; then
   report_failure "external list response consumers must use rustfs-storage-api contracts: $(paste -sd '; ' "$STORE_API_EXTERNAL_LIST_CONSUMER_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  find crates/ecstore/src -type f -name '*.rs' -print0 |
+    xargs -0 perl -0ne '
+      while (/crate::object_api(?:::\{[^}]*\b(?:ListObjectsInfo|ListObjectsV2Info|ListObjectVersionsInfo|ObjectInfoOrErr|WalkOptions)\b|::(?:ListObjectsInfo|ListObjectsV2Info|ListObjectVersionsInfo|ObjectInfoOrErr|WalkOptions)\b)/sg) {
+        my $prefix = substr($_, 0, $-[0]);
+        my $line = ($prefix =~ tr/\n//) + 1;
+        my $match = $&;
+        $match =~ s/\s+/ /g;
+        print "$ARGV:$line:$match\n";
+      }
+    ' || true
+) >"$ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE"
+
+if [[ -s "$ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE" ]]; then
+  report_failure "ECStore internal list/walk consumers must bind rustfs-storage-api generic contracts directly: $(paste -sd '; ' "$ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Migrates ECStore internal list/walk contract consumers to local aliases over the generic `rustfs-storage-api` list contracts.

The public `rustfs_ecstore::object_api` compatibility aliases remain available for downstream callers, while ECStore implementation bounds and internal modules no longer depend on those aliases for list responses, walk options, or walk result items.

This is stacked on #3613.

## Verification
- `cargo check -p rustfs-ecstore --tests`
- `cargo test -p rustfs-ecstore --test ecstore_contract_compat_test -- --nocapture`
- `cargo check --tests -p rustfs-ecstore -p rustfs-heal -p rustfs-scanner -p rustfs-iam -p rustfs-s3select-api -p rustfs-notify -p rustfs-protocols -p rustfs`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
No runtime behavior change expected. ECStore public object API compatibility remains available through `rustfs_ecstore::object_api`; internal list and walk contract bindings now point directly at `rustfs-storage-api` generic contracts.

## Additional Notes
Stacked on #3613 while earlier ECStore cleanup PRs wait for CI.
