### PR TITLE
refactor: prune admin app compat re-exports

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -144,8 +144,8 @@ pub mod rebalance {
 
 pub mod rio {
     pub use crate::rio::{
-        DecryptReader, DynReader, EncryptReader, HardLimitReader, HashReader, WriteEncryption, WritePlan, boxed_reader,
-        compression_metadata_value, wrap_reader,
+        DecryptReader, DynReader, EncryptReader, HardLimitReader, HashReader, ReadStream, Reader, WriteEncryption, WritePlan,
+        boxed_reader, compression_metadata_value, wrap_reader,
     };
 }
 

--- a/crates/ecstore/src/bucket/replication/mod.rs
+++ b/crates/ecstore/src/bucket/replication/mod.rs
@@ -23,5 +23,5 @@ pub use config::*;
 pub use datatypes::*;
 pub use replication_pool::*;
 pub use replication_resyncer::*;
-pub use replication_state::BucketStats;
+pub use replication_state::{BucketStats, ReplicationStats};
 pub use rule::*;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -246,6 +246,22 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Verification: RustFS compile coverage, storage-owner re-export residual
     scan, migration guard, formatting, diff hygiene, Rust risk scan,
     pre-commit quality gate, and three-expert review.
+- [x] `API-088` Prune admin and app compatibility re-exports.
+  - Completed slice: replace RustFS admin and app `storage_compat.rs` ECStore
+    API re-exports with local constants, type aliases, proxy statics, and
+    wrapper functions; keep only temporary trait imports required for method
+    resolution.
+  - Acceptance: admin handlers and app object/runtime paths keep their existing
+    compatibility names while the admin and app boundaries no longer expose
+    direct ECStore API symbol re-exports for functions, constants, globals, or
+    DTO aliases.
+  - Must preserve: admin config reads/writes, bucket metadata access, lifecycle
+    enqueue/restore behavior, replication admission and scheduling, object-lock
+    checks, RIO reader wrapping, data usage accounting, global object-store
+    access, and local disk initialization behavior.
+  - Verification: RustFS compile coverage, admin/app re-export residual scan,
+    migration guard, formatting, diff hygiene, Rust risk scan, pre-commit
+    quality gate, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
     [`placement-repair-invariants.md`](placement-repair-invariants.md) records

--- a/rustfs/src/admin/storage_compat.rs
+++ b/rustfs/src/admin/storage_compat.rs
@@ -12,108 +12,371 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+use std::sync::Arc;
+
+pub(crate) const RUSTFS_META_BUCKET: &str = rustfs_ecstore::api::disk::RUSTFS_META_BUCKET;
+pub(crate) const STORAGE_CLASS_SUB_SYS: &str = rustfs_ecstore::api::config::com::STORAGE_CLASS_SUB_SYS;
+
+pub(crate) type AdminError = rustfs_ecstore::api::client::admin_handler_utils::AdminError;
+pub(crate) type CollectMetricsOpts = rustfs_ecstore::api::metrics::CollectMetricsOpts;
+pub(crate) type DiskStat = rustfs_ecstore::api::rebalance::DiskStat;
+pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
+pub(crate) type EndpointServerPools = rustfs_ecstore::api::layout::EndpointServerPools;
+pub(crate) type Error = rustfs_ecstore::api::error::Error;
+pub(crate) type MetricType = rustfs_ecstore::api::metrics::MetricType;
+pub(crate) type PeerRestClient = rustfs_ecstore::api::rpc::PeerRestClient;
+pub(crate) type RebalSaveOpt = rustfs_ecstore::api::rebalance::RebalSaveOpt;
+pub(crate) type RebalanceCleanupWarnings = rustfs_ecstore::api::rebalance::RebalanceCleanupWarnings;
+pub(crate) type RebalanceMeta = rustfs_ecstore::api::rebalance::RebalanceMeta;
+pub(crate) type RebalanceStats = rustfs_ecstore::api::rebalance::RebalanceStats;
+pub(crate) type Result<T> = rustfs_ecstore::api::error::Result<T>;
+pub(crate) type StorageError = rustfs_ecstore::api::error::StorageError;
+pub(crate) type TierConfig = rustfs_ecstore::api::tier::tier_config::TierConfig;
+pub(crate) type TierCreds = rustfs_ecstore::api::tier::tier_admin::TierCreds;
+pub(crate) type TierType = rustfs_ecstore::api::tier::tier_config::TierType;
+
+#[cfg(test)]
+pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
+#[cfg(test)]
+pub(crate) type Endpoints = rustfs_ecstore::api::layout::Endpoints;
+#[cfg(test)]
+pub(crate) type PoolEndpoints = rustfs_ecstore::api::layout::PoolEndpoints;
+#[cfg(test)]
+pub(crate) type RebalStatus = rustfs_ecstore::api::rebalance::RebalStatus;
+#[cfg(test)]
+pub(crate) type RebalanceInfo = rustfs_ecstore::api::rebalance::RebalanceInfo;
+
 pub(crate) mod bandwidth {
     pub(crate) mod monitor {
-        pub(crate) use rustfs_ecstore::api::bucket::bandwidth::monitor::BandwidthDetails;
+        pub(crate) type BandwidthDetails = rustfs_ecstore::api::bucket::bandwidth::monitor::BandwidthDetails;
     }
 }
+
 pub(crate) mod bucket_target_sys {
-    pub(crate) use rustfs_ecstore::api::bucket::bucket_target_sys::{
-        AdvancedPutOptions, BucketTargetError, BucketTargetSys, PutObjectOptions, RemoveObjectOptions, S3ClientError,
-        TargetClient,
-    };
+    pub(crate) type AdvancedPutOptions = rustfs_ecstore::api::bucket::bucket_target_sys::AdvancedPutOptions;
+    pub(crate) type BucketTargetError = rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetError;
+    pub(crate) type BucketTargetSys = rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys;
+    pub(crate) type PutObjectOptions = rustfs_ecstore::api::bucket::bucket_target_sys::PutObjectOptions;
+    pub(crate) type RemoveObjectOptions = rustfs_ecstore::api::bucket::bucket_target_sys::RemoveObjectOptions;
+    pub(crate) type S3ClientError = rustfs_ecstore::api::bucket::bucket_target_sys::S3ClientError;
+    pub(crate) type TargetClient = rustfs_ecstore::api::bucket::bucket_target_sys::TargetClient;
 }
+
 pub(crate) mod lifecycle {
     pub(crate) mod bucket_lifecycle_ops {
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
+        use super::super::DailyAllTierStats;
+
+        pub(crate) struct GlobalTransitionStateCompat;
+
+        #[allow(non_upper_case_globals)]
+        pub(crate) static GLOBAL_TransitionState: GlobalTransitionStateCompat = GlobalTransitionStateCompat;
+
+        impl GlobalTransitionStateCompat {
+            pub(crate) fn get_daily_all_tier_stats(&self) -> DailyAllTierStats {
+                rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState.get_daily_all_tier_stats()
+            }
+        }
     }
 
     pub(crate) mod tier_last_day_stats {
         #[cfg(test)]
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::tier_last_day_stats::LastDayTierStats;
+        pub(crate) type LastDayTierStats = rustfs_ecstore::api::bucket::lifecycle::tier_last_day_stats::LastDayTierStats;
     }
 }
+
 pub(crate) mod metadata {
-    pub(crate) use rustfs_ecstore::api::bucket::metadata::{
-        BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE,
-        BUCKET_REPLICATION_CONFIG, BUCKET_SSECONFIG, BUCKET_TAGGING_CONFIG, BUCKET_TARGETS_FILE, BUCKET_VERSIONING_CONFIG,
-        BucketMetadata, OBJECT_LOCK_CONFIG, table_catalog_path_hash,
-    };
+    pub(crate) const BUCKET_CORS_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_CORS_CONFIG;
+    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
+    pub(crate) const BUCKET_POLICY_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_POLICY_CONFIG;
+    pub(crate) const BUCKET_QUOTA_CONFIG_FILE: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_QUOTA_CONFIG_FILE;
+    pub(crate) const BUCKET_REPLICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_REPLICATION_CONFIG;
+    pub(crate) const BUCKET_SSECONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_SSECONFIG;
+    pub(crate) const BUCKET_TAGGING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TAGGING_CONFIG;
+    pub(crate) const BUCKET_TARGETS_FILE: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TARGETS_FILE;
+    pub(crate) const BUCKET_VERSIONING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_VERSIONING_CONFIG;
+    pub(crate) const OBJECT_LOCK_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::OBJECT_LOCK_CONFIG;
+
+    pub(crate) type BucketMetadata = rustfs_ecstore::api::bucket::metadata::BucketMetadata;
+
+    pub(crate) fn table_catalog_path_hash(value: &str) -> String {
+        rustfs_ecstore::api::bucket::metadata::table_catalog_path_hash(value)
+    }
 }
+
 pub(crate) mod metadata_sys {
-    pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::{
-        BucketMetadataSys, delete, get, get_bucket_policy, get_bucket_targets_config, get_config_from_disk, get_lifecycle_config,
-        get_notification_config, get_object_lock_config, get_quota_config, get_replication_config, get_sse_config,
-        get_tagging_config, get_versioning_config, list_bucket_targets, update,
+    use std::sync::Arc;
+
+    use rustfs_policy::policy::BucketPolicy;
+    use s3s::dto::{
+        BucketLifecycleConfiguration, NotificationConfiguration, ObjectLockConfiguration, ServerSideEncryptionConfiguration,
+        Tagging, VersioningConfiguration,
     };
-}
-pub(crate) mod quota {
-    pub(crate) mod checker {
-        pub(crate) use rustfs_ecstore::api::bucket::quota::checker::QuotaChecker;
+    use time::OffsetDateTime;
+
+    use super::Result;
+    use super::metadata::BucketMetadata;
+    use super::quota::BucketQuota;
+    use super::target::BucketTargets;
+
+    pub(crate) type BucketMetadataSys = rustfs_ecstore::api::bucket::metadata_sys::BucketMetadataSys;
+
+    pub(crate) async fn get(bucket: &str) -> Result<Arc<BucketMetadata>> {
+        rustfs_ecstore::api::bucket::metadata_sys::get(bucket).await
     }
 
-    pub(crate) use rustfs_ecstore::api::bucket::quota::{BucketQuota, QuotaError, QuotaOperation};
+    pub(crate) async fn update(bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime> {
+        rustfs_ecstore::api::bucket::metadata_sys::update(bucket, config_file, data).await
+    }
+
+    pub(crate) async fn delete(bucket: &str, config_file: &str) -> Result<OffsetDateTime> {
+        rustfs_ecstore::api::bucket::metadata_sys::delete(bucket, config_file).await
+    }
+
+    pub(crate) async fn get_bucket_policy(bucket: &str) -> Result<(BucketPolicy, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_policy(bucket).await
+    }
+
+    pub(crate) async fn get_bucket_targets_config(bucket: &str) -> Result<BucketTargets> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_targets_config(bucket).await
+    }
+
+    pub(crate) async fn get_config_from_disk(bucket: &str) -> Result<BucketMetadata> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_config_from_disk(bucket).await
+    }
+
+    pub(crate) async fn get_lifecycle_config(bucket: &str) -> Result<(BucketLifecycleConfiguration, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_lifecycle_config(bucket).await
+    }
+
+    pub(crate) async fn get_notification_config(bucket: &str) -> Result<Option<NotificationConfiguration>> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_notification_config(bucket).await
+    }
+
+    pub(crate) async fn get_object_lock_config(bucket: &str) -> Result<(ObjectLockConfiguration, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_object_lock_config(bucket).await
+    }
+
+    pub(crate) async fn get_quota_config(bucket: &str) -> Result<(BucketQuota, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_quota_config(bucket).await
+    }
+
+    pub(crate) async fn get_replication_config(bucket: &str) -> Result<(s3s::dto::ReplicationConfiguration, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_replication_config(bucket).await
+    }
+
+    pub(crate) async fn get_sse_config(bucket: &str) -> Result<(ServerSideEncryptionConfiguration, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_sse_config(bucket).await
+    }
+
+    pub(crate) async fn get_tagging_config(bucket: &str) -> Result<(Tagging, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_tagging_config(bucket).await
+    }
+
+    pub(crate) async fn get_versioning_config(bucket: &str) -> Result<(VersioningConfiguration, OffsetDateTime)> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_versioning_config(bucket).await
+    }
+
+    pub(crate) async fn list_bucket_targets(bucket: &str) -> Result<BucketTargets> {
+        rustfs_ecstore::api::bucket::metadata_sys::list_bucket_targets(bucket).await
+    }
 }
+
+pub(crate) mod quota {
+    pub(crate) mod checker {
+        pub(crate) type QuotaChecker = rustfs_ecstore::api::bucket::quota::checker::QuotaChecker;
+    }
+
+    pub(crate) type BucketQuota = rustfs_ecstore::api::bucket::quota::BucketQuota;
+    pub(crate) type QuotaError = rustfs_ecstore::api::bucket::quota::QuotaError;
+    pub(crate) type QuotaOperation = rustfs_ecstore::api::bucket::quota::QuotaOperation;
+}
+
 pub(crate) mod replication {
-    pub(crate) use rustfs_ecstore::api::bucket::replication::{
-        BucketReplicationResyncStatus, BucketStats, GLOBAL_REPLICATION_STATS, ObjectOpts, ReplicationConfigurationExt,
-        ResyncOpts, get_global_replication_pool,
-    };
+    use std::sync::Arc;
+
+    pub(crate) use rustfs_ecstore::api::bucket::replication::ReplicationConfigurationExt;
+
+    pub(crate) type BucketReplicationResyncStatus = rustfs_ecstore::api::bucket::replication::BucketReplicationResyncStatus;
+    pub(crate) type BucketStats = rustfs_ecstore::api::bucket::replication::BucketStats;
+    pub(crate) type DynReplicationPool = rustfs_ecstore::api::bucket::replication::DynReplicationPool;
+    pub(crate) type ObjectOpts = rustfs_ecstore::api::bucket::replication::ObjectOpts;
+    pub(crate) type ReplicationStats = rustfs_ecstore::api::bucket::replication::ReplicationStats;
+    pub(crate) type ResyncOpts = rustfs_ecstore::api::bucket::replication::ResyncOpts;
     #[cfg(test)]
-    pub(crate) use rustfs_ecstore::api::bucket::replication::{ResyncStatusType, TargetReplicationResyncStatus};
+    pub(crate) type ResyncStatusType = rustfs_ecstore::api::bucket::replication::ResyncStatusType;
+    #[cfg(test)]
+    pub(crate) type TargetReplicationResyncStatus = rustfs_ecstore::api::bucket::replication::TargetReplicationResyncStatus;
+
+    pub(crate) struct GlobalReplicationStatsCompat;
+
+    pub(crate) static GLOBAL_REPLICATION_STATS: GlobalReplicationStatsCompat = GlobalReplicationStatsCompat;
+
+    impl GlobalReplicationStatsCompat {
+        pub(crate) fn get(&self) -> Option<&'static Arc<ReplicationStats>> {
+            rustfs_ecstore::api::bucket::replication::GLOBAL_REPLICATION_STATS.get()
+        }
+    }
+
+    pub(crate) fn get_global_replication_pool() -> Option<Arc<DynReplicationPool>> {
+        rustfs_ecstore::api::bucket::replication::get_global_replication_pool()
+    }
 }
+
 pub(crate) mod target {
-    pub(crate) use rustfs_ecstore::api::bucket::target::{ARN, BucketTarget, BucketTargetType, BucketTargets, Credentials};
+    #[allow(clippy::upper_case_acronyms)]
+    pub(crate) type ARN = rustfs_ecstore::api::bucket::target::ARN;
+    pub(crate) type BucketTarget = rustfs_ecstore::api::bucket::target::BucketTarget;
+    pub(crate) type BucketTargetType = rustfs_ecstore::api::bucket::target::BucketTargetType;
+    pub(crate) type BucketTargets = rustfs_ecstore::api::bucket::target::BucketTargets;
+    pub(crate) type Credentials = rustfs_ecstore::api::bucket::target::Credentials;
 }
+
 pub(crate) mod utils {
-    pub(crate) use rustfs_ecstore::api::bucket::utils::{deserialize, is_valid_object_prefix, serialize};
+    pub(crate) fn deserialize<T>(input: &[u8]) -> s3s::xml::DeResult<T>
+    where
+        T: for<'xml> s3s::xml::Deserialize<'xml>,
+    {
+        rustfs_ecstore::api::bucket::utils::deserialize(input)
+    }
+
+    pub(crate) fn is_valid_object_prefix(object: &str) -> bool {
+        rustfs_ecstore::api::bucket::utils::is_valid_object_prefix(object)
+    }
+
+    pub(crate) fn serialize<T: s3s::xml::Serialize>(val: &T) -> s3s::xml::SerResult<Vec<u8>> {
+        rustfs_ecstore::api::bucket::utils::serialize(val)
+    }
 }
+
 pub(crate) mod versioning {
     pub(crate) use rustfs_ecstore::api::bucket::versioning::VersioningApi;
 }
+
 pub(crate) mod versioning_sys {
-    pub(crate) use rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
+    pub(crate) type BucketVersioningSys = rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
 }
-pub(crate) use rustfs_ecstore::api::bucket::lifecycle::tier_last_day_stats::DailyAllTierStats;
-pub(crate) use rustfs_ecstore::api::capacity::is_reserved_or_invalid_bucket;
-pub(crate) use rustfs_ecstore::api::client::admin_handler_utils::AdminError;
-pub(crate) use rustfs_ecstore::api::config::com::{
-    STORAGE_CLASS_SUB_SYS, delete_config as delete_admin_config, read_config as read_admin_config,
-    read_config_without_migrate as read_admin_config_without_migrate, save_config as save_admin_config,
-    save_server_config as save_admin_server_config,
-};
+
 pub(crate) mod storageclass {
-    pub(crate) use rustfs_ecstore::api::config::storageclass::{
-        INLINE_BLOCK_ENV, OPTIMIZE_ENV, RRS, RRS_ENV, STANDARD, STANDARD_ENV, lookup_config,
-    };
+    pub(crate) const INLINE_BLOCK_ENV: &str = rustfs_ecstore::api::config::storageclass::INLINE_BLOCK_ENV;
+    pub(crate) const OPTIMIZE_ENV: &str = rustfs_ecstore::api::config::storageclass::OPTIMIZE_ENV;
+    pub(crate) const RRS: &str = rustfs_ecstore::api::config::storageclass::RRS;
+    pub(crate) const RRS_ENV: &str = rustfs_ecstore::api::config::storageclass::RRS_ENV;
+    pub(crate) const STANDARD: &str = rustfs_ecstore::api::config::storageclass::STANDARD;
+    pub(crate) const STANDARD_ENV: &str = rustfs_ecstore::api::config::storageclass::STANDARD_ENV;
+
+    pub(crate) type Config = rustfs_ecstore::api::config::storageclass::Config;
+
+    pub(crate) fn lookup_config(kvs: &rustfs_config::server_config::KVS, set_drive_count: usize) -> super::Result<Config> {
+        rustfs_ecstore::api::config::storageclass::lookup_config(kvs, set_drive_count)
+    }
 }
-pub(crate) use rustfs_ecstore::api::config::{init as init_admin_config_defaults, set_global_storage_class};
-pub(crate) use rustfs_ecstore::api::data_usage::load_data_usage_from_backend;
-pub(crate) use rustfs_ecstore::api::disk::RUSTFS_META_BUCKET;
-#[cfg(test)]
-pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint;
-pub(crate) use rustfs_ecstore::api::error::{Error, StorageError};
-pub(crate) use rustfs_ecstore::api::global::{
-    GLOBAL_BOOT_TIME, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints_opt, get_global_region,
-    global_rustfs_port,
-};
-pub(crate) use rustfs_ecstore::api::layout::EndpointServerPools;
-#[cfg(test)]
-pub(crate) use rustfs_ecstore::api::layout::{Endpoints, PoolEndpoints};
-pub(crate) use rustfs_ecstore::api::metrics::{CollectMetricsOpts, MetricType, collect_local_metrics};
-pub(crate) use rustfs_ecstore::api::notification::get_global_notification_sys;
-pub(crate) use rustfs_ecstore::api::rebalance::{
-    DiskStat, RebalSaveOpt, RebalanceCleanupWarnings, RebalanceMeta, RebalanceStats,
-};
-#[cfg(test)]
-pub(crate) use rustfs_ecstore::api::rebalance::{RebalStatus, RebalanceInfo};
-pub(crate) use rustfs_ecstore::api::rpc::PeerRestClient;
-pub(crate) use rustfs_ecstore::api::storage::ECStore;
-pub(crate) use rustfs_ecstore::api::tier::tier::{
-    ERR_TIER_BACKEND_IN_USE, ERR_TIER_BACKEND_NOT_EMPTY, ERR_TIER_MISSING_CREDENTIALS,
-};
-pub(crate) use rustfs_ecstore::api::tier::tier_admin::TierCreds;
-pub(crate) use rustfs_ecstore::api::tier::tier_config::{TierConfig, TierType};
-pub(crate) use rustfs_ecstore::api::tier::tier_handlers::{
-    ERR_TIER_ALREADY_EXISTS, ERR_TIER_CONNECT_ERR, ERR_TIER_INVALID_CREDENTIALS, ERR_TIER_NAME_NOT_UPPERCASE, ERR_TIER_NOT_FOUND,
-};
+
+pub(crate) type DailyAllTierStats = rustfs_ecstore::api::bucket::lifecycle::tier_last_day_stats::DailyAllTierStats;
+
+pub(crate) fn is_reserved_or_invalid_bucket(bucket_entry: &str, strict: bool) -> bool {
+    rustfs_ecstore::api::capacity::is_reserved_or_invalid_bucket(bucket_entry, strict)
+}
+
+pub(crate) async fn read_admin_config(api: Arc<ECStore>, file: &str) -> Result<Vec<u8>> {
+    rustfs_ecstore::api::config::com::read_config(api, file).await
+}
+
+pub(crate) async fn read_admin_config_without_migrate(api: Arc<ECStore>) -> Result<rustfs_config::server_config::Config> {
+    rustfs_ecstore::api::config::com::read_config_without_migrate(api).await
+}
+
+pub(crate) async fn save_admin_config(api: Arc<ECStore>, file: &str, data: Vec<u8>) -> Result<()> {
+    rustfs_ecstore::api::config::com::save_config(api, file, data).await
+}
+
+pub(crate) async fn delete_admin_config(api: Arc<ECStore>, file: &str) -> Result<()> {
+    rustfs_ecstore::api::config::com::delete_config(api, file).await
+}
+
+pub(crate) async fn save_admin_server_config(api: Arc<ECStore>, cfg: &rustfs_config::server_config::Config) -> Result<()> {
+    rustfs_ecstore::api::config::com::save_server_config(api, cfg).await
+}
+
+pub(crate) fn init_admin_config_defaults() {
+    rustfs_ecstore::api::config::init();
+}
+
+pub(crate) fn set_global_storage_class(cfg: storageclass::Config) {
+    rustfs_ecstore::api::config::set_global_storage_class(cfg);
+}
+
+pub(crate) async fn load_data_usage_from_backend(
+    store: Arc<ECStore>,
+) -> std::result::Result<rustfs_data_usage::DataUsageInfo, Error> {
+    rustfs_ecstore::api::data_usage::load_data_usage_from_backend(store).await
+}
+
+pub(crate) fn get_global_bucket_monitor() -> Option<Arc<rustfs_ecstore::api::bucket::bandwidth::monitor::Monitor>> {
+    rustfs_ecstore::api::global::get_global_bucket_monitor()
+}
+
+pub(crate) fn get_global_deployment_id() -> Option<String> {
+    rustfs_ecstore::api::global::get_global_deployment_id()
+}
+
+pub(crate) fn get_global_endpoints_opt() -> Option<EndpointServerPools> {
+    rustfs_ecstore::api::global::get_global_endpoints_opt()
+}
+
+pub(crate) fn get_global_region() -> Option<s3s::region::Region> {
+    rustfs_ecstore::api::global::get_global_region()
+}
+
+pub(crate) fn global_rustfs_port() -> u16 {
+    rustfs_ecstore::api::global::global_rustfs_port()
+}
+
+pub(crate) async fn collect_local_metrics(
+    types: MetricType,
+    opts: &CollectMetricsOpts,
+) -> rustfs_madmin::metrics::RealtimeMetrics {
+    rustfs_ecstore::api::metrics::collect_local_metrics(types, opts).await
+}
+
+pub(crate) fn get_global_notification_sys() -> Option<&'static rustfs_ecstore::api::notification::NotificationSys> {
+    rustfs_ecstore::api::notification::get_global_notification_sys()
+}
+
+pub(crate) struct BootTimeCompat;
+
+pub(crate) static GLOBAL_BOOT_TIME: BootTimeCompat = BootTimeCompat;
+
+impl BootTimeCompat {
+    pub(crate) fn get(&self) -> Option<&'static std::time::SystemTime> {
+        rustfs_ecstore::api::global::GLOBAL_BOOT_TIME.get()
+    }
+}
+
+pub(crate) struct AdminErrorRef(fn() -> &'static AdminError);
+
+impl Deref for AdminErrorRef {
+    type Target = AdminError;
+
+    fn deref(&self) -> &Self::Target {
+        (self.0)()
+    }
+}
+
+pub(crate) static ERR_TIER_BACKEND_IN_USE: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier::ERR_TIER_BACKEND_IN_USE);
+pub(crate) static ERR_TIER_BACKEND_NOT_EMPTY: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier::ERR_TIER_BACKEND_NOT_EMPTY);
+pub(crate) static ERR_TIER_MISSING_CREDENTIALS: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier::ERR_TIER_MISSING_CREDENTIALS);
+pub(crate) static ERR_TIER_ALREADY_EXISTS: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_ALREADY_EXISTS);
+pub(crate) static ERR_TIER_CONNECT_ERR: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_CONNECT_ERR);
+pub(crate) static ERR_TIER_INVALID_CREDENTIALS: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_INVALID_CREDENTIALS);
+pub(crate) static ERR_TIER_NAME_NOT_UPPERCASE: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_NAME_NOT_UPPERCASE);
+pub(crate) static ERR_TIER_NOT_FOUND: AdminErrorRef =
+    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_NOT_FOUND);

--- a/rustfs/src/app/storage_compat.rs
+++ b/rustfs/src/app/storage_compat.rs
@@ -12,156 +12,542 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use rustfs_ecstore::api::admin::get_server_info;
-pub(crate) mod bucket_target_sys {
-    pub(crate) use rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys;
+use std::sync::Arc;
+
+pub(crate) const MIN_DISK_COMPRESSIBLE_SIZE: usize = rustfs_ecstore::api::compression::MIN_DISK_COMPRESSIBLE_SIZE;
+
+pub(crate) type DiskError = rustfs_ecstore::api::disk::error::DiskError;
+pub(crate) type DynReader = rustfs_ecstore::api::rio::DynReader;
+pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
+pub(crate) type EndpointServerPools = rustfs_ecstore::api::layout::EndpointServerPools;
+pub(crate) type Error = rustfs_ecstore::api::error::Error;
+pub(crate) type HashReader = rustfs_ecstore::api::rio::HashReader;
+pub(crate) type ObjectStoreResolver = dyn Fn() -> Option<Arc<ECStore>> + Send + Sync + 'static;
+pub(crate) type PoolDecommissionInfo = rustfs_ecstore::api::capacity::PoolDecommissionInfo;
+pub(crate) type PoolStatus = rustfs_ecstore::api::capacity::PoolStatus;
+pub(crate) type StorageError = rustfs_ecstore::api::error::StorageError;
+pub(crate) type TierConfigMgr = rustfs_ecstore::api::tier::tier::TierConfigMgr;
+pub(crate) type WriteEncryption = rustfs_ecstore::api::rio::WriteEncryption;
+pub(crate) type WritePlan = rustfs_ecstore::api::rio::WritePlan;
+
+#[cfg(test)]
+pub(crate) type DecryptReader<R> = rustfs_ecstore::api::rio::DecryptReader<R>;
+#[cfg(test)]
+pub(crate) type EncryptReader<R> = rustfs_ecstore::api::rio::EncryptReader<R>;
+#[cfg(test)]
+pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
+#[cfg(test)]
+pub(crate) type Endpoints = rustfs_ecstore::api::layout::Endpoints;
+#[cfg(test)]
+pub(crate) type HardLimitReader<R> = rustfs_ecstore::api::rio::HardLimitReader<R>;
+#[cfg(test)]
+pub(crate) type PoolEndpoints = rustfs_ecstore::api::layout::PoolEndpoints;
+#[cfg(test)]
+pub(crate) type TierConfig = rustfs_ecstore::api::tier::tier_config::TierConfig;
+#[cfg(test)]
+pub(crate) type TierType = rustfs_ecstore::api::tier::tier_config::TierType;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::tier::warm_backend::WarmBackend;
+#[cfg(test)]
+pub(crate) type WarmBackendGetOpts = rustfs_ecstore::api::tier::warm_backend::WarmBackendGetOpts;
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+pub(crate) fn EndpointServerPools(pools: Vec<PoolEndpoints>) -> EndpointServerPools {
+    rustfs_ecstore::api::layout::EndpointServerPools::from(pools)
 }
+
+pub(crate) async fn get_server_info(get_pools: bool) -> rustfs_madmin::InfoMessage {
+    rustfs_ecstore::api::admin::get_server_info(get_pools).await
+}
+
+pub(crate) mod bucket_target_sys {
+    pub(crate) type BucketTargetSys = rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys;
+}
+
 pub(crate) mod lifecycle {
+    use super::ECStore;
+
     pub(crate) mod bucket_lifecycle_audit {
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
+        pub(crate) type LcEventSrc = rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
     }
 
     pub(crate) mod bucket_lifecycle_ops {
+        use std::ops::Deref;
+        use std::sync::Arc;
+
+        use super::ECStore;
+        use super::bucket_lifecycle_audit::LcEventSrc;
+
+        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::RestoreRequestOps;
+
+        pub(crate) type ExpiryState = rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::ExpiryState;
+
+        pub(crate) struct GlobalExpiryStateCompat;
+
+        #[allow(non_upper_case_globals)]
+        pub(crate) static GLOBAL_ExpiryState: GlobalExpiryStateCompat = GlobalExpiryStateCompat;
+
+        impl Deref for GlobalExpiryStateCompat {
+            type Target = Arc<tokio::sync::RwLock<ExpiryState>>;
+
+            fn deref(&self) -> &Self::Target {
+                &rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
+            }
+        }
+
         #[cfg(test)]
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry;
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
-            GLOBAL_ExpiryState, RestoreRequestOps, enqueue_expiry_for_existing_objects, enqueue_transition_for_existing_objects,
-            enqueue_transition_immediate, post_restore_opts, validate_transition_tier,
-        };
+        pub(crate) async fn init_background_expiry(api: Arc<ECStore>) {
+            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(api).await;
+        }
+
+        pub(crate) async fn enqueue_expiry_for_existing_objects(
+            api: Arc<ECStore>,
+            bucket: &str,
+        ) -> Result<(), super::super::Error> {
+            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::enqueue_expiry_for_existing_objects(api, bucket).await
+        }
+
+        pub(crate) async fn enqueue_transition_for_existing_objects(
+            api: Arc<ECStore>,
+            bucket: &str,
+        ) -> Result<(), super::super::Error> {
+            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects(api, bucket)
+                .await
+        }
+
+        pub(crate) async fn enqueue_transition_immediate(oi: &rustfs_ecstore::api::object::ObjectInfo, src: LcEventSrc) {
+            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_immediate(oi, src).await;
+        }
+
+        pub(crate) async fn post_restore_opts(
+            version_id: &str,
+            bucket: &str,
+            object: &str,
+        ) -> Result<rustfs_ecstore::api::object::ObjectOptions, std::io::Error> {
+            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::post_restore_opts(version_id, bucket, object).await
+        }
+
+        pub(crate) async fn validate_transition_tier(lc: &s3s::dto::BucketLifecycleConfiguration) -> Result<(), std::io::Error> {
+            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::validate_transition_tier(lc).await
+        }
     }
 
     pub(crate) mod lifecycle_contract {
+        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::lifecycle::Lifecycle;
+
         #[cfg(test)]
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::lifecycle::IlmAction;
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::lifecycle::{
-            Event, Lifecycle, ObjectOpts, TRANSITION_COMPLETE, TransitionOptions, expected_expiry_time,
-        };
+        pub(crate) type IlmAction = rustfs_ecstore::api::bucket::lifecycle::lifecycle::IlmAction;
+        pub(crate) type Event = rustfs_ecstore::api::bucket::lifecycle::lifecycle::Event;
+        pub(crate) type ObjectOpts = rustfs_ecstore::api::bucket::lifecycle::lifecycle::ObjectOpts;
+        pub(crate) type TransitionOptions = rustfs_ecstore::api::bucket::lifecycle::lifecycle::TransitionOptions;
+
+        pub(crate) const TRANSITION_COMPLETE: &str = rustfs_ecstore::api::bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
+
+        pub(crate) fn expected_expiry_time(mod_time: time::OffsetDateTime, days: i32) -> time::OffsetDateTime {
+            rustfs_ecstore::api::bucket::lifecycle::lifecycle::expected_expiry_time(mod_time, days)
+        }
     }
     pub(crate) use lifecycle_contract as lifecycle;
 
     pub(crate) mod tier_delete_journal {
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry;
+        use std::sync::Arc;
+
+        use super::ECStore;
+
+        pub(crate) async fn persist_tier_delete_journal_entry(
+            api: Arc<ECStore>,
+            je: &rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::Jentry,
+        ) -> std::io::Result<()> {
+            rustfs_ecstore::api::bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry(api, je).await
+        }
     }
 
     pub(crate) mod tier_sweeper {
-        pub(crate) use rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::{
-            transitioned_delete_journal_entry, transitioned_force_delete_journal_entry,
-        };
+        pub(crate) type Jentry = rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::Jentry;
+
+        pub(crate) fn transitioned_delete_journal_entry(
+            version_id: Option<uuid::Uuid>,
+            versioned: bool,
+            suspended: bool,
+            transitioned: &rustfs_storage_api::TransitionedObject,
+        ) -> Option<Jentry> {
+            rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::transitioned_delete_journal_entry(
+                version_id,
+                versioned,
+                suspended,
+                transitioned,
+            )
+        }
+
+        pub(crate) fn transitioned_force_delete_journal_entry(
+            transitioned: &rustfs_storage_api::TransitionedObject,
+        ) -> Option<Jentry> {
+            rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::transitioned_force_delete_journal_entry(transitioned)
+        }
     }
 }
+
 pub(crate) mod metadata {
+    pub(crate) const BUCKET_CORS_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_CORS_CONFIG;
+    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
+    pub(crate) const BUCKET_POLICY_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_POLICY_CONFIG;
+    pub(crate) const BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG: &str =
+        rustfs_ecstore::api::bucket::metadata::BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG;
+    pub(crate) const BUCKET_REPLICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_REPLICATION_CONFIG;
+    pub(crate) const BUCKET_SSECONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_SSECONFIG;
+    pub(crate) const BUCKET_TAGGING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TAGGING_CONFIG;
+    pub(crate) const BUCKET_TARGETS_FILE: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TARGETS_FILE;
+    pub(crate) const BUCKET_VERSIONING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_VERSIONING_CONFIG;
     #[cfg(test)]
-    pub(crate) use rustfs_ecstore::api::bucket::metadata::OBJECT_LOCK_CONFIG;
-    pub(crate) use rustfs_ecstore::api::bucket::metadata::{
-        BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG,
-        BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG, BUCKET_REPLICATION_CONFIG, BUCKET_SSECONFIG, BUCKET_TAGGING_CONFIG,
-        BUCKET_TARGETS_FILE, BUCKET_VERSIONING_CONFIG,
-    };
+    pub(crate) const OBJECT_LOCK_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::OBJECT_LOCK_CONFIG;
 }
+
 pub(crate) mod metadata_sys {
-    #[cfg(test)]
-    pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::init_bucket_metadata_sys;
-    pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::{
-        BucketMetadataSys, delete, get_bucket_policy, get_bucket_policy_raw, get_bucket_targets_config, get_cors_config,
-        get_global_bucket_metadata_sys, get_lifecycle_config, get_notification_config, get_object_lock_config,
-        get_public_access_block_config, get_replication_config, get_sse_config, get_tagging_config, update,
+    use std::sync::Arc;
+
+    use rustfs_policy::policy::BucketPolicy;
+    use s3s::dto::{
+        BucketLifecycleConfiguration, CORSConfiguration, NotificationConfiguration, ObjectLockConfiguration,
+        PublicAccessBlockConfiguration, ServerSideEncryptionConfiguration, Tagging,
     };
+    use time::OffsetDateTime;
+    use tokio::sync::RwLock;
+
+    #[cfg(test)]
+    use super::ECStore;
+    use super::Error;
+    use super::target::BucketTargets;
+
+    pub(crate) type BucketMetadataSys = rustfs_ecstore::api::bucket::metadata_sys::BucketMetadataSys;
+
+    #[cfg(test)]
+    pub(crate) async fn init_bucket_metadata_sys(api: Arc<ECStore>, buckets: Vec<String>) {
+        rustfs_ecstore::api::bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
+    }
+
+    pub(crate) async fn delete(bucket: &str, config_file: &str) -> Result<OffsetDateTime, Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::delete(bucket, config_file).await
+    }
+
+    pub(crate) async fn get_bucket_policy(bucket: &str) -> Result<(BucketPolicy, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_policy(bucket).await
+    }
+
+    pub(crate) async fn get_bucket_policy_raw(bucket: &str) -> Result<(String, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_policy_raw(bucket).await
+    }
+
+    pub(crate) async fn get_bucket_targets_config(bucket: &str) -> Result<BucketTargets, Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_targets_config(bucket).await
+    }
+
+    pub(crate) async fn get_cors_config(bucket: &str) -> Result<(CORSConfiguration, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_cors_config(bucket).await
+    }
+
+    pub(crate) fn get_global_bucket_metadata_sys() -> Option<Arc<RwLock<BucketMetadataSys>>> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_global_bucket_metadata_sys()
+    }
+
+    pub(crate) async fn get_lifecycle_config(bucket: &str) -> Result<(BucketLifecycleConfiguration, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_lifecycle_config(bucket).await
+    }
+
+    pub(crate) async fn get_notification_config(bucket: &str) -> Result<Option<NotificationConfiguration>, Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_notification_config(bucket).await
+    }
+
+    pub(crate) async fn get_object_lock_config(bucket: &str) -> Result<(ObjectLockConfiguration, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_object_lock_config(bucket).await
+    }
+
+    pub(crate) async fn get_public_access_block_config(
+        bucket: &str,
+    ) -> Result<(PublicAccessBlockConfiguration, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_public_access_block_config(bucket).await
+    }
+
+    pub(crate) async fn get_replication_config(
+        bucket: &str,
+    ) -> Result<(s3s::dto::ReplicationConfiguration, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_replication_config(bucket).await
+    }
+
+    pub(crate) async fn get_sse_config(bucket: &str) -> Result<(ServerSideEncryptionConfiguration, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_sse_config(bucket).await
+    }
+
+    pub(crate) async fn get_tagging_config(bucket: &str) -> Result<(Tagging, OffsetDateTime), Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::get_tagging_config(bucket).await
+    }
+
+    pub(crate) async fn update(bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime, Error> {
+        rustfs_ecstore::api::bucket::metadata_sys::update(bucket, config_file, data).await
+    }
 }
+
 pub(crate) mod object_api_utils {
-    pub(crate) use rustfs_ecstore::api::client::object_api_utils::to_s3s_etag;
+    pub(crate) fn to_s3s_etag(etag: &str) -> s3s::dto::ETag {
+        rustfs_ecstore::api::client::object_api_utils::to_s3s_etag(etag)
+    }
 }
+
 pub(crate) mod object_lock {
     pub(crate) mod objectlock {
-        pub(crate) use rustfs_ecstore::api::bucket::object_lock::objectlock::{
-            get_object_legalhold_meta, get_object_retention_meta,
-        };
+        pub(crate) fn get_object_legalhold_meta(
+            meta: &std::collections::HashMap<String, String>,
+        ) -> s3s::dto::ObjectLockLegalHold {
+            rustfs_ecstore::api::bucket::object_lock::objectlock::get_object_legalhold_meta(meta)
+        }
+
+        pub(crate) fn get_object_retention_meta(
+            meta: &std::collections::HashMap<String, String>,
+        ) -> s3s::dto::ObjectLockRetention {
+            rustfs_ecstore::api::bucket::object_lock::objectlock::get_object_retention_meta(meta)
+        }
     }
 
     pub(crate) mod objectlock_sys {
-        pub(crate) use rustfs_ecstore::api::bucket::object_lock::objectlock_sys::{
-            BucketObjectLockSys, check_object_lock_for_deletion, is_retention_active,
-        };
+        pub(crate) type BucketObjectLockSys = rustfs_ecstore::api::bucket::object_lock::objectlock_sys::BucketObjectLockSys;
+        pub(crate) type ObjectLockBlockReason = rustfs_ecstore::api::bucket::object_lock::objectlock_sys::ObjectLockBlockReason;
+
+        pub(crate) async fn check_object_lock_for_deletion(
+            bucket: &str,
+            obj_info: &rustfs_ecstore::api::object::ObjectInfo,
+            bypass_governance: bool,
+        ) -> Option<ObjectLockBlockReason> {
+            rustfs_ecstore::api::bucket::object_lock::objectlock_sys::check_object_lock_for_deletion(
+                bucket,
+                obj_info,
+                bypass_governance,
+            )
+            .await
+        }
+
+        pub(crate) fn is_retention_active(mode: &str, retain_until_date: Option<&s3s::dto::Date>) -> bool {
+            rustfs_ecstore::api::bucket::object_lock::objectlock_sys::is_retention_active(mode, retain_until_date)
+        }
     }
 
     pub(crate) use rustfs_ecstore::api::bucket::object_lock::ObjectLockApi;
 }
+
 pub(crate) mod policy_sys {
-    pub(crate) use rustfs_ecstore::api::bucket::policy_sys::PolicySys;
+    pub(crate) type PolicySys = rustfs_ecstore::api::bucket::policy_sys::PolicySys;
 }
+
 pub(crate) mod quota {
     pub(crate) mod checker {
-        pub(crate) use rustfs_ecstore::api::bucket::quota::checker::QuotaChecker;
+        pub(crate) type QuotaChecker = rustfs_ecstore::api::bucket::quota::checker::QuotaChecker;
     }
 
-    pub(crate) use rustfs_ecstore::api::bucket::quota::QuotaOperation;
+    pub(crate) type QuotaOperation = rustfs_ecstore::api::bucket::quota::QuotaOperation;
 }
+
 pub(crate) mod replication {
-    pub(crate) use rustfs_ecstore::api::bucket::replication::{
-        DeletedObjectReplicationInfo, ObjectOpts, ReplicationConfigurationExt, check_replicate_delete,
-        get_must_replicate_options, must_replicate, schedule_replication, schedule_replication_delete,
-    };
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    pub(crate) use rustfs_ecstore::api::bucket::replication::ReplicationConfigurationExt;
+
+    pub(crate) type DeletedObjectReplicationInfo = rustfs_ecstore::api::bucket::replication::DeletedObjectReplicationInfo;
+    pub(crate) type MustReplicateOptions = rustfs_ecstore::api::bucket::replication::MustReplicateOptions;
+    pub(crate) type ObjectOpts = rustfs_ecstore::api::bucket::replication::ObjectOpts;
+    pub(crate) type ReplicateDecision = rustfs_filemeta::ReplicateDecision;
+
+    pub(crate) async fn check_replicate_delete(
+        bucket: &str,
+        dobj: &rustfs_storage_api::ObjectToDelete,
+        oi: &rustfs_ecstore::api::object::ObjectInfo,
+        del_opts: &rustfs_ecstore::api::object::ObjectOptions,
+        gerr: Option<String>,
+    ) -> ReplicateDecision {
+        rustfs_ecstore::api::bucket::replication::check_replicate_delete(bucket, dobj, oi, del_opts, gerr).await
+    }
+
+    pub(crate) fn get_must_replicate_options(
+        user_defined: &HashMap<String, String>,
+        user_tags: String,
+        status: rustfs_filemeta::ReplicationStatusType,
+        op_type: rustfs_filemeta::ReplicationType,
+        opts: rustfs_ecstore::api::object::ObjectOptions,
+    ) -> MustReplicateOptions {
+        rustfs_ecstore::api::bucket::replication::get_must_replicate_options(user_defined, user_tags, status, op_type, opts)
+    }
+
+    pub(crate) async fn must_replicate(bucket: &str, object: &str, mopts: MustReplicateOptions) -> ReplicateDecision {
+        rustfs_ecstore::api::bucket::replication::must_replicate(bucket, object, mopts).await
+    }
+
+    pub(crate) async fn schedule_replication(
+        oi: rustfs_ecstore::api::object::ObjectInfo,
+        store: Arc<super::ECStore>,
+        dsc: ReplicateDecision,
+        op_type: rustfs_filemeta::ReplicationType,
+    ) {
+        rustfs_ecstore::api::bucket::replication::schedule_replication(oi, store, dsc, op_type).await;
+    }
+
+    pub(crate) async fn schedule_replication_delete(dv: DeletedObjectReplicationInfo) {
+        rustfs_ecstore::api::bucket::replication::schedule_replication_delete(dv).await;
+    }
 }
+
 pub(crate) mod tagging {
-    pub(crate) use rustfs_ecstore::api::bucket::tagging::decode_tags;
+    pub(crate) fn decode_tags(tags: &str) -> Vec<s3s::dto::Tag> {
+        rustfs_ecstore::api::bucket::tagging::decode_tags(tags)
+    }
 }
+
 pub(crate) mod target {
     #[cfg(test)]
-    pub(crate) use rustfs_ecstore::api::bucket::target::BucketTarget;
-    pub(crate) use rustfs_ecstore::api::bucket::target::{BucketTargetType, BucketTargets};
+    pub(crate) type BucketTarget = rustfs_ecstore::api::bucket::target::BucketTarget;
+    pub(crate) type BucketTargetType = rustfs_ecstore::api::bucket::target::BucketTargetType;
+    pub(crate) type BucketTargets = rustfs_ecstore::api::bucket::target::BucketTargets;
 }
+
 pub(crate) mod utils {
-    pub(crate) use rustfs_ecstore::api::bucket::utils::serialize;
+    pub(crate) fn serialize<T: s3s::xml::Serialize>(val: &T) -> s3s::xml::SerResult<Vec<u8>> {
+        rustfs_ecstore::api::bucket::utils::serialize(val)
+    }
 }
+
 pub(crate) mod versioning {
     pub(crate) use rustfs_ecstore::api::bucket::versioning::VersioningApi;
 }
+
 pub(crate) mod versioning_sys {
-    pub(crate) use rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
+    pub(crate) type BucketVersioningSys = rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
 }
-pub(crate) use rustfs_ecstore::api::capacity::{
-    PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
-};
+
 #[cfg(test)]
 pub(crate) mod transition_api {
-    pub(crate) use rustfs_ecstore::api::client::transition_api::{ReadCloser, ReaderImpl};
+    pub(crate) type ReadCloser = rustfs_ecstore::api::client::transition_api::ReadCloser;
+    pub(crate) type ReaderImpl = rustfs_ecstore::api::client::transition_api::ReaderImpl;
 }
-pub(crate) use rustfs_ecstore::api::compression::{MIN_DISK_COMPRESSIBLE_SIZE, is_disk_compressible};
+
 pub(crate) mod storageclass {
-    pub(crate) use rustfs_ecstore::api::config::storageclass::STANDARD;
+    pub(crate) const STANDARD: &str = rustfs_ecstore::api::config::storageclass::STANDARD;
     #[cfg(test)]
-    pub(crate) use rustfs_ecstore::api::config::storageclass::STANDARD_IA;
+    pub(crate) const STANDARD_IA: &str = rustfs_ecstore::api::config::storageclass::STANDARD_IA;
 }
-pub(crate) use rustfs_ecstore::api::data_usage::{
-    apply_bucket_usage_memory_overlay, load_data_usage_from_backend, record_bucket_object_delete_memory,
-    record_bucket_object_write_memory,
-};
+
+pub(crate) fn get_total_usable_capacity(disks: &[rustfs_madmin::Disk], info: &rustfs_madmin::StorageInfo) -> usize {
+    rustfs_ecstore::api::capacity::get_total_usable_capacity(disks, info)
+}
+
+pub(crate) fn get_total_usable_capacity_free(disks: &[rustfs_madmin::Disk], info: &rustfs_madmin::StorageInfo) -> usize {
+    rustfs_ecstore::api::capacity::get_total_usable_capacity_free(disks, info)
+}
+
+pub(crate) fn is_disk_compressible(headers: &http::HeaderMap, object_name: &str) -> bool {
+    rustfs_ecstore::api::compression::is_disk_compressible(headers, object_name)
+}
+
+pub(crate) async fn apply_bucket_usage_memory_overlay(data_usage_info: &mut rustfs_data_usage::DataUsageInfo) {
+    rustfs_ecstore::api::data_usage::apply_bucket_usage_memory_overlay(data_usage_info).await;
+}
+
+pub(crate) async fn load_data_usage_from_backend(
+    store: Arc<ECStore>,
+) -> std::result::Result<rustfs_data_usage::DataUsageInfo, Error> {
+    rustfs_ecstore::api::data_usage::load_data_usage_from_backend(store).await
+}
+
+pub(crate) async fn record_bucket_object_delete_memory(bucket: &str, deleted_size: u64, removed_current_object: bool) {
+    rustfs_ecstore::api::data_usage::record_bucket_object_delete_memory(bucket, deleted_size, removed_current_object).await;
+}
+
+pub(crate) async fn record_bucket_object_write_memory(bucket: &str, previous_current_size: Option<u64>, new_size: u64) {
+    rustfs_ecstore::api::data_usage::record_bucket_object_write_memory(bucket, previous_current_size, new_size).await;
+}
+
+pub(crate) fn is_all_buckets_not_found(errs: &[Option<DiskError>]) -> bool {
+    rustfs_ecstore::api::disk::error_reduce::is_all_buckets_not_found(errs)
+}
+
+pub(crate) fn is_err_bucket_not_found(err: &Error) -> bool {
+    rustfs_ecstore::api::error::is_err_bucket_not_found(err)
+}
+
+pub(crate) fn is_err_object_not_found(err: &Error) -> bool {
+    rustfs_ecstore::api::error::is_err_object_not_found(err)
+}
+
+pub(crate) fn is_err_version_not_found(err: &Error) -> bool {
+    rustfs_ecstore::api::error::is_err_version_not_found(err)
+}
+
 #[cfg(test)]
-pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint;
-pub(crate) use rustfs_ecstore::api::disk::error::DiskError;
-pub(crate) use rustfs_ecstore::api::disk::error_reduce::is_all_buckets_not_found;
-pub(crate) use rustfs_ecstore::api::error::{
-    Error, StorageError, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
-};
+pub(crate) struct GlobalTierConfigMgrCompat;
+
 #[cfg(test)]
-pub(crate) use rustfs_ecstore::api::global::GLOBAL_TierConfigMgr;
-pub(crate) use rustfs_ecstore::api::global::{
-    get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr, new_object_layer_fn, set_object_store_resolver,
-};
-pub(crate) use rustfs_ecstore::api::layout::EndpointServerPools;
+#[allow(non_upper_case_globals)]
+pub(crate) static GLOBAL_TierConfigMgr: GlobalTierConfigMgrCompat = GlobalTierConfigMgrCompat;
+
 #[cfg(test)]
-pub(crate) use rustfs_ecstore::api::layout::{Endpoints, PoolEndpoints};
-pub(crate) use rustfs_ecstore::api::notification::get_global_notification_sys;
+impl std::ops::Deref for GlobalTierConfigMgrCompat {
+    type Target = Arc<tokio::sync::RwLock<TierConfigMgr>>;
+
+    fn deref(&self) -> &Self::Target {
+        &rustfs_ecstore::api::global::GLOBAL_TierConfigMgr
+    }
+}
+
+pub(crate) fn get_global_endpoints_opt() -> Option<EndpointServerPools> {
+    rustfs_ecstore::api::global::get_global_endpoints_opt()
+}
+
+pub(crate) fn get_global_region() -> Option<s3s::region::Region> {
+    rustfs_ecstore::api::global::get_global_region()
+}
+
+pub(crate) fn get_global_tier_config_mgr() -> Arc<tokio::sync::RwLock<TierConfigMgr>> {
+    rustfs_ecstore::api::global::get_global_tier_config_mgr()
+}
+
+pub(crate) fn new_object_layer_fn() -> Option<Arc<ECStore>> {
+    rustfs_ecstore::api::global::new_object_layer_fn()
+}
+
+pub(crate) fn set_object_store_resolver(resolver: Arc<ObjectStoreResolver>) -> bool {
+    rustfs_ecstore::api::global::set_object_store_resolver(resolver)
+}
+
+pub(crate) fn get_global_notification_sys() -> Option<&'static rustfs_ecstore::api::notification::NotificationSys> {
+    rustfs_ecstore::api::notification::get_global_notification_sys()
+}
+
 #[cfg(test)]
-pub(crate) use rustfs_ecstore::api::rio::{DecryptReader, EncryptReader, HardLimitReader, boxed_reader};
-pub(crate) use rustfs_ecstore::api::rio::{
-    DynReader, HashReader, WriteEncryption, WritePlan, compression_metadata_value, wrap_reader,
-};
-pub(crate) use rustfs_ecstore::api::set_disk::{get_lock_acquire_timeout, is_valid_storage_class};
-pub(crate) use rustfs_ecstore::api::storage::ECStore;
+pub(crate) fn boxed_reader<R>(reader: R) -> DynReader
+where
+    R: rustfs_ecstore::api::rio::Reader + 'static,
+{
+    rustfs_ecstore::api::rio::boxed_reader(reader)
+}
+
+pub(crate) fn compression_metadata_value(algorithm: rustfs_utils::CompressionAlgorithm) -> String {
+    rustfs_ecstore::api::rio::compression_metadata_value(algorithm)
+}
+
+pub(crate) fn wrap_reader<R>(reader: R) -> DynReader
+where
+    R: rustfs_ecstore::api::rio::ReadStream + 'static,
+{
+    rustfs_ecstore::api::rio::wrap_reader(reader)
+}
+
+pub(crate) fn get_lock_acquire_timeout() -> tokio::time::Duration {
+    rustfs_ecstore::api::set_disk::get_lock_acquire_timeout()
+}
+
+pub(crate) fn is_valid_storage_class(storage_class: &str) -> bool {
+    rustfs_ecstore::api::set_disk::is_valid_storage_class(storage_class)
+}
+
 #[cfg(test)]
-pub(crate) use rustfs_ecstore::api::storage::init_local_disks;
-pub(crate) use rustfs_ecstore::api::tier::tier::TierConfigMgr;
-#[cfg(test)]
-pub(crate) use rustfs_ecstore::api::tier::tier_config::{TierConfig, TierType};
-#[cfg(test)]
-pub(crate) use rustfs_ecstore::api::tier::warm_backend::{WarmBackend, WarmBackendGetOpts};
+pub(crate) async fn init_local_disks(endpoint_pools: EndpointServerPools) -> Result<(), Error> {
+    rustfs_ecstore::api::storage::init_local_disks(endpoint_pools).await
+}


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Replace admin and app storage compatibility ECStore API passthroughs with local aliases, wrappers, and proxy statics.
- Export the narrow ECStore facade symbols needed by those wrappers.
- Document the completed API-088 migration slice.

## Verification
- `cargo fmt --all --check`
- `cargo check -p rustfs`
- `cargo check -p rustfs --tests`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- Rust risk scan for unwrap/expect, numeric casts, string errors, boxed errors, println/eprintln, and relaxed atomics
- `make pre-commit`

## Impact
Internal compatibility-boundary cleanup only. No user-facing behavior, deployment, or configuration impact expected.

## Additional Notes
N/A
