### PR TITLE
refactor: narrow remaining local compat exports

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-local-compat-explicit-exports`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103`.
-- Based on: latest `main` after the API-102 merge.
+- Branch: `overtrue/arch-remaining-local-compat-exports`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104`.
+- Based on: `overtrue/arch-local-compat-explicit-exports` after the API-103 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: narrow selected local compatibility boundaries from glob
+- Rust code changes: narrow remaining local compatibility boundaries from glob
   re-exports to explicit re-exports.
-- CI/script changes: guard narrowed local compatibility boundaries against
+- CI/script changes: guard all narrowed local compatibility boundaries against
   restoring glob re-exports.
-- Docs changes: record the API-103 local compatibility export cleanup.
+- Docs changes: record the API-104 remaining local compatibility export cleanup.
 
 ## Phase 0 Tasks
 
@@ -472,6 +472,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Must preserve: admin route behavior, dynamic config reload behavior, app
     context startup handles, storage core option/SSE/access behavior, and
     storage RPC request handling.
+  - Verification: RustFS test-target compile coverage, narrowed local
+    compatibility glob-export scan, migration and layer guards, formatting,
+    diff hygiene, Rust risk scan, pre-commit quality gate, and three-expert
+    review.
+- [x] `API-104` Narrow remaining local compatibility re-exports.
+  - Completed slice: replace the remaining admin handler and app usecase local
+    compatibility glob re-exports with explicit re-export lists.
+  - Acceptance: no narrowed RustFS local compatibility boundary restores a glob
+    re-export from its owner `storage_compat.rs` facade; migration rules reject
+    regressions across all narrowed files.
+  - Must preserve: admin handler config, bucket metadata, site replication,
+    tier, rebalance, metrics, heal, quota, and object-zip behavior; app bucket,
+    object, multipart, admin, lifecycle transition, quota, object-lock, and
+    replication usecase behavior.
   - Verification: RustFS test-target compile coverage, narrowed local
     compatibility glob-export scan, migration and layer guards, formatting,
     diff hygiene, Rust risk scan, pre-commit quality gate, and three-expert
@@ -3509,13 +3523,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-103 narrows selected local compatibility re-export surfaces without changing owner call sites or ECStore contracts. |
-| Migration preservation | pass | The new guard rejects restoring glob re-exports in narrowed local compatibility boundaries. |
+| Quality/architecture | pass | API-104 narrows the remaining local compatibility re-export surfaces without changing owner call sites or ECStore contracts. |
+| Migration preservation | pass | The guard now rejects restoring glob re-exports across all narrowed local compatibility boundaries. |
 | Testing/verification | pass | Focused compile, narrowed glob-export scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-104 current slice:
+  - `cargo check -p rustfs --tests`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Narrowed local compatibility glob-export scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-103 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/rustfs/src/admin/handlers/storage_compat.rs
+++ b/rustfs/src/admin/handlers/storage_compat.rs
@@ -12,4 +12,79 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::admin::storage_compat::*;
+pub(crate) use crate::admin::storage_compat::{
+    AdminError, AdminReplicationConfigExt, AdminVersioningConfigExt, CollectMetricsOpts, DailyAllTierStats, DiskStat, ECStore,
+    ERR_TIER_ALREADY_EXISTS, ERR_TIER_BACKEND_IN_USE, ERR_TIER_BACKEND_NOT_EMPTY, ERR_TIER_CONNECT_ERR,
+    ERR_TIER_INVALID_CREDENTIALS, ERR_TIER_MISSING_CREDENTIALS, ERR_TIER_NAME_NOT_UPPERCASE, ERR_TIER_NOT_FOUND,
+    EndpointServerPools, Error, MetricType, PeerRestClient, RUSTFS_META_BUCKET, RebalSaveOpt, RebalanceCleanupWarnings,
+    RebalanceMeta, RebalanceStats, STORAGE_CLASS_SUB_SYS, StorageError, TierConfig, TierCreds, TierType, collect_local_metrics,
+    delete_admin_config, get_global_deployment_id, get_global_endpoints_opt, get_global_notification_sys, get_global_region,
+    global_rustfs_port, init_admin_config_defaults, is_reserved_or_invalid_bucket, load_data_usage_from_backend,
+    read_admin_config, read_admin_config_without_migrate, save_admin_config, save_admin_server_config,
+};
+
+#[cfg(test)]
+pub(crate) use crate::admin::storage_compat::{Endpoint, Endpoints, PoolEndpoints, RebalStatus, RebalanceInfo};
+
+pub(crate) mod bucket_target_sys {
+    pub(crate) use crate::admin::storage_compat::bucket_target_sys::{BucketTargetError, BucketTargetSys};
+}
+
+pub(crate) mod lifecycle {
+    pub(crate) mod bucket_lifecycle_ops {
+        pub(crate) use crate::admin::storage_compat::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
+    }
+
+    pub(crate) mod tier_last_day_stats {
+        #[cfg(test)]
+        pub(crate) use crate::admin::storage_compat::lifecycle::tier_last_day_stats::LastDayTierStats;
+    }
+}
+
+pub(crate) mod metadata {
+    pub(crate) use crate::admin::storage_compat::metadata::{
+        BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE,
+        BUCKET_REPLICATION_CONFIG, BUCKET_SSECONFIG, BUCKET_TAGGING_CONFIG, BUCKET_TARGETS_FILE, BUCKET_VERSIONING_CONFIG,
+        BucketMetadata, OBJECT_LOCK_CONFIG, table_catalog_path_hash,
+    };
+}
+
+pub(crate) mod metadata_sys {
+    pub(crate) use crate::admin::storage_compat::metadata_sys::{
+        BucketMetadataSys, delete, get, get_bucket_policy, get_bucket_targets_config, get_config_from_disk, get_lifecycle_config,
+        get_notification_config, get_object_lock_config, get_quota_config, get_replication_config, get_sse_config,
+        get_tagging_config, get_versioning_config, list_bucket_targets, update,
+    };
+}
+
+pub(crate) mod quota {
+    pub(crate) use crate::admin::storage_compat::quota::{BucketQuota, QuotaError, QuotaOperation};
+
+    pub(crate) mod checker {
+        pub(crate) use crate::admin::storage_compat::quota::checker::QuotaChecker;
+    }
+}
+
+pub(crate) mod replication {
+    pub(crate) use crate::admin::storage_compat::replication::{
+        BucketStats, GLOBAL_REPLICATION_STATS, ResyncOpts, get_global_replication_pool,
+    };
+}
+
+pub(crate) mod storageclass {
+    pub(crate) use crate::admin::storage_compat::storageclass::{
+        INLINE_BLOCK_ENV, OPTIMIZE_ENV, RRS, RRS_ENV, STANDARD, STANDARD_ENV,
+    };
+}
+
+pub(crate) mod target {
+    pub(crate) use crate::admin::storage_compat::target::{ARN, BucketTarget, BucketTargetType, BucketTargets, Credentials};
+}
+
+pub(crate) mod utils {
+    pub(crate) use crate::admin::storage_compat::utils::{deserialize, is_valid_object_prefix, serialize};
+}
+
+pub(crate) mod versioning_sys {
+    pub(crate) use crate::admin::storage_compat::versioning_sys::BucketVersioningSys;
+}

--- a/rustfs/src/app/usecase_storage_compat.rs
+++ b/rustfs/src/app/usecase_storage_compat.rs
@@ -12,4 +12,148 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::app::storage_compat::*;
+pub(crate) use crate::app::storage_compat::{
+    AppObjectLockConfigExt, AppReplicationConfigExt, AppVersioningConfigExt, DiskError, DynReader, ECStore, EndpointServerPools,
+    Error, HashReader, MIN_DISK_COMPRESSIBLE_SIZE, PoolDecommissionInfo, PoolStatus, StorageError, WriteEncryption, WritePlan,
+    apply_bucket_usage_memory_overlay, compression_metadata_value, get_global_notification_sys, get_lock_acquire_timeout,
+    get_server_info, get_total_usable_capacity, get_total_usable_capacity_free, is_all_buckets_not_found, is_disk_compressible,
+    is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found, is_valid_storage_class,
+    load_data_usage_from_backend, predict_lifecycle_expiration, record_bucket_object_delete_memory,
+    record_bucket_object_write_memory, validate_restore_request, wrap_reader,
+};
+
+#[cfg(test)]
+pub(crate) use crate::app::storage_compat::{
+    AppWarmBackend, DecryptReader, EncryptReader, Endpoint, Endpoints, GLOBAL_TierConfigMgr, HardLimitReader, PoolEndpoints,
+    TierConfig, TierType, WarmBackendGetOpts, boxed_reader, init_local_disks,
+};
+
+pub(crate) mod bucket_target_sys {
+    pub(crate) use crate::app::storage_compat::bucket_target_sys::BucketTargetSys;
+}
+
+pub(crate) mod lifecycle {
+    pub(crate) mod bucket_lifecycle_audit {
+        pub(crate) use crate::app::storage_compat::lifecycle::bucket_lifecycle_audit::LcEventSrc;
+    }
+
+    pub(crate) mod bucket_lifecycle_ops {
+        pub(crate) use crate::app::storage_compat::lifecycle::bucket_lifecycle_ops::{
+            GLOBAL_ExpiryState, enqueue_expiry_for_existing_objects, enqueue_transition_for_existing_objects,
+            enqueue_transition_immediate, post_restore_opts, validate_lifecycle_config, validate_transition_tier,
+        };
+
+        #[cfg(test)]
+        pub(crate) use crate::app::storage_compat::lifecycle::bucket_lifecycle_ops::init_background_expiry;
+    }
+
+    pub(crate) mod lifecycle_contract {
+        pub(crate) use crate::app::storage_compat::lifecycle::lifecycle::{
+            Event, ObjectOpts, TRANSITION_COMPLETE, TransitionOptions, expected_expiry_time,
+        };
+
+        #[cfg(test)]
+        pub(crate) use crate::app::storage_compat::lifecycle::lifecycle::IlmAction;
+    }
+    pub(crate) use lifecycle_contract as lifecycle;
+
+    pub(crate) mod tier_delete_journal {
+        pub(crate) use crate::app::storage_compat::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry;
+    }
+
+    pub(crate) mod tier_sweeper {
+        pub(crate) use crate::app::storage_compat::lifecycle::tier_sweeper::{
+            transitioned_delete_journal_entry, transitioned_force_delete_journal_entry,
+        };
+    }
+}
+
+pub(crate) mod metadata {
+    pub(crate) use crate::app::storage_compat::metadata::{
+        BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG,
+        BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG, BUCKET_REPLICATION_CONFIG, BUCKET_SSECONFIG, BUCKET_TAGGING_CONFIG,
+        BUCKET_TARGETS_FILE, BUCKET_VERSIONING_CONFIG,
+    };
+
+    #[cfg(test)]
+    pub(crate) use crate::app::storage_compat::metadata::OBJECT_LOCK_CONFIG;
+}
+
+pub(crate) mod metadata_sys {
+    pub(crate) use crate::app::storage_compat::metadata_sys::{
+        BucketMetadataSys, delete, get_bucket_policy, get_bucket_policy_raw, get_bucket_targets_config, get_cors_config,
+        get_lifecycle_config, get_notification_config, get_object_lock_config, get_public_access_block_config,
+        get_replication_config, get_sse_config, get_tagging_config, update,
+    };
+
+    #[cfg(test)]
+    pub(crate) use crate::app::storage_compat::metadata_sys::init_bucket_metadata_sys;
+}
+
+pub(crate) mod object_api_utils {
+    pub(crate) use crate::app::storage_compat::object_api_utils::to_s3s_etag;
+}
+
+pub(crate) mod object_lock {
+    pub(crate) mod objectlock {
+        pub(crate) use crate::app::storage_compat::object_lock::objectlock::{
+            get_object_legalhold_meta, get_object_retention_meta,
+        };
+    }
+
+    pub(crate) mod objectlock_sys {
+        pub(crate) use crate::app::storage_compat::object_lock::objectlock_sys::{
+            BucketObjectLockSys, check_object_lock_for_deletion, is_retention_active,
+        };
+    }
+}
+
+pub(crate) mod policy_sys {
+    pub(crate) use crate::app::storage_compat::policy_sys::PolicySys;
+}
+
+pub(crate) mod quota {
+    pub(crate) use crate::app::storage_compat::quota::QuotaOperation;
+
+    pub(crate) mod checker {
+        pub(crate) use crate::app::storage_compat::quota::checker::QuotaChecker;
+    }
+}
+
+pub(crate) mod replication {
+    pub(crate) use crate::app::storage_compat::replication::{
+        DeletedObjectReplicationInfo, ObjectOpts, check_replicate_delete, get_must_replicate_options, must_replicate,
+        schedule_replication, schedule_replication_delete,
+    };
+}
+
+pub(crate) mod storageclass {
+    pub(crate) use crate::app::storage_compat::storageclass::STANDARD;
+
+    #[cfg(test)]
+    pub(crate) use crate::app::storage_compat::storageclass::STANDARD_IA;
+}
+
+pub(crate) mod tagging {
+    pub(crate) use crate::app::storage_compat::tagging::decode_tags;
+}
+
+pub(crate) mod target {
+    pub(crate) use crate::app::storage_compat::target::{BucketTargetType, BucketTargets};
+
+    #[cfg(test)]
+    pub(crate) use crate::app::storage_compat::target::BucketTarget;
+}
+
+#[cfg(test)]
+pub(crate) mod transition_api {
+    pub(crate) use crate::app::storage_compat::transition_api::{ReadCloser, ReaderImpl};
+}
+
+pub(crate) mod utils {
+    pub(crate) use crate::app::storage_compat::utils::serialize;
+}
+
+pub(crate) mod versioning_sys {
+    pub(crate) use crate::app::storage_compat::versioning_sys::BucketVersioningSys;
+}

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -852,8 +852,10 @@ fi
   cd "$ROOT_DIR"
   rg -n --no-heading 'pub\(crate\)\s+use\s+crate::(?:admin|app|storage)::storage_compat::\*;' \
     rustfs/src/admin/router_storage_compat.rs \
+    rustfs/src/admin/handlers/storage_compat.rs \
     rustfs/src/admin/service/storage_compat.rs \
     rustfs/src/app/context/storage_compat.rs \
+    rustfs/src/app/usecase_storage_compat.rs \
     rustfs/src/storage/core_storage_compat.rs \
     rustfs/src/storage/rpc/storage_compat.rs || true
 ) >"$RUSTFS_LOCAL_COMPAT_GLOB_EXPORT_HITS_FILE"


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Replace the remaining admin handler and app usecase local compatibility glob re-exports with explicit re-export lists.
- Extend the migration guard so all narrowed local compatibility boundaries reject owner facade glob re-exports.
- Record API-104 progress and verification.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check -p rustfs --tests`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Narrowed local compatibility glob-export scan
- Rust risk scan on changed Rust files and guard script
- `make pre-commit`

## Impact
No runtime behavior, user-facing API, deployment, or configuration changes expected. This is a compatibility-boundary cleanup.

## Additional Notes
Stacked on #3711.
