### PR TITLE
refactor: keep embedded identity with startup config

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,15 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-embedded-startup-result-shell`
-- Baseline: completed `R-046/R-047`.
-- Stacked on: embedded startup identity slice.
+- Branch: `overtrue/arch-embedded-startup-config-identity`
+- Baseline: completed `R-048/R-049`.
+- Stacked on: embedded startup result shell slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: consume embedded builder startup arguments directly and
-  keep startup-result-to-public-handle mapping plus ready logging at clear
-  ownership boundaries.
+- Rust code changes: keep embedded startup identity with prepared startup
+  config and remove the residual startup-argument clone contract.
 - CI/script changes: none.
-- Docs changes: record the embedded startup result shell slices.
+- Docs changes: record the embedded startup config identity slices.
 
 ## Phase 0 Tasks
 
@@ -2411,6 +2410,31 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     check, migration/layer guards, formatting, diff hygiene, Rust risk scan,
     branch freshness check, pre-commit quality gate, and three-expert review.
 
+- [x] `R-050` Keep embedded identity with prepared startup config.
+  - Do: return the embedded access key, secret key, and region alongside the
+    prepared startup config so startup result assembly uses one prepared owner.
+  - Acceptance: public server identity accessors still return configured
+    credentials and region for default, explicit, and generated-volume builds.
+  - Must preserve: credential initialization inputs, region initialization,
+    startup config ownership, startup error mapping, and no public API
+    signature changes.
+  - Verification: focused startup-server/startup-embedded/embedded checks,
+    RustFS lib check, migration/layer guards, formatting, diff hygiene, Rust
+    risk scan, branch freshness check, pre-commit quality gate, and
+    three-expert review.
+
+- [x] `R-051` Remove residual embedded startup argument clone contract.
+  - Do: drop the `Clone` derivation from embedded startup arguments now that
+    the public builder consumes startup state directly.
+  - Acceptance: builder chaining, configured volumes, retry-before-global-init
+    behavior, and startup ownership remain unchanged.
+  - Must preserve: public builder method chaining, prepared config contents,
+    temporary directory cleanup ownership, and no public API signature changes.
+  - Verification: focused startup-server/startup-embedded/embedded checks,
+    RustFS lib check, migration/layer guards, formatting, diff hygiene, Rust
+    risk scan, branch freshness check, pre-commit quality gate, and
+    three-expert review.
+
 - [x] `E-001/E-SET-001` Add ECStore layout skeleton and set-layout boundary.
   - Do: create the ECStore internal layout ownership buckets and pin static set
     layout versus runtime `Sets`/`SetDisks` orchestration boundaries before any
@@ -2660,13 +2684,28 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | R-048 and R-049 keep the public embedded builder as a shell over the startup owner and localize ready logging with startup completion. |
-| Migration preservation | passed | Builder chaining, defaults, configured identity, endpoint normalization, readiness publication order, and shutdown ownership stay unchanged. |
-| Testing/verification | passed | Focused startup-embedded/embedded checks, RustFS lib check, architecture/layer/unsafe guards, formatting, diff hygiene, Rust risk scan, and pre-commit gate passed. |
+| Quality/architecture | passed | R-050 and R-051 keep embedded identity with prepared startup config and remove the residual startup-argument clone contract without widening the public API. |
+| Migration preservation | passed | Builder chaining, configured identity, region setup, temporary volume ownership, startup error mapping, and shutdown ownership stay unchanged. |
+| Testing/verification | passed | Focused startup-server/startup-embedded/embedded checks, RustFS lib check, architecture/layer/unsafe guards, formatting, diff hygiene, Rust risk scan, and pre-commit gate passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 R-050/R-051 current slice:
+  - `cargo test -p rustfs --lib startup_server -- --nocapture`: passed.
+  - `cargo test -p rustfs --lib startup_embedded -- --nocapture`: passed.
+  - `cargo test -p rustfs --lib embedded -- --nocapture`: passed.
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `./scripts/check_unsafe_code_allowances.sh`: passed.
+  - Rust risk scan on changed Rust files: passed; only test-only `expect`
+    calls were present.
+  - `make pre-commit`: passed; nextest ran 6329 tests with 6329 passed and
+    111 skipped, and doctests passed.
 
 - Issue #660 R-048/R-049 current slice:
   - `cargo test -p rustfs --lib startup_embedded -- --nocapture`: passed.

--- a/rustfs/src/startup_embedded.rs
+++ b/rustfs/src/startup_embedded.rs
@@ -28,7 +28,6 @@ use crate::{
 use std::{io, net::SocketAddr, path::PathBuf};
 use tokio_util::sync::CancellationToken;
 
-#[derive(Clone)]
 pub(crate) struct EmbeddedStartupArgs {
     address: String,
     access_key: String,
@@ -104,19 +103,18 @@ pub(crate) async fn run_embedded_startup(args: EmbeddedStartupArgs) -> Result<Em
         volumes,
         region,
     } = args;
-    let server_access_key = access_key.clone();
-    let server_secret_key = secret_key.clone();
-    let server_region = region.clone();
-
     // Build is allowed to fail before irreversible global initialization
     // (for example on temporary I/O or directory setup errors), and in that
     // case callers can retry.
     let mut startup_guard = EmbeddedStartupGuard::new();
 
-    let EmbeddedStartupConfig { config, temp_dir_guard } =
-        prepare_embedded_startup_config(address, access_key, secret_key, volumes, region)
-            .await
-            .map_err(init_error)?;
+    let EmbeddedStartupConfig {
+        config,
+        identity,
+        temp_dir_guard,
+    } = prepare_embedded_startup_config(address, access_key, secret_key, volumes, region)
+        .await
+        .map_err(init_error)?;
 
     init_embedded_runtime_hooks(config.obs_endpoint.clone())
         .await
@@ -176,9 +174,9 @@ pub(crate) async fn run_embedded_startup(args: EmbeddedStartupArgs) -> Result<Em
 
     Ok(EmbeddedStartedServer {
         bound_addr,
-        access_key: server_access_key,
-        secret_key: server_secret_key,
-        region: server_region,
+        access_key: identity.access_key,
+        secret_key: identity.secret_key,
+        region: identity.region,
         shutdown_handle,
         cancel_token,
         temp_dir: temp_dir_guard.map(|guard| guard.keep()),

--- a/rustfs/src/startup_server.rs
+++ b/rustfs/src/startup_server.rs
@@ -54,7 +54,14 @@ pub struct EmbeddedStartupListenContext {
 
 pub(crate) struct EmbeddedStartupConfig {
     pub config: Config,
+    pub identity: EmbeddedServerIdentity,
     pub(crate) temp_dir_guard: Option<TempDir>,
+}
+
+pub(crate) struct EmbeddedServerIdentity {
+    pub access_key: String,
+    pub secret_key: String,
+    pub region: String,
 }
 
 pub(crate) struct EmbeddedHttpServer {
@@ -141,12 +148,20 @@ pub(crate) async fn prepare_embedded_startup_config(
     }
 
     let mut config = Config::new(&address, volumes);
-    config.access_key = access_key;
-    config.secret_key = secret_key;
-    config.region = Some(region);
+    config.access_key = access_key.clone();
+    config.secret_key = secret_key.clone();
+    config.region = Some(region.clone());
     config.console_enable = false;
 
-    Ok(EmbeddedStartupConfig { config, temp_dir_guard })
+    Ok(EmbeddedStartupConfig {
+        config,
+        identity: EmbeddedServerIdentity {
+            access_key,
+            secret_key,
+            region,
+        },
+        temp_dir_guard,
+    })
 }
 
 pub(crate) fn find_embedded_available_port() -> Result<u16> {
@@ -380,6 +395,9 @@ mod tests {
         assert_eq!(prepared.config.access_key, "access");
         assert_eq!(prepared.config.secret_key, "secret");
         assert_eq!(prepared.config.region.as_deref(), Some("us-west-2"));
+        assert_eq!(prepared.identity.access_key, "access");
+        assert_eq!(prepared.identity.secret_key, "secret");
+        assert_eq!(prepared.identity.region, "us-west-2");
         assert!(!prepared.config.console_enable);
         assert_eq!(prepared.config.volumes.len(), 1);
         assert!(std::path::Path::new(&prepared.config.volumes[0]).exists());


### PR DESCRIPTION
## Related Issues

Issue #660

## Summary of Changes

- Carry embedded server identity through the startup config boundary.
- Keep embedded startup argument preparation explicit before server startup.
- Record the R-050/R-051 migration slice and verification results.

## Verification

- `cargo test -p rustfs --lib startup_server -- --nocapture`
- `cargo test -p rustfs --lib startup_embedded -- --nocapture`
- `cargo test -p rustfs --lib embedded -- --nocapture`
- `cargo test -p rustfs --lib startup_ -- --nocapture`
- `cargo check -p rustfs --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_unsafe_code_allowances.sh`
- Rust risk scan on changed Rust files
- `make pre-commit`

## Impact

No user-facing behavior change. The embedded startup path keeps existing defaults and custom identity handling while making the config handoff explicit.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
