### PR TITLE
test(s3): reclassify passing atomic conditional write

### DIFF
--- a/scripts/s3-tests/excluded_tests.txt
+++ b/scripts/s3-tests/excluded_tests.txt
@@ -9,7 +9,6 @@
 
 # Vendor-specific / non-portable tests
 test_account_usage
-test_atomic_conditional_write_1mb
 test_bucket_get_location
 test_bucket_head_extended
 test_bucket_header_acl_grants

--- a/scripts/s3-tests/implemented_tests.txt
+++ b/scripts/s3-tests/implemented_tests.txt
@@ -371,6 +371,7 @@ test_list_buckets_invalid_auth
 test_atomic_read_1mb
 test_atomic_read_4mb
 test_atomic_read_8mb
+test_atomic_conditional_write_1mb
 test_atomic_write_1mb
 test_atomic_write_4mb
 test_atomic_write_8mb


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Move `test_atomic_conditional_write_1mb` from excluded S3 tests to implemented tests after exact-node validation passed.

## Verification
- `PATH="$HOME/.cargo/bin:$PATH" TEST_MODE=s3-audit-candidates MAXFAIL=0 XDIST=0 scripts/s3-tests/run.sh` (299 exact candidates; 1 passed, 208 failed, 90 skipped)
- `PATH="$HOME/.cargo/bin:$PATH" TEST_MODE=s3-audit-single MAXFAIL=1 XDIST=0 DEPLOY_MODE=binary scripts/s3-tests/run.sh` (exact `test_atomic_conditional_write_1mb`; passed)
- `git diff --check`

## Impact
- S3 compatibility gating now includes one additional passing atomic conditional write test.

## Additional Notes
- The full candidate sweep is expected to return non-zero while remaining candidates still fail or skip.
