### PR TITLE
refactor: expose remaining external owner symbols

### DIFF
--- a/crates/heal/src/heal/mod.rs
+++ b/crates/heal/src/heal/mod.rs
@@ -22,28 +22,35 @@ pub mod storage;
 pub mod task;
 pub mod utils;
 
-use rustfs_ecstore::api::data_usage as ecstore_data_usage;
-use rustfs_ecstore::api::disk as ecstore_disk;
-use rustfs_ecstore::api::error as ecstore_error;
-use rustfs_ecstore::api::global as ecstore_global;
-use rustfs_ecstore::api::storage as ecstore_storage;
+use rustfs_ecstore::api::data_usage::DATA_USAGE_CACHE_NAME as ECSTORE_DATA_USAGE_CACHE_NAME;
+use rustfs_ecstore::api::disk::endpoint::Endpoint as EcstoreEndpoint;
+use rustfs_ecstore::api::disk::error::{DiskError as EcstoreDiskError, Result as EcstoreDiskResult};
+use rustfs_ecstore::api::disk::{
+    BUCKET_META_PREFIX as ECSTORE_BUCKET_META_PREFIX, Bytes as EcstoreDiskBytes, DeleteOptions as EcstoreDeleteOptions,
+    DiskAPI as EcstoreDiskAPI, DiskStore as EcstoreDiskStore, RUSTFS_META_BUCKET as ECSTORE_RUSTFS_META_BUCKET,
+};
+#[cfg(test)]
+use rustfs_ecstore::api::disk::{DiskOption as EcstoreDiskOption, new_disk as ecstore_new_disk};
+use rustfs_ecstore::api::error::{Error as EcstoreErrorType, StorageError as EcstoreStorageError};
+use rustfs_ecstore::api::global::GLOBAL_LOCAL_DISK_MAP as ECSTORE_GLOBAL_LOCAL_DISK_MAP;
+use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
 
 pub use erasure_healer::ErasureSetHealer;
 pub use manager::{HealManager, HealOperationsSnapshot, HealPriorityCounts, HealSourceCounts};
 pub use resume::{CheckpointManager, ResumeCheckpoint, ResumeManager, ResumeState, ResumeUtils};
 pub use task::{HealOptions, HealPriority, HealRequest, HealTask, HealType};
 
-pub(crate) const DATA_USAGE_CACHE_NAME: &str = ecstore_data_usage::DATA_USAGE_CACHE_NAME;
-pub(crate) const BUCKET_META_PREFIX: &str = ecstore_disk::BUCKET_META_PREFIX;
-pub(crate) const RUSTFS_META_BUCKET: &str = ecstore_disk::RUSTFS_META_BUCKET;
+pub(crate) const DATA_USAGE_CACHE_NAME: &str = ECSTORE_DATA_USAGE_CACHE_NAME;
+pub(crate) const BUCKET_META_PREFIX: &str = ECSTORE_BUCKET_META_PREFIX;
+pub(crate) const RUSTFS_META_BUCKET: &str = ECSTORE_RUSTFS_META_BUCKET;
 
-pub(crate) type DiskError = ecstore_disk::error::DiskError;
-pub(crate) type DiskResult<T> = ecstore_disk::error::Result<T>;
-pub(crate) type DiskStore = ecstore_disk::DiskStore;
-pub(crate) type ECStore = ecstore_storage::ECStore;
-pub(crate) type EcstoreError = ecstore_error::Error;
-pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
-pub(crate) type StorageError = ecstore_error::StorageError;
+pub(crate) type DiskError = EcstoreDiskError;
+pub(crate) type DiskResult<T> = EcstoreDiskResult<T>;
+pub(crate) type DiskStore = EcstoreDiskStore;
+pub(crate) type ECStore = EcstoreStore;
+pub(crate) type EcstoreError = EcstoreErrorType;
+pub(crate) type Endpoint = EcstoreEndpoint;
+pub(crate) type StorageError = EcstoreStorageError;
 pub(crate) type LocalDiskMap = std::collections::HashMap<String, Option<DiskStore>>;
 
 pub(crate) struct GlobalLocalDiskMap;
@@ -52,24 +59,24 @@ pub(crate) static GLOBAL_LOCAL_DISK_MAP: GlobalLocalDiskMap = GlobalLocalDiskMap
 
 impl GlobalLocalDiskMap {
     pub(crate) async fn read(&self) -> tokio::sync::RwLockReadGuard<'static, LocalDiskMap> {
-        ecstore_global::GLOBAL_LOCAL_DISK_MAP.read().await
+        ECSTORE_GLOBAL_LOCAL_DISK_MAP.read().await
     }
 }
 
 #[cfg(test)]
-pub(crate) type DiskOption = ecstore_disk::DiskOption;
+pub(crate) type DiskOption = EcstoreDiskOption;
 
 #[cfg(test)]
-pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> ecstore_disk::error::Result<DiskStore> {
-    ecstore_disk::new_disk(ep, opt).await
+pub(crate) async fn new_disk(ep: &Endpoint, opt: &DiskOption) -> DiskResult<DiskStore> {
+    ecstore_new_disk(ep, opt).await
 }
 
 pub(crate) trait HealDiskExt {
     fn endpoint(&self) -> Endpoint;
     async fn get_disk_id(&self) -> DiskResult<Option<uuid::Uuid>>;
-    async fn read_all(&self, volume: &str, path: &str) -> DiskResult<ecstore_disk::Bytes>;
-    async fn write_all(&self, volume: &str, path: &str, data: ecstore_disk::Bytes) -> DiskResult<()>;
-    async fn delete(&self, volume: &str, path: &str, options: ecstore_disk::DeleteOptions) -> DiskResult<()>;
+    async fn read_all(&self, volume: &str, path: &str) -> DiskResult<EcstoreDiskBytes>;
+    async fn write_all(&self, volume: &str, path: &str, data: EcstoreDiskBytes) -> DiskResult<()>;
+    async fn delete(&self, volume: &str, path: &str, options: EcstoreDeleteOptions) -> DiskResult<()>;
     async fn list_dir(&self, origvolume: &str, volume: &str, dir_path: &str, count: i32) -> DiskResult<Vec<String>>;
     #[cfg(test)]
     async fn make_volume(&self, volume: &str) -> DiskResult<()>;
@@ -77,35 +84,35 @@ pub(crate) trait HealDiskExt {
 
 impl<T> HealDiskExt for T
 where
-    T: ecstore_disk::DiskAPI,
+    T: EcstoreDiskAPI,
 {
     fn endpoint(&self) -> Endpoint {
-        ecstore_disk::DiskAPI::endpoint(self)
+        EcstoreDiskAPI::endpoint(self)
     }
 
     async fn get_disk_id(&self) -> DiskResult<Option<uuid::Uuid>> {
-        ecstore_disk::DiskAPI::get_disk_id(self).await
+        EcstoreDiskAPI::get_disk_id(self).await
     }
 
-    async fn read_all(&self, volume: &str, path: &str) -> DiskResult<ecstore_disk::Bytes> {
-        ecstore_disk::DiskAPI::read_all(self, volume, path).await
+    async fn read_all(&self, volume: &str, path: &str) -> DiskResult<EcstoreDiskBytes> {
+        EcstoreDiskAPI::read_all(self, volume, path).await
     }
 
-    async fn write_all(&self, volume: &str, path: &str, data: ecstore_disk::Bytes) -> DiskResult<()> {
-        ecstore_disk::DiskAPI::write_all(self, volume, path, data).await
+    async fn write_all(&self, volume: &str, path: &str, data: EcstoreDiskBytes) -> DiskResult<()> {
+        EcstoreDiskAPI::write_all(self, volume, path, data).await
     }
 
-    async fn delete(&self, volume: &str, path: &str, options: ecstore_disk::DeleteOptions) -> DiskResult<()> {
-        ecstore_disk::DiskAPI::delete(self, volume, path, options).await
+    async fn delete(&self, volume: &str, path: &str, options: EcstoreDeleteOptions) -> DiskResult<()> {
+        EcstoreDiskAPI::delete(self, volume, path, options).await
     }
 
     async fn list_dir(&self, origvolume: &str, volume: &str, dir_path: &str, count: i32) -> DiskResult<Vec<String>> {
-        ecstore_disk::DiskAPI::list_dir(self, origvolume, volume, dir_path, count).await
+        EcstoreDiskAPI::list_dir(self, origvolume, volume, dir_path, count).await
     }
 
     #[cfg(test)]
     async fn make_volume(&self, volume: &str) -> DiskResult<()> {
-        ecstore_disk::DiskAPI::make_volume(self, volume).await
+        EcstoreDiskAPI::make_volume(self, volume).await
     }
 }
 

--- a/crates/iam/src/lib.rs
+++ b/crates/iam/src/lib.rs
@@ -15,11 +15,21 @@
 use crate::error::{Error, Result};
 use manager::IamCache;
 use oidc::OidcSys;
-use rustfs_ecstore::api::config as ecstore_config;
-use rustfs_ecstore::api::error as ecstore_error;
-use rustfs_ecstore::api::global as ecstore_global;
-use rustfs_ecstore::api::notification as ecstore_notification;
-use rustfs_ecstore::api::storage as ecstore_storage;
+use rustfs_ecstore::api::config::RUSTFS_CONFIG_PREFIX as ECSTORE_RUSTFS_CONFIG_PREFIX;
+use rustfs_ecstore::api::config::com::{
+    delete_config as ecstore_delete_config, read_config_no_lock as ecstore_read_config_no_lock,
+    read_config_with_metadata as ecstore_read_config_with_metadata, save_config as ecstore_save_config,
+    save_config_with_opts as ecstore_save_config_with_opts,
+};
+use rustfs_ecstore::api::error::{
+    Error as EcstoreErrorType, Result as EcstoreResultType, StorageError as EcstoreStorageError,
+    classify_system_path_failure_reason as ecstore_classify_system_path_failure_reason,
+};
+use rustfs_ecstore::api::global::is_first_cluster_node_local as ecstore_is_first_cluster_node_local;
+use rustfs_ecstore::api::notification::{
+    NotificationPeerErr as EcstoreNotificationPeerErr, get_global_notification_sys as ecstore_get_global_notification_sys,
+};
+use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
 use std::sync::{Arc, OnceLock};
 use store::object::ObjectStore;
 use sys::IamSys;
@@ -41,17 +51,17 @@ pub mod store;
 pub mod sys;
 pub mod utils;
 
-pub(crate) const IAM_CONFIG_ROOT_PREFIX: &str = ecstore_config::RUSTFS_CONFIG_PREFIX;
+pub(crate) const IAM_CONFIG_ROOT_PREFIX: &str = ECSTORE_RUSTFS_CONFIG_PREFIX;
 
-pub(crate) type IamEcstoreError = ecstore_error::Error;
-pub(crate) type IamStorageError = ecstore_error::StorageError;
-pub(crate) type IamStorageResult<T> = ecstore_error::Result<T>;
-pub(crate) type IamStore = ecstore_storage::ECStore;
+pub(crate) type IamEcstoreError = EcstoreErrorType;
+pub(crate) type IamStorageError = EcstoreStorageError;
+pub(crate) type IamStorageResult<T> = EcstoreResultType<T>;
+pub(crate) type IamStore = EcstoreStore;
 pub(crate) type IamConfigObjectInfo = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub(crate) type IamConfigObjectOptions = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
 
 pub(crate) async fn read_iam_config_no_lock(api: Arc<IamStore>, file: &str) -> IamStorageResult<Vec<u8>> {
-    ecstore_config::com::read_config_no_lock(api, file).await
+    ecstore_read_config_no_lock(api, file).await
 }
 
 pub(crate) async fn read_iam_config_with_metadata(
@@ -59,11 +69,11 @@ pub(crate) async fn read_iam_config_with_metadata(
     file: &str,
     opts: &IamConfigObjectOptions,
 ) -> IamStorageResult<(Vec<u8>, IamConfigObjectInfo)> {
-    ecstore_config::com::read_config_with_metadata(api, file, opts).await
+    ecstore_read_config_with_metadata(api, file, opts).await
 }
 
 pub(crate) async fn save_iam_config(api: Arc<IamStore>, file: &str, data: Vec<u8>) -> IamStorageResult<()> {
-    ecstore_config::com::save_config(api, file, data).await
+    ecstore_save_config(api, file, data).await
 }
 
 pub(crate) async fn save_iam_config_with_opts(
@@ -72,33 +82,33 @@ pub(crate) async fn save_iam_config_with_opts(
     data: Vec<u8>,
     opts: &IamConfigObjectOptions,
 ) -> IamStorageResult<()> {
-    ecstore_config::com::save_config_with_opts(api, file, data, opts).await
+    ecstore_save_config_with_opts(api, file, data, opts).await
 }
 
 pub(crate) async fn delete_iam_config(api: Arc<IamStore>, file: &str) -> IamStorageResult<()> {
-    ecstore_config::com::delete_config(api, file).await
+    ecstore_delete_config(api, file).await
 }
 
 pub(crate) fn classify_iam_system_path_failure_reason(err: &IamEcstoreError) -> &'static str {
-    ecstore_error::classify_system_path_failure_reason(err)
+    ecstore_classify_system_path_failure_reason(err)
 }
 
 pub(crate) async fn is_iam_first_cluster_node_local() -> bool {
-    ecstore_global::is_first_cluster_node_local().await
+    ecstore_is_first_cluster_node_local().await
 }
 
 pub(crate) struct IamNotificationPeerErr {
     pub(crate) err: Option<IamEcstoreError>,
 }
 
-impl From<ecstore_notification::NotificationPeerErr> for IamNotificationPeerErr {
-    fn from(value: ecstore_notification::NotificationPeerErr) -> Self {
+impl From<EcstoreNotificationPeerErr> for IamNotificationPeerErr {
+    fn from(value: EcstoreNotificationPeerErr) -> Self {
         Self { err: value.err }
     }
 }
 
 pub(crate) async fn notify_iam_delete_policy(policy_name: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_policy(policy_name)
             .await
@@ -110,7 +120,7 @@ pub(crate) async fn notify_iam_delete_policy(policy_name: &str) -> Vec<IamNotifi
 }
 
 pub(crate) async fn notify_iam_load_policy(policy_name: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_policy(policy_name)
             .await
@@ -122,7 +132,7 @@ pub(crate) async fn notify_iam_load_policy(policy_name: &str) -> Vec<IamNotifica
 }
 
 pub(crate) async fn notify_iam_delete_user(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_user(access_key)
             .await
@@ -134,7 +144,7 @@ pub(crate) async fn notify_iam_delete_user(access_key: &str) -> Vec<IamNotificat
 }
 
 pub(crate) async fn notify_iam_load_user(access_key: &str, temp: bool) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_user(access_key, temp)
             .await
@@ -146,7 +156,7 @@ pub(crate) async fn notify_iam_load_user(access_key: &str, temp: bool) -> Vec<Ia
 }
 
 pub(crate) async fn notify_iam_load_service_account(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_service_account(access_key)
             .await
@@ -158,7 +168,7 @@ pub(crate) async fn notify_iam_load_service_account(access_key: &str) -> Vec<Iam
 }
 
 pub(crate) async fn notify_iam_delete_service_account(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_service_account(access_key)
             .await
@@ -170,7 +180,7 @@ pub(crate) async fn notify_iam_delete_service_account(access_key: &str) -> Vec<I
 }
 
 pub(crate) async fn notify_iam_load_group(group: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys.load_group(group).await.into_iter().map(Into::into).collect(),
         None => Vec::new(),
     }
@@ -181,7 +191,7 @@ pub(crate) async fn notify_iam_load_policy_mapping(
     user_type: u64,
     is_group: bool,
 ) -> Vec<IamNotificationPeerErr> {
-    match ecstore_notification::get_global_notification_sys() {
+    match ecstore_get_global_notification_sys() {
         Some(notification_sys) => notification_sys
             .load_policy_mapping(user_or_group, user_type, is_group)
             .await

--- a/crates/obs/src/metrics/mod.rs
+++ b/crates/obs/src/metrics/mod.rs
@@ -19,12 +19,21 @@ pub mod scheduler;
 pub mod schema;
 pub mod stats_collector;
 
-pub(crate) use rustfs_ecstore::api::bucket as ecstore_bucket;
-pub(crate) use rustfs_ecstore::api::capacity as ecstore_capacity;
-pub(crate) use rustfs_ecstore::api::data_usage as ecstore_data_usage;
-pub(crate) use rustfs_ecstore::api::error as ecstore_error;
-pub(crate) use rustfs_ecstore::api::global as ecstore_global;
-pub(crate) use rustfs_ecstore::api::storage as ecstore_storage;
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
+    GLOBAL_ExpiryState as OBS_GLOBAL_EXPIRY_STATE, GLOBAL_TransitionState as OBS_GLOBAL_TRANSITION_STATE,
+};
+pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::get_quota_config as obs_get_quota_config;
+pub(crate) use rustfs_ecstore::api::bucket::replication::GLOBAL_REPLICATION_STATS as OBS_GLOBAL_REPLICATION_STATS;
+pub(crate) use rustfs_ecstore::api::capacity::{
+    get_total_usable_capacity as obs_get_total_usable_capacity,
+    get_total_usable_capacity_free as obs_get_total_usable_capacity_free,
+};
+pub(crate) use rustfs_ecstore::api::data_usage::load_data_usage_from_backend as obs_load_data_usage_from_backend;
+pub(crate) use rustfs_ecstore::api::error::Result as ObsEcstoreResult;
+pub(crate) use rustfs_ecstore::api::global::{
+    get_global_bucket_monitor as obs_get_global_bucket_monitor, resolve_object_store_handle as obs_resolve_object_store_handle,
+};
+pub(crate) use rustfs_ecstore::api::storage::ECStore as ObsStore;
 
 pub use collectors::*;
 pub use config::*;

--- a/crates/obs/src/metrics/scheduler.rs
+++ b/crates/obs/src/metrics/scheduler.rs
@@ -70,7 +70,7 @@ use crate::metrics::config::{
     ENV_BUCKET_REPLICATION_BANDWIDTH_METRICS_INTERVAL, ENV_CLUSTER_METRICS_INTERVAL, ENV_DEFAULT_METRICS_INTERVAL,
     ENV_NODE_METRICS_INTERVAL, ENV_NOTIFICATION_METRICS_INTERVAL, ENV_RESOURCE_METRICS_INTERVAL,
 };
-use crate::metrics::ecstore_global;
+use crate::metrics::obs_get_global_bucket_monitor;
 use crate::metrics::report::{PrometheusMetric, report_metrics};
 use crate::metrics::schema::bucket_replication::{
     BUCKET_L, BUCKET_REPL_BANDWIDTH_CURRENT_MD, BUCKET_REPL_BANDWIDTH_LIMIT_MD, TARGET_ARN_L,
@@ -599,7 +599,7 @@ pub fn init_metrics_runtime(token: CancellationToken) {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
-                    let monitor_available = ecstore_global::get_global_bucket_monitor().is_some();
+                    let monitor_available = obs_get_global_bucket_monitor().is_some();
                     let stats = collect_bucket_replication_bandwidth_stats();
 
                     let current_live_keys = repl_bw_live_keys(&stats);

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -26,7 +26,11 @@ use crate::metrics::collectors::{
     DriveDetailedStats, ErasureSetStats, HostNetworkStats, IamStats, IlmStats, MemoryStats, NetworkStats, ProcessStats,
     ProcessStatusType, ReplicationStats, ResourceStats, ScannerStats,
 };
-use crate::metrics::{ecstore_bucket, ecstore_capacity, ecstore_data_usage, ecstore_error, ecstore_global, ecstore_storage};
+use crate::metrics::{
+    OBS_GLOBAL_EXPIRY_STATE, OBS_GLOBAL_REPLICATION_STATS, OBS_GLOBAL_TRANSITION_STATE, ObsEcstoreResult, ObsStore,
+    obs_get_global_bucket_monitor, obs_get_quota_config, obs_get_total_usable_capacity, obs_get_total_usable_capacity_free,
+    obs_load_data_usage_from_backend, obs_resolve_object_store_handle,
+};
 use chrono::Utc;
 use rustfs_common::heal_channel::HealScanMode;
 use rustfs_common::metrics::global_metrics;
@@ -42,7 +46,6 @@ const LOG_COMPONENT_OBS: &str = "obs";
 const LOG_SUBSYSTEM_METRICS_COLLECTOR: &str = "metrics_collector";
 const EVENT_METRICS_COLLECTOR_STATE: &str = "metrics_collector_state";
 
-type ObsStore = ecstore_storage::ECStore;
 type ObsStorageInfo = <ObsStore as StorageAdminApi>::StorageInfo;
 
 struct ObsDataUsageInfo {
@@ -95,8 +98,8 @@ fn i32_to_u64_floor_zero(value: i32) -> u64 {
     u64::try_from(value.max(0)).unwrap_or(0)
 }
 
-async fn load_obs_data_usage_from_backend(store: Arc<ObsStore>) -> ecstore_error::Result<ObsDataUsageInfo> {
-    let data_usage = ecstore_data_usage::load_data_usage_from_backend(store).await?;
+async fn load_obs_data_usage_from_backend(store: Arc<ObsStore>) -> ObsEcstoreResult<ObsDataUsageInfo> {
+    let data_usage = obs_load_data_usage_from_backend(store).await?;
 
     Ok(ObsDataUsageInfo {
         buckets_count: data_usage.buckets_count,
@@ -125,19 +128,19 @@ async fn load_obs_data_usage_from_backend(store: Arc<ObsStore>) -> ecstore_error
 }
 
 fn resolve_obs_object_store_handle() -> Option<Arc<ObsStore>> {
-    ecstore_global::resolve_object_store_handle()
+    obs_resolve_object_store_handle()
 }
 
 fn obs_total_usable_capacity_bytes(storage_info: &ObsStorageInfo) -> u64 {
-    usize_to_u64_saturating(ecstore_capacity::get_total_usable_capacity(&storage_info.disks, storage_info))
+    usize_to_u64_saturating(obs_get_total_usable_capacity(&storage_info.disks, storage_info))
 }
 
 fn obs_total_usable_capacity_free_bytes(storage_info: &ObsStorageInfo) -> u64 {
-    usize_to_u64_saturating(ecstore_capacity::get_total_usable_capacity_free(&storage_info.disks, storage_info))
+    usize_to_u64_saturating(obs_get_total_usable_capacity_free(&storage_info.disks, storage_info))
 }
 
 async fn obs_bucket_quota_limit_bytes(bucket: &str) -> u64 {
-    ecstore_bucket::metadata_sys::get_quota_config(bucket)
+    obs_get_quota_config(bucket)
         .await
         .ok()
         .and_then(|(quota, _)| quota.get_quota_limit())
@@ -145,7 +148,7 @@ async fn obs_bucket_quota_limit_bytes(bucket: &str) -> u64 {
 }
 
 fn obs_bucket_replication_bandwidth_stats() -> Option<Vec<ObsBucketReplicationBandwidthStats>> {
-    let monitor = ecstore_global::get_global_bucket_monitor()?;
+    let monitor = obs_get_global_bucket_monitor()?;
     Some(
         monitor
             .get_report(|_| true)
@@ -163,12 +166,10 @@ fn obs_bucket_replication_bandwidth_stats() -> Option<Vec<ObsBucketReplicationBa
 
 async fn obs_ilm_runtime_snapshot() -> ObsIlmRuntimeSnapshot {
     let expiry_pending_tasks = {
-        let expiry = ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_ExpiryState
-            .read()
-            .await;
+        let expiry = OBS_GLOBAL_EXPIRY_STATE.read().await;
         usize_to_u64_saturating(expiry.pending_tasks())
     };
-    let transition = &ecstore_bucket::lifecycle::bucket_lifecycle_ops::GLOBAL_TransitionState;
+    let transition = &OBS_GLOBAL_TRANSITION_STATE;
 
     ObsIlmRuntimeSnapshot {
         expiry_pending_tasks,
@@ -183,7 +184,7 @@ async fn obs_ilm_runtime_snapshot() -> ObsIlmRuntimeSnapshot {
 }
 
 async fn obs_bucket_replication_detail_stats() -> Vec<BucketReplicationStats> {
-    let Some(stats) = ecstore_bucket::replication::GLOBAL_REPLICATION_STATS.get() else {
+    let Some(stats) = OBS_GLOBAL_REPLICATION_STATS.get() else {
         return Vec::new();
     };
 
@@ -255,7 +256,7 @@ async fn obs_bucket_replication_detail_stats() -> Vec<BucketReplicationStats> {
 }
 
 async fn obs_site_replication_stats() -> ReplicationStats {
-    let Some(stats) = ecstore_bucket::replication::GLOBAL_REPLICATION_STATS.get() else {
+    let Some(stats) = OBS_GLOBAL_REPLICATION_STATS.get() else {
         return ReplicationStats::default();
     };
 

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-scanner-owner-facade-symbols`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132`.
-- Based on: API-132 slice.
+- Branch: `overtrue/arch-remaining-external-owner-symbols`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133`.
+- Based on: API-133 slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: replace the scanner owner root ECStore module aliases with
-  explicit local symbols, type aliases, constants, and wrapper functions.
-- CI/script changes: treat scanner as a completed external owner root and reject
-  restored `ecstore_*` module aliases there.
-- Docs changes: record the API-133 scanner owner facade symbol cleanup.
+- Rust code changes: replace the remaining heal, IAM, and observability owner
+  root ECStore module aliases with explicit local symbols, type aliases,
+  constants, and wrapper functions.
+- CI/script changes: treat heal, IAM, and observability as completed external
+  owner roots and reject restored `ecstore_*` module aliases there.
+- Docs changes: record the API-134 remaining external owner facade symbol cleanup.
 
 ## Phase 0 Tasks
 
@@ -3908,6 +3909,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration/layer guards, formatting, diff hygiene, Rust risk scan, branch
     freshness check, pre-commit quality gate, and three-expert review.
 
+- [x] `API-134` Replace remaining external owner module aliases with symbols.
+  - Do: replace heal, IAM, and observability owner-root `ecstore_*` module
+    aliases with explicit local ECStore symbols, type aliases, constants, and
+    wrapper functions.
+  - Acceptance: heal, IAM, and observability no longer expose broad `ecstore_*`
+    module aliases, nested modules continue to consume owner-local symbols, and
+    the migration guard prevents reintroducing these owner-root module aliases.
+  - Must preserve: heal disk metadata and local disk lookup, IAM config
+    persistence and notification fanout, observability storage/data-usage,
+    quota, lifecycle, replication, capacity, and bucket monitor collection.
+  - Verification: focused heal/IAM/observability compile, completed-owner alias
+    residual scan, migration/layer guards, formatting, diff hygiene, Rust risk
+    scan, branch freshness check, pre-commit quality gate, and three-expert
+    review.
+
 ## Next PRs
 
 1. `pure-move`: continue pruning remaining facade compatibility and owner boundaries.
@@ -3916,13 +3932,27 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-133 replaces scanner owner-root ECStore module aliases with explicit local symbols and wrappers. |
-| Migration preservation | pass | Scanner lifecycle, disk, replication, tier, config, raw-list, and data-usage call paths keep the same ECStore targets through scanner-local symbols. |
-| Testing/verification | pass | Focused scanner compile, completed-owner alias residual scan, migration/layer guards, formatting, diff hygiene, full pre-commit, and diff-only Rust risk scan passed. |
+| Quality/architecture | pass | API-134 replaces the remaining heal, IAM, and observability owner-root ECStore module aliases with explicit local symbols and wrappers. |
+| Migration preservation | pass | Heal disk lookup, IAM config/notification wrappers, and observability data-usage/quota/lifecycle/replication/capacity paths keep the same ECStore targets through owner-local symbols. |
+| Testing/verification | pass | Focused heal/IAM/observability compile, completed-owner alias residual scan, migration/layer guards, formatting, diff hygiene, full pre-commit, and diff-only Rust risk scan passed. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-134 current slice:
+  - `cargo check --tests -p rustfs-heal -p rustfs-iam -p rustfs-obs`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `make pre-commit`: passed.
+  - Heal/IAM/observability completed-owner module-alias residual scan: passed.
+  - Rust risk scan: diff-only scan found explicit symbol imports and wrapper
+    calls only; no new unwrap/expect, panic/todo/unsafe, or risky behavior
+    added.
 
 - Issue #660 API-133 current slice:
   - `cargo check --tests -p rustfs-scanner`: passed.

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -1062,7 +1062,7 @@ fi
   rg -n --with-filename 'rustfs_ecstore::api::[a-z_]+::' rustfs/src crates fuzz \
     --glob '*.rs' \
     --glob '!crates/ecstore/**' |
-    rg -v '^(crates/notify/src/lib\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs):' || true
+    rg -v '^(crates/heal/src/heal/mod\.rs|crates/iam/src/lib\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs):' || true
 ) >"$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE"
 
 if [[ -s "$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE" ]]; then
@@ -1072,7 +1072,10 @@ fi
 (
   cd "$ROOT_DIR"
   rg -n --with-filename '^(?:pub\(crate\) )?use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' \
+    crates/heal/src/heal/mod.rs \
+    crates/iam/src/lib.rs \
     crates/notify/src/lib.rs \
+    crates/obs/src/metrics/mod.rs \
     crates/protocols/src/swift/mod.rs \
     crates/s3select-api/src/lib.rs \
     crates/scanner/src/lib.rs || true


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Replace remaining heal, IAM, and observability owner-root ECStore module aliases with explicit local symbols, type aliases, constants, and wrapper functions.
- Extend the architecture migration guard so heal, IAM, and observability completed owner roots cannot reintroduce broad `ecstore_*` module aliases.
- Record the API-134 migration progress and verification notes.

## Verification
- `cargo check --tests -p rustfs-heal -p rustfs-iam -p rustfs-obs`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `make pre-commit`
- Diff-only Rust risk scan

## Impact
No runtime behavior changes. This is a pure owner-boundary cleanup that keeps the same ECStore targets behind narrower local symbols.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
