### PR TITLE
test(ecstore): cover DNS resolver raw errors

### DIFF
--- a/crates/ecstore/src/layout/endpoints.rs
+++ b/crates/ecstore/src/layout/endpoints.rs
@@ -1040,6 +1040,12 @@ mod test {
     }
 
     #[test]
+    fn retryable_dns_error_accepts_resolver_raw_os_codes() {
+        assert!(is_retryable_dns_error(&Error::from_raw_os_error(-3)));
+        assert!(is_retryable_dns_error(&Error::from_raw_os_error(-2)));
+    }
+
+    #[test]
     fn retryable_dns_error_rejects_configuration_errors() {
         assert!(!is_retryable_dns_error(&Error::new(
             ErrorKind::InvalidInput,


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds a focused regression test for endpoint DNS retry classification so resolver raw OS error codes used by transient lookup failures stay retryable.

## Verification
- `cargo test -p rustfs-ecstore layout::endpoints::test::retryable_dns_error_accepts_resolver_raw_os_codes`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
Test-only change. No runtime behavior impact.

## Additional Notes
N/A
