### PR TITLE
refactor: use relative fuzz compat consumers

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-standalone-crate-compat-relative-consumers`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114`.
-- Based on: API-114 slice.
+- Branch: `overtrue/arch-fuzz-compat-relative-consumers`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115`.
+- Based on: API-115 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: collapse standalone scanner/IAM/observability/S3 Select/e2e
-  compatibility consumer paths into relative owner paths.
-- CI/script changes: guard selected standalone crate local consumers
-  against crate-qualified compatibility paths.
-- Docs changes: record the API-115 standalone crate local compatibility consumer
+- Rust code changes: collapse fuzz-target compatibility consumer paths into
+  relative owner paths.
+- CI/script changes: extend the standalone crate local consumer guard to fuzz
+  targets.
+- Docs changes: record the API-116 fuzz-target local compatibility consumer
   cleanup.
 
 ## Phase 0 Tasks
@@ -635,6 +635,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     compatibility consumer residual scan, migration and layer guards,
     formatting, diff hygiene, Rust risk scan, pre-commit quality gate, and
     three-expert review.
+- [x] `API-116` Collapse fuzz-target local compatibility consumers.
+  - Completed slice: replace crate-qualified bucket-validation and
+    path-containment fuzz-target local compatibility consumers with relative
+    owner paths.
+  - Acceptance: selected fuzz targets no longer point back to their local
+    compatibility facades through crate-qualified paths; migration rules reject
+    regressions.
+  - Must preserve: fuzz harness entrypoints, corpus behavior, bucket/object
+    validation coverage, and path-containment assertions.
+  - Verification: fuzz package compile coverage, fuzz-target local
+    compatibility consumer residual scan, migration and layer guards,
+    formatting, diff hygiene, Rust risk scan, and three-expert review.
 - [x] `G-012` Inventory placement and repair invariants.
   - Acceptance:
     [`placement-repair-invariants.md`](placement-repair-invariants.md) records
@@ -3668,13 +3680,24 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-115 keeps selected standalone crate local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped relative paths. |
-| Migration preservation | pass | The new guard rejects crate-qualified standalone crate local compatibility consumer paths while preserving the same facade names and aliases. |
-| Testing/verification | pass | Focused compile, standalone crate local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, risk scan, and full pre-commit passed. |
+| Quality/architecture | pass | API-116 keeps selected fuzz-target local compatibility consumers owner-relative by replacing crate-qualified compatibility paths with scoped relative paths. |
+| Migration preservation | pass | The extended guard rejects crate-qualified fuzz-target local compatibility consumer paths while preserving the same facade names and aliases. |
+| Testing/verification | pass | Fuzz package compile, fuzz-target local compatibility consumer residual scan, migration guard, layer guard, formatting, diff hygiene, and risk scan passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-116 current slice:
+  - `cargo check --manifest-path fuzz/Cargo.toml --bins`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Fuzz-target local compatibility consumer residual scan: passed.
+  - Rust risk scan on changed Rust files and guard script: passed.
 
 - Issue #660 API-115 current slice:
   - `cargo check -p rustfs --tests`: passed.

--- a/fuzz/fuzz_targets/bucket_validation.rs
+++ b/fuzz/fuzz_targets/bucket_validation.rs
@@ -4,7 +4,7 @@
 mod storage_compat;
 
 use libfuzzer_sys::fuzz_target;
-use crate::storage_compat::{
+use self::storage_compat::{
     check_bucket_and_object_names, check_list_objs_args, check_valid_bucket_name_strict, is_meta_bucketname,
 };
 

--- a/fuzz/fuzz_targets/path_containment.rs
+++ b/fuzz/fuzz_targets/path_containment.rs
@@ -4,7 +4,7 @@
 mod storage_compat;
 
 use libfuzzer_sys::fuzz_target;
-use crate::storage_compat::{check_object_name_for_length_and_slash, has_bad_path_component, is_valid_object_prefix};
+use self::storage_compat::{check_object_name_for_length_and_slash, has_bad_path_component, is_valid_object_prefix};
 use rustfs_utils::path::{clean, path_join};
 use std::path::{Path, PathBuf};
 

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -1181,6 +1181,7 @@ fi
     crates/obs/src \
     crates/s3select-api/src \
     crates/e2e_test/src \
+    fuzz/fuzz_targets \
     -g '*.rs' || true
 ) >"$STANDALONE_CRATE_LOCAL_COMPAT_RELATIVE_CONSUMER_HITS_FILE"
 


### PR DESCRIPTION
## Summary

- replace crate-qualified fuzz-target compatibility consumers with relative owner paths
- extend migration rules to reject fuzz-target compatibility consumer regressions

## Verification

- cargo check --manifest-path fuzz/Cargo.toml --bins
- cargo fmt --all --check
- git diff --check
- bash -n scripts/check_architecture_migration_rules.sh
- ./scripts/check_architecture_migration_rules.sh
- ./scripts/check_layer_dependencies.sh
- make pre-commit
