### PR TITLE
refactor: use relative standalone compat consumers

### DIFF
--- a/crates/e2e_test/src/reliant/grpc_lock_client.rs
+++ b/crates/e2e_test/src/reliant/grpc_lock_client.rs
@@ -15,7 +15,7 @@
 // Used by test_distributed_lock_4_nodes_grpc in lock.rs
 #![allow(dead_code)]
 
-use crate::storage_compat::node_service_time_out_client_no_auth;
+use super::super::storage_compat::node_service_time_out_client_no_auth;
 use async_trait::async_trait;
 use rustfs_lock::{
     LockClient, LockError, LockId, LockInfo, LockRequest, LockResponse, LockStats, LockStatus, LockType, Result,
@@ -41,7 +41,10 @@ impl GrpcLockClient {
         &self,
     ) -> Result<
         rustfs_protos::proto_gen::node_service::node_service_client::NodeServiceClient<
-            tonic::service::interceptor::InterceptedService<tonic::transport::Channel, crate::storage_compat::TonicInterceptor>,
+            tonic::service::interceptor::InterceptedService<
+                tonic::transport::Channel,
+                super::super::storage_compat::TonicInterceptor,
+            >,
         >,
     > {
         node_service_time_out_client_no_auth(&self.addr)

--- a/crates/e2e_test/src/reliant/node_interact_test.rs
+++ b/crates/e2e_test/src/reliant/node_interact_test.rs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::super::storage_compat::{VolumeInfo, WalkDirOptions};
+use super::super::storage_compat::{gen_tonic_signature_interceptor, node_service_time_out_client};
 use crate::common::workspace_root;
-use crate::storage_compat::{VolumeInfo, WalkDirOptions};
-use crate::storage_compat::{gen_tonic_signature_interceptor, node_service_time_out_client};
 use futures::future::join_all;
 use rmp_serde::{Deserializer, Serializer};
 use rustfs_filemeta::{MetaCacheEntry, MetacacheReader, MetacacheWriter};

--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::storage_compat::BucketTargetSys;
 use crate::common::{
     RustFSTestEnvironment, awscurl_available, awscurl_post_sts_form_urlencoded, init_logging, local_http_client,
 };
-use crate::storage_compat::BucketTargetSys;
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};

--- a/crates/iam/src/error.rs
+++ b/crates/iam/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage_compat::IamStorageError;
+use super::storage_compat::IamStorageError;
 use rustfs_policy::policy::Error as PolicyError;
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/crates/iam/src/lib.rs
+++ b/crates/iam/src/lib.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use self::storage_compat::IamStore;
 use crate::error::{Error, Result};
-use crate::storage_compat::IamStore;
 use manager::IamCache;
 use oidc::OidcSys;
 use std::sync::{Arc, OnceLock};

--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::storage_compat::is_iam_first_cluster_node_local;
 use crate::error::{Error, Result, is_err_config_not_found};
-use crate::storage_compat::is_iam_first_cluster_node_local;
 use crate::sys::{get_claims_from_token_with_secret, get_claims_from_token_with_secret_allow_missing_exp};
 use crate::{
     cache::{Cache, CacheEntity, LockedCache},

--- a/crates/iam/src/store/object.rs
+++ b/crates/iam/src/store/object.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{GroupInfo, MappedPolicy, Store, UserType};
-use crate::error::{Error, Result, is_err_config_not_found, is_err_no_such_group};
-use crate::storage_compat::{
+use super::super::storage_compat::{
     IAM_CONFIG_ROOT_PREFIX, IamStorageError, IamStore, classify_iam_system_path_failure_reason, delete_iam_config,
     read_iam_config_no_lock, read_iam_config_with_metadata, save_iam_config, save_iam_config_with_opts,
 };
+use super::{GroupInfo, MappedPolicy, Store, UserType};
+use crate::error::{Error, Result, is_err_config_not_found, is_err_no_such_group};
 use crate::{
     cache::{Cache, CacheEntity},
     error::{is_err_no_such_policy, is_err_no_such_user},

--- a/crates/iam/src/store/storage_compat.rs
+++ b/crates/iam/src/store/storage_compat.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage_compat::IamStore;
+use super::super::storage_compat::IamStore;
 
 pub(super) type IamObjectInfo = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub(super) type IamObjectOptions = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::storage_compat::{
+    notify_iam_delete_policy, notify_iam_delete_service_account, notify_iam_delete_user, notify_iam_load_group,
+    notify_iam_load_policy, notify_iam_load_policy_mapping, notify_iam_load_service_account, notify_iam_load_user,
+};
 use crate::error::Error as IamError;
 use crate::error::is_err_no_such_account;
 use crate::error::is_err_no_such_temp_account;
@@ -19,10 +23,6 @@ use crate::error::{Error, Result};
 use crate::manager::extract_jwt_claims;
 use crate::manager::get_default_policyes;
 use crate::manager::{IamCache, IamSyncMetricsSnapshot};
-use crate::storage_compat::{
-    notify_iam_delete_policy, notify_iam_delete_service_account, notify_iam_delete_user, notify_iam_load_group,
-    notify_iam_load_policy, notify_iam_load_policy_mapping, notify_iam_load_service_account, notify_iam_load_user,
-};
 use crate::store::GroupInfo;
 use crate::store::MappedPolicy;
 use crate::store::Store;

--- a/crates/obs/src/metrics/scheduler.rs
+++ b/crates/obs/src/metrics/scheduler.rs
@@ -23,6 +23,7 @@
 //! - Process disk I/O metrics
 //! - Host network I/O metrics
 
+use super::super::storage_compat::obs_bucket_monitor_available;
 use crate::metrics::collectors::{
     AuditTargetStats,
     BucketReplicationBandwidthStats,
@@ -81,7 +82,6 @@ use crate::metrics::stats_collector::{
     collect_ilm_metric_stats, collect_internode_network_stats, collect_process_metric_bundle, collect_replication_stats,
     collect_scanner_metric_stats, collect_system_cpu_and_memory_stats_with,
 };
-use crate::storage_compat::obs_bucket_monitor_available;
 use rustfs_audit::audit_target_metrics;
 use rustfs_notify::{notification_metrics_snapshot, notification_target_metrics};
 use rustfs_utils::get_env_opt_u64;

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -20,16 +20,16 @@
 //! RustFS internal sources (storage layer, bucket monitor, system info)
 //! and convert them to the Stats structs used by collectors.
 
+use super::super::storage_compat::{
+    load_obs_data_usage_from_backend, obs_bucket_quota_limit_bytes, obs_bucket_replication_bandwidth_stats,
+    obs_bucket_replication_detail_stats, obs_ilm_runtime_snapshot, obs_site_replication_stats, obs_total_usable_capacity_bytes,
+    obs_total_usable_capacity_free_bytes, resolve_obs_object_store_handle,
+};
 use crate::metrics::collectors::{
     BucketReplicationBandwidthStats, BucketReplicationStats, BucketStats, BucketUsageStats, ClusterConfigStats,
     ClusterHealthStats, ClusterStats, ClusterUsageStats, CpuStats, DiskStats, DriveCountStats, DriveDetailedStats,
     ErasureSetStats, HostNetworkStats, IamStats, IlmStats, MemoryStats, NetworkStats, ProcessStats, ProcessStatusType,
     ReplicationStats, ResourceStats, ScannerStats,
-};
-use crate::storage_compat::{
-    load_obs_data_usage_from_backend, obs_bucket_quota_limit_bytes, obs_bucket_replication_bandwidth_stats,
-    obs_bucket_replication_detail_stats, obs_ilm_runtime_snapshot, obs_site_replication_stats, obs_total_usable_capacity_bytes,
-    obs_total_usable_capacity_free_bytes, resolve_obs_object_store_handle,
 };
 use chrono::Utc;
 use rustfs_common::heal_channel::HealScanMode;

--- a/crates/s3select-api/src/object_store.rs
+++ b/crates/s3select-api/src/object_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage_compat::{
+use super::storage_compat::{
     SELECT_DEFAULT_READ_BUFFER_SIZE, SelectGetObjectReader, SelectObjectInfo, SelectObjectOptions, SelectStorageError,
     SelectStore, resolve_select_object_store_handle, select_default_read_buffer_size_u64, select_is_err_bucket_not_found,
     select_is_err_object_not_found, select_is_err_version_not_found,

--- a/crates/scanner/src/data_usage_define.rs
+++ b/crates/scanner/src/data_usage_define.rs
@@ -32,12 +32,12 @@ use rustfs_utils::path::{SLASH_SEPARATOR, path_join_buf};
 use tokio::time::{Duration, Instant, sleep, timeout};
 use tracing::warn;
 
-use crate::storage_compat::{
+use super::storage_compat::{
     BUCKET_META_PREFIX, EcstoreError as Error, EcstoreResult as StorageResult, RUSTFS_META_BUCKET, ReplicationConfig,
     ScannerObjectInfo as ObjectInfo, ScannerObjectOptions as ObjectOptions, StorageError, TRANSITION_COMPLETE, save_config,
     storageclass,
 };
-pub use crate::storage_compat::{
+pub use super::storage_compat::{
     ScannerGetObjectReader, ScannerObjectIO, ScannerObjectInfo, ScannerObjectOptions, ScannerObjectToDelete, ScannerPutObjReader,
 };
 

--- a/crates/scanner/src/runtime_config.rs
+++ b/crates/scanner/src/runtime_config.rs
@@ -816,8 +816,8 @@ pub(crate) fn scanner_alert_excess_folders() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::init_ecstore_config_for_scanner_tests;
     use super::{ScannerRuntimeConfigSource, lookup_scanner_runtime_config, validate_scanner_runtime_config};
-    use crate::storage_compat::init_ecstore_config_for_scanner_tests;
     use rustfs_config::server_config::{Config as ServerConfig, KVS};
     use rustfs_config::{
         DEFAULT_DELIMITER, ENV_SCANNER_BITROT_CYCLE_SECS, ENV_SCANNER_CACHE_SAVE_TIMEOUT_SECS, ENV_SCANNER_CYCLE,

--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -46,7 +46,7 @@ use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::storage_compat::{
+use super::storage_compat::{
     ECStore, EcstoreError, RUSTFS_META_BUCKET, ScannerLifecycleConfigExt as _, ScannerReplicationConfigExt as _,
     get_lifecycle_config, get_replication_config, is_erasure_sd, read_config, replace_bucket_usage_memory_from_info, save_config,
 };
@@ -1104,8 +1104,8 @@ pub async fn store_data_usage_in_backend(
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::EcstoreResult;
     use super::*;
-    use crate::storage_compat::EcstoreResult;
     use crate::{
         ScannerGetObjectReader as GetObjectReader, ScannerObjectInfo as ObjectInfo, ScannerObjectOptions as ObjectOptions,
         ScannerPutObjReader as PutObjReader,

--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -50,7 +50,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
-use crate::storage_compat::{
+use super::storage_compat::{
     BucketVersioningSys, Disk, DiskError, DiskInfoOptions, Evaluator, Event, LcEventSrc, ListPathRawOptions, ObjectOpts,
     ReplicationConfig, ReplicationQueueAdmission, ScannerDiskExt as _, ScannerLifecycleConfigExt as _,
     ScannerReplicationConfigExt as _, ScannerVersioningConfigExt as _, StorageError, apply_expiry_rule, apply_transition_rule,
@@ -2419,8 +2419,8 @@ pub async fn scan_data_folder(
 mod tests {
     use crate::SCANNER_SLEEPER;
 
+    use super::super::storage_compat::{DiskOption, Endpoint, new_disk};
     use super::*;
-    use crate::storage_compat::{DiskOption, Endpoint, new_disk};
     use rustfs_filemeta::{ReplicateObjectInfo, ReplicationType, ResyncDecision, ResyncTargetDecision, VersionPurgeStatusType};
     use serial_test::serial;
     #[cfg(unix)]

--- a/crates/scanner/src/scanner_io.rs
+++ b/crates/scanner/src/scanner_io.rs
@@ -42,14 +42,14 @@ use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
-use crate::ScannerObjectInfo as ObjectInfo;
-use crate::storage_compat::{
+use super::storage_compat::{
     BucketTargetSys, BucketVersioningSys, Disk, DiskError, ECStore, EcstoreError as Error, EcstoreResult as Result,
     ReplicationConfig, STORAGE_FORMAT_FILE, ScannerDiskExt as _, ScannerLifecycleConfigExt as _,
     ScannerReplicationConfigExt as _, ScannerVersioningConfigExt as _, SetDisks, StorageError, enqueue_global_free_version,
     get_lifecycle_config, get_object_lock_config, get_replication_config, list_global_tiers, resolve_scanner_object_store_handle,
     storageclass,
 };
+use crate::ScannerObjectInfo as ObjectInfo;
 
 pub(crate) const SCANNER_SKIP_FILE_ERROR: &str = "skip file";
 const LOG_COMPONENT_SCANNER: &str = "scanner";
@@ -1522,9 +1522,9 @@ impl ScannerIODisk for Disk {
 
 #[cfg(test)]
 mod tests {
+    use super::super::storage_compat::{DiskOption, Endpoint, new_disk, path2_bucket_object_with_base_path};
     use super::*;
     use crate::scanner_folder::ScannerItem;
-    use crate::storage_compat::{DiskOption, Endpoint, new_disk, path2_bucket_object_with_base_path};
     use serial_test::serial;
     use temp_env::with_var;
     use uuid::Uuid;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-admin-compat-relative-consumers`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112`.
-- Based on: API-111 slice.
+- Branch: `overtrue/arch-standalone-crate-compat-relative-consumers`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114`.
+- Based on: API-114 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: collapse crate-qualified admin handlers/service local
-  compatibility consumer paths into relative `super::`/`super::super::` paths.
-- CI/script changes: guard selected admin handlers/service local consumers
+- Rust code changes: collapse standalone scanner/IAM/observability/S3 Select/e2e
+  compatibility consumer paths into relative owner paths.
+- CI/script changes: guard selected standalone crate local consumers
   against crate-qualified compatibility paths.
-- Docs changes: record the API-112 relative admin local compatibility consumer
+- Docs changes: record the API-115 standalone crate local compatibility consumer
   cleanup.
 
 ## Phase 0 Tasks
@@ -620,6 +620,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     coverage, endpoint index tests, and scanner lifecycle integration coverage.
   - Verification: RustFS test-target compile coverage, config/heal/scanner
     local compatibility consumer residual scan, migration and layer guards,
+    formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
+    three-expert review.
+- [x] `API-115` Collapse standalone crate local compatibility consumers.
+  - Completed slice: replace crate-qualified scanner, IAM, observability,
+    S3 Select, and e2e local compatibility consumers with relative owner paths.
+  - Acceptance: selected standalone crate modules no longer point back to their
+    local compatibility facades through crate-qualified paths; migration rules
+    reject regressions.
+  - Must preserve: scanner data usage and object IO behavior, IAM storage
+    adapter contracts, observability metric collection, S3 Select object-store
+    reads, and e2e RPC helper coverage.
+  - Verification: standalone crate compile coverage, standalone local
+    compatibility consumer residual scan, migration and layer guards,
     formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
     three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
@@ -3655,25 +3668,28 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-114 keeps selected config/heal/scanner local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped relative paths. |
-| Migration preservation | pass | The new guard rejects crate-qualified config/heal/scanner local compatibility consumer paths while preserving the same facade names and aliases. |
-| Testing/verification | pass | Focused compile, config/heal/scanner local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-115 keeps selected standalone crate local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped relative paths. |
+| Migration preservation | pass | The new guard rejects crate-qualified standalone crate local compatibility consumer paths while preserving the same facade names and aliases. |
+| Testing/verification | pass | Focused compile, standalone crate local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
 
 ## Verification Notes
 
 Passed before push:
 
-- Issue #660 API-114 current slice:
+- Issue #660 API-115 current slice:
   - `cargo check -p rustfs --tests`: passed.
-  - `cargo check -p rustfs-heal --tests`: passed.
   - `cargo check -p rustfs-scanner --tests`: passed.
+  - `cargo check -p rustfs-iam --tests`: passed.
+  - `cargo check -p rustfs-obs --tests`: passed.
+  - `cargo check -p rustfs-s3select-api --tests`: passed.
+  - `cargo check -p e2e_test --tests`: passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.
   - `git diff --check`: passed.
   - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
   - `./scripts/check_architecture_migration_rules.sh`: passed.
   - `./scripts/check_layer_dependencies.sh`: passed.
-  - Config/heal/scanner local compatibility consumer residual scan: passed.
+  - Standalone crate local compatibility consumer residual scan: passed.
   - Rust risk scan on changed Rust files and guard script: passed.
   - `make pre-commit`: passed.
 

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -106,6 +106,7 @@ RUSTFS_STORAGE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_stora
 RUSTFS_ADMIN_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_admin_local_compat_relative_consumer_hits.txt"
 RUSTFS_APP_SERVER_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_app_server_local_compat_relative_consumer_hits.txt"
 RUSTFS_HEAL_TEST_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_heal_test_local_compat_relative_consumer_hits.txt"
+STANDALONE_CRATE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/standalone_crate_local_compat_relative_consumer_hits.txt"
 SCANNER_BUCKET_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/scanner_bucket_storage_compat_module_hits.txt"
 NOTIFY_STORAGE_COMPAT_MODULE_HITS_FILE="${TMP_DIR}/notify_storage_compat_module_hits.txt"
 OBS_STORAGE_COMPAT_PASSTHROUGH_HITS_FILE="${TMP_DIR}/obs_storage_compat_passthrough_hits.txt"
@@ -1170,6 +1171,21 @@ fi
 
 if [[ -s "$RUSTFS_HEAL_TEST_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
   report_failure "RustFS config/heal/scanner compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$RUSTFS_HEAL_TEST_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::storage_compat' \
+    crates/scanner/src \
+    crates/iam/src \
+    crates/obs/src \
+    crates/s3select-api/src \
+    crates/e2e_test/src \
+    -g '*.rs' || true
+) >"$STANDALONE_CRATE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE"
+
+if [[ -s "$STANDALONE_CRATE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE" ]]; then
+  report_failure "Standalone crate compatibility consumers must use relative owner paths instead of crate-qualified local compatibility paths: $(paste -sd '; ' "$STANDALONE_CRATE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Replace crate-qualified scanner, IAM, observability, S3 Select, and e2e local compatibility consumer paths with relative owner paths.
- Extend the architecture migration guard to reject reintroduced crate-qualified standalone compatibility consumer paths in those selected surfaces.
- Update the migration progress notes for API-115.

## Verification

- `cargo check --tests -p rustfs -p rustfs-scanner -p rustfs-iam -p rustfs-obs -p rustfs-s3select-api -p e2e_test`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Standalone local compatibility consumer residual scan
- Rust risk scan on changed Rust files and guard script
- `make pre-commit`

## Impact

No runtime behavior changes expected. This is a compatibility-path cleanup for selected standalone crate consumers.

## Additional Notes

N/A
