### PR TITLE
refactor: use relative local compat paths

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-compat-local-facade-self-refs`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107`.
-- Based on: API-106 slice.
+- Branch: `overtrue/arch-local-compat-relative-refs`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108`.
+- Based on: API-107 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: collapse crate-qualified ECStore facade self references in
-  RustFS app/admin compatibility boundaries into local `ecstore_*` and
-  `super::ecstore_*` paths.
-- CI/script changes: guard storage compatibility boundaries against
-  crate-qualified `storage_compat::ecstore_*` self paths.
-- Docs changes: record the API-107 local facade self-reference cleanup.
+- Rust code changes: collapse crate-qualified owner `storage_compat` paths in
+  RustFS app/admin/storage local compatibility bridge modules into relative
+  `super::storage_compat` paths.
+- CI/script changes: guard RustFS local compatibility bridge modules against
+  crate-qualified owner `storage_compat` self paths.
+- Docs changes: record the API-108 local compatibility relative path cleanup.
 
 ## Phase 0 Tasks
 
@@ -531,6 +531,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     behavior, public local compatibility names, and ECStore facade ownership.
   - Verification: RustFS test-target compile coverage, local facade
     self-reference residual scan, migration and layer guards, formatting, diff
+    hygiene, Rust risk scan, pre-commit quality gate, and three-expert review.
+- [x] `API-108` Collapse local compatibility bridge self paths.
+  - Completed slice: replace crate-qualified app/admin/storage
+    `storage_compat` references in local compatibility bridge modules with
+    relative `super::storage_compat` paths.
+  - Acceptance: RustFS local compatibility bridge modules no longer point back
+    to their owner `storage_compat` facades through crate-qualified paths;
+    migration rules reject regressions.
+  - Must preserve: all app usecase/context, admin router/handler/service, and
+    storage core/RPC compatibility re-export names and owner facade behavior.
+  - Verification: RustFS test-target compile coverage, local bridge owner
+    self-path residual scan, migration and layer guards, formatting, diff
     hygiene, Rust risk scan, pre-commit quality gate, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
@@ -3565,13 +3577,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-107 keeps app/admin compatibility wrappers local by replacing crate-qualified self references with direct `ecstore_*` aliases and scoped `super::` paths. |
-| Migration preservation | pass | The new guard rejects crate-qualified `storage_compat::ecstore_*` self paths while preserving existing wrapper names and ECStore facade ownership. |
-| Testing/verification | pass | Focused compile, self-reference residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-108 keeps local compatibility bridge modules owner-relative by replacing crate-qualified app/admin/storage `storage_compat` paths with scoped `super::` paths. |
+| Migration preservation | pass | The new guard rejects crate-qualified owner `storage_compat` self paths in RustFS local bridge modules while preserving existing re-export names. |
+| Testing/verification | pass | Focused compile, local bridge owner self-path residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-108 current slice:
+  - `cargo check -p rustfs --tests`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Full RustFS local bridge owner self-path residual scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-107 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/rustfs/src/admin/handlers/storage_compat.rs
+++ b/rustfs/src/admin/handlers/storage_compat.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::admin::storage_compat::{
+pub(crate) use super::super::storage_compat::{
     AdminError, AdminReplicationConfigExt, AdminVersioningConfigExt, CollectMetricsOpts, DailyAllTierStats, DiskStat, ECStore,
     ERR_TIER_ALREADY_EXISTS, ERR_TIER_BACKEND_IN_USE, ERR_TIER_BACKEND_NOT_EMPTY, ERR_TIER_CONNECT_ERR,
     ERR_TIER_INVALID_CREDENTIALS, ERR_TIER_MISSING_CREDENTIALS, ERR_TIER_NAME_NOT_UPPERCASE, ERR_TIER_NOT_FOUND,
@@ -24,25 +24,25 @@ pub(crate) use crate::admin::storage_compat::{
 };
 
 #[cfg(test)]
-pub(crate) use crate::admin::storage_compat::{Endpoint, Endpoints, PoolEndpoints, RebalStatus, RebalanceInfo};
+pub(crate) use super::super::storage_compat::{Endpoint, Endpoints, PoolEndpoints, RebalStatus, RebalanceInfo};
 
 pub(crate) mod bucket_target_sys {
-    pub(crate) use crate::admin::storage_compat::bucket_target_sys::{BucketTargetError, BucketTargetSys};
+    pub(crate) use super::super::super::storage_compat::bucket_target_sys::{BucketTargetError, BucketTargetSys};
 }
 
 pub(crate) mod lifecycle {
     pub(crate) mod bucket_lifecycle_ops {
-        pub(crate) use crate::admin::storage_compat::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
+        pub(crate) use super::super::super::super::storage_compat::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
     }
 
     pub(crate) mod tier_last_day_stats {
         #[cfg(test)]
-        pub(crate) use crate::admin::storage_compat::lifecycle::tier_last_day_stats::LastDayTierStats;
+        pub(crate) use super::super::super::super::storage_compat::lifecycle::tier_last_day_stats::LastDayTierStats;
     }
 }
 
 pub(crate) mod metadata {
-    pub(crate) use crate::admin::storage_compat::metadata::{
+    pub(crate) use super::super::super::storage_compat::metadata::{
         BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE,
         BUCKET_REPLICATION_CONFIG, BUCKET_SSECONFIG, BUCKET_TAGGING_CONFIG, BUCKET_TARGETS_FILE, BUCKET_VERSIONING_CONFIG,
         BucketMetadata, OBJECT_LOCK_CONFIG, table_catalog_path_hash,
@@ -50,7 +50,7 @@ pub(crate) mod metadata {
 }
 
 pub(crate) mod metadata_sys {
-    pub(crate) use crate::admin::storage_compat::metadata_sys::{
+    pub(crate) use super::super::super::storage_compat::metadata_sys::{
         BucketMetadataSys, delete, get, get_bucket_policy, get_bucket_targets_config, get_config_from_disk, get_lifecycle_config,
         get_notification_config, get_object_lock_config, get_quota_config, get_replication_config, get_sse_config,
         get_tagging_config, get_versioning_config, list_bucket_targets, update,
@@ -58,33 +58,35 @@ pub(crate) mod metadata_sys {
 }
 
 pub(crate) mod quota {
-    pub(crate) use crate::admin::storage_compat::quota::{BucketQuota, QuotaError, QuotaOperation};
+    pub(crate) use super::super::super::storage_compat::quota::{BucketQuota, QuotaError, QuotaOperation};
 
     pub(crate) mod checker {
-        pub(crate) use crate::admin::storage_compat::quota::checker::QuotaChecker;
+        pub(crate) use super::super::super::super::storage_compat::quota::checker::QuotaChecker;
     }
 }
 
 pub(crate) mod replication {
-    pub(crate) use crate::admin::storage_compat::replication::{
+    pub(crate) use super::super::super::storage_compat::replication::{
         BucketStats, GLOBAL_REPLICATION_STATS, ResyncOpts, get_global_replication_pool,
     };
 }
 
 pub(crate) mod storageclass {
-    pub(crate) use crate::admin::storage_compat::storageclass::{
+    pub(crate) use super::super::super::storage_compat::storageclass::{
         INLINE_BLOCK_ENV, OPTIMIZE_ENV, RRS, RRS_ENV, STANDARD, STANDARD_ENV,
     };
 }
 
 pub(crate) mod target {
-    pub(crate) use crate::admin::storage_compat::target::{ARN, BucketTarget, BucketTargetType, BucketTargets, Credentials};
+    pub(crate) use super::super::super::storage_compat::target::{
+        ARN, BucketTarget, BucketTargetType, BucketTargets, Credentials,
+    };
 }
 
 pub(crate) mod utils {
-    pub(crate) use crate::admin::storage_compat::utils::{deserialize, is_valid_object_prefix, serialize};
+    pub(crate) use super::super::super::storage_compat::utils::{deserialize, is_valid_object_prefix, serialize};
 }
 
 pub(crate) mod versioning_sys {
-    pub(crate) use crate::admin::storage_compat::versioning_sys::BucketVersioningSys;
+    pub(crate) use super::super::super::storage_compat::versioning_sys::BucketVersioningSys;
 }

--- a/rustfs/src/admin/router_storage_compat.rs
+++ b/rustfs/src/admin/router_storage_compat.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::admin::storage_compat::{
+pub(crate) use super::storage_compat::{
     AdminReplicationConfigExt, AdminVersioningConfigExt, GLOBAL_BOOT_TIME, PeerRestClient, StorageError,
     get_global_bucket_monitor, get_global_deployment_id, get_global_notification_sys, get_global_region,
     read_admin_config_without_migrate,
@@ -20,35 +20,35 @@ pub(crate) use crate::admin::storage_compat::{
 
 pub(crate) mod bandwidth {
     pub(crate) mod monitor {
-        pub(crate) use crate::admin::storage_compat::bandwidth::monitor::BandwidthDetails;
+        pub(crate) use super::super::super::storage_compat::bandwidth::monitor::BandwidthDetails;
     }
 }
 
 pub(crate) mod bucket_target_sys {
-    pub(crate) use crate::admin::storage_compat::bucket_target_sys::{
+    pub(crate) use super::super::storage_compat::bucket_target_sys::{
         AdvancedPutOptions, BucketTargetSys, PutObjectOptions, RemoveObjectOptions, S3ClientError, TargetClient,
     };
 }
 
 pub(crate) mod metadata {
-    pub(crate) use crate::admin::storage_compat::metadata::BUCKET_TARGETS_FILE;
+    pub(crate) use super::super::storage_compat::metadata::BUCKET_TARGETS_FILE;
 }
 
-pub(crate) use crate::admin::storage_compat::metadata_sys;
+pub(crate) use super::storage_compat::metadata_sys;
 
 pub(crate) mod replication {
-    pub(crate) use crate::admin::storage_compat::replication::{
+    pub(crate) use super::super::storage_compat::replication::{
         BucketReplicationResyncStatus, BucketStats, GLOBAL_REPLICATION_STATS, ObjectOpts, ResyncOpts, get_global_replication_pool,
     };
 
     #[cfg(test)]
-    pub(crate) use crate::admin::storage_compat::replication::{ResyncStatusType, TargetReplicationResyncStatus};
+    pub(crate) use super::super::storage_compat::replication::{ResyncStatusType, TargetReplicationResyncStatus};
 }
 
 pub(crate) mod target {
-    pub(crate) use crate::admin::storage_compat::target::{BucketTarget, BucketTargetType, BucketTargets};
+    pub(crate) use super::super::storage_compat::target::{BucketTarget, BucketTargetType, BucketTargets};
 }
 
 pub(crate) mod versioning_sys {
-    pub(crate) use crate::admin::storage_compat::versioning_sys::BucketVersioningSys;
+    pub(crate) use super::super::storage_compat::versioning_sys::BucketVersioningSys;
 }

--- a/rustfs/src/admin/service/storage_compat.rs
+++ b/rustfs/src/admin/service/storage_compat.rs
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::admin::storage_compat::{
+pub(crate) use super::super::storage_compat::{
     Error, STORAGE_CLASS_SUB_SYS, get_global_notification_sys, read_admin_config, read_admin_config_without_migrate,
     save_admin_config, set_global_storage_class,
 };
 
 #[cfg(test)]
-pub(crate) use crate::admin::storage_compat::init_admin_config_defaults;
+pub(crate) use super::super::storage_compat::init_admin_config_defaults;
 
 #[cfg(test)]
 pub(crate) mod metadata {
-    pub(crate) use crate::admin::storage_compat::metadata::{BUCKET_LIFECYCLE_CONFIG, BUCKET_REPLICATION_CONFIG};
+    pub(crate) use super::super::super::storage_compat::metadata::{BUCKET_LIFECYCLE_CONFIG, BUCKET_REPLICATION_CONFIG};
 }
 
 pub(crate) mod storageclass {
-    pub(crate) use crate::admin::storage_compat::storageclass::lookup_config;
+    pub(crate) use super::super::super::storage_compat::storageclass::lookup_config;
 }

--- a/rustfs/src/app/context/storage_compat.rs
+++ b/rustfs/src/app/context/storage_compat.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::app::storage_compat::{
+pub(crate) use super::super::storage_compat::{
     ECStore, EndpointServerPools, TierConfigMgr, get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr,
     new_object_layer_fn, set_object_store_resolver,
 };
 
 pub(crate) mod metadata_sys {
-    pub(crate) use crate::app::storage_compat::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys};
+    pub(crate) use super::super::super::storage_compat::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys};
 }
 
 #[cfg(test)]
-pub(crate) use crate::app::storage_compat::{Endpoint, Endpoints, PoolEndpoints, init_local_disks};
+pub(crate) use super::super::storage_compat::{Endpoint, Endpoints, PoolEndpoints, init_local_disks};

--- a/rustfs/src/app/usecase_storage_compat.rs
+++ b/rustfs/src/app/usecase_storage_compat.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::app::storage_compat::{
+pub(crate) use super::storage_compat::{
     AppObjectLockConfigExt, AppReplicationConfigExt, AppVersioningConfigExt, DiskError, DynReader, ECStore, EndpointServerPools,
     Error, HashReader, MIN_DISK_COMPRESSIBLE_SIZE, PoolDecommissionInfo, PoolStatus, StorageError, WriteEncryption, WritePlan,
     apply_bucket_usage_memory_overlay, compression_metadata_value, get_global_notification_sys, get_lock_acquire_timeout,
@@ -23,137 +23,137 @@ pub(crate) use crate::app::storage_compat::{
 };
 
 #[cfg(test)]
-pub(crate) use crate::app::storage_compat::{
+pub(crate) use super::storage_compat::{
     AppWarmBackend, DecryptReader, EncryptReader, Endpoint, Endpoints, GLOBAL_TierConfigMgr, HardLimitReader, PoolEndpoints,
     TierConfig, TierType, WarmBackendGetOpts, boxed_reader, init_local_disks,
 };
 
 pub(crate) mod bucket_target_sys {
-    pub(crate) use crate::app::storage_compat::bucket_target_sys::BucketTargetSys;
+    pub(crate) use super::super::storage_compat::bucket_target_sys::BucketTargetSys;
 }
 
 pub(crate) mod lifecycle {
     pub(crate) mod bucket_lifecycle_audit {
-        pub(crate) use crate::app::storage_compat::lifecycle::bucket_lifecycle_audit::LcEventSrc;
+        pub(crate) use super::super::super::storage_compat::lifecycle::bucket_lifecycle_audit::LcEventSrc;
     }
 
     pub(crate) mod bucket_lifecycle_ops {
-        pub(crate) use crate::app::storage_compat::lifecycle::bucket_lifecycle_ops::{
+        pub(crate) use super::super::super::storage_compat::lifecycle::bucket_lifecycle_ops::{
             GLOBAL_ExpiryState, enqueue_expiry_for_existing_objects, enqueue_transition_for_existing_objects,
             enqueue_transition_immediate, post_restore_opts, validate_lifecycle_config, validate_transition_tier,
         };
 
         #[cfg(test)]
-        pub(crate) use crate::app::storage_compat::lifecycle::bucket_lifecycle_ops::init_background_expiry;
+        pub(crate) use super::super::super::storage_compat::lifecycle::bucket_lifecycle_ops::init_background_expiry;
     }
 
     pub(crate) mod lifecycle_contract {
-        pub(crate) use crate::app::storage_compat::lifecycle::lifecycle::{
+        pub(crate) use super::super::super::storage_compat::lifecycle::lifecycle::{
             Event, ObjectOpts, TRANSITION_COMPLETE, TransitionOptions, expected_expiry_time,
         };
 
         #[cfg(test)]
-        pub(crate) use crate::app::storage_compat::lifecycle::lifecycle::IlmAction;
+        pub(crate) use super::super::super::storage_compat::lifecycle::lifecycle::IlmAction;
     }
     pub(crate) use lifecycle_contract as lifecycle;
 
     pub(crate) mod tier_delete_journal {
-        pub(crate) use crate::app::storage_compat::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry;
+        pub(crate) use super::super::super::storage_compat::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry;
     }
 
     pub(crate) mod tier_sweeper {
-        pub(crate) use crate::app::storage_compat::lifecycle::tier_sweeper::{
+        pub(crate) use super::super::super::storage_compat::lifecycle::tier_sweeper::{
             transitioned_delete_journal_entry, transitioned_force_delete_journal_entry,
         };
     }
 }
 
 pub(crate) mod metadata {
-    pub(crate) use crate::app::storage_compat::metadata::{
+    pub(crate) use super::super::storage_compat::metadata::{
         BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG,
         BUCKET_PUBLIC_ACCESS_BLOCK_CONFIG, BUCKET_REPLICATION_CONFIG, BUCKET_SSECONFIG, BUCKET_TAGGING_CONFIG,
         BUCKET_TARGETS_FILE, BUCKET_VERSIONING_CONFIG,
     };
 
     #[cfg(test)]
-    pub(crate) use crate::app::storage_compat::metadata::OBJECT_LOCK_CONFIG;
+    pub(crate) use super::super::storage_compat::metadata::OBJECT_LOCK_CONFIG;
 }
 
 pub(crate) mod metadata_sys {
-    pub(crate) use crate::app::storage_compat::metadata_sys::{
+    pub(crate) use super::super::storage_compat::metadata_sys::{
         BucketMetadataSys, delete, get_bucket_policy, get_bucket_policy_raw, get_bucket_targets_config, get_cors_config,
         get_lifecycle_config, get_notification_config, get_object_lock_config, get_public_access_block_config,
         get_replication_config, get_sse_config, get_tagging_config, update,
     };
 
     #[cfg(test)]
-    pub(crate) use crate::app::storage_compat::metadata_sys::init_bucket_metadata_sys;
+    pub(crate) use super::super::storage_compat::metadata_sys::init_bucket_metadata_sys;
 }
 
 pub(crate) mod object_api_utils {
-    pub(crate) use crate::app::storage_compat::object_api_utils::to_s3s_etag;
+    pub(crate) use super::super::storage_compat::object_api_utils::to_s3s_etag;
 }
 
 pub(crate) mod object_lock {
     pub(crate) mod objectlock {
-        pub(crate) use crate::app::storage_compat::object_lock::objectlock::{
+        pub(crate) use super::super::super::storage_compat::object_lock::objectlock::{
             get_object_legalhold_meta, get_object_retention_meta,
         };
     }
 
     pub(crate) mod objectlock_sys {
-        pub(crate) use crate::app::storage_compat::object_lock::objectlock_sys::{
+        pub(crate) use super::super::super::storage_compat::object_lock::objectlock_sys::{
             BucketObjectLockSys, check_object_lock_for_deletion, is_retention_active,
         };
     }
 }
 
 pub(crate) mod policy_sys {
-    pub(crate) use crate::app::storage_compat::policy_sys::PolicySys;
+    pub(crate) use super::super::storage_compat::policy_sys::PolicySys;
 }
 
 pub(crate) mod quota {
-    pub(crate) use crate::app::storage_compat::quota::QuotaOperation;
+    pub(crate) use super::super::storage_compat::quota::QuotaOperation;
 
     pub(crate) mod checker {
-        pub(crate) use crate::app::storage_compat::quota::checker::QuotaChecker;
+        pub(crate) use super::super::super::storage_compat::quota::checker::QuotaChecker;
     }
 }
 
 pub(crate) mod replication {
-    pub(crate) use crate::app::storage_compat::replication::{
+    pub(crate) use super::super::storage_compat::replication::{
         DeletedObjectReplicationInfo, ObjectOpts, check_replicate_delete, get_must_replicate_options, must_replicate,
         schedule_replication, schedule_replication_delete,
     };
 }
 
 pub(crate) mod storageclass {
-    pub(crate) use crate::app::storage_compat::storageclass::STANDARD;
+    pub(crate) use super::super::storage_compat::storageclass::STANDARD;
 
     #[cfg(test)]
-    pub(crate) use crate::app::storage_compat::storageclass::STANDARD_IA;
+    pub(crate) use super::super::storage_compat::storageclass::STANDARD_IA;
 }
 
 pub(crate) mod tagging {
-    pub(crate) use crate::app::storage_compat::tagging::decode_tags;
+    pub(crate) use super::super::storage_compat::tagging::decode_tags;
 }
 
 pub(crate) mod target {
-    pub(crate) use crate::app::storage_compat::target::{BucketTargetType, BucketTargets};
+    pub(crate) use super::super::storage_compat::target::{BucketTargetType, BucketTargets};
 
     #[cfg(test)]
-    pub(crate) use crate::app::storage_compat::target::BucketTarget;
+    pub(crate) use super::super::storage_compat::target::BucketTarget;
 }
 
 #[cfg(test)]
 pub(crate) mod transition_api {
-    pub(crate) use crate::app::storage_compat::transition_api::{ReadCloser, ReaderImpl};
+    pub(crate) use super::super::storage_compat::transition_api::{ReadCloser, ReaderImpl};
 }
 
 pub(crate) mod utils {
-    pub(crate) use crate::app::storage_compat::utils::serialize;
+    pub(crate) use super::super::storage_compat::utils::serialize;
 }
 
 pub(crate) mod versioning_sys {
-    pub(crate) use crate::app::storage_compat::versioning_sys::BucketVersioningSys;
+    pub(crate) use super::super::storage_compat::versioning_sys::BucketVersioningSys;
 }

--- a/rustfs/src/storage/core_storage_compat.rs
+++ b/rustfs/src/storage/core_storage_compat.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::storage::storage_compat::{
+pub(crate) use super::storage_compat::{
     BUCKET_ACCELERATE_CONFIG, BUCKET_LOGGING_CONFIG, BUCKET_REQUEST_PAYMENT_CONFIG, BUCKET_VERSIONING_CONFIG,
     BUCKET_WEBSITE_CONFIG, BucketVersioningSys, ECStore, Error, GetObjectReader, OBJECT_LOCK_CONFIG, ObjectInfo, ObjectOptions,
     PolicySys, PutObjReader, Result, StorageError, StorageReplicationConfigExt, StorageVersioningConfigExt, WriteEncryption,
@@ -25,7 +25,7 @@ pub(crate) use crate::storage::storage_compat::{
 };
 
 #[cfg(test)]
-pub(crate) use crate::storage::storage_compat::{
+pub(crate) use super::storage_compat::{
     BucketMetadata, DEFAULT_READ_BUFFER_SIZE, bucket_metadata_sys_initialized, get_global_bucket_metadata_sys,
     set_bucket_metadata,
 };

--- a/rustfs/src/storage/rpc/storage_compat.rs
+++ b/rustfs/src/storage/rpc/storage_compat.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::storage::storage_compat::{
+pub(crate) use super::super::storage_compat::{
     CollectMetricsOpts, DEFAULT_READ_BUFFER_SIZE, DeleteOptions, DiskError, DiskInfoOptions, DiskStore, FileInfoVersions,
     LocalPeerS3Client, MetricType, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, ReadMultipleReq, ReadMultipleResp, ReadOptions, Result,
     SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC, StorageDiskRpcExt, StoragePeerS3ClientExt, UpdateMetadataOpts,
@@ -22,4 +22,4 @@ pub(crate) use crate::storage::storage_compat::{
 };
 
 #[cfg(test)]
-pub(crate) use crate::storage::storage_compat::{Error, STORAGE_CLASS_SUB_SYS};
+pub(crate) use super::super::storage_compat::{Error, STORAGE_CLASS_SUB_SYS};

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -98,6 +98,7 @@ RUSTFS_ROOT_E2E_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/rustfs_root_e2e_com
 ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_raw_facade_path_hits.txt"
 ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE="${TMP_DIR}/all_storage_compat_grouped_facade_import_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
+RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE="${TMP_DIR}/rustfs_local_compat_owner_self_path_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -1034,6 +1035,18 @@ fi
 
 if [[ -s "$ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE" ]]; then
   report_failure "storage compatibility boundaries must reference local ECStore facade aliases directly or through super::, not crate-qualified storage_compat self paths: $(paste -sd '; ' "$ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::(?:admin|app|storage)::storage_compat' \
+    rustfs/src/admin rustfs/src/app rustfs/src/storage \
+    --glob '*storage_compat.rs' \
+    --glob '*_storage_compat.rs' || true
+) >"$RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE"
+
+if [[ -s "$RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE" ]]; then
+  report_failure "RustFS local compatibility bridge modules must use relative owner storage_compat paths instead of crate-qualified owner self paths: $(paste -sd '; ' "$RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Replace crate-qualified app/admin/storage `storage_compat` references in local compatibility bridge modules with relative `super::storage_compat` paths.
- Add a migration guard that rejects crate-qualified owner `storage_compat` self paths in RustFS local compatibility bridge modules.
- Record API-108 progress and the pre-push review log.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `git diff --check`
- RustFS local bridge owner self-path residual scan
- Rust risk scan
- `cargo check -p rustfs --tests`
- `make pre-commit`

## Impact
No runtime behavior change expected. This keeps local compatibility bridge modules owner-relative while preserving the same re-export names.

## Additional Notes
N/A
