### PR TITLE
refactor: prune consumer storage compat paths

### DIFF
--- a/crates/heal/src/heal/storage_compat.rs
+++ b/crates/heal/src/heal/storage_compat.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) const DATA_USAGE_CACHE_NAME: &str = rustfs_ecstore::api::data_usage::DATA_USAGE_CACHE_NAME;
-pub(crate) const BUCKET_META_PREFIX: &str = rustfs_ecstore::api::disk::BUCKET_META_PREFIX;
-pub(crate) const RUSTFS_META_BUCKET: &str = rustfs_ecstore::api::disk::RUSTFS_META_BUCKET;
+use rustfs_ecstore::api::{
+    data_usage as ecstore_data_usage, disk as ecstore_disk, error as ecstore_error, global as ecstore_global,
+    storage as ecstore_storage,
+};
 
-pub(crate) type DiskError = rustfs_ecstore::api::disk::error::DiskError;
-pub(crate) type DiskStore = rustfs_ecstore::api::disk::DiskStore;
-pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
-pub(crate) type EcstoreError = rustfs_ecstore::api::error::Error;
-pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
-pub(crate) type StorageError = rustfs_ecstore::api::error::StorageError;
+pub(crate) const DATA_USAGE_CACHE_NAME: &str = ecstore_data_usage::DATA_USAGE_CACHE_NAME;
+pub(crate) const BUCKET_META_PREFIX: &str = ecstore_disk::BUCKET_META_PREFIX;
+pub(crate) const RUSTFS_META_BUCKET: &str = ecstore_disk::RUSTFS_META_BUCKET;
+
+pub(crate) type DiskError = ecstore_disk::error::DiskError;
+pub(crate) type DiskStore = ecstore_disk::DiskStore;
+pub(crate) type ECStore = ecstore_storage::ECStore;
+pub(crate) type EcstoreError = ecstore_error::Error;
+pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
+pub(crate) type StorageError = ecstore_error::StorageError;
 pub(crate) type LocalDiskMap = std::collections::HashMap<String, Option<DiskStore>>;
 
 pub(crate) struct GlobalLocalDiskMap;
@@ -30,16 +35,16 @@ pub(crate) static GLOBAL_LOCAL_DISK_MAP: GlobalLocalDiskMap = GlobalLocalDiskMap
 
 impl GlobalLocalDiskMap {
     pub(crate) async fn read(&self) -> tokio::sync::RwLockReadGuard<'static, LocalDiskMap> {
-        rustfs_ecstore::api::global::GLOBAL_LOCAL_DISK_MAP.read().await
+        ecstore_global::GLOBAL_LOCAL_DISK_MAP.read().await
     }
 }
 
 #[cfg(test)]
-pub(crate) type DiskOption = rustfs_ecstore::api::disk::DiskOption;
+pub(crate) type DiskOption = ecstore_disk::DiskOption;
 
 #[cfg(test)]
-pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> rustfs_ecstore::api::disk::error::Result<DiskStore> {
-    rustfs_ecstore::api::disk::new_disk(ep, opt).await
+pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> ecstore_disk::error::Result<DiskStore> {
+    ecstore_disk::new_disk(ep, opt).await
 }
 
 pub type HealObjectInfo = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;

--- a/crates/heal/tests/common/storage_compat.rs
+++ b/crates/heal/tests/common/storage_compat.rs
@@ -16,22 +16,26 @@
 
 use std::sync::Arc;
 
-pub(crate) type DiskStore = rustfs_ecstore::api::disk::DiskStore;
-pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
-pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
-pub(crate) type EndpointServerPools = rustfs_ecstore::api::layout::EndpointServerPools;
-pub(crate) type Endpoints = rustfs_ecstore::api::layout::Endpoints;
-pub(crate) type PoolEndpoints = rustfs_ecstore::api::layout::PoolEndpoints;
+use rustfs_ecstore::api::{
+    bucket as ecstore_bucket, disk as ecstore_disk, error as ecstore_error, layout as ecstore_layout, storage as ecstore_storage,
+};
+
+pub(crate) type DiskStore = ecstore_disk::DiskStore;
+pub(crate) type ECStore = ecstore_storage::ECStore;
+pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
+pub(crate) type EndpointServerPools = ecstore_layout::EndpointServerPools;
+pub(crate) type Endpoints = ecstore_layout::Endpoints;
+pub(crate) type PoolEndpoints = ecstore_layout::PoolEndpoints;
 
 #[allow(non_snake_case)]
 pub(crate) fn EndpointServerPools(pools: Vec<PoolEndpoints>) -> EndpointServerPools {
-    rustfs_ecstore::api::layout::EndpointServerPools::from(pools)
+    ecstore_layout::EndpointServerPools::from(pools)
 }
 
 pub(crate) async fn init_bucket_metadata_sys(api: Arc<ECStore>, buckets: Vec<String>) {
-    rustfs_ecstore::api::bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
+    ecstore_bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
 }
 
-pub(crate) async fn init_local_disks(endpoint_pools: EndpointServerPools) -> rustfs_ecstore::api::error::Result<()> {
-    rustfs_ecstore::api::storage::init_local_disks(endpoint_pools).await
+pub(crate) async fn init_local_disks(endpoint_pools: EndpointServerPools) -> ecstore_error::Result<()> {
+    ecstore_storage::init_local_disks(endpoint_pools).await
 }

--- a/crates/iam/src/storage_compat.rs
+++ b/crates/iam/src/storage_compat.rs
@@ -14,17 +14,22 @@
 
 use std::sync::Arc;
 
-pub(crate) const IAM_CONFIG_ROOT_PREFIX: &str = rustfs_ecstore::api::config::RUSTFS_CONFIG_PREFIX;
+use rustfs_ecstore::api::{
+    config as ecstore_config, error as ecstore_error, global as ecstore_global, notification as ecstore_notification,
+    storage as ecstore_storage,
+};
 
-pub(crate) type IamEcstoreError = rustfs_ecstore::api::error::Error;
-pub(crate) type IamStorageError = rustfs_ecstore::api::error::StorageError;
-pub(crate) type IamStorageResult<T> = rustfs_ecstore::api::error::Result<T>;
-pub(crate) type IamStore = rustfs_ecstore::api::storage::ECStore;
+pub(crate) const IAM_CONFIG_ROOT_PREFIX: &str = ecstore_config::RUSTFS_CONFIG_PREFIX;
+
+pub(crate) type IamEcstoreError = ecstore_error::Error;
+pub(crate) type IamStorageError = ecstore_error::StorageError;
+pub(crate) type IamStorageResult<T> = ecstore_error::Result<T>;
+pub(crate) type IamStore = ecstore_storage::ECStore;
 pub(crate) type IamConfigObjectInfo = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub(crate) type IamConfigObjectOptions = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
 
 pub(crate) async fn read_iam_config_no_lock(api: Arc<IamStore>, file: &str) -> IamStorageResult<Vec<u8>> {
-    rustfs_ecstore::api::config::com::read_config_no_lock(api, file).await
+    ecstore_config::com::read_config_no_lock(api, file).await
 }
 
 pub(crate) async fn read_iam_config_with_metadata(
@@ -32,11 +37,11 @@ pub(crate) async fn read_iam_config_with_metadata(
     file: &str,
     opts: &IamConfigObjectOptions,
 ) -> IamStorageResult<(Vec<u8>, IamConfigObjectInfo)> {
-    rustfs_ecstore::api::config::com::read_config_with_metadata(api, file, opts).await
+    ecstore_config::com::read_config_with_metadata(api, file, opts).await
 }
 
 pub(crate) async fn save_iam_config(api: Arc<IamStore>, file: &str, data: Vec<u8>) -> IamStorageResult<()> {
-    rustfs_ecstore::api::config::com::save_config(api, file, data).await
+    ecstore_config::com::save_config(api, file, data).await
 }
 
 pub(crate) async fn save_iam_config_with_opts(
@@ -45,33 +50,33 @@ pub(crate) async fn save_iam_config_with_opts(
     data: Vec<u8>,
     opts: &IamConfigObjectOptions,
 ) -> IamStorageResult<()> {
-    rustfs_ecstore::api::config::com::save_config_with_opts(api, file, data, opts).await
+    ecstore_config::com::save_config_with_opts(api, file, data, opts).await
 }
 
 pub(crate) async fn delete_iam_config(api: Arc<IamStore>, file: &str) -> IamStorageResult<()> {
-    rustfs_ecstore::api::config::com::delete_config(api, file).await
+    ecstore_config::com::delete_config(api, file).await
 }
 
 pub(crate) fn classify_iam_system_path_failure_reason(err: &IamEcstoreError) -> &'static str {
-    rustfs_ecstore::api::error::classify_system_path_failure_reason(err)
+    ecstore_error::classify_system_path_failure_reason(err)
 }
 
 pub(crate) async fn is_iam_first_cluster_node_local() -> bool {
-    rustfs_ecstore::api::global::is_first_cluster_node_local().await
+    ecstore_global::is_first_cluster_node_local().await
 }
 
 pub(crate) struct IamNotificationPeerErr {
     pub(crate) err: Option<IamEcstoreError>,
 }
 
-impl From<rustfs_ecstore::api::notification::NotificationPeerErr> for IamNotificationPeerErr {
-    fn from(value: rustfs_ecstore::api::notification::NotificationPeerErr) -> Self {
+impl From<ecstore_notification::NotificationPeerErr> for IamNotificationPeerErr {
+    fn from(value: ecstore_notification::NotificationPeerErr) -> Self {
         Self { err: value.err }
     }
 }
 
 pub(crate) async fn notify_iam_delete_policy(policy_name: &str) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_policy(policy_name)
             .await
@@ -83,7 +88,7 @@ pub(crate) async fn notify_iam_delete_policy(policy_name: &str) -> Vec<IamNotifi
 }
 
 pub(crate) async fn notify_iam_load_policy(policy_name: &str) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_policy(policy_name)
             .await
@@ -95,7 +100,7 @@ pub(crate) async fn notify_iam_load_policy(policy_name: &str) -> Vec<IamNotifica
 }
 
 pub(crate) async fn notify_iam_delete_user(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_user(access_key)
             .await
@@ -107,7 +112,7 @@ pub(crate) async fn notify_iam_delete_user(access_key: &str) -> Vec<IamNotificat
 }
 
 pub(crate) async fn notify_iam_load_user(access_key: &str, temp: bool) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_user(access_key, temp)
             .await
@@ -119,7 +124,7 @@ pub(crate) async fn notify_iam_load_user(access_key: &str, temp: bool) -> Vec<Ia
 }
 
 pub(crate) async fn notify_iam_load_service_account(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_service_account(access_key)
             .await
@@ -131,7 +136,7 @@ pub(crate) async fn notify_iam_load_service_account(access_key: &str) -> Vec<Iam
 }
 
 pub(crate) async fn notify_iam_delete_service_account(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_service_account(access_key)
             .await
@@ -143,7 +148,7 @@ pub(crate) async fn notify_iam_delete_service_account(access_key: &str) -> Vec<I
 }
 
 pub(crate) async fn notify_iam_load_group(group: &str) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys.load_group(group).await.into_iter().map(Into::into).collect(),
         None => Vec::new(),
     }
@@ -154,7 +159,7 @@ pub(crate) async fn notify_iam_load_policy_mapping(
     user_type: u64,
     is_group: bool,
 ) -> Vec<IamNotificationPeerErr> {
-    match rustfs_ecstore::api::notification::get_global_notification_sys() {
+    match ecstore_notification::get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_policy_mapping(user_or_group, user_type, is_group)
             .await

--- a/crates/notify/src/storage_compat.rs
+++ b/crates/notify/src/storage_compat.rs
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 use rustfs_config::server_config::Config;
+use rustfs_ecstore::api::{
+    config::com as ecstore_config_com, global::resolve_object_store_handle as ecstore_resolve_object_store_handle,
+    storage as ecstore_storage,
+};
 use std::sync::Arc;
 
-type NotifyStore = rustfs_ecstore::api::storage::ECStore;
+type NotifyStore = ecstore_storage::ECStore;
 
 #[derive(Debug)]
 pub(crate) enum NotifyConfigStoreError {
@@ -44,17 +48,17 @@ where
 }
 
 fn resolve_notify_object_store_handle() -> Option<Arc<NotifyStore>> {
-    rustfs_ecstore::api::global::resolve_object_store_handle()
+    ecstore_resolve_object_store_handle()
 }
 
 async fn read_notify_server_config_without_migrate(store: Arc<NotifyStore>) -> Result<Config, NotifyConfigStoreError> {
-    rustfs_ecstore::api::config::com::read_config_without_migrate(store)
+    ecstore_config_com::read_config_without_migrate(store)
         .await
         .map_err(|err| NotifyConfigStoreError::Read(err.to_string()))
 }
 
 async fn save_notify_server_config(store: Arc<NotifyStore>, config: &Config) -> Result<(), NotifyConfigStoreError> {
-    rustfs_ecstore::api::config::com::save_server_config(store, config)
+    ecstore_config_com::save_server_config(store, config)
         .await
         .map_err(|err| NotifyConfigStoreError::Save(err.to_string()))
 }

--- a/crates/obs/src/storage_compat.rs
+++ b/crates/obs/src/storage_compat.rs
@@ -16,12 +16,16 @@ use crate::metrics::collectors::{
     BucketReplicationStats as MetricBucketReplicationStats, BucketReplicationTargetStats,
     ReplicationStats as MetricReplicationStats,
 };
+use rustfs_ecstore::api::{
+    bucket as ecstore_bucket, capacity as ecstore_capacity, data_usage as ecstore_data_usage, error as ecstore_error,
+    global as ecstore_global, storage as ecstore_storage,
+};
 use rustfs_storage_api::StorageAdminApi;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub(crate) type ObsStore = rustfs_ecstore::api::storage::ECStore;
+pub(crate) type ObsStore = ecstore_storage::ECStore;
 type ObsStorageInfo = <ObsStore as StorageAdminApi>::StorageInfo;
 
 pub(crate) struct ObsDataUsageInfo {
@@ -42,10 +46,8 @@ pub(crate) struct ObsBucketUsageInfo {
     pub(crate) delete_markers_count: u64,
 }
 
-pub(crate) async fn load_obs_data_usage_from_backend(
-    store: Arc<ObsStore>,
-) -> rustfs_ecstore::api::error::Result<ObsDataUsageInfo> {
-    let data_usage = rustfs_ecstore::api::data_usage::load_data_usage_from_backend(store).await?;
+pub(crate) async fn load_obs_data_usage_from_backend(store: Arc<ObsStore>) -> ecstore_error::Result<ObsDataUsageInfo> {
+    let data_usage = ecstore_data_usage::load_data_usage_from_backend(store).await?;
 
     Ok(ObsDataUsageInfo {
         buckets_count: data_usage.buckets_count,
@@ -94,25 +96,19 @@ pub(crate) struct ObsIlmRuntimeSnapshot {
 }
 
 pub(crate) fn resolve_obs_object_store_handle() -> Option<Arc<ObsStore>> {
-    rustfs_ecstore::api::global::resolve_object_store_handle()
+    ecstore_global::resolve_object_store_handle()
 }
 
 pub(crate) fn obs_total_usable_capacity_bytes(storage_info: &ObsStorageInfo) -> u64 {
-    usize_to_u64_saturating(rustfs_ecstore::api::capacity::get_total_usable_capacity(
-        &storage_info.disks,
-        storage_info,
-    ))
+    usize_to_u64_saturating(ecstore_capacity::get_total_usable_capacity(&storage_info.disks, storage_info))
 }
 
 pub(crate) fn obs_total_usable_capacity_free_bytes(storage_info: &ObsStorageInfo) -> u64 {
-    usize_to_u64_saturating(rustfs_ecstore::api::capacity::get_total_usable_capacity_free(
-        &storage_info.disks,
-        storage_info,
-    ))
+    usize_to_u64_saturating(ecstore_capacity::get_total_usable_capacity_free(&storage_info.disks, storage_info))
 }
 
 pub(crate) async fn obs_bucket_quota_limit_bytes(bucket: &str) -> u64 {
-    rustfs_ecstore::api::bucket::metadata_sys::get_quota_config(bucket)
+    ecstore_bucket::metadata_sys::get_quota_config(bucket)
         .await
         .ok()
         .and_then(|(quota, _)| quota.get_quota_limit())
@@ -120,11 +116,11 @@ pub(crate) async fn obs_bucket_quota_limit_bytes(bucket: &str) -> u64 {
 }
 
 pub(crate) fn obs_bucket_monitor_available() -> bool {
-    rustfs_ecstore::api::global::get_global_bucket_monitor().is_some()
+    ecstore_global::get_global_bucket_monitor().is_some()
 }
 
 pub(crate) fn obs_bucket_replication_bandwidth_stats() -> Option<Vec<ObsBucketReplicationBandwidthStats>> {
-    let monitor = rustfs_ecstore::api::global::get_global_bucket_monitor()?;
+    let monitor = ecstore_global::get_global_bucket_monitor()?;
     Some(
         monitor
             .get_report(|_| true)
@@ -142,12 +138,12 @@ pub(crate) fn obs_bucket_replication_bandwidth_stats() -> Option<Vec<ObsBucketRe
 
 pub(crate) async fn obs_ilm_runtime_snapshot() -> ObsIlmRuntimeSnapshot {
     let expiry_pending_tasks = {
-        let expiry = rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
+        let expiry = ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
             .read()
             .await;
         usize_to_u64_saturating(expiry.pending_tasks())
     };
-    let transition = &rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
+    let transition = &ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
 
     ObsIlmRuntimeSnapshot {
         expiry_pending_tasks,
@@ -162,7 +158,7 @@ pub(crate) async fn obs_ilm_runtime_snapshot() -> ObsIlmRuntimeSnapshot {
 }
 
 pub(crate) async fn obs_bucket_replication_detail_stats() -> Vec<MetricBucketReplicationStats> {
-    let Some(stats) = rustfs_ecstore::api::bucket::replication::GLOBAL_REPLICATION_STATS.get() else {
+    let Some(stats) = ecstore_bucket::replication::GLOBAL_REPLICATION_STATS.get() else {
         return Vec::new();
     };
 
@@ -234,7 +230,7 @@ pub(crate) async fn obs_bucket_replication_detail_stats() -> Vec<MetricBucketRep
 }
 
 pub(crate) async fn obs_site_replication_stats() -> MetricReplicationStats {
-    let Some(stats) = rustfs_ecstore::api::bucket::replication::GLOBAL_REPLICATION_STATS.get() else {
+    let Some(stats) = ecstore_bucket::replication::GLOBAL_REPLICATION_STATS.get() else {
         return MetricReplicationStats::default();
     };
 

--- a/crates/protocols/src/swift/storage_compat.rs
+++ b/crates/protocols/src/swift/storage_compat.rs
@@ -14,22 +14,26 @@
 
 use std::sync::Arc;
 
-pub(super) type SwiftBucketMetadata = rustfs_ecstore::api::bucket::metadata::BucketMetadata;
-pub(super) type SwiftStorageResult<T> = rustfs_ecstore::api::error::Result<T>;
-pub(super) type SwiftStore = rustfs_ecstore::api::storage::ECStore;
+use rustfs_ecstore::api::{
+    bucket as ecstore_bucket, error as ecstore_error, global as ecstore_global, storage as ecstore_storage,
+};
+
+pub(super) type SwiftBucketMetadata = ecstore_bucket::metadata::BucketMetadata;
+pub(super) type SwiftStorageResult<T> = ecstore_error::Result<T>;
+pub(super) type SwiftStore = ecstore_storage::ECStore;
 pub type SwiftGetObjectReader = <SwiftStore as rustfs_storage_api::ObjectIO>::GetObjectReader;
 pub type SwiftObjectInfo = <SwiftStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub type SwiftObjectOptions = <SwiftStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
 pub type SwiftPutObjReader = <SwiftStore as rustfs_storage_api::ObjectIO>::PutObjectReader;
 
 pub fn resolve_swift_object_store_handle() -> Option<Arc<SwiftStore>> {
-    rustfs_ecstore::api::global::resolve_object_store_handle()
+    ecstore_global::resolve_object_store_handle()
 }
 
 pub async fn get_swift_bucket_metadata(bucket: &str) -> SwiftStorageResult<Arc<SwiftBucketMetadata>> {
-    rustfs_ecstore::api::bucket::metadata_sys::get(bucket).await
+    ecstore_bucket::metadata_sys::get(bucket).await
 }
 
 pub async fn set_swift_bucket_metadata(bucket: String, metadata: SwiftBucketMetadata) -> SwiftStorageResult<()> {
-    rustfs_ecstore::api::bucket::metadata_sys::set_bucket_metadata(bucket, metadata).await
+    ecstore_bucket::metadata_sys::set_bucket_metadata(bucket, metadata).await
 }

--- a/crates/s3select-api/src/storage_compat.rs
+++ b/crates/s3select-api/src/storage_compat.rs
@@ -12,30 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) type SelectStorageError = rustfs_ecstore::api::error::StorageError;
-pub(crate) type SelectStore = rustfs_ecstore::api::storage::ECStore;
+use rustfs_ecstore::api::{
+    error as ecstore_error, global as ecstore_global, set_disk as ecstore_set_disk, storage as ecstore_storage,
+};
+
+pub(crate) type SelectStorageError = ecstore_error::StorageError;
+pub(crate) type SelectStore = ecstore_storage::ECStore;
 pub(crate) type SelectGetObjectReader = <SelectStore as rustfs_storage_api::ObjectIO>::GetObjectReader;
 pub(crate) type SelectObjectInfo = <SelectStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub(crate) type SelectObjectOptions = <SelectStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
 
-pub(crate) const SELECT_DEFAULT_READ_BUFFER_SIZE: usize = rustfs_ecstore::api::set_disk::DEFAULT_READ_BUFFER_SIZE;
+pub(crate) const SELECT_DEFAULT_READ_BUFFER_SIZE: usize = ecstore_set_disk::DEFAULT_READ_BUFFER_SIZE;
 
 pub(crate) fn select_default_read_buffer_size_u64() -> u64 {
     u64::try_from(SELECT_DEFAULT_READ_BUFFER_SIZE).unwrap_or(u64::MAX)
 }
 
 pub(crate) fn resolve_select_object_store_handle() -> Option<std::sync::Arc<SelectStore>> {
-    rustfs_ecstore::api::global::resolve_object_store_handle()
+    ecstore_global::resolve_object_store_handle()
 }
 
 pub(crate) fn select_is_err_bucket_not_found(err: &SelectStorageError) -> bool {
-    rustfs_ecstore::api::error::is_err_bucket_not_found(err)
+    ecstore_error::is_err_bucket_not_found(err)
 }
 
 pub(crate) fn select_is_err_object_not_found(err: &SelectStorageError) -> bool {
-    rustfs_ecstore::api::error::is_err_object_not_found(err)
+    ecstore_error::is_err_object_not_found(err)
 }
 
 pub(crate) fn select_is_err_version_not_found(err: &SelectStorageError) -> bool {
-    rustfs_ecstore::api::error::is_err_version_not_found(err)
+    ecstore_error::is_err_version_not_found(err)
 }

--- a/crates/scanner/src/storage_compat.rs
+++ b/crates/scanner/src/storage_compat.rs
@@ -13,35 +13,40 @@
 // limitations under the License.
 
 use http::HeaderMap;
+use rustfs_ecstore::api::{
+    bucket as ecstore_bucket, cache as ecstore_cache, capacity as ecstore_capacity, config as ecstore_config,
+    data_usage as ecstore_data_usage, disk as ecstore_disk, error as ecstore_error, global as ecstore_global,
+    set_disk as ecstore_set_disk, storage as ecstore_storage, tier as ecstore_tier,
+};
 use rustfs_storage_api::{HTTPRangeSpec, ObjectIO, ObjectToDelete};
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
-pub(crate) const BUCKET_META_PREFIX: &str = rustfs_ecstore::api::disk::BUCKET_META_PREFIX;
-pub(crate) const RUSTFS_META_BUCKET: &str = rustfs_ecstore::api::disk::RUSTFS_META_BUCKET;
-pub(crate) const STORAGE_FORMAT_FILE: &str = rustfs_ecstore::api::disk::STORAGE_FORMAT_FILE;
-pub(crate) const TRANSITION_COMPLETE: &str = rustfs_ecstore::api::bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
+pub(crate) const BUCKET_META_PREFIX: &str = ecstore_disk::BUCKET_META_PREFIX;
+pub(crate) const RUSTFS_META_BUCKET: &str = ecstore_disk::RUSTFS_META_BUCKET;
+pub(crate) const STORAGE_FORMAT_FILE: &str = ecstore_disk::STORAGE_FORMAT_FILE;
+pub(crate) const TRANSITION_COMPLETE: &str = ecstore_bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
 
-pub(crate) type Disk = rustfs_ecstore::api::disk::Disk;
+pub(crate) type Disk = ecstore_disk::Disk;
 #[cfg(test)]
-pub(crate) type DiskStore = rustfs_ecstore::api::disk::DiskStore;
-pub(crate) type DiskError = rustfs_ecstore::api::disk::error::DiskError;
-pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
-pub(crate) type EcstoreError = rustfs_ecstore::api::error::Error;
-pub(crate) type EcstoreResult<T> = rustfs_ecstore::api::error::Result<T>;
-pub(crate) type ListPathRawOptions = rustfs_ecstore::api::cache::ListPathRawOptions;
-pub(crate) type BucketTargetSys = rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys;
-pub(crate) type BucketVersioningSys = rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
-pub(crate) type DiskInfoOptions = rustfs_ecstore::api::disk::DiskInfoOptions;
-pub(crate) type Evaluator = rustfs_ecstore::api::bucket::lifecycle::evaluator::Evaluator;
-pub(crate) type Event = rustfs_ecstore::api::bucket::lifecycle::lifecycle::Event;
-pub(crate) type LcEventSrc = rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
-pub(crate) type ObjectOpts = rustfs_ecstore::api::bucket::lifecycle::lifecycle::ObjectOpts;
-pub(crate) type ReplicationConfig = rustfs_ecstore::api::bucket::replication::ReplicationConfig;
-pub(crate) type ReplicationHealQueueResult = rustfs_ecstore::api::bucket::replication::ReplicationHealQueueResult;
-pub(crate) type ReplicationQueueAdmission = rustfs_ecstore::api::bucket::replication::ReplicationQueueAdmission;
-pub(crate) type SetDisks = rustfs_ecstore::api::set_disk::SetDisks;
-pub(crate) type StorageError = rustfs_ecstore::api::error::StorageError;
+pub(crate) type DiskStore = ecstore_disk::DiskStore;
+pub(crate) type DiskError = ecstore_disk::error::DiskError;
+pub(crate) type ECStore = ecstore_storage::ECStore;
+pub(crate) type EcstoreError = ecstore_error::Error;
+pub(crate) type EcstoreResult<T> = ecstore_error::Result<T>;
+pub(crate) type ListPathRawOptions = ecstore_cache::ListPathRawOptions;
+pub(crate) type BucketTargetSys = ecstore_bucket::bucket_target_sys::BucketTargetSys;
+pub(crate) type BucketVersioningSys = ecstore_bucket::versioning_sys::BucketVersioningSys;
+pub(crate) type DiskInfoOptions = ecstore_disk::DiskInfoOptions;
+pub(crate) type Evaluator = ecstore_bucket::lifecycle::evaluator::Evaluator;
+pub(crate) type Event = ecstore_bucket::lifecycle::lifecycle::Event;
+pub(crate) type LcEventSrc = ecstore_bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
+pub(crate) type ObjectOpts = ecstore_bucket::lifecycle::lifecycle::ObjectOpts;
+pub(crate) type ReplicationConfig = ecstore_bucket::replication::ReplicationConfig;
+pub(crate) type ReplicationHealQueueResult = ecstore_bucket::replication::ReplicationHealQueueResult;
+pub(crate) type ReplicationQueueAdmission = ecstore_bucket::replication::ReplicationQueueAdmission;
+pub(crate) type SetDisks = ecstore_set_disk::SetDisks;
+pub(crate) type StorageError = ecstore_error::StorageError;
 
 pub type ScannerGetObjectReader = <ECStore as ObjectIO>::GetObjectReader;
 pub type ScannerObjectInfo = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
@@ -50,57 +55,59 @@ pub type ScannerObjectToDelete = ObjectToDelete;
 pub type ScannerPutObjReader = <ECStore as ObjectIO>::PutObjectReader;
 
 pub(crate) mod storageclass {
-    pub(crate) const RRS: &str = rustfs_ecstore::api::config::storageclass::RRS;
-    pub(crate) const STANDARD: &str = rustfs_ecstore::api::config::storageclass::STANDARD;
+    use super::ecstore_config;
+
+    pub(crate) const RRS: &str = ecstore_config::storageclass::RRS;
+    pub(crate) const STANDARD: &str = ecstore_config::storageclass::STANDARD;
 }
 
 #[cfg(test)]
 pub(crate) fn init_ecstore_config_for_scanner_tests() {
-    rustfs_ecstore::api::config::init();
+    ecstore_config::init();
 }
 
 #[cfg(test)]
-pub(crate) type DiskOption = rustfs_ecstore::api::disk::DiskOption;
+pub(crate) type DiskOption = ecstore_disk::DiskOption;
 #[cfg(test)]
-pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
+pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
 
 #[cfg(test)]
-pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> rustfs_ecstore::api::disk::error::Result<DiskStore> {
-    rustfs_ecstore::api::disk::new_disk(ep, opt).await
+pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> ecstore_disk::error::Result<DiskStore> {
+    ecstore_disk::new_disk(ep, opt).await
 }
 
 pub(crate) async fn get_lifecycle_config(
     bucket: &str,
 ) -> EcstoreResult<(s3s::dto::BucketLifecycleConfiguration, time::OffsetDateTime)> {
-    rustfs_ecstore::api::bucket::metadata_sys::get_lifecycle_config(bucket).await
+    ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
 }
 
 pub(crate) async fn get_object_lock_config(
     bucket: &str,
 ) -> EcstoreResult<(s3s::dto::ObjectLockConfiguration, time::OffsetDateTime)> {
-    rustfs_ecstore::api::bucket::metadata_sys::get_object_lock_config(bucket).await
+    ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
 }
 
 pub(crate) async fn get_replication_config(
     bucket: &str,
 ) -> EcstoreResult<(s3s::dto::ReplicationConfiguration, time::OffsetDateTime)> {
-    rustfs_ecstore::api::bucket::metadata_sys::get_replication_config(bucket).await
+    ecstore_bucket::metadata_sys::get_replication_config(bucket).await
 }
 
 pub(crate) async fn apply_transition_rule(event: &Event, src: &LcEventSrc, oi: &ScannerObjectInfo) -> bool {
-    rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::apply_transition_rule(event, src, oi).await
+    ecstore_bucket::lifecycle::bucket_lifecycle_ops::apply_transition_rule(event, src, oi).await
 }
 
 pub(crate) async fn apply_expiry_rule(event: &Event, src: &LcEventSrc, oi: &ScannerObjectInfo) -> bool {
-    rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::apply_expiry_rule(event, src, oi).await
+    ecstore_bucket::lifecycle::bucket_lifecycle_ops::apply_expiry_rule(event, src, oi).await
 }
 
-pub(crate) async fn list_global_tiers() -> Vec<rustfs_ecstore::api::tier::tier_config::TierConfig> {
-    rustfs_ecstore::api::global::GLOBAL_TierConfigMgr.read().await.list_tiers()
+pub(crate) async fn list_global_tiers() -> Vec<ecstore_tier::tier_config::TierConfig> {
+    ecstore_global::GLOBAL_TierConfigMgr.read().await.list_tiers()
 }
 
 pub(crate) async fn enqueue_global_free_version(oi: ScannerObjectInfo) {
-    rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
+    ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
         .write()
         .await
         .enqueue_free_version(oi)
@@ -113,7 +120,7 @@ pub(crate) async fn enqueue_global_newer_noncurrent(
     event: Event,
     src: &LcEventSrc,
 ) -> bool {
-    rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
+    ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
         .write()
         .await
         .enqueue_by_newer_noncurrent(bucket, to_delete_objs, event, src)
@@ -126,53 +133,53 @@ pub(crate) async fn queue_replication_heal_internal(
     rcfg: ReplicationConfig,
     retry_count: u32,
 ) -> ReplicationHealQueueResult {
-    rustfs_ecstore::api::bucket::replication::queue_replication_heal_internal(bucket, oi, rcfg, retry_count).await
+    ecstore_bucket::replication::queue_replication_heal_internal(bucket, oi, rcfg, retry_count).await
 }
 
 pub(crate) fn resolve_scanner_object_store_handle() -> Option<Arc<ECStore>> {
-    rustfs_ecstore::api::global::resolve_object_store_handle()
+    ecstore_global::resolve_object_store_handle()
 }
 
 pub(crate) fn is_reserved_or_invalid_bucket(bucket: &str, strict: bool) -> bool {
-    rustfs_ecstore::api::capacity::is_reserved_or_invalid_bucket(bucket, strict)
+    ecstore_capacity::is_reserved_or_invalid_bucket(bucket, strict)
 }
 
 pub(crate) fn path2_bucket_object(name: &str) -> (String, String) {
-    rustfs_ecstore::api::capacity::path2_bucket_object(name)
+    ecstore_capacity::path2_bucket_object(name)
 }
 
 pub(crate) fn path2_bucket_object_with_base_path(base_path: &str, path: &str) -> (String, String) {
-    rustfs_ecstore::api::capacity::path2_bucket_object_with_base_path(base_path, path)
+    ecstore_capacity::path2_bucket_object_with_base_path(base_path, path)
 }
 
 pub(crate) async fn is_erasure() -> bool {
-    rustfs_ecstore::api::global::is_erasure().await
+    ecstore_global::is_erasure().await
 }
 
 pub(crate) async fn is_erasure_sd() -> bool {
-    rustfs_ecstore::api::global::is_erasure_sd().await
+    ecstore_global::is_erasure_sd().await
 }
 
 pub(crate) async fn read_config<S>(api: Arc<S>, file: &str) -> EcstoreResult<Vec<u8>>
 where
     S: ScannerObjectIO,
 {
-    rustfs_ecstore::api::config::com::read_config(api, file).await
+    ecstore_config::com::read_config(api, file).await
 }
 
 pub(crate) async fn save_config<S>(api: Arc<S>, file: &str, data: Vec<u8>) -> EcstoreResult<()>
 where
     S: ScannerObjectIO,
 {
-    rustfs_ecstore::api::config::com::save_config(api, file, data).await
+    ecstore_config::com::save_config(api, file, data).await
 }
 
 pub(crate) async fn list_path_raw(rx: CancellationToken, opts: ListPathRawOptions) -> std::result::Result<(), DiskError> {
-    rustfs_ecstore::api::cache::list_path_raw(rx, opts).await
+    ecstore_cache::list_path_raw(rx, opts).await
 }
 
 pub(crate) async fn replace_bucket_usage_memory_from_info(data_usage_info: &rustfs_data_usage::DataUsageInfo) {
-    rustfs_ecstore::api::data_usage::replace_bucket_usage_memory_from_info(data_usage_info).await;
+    ecstore_data_usage::replace_bucket_usage_memory_from_info(data_usage_info).await;
 }
 
 pub trait ScannerObjectIO:

--- a/crates/scanner/tests/common/storage_compat.rs
+++ b/crates/scanner/tests/common/storage_compat.rs
@@ -16,31 +16,36 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+
+use rustfs_ecstore::api::{
+    bucket as ecstore_bucket, capacity as ecstore_capacity, client as ecstore_client, disk as ecstore_disk,
+    error as ecstore_error, global as ecstore_global, layout as ecstore_layout, storage as ecstore_storage, tier as ecstore_tier,
+};
 use time::OffsetDateTime;
 
-pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = rustfs_ecstore::api::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
-pub(crate) const STORAGE_FORMAT_FILE: &str = rustfs_ecstore::api::disk::STORAGE_FORMAT_FILE;
+pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+pub(crate) const STORAGE_FORMAT_FILE: &str = ecstore_disk::STORAGE_FORMAT_FILE;
 
-pub(crate) type BucketMetadata = rustfs_ecstore::api::bucket::metadata::BucketMetadata;
-pub(crate) type BucketVersioningSys = rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
-pub(crate) type DiskOption = rustfs_ecstore::api::disk::DiskOption;
-pub(crate) type ECStore = rustfs_ecstore::api::storage::ECStore;
-pub(crate) type Endpoint = rustfs_ecstore::api::disk::endpoint::Endpoint;
-pub(crate) type EndpointServerPools = rustfs_ecstore::api::layout::EndpointServerPools;
-pub(crate) type Endpoints = rustfs_ecstore::api::layout::Endpoints;
-pub(crate) type PoolEndpoints = rustfs_ecstore::api::layout::PoolEndpoints;
-pub(crate) type ReadCloser = rustfs_ecstore::api::client::transition_api::ReadCloser;
-pub(crate) type ReaderImpl = rustfs_ecstore::api::client::transition_api::ReaderImpl;
-pub(crate) type TierConfig = rustfs_ecstore::api::tier::tier_config::TierConfig;
-pub(crate) type TierConfigMgr = rustfs_ecstore::api::tier::tier::TierConfigMgr;
-pub(crate) type TierMinIO = rustfs_ecstore::api::tier::tier_config::TierMinIO;
-pub(crate) type TierType = rustfs_ecstore::api::tier::tier_config::TierType;
-pub(crate) type TransitionOptions = rustfs_ecstore::api::bucket::lifecycle::lifecycle::TransitionOptions;
-pub(crate) type WarmBackendGetOpts = rustfs_ecstore::api::tier::warm_backend::WarmBackendGetOpts;
+pub(crate) type BucketMetadata = ecstore_bucket::metadata::BucketMetadata;
+pub(crate) type BucketVersioningSys = ecstore_bucket::versioning_sys::BucketVersioningSys;
+pub(crate) type DiskOption = ecstore_disk::DiskOption;
+pub(crate) type ECStore = ecstore_storage::ECStore;
+pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
+pub(crate) type EndpointServerPools = ecstore_layout::EndpointServerPools;
+pub(crate) type Endpoints = ecstore_layout::Endpoints;
+pub(crate) type PoolEndpoints = ecstore_layout::PoolEndpoints;
+pub(crate) type ReadCloser = ecstore_client::transition_api::ReadCloser;
+pub(crate) type ReaderImpl = ecstore_client::transition_api::ReaderImpl;
+pub(crate) type TierConfig = ecstore_tier::tier_config::TierConfig;
+pub(crate) type TierConfigMgr = ecstore_tier::tier::TierConfigMgr;
+pub(crate) type TierMinIO = ecstore_tier::tier_config::TierMinIO;
+pub(crate) type TierType = ecstore_tier::tier_config::TierType;
+pub(crate) type TransitionOptions = ecstore_bucket::lifecycle::lifecycle::TransitionOptions;
+pub(crate) type WarmBackendGetOpts = ecstore_tier::warm_backend::WarmBackendGetOpts;
 
 #[allow(non_snake_case)]
 pub(crate) fn EndpointServerPools(pools: Vec<PoolEndpoints>) -> EndpointServerPools {
-    rustfs_ecstore::api::layout::EndpointServerPools::from(pools)
+    ecstore_layout::EndpointServerPools::from(pools)
 }
 
 pub(crate) struct GlobalTierConfigMgrCompat;
@@ -52,55 +57,49 @@ impl std::ops::Deref for GlobalTierConfigMgrCompat {
     type Target = Arc<tokio::sync::RwLock<TierConfigMgr>>;
 
     fn deref(&self) -> &Self::Target {
-        &rustfs_ecstore::api::global::GLOBAL_TierConfigMgr
+        &ecstore_global::GLOBAL_TierConfigMgr
     }
 }
 
 pub(crate) fn build_transition_put_options(
     storage_class: String,
     metadata: HashMap<String, String>,
-) -> rustfs_ecstore::api::client::api_put_object::PutObjectOptions {
-    rustfs_ecstore::api::tier::warm_backend::build_transition_put_options(storage_class, metadata)
+) -> ecstore_client::api_put_object::PutObjectOptions {
+    ecstore_tier::warm_backend::build_transition_put_options(storage_class, metadata)
 }
 
-pub(crate) async fn enqueue_transition_for_existing_objects(
-    api: Arc<ECStore>,
-    bucket: &str,
-) -> rustfs_ecstore::api::error::Result<()> {
-    rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects(api, bucket).await
+pub(crate) async fn enqueue_transition_for_existing_objects(api: Arc<ECStore>, bucket: &str) -> ecstore_error::Result<()> {
+    ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects(api, bucket).await
 }
 
 pub(crate) async fn init_background_expiry(api: Arc<ECStore>) {
-    rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(api).await;
+    ecstore_bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(api).await;
 }
 
-pub(crate) async fn get_bucket_metadata(bucket: &str) -> rustfs_ecstore::api::error::Result<Arc<BucketMetadata>> {
-    rustfs_ecstore::api::bucket::metadata_sys::get(bucket).await
+pub(crate) async fn get_bucket_metadata(bucket: &str) -> ecstore_error::Result<Arc<BucketMetadata>> {
+    ecstore_bucket::metadata_sys::get(bucket).await
 }
 
 pub(crate) async fn init_bucket_metadata_sys(api: Arc<ECStore>, buckets: Vec<String>) {
-    rustfs_ecstore::api::bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
+    ecstore_bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
 }
 
-pub(crate) async fn init_local_disks(endpoint_pools: EndpointServerPools) -> rustfs_ecstore::api::error::Result<()> {
-    rustfs_ecstore::api::storage::init_local_disks(endpoint_pools).await
+pub(crate) async fn init_local_disks(endpoint_pools: EndpointServerPools) -> ecstore_error::Result<()> {
+    ecstore_storage::init_local_disks(endpoint_pools).await
 }
 
-pub(crate) async fn new_disk(
-    ep: &Endpoint,
-    opt: &DiskOption,
-) -> rustfs_ecstore::api::disk::error::Result<rustfs_ecstore::api::disk::DiskStore> {
-    rustfs_ecstore::api::disk::new_disk(ep, opt).await
+pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> ecstore_disk::error::Result<ecstore_disk::DiskStore> {
+    ecstore_disk::new_disk(ep, opt).await
 }
 
 pub(crate) fn path2_bucket_object_with_base_path(base_path: &str, path: &str) -> (String, String) {
-    rustfs_ecstore::api::capacity::path2_bucket_object_with_base_path(base_path, path)
+    ecstore_capacity::path2_bucket_object_with_base_path(base_path, path)
 }
 
 pub(crate) async fn update_bucket_metadata(
     bucket: &str,
     config_file: &str,
     data: Vec<u8>,
-) -> rustfs_ecstore::api::error::Result<OffsetDateTime> {
-    rustfs_ecstore::api::bucket::metadata_sys::update(bucket, config_file, data).await
+) -> ecstore_error::Result<OffsetDateTime> {
+    ecstore_bucket::metadata_sys::update(bucket, config_file, data).await
 }

--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -190,6 +190,10 @@ paths centralized behind local `ecstore_*` module aliases rather than scattering
 The RustFS app/admin storage compatibility boundaries must likewise route raw
 ECStore facade access through their local `ecstore_*` module aliases instead of
 scattering `rustfs_ecstore::api::...` paths through compatibility wrappers.
+Peripheral consumer storage compatibility boundaries must follow the same
+pattern. IAM, heal, scanner, notify, observability, Swift, S3 Select, test, and
+fuzz storage compatibility modules keep raw ECStore facade access centralized
+behind local `ecstore_*` module aliases.
 Scanner, notify, observability, and e2e `storage_compat.rs` boundaries must
 also stay narrow. Scanner must not restore grouped bucket compatibility exports
 for target, lifecycle, metadata, replication, or versioning modules. Notify

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-outer-compat-raw-facade-prune`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092`.
-- Stacked on: `overtrue/arch-outer-compat-call-facade-prune` pending API-092 merge.
+- Branch: `overtrue/arch-outer-consumer-compat-raw-facade-prune`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093`.
+- Stacked on: `overtrue/arch-outer-compat-raw-facade-prune` pending API-093 merge.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: centralize RustFS app/admin raw ECStore facade paths behind
-  local `ecstore_*` module aliases.
-- CI/script changes: guard the RustFS app/admin storage compatibility
-  boundaries against restoring scattered raw ECStore facade paths.
-- Docs changes: record the API-093 app/admin facade path cleanup.
+- Rust code changes: centralize peripheral consumer storage compatibility raw
+  ECStore facade paths behind local `ecstore_*` module aliases.
+- CI/script changes: guard peripheral consumer storage compatibility boundaries
+  against restoring scattered raw ECStore facade paths.
+- Docs changes: record the API-094 consumer facade path cleanup.
 
 ## Phase 0 Tasks
 
@@ -331,6 +331,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     usage, notification, tier, layout, compression, admin rebalance, metrics,
     bucket target, quota, storage class, and server configuration compatibility.
   - Verification: RustFS compile coverage, app/admin raw facade path residual
+    scan, migration guard, formatting, diff hygiene, Rust risk scan,
+    pre-commit quality gate, and three-expert review.
+- [x] `API-094` Prune consumer raw facade paths.
+  - Completed slice: replace scattered raw `rustfs_ecstore::api::...` paths in
+    peripheral consumer storage compatibility boundaries with local
+    `ecstore_*` module aliases.
+  - Acceptance: IAM, heal, scanner, notify, observability, Swift, S3 Select,
+    test, and fuzz storage compatibility modules no longer contain raw
+    `rustfs_ecstore::api::...` facade paths outside centralized local alias
+    imports.
+  - Must preserve: IAM config and notifications, heal disk lookup, scanner
+    lifecycle and tier helpers, notify server config IO, observability runtime
+    metrics, Swift metadata wrappers, S3 Select error checks, and test/fuzz
+    harness wrappers.
+  - Verification: RustFS compile coverage, consumer raw facade path residual
     scan, migration guard, formatting, diff hygiene, Rust risk scan,
     pre-commit quality gate, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
@@ -3366,13 +3381,24 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | passed | API-093 centralizes RustFS app/admin ECStore facade paths behind local `ecstore_*` module aliases without adding nested compatibility modules. |
-| Migration preservation | passed | App lifecycle, metadata, object-lock, replication, data usage, notification, tier, layout, compression, admin rebalance, metrics, bucket target, quota, storage class, and server configuration compatibility keep the same ECStore contracts. |
-| Testing/verification | passed | RustFS compile coverage, app/admin raw facade path residual scan, migration and layer guards, formatting, diff hygiene, Rust risk scan, full pre-commit, and three-expert review passed. |
+| Quality/architecture | passed | API-094 centralizes peripheral consumer ECStore facade paths behind local `ecstore_*` module aliases without adding nested compatibility modules. |
+| Migration preservation | passed | IAM config and notifications, heal disk lookup, scanner lifecycle and tier helpers, notify server config IO, observability runtime metrics, Swift metadata wrappers, S3 Select error checks, and test/fuzz harness wrappers keep the same ECStore contracts. |
+| Testing/verification | passed | RustFS compile coverage, consumer raw facade path residual scan, migration and layer guards, formatting, diff hygiene, Rust risk scan, full pre-commit, and three-expert review passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-094 current slice:
+  - `cargo check -p rustfs`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Consumer raw facade path residual scan: passed.
+  - Rust risk scan on changed Rust files: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-093 current slice:
   - `cargo check -p rustfs`: passed.

--- a/fuzz/fuzz_targets/bucket_validation/storage_compat.rs
+++ b/fuzz/fuzz_targets/bucket_validation/storage_compat.rs
@@ -12,22 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) fn check_bucket_and_object_names(bucket: &str, object: &str) -> rustfs_ecstore::api::error::Result<()> {
-    rustfs_ecstore::api::bucket::utils::check_bucket_and_object_names(bucket, object)
+use rustfs_ecstore::api::{bucket as ecstore_bucket, error as ecstore_error};
+
+pub(crate) fn check_bucket_and_object_names(bucket: &str, object: &str) -> ecstore_error::Result<()> {
+    ecstore_bucket::utils::check_bucket_and_object_names(bucket, object)
 }
 
 pub(crate) fn check_list_objs_args(
     bucket: &str,
     prefix: &str,
     marker: &Option<String>,
-) -> rustfs_ecstore::api::error::Result<()> {
-    rustfs_ecstore::api::bucket::utils::check_list_objs_args(bucket, prefix, marker)
+) -> ecstore_error::Result<()> {
+    ecstore_bucket::utils::check_list_objs_args(bucket, prefix, marker)
 }
 
-pub(crate) fn check_valid_bucket_name_strict(bucket_name: &str) -> rustfs_ecstore::api::error::Result<()> {
-    rustfs_ecstore::api::bucket::utils::check_valid_bucket_name_strict(bucket_name)
+pub(crate) fn check_valid_bucket_name_strict(bucket_name: &str) -> ecstore_error::Result<()> {
+    ecstore_bucket::utils::check_valid_bucket_name_strict(bucket_name)
 }
 
 pub(crate) fn is_meta_bucketname(name: &str) -> bool {
-    rustfs_ecstore::api::bucket::utils::is_meta_bucketname(name)
+    ecstore_bucket::utils::is_meta_bucketname(name)
 }

--- a/fuzz/fuzz_targets/path_containment/storage_compat.rs
+++ b/fuzz/fuzz_targets/path_containment/storage_compat.rs
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rustfs_ecstore::api::{bucket as ecstore_bucket, error as ecstore_error};
+
 pub(crate) fn check_object_name_for_length_and_slash(
     bucket: &str,
     object: &str,
-) -> rustfs_ecstore::api::error::Result<()> {
-    rustfs_ecstore::api::bucket::utils::check_object_name_for_length_and_slash(bucket, object)
+) -> ecstore_error::Result<()> {
+    ecstore_bucket::utils::check_object_name_for_length_and_slash(bucket, object)
 }
 
 pub(crate) fn has_bad_path_component(path: &str) -> bool {
-    rustfs_ecstore::api::bucket::utils::has_bad_path_component(path)
+    ecstore_bucket::utils::has_bad_path_component(path)
 }
 
 pub(crate) fn is_valid_object_prefix(object: &str) -> bool {
-    rustfs_ecstore::api::bucket::utils::is_valid_object_prefix(object)
+    ecstore_bucket::utils::is_valid_object_prefix(object)
 }

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -90,6 +90,7 @@ RUSTFS_OUTER_COMPAT_FACADE_ALIAS_HITS_FILE="${TMP_DIR}/rustfs_outer_compat_facad
 RUSTFS_OUTER_COMPAT_SIGNATURE_ALIAS_HITS_FILE="${TMP_DIR}/rustfs_outer_compat_signature_alias_hits.txt"
 RUSTFS_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_storage_compat_raw_facade_path_hits.txt"
 RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_app_admin_compat_raw_facade_path_hits.txt"
+OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/outer_consumer_compat_raw_facade_path_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -925,6 +926,27 @@ fi
 
 if [[ -s "$RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
   report_failure "RustFS app/admin storage compatibility must use local ecstore_* module aliases instead of scattered raw ECStore facade paths: $(paste -sd '; ' "$RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'rustfs_ecstore::api::' \
+    crates/iam/src/storage_compat.rs \
+    crates/heal/src/heal/storage_compat.rs \
+    crates/obs/src/storage_compat.rs \
+    crates/notify/src/storage_compat.rs \
+    crates/protocols/src/swift/storage_compat.rs \
+    crates/s3select-api/src/storage_compat.rs \
+    crates/scanner/src/storage_compat.rs \
+    crates/heal/tests/common/storage_compat.rs \
+    crates/scanner/tests/common/storage_compat.rs \
+    fuzz/fuzz_targets/path_containment/storage_compat.rs \
+    fuzz/fuzz_targets/bucket_validation/storage_compat.rs \
+    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::\{' || true
+) >"$OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE"
+
+if [[ -s "$OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
+  report_failure "outer consumer storage compatibility must use local ecstore_* module aliases instead of scattered raw ECStore facade paths: $(paste -sd '; ' "$OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Prune remaining peripheral consumer ECStore facade paths behind local module aliases.
- Keep existing IAM, notify, heal, scanner, observability, Swift metadata, S3 Select, test, and fuzz contracts unchanged.
- Record the API-094 migration checkpoint and verification notes.

## Verification

- `cargo check -p rustfs`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Consumer raw facade path residual scan
- Rust risk scan on changed Rust files
- `make pre-commit`

## Impact

No user-facing behavior, API, deployment, or configuration impact expected. This is an architecture cleanup.

## Additional Notes

N/A
