### PR TITLE
refactor: use relative admin compat consumers

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-storage-rpc-s3-local-compat-consumers`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111`.
-- Based on: API-110 slice.
+- Branch: `overtrue/arch-admin-compat-relative-consumers`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112`.
+- Based on: API-111 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: collapse crate-qualified storage RPC and S3 API local
+- Rust code changes: collapse crate-qualified admin handlers/service local
   compatibility consumer paths into relative `super::`/`super::super::` paths.
-- CI/script changes: guard selected storage RPC and S3 API local consumers
+- CI/script changes: guard selected admin handlers/service local consumers
   against crate-qualified compatibility paths.
-- Docs changes: record the API-111 relative storage RPC/S3 API local
-  compatibility consumer cleanup.
+- Docs changes: record the API-112 relative admin local compatibility consumer
+  cleanup.
 
 ## Phase 0 Tasks
 
@@ -582,6 +582,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     helper behavior.
   - Verification: RustFS test-target compile coverage, storage RPC/S3 API
     local compatibility consumer residual scan, migration and layer guards,
+    formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
+    three-expert review.
+- [x] `API-112` Collapse admin local compatibility consumers.
+  - Completed slice: replace crate-qualified admin handlers/service local
+    compatibility consumers with relative owner paths.
+  - Acceptance: selected admin handlers and service modules no longer point back
+    to local compatibility facades through crate-qualified paths; migration
+    rules reject regressions.
+  - Must preserve: admin route contracts, replication/config/rebalance/heal
+    handler behavior, service config reload behavior, and admin test coverage.
+  - Verification: RustFS test-target compile coverage, admin local
+    compatibility consumer residual scan, migration and layer guards,
     formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
     three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
@@ -3617,13 +3629,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-111 keeps selected storage RPC and S3 API local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped `super::` or `super::super::` paths. |
-| Migration preservation | pass | The new guard rejects crate-qualified storage RPC/S3 API local compatibility consumer paths while preserving the same facade names and aliases. |
-| Testing/verification | pass | Focused compile, storage RPC/S3 API local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-112 keeps selected admin handlers/service local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped `super::` or `super::super::` paths. |
+| Migration preservation | pass | The new guard rejects crate-qualified admin handlers/service local compatibility consumer paths while preserving the same facade names and aliases. |
+| Testing/verification | pass | Focused compile, admin local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-112 current slice:
+  - `cargo check -p rustfs --tests`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Admin local compatibility consumer residual scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-111 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/rustfs/src/admin/handlers/account_info.rs
+++ b/rustfs/src/admin/handlers/account_info.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::storage_compat::versioning_sys::BucketVersioningSys;
 use crate::admin::auth::authenticate_request;
-use crate::admin::handlers::storage_compat::versioning_sys::BucketVersioningSys;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::app::context::resolve_object_store_handle;
 use crate::auth::get_condition_values;

--- a/rustfs/src/admin/handlers/audit_runtime_config.rs
+++ b/rustfs/src/admin/handlers/audit_runtime_config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::handlers::storage_compat::{read_admin_config_without_migrate, save_admin_server_config};
+use super::storage_compat::{read_admin_config_without_migrate, save_admin_server_config};
 use crate::admin::handlers::target_descriptor::AdminTargetSpec;
 use crate::app::context::resolve_object_store_handle;
 use rustfs_audit::{audit_system, start_audit_system as start_global_audit_system, system::AuditSystemState};

--- a/rustfs/src/admin/handlers/bucket_meta.rs
+++ b/rustfs/src/admin/handlers/bucket_meta.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::handlers::storage_compat::utils::{deserialize, serialize};
-use crate::admin::handlers::storage_compat::{
+use super::storage_compat::utils::{deserialize, serialize};
+use super::storage_compat::{
     StorageError,
     metadata::{
         BUCKET_LIFECYCLE_CONFIG, BUCKET_NOTIFICATION_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE,

--- a/rustfs/src/admin/handlers/config_admin.rs
+++ b/rustfs/src/admin/handlers/config_admin.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::auth::validate_admin_request;
-use crate::admin::handlers::storage_compat::storageclass::{INLINE_BLOCK_ENV, OPTIMIZE_ENV, RRS_ENV, STANDARD_ENV};
-use crate::admin::handlers::storage_compat::{
+use super::storage_compat::storageclass::{INLINE_BLOCK_ENV, OPTIMIZE_ENV, RRS_ENV, STANDARD_ENV};
+use super::storage_compat::{
     RUSTFS_META_BUCKET, STORAGE_CLASS_SUB_SYS, delete_admin_config, read_admin_config, read_admin_config_without_migrate,
     save_admin_config, save_admin_server_config,
 };
+use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::service::config::{
     apply_dynamic_config_for_subsystem, is_dynamic_config_subsystem, signal_config_snapshot_reload, signal_dynamic_config_reload,
@@ -710,7 +710,7 @@ fn success_response(config_applied: bool) -> S3Result<S3Response<(StatusCode, Bo
     Ok(S3Response::with_headers((StatusCode::OK, Body::default()), headers))
 }
 
-fn object_store() -> S3Result<std::sync::Arc<crate::admin::handlers::storage_compat::ECStore>> {
+fn object_store() -> S3Result<std::sync::Arc<super::storage_compat::ECStore>> {
     resolve_object_store_handle().ok_or_else(|| s3_error!(InternalError, "server storage not initialized"))
 }
 
@@ -755,7 +755,7 @@ fn config_update_sub_system(directives: &[ConfigDirective]) -> S3Result<Option<&
 
 fn validate_config_directives(directives: &[ConfigDirective]) -> S3Result<()> {
     if DEFAULT_KVS.get().is_none() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::storage_compat::init_admin_config_defaults();
     }
     let Some(defaults) = DEFAULT_KVS.get() else {
         return Err(s3_error!(InternalError, "config defaults are not initialized"));
@@ -1409,7 +1409,7 @@ fn env_help_key(sub_system: &str, key: &str) -> String {
 
 fn default_help_postfix(sub_system: &str, key: &str) -> String {
     if DEFAULT_KVS.get().is_none() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::storage_compat::init_admin_config_defaults();
     }
 
     DEFAULT_KVS
@@ -1896,7 +1896,7 @@ mod tests {
 
     #[test]
     fn full_config_export_can_be_reapplied() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         let mut original = ServerConfig::new();
         apply_set_directives(
             &mut original,
@@ -1943,7 +1943,7 @@ identity_openid config_url="https://issuer.example" client_id="console""#,
 
     #[test]
     fn build_help_response_appends_default_value_postfix() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         let response = build_help_response(Some("identity_openid"), Some("scopes"), false).expect("help response");
 
         assert_eq!(response.keys_help.len(), 2);
@@ -2056,7 +2056,7 @@ identity_openid config_url="https://issuer.example" client_id="console""#,
 
     #[test]
     fn render_selected_config_includes_env_override_lines() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         temp_env::with_vars(
             [
                 ("RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY", Some("http://env.example")),
@@ -2092,7 +2092,7 @@ identity_openid config_url="https://issuer.example" client_id="console""#,
 
     #[test]
     fn render_selected_config_lists_env_only_targets() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         temp_env::with_vars([("RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY", Some("http://env.example"))], || {
             let config = ServerConfig::new();
             let rendered = String::from_utf8(
@@ -2115,7 +2115,7 @@ identity_openid config_url="https://issuer.example" client_id="console""#,
 
     #[test]
     fn render_selected_config_supports_specific_env_only_target_queries() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         temp_env::with_vars([("RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY", Some("http://env.example"))], || {
             let config = ServerConfig::new();
             let rendered = String::from_utf8(
@@ -2138,7 +2138,7 @@ identity_openid config_url="https://issuer.example" client_id="console""#,
 
     #[test]
     fn render_selected_config_orders_default_before_named_targets() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         temp_env::with_vars([("RUSTFS_NOTIFY_WEBHOOK_ENDPOINT_ALPHA", Some("http://alpha.example"))], || {
             let mut config = ServerConfig::new();
             apply_set_directives(
@@ -2319,7 +2319,7 @@ identity_openid client_id="existing-client""#,
 
     #[test]
     fn storage_class_get_target_none_matches_full_export() {
-        crate::admin::handlers::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         let mut config = ServerConfig::new();
         apply_set_directives(
             &mut config,

--- a/rustfs/src/admin/handlers/heal.rs
+++ b/rustfs/src/admin/handlers/heal.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::storage_compat::is_reserved_or_invalid_bucket;
+use super::storage_compat::utils::is_valid_object_prefix;
 use crate::admin::auth::{authenticate_request, validate_admin_request};
-use crate::admin::handlers::storage_compat::is_reserved_or_invalid_bucket;
-use crate::admin::handlers::storage_compat::utils::is_valid_object_prefix;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::app::context::resolve_object_store_handle;
 use crate::server::ADMIN_PREFIX;
@@ -378,10 +378,10 @@ fn should_handle_root_heal_directly(hip: &HealInitParams) -> bool {
         && hip.hs.set.is_none()
 }
 
-fn map_root_heal_status(heal_err: Option<crate::admin::handlers::storage_compat::Error>) -> S3Result<()> {
+fn map_root_heal_status(heal_err: Option<super::storage_compat::Error>) -> S3Result<()> {
     match heal_err {
         None => Ok(()),
-        Some(crate::admin::handlers::storage_compat::StorageError::NoHealRequired) => {
+        Some(super::storage_compat::StorageError::NoHealRequired) => {
             info!(
                 event = EVENT_ADMIN_RESPONSE_EMITTED,
                 component = LOG_COMPONENT_ADMIN_API,
@@ -730,13 +730,13 @@ impl Operation for BackgroundHealStatusHandler {
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::StorageError;
     use super::extract_heal_init_params;
     use super::{
         HealInitParams, HealResp, build_heal_channel_request, encode_background_heal_status, encode_heal_start_success,
         encode_heal_task_status, heal_channel_response_items, heal_channel_response_summary, json_response, map_heal_response,
         map_root_heal_status, should_handle_root_heal_directly, validate_heal_request_mode, validate_heal_target,
     };
-    use crate::admin::handlers::storage_compat::StorageError;
     use bytes::Bytes;
     use http::StatusCode;
     use http::Uri;

--- a/rustfs/src/admin/handlers/kms_dynamic.rs
+++ b/rustfs/src/admin/handlers/kms_dynamic.rs
@@ -14,8 +14,8 @@
 
 //! KMS dynamic configuration admin API handlers
 
+use super::storage_compat::{read_admin_config, save_admin_config};
 use crate::admin::auth::validate_admin_request;
-use crate::admin::handlers::storage_compat::{read_admin_config, save_admin_config};
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::app::context::{resolve_kms_runtime_service_manager, resolve_object_store_handle};
 use crate::auth::{check_key_valid, get_session_token};

--- a/rustfs/src/admin/handlers/metrics.rs
+++ b/rustfs/src/admin/handlers/metrics.rs
@@ -18,8 +18,8 @@
 //! keeping the response format explicitly NDJSON. It is not a Prometheus text
 //! exposition endpoint.
 
+use super::storage_compat::{CollectMetricsOpts, MetricType, collect_local_metrics};
 use crate::admin::auth::validate_admin_request;
-use crate::admin::handlers::storage_compat::{CollectMetricsOpts, MetricType, collect_local_metrics};
 use crate::admin::router::Operation;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::RemoteAddr;

--- a/rustfs/src/admin/handlers/object_zip_download.rs
+++ b/rustfs/src/admin/handlers/object_zip_download.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::handlers::storage_compat::get_global_region;
+use super::storage_compat::get_global_region;
 use crate::admin::router::{ADMIN_OBJECT_ZIP_DOWNLOADS_PATH, AdminOperation, Operation, S3Router};
 use crate::app::context::resolve_object_store_handle;
 use crate::auth::{check_key_valid, get_session_token};
@@ -649,7 +649,7 @@ async fn preflight_zip_items(request: &CreateObjectZipDownloadRequest, items: &[
     Ok(())
 }
 
-fn storage_error_to_s3(err: crate::admin::handlers::storage_compat::Error) -> s3s::S3Error {
+fn storage_error_to_s3(err: super::storage_compat::Error) -> s3s::S3Error {
     ApiError::from(err).into()
 }
 

--- a/rustfs/src/admin/handlers/oidc.rs
+++ b/rustfs/src/admin/handlers/oidc.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::storage_compat::{read_admin_config_without_migrate, save_admin_server_config};
 use super::sts::create_oidc_sts_credentials;
 use crate::admin::auth::validate_admin_request;
-use crate::admin::handlers::storage_compat::{read_admin_config_without_migrate, save_admin_server_config};
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::app::context::resolve_object_store_handle;
 use crate::auth::{check_key_valid, get_session_token};

--- a/rustfs/src/admin/handlers/pools.rs
+++ b/rustfs/src/admin/handlers/pools.rs
@@ -194,7 +194,7 @@ macro_rules! log_pool_response_emitted {
     };
 }
 
-fn endpoints_from_context() -> Option<crate::admin::handlers::storage_compat::EndpointServerPools> {
+fn endpoints_from_context() -> Option<super::storage_compat::EndpointServerPools> {
     resolve_endpoints_handle()
 }
 

--- a/rustfs/src/admin/handlers/quota.rs
+++ b/rustfs/src/admin/handlers/quota.rs
@@ -14,10 +14,10 @@
 
 //! Quota admin handlers for HTTP API
 
+use super::storage_compat::metadata_sys::BucketMetadataSys;
+use super::storage_compat::quota::checker::QuotaChecker;
+use super::storage_compat::quota::{BucketQuota, QuotaError, QuotaOperation};
 use crate::admin::auth::{validate_admin_request, validate_admin_request_with_bucket};
-use crate::admin::handlers::storage_compat::metadata_sys::BucketMetadataSys;
-use crate::admin::handlers::storage_compat::quota::checker::QuotaChecker;
-use crate::admin::handlers::storage_compat::quota::{BucketQuota, QuotaError, QuotaOperation};
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::app::context::{resolve_bucket_metadata_handle, resolve_object_store_handle};
 use crate::auth::{check_key_valid, get_session_token};
@@ -175,7 +175,7 @@ async fn current_usage_from_context(bucket: &str) -> u64 {
         return 0;
     };
 
-    match crate::admin::handlers::storage_compat::load_data_usage_from_backend(store).await {
+    match super::storage_compat::load_data_usage_from_backend(store).await {
         Ok(data_usage_info) => data_usage_info
             .buckets_usage
             .get(bucket)

--- a/rustfs/src/admin/handlers/rebalance.rs
+++ b/rustfs/src/admin/handlers/rebalance.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::handlers::storage_compat::{
+use super::storage_compat::{
     DiskStat, ECStore, NotificationSys, RebalSaveOpt, RebalanceCleanupWarnings, RebalanceMeta, RebalanceStopPropagationRecord,
     StorageError, decode_rebalance_stop_propagation_record, get_global_notification_sys,
 };
@@ -296,7 +296,7 @@ fn build_rebalance_pool_progress(
     now: OffsetDateTime,
     stop_time: Option<OffsetDateTime>,
     percent_free_goal: f64,
-    ps: &crate::admin::handlers::storage_compat::RebalanceStats,
+    ps: &super::storage_compat::RebalanceStats,
 ) -> Option<RebalPoolProgress> {
     let total_bytes_to_rebal = ps.init_capacity as f64 * percent_free_goal - ps.init_free_space as f64;
     let terminal_time = ps.info.end_time.or(stop_time);
@@ -339,7 +339,7 @@ fn build_rebalance_pool_statuses(
     now: OffsetDateTime,
     stop_time: Option<OffsetDateTime>,
     percent_free_goal: f64,
-    pool_stats: &[crate::admin::handlers::storage_compat::RebalanceStats],
+    pool_stats: &[super::storage_compat::RebalanceStats],
     disk_stats: &[DiskStat],
 ) -> Vec<RebalancePoolStatus> {
     pool_stats
@@ -895,6 +895,10 @@ mod offsetdatetime_rfc3339 {
 
 #[cfg(test)]
 mod rebalance_handler_tests {
+    use super::super::storage_compat::{
+        DiskStat, RebalStatus, RebalanceCleanupWarningEntry, RebalanceCleanupWarnings, RebalanceInfo, RebalanceMeta,
+        RebalanceStats, RebalanceStopPropagationRecord, encode_rebalance_stop_propagation_record,
+    };
     use super::build_rebalance_pool_progress;
     use super::calculate_rebalance_progress;
     use super::{
@@ -902,10 +906,6 @@ mod rebalance_handler_tests {
         build_rebalance_admin_status, build_rebalance_pool_statuses, build_rebalance_stop_propagation_status,
         rebalance_pool_used, rebalance_query_present, rebalance_remaining_buckets, rebalance_rollback_failure_message,
         rebalance_rollback_stop_failure_message, rebalance_start_rollback_error, rebalance_used_pct, rollback_result_label,
-    };
-    use crate::admin::handlers::storage_compat::{
-        DiskStat, RebalStatus, RebalanceCleanupWarningEntry, RebalanceCleanupWarnings, RebalanceInfo, RebalanceMeta,
-        RebalanceStats, RebalanceStopPropagationRecord, encode_rebalance_stop_propagation_record,
     };
     use time::OffsetDateTime;
 

--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::storage_compat::StorageError;
+use super::storage_compat::bucket_target_sys::{BucketTargetError, BucketTargetSys};
+use super::storage_compat::global_rustfs_port;
+use super::storage_compat::metadata::BUCKET_TARGETS_FILE;
+use super::storage_compat::metadata_sys;
+use super::storage_compat::metadata_sys::get_replication_config;
+use super::storage_compat::replication::BucketStats;
+use super::storage_compat::replication::GLOBAL_REPLICATION_STATS;
+use super::storage_compat::target::BucketTarget;
 use crate::admin::auth::validate_admin_request;
 use crate::admin::handlers::site_replication::site_replication_peer_deployment_id_for_endpoint;
-use crate::admin::handlers::storage_compat::StorageError;
-use crate::admin::handlers::storage_compat::bucket_target_sys::{BucketTargetError, BucketTargetSys};
-use crate::admin::handlers::storage_compat::global_rustfs_port;
-use crate::admin::handlers::storage_compat::metadata::BUCKET_TARGETS_FILE;
-use crate::admin::handlers::storage_compat::metadata_sys;
-use crate::admin::handlers::storage_compat::metadata_sys::get_replication_config;
-use crate::admin::handlers::storage_compat::replication::BucketStats;
-use crate::admin::handlers::storage_compat::replication::GLOBAL_REPLICATION_STATS;
-use crate::admin::handlers::storage_compat::target::BucketTarget;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::utils::read_compatible_admin_body;
 use crate::app::context::resolve_object_store_handle;

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::auth::validate_admin_request;
-use crate::admin::handlers::storage_compat::Error as StorageError;
-use crate::admin::handlers::storage_compat::bucket_target_sys::BucketTargetSys;
-use crate::admin::handlers::storage_compat::metadata::{
+use super::storage_compat::Error as StorageError;
+use super::storage_compat::bucket_target_sys::BucketTargetSys;
+use super::storage_compat::metadata::{
     BUCKET_CORS_CONFIG, BUCKET_LIFECYCLE_CONFIG, BUCKET_POLICY_CONFIG, BUCKET_QUOTA_CONFIG_FILE, BUCKET_REPLICATION_CONFIG,
     BUCKET_SSECONFIG, BUCKET_TAGGING_CONFIG, BUCKET_TARGETS_FILE, BUCKET_VERSIONING_CONFIG, OBJECT_LOCK_CONFIG,
 };
-use crate::admin::handlers::storage_compat::metadata_sys;
-use crate::admin::handlers::storage_compat::replication::GLOBAL_REPLICATION_STATS;
-use crate::admin::handlers::storage_compat::replication::{ResyncOpts, get_global_replication_pool};
-use crate::admin::handlers::storage_compat::target::{ARN, BucketTarget, BucketTargetType, BucketTargets, Credentials};
-use crate::admin::handlers::storage_compat::utils::{deserialize, serialize};
-use crate::admin::handlers::storage_compat::{AdminReplicationConfigExt as _, AdminVersioningConfigExt as _};
-use crate::admin::handlers::storage_compat::{delete_admin_config, read_admin_config, save_admin_config};
-use crate::admin::handlers::storage_compat::{
-    get_global_deployment_id, get_global_endpoints_opt, get_global_region, global_rustfs_port,
-};
+use super::storage_compat::metadata_sys;
+use super::storage_compat::replication::GLOBAL_REPLICATION_STATS;
+use super::storage_compat::replication::{ResyncOpts, get_global_replication_pool};
+use super::storage_compat::target::{ARN, BucketTarget, BucketTargetType, BucketTargets, Credentials};
+use super::storage_compat::utils::{deserialize, serialize};
+use super::storage_compat::{AdminReplicationConfigExt as _, AdminVersioningConfigExt as _};
+use super::storage_compat::{delete_admin_config, read_admin_config, save_admin_config};
+use super::storage_compat::{get_global_deployment_id, get_global_endpoints_opt, get_global_region, global_rustfs_port};
+use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::site_replication_identity::{
     canonical_endpoint, deployment_id_for_endpoint, normalize_peer_map_by_identity_with, same_identity_endpoint,
@@ -654,7 +652,7 @@ async fn site_replication_peer_client() -> S3Result<reqwest::Client> {
     built
 }
 
-fn runtime_tls_enabled_with(endpoints: Option<&crate::admin::handlers::storage_compat::EndpointServerPools>) -> bool {
+fn runtime_tls_enabled_with(endpoints: Option<&super::storage_compat::EndpointServerPools>) -> bool {
     if !rustfs_utils::get_env_str(ENV_RUSTFS_TLS_PATH, DEFAULT_RUSTFS_TLS_PATH).is_empty() {
         return true;
     }
@@ -3355,7 +3353,7 @@ fn is_stale_update(local_updated_at: OffsetDateTime, incoming_updated_at: Option
 }
 
 fn bucket_meta_local_updated_at(
-    bucket_meta: &crate::admin::handlers::storage_compat::metadata::BucketMetadata,
+    bucket_meta: &super::storage_compat::metadata::BucketMetadata,
     config_file: &str,
 ) -> OffsetDateTime {
     match config_file {
@@ -4575,9 +4573,9 @@ impl Operation for SRRotateServiceAccountHandler {
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::Endpoint;
+    use super::super::storage_compat::{EndpointServerPools, Endpoints, PoolEndpoints};
     use super::*;
-    use crate::admin::handlers::storage_compat::Endpoint;
-    use crate::admin::handlers::storage_compat::{EndpointServerPools, Endpoints, PoolEndpoints};
     use http::{HeaderMap, HeaderValue, Uri};
     use rustfs_common::{get_global_outbound_tls_generation, set_global_outbound_tls_generation};
     use rustfs_policy::policy::action::S3Action;

--- a/rustfs/src/admin/handlers/sts.rs
+++ b/rustfs/src/admin/handlers/sts.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::is_admin::IsAdminHandler;
-use crate::admin::handlers::storage_compat::utils::serialize;
+use super::storage_compat::utils::serialize;
 use crate::{
     admin::{
         handlers::site_replication::site_replication_iam_change_hook,

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::handlers::storage_compat::{ECStore, metadata::table_catalog_path_hash, metadata_sys};
+use super::storage_compat::{ECStore, metadata::table_catalog_path_hash, metadata_sys};
 use crate::admin::{
     auth::{AdminResourceScope, validate_admin_request, validate_admin_request_with_bucket_object},
     router::{AdminOperation, Operation, S3Router},

--- a/rustfs/src/admin/handlers/tier.rs
+++ b/rustfs/src/admin/handlers/tier.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 #![allow(unused_variables, unused_mut, unused_must_use)]
 
-use crate::admin::handlers::storage_compat::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
-use crate::admin::handlers::storage_compat::{
+use super::storage_compat::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
+use super::storage_compat::{
     AdminError, DailyAllTierStats, ERR_TIER_ALREADY_EXISTS, ERR_TIER_BACKEND_IN_USE, ERR_TIER_BACKEND_NOT_EMPTY,
     ERR_TIER_CONNECT_ERR, ERR_TIER_INVALID_CREDENTIALS, ERR_TIER_MISSING_CREDENTIALS, ERR_TIER_NAME_NOT_UPPERCASE,
     ERR_TIER_NOT_FOUND, TierConfig, TierCreds, TierType, get_global_notification_sys, storageclass,
@@ -930,8 +930,8 @@ impl Operation for ClearTier {
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::lifecycle::tier_last_day_stats::LastDayTierStats;
     use super::*;
-    use crate::admin::handlers::storage_compat::lifecycle::tier_last_day_stats::LastDayTierStats;
     use http::Uri;
     use matchit::Router;
 

--- a/rustfs/src/admin/handlers/trace.rs
+++ b/rustfs/src/admin/handlers/trace.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::handlers::storage_compat::PeerRestClient;
+use super::storage_compat::PeerRestClient;
 use crate::admin::router::Operation;
 use crate::app::context::resolve_endpoints_handle;
 use http::StatusCode;

--- a/rustfs/src/admin/service/config.rs
+++ b/rustfs/src/admin/service/config.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::service::storage_compat::get_global_notification_sys;
-use crate::admin::service::storage_compat::set_global_storage_class;
-use crate::admin::service::storage_compat::storageclass;
-use crate::admin::service::storage_compat::{STORAGE_CLASS_SUB_SYS, read_admin_config_without_migrate};
+use super::storage_compat::get_global_notification_sys;
+use super::storage_compat::set_global_storage_class;
+use super::storage_compat::storageclass;
+use super::storage_compat::{STORAGE_CLASS_SUB_SYS, read_admin_config_without_migrate};
 use crate::app::context::resolve_object_store_handle;
 use rustfs_audit::reload_audit_config;
 use rustfs_config::audit::{AUDIT_MQTT_SUB_SYS, AUDIT_REDIS_DEFAULT_CHANNEL, AUDIT_WEBHOOK_SUB_SYS};
@@ -370,8 +370,8 @@ pub async fn signal_config_snapshot_reload() {
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::metadata::{BUCKET_LIFECYCLE_CONFIG, BUCKET_REPLICATION_CONFIG};
     use super::*;
-    use crate::admin::service::storage_compat::metadata::{BUCKET_LIFECYCLE_CONFIG, BUCKET_REPLICATION_CONFIG};
     use rustfs_config::notify::NOTIFY_WEBHOOK_SUB_SYS;
     use rustfs_config::oidc::{OIDC_CLIENT_ID, OIDC_CONFIG_URL, OIDC_SCOPES};
     use rustfs_config::{HEAL_SUB_SYS, SCANNER_SUB_SYS};
@@ -427,7 +427,7 @@ mod tests {
 
     #[test]
     fn validate_notify_subsystem_config_rejects_invalid_webhook_endpoint() {
-        crate::admin::service::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         let mut config = ServerConfig::new();
         let targets = config.0.get_mut(NOTIFY_WEBHOOK_SUB_SYS).expect("notify webhook defaults");
         let kvs = targets.get_mut(DEFAULT_DELIMITER).expect("default target");
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn validate_audit_subsystem_config_rejects_relative_queue_dir() {
-        crate::admin::service::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         let mut config = ServerConfig::new();
         let targets = config.0.get_mut(AUDIT_MQTT_SUB_SYS).expect("audit mqtt defaults");
         let kvs = targets.get_mut(DEFAULT_DELIMITER).expect("default target");
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn validate_identity_openid_config_rejects_missing_openid_scope() {
-        crate::admin::service::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         let mut config = ServerConfig::new();
         let targets = config.0.get_mut(IDENTITY_OPENID_SUB_SYS).expect("openid defaults");
         let kvs = targets.get_mut(DEFAULT_DELIMITER).expect("default target");
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn validate_identity_openid_config_rejects_invalid_named_provider_id() {
-        crate::admin::service::storage_compat::init_admin_config_defaults();
+        super::super::storage_compat::init_admin_config_defaults();
         let mut config = ServerConfig::new();
         let targets = config.0.get_mut(IDENTITY_OPENID_SUB_SYS).expect("openid defaults");
         let default_kvs = targets.get(DEFAULT_DELIMITER).cloned().expect("default target");

--- a/rustfs/src/admin/service/site_replication.rs
+++ b/rustfs/src/admin/service/site_replication.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::service::storage_compat::Error as StorageError;
-use crate::admin::service::storage_compat::{read_admin_config, save_admin_config};
+use super::storage_compat::Error as StorageError;
+use super::storage_compat::{read_admin_config, save_admin_config};
 use crate::admin::site_replication_identity::{deployment_id_for_endpoint, normalize_peer_map_by_identity_with};
 use crate::app::context::resolve_object_store_handle;
 use rustfs_madmin::PeerInfo;

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -103,6 +103,7 @@ RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_compat_re
 RUSTFS_STORAGE_CORE_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_core_compat_relative_consumer_hits.txt"
 RUSTFS_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_local_compat_relative_consumer_hits.txt"
 RUSTFS_STORAGE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_local_compat_relative_consumer_hits.txt"
+RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_admin_local_compat_relative_consumer_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -1114,6 +1115,24 @@ fi
 
 if [[ -s "$RUSTFS_STORAGE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
   report_failure "RustFS storage RPC/S3 API compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$RUSTFS_STORAGE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  {
+    rg -n --with-filename 'crate::admin::handlers::storage_compat' \
+      rustfs/src/admin/handlers \
+      -g '*.rs' \
+      -g '!storage_compat.rs' || true
+    rg -n --with-filename 'crate::admin::service::storage_compat' \
+      rustfs/src/admin/service \
+      -g '*.rs' \
+      -g '!storage_compat.rs' || true
+  }
+) >"$RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE"
+
+if [[ -s "$RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
+  report_failure "RustFS admin compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Replace crate-qualified admin handler and admin service compatibility consumer paths with relative owner paths.
- Add a migration guard for admin local compatibility consumers.
- Record API-112 progress in the architecture migration tracker.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Admin local compatibility consumer residual scan
- `cargo check -p rustfs --tests`
- Earlier full `make pre-commit` before rebase

## Impact
No runtime behavior change expected. This keeps admin local compatibility consumers owner-relative while preserving the same facade names and aliases.

## Additional Notes
N/A
