### PR TITLE
fix(multipart): include upload owner metadata

### DIFF
--- a/rustfs/src/storage/s3_api/multipart.rs
+++ b/rustfs/src/storage/s3_api/multipart.rs
@@ -153,6 +153,9 @@ pub(crate) fn build_list_multipart_uploads_output(
     prefix: String,
     result: ListMultipartsInfo,
 ) -> ListMultipartUploadsOutput {
+    let owner = rustfs_owner();
+    let initiator = rustfs_initiator();
+
     ListMultipartUploadsOutput {
         bucket: Some(bucket),
         prefix: Some(prefix),
@@ -169,6 +172,8 @@ pub(crate) fn build_list_multipart_uploads_output(
                     key: Some(u.object),
                     upload_id: Some(u.upload_id),
                     initiated: u.initiated.map(Timestamp::from),
+                    owner: Some(owner.clone()),
+                    initiator: Some(initiator.clone()),
                     ..Default::default()
                 })
                 .collect(),
@@ -298,6 +303,8 @@ mod tests {
         assert_eq!(uploads[0].key.as_deref(), Some("obj-a"));
         assert_eq!(uploads[0].upload_id.as_deref(), Some("upload-a"));
         assert_eq!(uploads[0].initiated, Some(Timestamp::from(OffsetDateTime::UNIX_EPOCH)));
+        assert_eq!(uploads[0].owner, Some(rustfs_owner()));
+        assert_eq!(uploads[0].initiator, Some(rustfs_initiator()));
 
         assert_eq!(common_prefixes.len(), 2);
         assert_eq!(common_prefixes[0].prefix.as_deref(), Some("prefix-a/"));


### PR DESCRIPTION
## Related Issues
Fixes rustfs/backlog#623.
Part of rustfs/backlog#618.

## Summary of Changes
- Populate `owner` and `initiator` for each `ListMultipartUploads` entry so multipart listing responses match MinIO/AWS client expectations more closely.
- Keep the existing upload key, upload ID, initiated time, and common-prefix mapping unchanged.
- Extend multipart response-shape regression coverage.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs test_list_multipart_uploads_output_maps_uploads_and_prefixes -- --nocapture`
- `cargo test -p rustfs execute_list_multipart_uploads_rejects_invalid_key_marker_before_store_lookup -- --nocapture`
- `make pre-commit`

## Impact
Multipart upload listing responses now include owner/initiator metadata instead of leaving those nested objects empty, which improves SDK compatibility for clients that expect `ID` fields on multipart listing items.

## Additional Notes
This patch intentionally focuses on the multipart response shape only. It does not change the current `AbortMultipartUpload` error-boundary behavior.
