### PR TITLE
fix(security): extend outbound egress guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9604,6 +9604,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -41,6 +41,7 @@ use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use reqwest::Client as HttpClient;
 use rustfs_config::{DEFAULT_TRUST_LEAF_CERT_AS_CA, ENV_TRUST_LEAF_CERT_AS_CA, RUSTFS_CA_CERT, RUSTFS_TLS_CERT};
 use rustfs_filemeta::{ReplicationStatusType, ReplicationType};
+use rustfs_utils::egress::validate_outbound_url;
 use rustfs_utils::http::{
     AMZ_BUCKET_REPLICATION_STATUS, AMZ_OBJECT_LOCK_BYPASS_GOVERNANCE, AMZ_OBJECT_LOCK_LEGAL_HOLD, AMZ_OBJECT_LOCK_MODE,
     AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE, AMZ_STORAGE_CLASS, AMZ_WEBSITE_REDIRECT_LOCATION, is_amz_header, is_minio_header,
@@ -646,6 +647,16 @@ impl BucketTargetSys {
         } else {
             format!("http://{}", target.endpoint)
         };
+        let parsed_endpoint = Url::parse(&endpoint).map_err(|err| BucketTargetError::RemoteTargetConnectionErr {
+            bucket: target.target_bucket.clone(),
+            access_key: credentials.access_key.clone(),
+            error: format!("invalid target endpoint: {err}"),
+        })?;
+        validate_outbound_url(&parsed_endpoint).map_err(|err| BucketTargetError::RemoteTargetConnectionErr {
+            bucket: target.target_bucket.clone(),
+            access_key: credentials.access_key.clone(),
+            error: format!("target endpoint is not allowed: {err}"),
+        })?;
 
         let mut config_builder = S3Config::builder()
             .endpoint_url(endpoint.clone())
@@ -1616,5 +1627,28 @@ mod tests {
             rustfs_utils::http::get_header(&headers, SUFFIX_SOURCE_DELETEMARKER).is_none(),
             "delete-marker version purges must not masquerade as delete-marker creations"
         );
+    }
+
+    #[tokio::test]
+    async fn get_remote_target_client_internal_rejects_loopback_endpoint() {
+        let sys = BucketTargetSys::default();
+        let err = sys
+            .get_remote_target_client_internal(&BucketTarget {
+                endpoint: "127.0.0.1:9000".to_string(),
+                secure: true,
+                target_bucket: "bucket".to_string(),
+                region: "us-east-1".to_string(),
+                credentials: Some(Credentials {
+                    access_key: "access".to_string(),
+                    secret_key: "secret".to_string(),
+                    session_token: None,
+                    expiration: None,
+                }),
+                ..Default::default()
+            })
+            .await
+            .expect_err("loopback endpoint should be rejected");
+
+        assert!(err.to_string().contains("not allowed"));
     }
 }

--- a/crates/ecstore/src/tier/warm_backend_s3.rs
+++ b/crates/ecstore/src/tier/warm_backend_s3.rs
@@ -36,6 +36,7 @@ use crate::tier::{
     tier_config::TierS3,
     warm_backend::{WarmBackend, WarmBackendGetOpts, build_transition_put_options},
 };
+use rustfs_utils::egress::validate_outbound_url;
 use rustfs_utils::path::SLASH_SEPARATOR;
 
 pub struct WarmBackendS3 {
@@ -54,6 +55,7 @@ impl WarmBackendS3 {
                 return Err(std::io::Error::other(err.to_string()));
             }
         };
+        validate_outbound_url(&u).map_err(|err| std::io::Error::other(format!("tier endpoint is not allowed: {err}")))?;
 
         if conf.aws_role_web_identity_token_file == "" && conf.aws_role_arn != ""
             || conf.aws_role_web_identity_token_file != "" && conf.aws_role_arn == ""
@@ -117,6 +119,28 @@ impl WarmBackendS3 {
             dest_obj = format!("{}/{}", &self.prefix, object);
         }
         return dest_obj;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn new_rejects_loopback_endpoint_before_network_setup() {
+        let conf = TierS3 {
+            endpoint: "https://127.0.0.1:9000".to_string(),
+            bucket: "tier-bucket".to_string(),
+            access_key: "access".to_string(),
+            secret_key: "secret".to_string(),
+            region: "us-east-1".to_string(),
+            ..Default::default()
+        };
+
+        match WarmBackendS3::new(&conf, "tier").await {
+            Ok(_) => panic!("loopback endpoint should be rejected"),
+            Err(err) => assert!(err.to_string().contains("not allowed")),
+        }
     }
 }
 

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -36,7 +36,8 @@ time = { workspace = true }
 moka = { workspace = true }
 rustfs-credentials = { workspace = true }
 rustfs-policy = { workspace = true }
-rustfs-utils = { workspace = true }
+rustfs-utils = { workspace = true, features = ["egress"] }
+url = { workspace = true }
 # Middleware dependencies
 tower = { workspace = true }
 http = { workspace = true }

--- a/crates/keystone/src/config.rs
+++ b/crates/keystone/src/config.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use crate::{KeystoneError, KeystoneVersion, Result};
+use rustfs_utils::egress::validate_outbound_url;
 use rustfs_utils::{get_env_bool, get_env_opt_str, get_env_str, get_env_u64};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
+use url::Url;
 
 /// Keystone integration configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -164,6 +166,9 @@ impl KeystoneConfig {
             return Err(KeystoneError::ConfigError("auth_url is required".to_string()));
         }
 
+        let parsed = Url::parse(&self.auth_url).map_err(|err| KeystoneError::ConfigError(format!("invalid auth_url: {err}")))?;
+        validate_outbound_url(&parsed).map_err(|err| KeystoneError::ConfigError(format!("auth_url is not allowed: {err}")))?;
+
         // Validate version
         self.get_version()?;
 
@@ -265,5 +270,17 @@ mod tests {
                 assert_eq!(config.timeout_seconds, 99);
             },
         );
+    }
+
+    #[test]
+    fn test_validate_rejects_loopback_auth_url() {
+        let config = KeystoneConfig {
+            enable: true,
+            auth_url: "https://127.0.0.1:5000".to_string(),
+            ..Default::default()
+        };
+
+        let err = config.validate().expect_err("loopback auth_url should be rejected");
+        assert!(err.to_string().contains("not allowed"));
     }
 }


### PR DESCRIPTION
## Related Issues
- Fixes rustfs/backlog#700
- Related to rustfs/rustfs#3520

## Summary of Changes
- extend the shared outbound egress guard to the remaining first-batch HTTP(S) surfaces in tier warm-backend setup, replication target client construction, and Keystone configuration validation
- reject loopback and other blocked outbound endpoints before any network setup is attempted in those flows
- add focused regression coverage for warm tier endpoints, replication targets, and Keystone `auth_url` validation
- wire the Keystone crate to the shared `egress` helper feature set needed for consistent outbound validation

## Verification
- `cargo fmt --all`
- `cargo test -p rustfs-ecstore new_rejects_loopback_endpoint_before_network_setup -- --nocapture`
- `cargo test -p rustfs-ecstore get_remote_target_client_internal_rejects_loopback_endpoint -- --nocapture`
- `cargo test -p rustfs-keystone test_validate_rejects_loopback_auth_url -- --nocapture`
- `cargo test -p rustfs-keystone`
- `cargo test -p rustfs-ecstore`
- `make pre-commit`

## Impact
- expands outbound SSRF hardening coverage across additional HTTP(S) integration points
- preserves valid public endpoint behavior while failing closed for blocked destinations
- no new configuration knobs or API contract changes

## Additional Notes
- this PR intentionally scopes only the first broader rollout slice for `rustfs/backlog#700`; remaining outbound surfaces can continue in follow-up patches if needed
