### PR TITLE
refactor: prune app admin raw facade paths

### DIFF
--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -187,6 +187,9 @@ expose the raw ECStore facade path once narrowed.
 The RustFS storage owner compatibility boundary must keep raw ECStore facade
 paths centralized behind local `ecstore_*` module aliases rather than scattering
 `rustfs_ecstore::api::...` references through its aliases and wrappers.
+The RustFS app/admin storage compatibility boundaries must likewise route raw
+ECStore facade access through their local `ecstore_*` module aliases instead of
+scattering `rustfs_ecstore::api::...` paths through compatibility wrappers.
 Scanner, notify, observability, and e2e `storage_compat.rs` boundaries must
 also stay narrow. Scanner must not restore grouped bucket compatibility exports
 for target, lifecycle, metadata, replication, or versioning modules. Notify

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-outer-compat-call-facade-prune`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091`.
-- Stacked on: `origin/main` after API-091 merged.
+- Branch: `overtrue/arch-outer-compat-raw-facade-prune`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092`.
+- Stacked on: `overtrue/arch-outer-compat-call-facade-prune` pending API-092 merge.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: centralize RustFS storage-owner raw ECStore facade paths
-  behind local `ecstore_*` module aliases.
-- CI/script changes: guard the RustFS storage-owner compatibility boundary
-  against restoring scattered raw ECStore facade paths.
-- Docs changes: record the API-092 storage-owner facade path cleanup.
+- Rust code changes: centralize RustFS app/admin raw ECStore facade paths behind
+  local `ecstore_*` module aliases.
+- CI/script changes: guard the RustFS app/admin storage compatibility
+  boundaries against restoring scattered raw ECStore facade paths.
+- Docs changes: record the API-093 app/admin facade path cleanup.
 
 ## Phase 0 Tasks
 
@@ -318,6 +318,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     associated type compatibility.
   - Verification: RustFS compile coverage, storage-owner raw facade path
     residual scan, migration guard, formatting, diff hygiene, Rust risk scan,
+    pre-commit quality gate, and three-expert review.
+- [x] `API-093` Prune app/admin raw facade paths.
+  - Completed slice: replace scattered raw `rustfs_ecstore::api::...` paths in
+    the RustFS app/admin storage compatibility boundaries with local `ecstore_*`
+    module aliases.
+  - Acceptance: `rustfs/src/app/storage_compat.rs` and
+    `rustfs/src/admin/storage_compat.rs` no longer contain raw
+    `rustfs_ecstore::api::...` facade paths outside their centralized local
+    `ecstore_*` aliases.
+  - Must preserve: app lifecycle, metadata, object-lock, replication, data
+    usage, notification, tier, layout, compression, admin rebalance, metrics,
+    bucket target, quota, storage class, and server configuration compatibility.
+  - Verification: RustFS compile coverage, app/admin raw facade path residual
+    scan, migration guard, formatting, diff hygiene, Rust risk scan,
     pre-commit quality gate, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
@@ -3352,13 +3366,24 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | API-092 centralizes RustFS storage-owner ECStore facade paths behind local `ecstore_*` module aliases. |
-| Migration preservation | passed | Storage metadata, object-lock, replication stats, tagging, RPC signature, metrics, tier reload, local disk lookup, and object I/O associated type compatibility keep the same ECStore contracts. |
-| Testing/verification | passed | RustFS compile coverage, storage-owner raw facade path residual scan, migration guard, formatting, diff hygiene, Rust risk scan, full pre-commit, and three-expert review passed. |
+| Quality/architecture | passed | API-093 centralizes RustFS app/admin ECStore facade paths behind local `ecstore_*` module aliases without adding nested compatibility modules. |
+| Migration preservation | passed | App lifecycle, metadata, object-lock, replication, data usage, notification, tier, layout, compression, admin rebalance, metrics, bucket target, quota, storage class, and server configuration compatibility keep the same ECStore contracts. |
+| Testing/verification | passed | RustFS compile coverage, app/admin raw facade path residual scan, migration and layer guards, formatting, diff hygiene, Rust risk scan, full pre-commit, and three-expert review passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-093 current slice:
+  - `cargo check -p rustfs`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - RustFS app/admin raw facade path residual scan: passed.
+  - Rust risk scan on changed Rust files: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-092 current slice:
   - `cargo check -p rustfs`: passed.

--- a/rustfs/src/admin/storage_compat.rs
+++ b/rustfs/src/admin/storage_compat.rs
@@ -15,54 +15,61 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-pub(crate) const RUSTFS_META_BUCKET: &str = rustfs_ecstore::api::disk::RUSTFS_META_BUCKET;
-pub(crate) const STORAGE_CLASS_SUB_SYS: &str = rustfs_ecstore::api::config::com::STORAGE_CLASS_SUB_SYS;
+use rustfs_ecstore::api::{
+    bucket as ecstore_bucket, capacity as ecstore_capacity, client as ecstore_client, config as ecstore_config,
+    data_usage as ecstore_data_usage, disk as ecstore_disk, error as ecstore_error, global as ecstore_global,
+    layout as ecstore_layout, metrics as ecstore_metrics, notification as ecstore_notification, rebalance as ecstore_rebalance,
+    rpc as ecstore_rpc, storage as ecstore_storage, tier as ecstore_tier,
+};
 
-pub(crate) type AdminError = rustfs_ecstore::api::client::admin_handler_utils::AdminError;
-pub(crate) type CollectMetricsOpts = rustfs_ecstore::api::metrics::CollectMetricsOpts;
-pub(crate) type DiskStat = rustfs_ecstore::api::rebalance::DiskStat;
-pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
-pub(crate) type EndpointServerPools = rustfs_ecstore::api::layout::EndpointServerPools;
-pub(crate) type MetricType = rustfs_ecstore::api::metrics::MetricType;
-pub(crate) type NotificationSys = rustfs_ecstore::api::notification::NotificationSys;
-pub(crate) type PeerRestClient = rustfs_ecstore::api::rpc::PeerRestClient;
-pub(crate) type RebalSaveOpt = rustfs_ecstore::api::rebalance::RebalSaveOpt;
-pub(crate) type RebalanceCleanupWarnings = rustfs_ecstore::api::rebalance::RebalanceCleanupWarnings;
-pub(crate) type RebalanceMeta = rustfs_ecstore::api::rebalance::RebalanceMeta;
-pub(crate) type RebalanceStats = rustfs_ecstore::api::rebalance::RebalanceStats;
-pub(crate) type StorageError = rustfs_ecstore::api::error::StorageError;
+pub(crate) const RUSTFS_META_BUCKET: &str = crate::admin::storage_compat::ecstore_disk::RUSTFS_META_BUCKET;
+pub(crate) const STORAGE_CLASS_SUB_SYS: &str = crate::admin::storage_compat::ecstore_config::com::STORAGE_CLASS_SUB_SYS;
+
+pub(crate) type AdminError = crate::admin::storage_compat::ecstore_client::admin_handler_utils::AdminError;
+pub(crate) type CollectMetricsOpts = crate::admin::storage_compat::ecstore_metrics::CollectMetricsOpts;
+pub(crate) type DiskStat = crate::admin::storage_compat::ecstore_rebalance::DiskStat;
+pub(crate) type ECStore = crate::admin::storage_compat::ecstore_storage::ECStore;
+pub(crate) type EndpointServerPools = crate::admin::storage_compat::ecstore_layout::EndpointServerPools;
+pub(crate) type MetricType = crate::admin::storage_compat::ecstore_metrics::MetricType;
+pub(crate) type NotificationSys = crate::admin::storage_compat::ecstore_notification::NotificationSys;
+pub(crate) type PeerRestClient = crate::admin::storage_compat::ecstore_rpc::PeerRestClient;
+pub(crate) type RebalSaveOpt = crate::admin::storage_compat::ecstore_rebalance::RebalSaveOpt;
+pub(crate) type RebalanceCleanupWarnings = crate::admin::storage_compat::ecstore_rebalance::RebalanceCleanupWarnings;
+pub(crate) type RebalanceMeta = crate::admin::storage_compat::ecstore_rebalance::RebalanceMeta;
+pub(crate) type RebalanceStats = crate::admin::storage_compat::ecstore_rebalance::RebalanceStats;
+pub(crate) type StorageError = crate::admin::storage_compat::ecstore_error::StorageError;
 pub(crate) type Error = StorageError;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
-pub(crate) type TierConfig = rustfs_ecstore::api::tier::tier_config::TierConfig;
-pub(crate) type TierCreds = rustfs_ecstore::api::tier::tier_admin::TierCreds;
-pub(crate) type TierType = rustfs_ecstore::api::tier::tier_config::TierType;
+pub(crate) type TierConfig = crate::admin::storage_compat::ecstore_tier::tier_config::TierConfig;
+pub(crate) type TierCreds = crate::admin::storage_compat::ecstore_tier::tier_admin::TierCreds;
+pub(crate) type TierType = crate::admin::storage_compat::ecstore_tier::tier_config::TierType;
 
 #[cfg(test)]
-pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
+pub(crate) type Endpoint = crate::admin::storage_compat::ecstore_disk::endpoint::Endpoint;
 #[cfg(test)]
-pub(crate) type Endpoints = rustfs_ecstore::api::layout::Endpoints;
+pub(crate) type Endpoints = crate::admin::storage_compat::ecstore_layout::Endpoints;
 #[cfg(test)]
-pub(crate) type PoolEndpoints = rustfs_ecstore::api::layout::PoolEndpoints;
+pub(crate) type PoolEndpoints = crate::admin::storage_compat::ecstore_layout::PoolEndpoints;
 #[cfg(test)]
-pub(crate) type RebalStatus = rustfs_ecstore::api::rebalance::RebalStatus;
+pub(crate) type RebalStatus = crate::admin::storage_compat::ecstore_rebalance::RebalStatus;
 #[cfg(test)]
-pub(crate) type RebalanceInfo = rustfs_ecstore::api::rebalance::RebalanceInfo;
+pub(crate) type RebalanceInfo = crate::admin::storage_compat::ecstore_rebalance::RebalanceInfo;
 
 pub(crate) mod bandwidth {
     pub(crate) mod monitor {
-        pub(crate) type BandwidthDetails = rustfs_ecstore::api::bucket::bandwidth::monitor::BandwidthDetails;
-        pub(crate) type Monitor = rustfs_ecstore::api::bucket::bandwidth::monitor::Monitor;
+        pub(crate) type BandwidthDetails = crate::admin::storage_compat::ecstore_bucket::bandwidth::monitor::BandwidthDetails;
+        pub(crate) type Monitor = crate::admin::storage_compat::ecstore_bucket::bandwidth::monitor::Monitor;
     }
 }
 
 pub(crate) mod bucket_target_sys {
-    pub(crate) type AdvancedPutOptions = rustfs_ecstore::api::bucket::bucket_target_sys::AdvancedPutOptions;
-    pub(crate) type BucketTargetError = rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetError;
-    pub(crate) type BucketTargetSys = rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys;
-    pub(crate) type PutObjectOptions = rustfs_ecstore::api::bucket::bucket_target_sys::PutObjectOptions;
-    pub(crate) type RemoveObjectOptions = rustfs_ecstore::api::bucket::bucket_target_sys::RemoveObjectOptions;
-    pub(crate) type S3ClientError = rustfs_ecstore::api::bucket::bucket_target_sys::S3ClientError;
-    pub(crate) type TargetClient = rustfs_ecstore::api::bucket::bucket_target_sys::TargetClient;
+    pub(crate) type AdvancedPutOptions = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::AdvancedPutOptions;
+    pub(crate) type BucketTargetError = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::BucketTargetError;
+    pub(crate) type BucketTargetSys = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::BucketTargetSys;
+    pub(crate) type PutObjectOptions = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::PutObjectOptions;
+    pub(crate) type RemoveObjectOptions = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::RemoveObjectOptions;
+    pub(crate) type S3ClientError = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::S3ClientError;
+    pub(crate) type TargetClient = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::TargetClient;
 }
 
 pub(crate) mod lifecycle {
@@ -76,34 +83,41 @@ pub(crate) mod lifecycle {
 
         impl GlobalTransitionStateCompat {
             pub(crate) fn get_daily_all_tier_stats(&self) -> DailyAllTierStats {
-                rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState.get_daily_all_tier_stats()
+                crate::admin::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState
+                    .get_daily_all_tier_stats()
             }
         }
     }
 
     pub(crate) mod tier_last_day_stats {
         #[cfg(test)]
-        pub(crate) type LastDayTierStats = rustfs_ecstore::api::bucket::lifecycle::tier_last_day_stats::LastDayTierStats;
+        pub(crate) type LastDayTierStats =
+            crate::admin::storage_compat::ecstore_bucket::lifecycle::tier_last_day_stats::LastDayTierStats;
     }
 }
 
 pub(crate) mod metadata {
-    pub(crate) const BUCKET_CORS_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_CORS_CONFIG;
-    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
-    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
-    pub(crate) const BUCKET_POLICY_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_POLICY_CONFIG;
-    pub(crate) const BUCKET_QUOTA_CONFIG_FILE: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_QUOTA_CONFIG_FILE;
-    pub(crate) const BUCKET_REPLICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_REPLICATION_CONFIG;
-    pub(crate) const BUCKET_SSECONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_SSECONFIG;
-    pub(crate) const BUCKET_TAGGING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TAGGING_CONFIG;
-    pub(crate) const BUCKET_TARGETS_FILE: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TARGETS_FILE;
-    pub(crate) const BUCKET_VERSIONING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_VERSIONING_CONFIG;
-    pub(crate) const OBJECT_LOCK_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::OBJECT_LOCK_CONFIG;
+    pub(crate) const BUCKET_CORS_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_CORS_CONFIG;
+    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str =
+        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str =
+        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
+    pub(crate) const BUCKET_POLICY_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_POLICY_CONFIG;
+    pub(crate) const BUCKET_QUOTA_CONFIG_FILE: &str =
+        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_QUOTA_CONFIG_FILE;
+    pub(crate) const BUCKET_REPLICATION_CONFIG: &str =
+        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_REPLICATION_CONFIG;
+    pub(crate) const BUCKET_SSECONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_SSECONFIG;
+    pub(crate) const BUCKET_TAGGING_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_TAGGING_CONFIG;
+    pub(crate) const BUCKET_TARGETS_FILE: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_TARGETS_FILE;
+    pub(crate) const BUCKET_VERSIONING_CONFIG: &str =
+        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_VERSIONING_CONFIG;
+    pub(crate) const OBJECT_LOCK_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::OBJECT_LOCK_CONFIG;
 
-    pub(crate) type BucketMetadata = rustfs_ecstore::api::bucket::metadata::BucketMetadata;
+    pub(crate) type BucketMetadata = crate::admin::storage_compat::ecstore_bucket::metadata::BucketMetadata;
 
     pub(crate) fn table_catalog_path_hash(value: &str) -> String {
-        rustfs_ecstore::api::bucket::metadata::table_catalog_path_hash(value)
+        crate::admin::storage_compat::ecstore_bucket::metadata::table_catalog_path_hash(value)
     }
 }
 
@@ -122,92 +136,94 @@ pub(crate) mod metadata_sys {
     use super::quota::BucketQuota;
     use super::target::BucketTargets;
 
-    pub(crate) type BucketMetadataSys = rustfs_ecstore::api::bucket::metadata_sys::BucketMetadataSys;
+    pub(crate) type BucketMetadataSys = crate::admin::storage_compat::ecstore_bucket::metadata_sys::BucketMetadataSys;
 
     pub(crate) async fn get(bucket: &str) -> Result<Arc<BucketMetadata>> {
-        rustfs_ecstore::api::bucket::metadata_sys::get(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get(bucket).await
     }
 
     pub(crate) async fn update(bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime> {
-        rustfs_ecstore::api::bucket::metadata_sys::update(bucket, config_file, data).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::update(bucket, config_file, data).await
     }
 
     pub(crate) async fn delete(bucket: &str, config_file: &str) -> Result<OffsetDateTime> {
-        rustfs_ecstore::api::bucket::metadata_sys::delete(bucket, config_file).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::delete(bucket, config_file).await
     }
 
     pub(crate) async fn get_bucket_policy(bucket: &str) -> Result<(BucketPolicy, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_policy(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_bucket_policy(bucket).await
     }
 
     pub(crate) async fn get_bucket_targets_config(bucket: &str) -> Result<BucketTargets> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_targets_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_bucket_targets_config(bucket).await
     }
 
     pub(crate) async fn get_config_from_disk(bucket: &str) -> Result<BucketMetadata> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_config_from_disk(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_config_from_disk(bucket).await
     }
 
     pub(crate) async fn get_lifecycle_config(bucket: &str) -> Result<(BucketLifecycleConfiguration, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_lifecycle_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
     }
 
     pub(crate) async fn get_notification_config(bucket: &str) -> Result<Option<NotificationConfiguration>> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_notification_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_notification_config(bucket).await
     }
 
     pub(crate) async fn get_object_lock_config(bucket: &str) -> Result<(ObjectLockConfiguration, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_object_lock_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
     }
 
     pub(crate) async fn get_quota_config(bucket: &str) -> Result<(BucketQuota, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_quota_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_quota_config(bucket).await
     }
 
     pub(crate) async fn get_replication_config(bucket: &str) -> Result<(s3s::dto::ReplicationConfiguration, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_replication_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_replication_config(bucket).await
     }
 
     pub(crate) async fn get_sse_config(bucket: &str) -> Result<(ServerSideEncryptionConfiguration, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_sse_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_sse_config(bucket).await
     }
 
     pub(crate) async fn get_tagging_config(bucket: &str) -> Result<(Tagging, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_tagging_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_tagging_config(bucket).await
     }
 
     pub(crate) async fn get_versioning_config(bucket: &str) -> Result<(VersioningConfiguration, OffsetDateTime)> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_versioning_config(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_versioning_config(bucket).await
     }
 
     pub(crate) async fn list_bucket_targets(bucket: &str) -> Result<BucketTargets> {
-        rustfs_ecstore::api::bucket::metadata_sys::list_bucket_targets(bucket).await
+        crate::admin::storage_compat::ecstore_bucket::metadata_sys::list_bucket_targets(bucket).await
     }
 }
 
 pub(crate) mod quota {
     pub(crate) mod checker {
-        pub(crate) type QuotaChecker = rustfs_ecstore::api::bucket::quota::checker::QuotaChecker;
+        pub(crate) type QuotaChecker = crate::admin::storage_compat::ecstore_bucket::quota::checker::QuotaChecker;
     }
 
-    pub(crate) type BucketQuota = rustfs_ecstore::api::bucket::quota::BucketQuota;
-    pub(crate) type QuotaError = rustfs_ecstore::api::bucket::quota::QuotaError;
-    pub(crate) type QuotaOperation = rustfs_ecstore::api::bucket::quota::QuotaOperation;
+    pub(crate) type BucketQuota = crate::admin::storage_compat::ecstore_bucket::quota::BucketQuota;
+    pub(crate) type QuotaError = crate::admin::storage_compat::ecstore_bucket::quota::QuotaError;
+    pub(crate) type QuotaOperation = crate::admin::storage_compat::ecstore_bucket::quota::QuotaOperation;
 }
 
 pub(crate) mod replication {
     use std::sync::Arc;
 
-    pub(crate) type BucketReplicationResyncStatus = rustfs_ecstore::api::bucket::replication::BucketReplicationResyncStatus;
-    pub(crate) type BucketStats = rustfs_ecstore::api::bucket::replication::BucketStats;
-    pub(crate) type DynReplicationPool = rustfs_ecstore::api::bucket::replication::DynReplicationPool;
-    pub(crate) type ObjectOpts = rustfs_ecstore::api::bucket::replication::ObjectOpts;
-    pub(crate) type ReplicationStats = rustfs_ecstore::api::bucket::replication::ReplicationStats;
-    pub(crate) type ResyncOpts = rustfs_ecstore::api::bucket::replication::ResyncOpts;
+    pub(crate) type BucketReplicationResyncStatus =
+        crate::admin::storage_compat::ecstore_bucket::replication::BucketReplicationResyncStatus;
+    pub(crate) type BucketStats = crate::admin::storage_compat::ecstore_bucket::replication::BucketStats;
+    pub(crate) type DynReplicationPool = crate::admin::storage_compat::ecstore_bucket::replication::DynReplicationPool;
+    pub(crate) type ObjectOpts = crate::admin::storage_compat::ecstore_bucket::replication::ObjectOpts;
+    pub(crate) type ReplicationStats = crate::admin::storage_compat::ecstore_bucket::replication::ReplicationStats;
+    pub(crate) type ResyncOpts = crate::admin::storage_compat::ecstore_bucket::replication::ResyncOpts;
     #[cfg(test)]
-    pub(crate) type ResyncStatusType = rustfs_ecstore::api::bucket::replication::ResyncStatusType;
+    pub(crate) type ResyncStatusType = crate::admin::storage_compat::ecstore_bucket::replication::ResyncStatusType;
     #[cfg(test)]
-    pub(crate) type TargetReplicationResyncStatus = rustfs_ecstore::api::bucket::replication::TargetReplicationResyncStatus;
+    pub(crate) type TargetReplicationResyncStatus =
+        crate::admin::storage_compat::ecstore_bucket::replication::TargetReplicationResyncStatus;
 
     pub(crate) struct GlobalReplicationStatsCompat;
 
@@ -215,22 +231,22 @@ pub(crate) mod replication {
 
     impl GlobalReplicationStatsCompat {
         pub(crate) fn get(&self) -> Option<&'static Arc<ReplicationStats>> {
-            rustfs_ecstore::api::bucket::replication::GLOBAL_REPLICATION_STATS.get()
+            crate::admin::storage_compat::ecstore_bucket::replication::GLOBAL_REPLICATION_STATS.get()
         }
     }
 
     pub(crate) fn get_global_replication_pool() -> Option<Arc<DynReplicationPool>> {
-        rustfs_ecstore::api::bucket::replication::get_global_replication_pool()
+        crate::admin::storage_compat::ecstore_bucket::replication::get_global_replication_pool()
     }
 }
 
 pub(crate) mod target {
     #[allow(clippy::upper_case_acronyms)]
-    pub(crate) type ARN = rustfs_ecstore::api::bucket::target::ARN;
-    pub(crate) type BucketTarget = rustfs_ecstore::api::bucket::target::BucketTarget;
-    pub(crate) type BucketTargetType = rustfs_ecstore::api::bucket::target::BucketTargetType;
-    pub(crate) type BucketTargets = rustfs_ecstore::api::bucket::target::BucketTargets;
-    pub(crate) type Credentials = rustfs_ecstore::api::bucket::target::Credentials;
+    pub(crate) type ARN = crate::admin::storage_compat::ecstore_bucket::target::ARN;
+    pub(crate) type BucketTarget = crate::admin::storage_compat::ecstore_bucket::target::BucketTarget;
+    pub(crate) type BucketTargetType = crate::admin::storage_compat::ecstore_bucket::target::BucketTargetType;
+    pub(crate) type BucketTargets = crate::admin::storage_compat::ecstore_bucket::target::BucketTargets;
+    pub(crate) type Credentials = crate::admin::storage_compat::ecstore_bucket::target::Credentials;
 }
 
 pub(crate) mod utils {
@@ -238,108 +254,109 @@ pub(crate) mod utils {
     where
         T: for<'xml> s3s::xml::Deserialize<'xml>,
     {
-        rustfs_ecstore::api::bucket::utils::deserialize(input)
+        crate::admin::storage_compat::ecstore_bucket::utils::deserialize(input)
     }
 
     pub(crate) fn is_valid_object_prefix(object: &str) -> bool {
-        rustfs_ecstore::api::bucket::utils::is_valid_object_prefix(object)
+        crate::admin::storage_compat::ecstore_bucket::utils::is_valid_object_prefix(object)
     }
 
     pub(crate) fn serialize<T: s3s::xml::Serialize>(val: &T) -> s3s::xml::SerResult<Vec<u8>> {
-        rustfs_ecstore::api::bucket::utils::serialize(val)
+        crate::admin::storage_compat::ecstore_bucket::utils::serialize(val)
     }
 }
 
 pub(crate) mod versioning {}
 
 pub(crate) mod versioning_sys {
-    pub(crate) type BucketVersioningSys = rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
+    pub(crate) type BucketVersioningSys = crate::admin::storage_compat::ecstore_bucket::versioning_sys::BucketVersioningSys;
 }
 
 pub(crate) mod storageclass {
-    pub(crate) const INLINE_BLOCK_ENV: &str = rustfs_ecstore::api::config::storageclass::INLINE_BLOCK_ENV;
-    pub(crate) const OPTIMIZE_ENV: &str = rustfs_ecstore::api::config::storageclass::OPTIMIZE_ENV;
-    pub(crate) const RRS: &str = rustfs_ecstore::api::config::storageclass::RRS;
-    pub(crate) const RRS_ENV: &str = rustfs_ecstore::api::config::storageclass::RRS_ENV;
-    pub(crate) const STANDARD: &str = rustfs_ecstore::api::config::storageclass::STANDARD;
-    pub(crate) const STANDARD_ENV: &str = rustfs_ecstore::api::config::storageclass::STANDARD_ENV;
+    pub(crate) const INLINE_BLOCK_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::INLINE_BLOCK_ENV;
+    pub(crate) const OPTIMIZE_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::OPTIMIZE_ENV;
+    pub(crate) const RRS: &str = crate::admin::storage_compat::ecstore_config::storageclass::RRS;
+    pub(crate) const RRS_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::RRS_ENV;
+    pub(crate) const STANDARD: &str = crate::admin::storage_compat::ecstore_config::storageclass::STANDARD;
+    pub(crate) const STANDARD_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::STANDARD_ENV;
 
-    pub(crate) type Config = rustfs_ecstore::api::config::storageclass::Config;
+    pub(crate) type Config = crate::admin::storage_compat::ecstore_config::storageclass::Config;
 
     pub(crate) fn lookup_config(kvs: &rustfs_config::server_config::KVS, set_drive_count: usize) -> super::Result<Config> {
-        rustfs_ecstore::api::config::storageclass::lookup_config(kvs, set_drive_count)
+        crate::admin::storage_compat::ecstore_config::storageclass::lookup_config(kvs, set_drive_count)
     }
 }
 
-pub(crate) type DailyAllTierStats = rustfs_ecstore::api::bucket::lifecycle::tier_last_day_stats::DailyAllTierStats;
+pub(crate) type DailyAllTierStats =
+    crate::admin::storage_compat::ecstore_bucket::lifecycle::tier_last_day_stats::DailyAllTierStats;
 
 pub(crate) fn is_reserved_or_invalid_bucket(bucket_entry: &str, strict: bool) -> bool {
-    rustfs_ecstore::api::capacity::is_reserved_or_invalid_bucket(bucket_entry, strict)
+    crate::admin::storage_compat::ecstore_capacity::is_reserved_or_invalid_bucket(bucket_entry, strict)
 }
 
 pub(crate) async fn read_admin_config(api: Arc<ECStore>, file: &str) -> Result<Vec<u8>> {
-    rustfs_ecstore::api::config::com::read_config(api, file).await
+    crate::admin::storage_compat::ecstore_config::com::read_config(api, file).await
 }
 
 pub(crate) async fn read_admin_config_without_migrate(api: Arc<ECStore>) -> Result<rustfs_config::server_config::Config> {
-    rustfs_ecstore::api::config::com::read_config_without_migrate(api).await
+    crate::admin::storage_compat::ecstore_config::com::read_config_without_migrate(api).await
 }
 
 pub(crate) async fn save_admin_config(api: Arc<ECStore>, file: &str, data: Vec<u8>) -> Result<()> {
-    rustfs_ecstore::api::config::com::save_config(api, file, data).await
+    crate::admin::storage_compat::ecstore_config::com::save_config(api, file, data).await
 }
 
 pub(crate) async fn delete_admin_config(api: Arc<ECStore>, file: &str) -> Result<()> {
-    rustfs_ecstore::api::config::com::delete_config(api, file).await
+    crate::admin::storage_compat::ecstore_config::com::delete_config(api, file).await
 }
 
 pub(crate) async fn save_admin_server_config(api: Arc<ECStore>, cfg: &rustfs_config::server_config::Config) -> Result<()> {
-    rustfs_ecstore::api::config::com::save_server_config(api, cfg).await
+    crate::admin::storage_compat::ecstore_config::com::save_server_config(api, cfg).await
 }
 
 pub(crate) fn init_admin_config_defaults() {
-    rustfs_ecstore::api::config::init();
+    crate::admin::storage_compat::ecstore_config::init();
 }
 
 pub(crate) fn set_global_storage_class(cfg: storageclass::Config) {
-    rustfs_ecstore::api::config::set_global_storage_class(cfg);
+    crate::admin::storage_compat::ecstore_config::set_global_storage_class(cfg);
 }
 
 pub(crate) async fn load_data_usage_from_backend(
     store: Arc<ECStore>,
 ) -> std::result::Result<rustfs_data_usage::DataUsageInfo, Error> {
-    rustfs_ecstore::api::data_usage::load_data_usage_from_backend(store).await
+    crate::admin::storage_compat::ecstore_data_usage::load_data_usage_from_backend(store).await
 }
 
 pub(crate) fn get_global_bucket_monitor() -> Option<Arc<bandwidth::monitor::Monitor>> {
-    rustfs_ecstore::api::global::get_global_bucket_monitor()
+    crate::admin::storage_compat::ecstore_global::get_global_bucket_monitor()
 }
 
 pub(crate) fn get_global_deployment_id() -> Option<String> {
-    rustfs_ecstore::api::global::get_global_deployment_id()
+    crate::admin::storage_compat::ecstore_global::get_global_deployment_id()
 }
 
 pub(crate) fn get_global_endpoints_opt() -> Option<EndpointServerPools> {
-    rustfs_ecstore::api::global::get_global_endpoints_opt()
+    crate::admin::storage_compat::ecstore_global::get_global_endpoints_opt()
 }
 
 pub(crate) fn get_global_region() -> Option<s3s::region::Region> {
-    rustfs_ecstore::api::global::get_global_region()
+    crate::admin::storage_compat::ecstore_global::get_global_region()
 }
 
 pub(crate) fn global_rustfs_port() -> u16 {
-    rustfs_ecstore::api::global::global_rustfs_port()
+    crate::admin::storage_compat::ecstore_global::global_rustfs_port()
 }
 
 pub(crate) async fn collect_local_metrics(
     types: MetricType,
     opts: &CollectMetricsOpts,
 ) -> rustfs_madmin::metrics::RealtimeMetrics {
-    rustfs_ecstore::api::metrics::collect_local_metrics(types, opts).await
+    crate::admin::storage_compat::ecstore_metrics::collect_local_metrics(types, opts).await
 }
 
 pub(crate) fn get_global_notification_sys() -> Option<&'static NotificationSys> {
-    rustfs_ecstore::api::notification::get_global_notification_sys()
+    crate::admin::storage_compat::ecstore_notification::get_global_notification_sys()
 }
 
 pub(crate) struct BootTimeCompat;
@@ -348,7 +365,7 @@ pub(crate) static GLOBAL_BOOT_TIME: BootTimeCompat = BootTimeCompat;
 
 impl BootTimeCompat {
     pub(crate) fn get(&self) -> Option<&'static std::time::SystemTime> {
-        rustfs_ecstore::api::global::GLOBAL_BOOT_TIME.get()
+        crate::admin::storage_compat::ecstore_global::GLOBAL_BOOT_TIME.get()
     }
 }
 
@@ -363,18 +380,18 @@ impl Deref for AdminErrorRef {
 }
 
 pub(crate) static ERR_TIER_BACKEND_IN_USE: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier::ERR_TIER_BACKEND_IN_USE);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier::ERR_TIER_BACKEND_IN_USE);
 pub(crate) static ERR_TIER_BACKEND_NOT_EMPTY: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier::ERR_TIER_BACKEND_NOT_EMPTY);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier::ERR_TIER_BACKEND_NOT_EMPTY);
 pub(crate) static ERR_TIER_MISSING_CREDENTIALS: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier::ERR_TIER_MISSING_CREDENTIALS);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier::ERR_TIER_MISSING_CREDENTIALS);
 pub(crate) static ERR_TIER_ALREADY_EXISTS: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_ALREADY_EXISTS);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_ALREADY_EXISTS);
 pub(crate) static ERR_TIER_CONNECT_ERR: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_CONNECT_ERR);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_CONNECT_ERR);
 pub(crate) static ERR_TIER_INVALID_CREDENTIALS: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_INVALID_CREDENTIALS);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_INVALID_CREDENTIALS);
 pub(crate) static ERR_TIER_NAME_NOT_UPPERCASE: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_NAME_NOT_UPPERCASE);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_NAME_NOT_UPPERCASE);
 pub(crate) static ERR_TIER_NOT_FOUND: AdminErrorRef =
-    AdminErrorRef(|| &rustfs_ecstore::api::tier::tier_handlers::ERR_TIER_NOT_FOUND);
+    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_NOT_FOUND);

--- a/rustfs/src/app/storage_compat.rs
+++ b/rustfs/src/app/storage_compat.rs
@@ -14,63 +14,70 @@
 
 use std::sync::Arc;
 
-pub(crate) const MIN_DISK_COMPRESSIBLE_SIZE: usize = rustfs_ecstore::api::compression::MIN_DISK_COMPRESSIBLE_SIZE;
+use rustfs_ecstore::api::{
+    admin as ecstore_admin, bucket as ecstore_bucket, capacity as ecstore_capacity, client as ecstore_client,
+    compression as ecstore_compression, config as ecstore_config, data_usage as ecstore_data_usage, disk as ecstore_disk,
+    error as ecstore_error, global as ecstore_global, layout as ecstore_layout, notification as ecstore_notification,
+    rio as ecstore_rio, set_disk as ecstore_set_disk, storage as ecstore_storage, tier as ecstore_tier,
+};
 
-pub(crate) type DiskError = rustfs_ecstore::api::disk::error::DiskError;
-pub(crate) type DynReader = rustfs_ecstore::api::rio::DynReader;
-pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
-pub(crate) type EndpointServerPools = rustfs_ecstore::api::layout::EndpointServerPools;
-pub(crate) type HashReader = rustfs_ecstore::api::rio::HashReader;
-pub(crate) type NotificationSys = rustfs_ecstore::api::notification::NotificationSys;
+pub(crate) const MIN_DISK_COMPRESSIBLE_SIZE: usize = crate::app::storage_compat::ecstore_compression::MIN_DISK_COMPRESSIBLE_SIZE;
+
+pub(crate) type DiskError = crate::app::storage_compat::ecstore_disk::error::DiskError;
+pub(crate) type DynReader = crate::app::storage_compat::ecstore_rio::DynReader;
+pub(crate) type ECStore = crate::app::storage_compat::ecstore_storage::ECStore;
+pub(crate) type EndpointServerPools = crate::app::storage_compat::ecstore_layout::EndpointServerPools;
+pub(crate) type HashReader = crate::app::storage_compat::ecstore_rio::HashReader;
+pub(crate) type NotificationSys = crate::app::storage_compat::ecstore_notification::NotificationSys;
 pub(crate) type ObjectStoreResolver = dyn Fn() -> Option<Arc<ECStore>> + Send + Sync + 'static;
 pub(crate) type ObjectInfo = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub(crate) type ObjectOptions = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
-pub(crate) type PoolDecommissionInfo = rustfs_ecstore::api::capacity::PoolDecommissionInfo;
-pub(crate) type PoolStatus = rustfs_ecstore::api::capacity::PoolStatus;
-pub(crate) type StorageError = rustfs_ecstore::api::error::StorageError;
+pub(crate) type PoolDecommissionInfo = crate::app::storage_compat::ecstore_capacity::PoolDecommissionInfo;
+pub(crate) type PoolStatus = crate::app::storage_compat::ecstore_capacity::PoolStatus;
+pub(crate) type StorageError = crate::app::storage_compat::ecstore_error::StorageError;
 pub(crate) type Error = StorageError;
-pub(crate) type TierConfigMgr = rustfs_ecstore::api::tier::tier::TierConfigMgr;
-pub(crate) type WriteEncryption = rustfs_ecstore::api::rio::WriteEncryption;
-pub(crate) type WritePlan = rustfs_ecstore::api::rio::WritePlan;
+pub(crate) type TierConfigMgr = crate::app::storage_compat::ecstore_tier::tier::TierConfigMgr;
+pub(crate) type WriteEncryption = crate::app::storage_compat::ecstore_rio::WriteEncryption;
+pub(crate) type WritePlan = crate::app::storage_compat::ecstore_rio::WritePlan;
 
 #[cfg(test)]
-pub(crate) type DecryptReader<R> = rustfs_ecstore::api::rio::DecryptReader<R>;
+pub(crate) type DecryptReader<R> = crate::app::storage_compat::ecstore_rio::DecryptReader<R>;
 #[cfg(test)]
-pub(crate) type EncryptReader<R> = rustfs_ecstore::api::rio::EncryptReader<R>;
+pub(crate) type EncryptReader<R> = crate::app::storage_compat::ecstore_rio::EncryptReader<R>;
 #[cfg(test)]
-pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
+pub(crate) type Endpoint = crate::app::storage_compat::ecstore_disk::endpoint::Endpoint;
 #[cfg(test)]
-pub(crate) type Endpoints = rustfs_ecstore::api::layout::Endpoints;
+pub(crate) type Endpoints = crate::app::storage_compat::ecstore_layout::Endpoints;
 #[cfg(test)]
-pub(crate) type HardLimitReader<R> = rustfs_ecstore::api::rio::HardLimitReader<R>;
+pub(crate) type HardLimitReader<R> = crate::app::storage_compat::ecstore_rio::HardLimitReader<R>;
 #[cfg(test)]
-pub(crate) type PoolEndpoints = rustfs_ecstore::api::layout::PoolEndpoints;
+pub(crate) type PoolEndpoints = crate::app::storage_compat::ecstore_layout::PoolEndpoints;
 #[cfg(test)]
-pub(crate) type TierConfig = rustfs_ecstore::api::tier::tier_config::TierConfig;
+pub(crate) type TierConfig = crate::app::storage_compat::ecstore_tier::tier_config::TierConfig;
 #[cfg(test)]
-pub(crate) type TierType = rustfs_ecstore::api::tier::tier_config::TierType;
+pub(crate) type TierType = crate::app::storage_compat::ecstore_tier::tier_config::TierType;
 #[cfg(test)]
-pub(crate) type WarmBackendGetOpts = rustfs_ecstore::api::tier::warm_backend::WarmBackendGetOpts;
+pub(crate) type WarmBackendGetOpts = crate::app::storage_compat::ecstore_tier::warm_backend::WarmBackendGetOpts;
 
 #[cfg(test)]
 #[allow(non_snake_case)]
 pub(crate) fn EndpointServerPools(pools: Vec<PoolEndpoints>) -> EndpointServerPools {
-    rustfs_ecstore::api::layout::EndpointServerPools::from(pools)
+    crate::app::storage_compat::ecstore_layout::EndpointServerPools::from(pools)
 }
 
 pub(crate) async fn get_server_info(get_pools: bool) -> rustfs_madmin::InfoMessage {
-    rustfs_ecstore::api::admin::get_server_info(get_pools).await
+    crate::app::storage_compat::ecstore_admin::get_server_info(get_pools).await
 }
 
 pub(crate) mod bucket_target_sys {
-    pub(crate) type BucketTargetSys = rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys;
+    pub(crate) type BucketTargetSys = crate::app::storage_compat::ecstore_bucket::bucket_target_sys::BucketTargetSys;
 }
 
 pub(crate) mod lifecycle {
     use super::ECStore;
 
     pub(crate) mod bucket_lifecycle_audit {
-        pub(crate) type LcEventSrc = rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
+        pub(crate) type LcEventSrc = crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
     }
 
     pub(crate) mod bucket_lifecycle_ops {
@@ -80,7 +87,7 @@ pub(crate) mod lifecycle {
         use super::ECStore;
         use super::bucket_lifecycle_audit::LcEventSrc;
 
-        pub(crate) type ExpiryState = rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::ExpiryState;
+        pub(crate) type ExpiryState = crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::ExpiryState;
 
         pub(crate) struct GlobalExpiryStateCompat;
 
@@ -91,32 +98,38 @@ pub(crate) mod lifecycle {
             type Target = Arc<tokio::sync::RwLock<ExpiryState>>;
 
             fn deref(&self) -> &Self::Target {
-                &rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
+                &crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
             }
         }
 
         #[cfg(test)]
         pub(crate) async fn init_background_expiry(api: Arc<ECStore>) {
-            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(api).await;
+            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(api).await;
         }
 
         pub(crate) async fn enqueue_expiry_for_existing_objects(
             api: Arc<ECStore>,
             bucket: &str,
         ) -> Result<(), super::super::Error> {
-            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::enqueue_expiry_for_existing_objects(api, bucket).await
+            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_expiry_for_existing_objects(
+                api, bucket,
+            )
+            .await
         }
 
         pub(crate) async fn enqueue_transition_for_existing_objects(
             api: Arc<ECStore>,
             bucket: &str,
         ) -> Result<(), super::super::Error> {
-            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects(api, bucket)
-                .await
+            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects(
+                api, bucket,
+            )
+            .await
         }
 
         pub(crate) async fn enqueue_transition_immediate(oi: &super::super::ObjectInfo, src: LcEventSrc) {
-            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_immediate(oi, src).await;
+            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_immediate(oi, src)
+                .await;
         }
 
         pub(crate) async fn post_restore_opts(
@@ -124,18 +137,21 @@ pub(crate) mod lifecycle {
             bucket: &str,
             object: &str,
         ) -> Result<super::super::ObjectOptions, std::io::Error> {
-            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::post_restore_opts(version_id, bucket, object).await
+            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::post_restore_opts(
+                version_id, bucket, object,
+            )
+            .await
         }
 
         pub(crate) async fn validate_transition_tier(lc: &s3s::dto::BucketLifecycleConfiguration) -> Result<(), std::io::Error> {
-            rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::validate_transition_tier(lc).await
+            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::validate_transition_tier(lc).await
         }
 
         pub(crate) async fn validate_lifecycle_config(
             lc: &s3s::dto::BucketLifecycleConfiguration,
             lock_config: &s3s::dto::ObjectLockConfiguration,
         ) -> Result<(), std::io::Error> {
-            use rustfs_ecstore::api::bucket::lifecycle::lifecycle::Lifecycle as _;
+            use crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::Lifecycle as _;
 
             lc.validate(lock_config).await
         }
@@ -143,15 +159,16 @@ pub(crate) mod lifecycle {
 
     pub(crate) mod lifecycle_contract {
         #[cfg(test)]
-        pub(crate) type IlmAction = rustfs_ecstore::api::bucket::lifecycle::lifecycle::IlmAction;
-        pub(crate) type Event = rustfs_ecstore::api::bucket::lifecycle::lifecycle::Event;
-        pub(crate) type ObjectOpts = rustfs_ecstore::api::bucket::lifecycle::lifecycle::ObjectOpts;
-        pub(crate) type TransitionOptions = rustfs_ecstore::api::bucket::lifecycle::lifecycle::TransitionOptions;
+        pub(crate) type IlmAction = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::IlmAction;
+        pub(crate) type Event = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::Event;
+        pub(crate) type ObjectOpts = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::ObjectOpts;
+        pub(crate) type TransitionOptions = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::TransitionOptions;
 
-        pub(crate) const TRANSITION_COMPLETE: &str = rustfs_ecstore::api::bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
+        pub(crate) const TRANSITION_COMPLETE: &str =
+            crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
 
         pub(crate) fn expected_expiry_time(mod_time: time::OffsetDateTime, days: i32) -> time::OffsetDateTime {
-            rustfs_ecstore::api::bucket::lifecycle::lifecycle::expected_expiry_time(mod_time, days)
+            crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::expected_expiry_time(mod_time, days)
         }
     }
     pub(crate) use lifecycle_contract as lifecycle;
@@ -165,12 +182,13 @@ pub(crate) mod lifecycle {
             api: Arc<ECStore>,
             je: &super::tier_sweeper::Jentry,
         ) -> std::io::Result<()> {
-            rustfs_ecstore::api::bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry(api, je).await
+            crate::app::storage_compat::ecstore_bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry(api, je)
+                .await
         }
     }
 
     pub(crate) mod tier_sweeper {
-        pub(crate) type Jentry = rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::Jentry;
+        pub(crate) type Jentry = crate::app::storage_compat::ecstore_bucket::lifecycle::tier_sweeper::Jentry;
 
         pub(crate) fn transitioned_delete_journal_entry(
             version_id: Option<uuid::Uuid>,
@@ -178,7 +196,7 @@ pub(crate) mod lifecycle {
             suspended: bool,
             transitioned: &rustfs_storage_api::TransitionedObject,
         ) -> Option<Jentry> {
-            rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::transitioned_delete_journal_entry(
+            crate::app::storage_compat::ecstore_bucket::lifecycle::tier_sweeper::transitioned_delete_journal_entry(
                 version_id,
                 versioned,
                 suspended,
@@ -189,25 +207,31 @@ pub(crate) mod lifecycle {
         pub(crate) fn transitioned_force_delete_journal_entry(
             transitioned: &rustfs_storage_api::TransitionedObject,
         ) -> Option<Jentry> {
-            rustfs_ecstore::api::bucket::lifecycle::tier_sweeper::transitioned_force_delete_journal_entry(transitioned)
+            crate::app::storage_compat::ecstore_bucket::lifecycle::tier_sweeper::transitioned_force_delete_journal_entry(
+                transitioned,
+            )
         }
     }
 }
 
 pub(crate) mod metadata {
-    pub(crate) const BUCKET_CORS_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_CORS_CONFIG;
-    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
-    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
-    pub(crate) const BUCKET_POLICY_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_POLICY_CONFIG;
+    pub(crate) const BUCKET_CORS_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_CORS_CONFIG;
+    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str =
+        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str =
+        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
+    pub(crate) const BUCKET_POLICY_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_POLICY_CONFIG;
     pub(crate) const BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG: &str =
-        rustfs_ecstore::api::bucket::metadata::BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG;
-    pub(crate) const BUCKET_REPLICATION_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_REPLICATION_CONFIG;
-    pub(crate) const BUCKET_SSECONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_SSECONFIG;
-    pub(crate) const BUCKET_TAGGING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TAGGING_CONFIG;
-    pub(crate) const BUCKET_TARGETS_FILE: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_TARGETS_FILE;
-    pub(crate) const BUCKET_VERSIONING_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_VERSIONING_CONFIG;
+        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG;
+    pub(crate) const BUCKET_REPLICATION_CONFIG: &str =
+        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_REPLICATION_CONFIG;
+    pub(crate) const BUCKET_SSECONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_SSECONFIG;
+    pub(crate) const BUCKET_TAGGING_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_TAGGING_CONFIG;
+    pub(crate) const BUCKET_TARGETS_FILE: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_TARGETS_FILE;
+    pub(crate) const BUCKET_VERSIONING_CONFIG: &str =
+        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_VERSIONING_CONFIG;
     #[cfg(test)]
-    pub(crate) const OBJECT_LOCK_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::OBJECT_LOCK_CONFIG;
+    pub(crate) const OBJECT_LOCK_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::OBJECT_LOCK_CONFIG;
 }
 
 pub(crate) mod metadata_sys {
@@ -226,77 +250,77 @@ pub(crate) mod metadata_sys {
     use super::Error;
     use super::target::BucketTargets;
 
-    pub(crate) type BucketMetadataSys = rustfs_ecstore::api::bucket::metadata_sys::BucketMetadataSys;
+    pub(crate) type BucketMetadataSys = crate::app::storage_compat::ecstore_bucket::metadata_sys::BucketMetadataSys;
 
     #[cfg(test)]
     pub(crate) async fn init_bucket_metadata_sys(api: Arc<ECStore>, buckets: Vec<String>) {
-        rustfs_ecstore::api::bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
     }
 
     pub(crate) async fn delete(bucket: &str, config_file: &str) -> Result<OffsetDateTime, Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::delete(bucket, config_file).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::delete(bucket, config_file).await
     }
 
     pub(crate) async fn get_bucket_policy(bucket: &str) -> Result<(BucketPolicy, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_policy(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_bucket_policy(bucket).await
     }
 
     pub(crate) async fn get_bucket_policy_raw(bucket: &str) -> Result<(String, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_policy_raw(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_bucket_policy_raw(bucket).await
     }
 
     pub(crate) async fn get_bucket_targets_config(bucket: &str) -> Result<BucketTargets, Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_bucket_targets_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_bucket_targets_config(bucket).await
     }
 
     pub(crate) async fn get_cors_config(bucket: &str) -> Result<(CORSConfiguration, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_cors_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_cors_config(bucket).await
     }
 
     pub(crate) fn get_global_bucket_metadata_sys() -> Option<Arc<RwLock<BucketMetadataSys>>> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_global_bucket_metadata_sys()
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_global_bucket_metadata_sys()
     }
 
     pub(crate) async fn get_lifecycle_config(bucket: &str) -> Result<(BucketLifecycleConfiguration, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_lifecycle_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
     }
 
     pub(crate) async fn get_notification_config(bucket: &str) -> Result<Option<NotificationConfiguration>, Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_notification_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_notification_config(bucket).await
     }
 
     pub(crate) async fn get_object_lock_config(bucket: &str) -> Result<(ObjectLockConfiguration, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_object_lock_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
     }
 
     pub(crate) async fn get_public_access_block_config(
         bucket: &str,
     ) -> Result<(PublicAccessBlockConfiguration, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_public_access_block_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_public_access_block_config(bucket).await
     }
 
     pub(crate) async fn get_replication_config(
         bucket: &str,
     ) -> Result<(s3s::dto::ReplicationConfiguration, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_replication_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_replication_config(bucket).await
     }
 
     pub(crate) async fn get_sse_config(bucket: &str) -> Result<(ServerSideEncryptionConfiguration, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_sse_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_sse_config(bucket).await
     }
 
     pub(crate) async fn get_tagging_config(bucket: &str) -> Result<(Tagging, OffsetDateTime), Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::get_tagging_config(bucket).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_tagging_config(bucket).await
     }
 
     pub(crate) async fn update(bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime, Error> {
-        rustfs_ecstore::api::bucket::metadata_sys::update(bucket, config_file, data).await
+        crate::app::storage_compat::ecstore_bucket::metadata_sys::update(bucket, config_file, data).await
     }
 }
 
 pub(crate) mod object_api_utils {
     pub(crate) fn to_s3s_etag(etag: &str) -> s3s::dto::ETag {
-        rustfs_ecstore::api::client::object_api_utils::to_s3s_etag(etag)
+        crate::app::storage_compat::ecstore_client::object_api_utils::to_s3s_etag(etag)
     }
 }
 
@@ -305,26 +329,28 @@ pub(crate) mod object_lock {
         pub(crate) fn get_object_legalhold_meta(
             meta: &std::collections::HashMap<String, String>,
         ) -> s3s::dto::ObjectLockLegalHold {
-            rustfs_ecstore::api::bucket::object_lock::objectlock::get_object_legalhold_meta(meta)
+            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock::get_object_legalhold_meta(meta)
         }
 
         pub(crate) fn get_object_retention_meta(
             meta: &std::collections::HashMap<String, String>,
         ) -> s3s::dto::ObjectLockRetention {
-            rustfs_ecstore::api::bucket::object_lock::objectlock::get_object_retention_meta(meta)
+            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock::get_object_retention_meta(meta)
         }
     }
 
     pub(crate) mod objectlock_sys {
-        pub(crate) type BucketObjectLockSys = rustfs_ecstore::api::bucket::object_lock::objectlock_sys::BucketObjectLockSys;
-        pub(crate) type ObjectLockBlockReason = rustfs_ecstore::api::bucket::object_lock::objectlock_sys::ObjectLockBlockReason;
+        pub(crate) type BucketObjectLockSys =
+            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::BucketObjectLockSys;
+        pub(crate) type ObjectLockBlockReason =
+            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::ObjectLockBlockReason;
 
         pub(crate) async fn check_object_lock_for_deletion(
             bucket: &str,
             obj_info: &super::super::ObjectInfo,
             bypass_governance: bool,
         ) -> Option<ObjectLockBlockReason> {
-            rustfs_ecstore::api::bucket::object_lock::objectlock_sys::check_object_lock_for_deletion(
+            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::check_object_lock_for_deletion(
                 bucket,
                 obj_info,
                 bypass_governance,
@@ -333,30 +359,31 @@ pub(crate) mod object_lock {
         }
 
         pub(crate) fn is_retention_active(mode: &str, retain_until_date: Option<&s3s::dto::Date>) -> bool {
-            rustfs_ecstore::api::bucket::object_lock::objectlock_sys::is_retention_active(mode, retain_until_date)
+            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::is_retention_active(mode, retain_until_date)
         }
     }
 }
 
 pub(crate) mod policy_sys {
-    pub(crate) type PolicySys = rustfs_ecstore::api::bucket::policy_sys::PolicySys;
+    pub(crate) type PolicySys = crate::app::storage_compat::ecstore_bucket::policy_sys::PolicySys;
 }
 
 pub(crate) mod quota {
     pub(crate) mod checker {
-        pub(crate) type QuotaChecker = rustfs_ecstore::api::bucket::quota::checker::QuotaChecker;
+        pub(crate) type QuotaChecker = crate::app::storage_compat::ecstore_bucket::quota::checker::QuotaChecker;
     }
 
-    pub(crate) type QuotaOperation = rustfs_ecstore::api::bucket::quota::QuotaOperation;
+    pub(crate) type QuotaOperation = crate::app::storage_compat::ecstore_bucket::quota::QuotaOperation;
 }
 
 pub(crate) mod replication {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    pub(crate) type DeletedObjectReplicationInfo = rustfs_ecstore::api::bucket::replication::DeletedObjectReplicationInfo;
-    pub(crate) type MustReplicateOptions = rustfs_ecstore::api::bucket::replication::MustReplicateOptions;
-    pub(crate) type ObjectOpts = rustfs_ecstore::api::bucket::replication::ObjectOpts;
+    pub(crate) type DeletedObjectReplicationInfo =
+        crate::app::storage_compat::ecstore_bucket::replication::DeletedObjectReplicationInfo;
+    pub(crate) type MustReplicateOptions = crate::app::storage_compat::ecstore_bucket::replication::MustReplicateOptions;
+    pub(crate) type ObjectOpts = crate::app::storage_compat::ecstore_bucket::replication::ObjectOpts;
     pub(crate) type ReplicateDecision = rustfs_filemeta::ReplicateDecision;
 
     pub(crate) async fn check_replicate_delete(
@@ -366,7 +393,7 @@ pub(crate) mod replication {
         del_opts: &super::ObjectOptions,
         gerr: Option<String>,
     ) -> ReplicateDecision {
-        rustfs_ecstore::api::bucket::replication::check_replicate_delete(bucket, dobj, oi, del_opts, gerr).await
+        crate::app::storage_compat::ecstore_bucket::replication::check_replicate_delete(bucket, dobj, oi, del_opts, gerr).await
     }
 
     pub(crate) fn get_must_replicate_options(
@@ -376,11 +403,17 @@ pub(crate) mod replication {
         op_type: rustfs_filemeta::ReplicationType,
         opts: super::ObjectOptions,
     ) -> MustReplicateOptions {
-        rustfs_ecstore::api::bucket::replication::get_must_replicate_options(user_defined, user_tags, status, op_type, opts)
+        crate::app::storage_compat::ecstore_bucket::replication::get_must_replicate_options(
+            user_defined,
+            user_tags,
+            status,
+            op_type,
+            opts,
+        )
     }
 
     pub(crate) async fn must_replicate(bucket: &str, object: &str, mopts: MustReplicateOptions) -> ReplicateDecision {
-        rustfs_ecstore::api::bucket::replication::must_replicate(bucket, object, mopts).await
+        crate::app::storage_compat::ecstore_bucket::replication::must_replicate(bucket, object, mopts).await
     }
 
     pub(crate) async fn schedule_replication(
@@ -389,95 +422,101 @@ pub(crate) mod replication {
         dsc: ReplicateDecision,
         op_type: rustfs_filemeta::ReplicationType,
     ) {
-        rustfs_ecstore::api::bucket::replication::schedule_replication(oi, store, dsc, op_type).await;
+        crate::app::storage_compat::ecstore_bucket::replication::schedule_replication(oi, store, dsc, op_type).await;
     }
 
     pub(crate) async fn schedule_replication_delete(dv: DeletedObjectReplicationInfo) {
-        rustfs_ecstore::api::bucket::replication::schedule_replication_delete(dv).await;
+        crate::app::storage_compat::ecstore_bucket::replication::schedule_replication_delete(dv).await;
     }
 }
 
 pub(crate) mod tagging {
     pub(crate) fn decode_tags(tags: &str) -> Vec<s3s::dto::Tag> {
-        rustfs_ecstore::api::bucket::tagging::decode_tags(tags)
+        crate::app::storage_compat::ecstore_bucket::tagging::decode_tags(tags)
     }
 }
 
 pub(crate) mod target {
     #[cfg(test)]
-    pub(crate) type BucketTarget = rustfs_ecstore::api::bucket::target::BucketTarget;
-    pub(crate) type BucketTargetType = rustfs_ecstore::api::bucket::target::BucketTargetType;
-    pub(crate) type BucketTargets = rustfs_ecstore::api::bucket::target::BucketTargets;
+    pub(crate) type BucketTarget = crate::app::storage_compat::ecstore_bucket::target::BucketTarget;
+    pub(crate) type BucketTargetType = crate::app::storage_compat::ecstore_bucket::target::BucketTargetType;
+    pub(crate) type BucketTargets = crate::app::storage_compat::ecstore_bucket::target::BucketTargets;
 }
 
 pub(crate) mod utils {
     pub(crate) fn serialize<T: s3s::xml::Serialize>(val: &T) -> s3s::xml::SerResult<Vec<u8>> {
-        rustfs_ecstore::api::bucket::utils::serialize(val)
+        crate::app::storage_compat::ecstore_bucket::utils::serialize(val)
     }
 }
 
 pub(crate) mod versioning {}
 
 pub(crate) mod versioning_sys {
-    pub(crate) type BucketVersioningSys = rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
+    pub(crate) type BucketVersioningSys = crate::app::storage_compat::ecstore_bucket::versioning_sys::BucketVersioningSys;
 }
 
 #[cfg(test)]
 pub(crate) mod transition_api {
-    pub(crate) type ReadCloser = rustfs_ecstore::api::client::transition_api::ReadCloser;
-    pub(crate) type ReaderImpl = rustfs_ecstore::api::client::transition_api::ReaderImpl;
+    pub(crate) type ReadCloser = crate::app::storage_compat::ecstore_client::transition_api::ReadCloser;
+    pub(crate) type ReaderImpl = crate::app::storage_compat::ecstore_client::transition_api::ReaderImpl;
 }
 
 pub(crate) mod storageclass {
-    pub(crate) const STANDARD: &str = rustfs_ecstore::api::config::storageclass::STANDARD;
+    pub(crate) const STANDARD: &str = crate::app::storage_compat::ecstore_config::storageclass::STANDARD;
     #[cfg(test)]
-    pub(crate) const STANDARD_IA: &str = rustfs_ecstore::api::config::storageclass::STANDARD_IA;
+    pub(crate) const STANDARD_IA: &str = crate::app::storage_compat::ecstore_config::storageclass::STANDARD_IA;
 }
 
 pub(crate) fn get_total_usable_capacity(disks: &[rustfs_madmin::Disk], info: &rustfs_madmin::StorageInfo) -> usize {
-    rustfs_ecstore::api::capacity::get_total_usable_capacity(disks, info)
+    crate::app::storage_compat::ecstore_capacity::get_total_usable_capacity(disks, info)
 }
 
 pub(crate) fn get_total_usable_capacity_free(disks: &[rustfs_madmin::Disk], info: &rustfs_madmin::StorageInfo) -> usize {
-    rustfs_ecstore::api::capacity::get_total_usable_capacity_free(disks, info)
+    crate::app::storage_compat::ecstore_capacity::get_total_usable_capacity_free(disks, info)
 }
 
 pub(crate) fn is_disk_compressible(headers: &http::HeaderMap, object_name: &str) -> bool {
-    rustfs_ecstore::api::compression::is_disk_compressible(headers, object_name)
+    crate::app::storage_compat::ecstore_compression::is_disk_compressible(headers, object_name)
 }
 
 pub(crate) async fn apply_bucket_usage_memory_overlay(data_usage_info: &mut rustfs_data_usage::DataUsageInfo) {
-    rustfs_ecstore::api::data_usage::apply_bucket_usage_memory_overlay(data_usage_info).await;
+    crate::app::storage_compat::ecstore_data_usage::apply_bucket_usage_memory_overlay(data_usage_info).await;
 }
 
 pub(crate) async fn load_data_usage_from_backend(
     store: Arc<ECStore>,
 ) -> std::result::Result<rustfs_data_usage::DataUsageInfo, Error> {
-    rustfs_ecstore::api::data_usage::load_data_usage_from_backend(store).await
+    crate::app::storage_compat::ecstore_data_usage::load_data_usage_from_backend(store).await
 }
 
 pub(crate) async fn record_bucket_object_delete_memory(bucket: &str, deleted_size: u64, removed_current_object: bool) {
-    rustfs_ecstore::api::data_usage::record_bucket_object_delete_memory(bucket, deleted_size, removed_current_object).await;
+    crate::app::storage_compat::ecstore_data_usage::record_bucket_object_delete_memory(
+        bucket,
+        deleted_size,
+        removed_current_object,
+    )
+    .await;
 }
 
 pub(crate) async fn record_bucket_object_write_memory(bucket: &str, previous_current_size: Option<u64>, new_size: u64) {
-    rustfs_ecstore::api::data_usage::record_bucket_object_write_memory(bucket, previous_current_size, new_size).await;
+    crate::app::storage_compat::ecstore_data_usage::record_bucket_object_write_memory(bucket, previous_current_size, new_size)
+        .await;
 }
 
 pub(crate) fn is_all_buckets_not_found(errs: &[Option<DiskError>]) -> bool {
-    rustfs_ecstore::api::disk::error_reduce::is_all_buckets_not_found(errs)
+    crate::app::storage_compat::ecstore_disk::error_reduce::is_all_buckets_not_found(errs)
 }
 
 pub(crate) fn is_err_bucket_not_found(err: &Error) -> bool {
-    rustfs_ecstore::api::error::is_err_bucket_not_found(err)
+    crate::app::storage_compat::ecstore_error::is_err_bucket_not_found(err)
 }
 
 pub(crate) fn is_err_object_not_found(err: &Error) -> bool {
-    rustfs_ecstore::api::error::is_err_object_not_found(err)
+    crate::app::storage_compat::ecstore_error::is_err_object_not_found(err)
 }
 
 pub(crate) fn is_err_version_not_found(err: &Error) -> bool {
-    rustfs_ecstore::api::error::is_err_version_not_found(err)
+    crate::app::storage_compat::ecstore_error::is_err_version_not_found(err)
 }
 
 #[cfg(test)]
@@ -492,62 +531,62 @@ impl std::ops::Deref for GlobalTierConfigMgrCompat {
     type Target = Arc<tokio::sync::RwLock<TierConfigMgr>>;
 
     fn deref(&self) -> &Self::Target {
-        &rustfs_ecstore::api::global::GLOBAL_TierConfigMgr
+        &crate::app::storage_compat::ecstore_global::GLOBAL_TierConfigMgr
     }
 }
 
 pub(crate) fn get_global_endpoints_opt() -> Option<EndpointServerPools> {
-    rustfs_ecstore::api::global::get_global_endpoints_opt()
+    crate::app::storage_compat::ecstore_global::get_global_endpoints_opt()
 }
 
 pub(crate) fn get_global_region() -> Option<s3s::region::Region> {
-    rustfs_ecstore::api::global::get_global_region()
+    crate::app::storage_compat::ecstore_global::get_global_region()
 }
 
 pub(crate) fn get_global_tier_config_mgr() -> Arc<tokio::sync::RwLock<TierConfigMgr>> {
-    rustfs_ecstore::api::global::get_global_tier_config_mgr()
+    crate::app::storage_compat::ecstore_global::get_global_tier_config_mgr()
 }
 
 pub(crate) fn new_object_layer_fn() -> Option<Arc<ECStore>> {
-    rustfs_ecstore::api::global::new_object_layer_fn()
+    crate::app::storage_compat::ecstore_global::new_object_layer_fn()
 }
 
 pub(crate) fn set_object_store_resolver(resolver: Arc<ObjectStoreResolver>) -> bool {
-    rustfs_ecstore::api::global::set_object_store_resolver(resolver)
+    crate::app::storage_compat::ecstore_global::set_object_store_resolver(resolver)
 }
 
 pub(crate) fn get_global_notification_sys() -> Option<&'static NotificationSys> {
-    rustfs_ecstore::api::notification::get_global_notification_sys()
+    crate::app::storage_compat::ecstore_notification::get_global_notification_sys()
 }
 
 #[cfg(test)]
 pub(crate) fn boxed_reader<R>(reader: R) -> DynReader
 where
-    R: rustfs_ecstore::api::rio::Reader + 'static,
+    R: crate::app::storage_compat::ecstore_rio::Reader + 'static,
 {
-    rustfs_ecstore::api::rio::boxed_reader(reader)
+    crate::app::storage_compat::ecstore_rio::boxed_reader(reader)
 }
 
 pub(crate) fn compression_metadata_value(algorithm: rustfs_utils::CompressionAlgorithm) -> String {
-    rustfs_ecstore::api::rio::compression_metadata_value(algorithm)
+    crate::app::storage_compat::ecstore_rio::compression_metadata_value(algorithm)
 }
 
 pub(crate) fn wrap_reader<R>(reader: R) -> DynReader
 where
-    R: rustfs_ecstore::api::rio::ReadStream + 'static,
+    R: crate::app::storage_compat::ecstore_rio::ReadStream + 'static,
 {
-    rustfs_ecstore::api::rio::wrap_reader(reader)
+    crate::app::storage_compat::ecstore_rio::wrap_reader(reader)
 }
 
 pub(crate) fn get_lock_acquire_timeout() -> tokio::time::Duration {
-    rustfs_ecstore::api::set_disk::get_lock_acquire_timeout()
+    crate::app::storage_compat::ecstore_set_disk::get_lock_acquire_timeout()
 }
 
 pub(crate) fn is_valid_storage_class(storage_class: &str) -> bool {
-    rustfs_ecstore::api::set_disk::is_valid_storage_class(storage_class)
+    crate::app::storage_compat::ecstore_set_disk::is_valid_storage_class(storage_class)
 }
 
 #[cfg(test)]
 pub(crate) async fn init_local_disks(endpoint_pools: EndpointServerPools) -> Result<(), Error> {
-    rustfs_ecstore::api::storage::init_local_disks(endpoint_pools).await
+    crate::app::storage_compat::ecstore_storage::init_local_disks(endpoint_pools).await
 }

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -89,6 +89,7 @@ RUSTFS_APP_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/rustfs_app_bucket_
 RUSTFS_OUTER_COMPAT_FACADE_ALIAS_HITS_FILE="${TMP_DIR}/rustfs_outer_compat_facade_alias_hits.txt"
 RUSTFS_OUTER_COMPAT_SIGNATURE_ALIAS_HITS_FILE="${TMP_DIR}/rustfs_outer_compat_signature_alias_hits.txt"
 RUSTFS_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_storage_compat_raw_facade_path_hits.txt"
+RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_app_admin_compat_raw_facade_path_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -914,6 +915,16 @@ fi
 
 if [[ -s "$RUSTFS_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
   report_failure "RustFS storage owner compatibility must use local ecstore_* module aliases instead of scattered raw ECStore facade paths: $(paste -sd '; ' "$RUSTFS_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'rustfs_ecstore::api::' rustfs/src/app/storage_compat.rs rustfs/src/admin/storage_compat.rs \
+    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::\{' || true
+) >"$RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE"
+
+if [[ -s "$RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
+  report_failure "RustFS app/admin storage compatibility must use local ecstore_* module aliases instead of scattered raw ECStore facade paths: $(paste -sd '; ' "$RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

rustfs/backlog#660

## Summary of Changes

- Centralize RustFS app/admin storage compatibility raw ECStore facade paths behind local `ecstore_*` module aliases.
- Add a migration guard to prevent restoring scattered raw ECStore API paths in these compatibility boundaries.
- Update the architecture migration notes for the API-093 slice.

## Verification

- `make pre-commit`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo check -p rustfs`

## Impact

No runtime behavior changes. This is a compatibility-boundary cleanup only.

## Additional Notes

Stacked after #3702.
