### PR TITLE
fix(object): normalize storage class responses

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -2897,12 +2897,7 @@ impl DefaultObjectUsecase {
         validate_ssec_for_read(&info.user_defined, sse_customer_key.as_ref(), sse_customer_key_md5.as_ref())?;
 
         let metadata_map = info.user_defined.clone();
-        let storage_class = info
-            .storage_class
-            .clone()
-            .or_else(|| metadata_map.get(AMZ_STORAGE_CLASS).cloned())
-            .filter(|s| !s.is_empty())
-            .map(StorageClass::from);
+        let storage_class = response_storage_class(&info, &metadata_map);
 
         debug!(
             "GetObjectAttributes raw object_attributes={:?}",
@@ -5824,6 +5819,18 @@ mod tests {
                 .as_ref()
                 .map(StorageClass::as_str),
             Some(storageclass::STANDARD_IA)
+        );
+
+        let mut metadata = HashMap::new();
+        metadata.insert(AMZ_STORAGE_CLASS.to_string(), storageclass::STANDARD.to_string());
+        let standard_metadata_info = ObjectInfo {
+            storage_class: None,
+            user_defined: Arc::new(metadata.clone()),
+            ..Default::default()
+        };
+        assert!(
+            response_storage_class(&standard_metadata_info, &metadata).is_none(),
+            "STANDARD must be omitted even when it only arrives via metadata fallback"
         );
     }
 


### PR DESCRIPTION
## Related Issues
Fixes rustfs/backlog#625.
Part of rustfs/backlog#618.

## Summary of Changes
- Reuse the shared `response_storage_class` mapping for `GetObjectAttributes` so metadata responses follow the same storage-class omission rules as `HeadObject`.
- Omit `STANDARD` storage class values even when they only arrive through metadata fallback.
- Add regression coverage for the `STANDARD` metadata fallback case.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs response_storage_class_omits_standard_and_keeps_non_default -- --nocapture`
- `cargo test -p rustfs execute_get_object_attributes_returns_internal_error_when_store_uninitialized -- --nocapture`
- `make pre-commit`

## Impact
`HeadObject` and `GetObjectAttributes` now return consistent `StorageClass` metadata, which avoids sending `STANDARD` back to SDKs that expect the default class to be omitted.

## Additional Notes
This patch is intentionally limited to metadata response normalization. It does not change storage-class validation for writes or multipart flows.
