### PR TITLE
refactor: prune final ecstore object aliases

### DIFF
--- a/crates/heal/src/heal/storage_compat.rs
+++ b/crates/heal/src/heal/storage_compat.rs
@@ -29,6 +29,6 @@ pub(crate) use rustfs_ecstore::global::GLOBAL_LOCAL_DISK_MAP;
 #[cfg(test)]
 pub(crate) use rustfs_ecstore::disk::{DiskOption, new_disk};
 
-pub type HealObjectInfo = rustfs_ecstore::object_api::ObjectInfo;
-pub type HealObjectOptions = rustfs_ecstore::object_api::ObjectOptions;
-pub type HealPutObjReader = rustfs_ecstore::object_api::PutObjReader;
+pub type HealObjectInfo = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
+pub type HealObjectOptions = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
+pub type HealPutObjReader = <ECStore as rustfs_storage_api::ObjectIO>::PutObjectReader;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-consumer-object-boundary-prune`
-- Baseline: latest `upstream/main`
-  (`08b8f58e64e87efac48c5a1c596fb4a8ea65e5f2`).
+- Branch: `overtrue/arch-final-object-boundary-prune`
+- Baseline: stacked after `rustfs/rustfs#3622`
+  (`4300bf04f3a82ef4cc2605f417f89e7b4643b99e`).
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: route scanner, s3select, and Swift object reader,
+- Rust code changes: route heal and RustFS storage object reader, writer,
   metadata, and options aliases through `rustfs_storage_api` associated types.
 - CI/script changes: shrink the remaining external `rustfs_ecstore::object_api`
-  compatibility alias snapshot by removing scanner, s3select, and Swift object
-  aliases.
-- Docs changes: record the API-070 consumer object boundary prune slice.
+  compatibility alias snapshot to empty.
+- Docs changes: record the API-071 final object boundary prune slice.
 
 ## Phase 0 Tasks
 
@@ -376,6 +375,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     compatibility boundary.
   - Verification: focused consumer compile/tests, migration and layer guards,
     formatting, diff hygiene, full pre-commit, and three-expert review.
+
+- [x] `API-071` Prune final direct ECStore object aliases.
+  - Completed slice: replace heal and RustFS storage
+    `GetObjectReader`/`ObjectInfo`/`ObjectOptions`/`PutObjReader`
+    compatibility aliases with concrete store `rustfs_storage_api` associated
+    types.
+  - Acceptance: no external `storage_compat.rs` module names
+    `rustfs_ecstore::object_api::{GetObjectReader,ObjectInfo,ObjectOptions,PutObjReader}`
+    directly, and the external object-api alias allowlist is empty.
+  - Must preserve: heal object metadata and rewrite reader construction,
+    RustFS storage object read/write paths, S3 response metadata semantics,
+    SSE/encryption handling, and storage object option behavior.
+  - Verification: focused heal/storage compile/tests, migration and layer
+    guards, formatting, diff hygiene, full pre-commit, and three-expert review.
 
 - [x] `TEST-PRTYPE-001` Check PR type enum consistency.
   - Acceptance: `./scripts/check_architecture_migration_rules.sh` parses the

--- a/rustfs/src/storage/storage_compat.rs
+++ b/rustfs/src/storage/storage_compat.rs
@@ -39,7 +39,7 @@ pub(crate) use rustfs_ecstore::rpc::{
 pub(crate) use rustfs_ecstore::set_disk::DEFAULT_READ_BUFFER_SIZE;
 pub(crate) use rustfs_ecstore::store::{ECStore, all_local_disk_path, find_local_disk_by_ref};
 
-pub(crate) type GetObjectReader = rustfs_ecstore::object_api::GetObjectReader;
-pub(crate) type ObjectInfo = rustfs_ecstore::object_api::ObjectInfo;
-pub(crate) type ObjectOptions = rustfs_ecstore::object_api::ObjectOptions;
-pub(crate) type PutObjReader = rustfs_ecstore::object_api::PutObjReader;
+pub(crate) type GetObjectReader = <ECStore as rustfs_storage_api::ObjectIO>::GetObjectReader;
+pub(crate) type ObjectInfo = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
+pub(crate) type ObjectOptions = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
+pub(crate) type PutObjReader = <ECStore as rustfs_storage_api::ObjectIO>::PutObjectReader;

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -530,13 +530,6 @@ if [[ -s "$ECSTORE_OBJECT_API_STORAGE_ALIAS_HITS_FILE" ]]; then
 fi
 
 cat >"$ECSTORE_OBJECT_API_EXTERNAL_ALIAS_EXPECTED_FILE" <<'EOF'
-crates/heal/src/heal/storage_compat.rs:HealObjectInfo=ObjectInfo
-crates/heal/src/heal/storage_compat.rs:HealObjectOptions=ObjectOptions
-crates/heal/src/heal/storage_compat.rs:HealPutObjReader=PutObjReader
-rustfs/src/storage/storage_compat.rs:GetObjectReader=GetObjectReader
-rustfs/src/storage/storage_compat.rs:ObjectInfo=ObjectInfo
-rustfs/src/storage/storage_compat.rs:ObjectOptions=ObjectOptions
-rustfs/src/storage/storage_compat.rs:PutObjReader=PutObjReader
 EOF
 
 (


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Routes the remaining heal and RustFS storage object reader/metadata/options aliases through concrete `rustfs_storage_api` associated types instead of directly naming `rustfs_ecstore::object_api` object types.

This empties the migration guard allowlist for external ECStore object API compatibility aliases while preserving heal and RustFS storage local compatibility boundaries.

## Verification

- `cargo check -p rustfs-heal`
- `cargo check -p rustfs --lib`
- `cargo test -p rustfs-heal`
- `cargo test -p rustfs --lib storage:: -- --nocapture`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact

No runtime behavior change expected. The concrete ECStore object reader, writer, metadata, and option types remain bound through the storage API trait surface.

## Additional Notes

Stacked on #3622 until its consumer boundary cleanup lands.
