### PR TITLE
refactor: use relative root compat paths

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-local-compat-relative-refs`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108`.
-- Based on: API-107 slice.
+- Branch: `overtrue/arch-root-compat-relative-consumers`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109`.
+- Based on: API-108 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: collapse crate-qualified owner `storage_compat` paths in
-  RustFS app/admin/storage local compatibility bridge modules into relative
-  `super::storage_compat` paths.
-- CI/script changes: guard RustFS local compatibility bridge modules against
-  crate-qualified owner `storage_compat` self paths.
-- Docs changes: record the API-108 local compatibility relative path cleanup.
+- Rust code changes: collapse crate-qualified root compatibility and storage
+  owner compatibility consumer paths into relative `super::`/`self::` paths.
+- CI/script changes: guard selected RustFS root and storage owner consumers
+  against crate-qualified compatibility paths.
+- Docs changes: record the API-109 relative compatibility consumer cleanup.
 
 ## Phase 0 Tasks
 
@@ -544,6 +543,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Verification: RustFS test-target compile coverage, local bridge owner
     self-path residual scan, migration and layer guards, formatting, diff
     hygiene, Rust risk scan, pre-commit quality gate, and three-expert review.
+- [x] `API-109` Collapse root compatibility consumer paths.
+  - Completed slice: replace crate-qualified root compatibility consumers in
+    startup/runtime/table/error/workload modules plus selected storage owner
+    consumers with relative `super::` or `self::` paths.
+  - Acceptance: selected root and storage owner modules no longer point back to
+    local compatibility facades through crate-qualified paths; migration rules
+    reject regressions.
+  - Must preserve: startup notification/storage/background/service behavior,
+    runtime capability snapshots, workload admission wiring, table catalog
+    helpers, root error aliases, storage SSE/access/ECFS helper behavior, and
+    public storage module aliases.
+  - Verification: RustFS test-target compile coverage, root/storage owner
+    compatibility consumer residual scans, migration and layer guards,
+    formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
+    three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
     [`placement-repair-invariants.md`](placement-repair-invariants.md) records
@@ -3577,13 +3591,26 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-108 keeps local compatibility bridge modules owner-relative by replacing crate-qualified app/admin/storage `storage_compat` paths with scoped `super::` paths. |
-| Migration preservation | pass | The new guard rejects crate-qualified owner `storage_compat` self paths in RustFS local bridge modules while preserving existing re-export names. |
-| Testing/verification | pass | Focused compile, local bridge owner self-path residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-109 keeps selected root and storage owner compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped `super::` or `self::` paths. |
+| Migration preservation | pass | The new guards reject crate-qualified root compatibility and storage owner compatibility consumer paths while preserving the same local facade names and aliases. |
+| Testing/verification | pass | Focused compile, root/storage owner residual scans, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-109 current slice:
+  - `cargo check -p rustfs --tests`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Root compatibility consumer residual scan: passed.
+  - Storage owner compatibility consumer residual scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-108 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error_storage_compat::{QuotaError, StorageError};
+use super::error_storage_compat::{QuotaError, StorageError};
 use rustfs_storage_api::HTTPRangeError;
 use s3s::{S3Error, S3ErrorCode};
 

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::startup_storage_compat::{get_global_region, get_notification_config};
 use crate::server::ShutdownHandle;
-use crate::startup_storage_compat::{get_global_region, get_notification_config};
 use crate::storage::{process_lambda_configurations, process_queue_configurations, process_topic_configurations};
 use crate::{admin, config, version};
 use rustfs_config::{

--- a/rustfs/src/runtime_capabilities.rs
+++ b/rustfs/src/runtime_capabilities.rs
@@ -18,7 +18,7 @@ use rustfs_storage_api::{
     UserspaceProfilingCapability,
 };
 
-use crate::runtime_capabilities_storage_compat::{EndpointServerPools, topology_snapshot_from_endpoint_pools_with_capabilities};
+use super::runtime_capabilities_storage_compat::{EndpointServerPools, topology_snapshot_from_endpoint_pools_with_capabilities};
 
 const NOT_WIRED_INTO_RUNTIME: &str = "not wired into runtime";
 const STORAGE_MEDIA_NOT_REPORTED: &str = "storage media not reported by endpoints";
@@ -131,8 +131,8 @@ fn cgroup_memory_status() -> CapabilityStatus {
 
 #[cfg(test)]
 mod tests {
+    use super::super::runtime_capabilities_storage_compat::{Endpoint, Endpoints, PoolEndpoints};
     use super::*;
-    use crate::runtime_capabilities_storage_compat::{Endpoint, Endpoints, PoolEndpoints};
     use rustfs_storage_api::{CapabilityState, ObservabilitySnapshotProvider, TopologySnapshotProvider};
 
     #[tokio::test]

--- a/rustfs/src/startup_background.rs
+++ b/rustfs/src/startup_background.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::startup_storage_compat::ECStore;
+use super::startup_storage_compat::ECStore;
 use rustfs_heal::{create_ahm_services_cancel_token, heal::storage::ECStoreHealStorage, init_heal_manager};
 use rustfs_utils::get_env_bool_with_aliases;
 use std::{io::Result, sync::Arc};

--- a/rustfs/src/startup_bucket_metadata.rs
+++ b/rustfs/src/startup_bucket_metadata.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::startup_storage_compat::{
+use super::startup_storage_compat::{
     ECStore, get_global_replication_pool, init_bucket_metadata_sys, try_migrate_bucket_metadata, try_migrate_iam_config,
 };
 use rustfs_storage_api::{BucketOperations, BucketOptions};

--- a/rustfs/src/startup_fs_guard.rs
+++ b/rustfs/src/startup_fs_guard.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::startup_storage_compat::EndpointServerPools;
+use super::startup_storage_compat::EndpointServerPools;
 use rustfs_config::{
     DEFAULT_RUSTFS_UNSUPPORTED_FS_POLICY, ENV_RUSTFS_UNSUPPORTED_FS_POLICY, RUSTFS_UNSUPPORTED_FS_POLICY_FAIL,
     RUSTFS_UNSUPPORTED_FS_POLICY_WARN,

--- a/rustfs/src/startup_iam.rs
+++ b/rustfs/src/startup_iam.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::startup_storage_compat::ECStore;
 use crate::app::context::AppContext;
 use crate::server::{ServiceStateManager, publish_ready_when_runtime_ready};
-use crate::startup_storage_compat::ECStore;
 use rustfs_common::{GlobalReadiness, SystemStage};
 use rustfs_iam::init_iam_sys;
 use rustfs_kms::KmsServiceManager;

--- a/rustfs/src/startup_notification.rs
+++ b/rustfs/src/startup_notification.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::startup_storage_compat::{EcstoreResult, EndpointServerPools, new_global_notification_sys};
 use crate::init::add_bucket_notification_configuration;
-use crate::startup_storage_compat::{EcstoreResult, EndpointServerPools, new_global_notification_sys};
 use std::{
     future::Future,
     io::{Error, Result},
@@ -80,7 +80,7 @@ mod tests {
     #[tokio::test]
     async fn notification_system_returns_source_error() {
         let result =
-            init_notification_system_with(|| async { Err(crate::startup_storage_compat::EcstoreError::FaultyDisk) }).await;
+            init_notification_system_with(|| async { Err(super::super::startup_storage_compat::EcstoreError::FaultyDisk) }).await;
 
         assert!(result.is_err());
     }

--- a/rustfs/src/startup_server.rs
+++ b/rustfs/src/startup_server.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::startup_storage_compat::{set_global_region, set_global_rustfs_port};
+use super::startup_storage_compat::{set_global_region, set_global_rustfs_port};
 use crate::{
     capacity::capacity_integration::init_capacity_management,
     config::Config,

--- a/rustfs/src/startup_services.rs
+++ b/rustfs/src/startup_services.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::startup_storage_compat::{ECStore, EndpointServerPools};
+use super::startup_storage_compat::{ECStore, EndpointServerPools};
 use crate::{
     config::Config,
     init::{init_buffer_profile_system, init_kms_system},

--- a/rustfs/src/startup_storage.rs
+++ b/rustfs/src/startup_storage.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::startup_fs_guard::enforce_unsupported_fs_policy;
-use crate::startup_storage_compat::{
+use super::startup_storage_compat::{
     ECStore, EndpointServerPools, init_background_replication, init_ecstore_config, init_global_config_sys, init_local_disks,
     init_lock_clients, prewarm_local_disk_id_map, set_global_endpoints, try_migrate_server_config, update_erasure_type,
 };
+use crate::startup_fs_guard::enforce_unsupported_fs_policy;
 use rustfs_common::{GlobalReadiness, SystemStage};
 use std::{
     io::{Error, Result},

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::core_storage_compat::ECStore;
+use super::core_storage_compat::resolve_object_store_handle;
+use super::core_storage_compat::{
+    PolicySys, StorageError, get_bucket_metadata, get_bucket_policy_raw, get_public_access_block_config, is_err_bucket_not_found,
+};
 use super::ecfs::FS;
 use crate::auth::{check_key_valid, get_condition_values_with_query_and_client_info, get_session_token};
 use crate::error::ApiError;
 use crate::license::license_check;
 use crate::server::RemoteAddr;
-use crate::storage::core_storage_compat::ECStore;
-use crate::storage::core_storage_compat::resolve_object_store_handle;
-use crate::storage::core_storage_compat::{
-    PolicySys, StorageError, get_bucket_metadata, get_bucket_policy_raw, get_public_access_block_config, is_err_bucket_not_found,
-};
 use crate::storage::request_context::RequestContext;
 use metrics::counter;
 use rustfs_iam::error::Error as IamError;
@@ -930,7 +930,7 @@ impl S3Access for FS {
         let req_info = ReqInfo {
             cred,
             is_owner,
-            region: crate::storage::core_storage_compat::get_global_region(),
+            region: super::core_storage_compat::get_global_region(),
             request_context,
             ..Default::default()
         };

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -12,13 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::app::bucket_usecase::DefaultBucketUsecase;
-use crate::app::context::resolve_object_store_handle;
-use crate::app::multipart_usecase::DefaultMultipartUsecase;
-use crate::app::object_usecase::DefaultObjectUsecase;
-use crate::error::ApiError;
-use crate::storage::access::has_bypass_governance_header;
-use crate::storage::core_storage_compat::{
+use super::core_storage_compat::{
     BUCKET_ACCELERATE_CONFIG, BUCKET_LOGGING_CONFIG, BUCKET_REQUEST_PAYMENT_CONFIG, BUCKET_VERSIONING_CONFIG,
     BUCKET_WEBSITE_CONFIG, BucketVersioningSys, OBJECT_LOCK_CONFIG, StorageError, check_retention_for_modification, decode_tags,
     decode_tags_to_map, delete_bucket_metadata_config, encode_tags, get_bucket_accelerate_config, get_bucket_logging_config,
@@ -26,7 +20,13 @@ use crate::storage::core_storage_compat::{
     is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found, record_replication_proxy, serialize,
     update_bucket_metadata_config,
 };
-use crate::storage::core_storage_compat::{StorageReplicationConfigExt as _, StorageVersioningConfigExt as _};
+use super::core_storage_compat::{StorageReplicationConfigExt as _, StorageVersioningConfigExt as _};
+use crate::app::bucket_usecase::DefaultBucketUsecase;
+use crate::app::context::resolve_object_store_handle;
+use crate::app::multipart_usecase::DefaultMultipartUsecase;
+use crate::app::object_usecase::DefaultObjectUsecase;
+use crate::error::ApiError;
+use crate::storage::access::has_bypass_governance_header;
 use crate::storage::helper::OperationHelper;
 use crate::storage::options::get_opts;
 use crate::storage::s3_api::acl;

--- a/rustfs/src/storage/ecfs_extend.rs
+++ b/rustfs/src/storage/ecfs_extend.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::config::{RustFSBufferConfig, WorkloadProfile, get_global_buffer_config, is_buffer_profile_enabled};
-use crate::error::ApiError;
-use crate::server::cors;
-use crate::storage::core_storage_compat::StorageReplicationConfigExt as _;
-use crate::storage::core_storage_compat::{
+use super::core_storage_compat::StorageReplicationConfigExt as _;
+use super::core_storage_compat::{
     StorageError, add_object_lock_years, get_bucket_cors_config, get_bucket_object_lock_config, get_bucket_replication_config,
     resolve_object_store_handle,
 };
+use crate::config::{RustFSBufferConfig, WorkloadProfile, get_global_buffer_config, is_buffer_profile_enabled};
+use crate::error::ApiError;
+use crate::server::cors;
 use crate::storage::ecfs::ListObjectUnorderedQuery;
 use http::header::{IF_MATCH, IF_MODIFIED_SINCE, IF_NONE_MATCH, IF_UNMODIFIED_SINCE};
 use http::{HeaderMap, HeaderValue, StatusCode};
@@ -738,7 +738,7 @@ pub(crate) async fn has_replication_rules(bucket: &str, objects: &[ObjectToDelet
 }
 
 /// Helper function to get store and validate bucket exists
-pub(crate) async fn get_validated_store(bucket: &str) -> S3Result<Arc<crate::storage::core_storage_compat::ECStore>> {
+pub(crate) async fn get_validated_store(bucket: &str) -> S3Result<Arc<super::core_storage_compat::ECStore>> {
     let Some(store) = resolve_object_store_handle() else {
         return Err(S3Error::with_message(S3ErrorCode::InternalError, "Not init".to_string()));
     };

--- a/rustfs/src/storage/head_prefix.rs
+++ b/rustfs/src/storage/head_prefix.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage::core_storage_compat::ECStore;
+use super::core_storage_compat::ECStore;
 use rustfs_storage_api::ListOperations as _;
 use std::sync::Arc;
 

--- a/rustfs/src/storage/mod.rs
+++ b/rustfs/src/storage/mod.rs
@@ -30,11 +30,11 @@ pub mod timeout_wrapper;
 pub mod tonic_service;
 
 pub(crate) type StorageDeletedObject = rustfs_storage_api::DeletedObject;
-pub(crate) type StorageGetObjectReader = crate::storage::core_storage_compat::GetObjectReader;
-pub(crate) type StorageObjectInfo = crate::storage::core_storage_compat::ObjectInfo;
-pub(crate) type StorageObjectOptions = crate::storage::core_storage_compat::ObjectOptions;
+pub(crate) type StorageGetObjectReader = self::core_storage_compat::GetObjectReader;
+pub(crate) type StorageObjectInfo = self::core_storage_compat::ObjectInfo;
+pub(crate) type StorageObjectOptions = self::core_storage_compat::ObjectOptions;
 pub(crate) type StorageObjectToDelete = rustfs_storage_api::ObjectToDelete;
-pub(crate) type StoragePutObjReader = crate::storage::core_storage_compat::PutObjReader;
+pub(crate) type StoragePutObjReader = self::core_storage_compat::PutObjReader;
 
 #[cfg(test)]
 mod concurrent_fix_test;

--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage::core_storage_compat::BucketVersioningSys;
-use crate::storage::core_storage_compat::Result;
-use crate::storage::core_storage_compat::StorageError;
+use super::core_storage_compat::BucketVersioningSys;
+use super::core_storage_compat::Result;
+use super::core_storage_compat::StorageError;
 use http::header::{IF_MATCH, IF_NONE_MATCH};
 use http::{HeaderMap, HeaderValue};
 use rustfs_utils::http::{

--- a/rustfs/src/storage/sse.rs
+++ b/rustfs/src/storage/sse.rs
@@ -69,7 +69,7 @@
 //! }
 //! ```
 
-use crate::storage::core_storage_compat::StorageError;
+use super::core_storage_compat::StorageError;
 #[cfg(feature = "rio-v2")]
 use aes_gcm::aead::Payload;
 use aes_gcm::{
@@ -133,9 +133,9 @@ const SEALED_KEY_SIZE: usize = DARE_HEADER_SIZE + 32 + DARE_TAG_SIZE;
 #[cfg(feature = "rio-v2")]
 const OBJECT_KEY_DERIVATION_CONTEXT: &[u8] = b"object-encryption-key generation";
 
+use super::core_storage_compat::Error;
+use super::core_storage_compat::get_bucket_sse_config;
 use crate::error::ApiError;
-use crate::storage::core_storage_compat::Error;
-use crate::storage::core_storage_compat::get_bucket_sse_config;
 use rustfs_utils::http::headers::{
     AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM, AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY,
     AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5, AMZ_SERVER_SIDE_ENCRYPTION_KMS_CONTEXT,
@@ -751,19 +751,19 @@ pub struct ManagedSealedKey {
 }
 
 impl EncryptionMaterial {
-    pub fn write_encryption(&self, multipart_part_number: Option<usize>) -> crate::storage::core_storage_compat::WriteEncryption {
+    pub fn write_encryption(&self, multipart_part_number: Option<usize>) -> super::core_storage_compat::WriteEncryption {
         match (self.key_kind, multipart_part_number) {
             (EncryptionKeyKind::Object, Some(part_number)) => {
-                crate::storage::core_storage_compat::WriteEncryption::multipart_object_key(self.key_bytes, part_number as u32)
+                super::core_storage_compat::WriteEncryption::multipart_object_key(self.key_bytes, part_number as u32)
             }
             (EncryptionKeyKind::Object, None) => {
-                crate::storage::core_storage_compat::WriteEncryption::singlepart_object_key(self.key_bytes)
+                super::core_storage_compat::WriteEncryption::singlepart_object_key(self.key_bytes)
             }
             (EncryptionKeyKind::Direct, Some(part_number)) => {
-                crate::storage::core_storage_compat::WriteEncryption::multipart(self.key_bytes, self.base_nonce, part_number)
+                super::core_storage_compat::WriteEncryption::multipart(self.key_bytes, self.base_nonce, part_number)
             }
             (EncryptionKeyKind::Direct, None) => {
-                crate::storage::core_storage_compat::WriteEncryption::singlepart(self.key_bytes, self.base_nonce)
+                super::core_storage_compat::WriteEncryption::singlepart(self.key_bytes, self.base_nonce)
             }
         }
     }

--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -27,7 +27,7 @@ use std::{
     time::{Duration as StdDuration, Instant},
 };
 
-use crate::table_catalog_storage_compat::{
+use super::table_catalog_storage_compat::{
     BUCKET_TABLE_CATALOG_META_PREFIX, BUCKET_TABLE_CATALOG_TABLE_BUCKETS_PREFIX, BUCKET_TABLE_CONFIG,
     BUCKET_TABLE_RESERVED_PREFIX, EcstoreError, RUSTFS_META_BUCKET, StorageError, get_bucket_metadata, get_lock_acquire_timeout,
     table_catalog_path_hash,

--- a/rustfs/src/workload_admission.rs
+++ b/rustfs/src/workload_admission.rs
@@ -17,10 +17,10 @@ use rustfs_concurrency::{
     WorkloadClass,
 };
 
-use crate::storage::concurrency::get_concurrency_manager;
-use crate::workload_admission_storage_compat::{
+use super::workload_admission_storage_compat::{
     get_global_bucket_metadata_sys, get_global_replication_pool, replication_queue_current_count,
 };
+use crate::storage::concurrency::get_concurrency_manager;
 
 const BUCKET_METADATA_RUNTIME_NOT_INITIALIZED: &str = "bucket metadata runtime not initialized";
 const HEAL_MANAGER_NOT_INITIALIZED: &str = "heal manager not initialized";

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -99,6 +99,8 @@ ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_raw_
 ALL_STORAGE_COMPAT_GROUPED_FACADE_IMPORT_HITS_FILE="${TMP_DIR}/all_storage_compat_grouped_facade_import_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
 RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE="${TMP_DIR}/rustfs_local_compat_owner_self_path_hits.txt"
+RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_compat_relative_consumer_hits.txt"
+RUSTFS_STORAGE_CORE_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_core_compat_relative_consumer_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -1047,6 +1049,37 @@ fi
 
 if [[ -s "$RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE" ]]; then
   report_failure "RustFS local compatibility bridge modules must use relative owner storage_compat paths instead of crate-qualified owner self paths: $(paste -sd '; ' "$RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::(?:startup_storage_compat|runtime_capabilities_storage_compat|workload_admission_storage_compat|table_catalog_storage_compat|error_storage_compat)' \
+    rustfs/src/startup_*.rs \
+    rustfs/src/init.rs \
+    rustfs/src/runtime_capabilities.rs \
+    rustfs/src/workload_admission.rs \
+    rustfs/src/table_catalog.rs \
+    rustfs/src/error.rs || true
+) >"$RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE"
+
+if [[ -s "$RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
+  report_failure "RustFS root compatibility consumers must use relative owner paths instead of crate-qualified root compatibility paths: $(paste -sd '; ' "$RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::storage::core_storage_compat' \
+    rustfs/src/storage/mod.rs \
+    rustfs/src/storage/ecfs.rs \
+    rustfs/src/storage/ecfs_extend.rs \
+    rustfs/src/storage/access.rs \
+    rustfs/src/storage/head_prefix.rs \
+    rustfs/src/storage/options.rs \
+    rustfs/src/storage/sse.rs || true
+) >"$RUSTFS_STORAGE_CORE_COMPAT_RELATIVE_CONSUMER_HITS_FILE"
+
+if [[ -s "$RUSTFS_STORAGE_CORE_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
+  report_failure "RustFS storage owner consumers must use relative core_storage_compat paths instead of crate-qualified storage owner paths: $(paste -sd '; ' "$RUSTFS_STORAGE_CORE_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Replace crate-qualified root compatibility consumers in startup, runtime, table, error, and workload modules with relative owner paths.
- Replace selected storage owner `core_storage_compat` consumer paths with `super::` or `self::` references.
- Add migration guards for the root and storage owner compatibility consumer paths and record API-109 progress.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `git diff --check`
- Root compatibility consumer residual scan
- Storage owner compatibility consumer residual scan
- Rust added-line risk scan
- `cargo check -p rustfs --tests`
- `make pre-commit`
- Post-rebase focused checks against `origin/main`

## Impact
No runtime behavior change expected. This keeps selected compatibility consumers owner-relative while preserving the same local facade names and aliases.

## Additional Notes
N/A
