### PR TITLE
refactor: prune root runtime compat aliases

### DIFF
--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -146,6 +146,9 @@ RustFS root `storage_compat.rs` must expose bucket metadata and quota contracts
 as explicit aliases only. Broad `metadata`, `metadata_sys`, and `quota` module
 passthroughs are reserved to narrower app/admin/storage compatibility
 boundaries that still need module-local owner cleanup.
+Root runtime storage config initialization and disk endpoint contracts must also
+stay explicit aliases. The root compatibility boundary must not restore `com`,
+bare `init`, or grouped `endpoint::Endpoint` passthroughs.
 
 ECStore ClusterControlPlane read models must stay owned by the crate-private
 `cluster` module. Public access goes through `rustfs_ecstore::api::cluster` so

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-root-runtime-compat-boundaries`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059`.
-- Stacked on: main after workload admission provider composition.
+- Branch: `overtrue/arch-root-runtime-compat-aliases`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079`.
+- Stacked on: API-079 root runtime bucket compatibility pruning.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: prune broad root bucket metadata/quota compatibility module
-  passthroughs into explicit aliases for the current RustFS root consumers.
-- CI/script changes: guard against restoring broad root bucket compatibility
+- Rust code changes: prune root config read/write, config initialization, and
+  disk endpoint compatibility passthroughs into explicit aliases for startup
+  and runtime consumers.
+- CI/script changes: guard against restoring broad root config and disk endpoint
   module passthroughs.
-- Docs changes: record the API-079 root runtime bucket compatibility boundary.
+- Docs changes: record the API-080 root runtime compatibility alias boundary.
 
 ## Phase 0 Tasks
 
@@ -122,6 +123,23 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Must preserve: bucket notification loading, notifier event registration,
     table-bucket mutation guards, quota error to S3 error mapping, ECStore
     bucket metadata ownership, and all app/admin/storage compatibility paths.
+  - Verification: RustFS compile coverage, formatting, diff hygiene, risk
+    scan, architecture guard, pre-commit quality gate, and three-expert review.
+- [x] `API-080` Prune root runtime config and disk compatibility aliases.
+  - Completed slice: replace root config `com` passthroughs with explicit
+    config read/write aliases for module switches, expose ECStore config
+    initialization as `init_ecstore_config`, split disk endpoint access into an
+    explicit `Endpoint` alias, and guard these root aliases against broad
+    module restores.
+  - Acceptance: startup storage initializes ECStore config through a direct
+    compatibility alias, module switch persistence uses direct config IO
+    aliases, root runtime disk endpoint consumers keep the same endpoint type,
+    and app/admin/storage local compatibility modules remain unchanged for
+    their own cleanup slices.
+  - Must preserve: startup storage initialization order, global config
+    migration/retry behavior, module switch persistence semantics, endpoint
+    parsing/layout behavior, local disk and lock-client initialization,
+    readiness marking, and all app/admin/storage compatibility paths.
   - Verification: RustFS compile coverage, formatting, diff hygiene, risk
     scan, architecture guard, pre-commit quality gate, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
@@ -3157,13 +3175,22 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | API-079 narrows the root RustFS bucket compatibility boundary to explicit aliases without adding new ECStore ownership cycles. |
-| Migration preservation | passed | Bucket notification loading, table-catalog metadata checks, quota error mapping, and app/admin/storage compatibility paths remain preserved. |
+| Quality/architecture | passed | API-080 narrows root runtime config and disk endpoint compatibility to explicit aliases without adding new ECStore ownership cycles. |
+| Migration preservation | passed | Startup config initialization, module switch persistence, endpoint handling, local disk/lock setup, readiness, and app/admin/storage compatibility paths remain preserved. |
 | Testing/verification | passed | RustFS compile coverage, migration guard, formatting, diff hygiene, added-line risk scan, full pre-commit, and three-expert review passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-080 current slice:
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - Rust added-line risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 C-013 current slice:
   - `cargo test -p rustfs-concurrency workload::tests:: -- --nocapture`:

--- a/rustfs/src/server/module_switch.rs
+++ b/rustfs/src/server/module_switch.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use crate::storage_compat::{
-    EcstoreError as StorageError,
-    com::{read_config, save_config},
-    resolve_object_store_handle,
+    EcstoreError as StorageError, read_ecstore_config, resolve_object_store_handle, save_ecstore_config,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -166,7 +164,7 @@ pub(crate) async fn refresh_persisted_module_switches_from_store() -> Result<Per
         return Err("storage layer not initialized".to_string());
     };
 
-    let (config, configured) = match read_config(store, MODULE_SWITCH_CONFIG_PATH).await {
+    let (config, configured) = match read_ecstore_config(store, MODULE_SWITCH_CONFIG_PATH).await {
         Ok(data) => (
             serde_json::from_slice::<PersistedModuleSwitches>(&data)
                 .map_err(|e| format!("failed to deserialize module switch config: {e}"))?,
@@ -188,7 +186,7 @@ pub(crate) async fn save_persisted_module_switches_to_store(config: PersistedMod
     };
 
     let data = serde_json::to_vec(&config).map_err(|e| format!("failed to serialize module switch config: {e}"))?;
-    save_config(store, MODULE_SWITCH_CONFIG_PATH, data)
+    save_ecstore_config(store, MODULE_SWITCH_CONFIG_PATH, data)
         .await
         .map_err(|e| format!("failed to save module switch config: {e}"))?;
 

--- a/rustfs/src/startup_storage.rs
+++ b/rustfs/src/startup_storage.rs
@@ -14,9 +14,8 @@
 
 use crate::startup_fs_guard::enforce_unsupported_fs_policy;
 use crate::storage_compat::{
-    ECStore, EndpointServerPools, init as init_ecstore_config, init_background_replication, init_global_config_sys,
-    init_local_disks, init_lock_clients, prewarm_local_disk_id_map, set_global_endpoints, try_migrate_server_config,
-    update_erasure_type,
+    ECStore, EndpointServerPools, init_background_replication, init_ecstore_config, init_global_config_sys, init_local_disks,
+    init_lock_clients, prewarm_local_disk_id_map, set_global_endpoints, try_migrate_server_config, update_erasure_type,
 };
 use rustfs_common::{GlobalReadiness, SystemStage};
 use std::{

--- a/rustfs/src/storage_compat.rs
+++ b/rustfs/src/storage_compat.rs
@@ -25,8 +25,10 @@ pub(crate) use rustfs_ecstore::api::bucket::replication::{
     GLOBAL_REPLICATION_STATS, get_global_replication_pool, init_background_replication,
 };
 pub(crate) use rustfs_ecstore::api::cluster::topology_snapshot_from_endpoint_pools_with_capabilities;
-pub(crate) use rustfs_ecstore::api::config::{com, init, init_global_config_sys, try_migrate_server_config};
-pub(crate) use rustfs_ecstore::api::disk::{DiskAPI, RUSTFS_META_BUCKET, endpoint::Endpoint};
+pub(crate) use rustfs_ecstore::api::config::com::{read_config as read_ecstore_config, save_config as save_ecstore_config};
+pub(crate) use rustfs_ecstore::api::config::{init as init_ecstore_config, init_global_config_sys, try_migrate_server_config};
+pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint;
+pub(crate) use rustfs_ecstore::api::disk::{DiskAPI, RUSTFS_META_BUCKET};
 pub(crate) use rustfs_ecstore::api::error::{Error as EcstoreError, Result as EcstoreResult, StorageError};
 pub(crate) use rustfs_ecstore::api::event::{EventArgs as EcstoreEventArgs, register_event_dispatch_hook};
 pub(crate) use rustfs_ecstore::api::global::{

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -79,6 +79,7 @@ RUSTFS_NESTED_STORAGE_COMPAT_HITS_FILE="${TMP_DIR}/rustfs_nested_storage_compat_
 RUSTFS_RUNTIME_SCALAR_STORAGE_COMPAT_HITS_FILE="${TMP_DIR}/rustfs_runtime_scalar_storage_compat_hits.txt"
 RUSTFS_RUNTIME_SECONDARY_STORAGE_COMPAT_HITS_FILE="${TMP_DIR}/rustfs_runtime_secondary_storage_compat_hits.txt"
 RUSTFS_ROOT_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/rustfs_root_bucket_storage_compat_module_hits.txt"
+RUSTFS_ROOT_RUNTIME_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/rustfs_root_runtime_storage_compat_module_hits.txt"
 PRODUCTION_UNUSED_COMPAT_ALLOW_HITS_FILE="${TMP_DIR}/production_unused_compat_allow_hits.txt"
 BROAD_STORE_API_COMPAT_REEXPORT_HITS_FILE="${TMP_DIR}/broad_store_api_compat_reexport_hits.txt"
 NESTED_STORE_API_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/nested_store_api_compat_module_hits.txt"
@@ -774,6 +775,16 @@ fi
 
 if [[ -s "$RUSTFS_ROOT_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE" ]]; then
   report_failure "RustFS root storage compatibility must expose bucket metadata/quota contracts as explicit aliases: $(paste -sd '; ' "$RUSTFS_ROOT_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'pub\(crate\)\s+use rustfs_ecstore::api::config::\{[^}]*\bcom\b[^}]*\}\s*;|pub\(crate\)\s+use rustfs_ecstore::api::config::\{[^}]*\binit\s*(?:,|})[^}]*\}\s*;|pub\(crate\)\s+use rustfs_ecstore::api::disk::\{[^}]*\bendpoint::Endpoint\b[^}]*\}\s*;' \
+    rustfs/src/storage_compat.rs || true
+) >"$RUSTFS_ROOT_RUNTIME_STORAGE_COMPAT_MODULE_HITS_FILE"
+
+if [[ -s "$RUSTFS_ROOT_RUNTIME_STORAGE_COMPAT_MODULE_HITS_FILE" ]]; then
+  report_failure "RustFS root storage compatibility must expose config init and disk endpoint contracts as explicit aliases: $(paste -sd '; ' "$RUSTFS_ROOT_RUNTIME_STORAGE_COMPAT_MODULE_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

- rustfs/backlog#660

## Summary of Changes

- Replace RustFS root config module passthroughs with explicit ECStore config read/write and init aliases.
- Split the root disk endpoint compatibility import into an explicit `Endpoint` alias.
- Add an architecture migration guard and documentation for the API-080 root runtime compatibility alias boundary.

## Verification

- `make pre-commit`
- `cargo check -p rustfs --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- Rust added-line risk scan on changed Rust files and guard script

## Impact

No runtime behavior change. Startup storage config initialization, module switch persistence, endpoint handling, and app/admin/storage compatibility paths remain unchanged.

## Additional Notes

N/A
