### PR TITLE
refactor: collapse compat facade self refs

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-compat-facade-import-aliases`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106`.
-- Based on: `main` after the API-105 slice.
+- Branch: `overtrue/arch-compat-local-facade-self-refs`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107`.
+- Based on: API-106 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: split grouped ECStore facade imports in storage
-  compatibility boundaries into explicit per-module `ecstore_*` aliases.
-- CI/script changes: guard all storage compatibility boundaries against grouped
-  ECStore facade imports and scattered raw facade paths.
-- Docs changes: record the API-106 compatibility facade import alias cleanup.
+- Rust code changes: collapse crate-qualified ECStore facade self references in
+  RustFS app/admin compatibility boundaries into local `ecstore_*` and
+  `super::ecstore_*` paths.
+- CI/script changes: guard storage compatibility boundaries against
+  crate-qualified `storage_compat::ecstore_*` self paths.
+- Docs changes: record the API-107 local facade self-reference cleanup.
 
 ## Phase 0 Tasks
 
@@ -516,6 +517,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     storage/admin/app/runtime/edge/test/fuzz behavior, and API surface.
   - Verification: RustFS test-target compile coverage, grouped-import and
     raw-facade residual scans, migration and layer guards, formatting, diff
+    hygiene, Rust risk scan, pre-commit quality gate, and three-expert review.
+- [x] `API-107` Collapse compatibility facade self references.
+  - Completed slice: replace crate-qualified app/admin
+    `storage_compat::ecstore_*` self references with local `ecstore_*` aliases
+    at the root boundary and `super::ecstore_*` paths inside nested
+    compatibility modules.
+  - Acceptance: RustFS app/admin compatibility boundaries no longer route
+    wrapper bodies and aliases through their own crate-qualified
+    `storage_compat::ecstore_*` paths; migration rules reject regressions.
+  - Must preserve: app bucket/lifecycle/object-lock/replication helper
+    behavior, admin bucket metadata/target/replication/tier/config helper
+    behavior, public local compatibility names, and ECStore facade ownership.
+  - Verification: RustFS test-target compile coverage, local facade
+    self-reference residual scan, migration and layer guards, formatting, diff
     hygiene, Rust risk scan, pre-commit quality gate, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
@@ -3550,13 +3565,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-106 keeps the compatibility boundary shape explicit by replacing grouped ECStore facade imports with one local module alias per dependency. |
-| Migration preservation | pass | The new guard rejects grouped facade imports and keeps wrapper bodies constrained to local `ecstore_*` aliases without changing compatibility call behavior. |
-| Testing/verification | pass | Focused compile, grouped-import and raw-facade residual scans, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-107 keeps app/admin compatibility wrappers local by replacing crate-qualified self references with direct `ecstore_*` aliases and scoped `super::` paths. |
+| Migration preservation | pass | The new guard rejects crate-qualified `storage_compat::ecstore_*` self paths while preserving existing wrapper names and ECStore facade ownership. |
+| Testing/verification | pass | Focused compile, self-reference residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-107 current slice:
+  - `cargo check -p rustfs --tests`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Full storage compatibility self-reference residual scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-106 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/rustfs/src/admin/storage_compat.rs
+++ b/rustfs/src/admin/storage_compat.rs
@@ -31,38 +31,38 @@ use rustfs_ecstore::api::rpc as ecstore_rpc;
 use rustfs_ecstore::api::storage as ecstore_storage;
 use rustfs_ecstore::api::tier as ecstore_tier;
 
-pub(crate) const RUSTFS_META_BUCKET: &str = crate::admin::storage_compat::ecstore_disk::RUSTFS_META_BUCKET;
-pub(crate) const STORAGE_CLASS_SUB_SYS: &str = crate::admin::storage_compat::ecstore_config::com::STORAGE_CLASS_SUB_SYS;
+pub(crate) const RUSTFS_META_BUCKET: &str = ecstore_disk::RUSTFS_META_BUCKET;
+pub(crate) const STORAGE_CLASS_SUB_SYS: &str = ecstore_config::com::STORAGE_CLASS_SUB_SYS;
 
-pub(crate) type AdminError = crate::admin::storage_compat::ecstore_client::admin_handler_utils::AdminError;
-pub(crate) type CollectMetricsOpts = crate::admin::storage_compat::ecstore_metrics::CollectMetricsOpts;
-pub(crate) type DiskStat = crate::admin::storage_compat::ecstore_rebalance::DiskStat;
-pub(crate) type ECStore = crate::admin::storage_compat::ecstore_storage::ECStore;
-pub(crate) type EndpointServerPools = crate::admin::storage_compat::ecstore_layout::EndpointServerPools;
-pub(crate) type MetricType = crate::admin::storage_compat::ecstore_metrics::MetricType;
-pub(crate) type NotificationSys = crate::admin::storage_compat::ecstore_notification::NotificationSys;
-pub(crate) type PeerRestClient = crate::admin::storage_compat::ecstore_rpc::PeerRestClient;
-pub(crate) type RebalSaveOpt = crate::admin::storage_compat::ecstore_rebalance::RebalSaveOpt;
-pub(crate) type RebalanceCleanupWarnings = crate::admin::storage_compat::ecstore_rebalance::RebalanceCleanupWarnings;
-pub(crate) type RebalanceMeta = crate::admin::storage_compat::ecstore_rebalance::RebalanceMeta;
-pub(crate) type RebalanceStats = crate::admin::storage_compat::ecstore_rebalance::RebalanceStats;
-pub(crate) type StorageError = crate::admin::storage_compat::ecstore_error::StorageError;
+pub(crate) type AdminError = ecstore_client::admin_handler_utils::AdminError;
+pub(crate) type CollectMetricsOpts = ecstore_metrics::CollectMetricsOpts;
+pub(crate) type DiskStat = ecstore_rebalance::DiskStat;
+pub(crate) type ECStore = ecstore_storage::ECStore;
+pub(crate) type EndpointServerPools = ecstore_layout::EndpointServerPools;
+pub(crate) type MetricType = ecstore_metrics::MetricType;
+pub(crate) type NotificationSys = ecstore_notification::NotificationSys;
+pub(crate) type PeerRestClient = ecstore_rpc::PeerRestClient;
+pub(crate) type RebalSaveOpt = ecstore_rebalance::RebalSaveOpt;
+pub(crate) type RebalanceCleanupWarnings = ecstore_rebalance::RebalanceCleanupWarnings;
+pub(crate) type RebalanceMeta = ecstore_rebalance::RebalanceMeta;
+pub(crate) type RebalanceStats = ecstore_rebalance::RebalanceStats;
+pub(crate) type StorageError = ecstore_error::StorageError;
 pub(crate) type Error = StorageError;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
-pub(crate) type TierConfig = crate::admin::storage_compat::ecstore_tier::tier_config::TierConfig;
-pub(crate) type TierCreds = crate::admin::storage_compat::ecstore_tier::tier_admin::TierCreds;
-pub(crate) type TierType = crate::admin::storage_compat::ecstore_tier::tier_config::TierType;
+pub(crate) type TierConfig = ecstore_tier::tier_config::TierConfig;
+pub(crate) type TierCreds = ecstore_tier::tier_admin::TierCreds;
+pub(crate) type TierType = ecstore_tier::tier_config::TierType;
 
 #[cfg(test)]
-pub(crate) type Endpoint = crate::admin::storage_compat::ecstore_disk::endpoint::Endpoint;
+pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
 #[cfg(test)]
-pub(crate) type Endpoints = crate::admin::storage_compat::ecstore_layout::Endpoints;
+pub(crate) type Endpoints = ecstore_layout::Endpoints;
 #[cfg(test)]
-pub(crate) type PoolEndpoints = crate::admin::storage_compat::ecstore_layout::PoolEndpoints;
+pub(crate) type PoolEndpoints = ecstore_layout::PoolEndpoints;
 #[cfg(test)]
-pub(crate) type RebalStatus = crate::admin::storage_compat::ecstore_rebalance::RebalStatus;
+pub(crate) type RebalStatus = ecstore_rebalance::RebalStatus;
 #[cfg(test)]
-pub(crate) type RebalanceInfo = crate::admin::storage_compat::ecstore_rebalance::RebalanceInfo;
+pub(crate) type RebalanceInfo = ecstore_rebalance::RebalanceInfo;
 
 pub(crate) trait AdminReplicationConfigExt {
     fn filter_target_arns(&self, obj: &replication::ObjectOpts) -> Vec<String>;
@@ -95,19 +95,19 @@ impl AdminVersioningConfigExt for s3s::dto::VersioningConfiguration {
 
 pub(crate) mod bandwidth {
     pub(crate) mod monitor {
-        pub(crate) type BandwidthDetails = crate::admin::storage_compat::ecstore_bucket::bandwidth::monitor::BandwidthDetails;
-        pub(crate) type Monitor = crate::admin::storage_compat::ecstore_bucket::bandwidth::monitor::Monitor;
+        pub(crate) type BandwidthDetails = super::super::ecstore_bucket::bandwidth::monitor::BandwidthDetails;
+        pub(crate) type Monitor = super::super::ecstore_bucket::bandwidth::monitor::Monitor;
     }
 }
 
 pub(crate) mod bucket_target_sys {
-    pub(crate) type AdvancedPutOptions = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::AdvancedPutOptions;
-    pub(crate) type BucketTargetError = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::BucketTargetError;
-    pub(crate) type BucketTargetSys = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::BucketTargetSys;
-    pub(crate) type PutObjectOptions = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::PutObjectOptions;
-    pub(crate) type RemoveObjectOptions = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::RemoveObjectOptions;
-    pub(crate) type S3ClientError = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::S3ClientError;
-    pub(crate) type TargetClient = crate::admin::storage_compat::ecstore_bucket::bucket_target_sys::TargetClient;
+    pub(crate) type AdvancedPutOptions = super::ecstore_bucket::bucket_target_sys::AdvancedPutOptions;
+    pub(crate) type BucketTargetError = super::ecstore_bucket::bucket_target_sys::BucketTargetError;
+    pub(crate) type BucketTargetSys = super::ecstore_bucket::bucket_target_sys::BucketTargetSys;
+    pub(crate) type PutObjectOptions = super::ecstore_bucket::bucket_target_sys::PutObjectOptions;
+    pub(crate) type RemoveObjectOptions = super::ecstore_bucket::bucket_target_sys::RemoveObjectOptions;
+    pub(crate) type S3ClientError = super::ecstore_bucket::bucket_target_sys::S3ClientError;
+    pub(crate) type TargetClient = super::ecstore_bucket::bucket_target_sys::TargetClient;
 }
 
 pub(crate) mod lifecycle {
@@ -121,41 +121,34 @@ pub(crate) mod lifecycle {
 
         impl GlobalTransitionStateCompat {
             pub(crate) fn get_daily_all_tier_stats(&self) -> DailyAllTierStats {
-                crate::admin::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState
-                    .get_daily_all_tier_stats()
+                super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState.get_daily_all_tier_stats()
             }
         }
     }
 
     pub(crate) mod tier_last_day_stats {
         #[cfg(test)]
-        pub(crate) type LastDayTierStats =
-            crate::admin::storage_compat::ecstore_bucket::lifecycle::tier_last_day_stats::LastDayTierStats;
+        pub(crate) type LastDayTierStats = super::super::ecstore_bucket::lifecycle::tier_last_day_stats::LastDayTierStats;
     }
 }
 
 pub(crate) mod metadata {
-    pub(crate) const BUCKET_CORS_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_CORS_CONFIG;
-    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str =
-        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
-    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str =
-        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
-    pub(crate) const BUCKET_POLICY_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_POLICY_CONFIG;
-    pub(crate) const BUCKET_QUOTA_CONFIG_FILE: &str =
-        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_QUOTA_CONFIG_FILE;
-    pub(crate) const BUCKET_REPLICATION_CONFIG: &str =
-        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_REPLICATION_CONFIG;
-    pub(crate) const BUCKET_SSECONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_SSECONFIG;
-    pub(crate) const BUCKET_TAGGING_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_TAGGING_CONFIG;
-    pub(crate) const BUCKET_TARGETS_FILE: &str = crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_TARGETS_FILE;
-    pub(crate) const BUCKET_VERSIONING_CONFIG: &str =
-        crate::admin::storage_compat::ecstore_bucket::metadata::BUCKET_VERSIONING_CONFIG;
-    pub(crate) const OBJECT_LOCK_CONFIG: &str = crate::admin::storage_compat::ecstore_bucket::metadata::OBJECT_LOCK_CONFIG;
+    pub(crate) const BUCKET_CORS_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_CORS_CONFIG;
+    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
+    pub(crate) const BUCKET_POLICY_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_POLICY_CONFIG;
+    pub(crate) const BUCKET_QUOTA_CONFIG_FILE: &str = super::ecstore_bucket::metadata::BUCKET_QUOTA_CONFIG_FILE;
+    pub(crate) const BUCKET_REPLICATION_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_REPLICATION_CONFIG;
+    pub(crate) const BUCKET_SSECONFIG: &str = super::ecstore_bucket::metadata::BUCKET_SSECONFIG;
+    pub(crate) const BUCKET_TAGGING_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_TAGGING_CONFIG;
+    pub(crate) const BUCKET_TARGETS_FILE: &str = super::ecstore_bucket::metadata::BUCKET_TARGETS_FILE;
+    pub(crate) const BUCKET_VERSIONING_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_VERSIONING_CONFIG;
+    pub(crate) const OBJECT_LOCK_CONFIG: &str = super::ecstore_bucket::metadata::OBJECT_LOCK_CONFIG;
 
-    pub(crate) type BucketMetadata = crate::admin::storage_compat::ecstore_bucket::metadata::BucketMetadata;
+    pub(crate) type BucketMetadata = super::ecstore_bucket::metadata::BucketMetadata;
 
     pub(crate) fn table_catalog_path_hash(value: &str) -> String {
-        crate::admin::storage_compat::ecstore_bucket::metadata::table_catalog_path_hash(value)
+        super::ecstore_bucket::metadata::table_catalog_path_hash(value)
     }
 }
 
@@ -174,94 +167,92 @@ pub(crate) mod metadata_sys {
     use super::quota::BucketQuota;
     use super::target::BucketTargets;
 
-    pub(crate) type BucketMetadataSys = crate::admin::storage_compat::ecstore_bucket::metadata_sys::BucketMetadataSys;
+    pub(crate) type BucketMetadataSys = super::ecstore_bucket::metadata_sys::BucketMetadataSys;
 
     pub(crate) async fn get(bucket: &str) -> Result<Arc<BucketMetadata>> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get(bucket).await
+        super::ecstore_bucket::metadata_sys::get(bucket).await
     }
 
     pub(crate) async fn update(bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::update(bucket, config_file, data).await
+        super::ecstore_bucket::metadata_sys::update(bucket, config_file, data).await
     }
 
     pub(crate) async fn delete(bucket: &str, config_file: &str) -> Result<OffsetDateTime> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::delete(bucket, config_file).await
+        super::ecstore_bucket::metadata_sys::delete(bucket, config_file).await
     }
 
     pub(crate) async fn get_bucket_policy(bucket: &str) -> Result<(BucketPolicy, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_bucket_policy(bucket).await
+        super::ecstore_bucket::metadata_sys::get_bucket_policy(bucket).await
     }
 
     pub(crate) async fn get_bucket_targets_config(bucket: &str) -> Result<BucketTargets> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_bucket_targets_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_bucket_targets_config(bucket).await
     }
 
     pub(crate) async fn get_config_from_disk(bucket: &str) -> Result<BucketMetadata> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_config_from_disk(bucket).await
+        super::ecstore_bucket::metadata_sys::get_config_from_disk(bucket).await
     }
 
     pub(crate) async fn get_lifecycle_config(bucket: &str) -> Result<(BucketLifecycleConfiguration, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
     }
 
     pub(crate) async fn get_notification_config(bucket: &str) -> Result<Option<NotificationConfiguration>> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_notification_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_notification_config(bucket).await
     }
 
     pub(crate) async fn get_object_lock_config(bucket: &str) -> Result<(ObjectLockConfiguration, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
     }
 
     pub(crate) async fn get_quota_config(bucket: &str) -> Result<(BucketQuota, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_quota_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_quota_config(bucket).await
     }
 
     pub(crate) async fn get_replication_config(bucket: &str) -> Result<(s3s::dto::ReplicationConfiguration, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_replication_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_replication_config(bucket).await
     }
 
     pub(crate) async fn get_sse_config(bucket: &str) -> Result<(ServerSideEncryptionConfiguration, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_sse_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_sse_config(bucket).await
     }
 
     pub(crate) async fn get_tagging_config(bucket: &str) -> Result<(Tagging, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_tagging_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_tagging_config(bucket).await
     }
 
     pub(crate) async fn get_versioning_config(bucket: &str) -> Result<(VersioningConfiguration, OffsetDateTime)> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::get_versioning_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_versioning_config(bucket).await
     }
 
     pub(crate) async fn list_bucket_targets(bucket: &str) -> Result<BucketTargets> {
-        crate::admin::storage_compat::ecstore_bucket::metadata_sys::list_bucket_targets(bucket).await
+        super::ecstore_bucket::metadata_sys::list_bucket_targets(bucket).await
     }
 }
 
 pub(crate) mod quota {
     pub(crate) mod checker {
-        pub(crate) type QuotaChecker = crate::admin::storage_compat::ecstore_bucket::quota::checker::QuotaChecker;
+        pub(crate) type QuotaChecker = super::super::ecstore_bucket::quota::checker::QuotaChecker;
     }
 
-    pub(crate) type BucketQuota = crate::admin::storage_compat::ecstore_bucket::quota::BucketQuota;
-    pub(crate) type QuotaError = crate::admin::storage_compat::ecstore_bucket::quota::QuotaError;
-    pub(crate) type QuotaOperation = crate::admin::storage_compat::ecstore_bucket::quota::QuotaOperation;
+    pub(crate) type BucketQuota = super::ecstore_bucket::quota::BucketQuota;
+    pub(crate) type QuotaError = super::ecstore_bucket::quota::QuotaError;
+    pub(crate) type QuotaOperation = super::ecstore_bucket::quota::QuotaOperation;
 }
 
 pub(crate) mod replication {
     use std::sync::Arc;
 
-    pub(crate) type BucketReplicationResyncStatus =
-        crate::admin::storage_compat::ecstore_bucket::replication::BucketReplicationResyncStatus;
-    pub(crate) type BucketStats = crate::admin::storage_compat::ecstore_bucket::replication::BucketStats;
-    pub(crate) type DynReplicationPool = crate::admin::storage_compat::ecstore_bucket::replication::DynReplicationPool;
-    pub(crate) type ObjectOpts = crate::admin::storage_compat::ecstore_bucket::replication::ObjectOpts;
-    pub(crate) type ReplicationStats = crate::admin::storage_compat::ecstore_bucket::replication::ReplicationStats;
-    pub(crate) type ResyncOpts = crate::admin::storage_compat::ecstore_bucket::replication::ResyncOpts;
+    pub(crate) type BucketReplicationResyncStatus = super::ecstore_bucket::replication::BucketReplicationResyncStatus;
+    pub(crate) type BucketStats = super::ecstore_bucket::replication::BucketStats;
+    pub(crate) type DynReplicationPool = super::ecstore_bucket::replication::DynReplicationPool;
+    pub(crate) type ObjectOpts = super::ecstore_bucket::replication::ObjectOpts;
+    pub(crate) type ReplicationStats = super::ecstore_bucket::replication::ReplicationStats;
+    pub(crate) type ResyncOpts = super::ecstore_bucket::replication::ResyncOpts;
     #[cfg(test)]
-    pub(crate) type ResyncStatusType = crate::admin::storage_compat::ecstore_bucket::replication::ResyncStatusType;
+    pub(crate) type ResyncStatusType = super::ecstore_bucket::replication::ResyncStatusType;
     #[cfg(test)]
-    pub(crate) type TargetReplicationResyncStatus =
-        crate::admin::storage_compat::ecstore_bucket::replication::TargetReplicationResyncStatus;
+    pub(crate) type TargetReplicationResyncStatus = super::ecstore_bucket::replication::TargetReplicationResyncStatus;
 
     pub(crate) struct GlobalReplicationStatsCompat;
 
@@ -269,22 +260,22 @@ pub(crate) mod replication {
 
     impl GlobalReplicationStatsCompat {
         pub(crate) fn get(&self) -> Option<&'static Arc<ReplicationStats>> {
-            crate::admin::storage_compat::ecstore_bucket::replication::GLOBAL_REPLICATION_STATS.get()
+            super::ecstore_bucket::replication::GLOBAL_REPLICATION_STATS.get()
         }
     }
 
     pub(crate) fn get_global_replication_pool() -> Option<Arc<DynReplicationPool>> {
-        crate::admin::storage_compat::ecstore_bucket::replication::get_global_replication_pool()
+        super::ecstore_bucket::replication::get_global_replication_pool()
     }
 }
 
 pub(crate) mod target {
     #[allow(clippy::upper_case_acronyms)]
-    pub(crate) type ARN = crate::admin::storage_compat::ecstore_bucket::target::ARN;
-    pub(crate) type BucketTarget = crate::admin::storage_compat::ecstore_bucket::target::BucketTarget;
-    pub(crate) type BucketTargetType = crate::admin::storage_compat::ecstore_bucket::target::BucketTargetType;
-    pub(crate) type BucketTargets = crate::admin::storage_compat::ecstore_bucket::target::BucketTargets;
-    pub(crate) type Credentials = crate::admin::storage_compat::ecstore_bucket::target::Credentials;
+    pub(crate) type ARN = super::ecstore_bucket::target::ARN;
+    pub(crate) type BucketTarget = super::ecstore_bucket::target::BucketTarget;
+    pub(crate) type BucketTargetType = super::ecstore_bucket::target::BucketTargetType;
+    pub(crate) type BucketTargets = super::ecstore_bucket::target::BucketTargets;
+    pub(crate) type Credentials = super::ecstore_bucket::target::Credentials;
 }
 
 pub(crate) mod utils {
@@ -292,109 +283,108 @@ pub(crate) mod utils {
     where
         T: for<'xml> s3s::xml::Deserialize<'xml>,
     {
-        crate::admin::storage_compat::ecstore_bucket::utils::deserialize(input)
+        super::ecstore_bucket::utils::deserialize(input)
     }
 
     pub(crate) fn is_valid_object_prefix(object: &str) -> bool {
-        crate::admin::storage_compat::ecstore_bucket::utils::is_valid_object_prefix(object)
+        super::ecstore_bucket::utils::is_valid_object_prefix(object)
     }
 
     pub(crate) fn serialize<T: s3s::xml::Serialize>(val: &T) -> s3s::xml::SerResult<Vec<u8>> {
-        crate::admin::storage_compat::ecstore_bucket::utils::serialize(val)
+        super::ecstore_bucket::utils::serialize(val)
     }
 }
 
 pub(crate) mod versioning {}
 
 pub(crate) mod versioning_sys {
-    pub(crate) type BucketVersioningSys = crate::admin::storage_compat::ecstore_bucket::versioning_sys::BucketVersioningSys;
+    pub(crate) type BucketVersioningSys = super::ecstore_bucket::versioning_sys::BucketVersioningSys;
 }
 
 pub(crate) mod storageclass {
-    pub(crate) const INLINE_BLOCK_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::INLINE_BLOCK_ENV;
-    pub(crate) const OPTIMIZE_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::OPTIMIZE_ENV;
-    pub(crate) const RRS: &str = crate::admin::storage_compat::ecstore_config::storageclass::RRS;
-    pub(crate) const RRS_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::RRS_ENV;
-    pub(crate) const STANDARD: &str = crate::admin::storage_compat::ecstore_config::storageclass::STANDARD;
-    pub(crate) const STANDARD_ENV: &str = crate::admin::storage_compat::ecstore_config::storageclass::STANDARD_ENV;
+    pub(crate) const INLINE_BLOCK_ENV: &str = super::ecstore_config::storageclass::INLINE_BLOCK_ENV;
+    pub(crate) const OPTIMIZE_ENV: &str = super::ecstore_config::storageclass::OPTIMIZE_ENV;
+    pub(crate) const RRS: &str = super::ecstore_config::storageclass::RRS;
+    pub(crate) const RRS_ENV: &str = super::ecstore_config::storageclass::RRS_ENV;
+    pub(crate) const STANDARD: &str = super::ecstore_config::storageclass::STANDARD;
+    pub(crate) const STANDARD_ENV: &str = super::ecstore_config::storageclass::STANDARD_ENV;
 
-    pub(crate) type Config = crate::admin::storage_compat::ecstore_config::storageclass::Config;
+    pub(crate) type Config = super::ecstore_config::storageclass::Config;
 
     pub(crate) fn lookup_config(kvs: &rustfs_config::server_config::KVS, set_drive_count: usize) -> super::Result<Config> {
-        crate::admin::storage_compat::ecstore_config::storageclass::lookup_config(kvs, set_drive_count)
+        super::ecstore_config::storageclass::lookup_config(kvs, set_drive_count)
     }
 }
 
-pub(crate) type DailyAllTierStats =
-    crate::admin::storage_compat::ecstore_bucket::lifecycle::tier_last_day_stats::DailyAllTierStats;
+pub(crate) type DailyAllTierStats = ecstore_bucket::lifecycle::tier_last_day_stats::DailyAllTierStats;
 
 pub(crate) fn is_reserved_or_invalid_bucket(bucket_entry: &str, strict: bool) -> bool {
-    crate::admin::storage_compat::ecstore_capacity::is_reserved_or_invalid_bucket(bucket_entry, strict)
+    ecstore_capacity::is_reserved_or_invalid_bucket(bucket_entry, strict)
 }
 
 pub(crate) async fn read_admin_config(api: Arc<ECStore>, file: &str) -> Result<Vec<u8>> {
-    crate::admin::storage_compat::ecstore_config::com::read_config(api, file).await
+    ecstore_config::com::read_config(api, file).await
 }
 
 pub(crate) async fn read_admin_config_without_migrate(api: Arc<ECStore>) -> Result<rustfs_config::server_config::Config> {
-    crate::admin::storage_compat::ecstore_config::com::read_config_without_migrate(api).await
+    ecstore_config::com::read_config_without_migrate(api).await
 }
 
 pub(crate) async fn save_admin_config(api: Arc<ECStore>, file: &str, data: Vec<u8>) -> Result<()> {
-    crate::admin::storage_compat::ecstore_config::com::save_config(api, file, data).await
+    ecstore_config::com::save_config(api, file, data).await
 }
 
 pub(crate) async fn delete_admin_config(api: Arc<ECStore>, file: &str) -> Result<()> {
-    crate::admin::storage_compat::ecstore_config::com::delete_config(api, file).await
+    ecstore_config::com::delete_config(api, file).await
 }
 
 pub(crate) async fn save_admin_server_config(api: Arc<ECStore>, cfg: &rustfs_config::server_config::Config) -> Result<()> {
-    crate::admin::storage_compat::ecstore_config::com::save_server_config(api, cfg).await
+    ecstore_config::com::save_server_config(api, cfg).await
 }
 
 pub(crate) fn init_admin_config_defaults() {
-    crate::admin::storage_compat::ecstore_config::init();
+    ecstore_config::init();
 }
 
 pub(crate) fn set_global_storage_class(cfg: storageclass::Config) {
-    crate::admin::storage_compat::ecstore_config::set_global_storage_class(cfg);
+    ecstore_config::set_global_storage_class(cfg);
 }
 
 pub(crate) async fn load_data_usage_from_backend(
     store: Arc<ECStore>,
 ) -> std::result::Result<rustfs_data_usage::DataUsageInfo, Error> {
-    crate::admin::storage_compat::ecstore_data_usage::load_data_usage_from_backend(store).await
+    ecstore_data_usage::load_data_usage_from_backend(store).await
 }
 
 pub(crate) fn get_global_bucket_monitor() -> Option<Arc<bandwidth::monitor::Monitor>> {
-    crate::admin::storage_compat::ecstore_global::get_global_bucket_monitor()
+    ecstore_global::get_global_bucket_monitor()
 }
 
 pub(crate) fn get_global_deployment_id() -> Option<String> {
-    crate::admin::storage_compat::ecstore_global::get_global_deployment_id()
+    ecstore_global::get_global_deployment_id()
 }
 
 pub(crate) fn get_global_endpoints_opt() -> Option<EndpointServerPools> {
-    crate::admin::storage_compat::ecstore_global::get_global_endpoints_opt()
+    ecstore_global::get_global_endpoints_opt()
 }
 
 pub(crate) fn get_global_region() -> Option<s3s::region::Region> {
-    crate::admin::storage_compat::ecstore_global::get_global_region()
+    ecstore_global::get_global_region()
 }
 
 pub(crate) fn global_rustfs_port() -> u16 {
-    crate::admin::storage_compat::ecstore_global::global_rustfs_port()
+    ecstore_global::global_rustfs_port()
 }
 
 pub(crate) async fn collect_local_metrics(
     types: MetricType,
     opts: &CollectMetricsOpts,
 ) -> rustfs_madmin::metrics::RealtimeMetrics {
-    crate::admin::storage_compat::ecstore_metrics::collect_local_metrics(types, opts).await
+    ecstore_metrics::collect_local_metrics(types, opts).await
 }
 
 pub(crate) fn get_global_notification_sys() -> Option<&'static NotificationSys> {
-    crate::admin::storage_compat::ecstore_notification::get_global_notification_sys()
+    ecstore_notification::get_global_notification_sys()
 }
 
 pub(crate) struct BootTimeCompat;
@@ -403,7 +393,7 @@ pub(crate) static GLOBAL_BOOT_TIME: BootTimeCompat = BootTimeCompat;
 
 impl BootTimeCompat {
     pub(crate) fn get(&self) -> Option<&'static std::time::SystemTime> {
-        crate::admin::storage_compat::ecstore_global::GLOBAL_BOOT_TIME.get()
+        ecstore_global::GLOBAL_BOOT_TIME.get()
     }
 }
 
@@ -417,19 +407,15 @@ impl Deref for AdminErrorRef {
     }
 }
 
-pub(crate) static ERR_TIER_BACKEND_IN_USE: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier::ERR_TIER_BACKEND_IN_USE);
-pub(crate) static ERR_TIER_BACKEND_NOT_EMPTY: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier::ERR_TIER_BACKEND_NOT_EMPTY);
+pub(crate) static ERR_TIER_BACKEND_IN_USE: AdminErrorRef = AdminErrorRef(|| &ecstore_tier::tier::ERR_TIER_BACKEND_IN_USE);
+pub(crate) static ERR_TIER_BACKEND_NOT_EMPTY: AdminErrorRef = AdminErrorRef(|| &ecstore_tier::tier::ERR_TIER_BACKEND_NOT_EMPTY);
 pub(crate) static ERR_TIER_MISSING_CREDENTIALS: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier::ERR_TIER_MISSING_CREDENTIALS);
+    AdminErrorRef(|| &ecstore_tier::tier::ERR_TIER_MISSING_CREDENTIALS);
 pub(crate) static ERR_TIER_ALREADY_EXISTS: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_ALREADY_EXISTS);
-pub(crate) static ERR_TIER_CONNECT_ERR: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_CONNECT_ERR);
+    AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_ALREADY_EXISTS);
+pub(crate) static ERR_TIER_CONNECT_ERR: AdminErrorRef = AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_CONNECT_ERR);
 pub(crate) static ERR_TIER_INVALID_CREDENTIALS: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_INVALID_CREDENTIALS);
+    AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_INVALID_CREDENTIALS);
 pub(crate) static ERR_TIER_NAME_NOT_UPPERCASE: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_NAME_NOT_UPPERCASE);
-pub(crate) static ERR_TIER_NOT_FOUND: AdminErrorRef =
-    AdminErrorRef(|| &crate::admin::storage_compat::ecstore_tier::tier_handlers::ERR_TIER_NOT_FOUND);
+    AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_NAME_NOT_UPPERCASE);
+pub(crate) static ERR_TIER_NOT_FOUND: AdminErrorRef = AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_NOT_FOUND);

--- a/rustfs/src/app/storage_compat.rs
+++ b/rustfs/src/app/storage_compat.rs
@@ -31,50 +31,50 @@ use rustfs_ecstore::api::set_disk as ecstore_set_disk;
 use rustfs_ecstore::api::storage as ecstore_storage;
 use rustfs_ecstore::api::tier as ecstore_tier;
 
-pub(crate) const MIN_DISK_COMPRESSIBLE_SIZE: usize = crate::app::storage_compat::ecstore_compression::MIN_DISK_COMPRESSIBLE_SIZE;
+pub(crate) const MIN_DISK_COMPRESSIBLE_SIZE: usize = ecstore_compression::MIN_DISK_COMPRESSIBLE_SIZE;
 
-pub(crate) type DiskError = crate::app::storage_compat::ecstore_disk::error::DiskError;
-pub(crate) type DynReader = crate::app::storage_compat::ecstore_rio::DynReader;
-pub(crate) type ECStore = crate::app::storage_compat::ecstore_storage::ECStore;
-pub(crate) type EndpointServerPools = crate::app::storage_compat::ecstore_layout::EndpointServerPools;
-pub(crate) type HashReader = crate::app::storage_compat::ecstore_rio::HashReader;
-pub(crate) type NotificationSys = crate::app::storage_compat::ecstore_notification::NotificationSys;
+pub(crate) type DiskError = ecstore_disk::error::DiskError;
+pub(crate) type DynReader = ecstore_rio::DynReader;
+pub(crate) type ECStore = ecstore_storage::ECStore;
+pub(crate) type EndpointServerPools = ecstore_layout::EndpointServerPools;
+pub(crate) type HashReader = ecstore_rio::HashReader;
+pub(crate) type NotificationSys = ecstore_notification::NotificationSys;
 pub(crate) type ObjectStoreResolver = dyn Fn() -> Option<Arc<ECStore>> + Send + Sync + 'static;
 pub(crate) type ObjectInfo = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub(crate) type ObjectOptions = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
-pub(crate) type PoolDecommissionInfo = crate::app::storage_compat::ecstore_capacity::PoolDecommissionInfo;
-pub(crate) type PoolStatus = crate::app::storage_compat::ecstore_capacity::PoolStatus;
-pub(crate) type StorageError = crate::app::storage_compat::ecstore_error::StorageError;
+pub(crate) type PoolDecommissionInfo = ecstore_capacity::PoolDecommissionInfo;
+pub(crate) type PoolStatus = ecstore_capacity::PoolStatus;
+pub(crate) type StorageError = ecstore_error::StorageError;
 pub(crate) type Error = StorageError;
-pub(crate) type TierConfigMgr = crate::app::storage_compat::ecstore_tier::tier::TierConfigMgr;
-pub(crate) type WriteEncryption = crate::app::storage_compat::ecstore_rio::WriteEncryption;
-pub(crate) type WritePlan = crate::app::storage_compat::ecstore_rio::WritePlan;
+pub(crate) type TierConfigMgr = ecstore_tier::tier::TierConfigMgr;
+pub(crate) type WriteEncryption = ecstore_rio::WriteEncryption;
+pub(crate) type WritePlan = ecstore_rio::WritePlan;
 
 #[cfg(test)]
-pub(crate) type DecryptReader<R> = crate::app::storage_compat::ecstore_rio::DecryptReader<R>;
+pub(crate) type DecryptReader<R> = ecstore_rio::DecryptReader<R>;
 #[cfg(test)]
-pub(crate) type EncryptReader<R> = crate::app::storage_compat::ecstore_rio::EncryptReader<R>;
+pub(crate) type EncryptReader<R> = ecstore_rio::EncryptReader<R>;
 #[cfg(test)]
-pub(crate) type Endpoint = crate::app::storage_compat::ecstore_disk::endpoint::Endpoint;
+pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
 #[cfg(test)]
-pub(crate) type Endpoints = crate::app::storage_compat::ecstore_layout::Endpoints;
+pub(crate) type Endpoints = ecstore_layout::Endpoints;
 #[cfg(test)]
-pub(crate) type HardLimitReader<R> = crate::app::storage_compat::ecstore_rio::HardLimitReader<R>;
+pub(crate) type HardLimitReader<R> = ecstore_rio::HardLimitReader<R>;
 #[cfg(test)]
-pub(crate) type PoolEndpoints = crate::app::storage_compat::ecstore_layout::PoolEndpoints;
+pub(crate) type PoolEndpoints = ecstore_layout::PoolEndpoints;
 #[cfg(test)]
-pub(crate) type TierConfig = crate::app::storage_compat::ecstore_tier::tier_config::TierConfig;
+pub(crate) type TierConfig = ecstore_tier::tier_config::TierConfig;
 #[cfg(test)]
-pub(crate) type TierType = crate::app::storage_compat::ecstore_tier::tier_config::TierType;
+pub(crate) type TierType = ecstore_tier::tier_config::TierType;
 #[cfg(test)]
-pub(crate) use crate::app::storage_compat::ecstore_tier::warm_backend::WarmBackend as AppWarmBackend;
+pub(crate) use ecstore_tier::warm_backend::WarmBackend as AppWarmBackend;
 #[cfg(test)]
-pub(crate) type WarmBackendGetOpts = crate::app::storage_compat::ecstore_tier::warm_backend::WarmBackendGetOpts;
+pub(crate) type WarmBackendGetOpts = ecstore_tier::warm_backend::WarmBackendGetOpts;
 
 #[cfg(test)]
 #[allow(non_snake_case)]
 pub(crate) fn EndpointServerPools(pools: Vec<PoolEndpoints>) -> EndpointServerPools {
-    crate::app::storage_compat::ecstore_layout::EndpointServerPools::from(pools)
+    ecstore_layout::EndpointServerPools::from(pools)
 }
 
 pub(crate) trait AppObjectLockConfigExt {
@@ -131,18 +131,18 @@ pub(crate) fn validate_restore_request(request: &s3s::dto::RestoreRequest, api: 
 }
 
 pub(crate) async fn get_server_info(get_pools: bool) -> rustfs_madmin::InfoMessage {
-    crate::app::storage_compat::ecstore_admin::get_server_info(get_pools).await
+    ecstore_admin::get_server_info(get_pools).await
 }
 
 pub(crate) mod bucket_target_sys {
-    pub(crate) type BucketTargetSys = crate::app::storage_compat::ecstore_bucket::bucket_target_sys::BucketTargetSys;
+    pub(crate) type BucketTargetSys = super::ecstore_bucket::bucket_target_sys::BucketTargetSys;
 }
 
 pub(crate) mod lifecycle {
     use super::ECStore;
 
     pub(crate) mod bucket_lifecycle_audit {
-        pub(crate) type LcEventSrc = crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
+        pub(crate) type LcEventSrc = super::super::ecstore_bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
     }
 
     pub(crate) mod bucket_lifecycle_ops {
@@ -152,7 +152,7 @@ pub(crate) mod lifecycle {
         use super::ECStore;
         use super::bucket_lifecycle_audit::LcEventSrc;
 
-        pub(crate) type ExpiryState = crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::ExpiryState;
+        pub(crate) type ExpiryState = super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::ExpiryState;
 
         pub(crate) struct GlobalExpiryStateCompat;
 
@@ -163,38 +163,32 @@ pub(crate) mod lifecycle {
             type Target = Arc<tokio::sync::RwLock<ExpiryState>>;
 
             fn deref(&self) -> &Self::Target {
-                &crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
+                &super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
             }
         }
 
         #[cfg(test)]
         pub(crate) async fn init_background_expiry(api: Arc<ECStore>) {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(api).await;
+            super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::init_background_expiry(api).await;
         }
 
         pub(crate) async fn enqueue_expiry_for_existing_objects(
             api: Arc<ECStore>,
             bucket: &str,
         ) -> Result<(), super::super::Error> {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_expiry_for_existing_objects(
-                api, bucket,
-            )
-            .await
+            super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_expiry_for_existing_objects(api, bucket).await
         }
 
         pub(crate) async fn enqueue_transition_for_existing_objects(
             api: Arc<ECStore>,
             bucket: &str,
         ) -> Result<(), super::super::Error> {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects(
-                api, bucket,
-            )
-            .await
+            super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_for_existing_objects(api, bucket)
+                .await
         }
 
         pub(crate) async fn enqueue_transition_immediate(oi: &super::super::ObjectInfo, src: LcEventSrc) {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_immediate(oi, src)
-                .await;
+            super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::enqueue_transition_immediate(oi, src).await;
         }
 
         pub(crate) async fn post_restore_opts(
@@ -202,21 +196,18 @@ pub(crate) mod lifecycle {
             bucket: &str,
             object: &str,
         ) -> Result<super::super::ObjectOptions, std::io::Error> {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::post_restore_opts(
-                version_id, bucket, object,
-            )
-            .await
+            super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::post_restore_opts(version_id, bucket, object).await
         }
 
         pub(crate) async fn validate_transition_tier(lc: &s3s::dto::BucketLifecycleConfiguration) -> Result<(), std::io::Error> {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::bucket_lifecycle_ops::validate_transition_tier(lc).await
+            super::super::ecstore_bucket::lifecycle::bucket_lifecycle_ops::validate_transition_tier(lc).await
         }
 
         pub(crate) async fn validate_lifecycle_config(
             lc: &s3s::dto::BucketLifecycleConfiguration,
             lock_config: &s3s::dto::ObjectLockConfiguration,
         ) -> Result<(), std::io::Error> {
-            use crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::Lifecycle as _;
+            use super::super::ecstore_bucket::lifecycle::lifecycle::Lifecycle as _;
 
             lc.validate(lock_config).await
         }
@@ -224,16 +215,15 @@ pub(crate) mod lifecycle {
 
     pub(crate) mod lifecycle_contract {
         #[cfg(test)]
-        pub(crate) type IlmAction = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::IlmAction;
-        pub(crate) type Event = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::Event;
-        pub(crate) type ObjectOpts = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::ObjectOpts;
-        pub(crate) type TransitionOptions = crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::TransitionOptions;
+        pub(crate) type IlmAction = super::super::ecstore_bucket::lifecycle::lifecycle::IlmAction;
+        pub(crate) type Event = super::super::ecstore_bucket::lifecycle::lifecycle::Event;
+        pub(crate) type ObjectOpts = super::super::ecstore_bucket::lifecycle::lifecycle::ObjectOpts;
+        pub(crate) type TransitionOptions = super::super::ecstore_bucket::lifecycle::lifecycle::TransitionOptions;
 
-        pub(crate) const TRANSITION_COMPLETE: &str =
-            crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
+        pub(crate) const TRANSITION_COMPLETE: &str = super::super::ecstore_bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
 
         pub(crate) fn expected_expiry_time(mod_time: time::OffsetDateTime, days: i32) -> time::OffsetDateTime {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::lifecycle::expected_expiry_time(mod_time, days)
+            super::super::ecstore_bucket::lifecycle::lifecycle::expected_expiry_time(mod_time, days)
         }
     }
     pub(crate) use lifecycle_contract as lifecycle;
@@ -247,13 +237,12 @@ pub(crate) mod lifecycle {
             api: Arc<ECStore>,
             je: &super::tier_sweeper::Jentry,
         ) -> std::io::Result<()> {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry(api, je)
-                .await
+            super::super::ecstore_bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry(api, je).await
         }
     }
 
     pub(crate) mod tier_sweeper {
-        pub(crate) type Jentry = crate::app::storage_compat::ecstore_bucket::lifecycle::tier_sweeper::Jentry;
+        pub(crate) type Jentry = super::super::ecstore_bucket::lifecycle::tier_sweeper::Jentry;
 
         pub(crate) fn transitioned_delete_journal_entry(
             version_id: Option<uuid::Uuid>,
@@ -261,7 +250,7 @@ pub(crate) mod lifecycle {
             suspended: bool,
             transitioned: &rustfs_storage_api::TransitionedObject,
         ) -> Option<Jentry> {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::tier_sweeper::transitioned_delete_journal_entry(
+            super::super::ecstore_bucket::lifecycle::tier_sweeper::transitioned_delete_journal_entry(
                 version_id,
                 versioned,
                 suspended,
@@ -272,31 +261,24 @@ pub(crate) mod lifecycle {
         pub(crate) fn transitioned_force_delete_journal_entry(
             transitioned: &rustfs_storage_api::TransitionedObject,
         ) -> Option<Jentry> {
-            crate::app::storage_compat::ecstore_bucket::lifecycle::tier_sweeper::transitioned_force_delete_journal_entry(
-                transitioned,
-            )
+            super::super::ecstore_bucket::lifecycle::tier_sweeper::transitioned_force_delete_journal_entry(transitioned)
         }
     }
 }
 
 pub(crate) mod metadata {
-    pub(crate) const BUCKET_CORS_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_CORS_CONFIG;
-    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str =
-        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
-    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str =
-        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
-    pub(crate) const BUCKET_POLICY_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_POLICY_CONFIG;
-    pub(crate) const BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG: &str =
-        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG;
-    pub(crate) const BUCKET_REPLICATION_CONFIG: &str =
-        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_REPLICATION_CONFIG;
-    pub(crate) const BUCKET_SSECONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_SSECONFIG;
-    pub(crate) const BUCKET_TAGGING_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_TAGGING_CONFIG;
-    pub(crate) const BUCKET_TARGETS_FILE: &str = crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_TARGETS_FILE;
-    pub(crate) const BUCKET_VERSIONING_CONFIG: &str =
-        crate::app::storage_compat::ecstore_bucket::metadata::BUCKET_VERSIONING_CONFIG;
+    pub(crate) const BUCKET_CORS_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_CORS_CONFIG;
+    pub(crate) const BUCKET_LIFECYCLE_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+    pub(crate) const BUCKET_NOTIFICATION_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_NOTIFICATION_CONFIG;
+    pub(crate) const BUCKET_POLICY_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_POLICY_CONFIG;
+    pub(crate) const BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG;
+    pub(crate) const BUCKET_REPLICATION_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_REPLICATION_CONFIG;
+    pub(crate) const BUCKET_SSECONFIG: &str = super::ecstore_bucket::metadata::BUCKET_SSECONFIG;
+    pub(crate) const BUCKET_TAGGING_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_TAGGING_CONFIG;
+    pub(crate) const BUCKET_TARGETS_FILE: &str = super::ecstore_bucket::metadata::BUCKET_TARGETS_FILE;
+    pub(crate) const BUCKET_VERSIONING_CONFIG: &str = super::ecstore_bucket::metadata::BUCKET_VERSIONING_CONFIG;
     #[cfg(test)]
-    pub(crate) const OBJECT_LOCK_CONFIG: &str = crate::app::storage_compat::ecstore_bucket::metadata::OBJECT_LOCK_CONFIG;
+    pub(crate) const OBJECT_LOCK_CONFIG: &str = super::ecstore_bucket::metadata::OBJECT_LOCK_CONFIG;
 }
 
 pub(crate) mod metadata_sys {
@@ -315,77 +297,77 @@ pub(crate) mod metadata_sys {
     use super::Error;
     use super::target::BucketTargets;
 
-    pub(crate) type BucketMetadataSys = crate::app::storage_compat::ecstore_bucket::metadata_sys::BucketMetadataSys;
+    pub(crate) type BucketMetadataSys = super::ecstore_bucket::metadata_sys::BucketMetadataSys;
 
     #[cfg(test)]
     pub(crate) async fn init_bucket_metadata_sys(api: Arc<ECStore>, buckets: Vec<String>) {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
+        super::ecstore_bucket::metadata_sys::init_bucket_metadata_sys(api, buckets).await;
     }
 
     pub(crate) async fn delete(bucket: &str, config_file: &str) -> Result<OffsetDateTime, Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::delete(bucket, config_file).await
+        super::ecstore_bucket::metadata_sys::delete(bucket, config_file).await
     }
 
     pub(crate) async fn get_bucket_policy(bucket: &str) -> Result<(BucketPolicy, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_bucket_policy(bucket).await
+        super::ecstore_bucket::metadata_sys::get_bucket_policy(bucket).await
     }
 
     pub(crate) async fn get_bucket_policy_raw(bucket: &str) -> Result<(String, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_bucket_policy_raw(bucket).await
+        super::ecstore_bucket::metadata_sys::get_bucket_policy_raw(bucket).await
     }
 
     pub(crate) async fn get_bucket_targets_config(bucket: &str) -> Result<BucketTargets, Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_bucket_targets_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_bucket_targets_config(bucket).await
     }
 
     pub(crate) async fn get_cors_config(bucket: &str) -> Result<(CORSConfiguration, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_cors_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_cors_config(bucket).await
     }
 
     pub(crate) fn get_global_bucket_metadata_sys() -> Option<Arc<RwLock<BucketMetadataSys>>> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_global_bucket_metadata_sys()
+        super::ecstore_bucket::metadata_sys::get_global_bucket_metadata_sys()
     }
 
     pub(crate) async fn get_lifecycle_config(bucket: &str) -> Result<(BucketLifecycleConfiguration, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
     }
 
     pub(crate) async fn get_notification_config(bucket: &str) -> Result<Option<NotificationConfiguration>, Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_notification_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_notification_config(bucket).await
     }
 
     pub(crate) async fn get_object_lock_config(bucket: &str) -> Result<(ObjectLockConfiguration, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
     }
 
     pub(crate) async fn get_public_access_block_config(
         bucket: &str,
     ) -> Result<(PublicAccessBlockConfiguration, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_public_access_block_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_public_access_block_config(bucket).await
     }
 
     pub(crate) async fn get_replication_config(
         bucket: &str,
     ) -> Result<(s3s::dto::ReplicationConfiguration, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_replication_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_replication_config(bucket).await
     }
 
     pub(crate) async fn get_sse_config(bucket: &str) -> Result<(ServerSideEncryptionConfiguration, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_sse_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_sse_config(bucket).await
     }
 
     pub(crate) async fn get_tagging_config(bucket: &str) -> Result<(Tagging, OffsetDateTime), Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::get_tagging_config(bucket).await
+        super::ecstore_bucket::metadata_sys::get_tagging_config(bucket).await
     }
 
     pub(crate) async fn update(bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime, Error> {
-        crate::app::storage_compat::ecstore_bucket::metadata_sys::update(bucket, config_file, data).await
+        super::ecstore_bucket::metadata_sys::update(bucket, config_file, data).await
     }
 }
 
 pub(crate) mod object_api_utils {
     pub(crate) fn to_s3s_etag(etag: &str) -> s3s::dto::ETag {
-        crate::app::storage_compat::ecstore_client::object_api_utils::to_s3s_etag(etag)
+        super::ecstore_client::object_api_utils::to_s3s_etag(etag)
     }
 }
 
@@ -394,28 +376,26 @@ pub(crate) mod object_lock {
         pub(crate) fn get_object_legalhold_meta(
             meta: &std::collections::HashMap<String, String>,
         ) -> s3s::dto::ObjectLockLegalHold {
-            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock::get_object_legalhold_meta(meta)
+            super::super::ecstore_bucket::object_lock::objectlock::get_object_legalhold_meta(meta)
         }
 
         pub(crate) fn get_object_retention_meta(
             meta: &std::collections::HashMap<String, String>,
         ) -> s3s::dto::ObjectLockRetention {
-            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock::get_object_retention_meta(meta)
+            super::super::ecstore_bucket::object_lock::objectlock::get_object_retention_meta(meta)
         }
     }
 
     pub(crate) mod objectlock_sys {
-        pub(crate) type BucketObjectLockSys =
-            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::BucketObjectLockSys;
-        pub(crate) type ObjectLockBlockReason =
-            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::ObjectLockBlockReason;
+        pub(crate) type BucketObjectLockSys = super::super::ecstore_bucket::object_lock::objectlock_sys::BucketObjectLockSys;
+        pub(crate) type ObjectLockBlockReason = super::super::ecstore_bucket::object_lock::objectlock_sys::ObjectLockBlockReason;
 
         pub(crate) async fn check_object_lock_for_deletion(
             bucket: &str,
             obj_info: &super::super::ObjectInfo,
             bypass_governance: bool,
         ) -> Option<ObjectLockBlockReason> {
-            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::check_object_lock_for_deletion(
+            super::super::ecstore_bucket::object_lock::objectlock_sys::check_object_lock_for_deletion(
                 bucket,
                 obj_info,
                 bypass_governance,
@@ -424,31 +404,30 @@ pub(crate) mod object_lock {
         }
 
         pub(crate) fn is_retention_active(mode: &str, retain_until_date: Option<&s3s::dto::Date>) -> bool {
-            crate::app::storage_compat::ecstore_bucket::object_lock::objectlock_sys::is_retention_active(mode, retain_until_date)
+            super::super::ecstore_bucket::object_lock::objectlock_sys::is_retention_active(mode, retain_until_date)
         }
     }
 }
 
 pub(crate) mod policy_sys {
-    pub(crate) type PolicySys = crate::app::storage_compat::ecstore_bucket::policy_sys::PolicySys;
+    pub(crate) type PolicySys = super::ecstore_bucket::policy_sys::PolicySys;
 }
 
 pub(crate) mod quota {
     pub(crate) mod checker {
-        pub(crate) type QuotaChecker = crate::app::storage_compat::ecstore_bucket::quota::checker::QuotaChecker;
+        pub(crate) type QuotaChecker = super::super::ecstore_bucket::quota::checker::QuotaChecker;
     }
 
-    pub(crate) type QuotaOperation = crate::app::storage_compat::ecstore_bucket::quota::QuotaOperation;
+    pub(crate) type QuotaOperation = super::ecstore_bucket::quota::QuotaOperation;
 }
 
 pub(crate) mod replication {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    pub(crate) type DeletedObjectReplicationInfo =
-        crate::app::storage_compat::ecstore_bucket::replication::DeletedObjectReplicationInfo;
-    pub(crate) type MustReplicateOptions = crate::app::storage_compat::ecstore_bucket::replication::MustReplicateOptions;
-    pub(crate) type ObjectOpts = crate::app::storage_compat::ecstore_bucket::replication::ObjectOpts;
+    pub(crate) type DeletedObjectReplicationInfo = super::ecstore_bucket::replication::DeletedObjectReplicationInfo;
+    pub(crate) type MustReplicateOptions = super::ecstore_bucket::replication::MustReplicateOptions;
+    pub(crate) type ObjectOpts = super::ecstore_bucket::replication::ObjectOpts;
     pub(crate) type ReplicateDecision = rustfs_filemeta::ReplicateDecision;
 
     pub(crate) async fn check_replicate_delete(
@@ -458,7 +437,7 @@ pub(crate) mod replication {
         del_opts: &super::ObjectOptions,
         gerr: Option<String>,
     ) -> ReplicateDecision {
-        crate::app::storage_compat::ecstore_bucket::replication::check_replicate_delete(bucket, dobj, oi, del_opts, gerr).await
+        super::ecstore_bucket::replication::check_replicate_delete(bucket, dobj, oi, del_opts, gerr).await
     }
 
     pub(crate) fn get_must_replicate_options(
@@ -468,17 +447,11 @@ pub(crate) mod replication {
         op_type: rustfs_filemeta::ReplicationType,
         opts: super::ObjectOptions,
     ) -> MustReplicateOptions {
-        crate::app::storage_compat::ecstore_bucket::replication::get_must_replicate_options(
-            user_defined,
-            user_tags,
-            status,
-            op_type,
-            opts,
-        )
+        super::ecstore_bucket::replication::get_must_replicate_options(user_defined, user_tags, status, op_type, opts)
     }
 
     pub(crate) async fn must_replicate(bucket: &str, object: &str, mopts: MustReplicateOptions) -> ReplicateDecision {
-        crate::app::storage_compat::ecstore_bucket::replication::must_replicate(bucket, object, mopts).await
+        super::ecstore_bucket::replication::must_replicate(bucket, object, mopts).await
     }
 
     pub(crate) async fn schedule_replication(
@@ -487,101 +460,95 @@ pub(crate) mod replication {
         dsc: ReplicateDecision,
         op_type: rustfs_filemeta::ReplicationType,
     ) {
-        crate::app::storage_compat::ecstore_bucket::replication::schedule_replication(oi, store, dsc, op_type).await;
+        super::ecstore_bucket::replication::schedule_replication(oi, store, dsc, op_type).await;
     }
 
     pub(crate) async fn schedule_replication_delete(dv: DeletedObjectReplicationInfo) {
-        crate::app::storage_compat::ecstore_bucket::replication::schedule_replication_delete(dv).await;
+        super::ecstore_bucket::replication::schedule_replication_delete(dv).await;
     }
 }
 
 pub(crate) mod tagging {
     pub(crate) fn decode_tags(tags: &str) -> Vec<s3s::dto::Tag> {
-        crate::app::storage_compat::ecstore_bucket::tagging::decode_tags(tags)
+        super::ecstore_bucket::tagging::decode_tags(tags)
     }
 }
 
 pub(crate) mod target {
     #[cfg(test)]
-    pub(crate) type BucketTarget = crate::app::storage_compat::ecstore_bucket::target::BucketTarget;
-    pub(crate) type BucketTargetType = crate::app::storage_compat::ecstore_bucket::target::BucketTargetType;
-    pub(crate) type BucketTargets = crate::app::storage_compat::ecstore_bucket::target::BucketTargets;
+    pub(crate) type BucketTarget = super::ecstore_bucket::target::BucketTarget;
+    pub(crate) type BucketTargetType = super::ecstore_bucket::target::BucketTargetType;
+    pub(crate) type BucketTargets = super::ecstore_bucket::target::BucketTargets;
 }
 
 pub(crate) mod utils {
     pub(crate) fn serialize<T: s3s::xml::Serialize>(val: &T) -> s3s::xml::SerResult<Vec<u8>> {
-        crate::app::storage_compat::ecstore_bucket::utils::serialize(val)
+        super::ecstore_bucket::utils::serialize(val)
     }
 }
 
 pub(crate) mod versioning {}
 
 pub(crate) mod versioning_sys {
-    pub(crate) type BucketVersioningSys = crate::app::storage_compat::ecstore_bucket::versioning_sys::BucketVersioningSys;
+    pub(crate) type BucketVersioningSys = super::ecstore_bucket::versioning_sys::BucketVersioningSys;
 }
 
 #[cfg(test)]
 pub(crate) mod transition_api {
-    pub(crate) type ReadCloser = crate::app::storage_compat::ecstore_client::transition_api::ReadCloser;
-    pub(crate) type ReaderImpl = crate::app::storage_compat::ecstore_client::transition_api::ReaderImpl;
+    pub(crate) type ReadCloser = super::ecstore_client::transition_api::ReadCloser;
+    pub(crate) type ReaderImpl = super::ecstore_client::transition_api::ReaderImpl;
 }
 
 pub(crate) mod storageclass {
-    pub(crate) const STANDARD: &str = crate::app::storage_compat::ecstore_config::storageclass::STANDARD;
+    pub(crate) const STANDARD: &str = super::ecstore_config::storageclass::STANDARD;
     #[cfg(test)]
-    pub(crate) const STANDARD_IA: &str = crate::app::storage_compat::ecstore_config::storageclass::STANDARD_IA;
+    pub(crate) const STANDARD_IA: &str = super::ecstore_config::storageclass::STANDARD_IA;
 }
 
 pub(crate) fn get_total_usable_capacity(disks: &[rustfs_madmin::Disk], info: &rustfs_madmin::StorageInfo) -> usize {
-    crate::app::storage_compat::ecstore_capacity::get_total_usable_capacity(disks, info)
+    ecstore_capacity::get_total_usable_capacity(disks, info)
 }
 
 pub(crate) fn get_total_usable_capacity_free(disks: &[rustfs_madmin::Disk], info: &rustfs_madmin::StorageInfo) -> usize {
-    crate::app::storage_compat::ecstore_capacity::get_total_usable_capacity_free(disks, info)
+    ecstore_capacity::get_total_usable_capacity_free(disks, info)
 }
 
 pub(crate) fn is_disk_compressible(headers: &http::HeaderMap, object_name: &str) -> bool {
-    crate::app::storage_compat::ecstore_compression::is_disk_compressible(headers, object_name)
+    ecstore_compression::is_disk_compressible(headers, object_name)
 }
 
 pub(crate) async fn apply_bucket_usage_memory_overlay(data_usage_info: &mut rustfs_data_usage::DataUsageInfo) {
-    crate::app::storage_compat::ecstore_data_usage::apply_bucket_usage_memory_overlay(data_usage_info).await;
+    ecstore_data_usage::apply_bucket_usage_memory_overlay(data_usage_info).await;
 }
 
 pub(crate) async fn load_data_usage_from_backend(
     store: Arc<ECStore>,
 ) -> std::result::Result<rustfs_data_usage::DataUsageInfo, Error> {
-    crate::app::storage_compat::ecstore_data_usage::load_data_usage_from_backend(store).await
+    ecstore_data_usage::load_data_usage_from_backend(store).await
 }
 
 pub(crate) async fn record_bucket_object_delete_memory(bucket: &str, deleted_size: u64, removed_current_object: bool) {
-    crate::app::storage_compat::ecstore_data_usage::record_bucket_object_delete_memory(
-        bucket,
-        deleted_size,
-        removed_current_object,
-    )
-    .await;
+    ecstore_data_usage::record_bucket_object_delete_memory(bucket, deleted_size, removed_current_object).await;
 }
 
 pub(crate) async fn record_bucket_object_write_memory(bucket: &str, previous_current_size: Option<u64>, new_size: u64) {
-    crate::app::storage_compat::ecstore_data_usage::record_bucket_object_write_memory(bucket, previous_current_size, new_size)
-        .await;
+    ecstore_data_usage::record_bucket_object_write_memory(bucket, previous_current_size, new_size).await;
 }
 
 pub(crate) fn is_all_buckets_not_found(errs: &[Option<DiskError>]) -> bool {
-    crate::app::storage_compat::ecstore_disk::error_reduce::is_all_buckets_not_found(errs)
+    ecstore_disk::error_reduce::is_all_buckets_not_found(errs)
 }
 
 pub(crate) fn is_err_bucket_not_found(err: &Error) -> bool {
-    crate::app::storage_compat::ecstore_error::is_err_bucket_not_found(err)
+    ecstore_error::is_err_bucket_not_found(err)
 }
 
 pub(crate) fn is_err_object_not_found(err: &Error) -> bool {
-    crate::app::storage_compat::ecstore_error::is_err_object_not_found(err)
+    ecstore_error::is_err_object_not_found(err)
 }
 
 pub(crate) fn is_err_version_not_found(err: &Error) -> bool {
-    crate::app::storage_compat::ecstore_error::is_err_version_not_found(err)
+    ecstore_error::is_err_version_not_found(err)
 }
 
 #[cfg(test)]
@@ -596,62 +563,62 @@ impl std::ops::Deref for GlobalTierConfigMgrCompat {
     type Target = Arc<tokio::sync::RwLock<TierConfigMgr>>;
 
     fn deref(&self) -> &Self::Target {
-        &crate::app::storage_compat::ecstore_global::GLOBAL_TierConfigMgr
+        &ecstore_global::GLOBAL_TierConfigMgr
     }
 }
 
 pub(crate) fn get_global_endpoints_opt() -> Option<EndpointServerPools> {
-    crate::app::storage_compat::ecstore_global::get_global_endpoints_opt()
+    ecstore_global::get_global_endpoints_opt()
 }
 
 pub(crate) fn get_global_region() -> Option<s3s::region::Region> {
-    crate::app::storage_compat::ecstore_global::get_global_region()
+    ecstore_global::get_global_region()
 }
 
 pub(crate) fn get_global_tier_config_mgr() -> Arc<tokio::sync::RwLock<TierConfigMgr>> {
-    crate::app::storage_compat::ecstore_global::get_global_tier_config_mgr()
+    ecstore_global::get_global_tier_config_mgr()
 }
 
 pub(crate) fn new_object_layer_fn() -> Option<Arc<ECStore>> {
-    crate::app::storage_compat::ecstore_global::new_object_layer_fn()
+    ecstore_global::new_object_layer_fn()
 }
 
 pub(crate) fn set_object_store_resolver(resolver: Arc<ObjectStoreResolver>) -> bool {
-    crate::app::storage_compat::ecstore_global::set_object_store_resolver(resolver)
+    ecstore_global::set_object_store_resolver(resolver)
 }
 
 pub(crate) fn get_global_notification_sys() -> Option<&'static NotificationSys> {
-    crate::app::storage_compat::ecstore_notification::get_global_notification_sys()
+    ecstore_notification::get_global_notification_sys()
 }
 
 #[cfg(test)]
 pub(crate) fn boxed_reader<R>(reader: R) -> DynReader
 where
-    R: crate::app::storage_compat::ecstore_rio::Reader + 'static,
+    R: ecstore_rio::Reader + 'static,
 {
-    crate::app::storage_compat::ecstore_rio::boxed_reader(reader)
+    ecstore_rio::boxed_reader(reader)
 }
 
 pub(crate) fn compression_metadata_value(algorithm: rustfs_utils::CompressionAlgorithm) -> String {
-    crate::app::storage_compat::ecstore_rio::compression_metadata_value(algorithm)
+    ecstore_rio::compression_metadata_value(algorithm)
 }
 
 pub(crate) fn wrap_reader<R>(reader: R) -> DynReader
 where
-    R: crate::app::storage_compat::ecstore_rio::ReadStream + 'static,
+    R: ecstore_rio::ReadStream + 'static,
 {
-    crate::app::storage_compat::ecstore_rio::wrap_reader(reader)
+    ecstore_rio::wrap_reader(reader)
 }
 
 pub(crate) fn get_lock_acquire_timeout() -> tokio::time::Duration {
-    crate::app::storage_compat::ecstore_set_disk::get_lock_acquire_timeout()
+    ecstore_set_disk::get_lock_acquire_timeout()
 }
 
 pub(crate) fn is_valid_storage_class(storage_class: &str) -> bool {
-    crate::app::storage_compat::ecstore_set_disk::is_valid_storage_class(storage_class)
+    ecstore_set_disk::is_valid_storage_class(storage_class)
 }
 
 #[cfg(test)]
 pub(crate) async fn init_local_disks(endpoint_pools: EndpointServerPools) -> Result<(), Error> {
-    crate::app::storage_compat::ecstore_storage::init_local_disks(endpoint_pools).await
+    ecstore_storage::init_local_disks(endpoint_pools).await
 }

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -97,6 +97,7 @@ OUTER_CONSUMER_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/outer_consumer_compa
 RUSTFS_ROOT_E2E_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_root_e2e_compat_raw_facade_path_hits.txt"
 ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_raw_facade_path_hits.txt"
 ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE="${TMP_DIR}/all_storage_compat_grouped_facade_import_hits.txt"
+ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -1022,6 +1023,17 @@ fi
 
 if [[ -s "$ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE" ]]; then
   report_failure "storage compatibility boundaries must import ECStore facade modules through explicit per-module ecstore_* aliases: $(paste -sd '; ' "$ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::(?:admin|app|storage)::storage_compat::ecstore_|crate::storage_compat::ecstore_' rustfs/src crates fuzz \
+    --glob '*storage_compat.rs' \
+    --glob '*_compat.rs' || true
+) >"$ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE"
+
+if [[ -s "$ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE" ]]; then
+  report_failure "storage compatibility boundaries must reference local ECStore facade aliases directly or through super::, not crate-qualified storage_compat self paths: $(paste -sd '; ' "$ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Replace crate-qualified app/admin `storage_compat::ecstore_*` self references with local `ecstore_*` aliases and scoped `super::` paths.
- Add a migration guard that rejects crate-qualified ECStore facade self paths in storage compatibility boundaries.
- Record API-107 progress and the pre-push review log.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `git diff --check`
- Storage compatibility self-reference residual scan
- Rust risk scan
- `cargo check -p rustfs --tests`
- `make pre-commit`

## Impact
No runtime behavior change expected. This keeps app/admin storage compatibility boundaries referencing local ECStore facade aliases directly.

## Additional Notes
N/A
