### PR TITLE
refactor: prune iam ecstore object aliases

### DIFF
--- a/crates/iam/src/storage_compat.rs
+++ b/crates/iam/src/storage_compat.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 pub(crate) const IAM_CONFIG_ROOT_PREFIX: &str = rustfs_ecstore::config::RUSTFS_CONFIG_PREFIX;
 
 pub(crate) type IamEcstoreError = rustfs_ecstore::error::Error;
-pub(crate) type IamConfigObjectInfo = rustfs_ecstore::object_api::ObjectInfo;
-pub(crate) type IamConfigObjectOptions = rustfs_ecstore::object_api::ObjectOptions;
 pub(crate) type IamStorageError = rustfs_ecstore::error::StorageError;
 pub(crate) type IamStorageResult<T> = rustfs_ecstore::error::Result<T>;
 pub(crate) type IamStore = rustfs_ecstore::store::ECStore;
+pub(crate) type IamConfigObjectInfo = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
+pub(crate) type IamConfigObjectOptions = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
 
 pub(crate) async fn read_iam_config_no_lock(api: Arc<IamStore>, file: &str) -> IamStorageResult<Vec<u8>> {
     rustfs_ecstore::config::com::read_config_no_lock(api, file).await

--- a/crates/iam/src/store/storage_compat.rs
+++ b/crates/iam/src/store/storage_compat.rs
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(super) type IamObjectInfo = rustfs_ecstore::object_api::ObjectInfo;
-pub(super) type IamObjectOptions = rustfs_ecstore::object_api::ObjectOptions;
+use crate::storage_compat::IamStore;
+
+pub(super) type IamObjectInfo = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
+pub(super) type IamObjectOptions = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-notify-object-info-boundary-prune`
-- Baseline: stacked after `rustfs/rustfs#3619`
-  (`dd2c1846ad8b35f589492885cca2154dd13ea918`).
+- Branch: `overtrue/arch-iam-object-boundary-prune`
+- Baseline: stacked after `rustfs/rustfs#3620`
+  (`c7bee5de904c9a1ea70f73ad6621895a30b3c387`).
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: remove notify's private ECStore `ObjectInfo` conversion
-  alias and perform the ECStore event object to `NotifyObjectInfo` mapping in
-  RustFS event/operation notification bridges.
+- Rust code changes: route IAM config/store object metadata and options aliases
+  through `rustfs_storage_api::ObjectOperations` associated types.
 - CI/script changes: shrink the remaining external `rustfs_ecstore::object_api`
-  compatibility alias snapshot by removing notify's object-info alias.
-- Docs changes: record the API-068 notify object-info boundary prune slice.
+  compatibility alias snapshot by removing IAM object-info/options aliases.
+- Docs changes: record the API-069 IAM object boundary prune slice.
 
 ## Phase 0 Tasks
 
@@ -347,6 +346,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Verification: focused RustFS event conversion test, focused notify/RustFS
     compile checks, migration and layer guards, formatting, diff hygiene, full
     pre-commit, and three-expert review.
+
+- [x] `API-069` Prune IAM direct ECStore object metadata/options aliases.
+  - Completed slice: replace IAM config and store `ObjectInfo`/`ObjectOptions`
+    compatibility aliases with `IamStore` `ObjectOperations` associated types.
+  - Acceptance: IAM no longer names
+    `rustfs_ecstore::object_api::{ObjectInfo,ObjectOptions}` directly, the
+    remaining object-api alias allowlist shrinks by four entries, and IAM config
+    read/write metadata and lazy-rewrite precondition behavior are unchanged.
+  - Must preserve: IAM config encryption/decryption, lazy rewrite ETag matching,
+    list walk item/error typing, metadata return shape, storage preconditions,
+    system-path failure classification, and notification peer behavior.
+  - Verification: focused IAM compile/tests, migration and layer guards,
+    formatting, diff hygiene, full pre-commit, and three-expert review.
 
 - [x] `TEST-PRTYPE-001` Check PR type enum consistency.
   - Acceptance: `./scripts/check_architecture_migration_rules.sh` parses the

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -533,10 +533,6 @@ cat >"$ECSTORE_OBJECT_API_EXTERNAL_ALIAS_EXPECTED_FILE" <<'EOF'
 crates/heal/src/heal/storage_compat.rs:HealObjectInfo=ObjectInfo
 crates/heal/src/heal/storage_compat.rs:HealObjectOptions=ObjectOptions
 crates/heal/src/heal/storage_compat.rs:HealPutObjReader=PutObjReader
-crates/iam/src/storage_compat.rs:IamConfigObjectInfo=ObjectInfo
-crates/iam/src/storage_compat.rs:IamConfigObjectOptions=ObjectOptions
-crates/iam/src/store/storage_compat.rs:IamObjectInfo=ObjectInfo
-crates/iam/src/store/storage_compat.rs:IamObjectOptions=ObjectOptions
 crates/protocols/src/swift/storage_compat.rs:SwiftGetObjectReader=GetObjectReader
 crates/protocols/src/swift/storage_compat.rs:SwiftObjectInfo=ObjectInfo
 crates/protocols/src/swift/storage_compat.rs:SwiftObjectOptions=ObjectOptions


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Routes IAM config and store object metadata/options aliases through the `IamStore` `ObjectOperations` associated types instead of directly naming `rustfs_ecstore::object_api` object types.

This shrinks the migration guard allowlist by four IAM entries while preserving IAM config metadata reads, storage preconditions, list walk typing, and lazy-rewrite ETag behavior.

## Verification

- `cargo test -p rustfs-iam`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact

No runtime behavior change expected. This narrows the IAM compatibility boundary without changing IAM config storage behavior.

## Additional Notes

Stacked on #3620 until its notify boundary cleanup lands.
