### PR TITLE
refactor: narrow local compat re-exports

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-storage-core-compat-consumer-batch`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102`.
-- Based on: latest `main` after the API-101 merge.
+- Branch: `overtrue/arch-local-compat-explicit-exports`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103`.
+- Based on: latest `main` after the API-102 merge.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: move storage core ECStore compatibility consumers behind
-  the `core_storage_compat` boundary.
-- CI/script changes: extend owner compatibility consumer guard coverage across
-  `rustfs/src/storage`.
-- Docs changes: record the API-102 storage core compatibility consumer cleanup.
+- Rust code changes: narrow selected local compatibility boundaries from glob
+  re-exports to explicit re-exports.
+- CI/script changes: guard narrowed local compatibility boundaries against
+  restoring glob re-exports.
+- Docs changes: record the API-103 local compatibility export cleanup.
 
 ## Phase 0 Tasks
 
@@ -462,6 +462,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Verification: RustFS test-target compile coverage, storage compatibility
     consumer residual scan, migration and layer guards, formatting, diff
     hygiene, Rust risk scan, pre-commit quality gate, and three-expert review.
+- [x] `API-103` Narrow selected local compatibility re-exports.
+  - Completed slice: replace glob re-exports in admin router/service, app
+    context, storage core, and storage RPC local compatibility boundaries with
+    explicit re-export lists.
+  - Acceptance: narrowed local compatibility boundaries expose only the symbols
+    consumed by their owners; migration rules reject restoring glob re-exports
+    in those files.
+  - Must preserve: admin route behavior, dynamic config reload behavior, app
+    context startup handles, storage core option/SSE/access behavior, and
+    storage RPC request handling.
+  - Verification: RustFS test-target compile coverage, narrowed local
+    compatibility glob-export scan, migration and layer guards, formatting,
+    diff hygiene, Rust risk scan, pre-commit quality gate, and three-expert
+    review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
     [`placement-repair-invariants.md`](placement-repair-invariants.md) records
@@ -3495,13 +3509,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-097 localizes disk/RPC/warm-backend method access behind owner-local compatibility traits and aliases without widening non-compat imports. |
-| Migration preservation | pass | RPC, heal, scanner, and transition-test call sites keep existing behavior while losing direct ECStore trait imports. |
-| Testing/verification | pass | Focused compile, residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-103 narrows selected local compatibility re-export surfaces without changing owner call sites or ECStore contracts. |
+| Migration preservation | pass | The new guard rejects restoring glob re-exports in narrowed local compatibility boundaries. |
+| Testing/verification | pass | Focused compile, narrowed glob-export scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-103 current slice:
+  - `cargo check -p rustfs --tests`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Narrowed local compatibility glob-export scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-102 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/rustfs/src/admin/router_storage_compat.rs
+++ b/rustfs/src/admin/router_storage_compat.rs
@@ -12,4 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::admin::storage_compat::*;
+pub(crate) use crate::admin::storage_compat::{
+    AdminReplicationConfigExt, AdminVersioningConfigExt, GLOBAL_BOOT_TIME, PeerRestClient, StorageError,
+    get_global_bucket_monitor, get_global_deployment_id, get_global_notification_sys, get_global_region,
+    read_admin_config_without_migrate,
+};
+
+pub(crate) mod bandwidth {
+    pub(crate) mod monitor {
+        pub(crate) use crate::admin::storage_compat::bandwidth::monitor::BandwidthDetails;
+    }
+}
+
+pub(crate) mod bucket_target_sys {
+    pub(crate) use crate::admin::storage_compat::bucket_target_sys::{
+        AdvancedPutOptions, BucketTargetSys, PutObjectOptions, RemoveObjectOptions, S3ClientError, TargetClient,
+    };
+}
+
+pub(crate) mod metadata {
+    pub(crate) use crate::admin::storage_compat::metadata::BUCKET_TARGETS_FILE;
+}
+
+pub(crate) use crate::admin::storage_compat::metadata_sys;
+
+pub(crate) mod replication {
+    pub(crate) use crate::admin::storage_compat::replication::{
+        BucketReplicationResyncStatus, BucketStats, GLOBAL_REPLICATION_STATS, ObjectOpts, ResyncOpts, get_global_replication_pool,
+    };
+
+    #[cfg(test)]
+    pub(crate) use crate::admin::storage_compat::replication::{ResyncStatusType, TargetReplicationResyncStatus};
+}
+
+pub(crate) mod target {
+    pub(crate) use crate::admin::storage_compat::target::{BucketTarget, BucketTargetType, BucketTargets};
+}
+
+pub(crate) mod versioning_sys {
+    pub(crate) use crate::admin::storage_compat::versioning_sys::BucketVersioningSys;
+}

--- a/rustfs/src/admin/service/storage_compat.rs
+++ b/rustfs/src/admin/service/storage_compat.rs
@@ -12,4 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::admin::storage_compat::*;
+pub(crate) use crate::admin::storage_compat::{
+    Error, STORAGE_CLASS_SUB_SYS, get_global_notification_sys, read_admin_config, read_admin_config_without_migrate,
+    save_admin_config, set_global_storage_class,
+};
+
+#[cfg(test)]
+pub(crate) use crate::admin::storage_compat::init_admin_config_defaults;
+
+#[cfg(test)]
+pub(crate) mod metadata {
+    pub(crate) use crate::admin::storage_compat::metadata::{BUCKET_LIFECYCLE_CONFIG, BUCKET_REPLICATION_CONFIG};
+}
+
+pub(crate) mod storageclass {
+    pub(crate) use crate::admin::storage_compat::storageclass::lookup_config;
+}

--- a/rustfs/src/app/context/storage_compat.rs
+++ b/rustfs/src/app/context/storage_compat.rs
@@ -12,4 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::app::storage_compat::*;
+pub(crate) use crate::app::storage_compat::{
+    ECStore, EndpointServerPools, TierConfigMgr, get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr,
+    new_object_layer_fn, set_object_store_resolver,
+};
+
+pub(crate) mod metadata_sys {
+    pub(crate) use crate::app::storage_compat::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys};
+}
+
+#[cfg(test)]
+pub(crate) use crate::app::storage_compat::{Endpoint, Endpoints, PoolEndpoints, init_local_disks};

--- a/rustfs/src/storage/core_storage_compat.rs
+++ b/rustfs/src/storage/core_storage_compat.rs
@@ -12,4 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::storage::storage_compat::*;
+pub(crate) use crate::storage::storage_compat::{
+    BUCKET_ACCELERATE_CONFIG, BUCKET_LOGGING_CONFIG, BUCKET_REQUEST_PAYMENT_CONFIG, BUCKET_VERSIONING_CONFIG,
+    BUCKET_WEBSITE_CONFIG, BucketVersioningSys, ECStore, Error, GetObjectReader, OBJECT_LOCK_CONFIG, ObjectInfo, ObjectOptions,
+    PolicySys, PutObjReader, Result, StorageError, StorageReplicationConfigExt, StorageVersioningConfigExt, WriteEncryption,
+    add_object_lock_years, check_retention_for_modification, decode_tags, decode_tags_to_map, delete_bucket_metadata_config,
+    encode_tags, get_bucket_accelerate_config, get_bucket_cors_config, get_bucket_logging_config, get_bucket_metadata,
+    get_bucket_object_lock_config, get_bucket_policy_raw, get_bucket_replication_config, get_bucket_request_payment_config,
+    get_bucket_sse_config, get_bucket_website_config, get_global_region, get_public_access_block_config, is_err_bucket_not_found,
+    is_err_object_not_found, is_err_version_not_found, record_replication_proxy, resolve_object_store_handle, serialize,
+    update_bucket_metadata_config,
+};
+
+#[cfg(test)]
+pub(crate) use crate::storage::storage_compat::{
+    BucketMetadata, DEFAULT_READ_BUFFER_SIZE, bucket_metadata_sys_initialized, get_global_bucket_metadata_sys,
+    set_bucket_metadata,
+};

--- a/rustfs/src/storage/rpc/storage_compat.rs
+++ b/rustfs/src/storage/rpc/storage_compat.rs
@@ -12,4 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::storage::storage_compat::*;
+pub(crate) use crate::storage::storage_compat::{
+    CollectMetricsOpts, DEFAULT_READ_BUFFER_SIZE, DeleteOptions, DiskError, DiskInfoOptions, DiskStore, FileInfoVersions,
+    LocalPeerS3Client, MetricType, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, ReadMultipleReq, ReadMultipleResp, ReadOptions, Result,
+    SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC, StorageDiskRpcExt, StoragePeerS3ClientExt, UpdateMetadataOpts,
+    WalkDirOptions, all_local_disk_path, collect_local_metrics, find_local_disk_by_ref, get_global_lock_client,
+    get_local_server_property, load_bucket_metadata, reload_transition_tier_config, resolve_object_store_handle,
+    set_bucket_metadata, verify_rpc_signature,
+};
+
+#[cfg(test)]
+pub(crate) use crate::storage::storage_compat::{Error, STORAGE_CLASS_SUB_SYS};

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -83,6 +83,7 @@ RUSTFS_ROOT_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/rustfs_root_bucke
 RUSTFS_ROOT_RUNTIME_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/rustfs_root_runtime_storage_compat_module_hits.txt"
 RUSTFS_ROOT_CONSUMER_COMPAT_HITS_FILE="${TMP_DIR}/rustfs_root_consumer_compat_hits.txt"
 RUSTFS_OWNER_COMPAT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_owner_compat_consumer_hits.txt"
+RUSTFS_LOCAL_COMPAT_GLOB_EXPORT_HITS_FILE="${TMP_DIR}/rustfs_local_compat_glob_export_hits.txt"
 RUSTFS_ADMIN_CONFIG_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/rustfs_admin_config_storage_compat_module_hits.txt"
 RUSTFS_STORAGE_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/rustfs_storage_bucket_storage_compat_module_hits.txt"
 RUSTFS_STORAGE_OWNER_COMPAT_REEXPORT_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_compat_reexport_hits.txt"
@@ -845,6 +846,20 @@ fi
 
 if [[ -s "$RUSTFS_OWNER_COMPAT_CONSUMER_HITS_FILE" ]]; then
   report_failure "RustFS owner compatibility consumers must route through their local compatibility boundary: $(paste -sd '; ' "$RUSTFS_OWNER_COMPAT_CONSUMER_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --no-heading 'pub\(crate\)\s+use\s+crate::(?:admin|app|storage)::storage_compat::\*;' \
+    rustfs/src/admin/router_storage_compat.rs \
+    rustfs/src/admin/service/storage_compat.rs \
+    rustfs/src/app/context/storage_compat.rs \
+    rustfs/src/storage/core_storage_compat.rs \
+    rustfs/src/storage/rpc/storage_compat.rs || true
+) >"$RUSTFS_LOCAL_COMPAT_GLOB_EXPORT_HITS_FILE"
+
+if [[ -s "$RUSTFS_LOCAL_COMPAT_GLOB_EXPORT_HITS_FILE" ]]; then
+  report_failure "Narrowed local compatibility boundaries must use explicit re-exports: $(paste -sd '; ' "$RUSTFS_LOCAL_COMPAT_GLOB_EXPORT_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Replace glob re-exports in selected local compatibility boundaries with explicit re-export lists.
- Cover admin router/service, app context, storage core, and storage RPC compatibility modules.
- Add a migration guard that rejects restoring glob re-exports in those narrowed local boundaries.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check -p rustfs --tests`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Narrowed local compatibility glob-export scan
- Rust risk scan on changed Rust files and guard script
- `make pre-commit`

## Impact
No runtime behavior, user-facing API, deployment, or configuration changes expected. This is a compatibility-boundary cleanup.

## Additional Notes
Based on #3710.
