### PR TITLE
refactor: use relative heal test compat consumers

### DIFF
--- a/crates/heal/src/error.rs
+++ b/crates/heal/src/error.rs
@@ -14,7 +14,7 @@
 
 use thiserror::Error;
 
-use crate::heal::storage_compat::{DiskError, EcstoreError};
+use super::heal::storage_compat::{DiskError, EcstoreError};
 
 /// Custom error type for heal operations
 /// This enum defines various error variants that can occur during

--- a/crates/heal/src/heal/channel.rs
+++ b/crates/heal/src/heal/channel.rs
@@ -494,10 +494,10 @@ impl HealChannelProcessor {
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::{DiskStore, Endpoint};
     use super::*;
     use crate::heal::manager::HealConfig;
     use crate::heal::storage::{HealObjectInfo, HealStorageAPI};
-    use crate::heal::storage_compat::{DiskStore, Endpoint};
     use rustfs_common::heal_channel::{
         HealAdmissionResult, HealChannelPriority, HealChannelRequest, HealRequestSource, HealScanMode,
     };

--- a/crates/heal/tests/endpoint_index_test.rs
+++ b/crates/heal/tests/endpoint_index_test.rs
@@ -16,7 +16,7 @@
 
 mod common;
 
-use crate::common::storage_compat::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_local_disks};
+use common::storage_compat::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_local_disks};
 use std::net::SocketAddr;
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;

--- a/crates/heal/tests/heal_bug_fixes_test.rs
+++ b/crates/heal/tests/heal_bug_fixes_test.rs
@@ -22,7 +22,7 @@ use rustfs_heal::heal::{
 
 #[test]
 fn test_heal_event_to_heal_request_no_panic() {
-    use crate::common::storage_compat::Endpoint;
+    use common::storage_compat::Endpoint;
 
     // Test that invalid pool/set indices don't cause panic
     // Create endpoint using try_from or similar method
@@ -47,7 +47,7 @@ fn test_heal_event_to_heal_request_no_panic() {
 
 #[test]
 fn test_heal_event_to_heal_request_valid_indices() {
-    use crate::common::storage_compat::Endpoint;
+    use common::storage_compat::Endpoint;
 
     // Test that valid indices work correctly
     let endpoint_result = Endpoint::try_from("http://localhost:9000");
@@ -192,11 +192,11 @@ fn test_heal_task_status_atomic_update() {
         }
         async fn get_disk_status(
             &self,
-            _endpoint: &crate::common::storage_compat::Endpoint,
+            _endpoint: &common::storage_compat::Endpoint,
         ) -> rustfs_heal::Result<rustfs_heal::heal::storage::DiskStatus> {
             Ok(rustfs_heal::heal::storage::DiskStatus::Ok)
         }
-        async fn format_disk(&self, _endpoint: &crate::common::storage_compat::Endpoint) -> rustfs_heal::Result<()> {
+        async fn format_disk(&self, _endpoint: &common::storage_compat::Endpoint) -> rustfs_heal::Result<()> {
             Ok(())
         }
         async fn get_bucket_info(&self, _bucket: &str) -> rustfs_heal::Result<Option<rustfs_storage_api::BucketInfo>> {
@@ -250,7 +250,7 @@ fn test_heal_task_status_atomic_update() {
         ) -> rustfs_heal::Result<(Vec<String>, Option<String>, bool)> {
             Ok((vec![], None, false))
         }
-        async fn get_disk_for_resume(&self, _set_disk_id: &str) -> rustfs_heal::Result<crate::common::storage_compat::DiskStore> {
+        async fn get_disk_for_resume(&self, _set_disk_id: &str) -> rustfs_heal::Result<common::storage_compat::DiskStore> {
             Err(rustfs_heal::Error::other("Not implemented in mock"))
         }
     }
@@ -320,11 +320,11 @@ async fn test_heal_task_transient_object_exists_skip_avoids_recreate() {
             Ok(Vec::new())
         }
 
-        async fn get_disk_status(&self, _endpoint: &crate::common::storage_compat::Endpoint) -> rustfs_heal::Result<DiskStatus> {
+        async fn get_disk_status(&self, _endpoint: &common::storage_compat::Endpoint) -> rustfs_heal::Result<DiskStatus> {
             Ok(DiskStatus::Ok)
         }
 
-        async fn format_disk(&self, _endpoint: &crate::common::storage_compat::Endpoint) -> rustfs_heal::Result<()> {
+        async fn format_disk(&self, _endpoint: &common::storage_compat::Endpoint) -> rustfs_heal::Result<()> {
             Ok(())
         }
 
@@ -394,7 +394,7 @@ async fn test_heal_task_transient_object_exists_skip_avoids_recreate() {
             Ok((Vec::new(), None, false))
         }
 
-        async fn get_disk_for_resume(&self, _set_disk_id: &str) -> rustfs_heal::Result<crate::common::storage_compat::DiskStore> {
+        async fn get_disk_for_resume(&self, _set_disk_id: &str) -> rustfs_heal::Result<common::storage_compat::DiskStore> {
             Err(rustfs_heal::Error::other("not implemented"))
         }
     }

--- a/crates/heal/tests/heal_integration_test.rs
+++ b/crates/heal/tests/heal_integration_test.rs
@@ -14,7 +14,7 @@
 
 mod common;
 
-use crate::common::storage_compat::{
+use common::storage_compat::{
     ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_bucket_metadata_sys, init_local_disks,
 };
 use http::HeaderMap;

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -14,7 +14,7 @@
 
 mod common;
 
-use crate::common::storage_compat::{
+use common::storage_compat::{
     BUCKET_LIFECYCLE_CONFIG, BucketVersioningSys, DiskOption, ECStore, Endpoint, EndpointServerPools, Endpoints,
     GLOBAL_TierConfigMgr, PoolEndpoints, ReadCloser, ReaderImpl, STORAGE_FORMAT_FILE, ScannerTestDiskExt as _,
     ScannerWarmBackend, TierConfig, TierMinIO, TierType, TransitionOptions, WarmBackendGetOpts, build_transition_put_options,

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -609,6 +609,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     compatibility consumer residual scan, migration and layer guards,
     formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
     three-expert review.
+- [x] `API-114` Collapse config, heal, and scanner test compatibility consumers.
+  - Completed slice: replace crate-qualified config test, heal crate, and
+    heal/scanner integration test local compatibility consumers with relative
+    owner paths.
+  - Acceptance: selected config, heal, and scanner test harnesses no longer
+    point back to local compatibility facades through crate-qualified paths;
+    migration rules reject regressions.
+  - Must preserve: config layout parsing tests, heal channel/storage test
+    coverage, endpoint index tests, and scanner lifecycle integration coverage.
+  - Verification: RustFS test-target compile coverage, config/heal/scanner
+    local compatibility consumer residual scan, migration and layer guards,
+    formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
+    three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
     [`placement-repair-invariants.md`](placement-repair-invariants.md) records
@@ -3642,23 +3655,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-113 keeps selected app context/server local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped `super::` or `super::super::` paths. |
-| Migration preservation | pass | The new guard rejects crate-qualified app context/server local compatibility consumer paths while preserving the same facade names and aliases. |
-| Testing/verification | pass | Focused compile, app context/server local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-114 keeps selected config/heal/scanner local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped relative paths. |
+| Migration preservation | pass | The new guard rejects crate-qualified config/heal/scanner local compatibility consumer paths while preserving the same facade names and aliases. |
+| Testing/verification | pass | Focused compile, config/heal/scanner local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
 
-- Issue #660 API-113 current slice:
+- Issue #660 API-114 current slice:
   - `cargo check -p rustfs --tests`: passed.
+  - `cargo check -p rustfs-heal --tests`: passed.
+  - `cargo check -p rustfs-scanner --tests`: passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.
   - `git diff --check`: passed.
   - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
   - `./scripts/check_architecture_migration_rules.sh`: passed.
   - `./scripts/check_layer_dependencies.sh`: passed.
-  - App context/server local compatibility consumer residual scan: passed.
+  - Config/heal/scanner local compatibility consumer residual scan: passed.
   - Rust risk scan on changed Rust files and guard script: passed.
   - `make pre-commit`: passed.
 

--- a/rustfs/src/config/config_test.rs
+++ b/rustfs/src/config/config_test.rs
@@ -15,8 +15,8 @@
 #[cfg(test)]
 #[allow(unsafe_op_in_unsafe_fn)]
 mod tests {
+    use super::super::super::config_storage_compat::DisksLayout;
     use crate::config::{CommandResult, Config, Opt, TlsCommands};
-    use crate::config_storage_compat::DisksLayout;
     use rustfs_config::{DEFAULT_CONSOLE_ADDRESS, DEFAULT_CONSOLE_ENABLE, DEFAULT_OBS_ENDPOINT, RUSTFS_REGION};
     use rustfs_credentials::{DEFAULT_ACCESS_KEY, DEFAULT_SECRET_KEY};
     use serial_test::serial;
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_volumes_and_disk_layout_parsing() {
-        use crate::config_storage_compat::DisksLayout;
+        use super::super::super::config_storage_compat::DisksLayout;
 
         // Test case 1: Single volume path
         let args = vec!["rustfs", "/data/vol1"];

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -105,6 +105,7 @@ RUSTFS_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_local_compat_
 RUSTFS_STORAGE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_local_compat_relative_consumer_hits.txt"
 RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_admin_local_compat_relative_consumer_hits.txt"
 RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_app_server_local_compat_relative_consumer_hits.txt"
+RUSTFS_HEAL_TEST_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_heal_test_local_compat_relative_consumer_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -1150,6 +1151,25 @@ fi
 
 if [[ -s "$RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
   report_failure "RustFS app context/server compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  {
+    rg -n --with-filename 'crate::config_storage_compat' \
+      rustfs/src/config/config_test.rs || true
+    rg -n --with-filename 'crate::heal::storage_compat' \
+      crates/heal/src/error.rs \
+      crates/heal/src/heal/channel.rs || true
+    rg -n --with-filename 'crate::common::storage_compat' \
+      crates/heal/tests \
+      crates/scanner/tests \
+      -g '*.rs' || true
+  }
+) >"$RUSTFS_HEAL_TEST_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE"
+
+if [[ -s "$RUSTFS_HEAL_TEST_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
+  report_failure "RustFS config/heal/scanner compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$RUSTFS_HEAL_TEST_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Replace crate-qualified config, heal, and scanner test compatibility consumer paths with relative owner paths.
- Extend the architecture migration guard to reject reintroduced crate-qualified local compatibility consumer paths in the selected config/heal/scanner surfaces.
- Update the migration progress notes for API-114.

## Verification

- `cargo check -p rustfs -p rustfs-heal -p rustfs-scanner --tests`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Config/heal/scanner local compatibility consumer residual scan
- Rust risk scan on changed Rust files and guard script
- `make pre-commit`

## Impact

No runtime behavior changes expected. This is a compatibility-path cleanup for selected test and heal/scanner surfaces.

## Additional Notes

N/A
