### PR TITLE
refactor: split compat facade imports

### DIFF
--- a/crates/e2e_test/src/storage_compat.rs
+++ b/crates/e2e_test/src/storage_compat.rs
@@ -14,7 +14,9 @@
 
 #![allow(dead_code, unused_imports)]
 
-use rustfs_ecstore::api::{bucket as ecstore_bucket, disk as ecstore_disk, rpc as ecstore_rpc};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::rpc as ecstore_rpc;
 
 pub(crate) type BucketTargetSys = ecstore_bucket::bucket_target_sys::BucketTargetSys;
 pub(crate) type TonicInterceptor = ecstore_rpc::TonicInterceptor;

--- a/crates/heal/src/heal/storage_compat.rs
+++ b/crates/heal/src/heal/storage_compat.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_ecstore::api::{
-    data_usage as ecstore_data_usage, disk as ecstore_disk, error as ecstore_error, global as ecstore_global,
-    storage as ecstore_storage,
-};
+use rustfs_ecstore::api::data_usage as ecstore_data_usage;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) const DATA_USAGE_CACHE_NAME: &str = ecstore_data_usage::DATA_USAGE_CACHE_NAME;
 pub(crate) const BUCKET_META_PREFIX: &str = ecstore_disk::BUCKET_META_PREFIX;

--- a/crates/heal/tests/common/storage_compat.rs
+++ b/crates/heal/tests/common/storage_compat.rs
@@ -16,9 +16,11 @@
 
 use std::sync::Arc;
 
-use rustfs_ecstore::api::{
-    bucket as ecstore_bucket, disk as ecstore_disk, error as ecstore_error, layout as ecstore_layout, storage as ecstore_storage,
-};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::layout as ecstore_layout;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) type DiskStore = ecstore_disk::DiskStore;
 pub(crate) type ECStore = ecstore_storage::ECStore;

--- a/crates/iam/src/storage_compat.rs
+++ b/crates/iam/src/storage_compat.rs
@@ -14,10 +14,11 @@
 
 use std::sync::Arc;
 
-use rustfs_ecstore::api::{
-    config as ecstore_config, error as ecstore_error, global as ecstore_global, notification as ecstore_notification,
-    storage as ecstore_storage,
-};
+use rustfs_ecstore::api::config as ecstore_config;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::notification as ecstore_notification;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) const IAM_CONFIG_ROOT_PREFIX: &str = ecstore_config::RUSTFS_CONFIG_PREFIX;
 

--- a/crates/notify/src/storage_compat.rs
+++ b/crates/notify/src/storage_compat.rs
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 use rustfs_config::server_config::Config;
-use rustfs_ecstore::api::{
-    config::com as ecstore_config_com, global::resolve_object_store_handle as ecstore_resolve_object_store_handle,
-    storage as ecstore_storage,
-};
+use rustfs_ecstore::api::config as ecstore_config;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::storage as ecstore_storage;
 use std::sync::Arc;
 
 type NotifyStore = ecstore_storage::ECStore;
@@ -48,17 +47,17 @@ where
 }
 
 fn resolve_notify_object_store_handle() -> Option<Arc<NotifyStore>> {
-    ecstore_resolve_object_store_handle()
+    ecstore_global::resolve_object_store_handle()
 }
 
 async fn read_notify_server_config_without_migrate(store: Arc<NotifyStore>) -> Result<Config, NotifyConfigStoreError> {
-    ecstore_config_com::read_config_without_migrate(store)
+    ecstore_config::com::read_config_without_migrate(store)
         .await
         .map_err(|err| NotifyConfigStoreError::Read(err.to_string()))
 }
 
 async fn save_notify_server_config(store: Arc<NotifyStore>, config: &Config) -> Result<(), NotifyConfigStoreError> {
-    ecstore_config_com::save_server_config(store, config)
+    ecstore_config::com::save_server_config(store, config)
         .await
         .map_err(|err| NotifyConfigStoreError::Save(err.to_string()))
 }

--- a/crates/obs/src/storage_compat.rs
+++ b/crates/obs/src/storage_compat.rs
@@ -16,10 +16,12 @@ use crate::metrics::collectors::{
     BucketReplicationStats as MetricBucketReplicationStats, BucketReplicationTargetStats,
     ReplicationStats as MetricReplicationStats,
 };
-use rustfs_ecstore::api::{
-    bucket as ecstore_bucket, capacity as ecstore_capacity, data_usage as ecstore_data_usage, error as ecstore_error,
-    global as ecstore_global, storage as ecstore_storage,
-};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::capacity as ecstore_capacity;
+use rustfs_ecstore::api::data_usage as ecstore_data_usage;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::storage as ecstore_storage;
 use rustfs_storage_api::StorageAdminApi;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/protocols/src/swift/storage_compat.rs
+++ b/crates/protocols/src/swift/storage_compat.rs
@@ -14,9 +14,10 @@
 
 use std::sync::Arc;
 
-use rustfs_ecstore::api::{
-    bucket as ecstore_bucket, error as ecstore_error, global as ecstore_global, storage as ecstore_storage,
-};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(super) type SwiftBucketMetadata = ecstore_bucket::metadata::BucketMetadata;
 pub(super) type SwiftStorageResult<T> = ecstore_error::Result<T>;

--- a/crates/s3select-api/src/storage_compat.rs
+++ b/crates/s3select-api/src/storage_compat.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_ecstore::api::{
-    error as ecstore_error, global as ecstore_global, set_disk as ecstore_set_disk, storage as ecstore_storage,
-};
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::set_disk as ecstore_set_disk;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) type SelectStorageError = ecstore_error::StorageError;
 pub(crate) type SelectStore = ecstore_storage::ECStore;

--- a/crates/scanner/src/storage_compat.rs
+++ b/crates/scanner/src/storage_compat.rs
@@ -13,11 +13,17 @@
 // limitations under the License.
 
 use http::HeaderMap;
-use rustfs_ecstore::api::{
-    bucket as ecstore_bucket, cache as ecstore_cache, capacity as ecstore_capacity, config as ecstore_config,
-    data_usage as ecstore_data_usage, disk as ecstore_disk, error as ecstore_error, global as ecstore_global,
-    set_disk as ecstore_set_disk, storage as ecstore_storage, tier as ecstore_tier,
-};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::cache as ecstore_cache;
+use rustfs_ecstore::api::capacity as ecstore_capacity;
+use rustfs_ecstore::api::config as ecstore_config;
+use rustfs_ecstore::api::data_usage as ecstore_data_usage;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::set_disk as ecstore_set_disk;
+use rustfs_ecstore::api::storage as ecstore_storage;
+use rustfs_ecstore::api::tier as ecstore_tier;
 use rustfs_storage_api::{HTTPRangeSpec, ObjectIO, ObjectToDelete};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/scanner/tests/common/storage_compat.rs
+++ b/crates/scanner/tests/common/storage_compat.rs
@@ -17,10 +17,15 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use rustfs_ecstore::api::{
-    bucket as ecstore_bucket, capacity as ecstore_capacity, client as ecstore_client, disk as ecstore_disk,
-    error as ecstore_error, global as ecstore_global, layout as ecstore_layout, storage as ecstore_storage, tier as ecstore_tier,
-};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::capacity as ecstore_capacity;
+use rustfs_ecstore::api::client as ecstore_client;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::layout as ecstore_layout;
+use rustfs_ecstore::api::storage as ecstore_storage;
+use rustfs_ecstore::api::tier as ecstore_tier;
 use time::OffsetDateTime;
 
 pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-root-compat-local-facade-aliases`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105`.
-- Based on: `overtrue/arch-remaining-local-compat-exports` after the API-104 slice.
+- Branch: `overtrue/arch-compat-facade-import-aliases`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106`.
+- Based on: `main` after the API-105 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: route the S3 API storage compatibility ETag helper through
-  a local ECStore client module alias.
-- CI/script changes: guard all storage compatibility boundaries against
-  scattered raw ECStore facade paths outside local `ecstore_*` module aliases.
-- Docs changes: record the API-105 root compatibility facade alias cleanup.
+- Rust code changes: split grouped ECStore facade imports in storage
+  compatibility boundaries into explicit per-module `ecstore_*` aliases.
+- CI/script changes: guard all storage compatibility boundaries against grouped
+  ECStore facade imports and scattered raw facade paths.
+- Docs changes: record the API-106 compatibility facade import alias cleanup.
 
 ## Phase 0 Tasks
 
@@ -503,6 +503,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     compatibility raw-facade residual scan, migration and layer guards,
     formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
     three-expert review.
+- [x] `API-106` Split compatibility facade imports.
+  - Completed slice: replace grouped `rustfs_ecstore::api::{...}` imports
+    across storage compatibility boundaries with explicit per-module
+    `ecstore_*` aliases and extend migration guards to reject grouped facade
+    imports.
+  - Acceptance: storage compatibility boundaries keep every ECStore facade
+    module dependency visible as its own local alias, and wrapper bodies or
+    signatures still cannot reintroduce scattered raw
+    `rustfs_ecstore::api::...` paths.
+  - Must preserve: all compatibility wrapper bodies, public alias names,
+    storage/admin/app/runtime/edge/test/fuzz behavior, and API surface.
+  - Verification: RustFS test-target compile coverage, grouped-import and
+    raw-facade residual scans, migration and layer guards, formatting, diff
+    hygiene, Rust risk scan, pre-commit quality gate, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
     [`placement-repair-invariants.md`](placement-repair-invariants.md) records
@@ -3536,13 +3550,26 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-105 keeps S3 API ETag conversion behind a local ECStore client alias and extends guard coverage without changing call behavior. |
-| Migration preservation | pass | The guard now rejects scattered raw ECStore facade paths across storage compatibility boundaries while preserving local `ecstore_*` imports. |
-| Testing/verification | pass | Focused compile, raw-facade residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-106 keeps the compatibility boundary shape explicit by replacing grouped ECStore facade imports with one local module alias per dependency. |
+| Migration preservation | pass | The new guard rejects grouped facade imports and keeps wrapper bodies constrained to local `ecstore_*` aliases without changing compatibility call behavior. |
+| Testing/verification | pass | Focused compile, grouped-import and raw-facade residual scans, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-106 current slice:
+  - `cargo check -p rustfs --tests`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Full storage compatibility grouped-import residual scan: passed.
+  - Full storage compatibility raw-facade residual scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-105 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/fuzz/fuzz_targets/bucket_validation/storage_compat.rs
+++ b/fuzz/fuzz_targets/bucket_validation/storage_compat.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_ecstore::api::{bucket as ecstore_bucket, error as ecstore_error};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::error as ecstore_error;
 
 pub(crate) fn check_bucket_and_object_names(bucket: &str, object: &str) -> ecstore_error::Result<()> {
     ecstore_bucket::utils::check_bucket_and_object_names(bucket, object)

--- a/fuzz/fuzz_targets/path_containment/storage_compat.rs
+++ b/fuzz/fuzz_targets/path_containment/storage_compat.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_ecstore::api::{bucket as ecstore_bucket, error as ecstore_error};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::error as ecstore_error;
 
 pub(crate) fn check_object_name_for_length_and_slash(
     bucket: &str,

--- a/rustfs/src/admin/storage_compat.rs
+++ b/rustfs/src/admin/storage_compat.rs
@@ -15,12 +15,21 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use rustfs_ecstore::api::{
-    bucket as ecstore_bucket, capacity as ecstore_capacity, client as ecstore_client, config as ecstore_config,
-    data_usage as ecstore_data_usage, disk as ecstore_disk, error as ecstore_error, global as ecstore_global,
-    layout as ecstore_layout, metrics as ecstore_metrics, notification as ecstore_notification, rebalance as ecstore_rebalance,
-    rpc as ecstore_rpc, storage as ecstore_storage, tier as ecstore_tier,
-};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::capacity as ecstore_capacity;
+use rustfs_ecstore::api::client as ecstore_client;
+use rustfs_ecstore::api::config as ecstore_config;
+use rustfs_ecstore::api::data_usage as ecstore_data_usage;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::layout as ecstore_layout;
+use rustfs_ecstore::api::metrics as ecstore_metrics;
+use rustfs_ecstore::api::notification as ecstore_notification;
+use rustfs_ecstore::api::rebalance as ecstore_rebalance;
+use rustfs_ecstore::api::rpc as ecstore_rpc;
+use rustfs_ecstore::api::storage as ecstore_storage;
+use rustfs_ecstore::api::tier as ecstore_tier;
 
 pub(crate) const RUSTFS_META_BUCKET: &str = crate::admin::storage_compat::ecstore_disk::RUSTFS_META_BUCKET;
 pub(crate) const STORAGE_CLASS_SUB_SYS: &str = crate::admin::storage_compat::ecstore_config::com::STORAGE_CLASS_SUB_SYS;

--- a/rustfs/src/app/storage_compat.rs
+++ b/rustfs/src/app/storage_compat.rs
@@ -14,12 +14,22 @@
 
 use std::sync::Arc;
 
-use rustfs_ecstore::api::{
-    admin as ecstore_admin, bucket as ecstore_bucket, capacity as ecstore_capacity, client as ecstore_client,
-    compression as ecstore_compression, config as ecstore_config, data_usage as ecstore_data_usage, disk as ecstore_disk,
-    error as ecstore_error, global as ecstore_global, layout as ecstore_layout, notification as ecstore_notification,
-    rio as ecstore_rio, set_disk as ecstore_set_disk, storage as ecstore_storage, tier as ecstore_tier,
-};
+use rustfs_ecstore::api::admin as ecstore_admin;
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::capacity as ecstore_capacity;
+use rustfs_ecstore::api::client as ecstore_client;
+use rustfs_ecstore::api::compression as ecstore_compression;
+use rustfs_ecstore::api::config as ecstore_config;
+use rustfs_ecstore::api::data_usage as ecstore_data_usage;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::layout as ecstore_layout;
+use rustfs_ecstore::api::notification as ecstore_notification;
+use rustfs_ecstore::api::rio as ecstore_rio;
+use rustfs_ecstore::api::set_disk as ecstore_set_disk;
+use rustfs_ecstore::api::storage as ecstore_storage;
+use rustfs_ecstore::api::tier as ecstore_tier;
 
 pub(crate) const MIN_DISK_COMPRESSIBLE_SIZE: usize = crate::app::storage_compat::ecstore_compression::MIN_DISK_COMPRESSIBLE_SIZE;
 

--- a/rustfs/src/capacity/storage_compat.rs
+++ b/rustfs/src/capacity/storage_compat.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_ecstore::api::{disk as ecstore_disk, storage as ecstore_storage};
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
 

--- a/rustfs/src/error_storage_compat.rs
+++ b/rustfs/src/error_storage_compat.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_ecstore::api::{bucket as ecstore_bucket, error as ecstore_error};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::error as ecstore_error;
 
 pub(crate) type QuotaError = ecstore_bucket::quota::QuotaError;
 pub(crate) type StorageError = ecstore_error::StorageError;

--- a/rustfs/src/runtime_capabilities_storage_compat.rs
+++ b/rustfs/src/runtime_capabilities_storage_compat.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rustfs_ecstore::api::cluster as ecstore_cluster;
 #[cfg(test)]
 use rustfs_ecstore::api::disk as ecstore_disk;
-use rustfs_ecstore::api::{cluster as ecstore_cluster, layout as ecstore_layout};
+use rustfs_ecstore::api::layout as ecstore_layout;
 
 #[cfg(test)]
 pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;

--- a/rustfs/src/server/storage_compat.rs
+++ b/rustfs/src/server/storage_compat.rs
@@ -14,10 +14,14 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use rustfs_ecstore::api::{
-    config as ecstore_config, disk as ecstore_disk, error as ecstore_error, event as ecstore_event, global as ecstore_global,
-    layout as ecstore_layout, rpc as ecstore_rpc, storage as ecstore_storage,
-};
+use rustfs_ecstore::api::config as ecstore_config;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::event as ecstore_event;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::layout as ecstore_layout;
+use rustfs_ecstore::api::rpc as ecstore_rpc;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) const TONIC_RPC_PREFIX: &str = ecstore_rpc::TONIC_RPC_PREFIX;
 

--- a/rustfs/src/startup_storage_compat.rs
+++ b/rustfs/src/startup_storage_compat.rs
@@ -14,10 +14,13 @@
 
 use std::sync::Arc;
 
-use rustfs_ecstore::api::{
-    bucket as ecstore_bucket, config as ecstore_config, error as ecstore_error, global as ecstore_global,
-    layout as ecstore_layout, notification as ecstore_notification, storage as ecstore_storage,
-};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::config as ecstore_config;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::layout as ecstore_layout;
+use rustfs_ecstore::api::notification as ecstore_notification;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) type ECStore = ecstore_storage::ECStore;
 #[cfg(test)]

--- a/rustfs/src/storage/storage_compat.rs
+++ b/rustfs/src/storage/storage_compat.rs
@@ -14,12 +14,18 @@
 
 use std::sync::Arc;
 
+use rustfs_ecstore::api::admin as ecstore_admin;
+use rustfs_ecstore::api::bucket as ecstore_bucket;
 #[cfg(test)]
 use rustfs_ecstore::api::config as ecstore_config;
-use rustfs_ecstore::api::{
-    admin as ecstore_admin, bucket as ecstore_bucket, disk as ecstore_disk, error as ecstore_error, global as ecstore_global,
-    metrics as ecstore_metrics, rio as ecstore_rio, rpc as ecstore_rpc, set_disk as ecstore_set_disk, storage as ecstore_storage,
-};
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::global as ecstore_global;
+use rustfs_ecstore::api::metrics as ecstore_metrics;
+use rustfs_ecstore::api::rio as ecstore_rio;
+use rustfs_ecstore::api::rpc as ecstore_rpc;
+use rustfs_ecstore::api::set_disk as ecstore_set_disk;
+use rustfs_ecstore::api::storage as ecstore_storage;
 
 pub(crate) const BUCKET_ACCELERATE_CONFIG: &str = ecstore_bucket::metadata::BUCKET_ACCELERATE_CONFIG;
 pub(crate) const BUCKET_LOGGING_CONFIG: &str = ecstore_bucket::metadata::BUCKET_LOGGING_CONFIG;

--- a/rustfs/src/table_catalog_storage_compat.rs
+++ b/rustfs/src/table_catalog_storage_compat.rs
@@ -14,7 +14,10 @@
 
 use std::{sync::Arc, time::Duration};
 
-use rustfs_ecstore::api::{bucket as ecstore_bucket, disk as ecstore_disk, error as ecstore_error, set_disk as ecstore_set_disk};
+use rustfs_ecstore::api::bucket as ecstore_bucket;
+use rustfs_ecstore::api::disk as ecstore_disk;
+use rustfs_ecstore::api::error as ecstore_error;
+use rustfs_ecstore::api::set_disk as ecstore_set_disk;
 
 pub(crate) const BUCKET_TABLE_CATALOG_META_PREFIX: &str = ecstore_bucket::metadata::BUCKET_TABLE_CATALOG_META_PREFIX;
 pub(crate) const BUCKET_TABLE_CATALOG_TABLE_BUCKETS_PREFIX: &str =

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -96,6 +96,7 @@ RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_app_admin_c
 OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/outer_consumer_compat_raw_facade_path_hits.txt"
 RUSTFS_ROOT_E2E_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_root_e2e_compat_raw_facade_path_hits.txt"
 ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_raw_facade_path_hits.txt"
+ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE="${TMP_DIR}/all_storage_compat_grouped_facade_import_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -952,7 +953,7 @@ fi
 (
   cd "$ROOT_DIR"
   rg -n --no-heading 'rustfs_ecstore::api::' rustfs/src/storage/storage_compat.rs \
-    | rg -v '^[0-9]+:use rustfs_ecstore::api::\{|^[0-9]+:use rustfs_ecstore::api::config as ecstore_config;' || true
+    | rg -v '^[0-9]+:use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' || true
 ) >"$RUSTFS_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE"
 
 if [[ -s "$RUSTFS_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
@@ -962,7 +963,7 @@ fi
 (
   cd "$ROOT_DIR"
   rg -n --no-heading 'rustfs_ecstore::api::' rustfs/src/app/storage_compat.rs rustfs/src/admin/storage_compat.rs \
-    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::\{' || true
+    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' || true
 ) >"$RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE"
 
 if [[ -s "$RUSTFS_APP_ADMIN_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
@@ -983,7 +984,7 @@ fi
     crates/scanner/tests/common/storage_compat.rs \
     fuzz/fuzz_targets/path_containment/storage_compat.rs \
     fuzz/fuzz_targets/bucket_validation/storage_compat.rs \
-    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::\{' || true
+    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' || true
 ) >"$OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE"
 
 if [[ -s "$OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
@@ -993,7 +994,7 @@ fi
 (
   cd "$ROOT_DIR"
   rg -n --with-filename --no-heading 'rustfs_ecstore::api::' crates/e2e_test/src/storage_compat.rs \
-    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::\{' || true
+    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' || true
 ) >"$RUSTFS_ROOT_E2E_COMPAT_RAW_FACADE_PATH_HITS_FILE"
 
 if [[ -s "$RUSTFS_ROOT_E2E_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
@@ -1005,12 +1006,22 @@ fi
   rg -n --with-filename 'rustfs_ecstore::api::' rustfs/src crates fuzz \
     --glob '*storage_compat.rs' \
     --glob '*_compat.rs' \
-    | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::\{' \
     | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' || true
 ) >"$ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE"
 
 if [[ -s "$ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE" ]]; then
   report_failure "storage compatibility boundaries must keep raw ECStore facade paths behind local ecstore_* module aliases: $(paste -sd '; ' "$ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename '^use rustfs_ecstore::api::\{' rustfs/src crates fuzz \
+    --glob '*storage_compat.rs' \
+    --glob '*_compat.rs' || true
+) >"$ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE"
+
+if [[ -s "$ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE" ]]; then
+  report_failure "storage compatibility boundaries must import ECStore facade modules through explicit per-module ecstore_* aliases: $(paste -sd '; ' "$ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Split grouped ECStore facade imports in storage compatibility boundaries into explicit per-module `ecstore_*` aliases.
- Extend architecture migration rules to reject grouped facade imports and raw facade paths outside local aliases.
- Record API-106 progress and the pre-push review log.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `git diff --check`
- Grouped facade import residual scan
- Raw facade path residual scan
- Rust risk scan
- `cargo check -p rustfs --tests`
- `make pre-commit`

## Impact
No runtime behavior change expected. This keeps storage compatibility boundaries using local ECStore facade module aliases.

## Additional Notes
N/A
