### PR TITLE
refactor: use relative app compat consumers

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -596,6 +596,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     compatibility consumer residual scan, migration and layer guards,
     formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
     three-expert review.
+- [x] `API-113` Collapse app context and server local compatibility consumers.
+  - Completed slice: replace crate-qualified app context and server readiness
+    local compatibility consumers with relative owner paths.
+  - Acceptance: selected app context and server readiness modules no longer
+    point back to local compatibility facades through crate-qualified paths;
+    migration rules reject regressions.
+  - Must preserve: app context dependency resolution, startup bootstrap,
+    default interface handles, readiness storage quorum behavior, and readiness
+    test coverage.
+  - Verification: RustFS test-target compile coverage, app context/server local
+    compatibility consumer residual scan, migration and layer guards,
+    formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
+    three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
     [`placement-repair-invariants.md`](placement-repair-invariants.md) records
@@ -3629,15 +3642,15 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-112 keeps selected admin handlers/service local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped `super::` or `super::super::` paths. |
-| Migration preservation | pass | The new guard rejects crate-qualified admin handlers/service local compatibility consumer paths while preserving the same facade names and aliases. |
-| Testing/verification | pass | Focused compile, admin local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-113 keeps selected app context/server local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped `super::` or `super::super::` paths. |
+| Migration preservation | pass | The new guard rejects crate-qualified app context/server local compatibility consumer paths while preserving the same facade names and aliases. |
+| Testing/verification | pass | Focused compile, app context/server local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
 
-- Issue #660 API-112 current slice:
+- Issue #660 API-113 current slice:
   - `cargo check -p rustfs --tests`: passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.
@@ -3645,7 +3658,7 @@ Passed before push:
   - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
   - `./scripts/check_architecture_migration_rules.sh`: passed.
   - `./scripts/check_layer_dependencies.sh`: passed.
-  - Admin local compatibility consumer residual scan: passed.
+  - App context/server local compatibility consumer residual scan: passed.
   - Rust risk scan on changed Rust files and guard script: passed.
   - `make pre-commit`: passed.
 

--- a/rustfs/src/app/context/compat.rs
+++ b/rustfs/src/app/context/compat.rs
@@ -17,11 +17,11 @@ use super::handles::{
     default_bucket_metadata_interface, default_endpoints_interface, default_kms_runtime_interface,
     default_server_config_interface, default_tier_config_interface,
 };
-use crate::app::context::storage_compat::ECStore;
-use crate::app::context::storage_compat::EndpointServerPools;
-use crate::app::context::storage_compat::TierConfigMgr;
-use crate::app::context::storage_compat::metadata_sys::BucketMetadataSys;
-use crate::app::context::storage_compat::new_object_layer_fn;
+use super::storage_compat::ECStore;
+use super::storage_compat::EndpointServerPools;
+use super::storage_compat::TierConfigMgr;
+use super::storage_compat::metadata_sys::BucketMetadataSys;
+use super::storage_compat::new_object_layer_fn;
 #[cfg(test)]
 use crate::config::RustFSBufferConfig;
 use rustfs_config::server_config::Config;
@@ -119,6 +119,10 @@ fn resolve_buffer_config_with(
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::Endpoint;
+    use super::super::storage_compat::init_local_disks;
+    use super::super::storage_compat::new_object_layer_fn;
+    use super::super::storage_compat::{Endpoints, PoolEndpoints};
     use super::*;
     use crate::app::context::global::AppContextTestInterfaces;
     use crate::app::context::handles::{default_notify_interface, default_region_interface};
@@ -126,10 +130,6 @@ mod tests {
         BucketMetadataInterface, BufferConfigInterface, EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface,
         ServerConfigInterface, TierConfigInterface,
     };
-    use crate::app::context::storage_compat::Endpoint;
-    use crate::app::context::storage_compat::init_local_disks;
-    use crate::app::context::storage_compat::new_object_layer_fn;
-    use crate::app::context::storage_compat::{Endpoints, PoolEndpoints};
     use crate::config::{RustFSBufferConfig, WorkloadProfile};
     use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
     use std::path::PathBuf;

--- a/rustfs/src/app/context/global.rs
+++ b/rustfs/src/app/context/global.rs
@@ -21,7 +21,7 @@ use super::interfaces::{
     BucketMetadataInterface, BufferConfigInterface, EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface,
     NotifyInterface, RegionInterface, ServerConfigInterface, TierConfigInterface,
 };
-use crate::app::context::storage_compat::{ECStore, set_object_store_resolver};
+use super::storage_compat::{ECStore, set_object_store_resolver};
 use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
 use rustfs_kms::KmsServiceManager;
 use std::sync::{Arc, OnceLock};

--- a/rustfs/src/app/context/handles.rs
+++ b/rustfs/src/app/context/handles.rs
@@ -16,10 +16,10 @@ use super::interfaces::{
     BucketMetadataInterface, BufferConfigInterface, EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface,
     NotifyInterface, RegionInterface, ServerConfigInterface, TierConfigInterface,
 };
-use crate::app::context::storage_compat::EndpointServerPools;
-use crate::app::context::storage_compat::TierConfigMgr;
-use crate::app::context::storage_compat::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys};
-use crate::app::context::storage_compat::{get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr};
+use super::storage_compat::EndpointServerPools;
+use super::storage_compat::TierConfigMgr;
+use super::storage_compat::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys};
+use super::storage_compat::{get_global_endpoints_opt, get_global_region, get_global_tier_config_mgr};
 use crate::config::{RustFSBufferConfig, get_global_buffer_config};
 use async_trait::async_trait;
 use rustfs_config::server_config::Config;

--- a/rustfs/src/app/context/interfaces.rs
+++ b/rustfs/src/app/context/interfaces.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::app::context::storage_compat::EndpointServerPools;
-use crate::app::context::storage_compat::TierConfigMgr;
-use crate::app::context::storage_compat::metadata_sys::BucketMetadataSys;
+use super::storage_compat::EndpointServerPools;
+use super::storage_compat::TierConfigMgr;
+use super::storage_compat::metadata_sys::BucketMetadataSys;
 use crate::config::RustFSBufferConfig;
 use async_trait::async_trait;
 use rustfs_config::server_config::Config;

--- a/rustfs/src/app/context/startup.rs
+++ b/rustfs/src/app/context/startup.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::global::{AppContext, get_global_app_context, init_global_app_context};
-use crate::app::context::storage_compat::ECStore;
+use super::storage_compat::ECStore;
 use rustfs_kms::KmsServiceManager;
 use std::io::{Error, Result};
 use std::sync::Arc;

--- a/rustfs/src/server/readiness.rs
+++ b/rustfs/src/server/readiness.rs
@@ -839,7 +839,7 @@ mod tests {
 
     #[test]
     fn aggregate_lock_quorum_status_requires_each_set_to_meet_quorum() {
-        use crate::server::storage_compat::{Endpoint, EndpointServerPools, Endpoints, PoolEndpoints};
+        use super::super::storage_compat::{Endpoint, EndpointServerPools, Endpoints, PoolEndpoints};
 
         let endpoints = vec![
             Endpoint {
@@ -896,7 +896,7 @@ mod tests {
 
     #[test]
     fn aggregate_lock_quorum_status_fails_when_any_set_loses_quorum() {
-        use crate::server::storage_compat::{Endpoint, EndpointServerPools, Endpoints, PoolEndpoints};
+        use super::super::storage_compat::{Endpoint, EndpointServerPools, Endpoints, PoolEndpoints};
 
         let endpoints = vec![
             Endpoint {

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -104,6 +104,7 @@ RUSTFS_STORAGE_CORE_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storag
 RUSTFS_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_local_compat_relative_consumer_hits.txt"
 RUSTFS_STORAGE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_local_compat_relative_consumer_hits.txt"
 RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_admin_local_compat_relative_consumer_hits.txt"
+RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_app_server_local_compat_relative_consumer_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -1133,6 +1134,22 @@ fi
 
 if [[ -s "$RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
   report_failure "RustFS admin compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  {
+    rg -n --with-filename 'crate::app::context::storage_compat' \
+      rustfs/src/app/context \
+      -g '*.rs' \
+      -g '!storage_compat.rs' || true
+    rg -n --with-filename 'crate::server::storage_compat' \
+      rustfs/src/server/readiness.rs || true
+  }
+) >"$RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE"
+
+if [[ -s "$RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
+  report_failure "RustFS app context/server compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Replace crate-qualified app context and server compatibility consumer paths with relative owner paths.
- Add a migration guard for app context and server local compatibility consumers.
- Record API-113 progress in the architecture migration tracker.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- App/server local compatibility consumer residual scan
- `cargo check -p rustfs --tests`
- Earlier full `make pre-commit` before rebase

## Impact
No runtime behavior change expected. This keeps app context and server local compatibility consumers owner-relative while preserving the same facade names and aliases.

## Additional Notes
N/A
