### PR TITLE
refactor: prune ecstore object api aliases

### DIFF
--- a/crates/ecstore/src/object_api/types.rs
+++ b/crates/ecstore/src/object_api/types.rs
@@ -4,14 +4,6 @@ use rustfs_storage_api::{
     VersionMarker,
 };
 
-pub type ListObjectsInfo = rustfs_storage_api::ListObjectsInfo<ObjectInfo>;
-pub type ListObjectsV2Info = rustfs_storage_api::ListObjectsV2Info<ObjectInfo>;
-pub type ListObjectVersionsInfo = rustfs_storage_api::ListObjectVersionsInfo<ObjectInfo>;
-pub type ObjectInfoOrErr = rustfs_storage_api::ObjectInfoOrErr<ObjectInfo, Error>;
-pub type WalkOptions = rustfs_storage_api::WalkOptions<WalkFilter>;
-pub type ObjectToDelete = rustfs_storage_api::ObjectToDelete;
-pub type DeletedObject = rustfs_storage_api::DeletedObject;
-
 #[derive(Debug, Default, Clone)]
 pub struct ObjectOptions {
     // Use the maximum parity (N/2), used when saving server configuration files
@@ -715,9 +707,6 @@ fn versions_after_marker(file_infos: &rustfs_filemeta::FileInfoVersions, marker:
         .map(|idx| &file_infos.versions[idx + 1..])
         .unwrap_or(&file_infos.versions)
 }
-
-type WalkFilter = fn(&FileInfo) -> bool;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ecstore/tests/ecstore_contract_compat_test.rs
+++ b/crates/ecstore/tests/ecstore_contract_compat_test.rs
@@ -16,22 +16,25 @@ use rustfs_common::heal_channel::HealOpts;
 use rustfs_ecstore::{
     disk::DiskStore,
     error::Error,
-    object_api::{
-        GetObjectReader, ListObjectVersionsInfo, ListObjectsV2Info, ObjectInfo, ObjectInfoOrErr, ObjectOptions, PutObjReader,
-        WalkOptions,
-    },
+    object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
     store::ECStore,
 };
 use rustfs_filemeta::FileInfo;
 use rustfs_lock::NamespaceLockWrapper;
 use rustfs_madmin::heal_commands::HealResultItem;
 use rustfs_storage_api::{
-    CompletePart, DeletedObject, HTTPRangeSpec, HealOperations as StorageHealOperations, ListMultipartsInfo, ListPartsInfo,
+    CompletePart, DeletedObject, HTTPRangeSpec, HealOperations as StorageHealOperations, ListMultipartsInfo,
+    ListObjectVersionsInfo as StorageListObjectVersionsInfo, ListObjectsV2Info as StorageListObjectsV2Info, ListPartsInfo,
     MultipartInfo, MultipartOperations as StorageMultipartOperations, MultipartUploadResult,
-    NamespaceLocking as StorageNamespaceLocking, ObjectIO as StorageObjectIO, ObjectOperations as StorageObjectOperations,
-    ObjectToDelete, PartInfo, StorageAdminApi,
+    NamespaceLocking as StorageNamespaceLocking, ObjectIO as StorageObjectIO, ObjectInfoOrErr as StorageObjectInfoOrErr,
+    ObjectOperations as StorageObjectOperations, ObjectToDelete, PartInfo, StorageAdminApi, WalkOptions as StorageWalkOptions,
 };
 use tokio_util::sync::CancellationToken;
+
+type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
+type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
+type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
+type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 
 fn storage_admin_api_type_name<T>() -> &'static str
 where

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,18 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-list-contracts-direct`
-- Baseline: stacked after `rustfs/rustfs#3613`
-  (`28fce7b377c38b286b69c62f1ab15711d0f59589`).
+- Branch: `overtrue/arch-ecstore-object-api-alias-prune`
+- Baseline: stacked after `rustfs/rustfs#3614`
+  (`3740e65246aed8c8ee9685ed0234997c7d54e1b5`).
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: migrate ECStore internal list/walk consumers to direct
-  aliases over the generic `rustfs-storage-api` list contracts, including
-  replication worker trait bounds.
-- CI/script changes: make the migration guard reject ECStore internal
-  `crate::object_api` imports of list/walk compatibility aliases, including
-  multi-line import forms.
-- Docs changes: record the API-065 ECStore list contract cleanup slice.
+- Rust code changes: remove unused public `rustfs-storage-api` passthrough
+  aliases from ECStore `object_api` and bind the ECStore contract test directly
+  to the storage-api generic list/delete/walk contracts.
+- CI/script changes: make the migration guard reject restoring ECStore
+  `object_api` storage-api passthrough aliases.
+- Docs changes: record the API-066 ECStore object API alias prune slice.
 
 ## Phase 0 Tasks
 
@@ -302,6 +301,22 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     compatibility.
   - Verification: focused ECStore compile checks, migration guard, formatting,
     diff hygiene, risk scan, and three-expert review.
+
+- [x] `API-066` Prune ECStore object API storage aliases.
+  - Completed slice: remove unused public storage-api passthrough aliases from
+    ECStore `object_api` for list responses, walk options, walk result items,
+    and delete-object DTOs, then bind the ECStore contract test directly to the
+    generic `rustfs-storage-api` contracts.
+  - Acceptance: ECStore `object_api` no longer exposes storage-api passthrough
+    aliases, the storage contract test still proves ECStore implements the
+    storage-api traits with the same associated concrete types, and migration
+    rules reject restoring the object_api passthrough aliases.
+  - Must preserve: ECStore-owned object metadata, object options, reader/writer
+    types, storage-api trait associated type bindings, list/delete/walk response
+    shapes, and runtime behavior.
+  - Verification: focused ECStore compile checks, storage contract test,
+    downstream compile checks, migration and layer guards, formatting, diff
+    hygiene, risk scan, full pre-commit, and three-expert review.
 
 - [x] `TEST-PRTYPE-001` Check PR type enum consistency.
   - Acceptance: `./scripts/check_architecture_migration_rules.sh` parses the

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -58,6 +58,7 @@ STORE_API_RANGE_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_range_helper_reexpor
 STORE_API_LIST_HELPER_REEXPORTS_FILE="${TMP_DIR}/store_api_list_helper_reexports.txt"
 STORE_API_LIST_RESPONSE_REEXPORTS_FILE="${TMP_DIR}/store_api_list_response_reexports.txt"
 ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE="${TMP_DIR}/ecstore_object_api_list_alias_internal_hits.txt"
+ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE="${TMP_DIR}/ecstore_object_api_storage_alias_hits.txt"
 STORE_API_DELETE_DTO_REEXPORTS_FILE="${TMP_DIR}/store_api_delete_dto_reexports.txt"
 STORE_API_DELETE_DTO_INTERNAL_HITS_FILE="${TMP_DIR}/store_api_delete_dto_internal_hits.txt"
 STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_definition_hits.txt"
@@ -512,6 +513,16 @@ fi
 
 if [[ -s "$ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE" ]]; then
   report_failure "ECStore internal list/walk consumers must bind rustfs-storage-api generic contracts directly: $(paste -sd '; ' "$ECSTORE_OBJECT_API_LIST_ALIAS_INTERNAL_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'pub type (?:ListObjectsInfo|ListObjectsV2Info|ListObjectVersionsInfo|ObjectInfoOrErr|WalkOptions|ObjectToDelete|DeletedObject)\b' \
+    crates/ecstore/src/object_api/types.rs || true
+) >"$ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE"
+
+if [[ -s "$ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE" ]]; then
+  report_failure "ECStore object_api must not re-export storage-api passthrough aliases: $(paste -sd '; ' "$ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Removes unused `rustfs-storage-api` passthrough aliases from `rustfs_ecstore::object_api`.

ECStore-owned object metadata, options, and readers remain available through `rustfs_ecstore::object_api`; list response, walk result, delete DTO, and walk option contracts now resolve directly from `rustfs-storage-api` in the contract test and implementation code.

This is stacked on #3614.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `git diff --check`
- `cargo check -p rustfs-ecstore --tests`
- `cargo test -p rustfs-ecstore --test ecstore_contract_compat_test -- --nocapture`
- `cargo check --tests -p rustfs-ecstore -p rustfs-heal -p rustfs-scanner -p rustfs-iam -p rustfs-s3select-api -p rustfs-notify -p rustfs-protocols -p rustfs`
- `make pre-commit`

## Impact
No runtime behavior change expected. Downstream code should import generic list, delete, and walk storage contracts from `rustfs-storage-api` instead of through `rustfs_ecstore::object_api`.

## Additional Notes
Stacked on #3614 while earlier ECStore cleanup PRs wait for CI.
