### PR TITLE
refactor: expose scanner ECStore owner symbols

### DIFF
--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -21,17 +21,58 @@
 )]
 
 use http::HeaderMap;
-use rustfs_ecstore::api::bucket as ecstore_bucket;
-use rustfs_ecstore::api::cache as ecstore_cache;
-use rustfs_ecstore::api::capacity as ecstore_capacity;
-use rustfs_ecstore::api::config as ecstore_config;
-use rustfs_ecstore::api::data_usage as ecstore_data_usage;
-use rustfs_ecstore::api::disk as ecstore_disk;
-use rustfs_ecstore::api::error as ecstore_error;
-use rustfs_ecstore::api::global as ecstore_global;
-use rustfs_ecstore::api::set_disk as ecstore_set_disk;
-use rustfs_ecstore::api::storage as ecstore_storage;
-use rustfs_ecstore::api::tier as ecstore_tier;
+use rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys as EcstoreBucketTargetSys;
+use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc as EcstoreLcEventSrc;
+use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
+    GLOBAL_ExpiryState as ECSTORE_GLOBAL_EXPIRY_STATE, apply_expiry_rule as ecstore_apply_expiry_rule,
+    apply_transition_rule as ecstore_apply_transition_rule,
+};
+use rustfs_ecstore::api::bucket::lifecycle::evaluator::Evaluator as EcstoreEvaluator;
+use rustfs_ecstore::api::bucket::lifecycle::lifecycle::{
+    Event as EcstoreEvent, Lifecycle as EcstoreLifecycle, ObjectOpts as EcstoreObjectOpts,
+    TRANSITION_COMPLETE as ECSTORE_TRANSITION_COMPLETE,
+};
+use rustfs_ecstore::api::bucket::metadata_sys::{
+    get_lifecycle_config as ecstore_get_lifecycle_config, get_object_lock_config as ecstore_get_object_lock_config,
+    get_replication_config as ecstore_get_replication_config,
+};
+use rustfs_ecstore::api::bucket::replication::{
+    ReplicationConfig as EcstoreReplicationConfig, ReplicationConfigurationExt as EcstoreReplicationConfigurationExt,
+    ReplicationHealQueueResult as EcstoreReplicationHealQueueResult,
+    ReplicationQueueAdmission as EcstoreReplicationQueueAdmission,
+    queue_replication_heal_internal as ecstore_queue_replication_heal_internal,
+};
+use rustfs_ecstore::api::bucket::versioning::VersioningApi as EcstoreVersioningApi;
+use rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys as EcstoreBucketVersioningSys;
+use rustfs_ecstore::api::cache::{ListPathRawOptions as EcstoreListPathRawOptions, list_path_raw as ecstore_list_path_raw};
+use rustfs_ecstore::api::capacity::{
+    is_reserved_or_invalid_bucket as ecstore_is_reserved_or_invalid_bucket, path2_bucket_object as ecstore_path2_bucket_object,
+    path2_bucket_object_with_base_path as ecstore_path2_bucket_object_with_base_path,
+};
+use rustfs_ecstore::api::config::com::{read_config as ecstore_read_config, save_config as ecstore_save_config};
+#[cfg(test)]
+use rustfs_ecstore::api::config::init as ecstore_config_init;
+use rustfs_ecstore::api::config::storageclass::{RRS as ECSTORE_STORAGECLASS_RRS, STANDARD as ECSTORE_STORAGECLASS_STANDARD};
+use rustfs_ecstore::api::data_usage::replace_bucket_usage_memory_from_info as ecstore_replace_bucket_usage_memory_from_info;
+#[cfg(test)]
+use rustfs_ecstore::api::disk::endpoint::Endpoint as EcstoreEndpoint;
+use rustfs_ecstore::api::disk::error::{DiskError as EcstoreDiskError, Result as EcstoreDiskResult};
+use rustfs_ecstore::api::disk::{
+    BUCKET_META_PREFIX as ECSTORE_BUCKET_META_PREFIX, Bytes as EcstoreDiskBytes, Disk as EcstoreDisk, DiskAPI as EcstoreDiskAPI,
+    DiskInfo as EcstoreDiskInfo, DiskInfoOptions as EcstoreDiskInfoOptions, DiskLocation as EcstoreDiskLocation,
+    RUSTFS_META_BUCKET as ECSTORE_RUSTFS_META_BUCKET, STORAGE_FORMAT_FILE as ECSTORE_STORAGE_FORMAT_FILE,
+    ScanGuard as EcstoreScanGuard,
+};
+#[cfg(test)]
+use rustfs_ecstore::api::disk::{DiskOption as EcstoreDiskOption, DiskStore as EcstoreDiskStore, new_disk as ecstore_new_disk};
+use rustfs_ecstore::api::error::{Error as EcstoreErrorType, Result as EcstoreResultType, StorageError as EcstoreStorageError};
+use rustfs_ecstore::api::global::{
+    GLOBAL_TierConfigMgr as ECSTORE_GLOBAL_TIER_CONFIG_MGR, is_erasure as ecstore_is_erasure,
+    is_erasure_sd as ecstore_is_erasure_sd, resolve_object_store_handle as ecstore_resolve_object_store_handle,
+};
+use rustfs_ecstore::api::set_disk::SetDisks as EcstoreSetDisks;
+use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
+use rustfs_ecstore::api::tier::tier_config::TierConfig as EcstoreTierConfig;
 use rustfs_storage_api::{HTTPRangeSpec, ObjectIO, ObjectToDelete};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -77,34 +118,36 @@ impl Drop for ScannerActivityGuard {
     }
 }
 
-pub(crate) const BUCKET_META_PREFIX: &str = ecstore_disk::BUCKET_META_PREFIX;
-pub(crate) const RUSTFS_META_BUCKET: &str = ecstore_disk::RUSTFS_META_BUCKET;
-pub(crate) const STORAGE_FORMAT_FILE: &str = ecstore_disk::STORAGE_FORMAT_FILE;
-pub(crate) const TRANSITION_COMPLETE: &str = ecstore_bucket::lifecycle::lifecycle::TRANSITION_COMPLETE;
+pub(crate) const BUCKET_META_PREFIX: &str = ECSTORE_BUCKET_META_PREFIX;
+pub(crate) const RUSTFS_META_BUCKET: &str = ECSTORE_RUSTFS_META_BUCKET;
+pub(crate) const STORAGE_FORMAT_FILE: &str = ECSTORE_STORAGE_FORMAT_FILE;
+pub(crate) const TRANSITION_COMPLETE: &str = ECSTORE_TRANSITION_COMPLETE;
 
-pub(crate) type Disk = ecstore_disk::Disk;
+pub(crate) type Disk = EcstoreDisk;
 #[cfg(test)]
-pub(crate) type DiskStore = ecstore_disk::DiskStore;
-pub(crate) type DiskLocation = ecstore_disk::DiskLocation;
-pub(crate) type DiskError = ecstore_disk::error::DiskError;
-pub(crate) type DiskResult<T> = ecstore_disk::error::Result<T>;
-pub(crate) type ECStore = ecstore_storage::ECStore;
-pub(crate) type EcstoreError = ecstore_error::Error;
-pub(crate) type EcstoreResult<T> = ecstore_error::Result<T>;
-pub(crate) type ListPathRawOptions = ecstore_cache::ListPathRawOptions;
-pub(crate) type BucketTargetSys = ecstore_bucket::bucket_target_sys::BucketTargetSys;
-pub(crate) type BucketVersioningSys = ecstore_bucket::versioning_sys::BucketVersioningSys;
-pub(crate) type DiskInfoOptions = ecstore_disk::DiskInfoOptions;
-pub(crate) type Evaluator = ecstore_bucket::lifecycle::evaluator::Evaluator;
-pub(crate) type Event = ecstore_bucket::lifecycle::lifecycle::Event;
-pub(crate) type LcEventSrc = ecstore_bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
-pub(crate) type ObjectOpts = ecstore_bucket::lifecycle::lifecycle::ObjectOpts;
-pub(crate) type ReplicationConfig = ecstore_bucket::replication::ReplicationConfig;
-pub(crate) type ReplicationHealQueueResult = ecstore_bucket::replication::ReplicationHealQueueResult;
-pub(crate) type ReplicationQueueAdmission = ecstore_bucket::replication::ReplicationQueueAdmission;
-pub(crate) type ScanGuard = ecstore_disk::ScanGuard;
-pub(crate) type SetDisks = ecstore_set_disk::SetDisks;
-pub(crate) type StorageError = ecstore_error::StorageError;
+pub(crate) type DiskStore = EcstoreDiskStore;
+pub(crate) type DiskLocation = EcstoreDiskLocation;
+pub(crate) type DiskError = EcstoreDiskError;
+pub(crate) type DiskResult<T> = EcstoreDiskResult<T>;
+pub(crate) type ECStore = EcstoreStore;
+pub(crate) type EcstoreError = EcstoreErrorType;
+pub(crate) type EcstoreResult<T> = EcstoreResultType<T>;
+pub(crate) type ListPathRawOptions = EcstoreListPathRawOptions;
+pub(crate) type BucketTargetSys = EcstoreBucketTargetSys;
+pub(crate) type BucketVersioningSys = EcstoreBucketVersioningSys;
+pub(crate) type DiskInfo = EcstoreDiskInfo;
+pub(crate) type DiskInfoOptions = EcstoreDiskInfoOptions;
+pub(crate) type DiskBytes = EcstoreDiskBytes;
+pub(crate) type Evaluator = EcstoreEvaluator;
+pub(crate) type Event = EcstoreEvent;
+pub(crate) type LcEventSrc = EcstoreLcEventSrc;
+pub(crate) type ObjectOpts = EcstoreObjectOpts;
+pub(crate) type ReplicationConfig = EcstoreReplicationConfig;
+pub(crate) type ReplicationHealQueueResult = EcstoreReplicationHealQueueResult;
+pub(crate) type ReplicationQueueAdmission = EcstoreReplicationQueueAdmission;
+pub(crate) type ScanGuard = EcstoreScanGuard;
+pub(crate) type SetDisks = EcstoreSetDisks;
+pub(crate) type StorageError = EcstoreStorageError;
 
 pub type ScannerGetObjectReader = <ECStore as ObjectIO>::GetObjectReader;
 pub type ScannerObjectInfo = <ECStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
@@ -113,43 +156,43 @@ pub type ScannerObjectToDelete = ObjectToDelete;
 pub type ScannerPutObjReader = <ECStore as ObjectIO>::PutObjectReader;
 
 pub(crate) mod storageclass {
-    use super::ecstore_config;
+    use super::{ECSTORE_STORAGECLASS_RRS, ECSTORE_STORAGECLASS_STANDARD};
 
-    pub(crate) const RRS: &str = ecstore_config::storageclass::RRS;
-    pub(crate) const STANDARD: &str = ecstore_config::storageclass::STANDARD;
+    pub(crate) const RRS: &str = ECSTORE_STORAGECLASS_RRS;
+    pub(crate) const STANDARD: &str = ECSTORE_STORAGECLASS_STANDARD;
 }
 
 #[cfg(test)]
 pub(crate) fn init_ecstore_config_for_scanner_tests() {
-    ecstore_config::init();
+    ecstore_config_init();
 }
 
 #[cfg(test)]
-pub(crate) type DiskOption = ecstore_disk::DiskOption;
+pub(crate) type DiskOption = EcstoreDiskOption;
 #[cfg(test)]
-pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
+pub(crate) type Endpoint = EcstoreEndpoint;
 
 #[cfg(test)]
-pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> ecstore_disk::error::Result<DiskStore> {
-    ecstore_disk::new_disk(ep, opt).await
+pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> DiskResult<DiskStore> {
+    ecstore_new_disk(ep, opt).await
 }
 
 pub(crate) async fn get_lifecycle_config(
     bucket: &str,
 ) -> EcstoreResult<(s3s::dto::BucketLifecycleConfiguration, time::OffsetDateTime)> {
-    ecstore_bucket::metadata_sys::get_lifecycle_config(bucket).await
+    ecstore_get_lifecycle_config(bucket).await
 }
 
 pub(crate) async fn get_object_lock_config(
     bucket: &str,
 ) -> EcstoreResult<(s3s::dto::ObjectLockConfiguration, time::OffsetDateTime)> {
-    ecstore_bucket::metadata_sys::get_object_lock_config(bucket).await
+    ecstore_get_object_lock_config(bucket).await
 }
 
 pub(crate) async fn get_replication_config(
     bucket: &str,
 ) -> EcstoreResult<(s3s::dto::ReplicationConfiguration, time::OffsetDateTime)> {
-    ecstore_bucket::metadata_sys::get_replication_config(bucket).await
+    ecstore_get_replication_config(bucket).await
 }
 
 pub(crate) trait ScannerLifecycleConfigExt {
@@ -158,9 +201,7 @@ pub(crate) trait ScannerLifecycleConfigExt {
 
 impl ScannerLifecycleConfigExt for s3s::dto::BucketLifecycleConfiguration {
     fn has_active_rules(&self, prefix: &str) -> bool {
-        <s3s::dto::BucketLifecycleConfiguration as ecstore_bucket::lifecycle::lifecycle::Lifecycle>::has_active_rules(
-            self, prefix,
-        )
+        <s3s::dto::BucketLifecycleConfiguration as EcstoreLifecycle>::has_active_rules(self, prefix)
     }
 }
 
@@ -170,9 +211,7 @@ pub(crate) trait ScannerReplicationConfigExt {
 
 impl ScannerReplicationConfigExt for s3s::dto::ReplicationConfiguration {
     fn has_active_rules(&self, prefix: &str, recursive: bool) -> bool {
-        <s3s::dto::ReplicationConfiguration as ecstore_bucket::replication::ReplicationConfigurationExt>::has_active_rules(
-            self, prefix, recursive,
-        )
+        <s3s::dto::ReplicationConfiguration as EcstoreReplicationConfigurationExt>::has_active_rules(self, prefix, recursive)
     }
 }
 
@@ -183,17 +222,17 @@ pub(crate) trait ScannerVersioningConfigExt {
 
 impl ScannerVersioningConfigExt for s3s::dto::VersioningConfiguration {
     fn prefix_enabled(&self, prefix: &str) -> bool {
-        <s3s::dto::VersioningConfiguration as ecstore_bucket::versioning::VersioningApi>::prefix_enabled(self, prefix)
+        <s3s::dto::VersioningConfiguration as EcstoreVersioningApi>::prefix_enabled(self, prefix)
     }
 
     fn versioned(&self, prefix: &str) -> bool {
-        <s3s::dto::VersioningConfiguration as ecstore_bucket::versioning::VersioningApi>::versioned(self, prefix)
+        <s3s::dto::VersioningConfiguration as EcstoreVersioningApi>::versioned(self, prefix)
     }
 }
 
 pub(crate) trait ScannerDiskExt {
-    async fn disk_info(&self, opts: &DiskInfoOptions) -> DiskResult<ecstore_disk::DiskInfo>;
-    async fn read_metadata(&self, volume: &str, path: &str) -> DiskResult<ecstore_disk::Bytes>;
+    async fn disk_info(&self, opts: &DiskInfoOptions) -> DiskResult<DiskInfo>;
+    async fn read_metadata(&self, volume: &str, path: &str) -> DiskResult<DiskBytes>;
     fn path(&self) -> PathBuf;
     fn get_disk_location(&self) -> DiskLocation;
     fn start_scan(&self) -> ScanGuard;
@@ -201,47 +240,43 @@ pub(crate) trait ScannerDiskExt {
 
 impl<T> ScannerDiskExt for T
 where
-    T: ecstore_disk::DiskAPI,
+    T: EcstoreDiskAPI,
 {
-    async fn disk_info(&self, opts: &DiskInfoOptions) -> DiskResult<ecstore_disk::DiskInfo> {
-        ecstore_disk::DiskAPI::disk_info(self, opts).await
+    async fn disk_info(&self, opts: &DiskInfoOptions) -> DiskResult<DiskInfo> {
+        EcstoreDiskAPI::disk_info(self, opts).await
     }
 
-    async fn read_metadata(&self, volume: &str, path: &str) -> DiskResult<ecstore_disk::Bytes> {
-        ecstore_disk::DiskAPI::read_metadata(self, volume, path).await
+    async fn read_metadata(&self, volume: &str, path: &str) -> DiskResult<DiskBytes> {
+        EcstoreDiskAPI::read_metadata(self, volume, path).await
     }
 
     fn path(&self) -> PathBuf {
-        ecstore_disk::DiskAPI::path(self)
+        EcstoreDiskAPI::path(self)
     }
 
     fn get_disk_location(&self) -> DiskLocation {
-        ecstore_disk::DiskAPI::get_disk_location(self)
+        EcstoreDiskAPI::get_disk_location(self)
     }
 
     fn start_scan(&self) -> ScanGuard {
-        ecstore_disk::DiskAPI::start_scan(self)
+        EcstoreDiskAPI::start_scan(self)
     }
 }
 
 pub(crate) async fn apply_transition_rule(event: &Event, src: &LcEventSrc, oi: &ScannerObjectInfo) -> bool {
-    ecstore_bucket::lifecycle::bucket_lifecycle_ops::apply_transition_rule(event, src, oi).await
+    ecstore_apply_transition_rule(event, src, oi).await
 }
 
 pub(crate) async fn apply_expiry_rule(event: &Event, src: &LcEventSrc, oi: &ScannerObjectInfo) -> bool {
-    ecstore_bucket::lifecycle::bucket_lifecycle_ops::apply_expiry_rule(event, src, oi).await
+    ecstore_apply_expiry_rule(event, src, oi).await
 }
 
-pub(crate) async fn list_global_tiers() -> Vec<ecstore_tier::tier_config::TierConfig> {
-    ecstore_global::GLOBAL_TierConfigMgr.read().await.list_tiers()
+pub(crate) async fn list_global_tiers() -> Vec<EcstoreTierConfig> {
+    ECSTORE_GLOBAL_TIER_CONFIG_MGR.read().await.list_tiers()
 }
 
 pub(crate) async fn enqueue_global_free_version(oi: ScannerObjectInfo) {
-    ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
-        .write()
-        .await
-        .enqueue_free_version(oi)
-        .await;
+    ECSTORE_GLOBAL_EXPIRY_STATE.write().await.enqueue_free_version(oi).await;
 }
 
 pub(crate) async fn enqueue_global_newer_noncurrent(
@@ -250,7 +285,7 @@ pub(crate) async fn enqueue_global_newer_noncurrent(
     event: Event,
     src: &LcEventSrc,
 ) -> bool {
-    ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
+    ECSTORE_GLOBAL_EXPIRY_STATE
         .write()
         .await
         .enqueue_by_newer_noncurrent(bucket, to_delete_objs, event, src)
@@ -263,53 +298,53 @@ pub(crate) async fn queue_replication_heal_internal(
     rcfg: ReplicationConfig,
     retry_count: u32,
 ) -> ReplicationHealQueueResult {
-    ecstore_bucket::replication::queue_replication_heal_internal(bucket, oi, rcfg, retry_count).await
+    ecstore_queue_replication_heal_internal(bucket, oi, rcfg, retry_count).await
 }
 
 pub(crate) fn resolve_scanner_object_store_handle() -> Option<Arc<ECStore>> {
-    ecstore_global::resolve_object_store_handle()
+    ecstore_resolve_object_store_handle()
 }
 
 pub(crate) fn is_reserved_or_invalid_bucket(bucket: &str, strict: bool) -> bool {
-    ecstore_capacity::is_reserved_or_invalid_bucket(bucket, strict)
+    ecstore_is_reserved_or_invalid_bucket(bucket, strict)
 }
 
 pub(crate) fn path2_bucket_object(name: &str) -> (String, String) {
-    ecstore_capacity::path2_bucket_object(name)
+    ecstore_path2_bucket_object(name)
 }
 
 pub(crate) fn path2_bucket_object_with_base_path(base_path: &str, path: &str) -> (String, String) {
-    ecstore_capacity::path2_bucket_object_with_base_path(base_path, path)
+    ecstore_path2_bucket_object_with_base_path(base_path, path)
 }
 
 pub(crate) async fn is_erasure() -> bool {
-    ecstore_global::is_erasure().await
+    ecstore_is_erasure().await
 }
 
 pub(crate) async fn is_erasure_sd() -> bool {
-    ecstore_global::is_erasure_sd().await
+    ecstore_is_erasure_sd().await
 }
 
 pub(crate) async fn read_config<S>(api: Arc<S>, file: &str) -> EcstoreResult<Vec<u8>>
 where
     S: ScannerObjectIO,
 {
-    ecstore_config::com::read_config(api, file).await
+    ecstore_read_config(api, file).await
 }
 
 pub(crate) async fn save_config<S>(api: Arc<S>, file: &str, data: Vec<u8>) -> EcstoreResult<()>
 where
     S: ScannerObjectIO,
 {
-    ecstore_config::com::save_config(api, file, data).await
+    ecstore_save_config(api, file, data).await
 }
 
 pub(crate) async fn list_path_raw(rx: CancellationToken, opts: ListPathRawOptions) -> std::result::Result<(), DiskError> {
-    ecstore_cache::list_path_raw(rx, opts).await
+    ecstore_list_path_raw(rx, opts).await
 }
 
 pub(crate) async fn replace_bucket_usage_memory_from_info(data_usage_info: &rustfs_data_usage::DataUsageInfo) {
-    ecstore_data_usage::replace_bucket_usage_memory_from_info(data_usage_info).await;
+    ecstore_replace_bucket_usage_memory_from_info(data_usage_info).await;
 }
 
 pub trait ScannerObjectIO:

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,16 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-external-owner-facade-symbols`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131`.
-- Based on: API-131 slice.
+- Branch: `overtrue/arch-scanner-owner-facade-symbols`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132`.
+- Based on: API-132 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: replace completed external owner root ECStore module
-  aliases for notify, Swift, and S3 Select with explicit local symbols and
-  wrapper functions.
-- CI/script changes: reject restored `ecstore_*` module aliases in completed
-  external owner roots while allowing explicit owner-root facade symbols.
-- Docs changes: record the API-132 external owner facade symbol cleanup.
+- Rust code changes: replace the scanner owner root ECStore module aliases with
+  explicit local symbols, type aliases, constants, and wrapper functions.
+- CI/script changes: treat scanner as a completed external owner root and reject
+  restored `ecstore_*` module aliases there.
+- Docs changes: record the API-133 scanner owner facade symbol cleanup.
 
 ## Phase 0 Tasks
 
@@ -3895,6 +3894,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     risk scan, branch freshness check, pre-commit quality gate, and
     three-expert review.
 
+- [x] `API-133` Replace scanner owner module aliases with symbols.
+  - Do: replace scanner owner-root `ecstore_*` module aliases with explicit
+    local ECStore symbols, type aliases, constants, and wrapper functions.
+  - Acceptance: scanner no longer exposes broad `ecstore_*` module aliases,
+    nested scanner modules continue to consume scanner-local symbols, and the
+    migration guard prevents reintroducing scanner owner-root module aliases.
+  - Must preserve: scanner lifecycle config reads, versioning/replication
+    helper traits, disk metadata access, tier listing, erasure checks,
+    replication-heal queueing, config persistence, raw list traversal, and
+    bucket usage replacement behavior.
+  - Verification: focused scanner compile, completed-owner alias residual scan,
+    migration/layer guards, formatting, diff hygiene, Rust risk scan, branch
+    freshness check, pre-commit quality gate, and three-expert review.
+
 ## Next PRs
 
 1. `pure-move`: continue pruning remaining facade compatibility and owner boundaries.
@@ -3903,13 +3916,26 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-132 replaces completed notify, Swift, and S3 Select owner-root ECStore module aliases with explicit local symbols and wrappers. |
-| Migration preservation | pass | Notify config persistence, Swift bucket metadata access, and S3 Select object-store behavior keep the same ECStore call paths through owner roots. |
-| Testing/verification | pass | Focused notify/Swift/S3 Select compile, completed-owner alias residual scan, migration/layer guards, formatting, diff hygiene, full pre-commit, and diff-only Rust risk scan passed. |
+| Quality/architecture | pass | API-133 replaces scanner owner-root ECStore module aliases with explicit local symbols and wrappers. |
+| Migration preservation | pass | Scanner lifecycle, disk, replication, tier, config, raw-list, and data-usage call paths keep the same ECStore targets through scanner-local symbols. |
+| Testing/verification | pass | Focused scanner compile, completed-owner alias residual scan, migration/layer guards, formatting, diff hygiene, full pre-commit, and diff-only Rust risk scan passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-133 current slice:
+  - `cargo check --tests -p rustfs-scanner`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `make pre-commit`: passed.
+  - Scanner completed-owner module-alias residual scan: passed.
+  - Rust risk scan: diff-only scan found explicit symbol imports and wrapper
+    calls only; no new unwrap/expect, panic/todo/unsafe, or risky behavior
+    added.
 
 - Issue #660 API-132 current slice:
   - `cargo check --tests -p rustfs-notify -p rustfs-s3select-api -p rustfs-protocols --features rustfs-protocols/swift`: passed.

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -1062,7 +1062,7 @@ fi
   rg -n --with-filename 'rustfs_ecstore::api::[a-z_]+::' rustfs/src crates fuzz \
     --glob '*.rs' \
     --glob '!crates/ecstore/**' |
-    rg -v '^(crates/notify/src/lib\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs):' || true
+    rg -v '^(crates/notify/src/lib\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs):' || true
 ) >"$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE"
 
 if [[ -s "$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE" ]]; then
@@ -1074,7 +1074,8 @@ fi
   rg -n --with-filename '^(?:pub\(crate\) )?use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' \
     crates/notify/src/lib.rs \
     crates/protocols/src/swift/mod.rs \
-    crates/s3select-api/src/lib.rs || true
+    crates/s3select-api/src/lib.rs \
+    crates/scanner/src/lib.rs || true
 ) >"$COMPLETED_EXTERNAL_OWNER_MODULE_ALIAS_HITS_FILE"
 
 if [[ -s "$COMPLETED_EXTERNAL_OWNER_MODULE_ALIAS_HITS_FILE" ]]; then


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Replace scanner owner-root ECStore module aliases with explicit local symbols, constants, type aliases, and wrapper functions.
- Keep nested scanner modules consuming scanner-local contracts while preserving the existing ECStore call targets.
- Extend the architecture migration guard so scanner cannot restore broad owner-root `ecstore_*` module aliases.
- Update the migration progress notes for the API-133 slice.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo check --tests -p rustfs-scanner`
- `make pre-commit`

## Impact
No user-facing behavior change. This only narrows the scanner ECStore owner boundary behind explicit scanner-local symbols.

## Additional Notes
N/A
 
---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
