### PR TITLE
refactor: route remaining app facade through storage owner

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-app-bucket-owner-symbols`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143`.
-- Based on: API-143 stacked slice.
+- Branch: `overtrue/arch-app-remaining-owner-symbols`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144`.
+- Based on: API-144 stacked slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: replace RustFS app bucket/client/config facade source
-  imports with storage-owner re-exports.
+- Rust code changes: replace remaining RustFS app facade ECStore source imports
+  with storage-owner re-exports.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
-  runtime/root-server/table/S3/app shared/app bucket facade regressions.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144 owner facade cleanup.
+  runtime/root-server/table/S3/app shared/app bucket/app ECStore facade
+  regressions.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4087,6 +4088,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     syntax check, formatting, diff hygiene, Rust risk scan, branch freshness
     check, pre-commit, and three-expert review.
 
+- [x] `API-145` Route remaining app facade ECStore source imports through storage owner re-exports.
+  - Do: expose app-needed admin, capacity, compression, data-usage, global, and
+    tier modules through storage owner re-exports, then source the remaining
+    app facade entries through `crate::storage`.
+  - Acceptance: `rustfs/src/app/mod.rs` contains no direct
+    `rustfs_ecstore::api::` source imports; migration guards reject restoring
+    any direct ECStore API source path in the app facade.
+  - Must preserve: server info, pool capacity summaries, compression checks,
+    bucket usage memory accounting, global tier manager access, and tier
+    config/warm backend compatibility paths.
+  - Verification: focused RustFS test-target compile, migration guard, shell
+    syntax check, formatting, diff hygiene, Rust risk scan, branch freshness
+    check, pre-commit, and three-expert review.
+
 ## Next PRs
 
 1. `pure-move`: continue pruning remaining facade compatibility and owner boundaries.
@@ -4095,9 +4110,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-144 routes app bucket/client/config facade sources through storage-owner re-exports and guards against restoring direct ECStore source paths. |
-| Migration preservation | pass | App facade shape stays unchanged; bucket, client transition, and storageclass compatibility paths still delegate to the same ECStore backend modules through storage. |
-| Testing/verification | pass | Focused RustFS test-target compile, shell syntax, migration guard, formatting, diff hygiene, Rust risk scan, and pre-commit passed for API-144. |
+| Quality/architecture | pass | API-145 clears the remaining direct ECStore source imports from the app facade and guards the completed app boundary. |
+| Migration preservation | pass | App facade shape stays unchanged; server info, capacity, compression, data usage, global tier manager, and tier compatibility paths still delegate to the same ECStore backend modules through storage. |
+| Testing/verification | pass | Focused RustFS test-target compile, shell syntax, migration guard, formatting, diff hygiene, Rust risk scan, and pre-commit passed for API-145. |
 
 ## Verification Notes
 
@@ -4151,6 +4166,18 @@ Passed before push:
     textual matches were reported by the broad error-type scan.
 
 - Issue #660 API-144 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `make pre-commit`: passed.
+  - Rust risk scan: no new production unwrap/expect, casts, panic/todo/unsafe,
+    or error-type risks added; only existing `DiskResult<Vec<String>>`
+    textual matches were reported by the broad error-type scan.
+
+- Issue #660 API-145 current slice:
   - `cargo check --tests -p rustfs`: passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.

--- a/rustfs/src/app/mod.rs
+++ b/rustfs/src/app/mod.rs
@@ -44,7 +44,7 @@ mod lifecycle_transition_api_test;
 use std::sync::Arc;
 
 mod ecstore_admin {
-    pub(crate) use rustfs_ecstore::api::admin::get_server_info;
+    pub(crate) use crate::storage::ecstore_admin::get_server_info;
 }
 
 mod ecstore_bucket {
@@ -55,7 +55,7 @@ mod ecstore_bucket {
 }
 
 mod ecstore_capacity {
-    pub(crate) use rustfs_ecstore::api::capacity::{
+    pub(crate) use crate::storage::ecstore_capacity::{
         PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
     };
 }
@@ -66,7 +66,7 @@ mod ecstore_client {
 }
 
 mod ecstore_compression {
-    pub(crate) use rustfs_ecstore::api::compression::{MIN_DISK_COMPRESSIBLE_SIZE, is_disk_compressible};
+    pub(crate) use crate::storage::ecstore_compression::{MIN_DISK_COMPRESSIBLE_SIZE, is_disk_compressible};
 }
 
 mod ecstore_config {
@@ -74,7 +74,7 @@ mod ecstore_config {
 }
 
 mod ecstore_data_usage {
-    pub(crate) use rustfs_ecstore::api::data_usage::{
+    pub(crate) use crate::storage::ecstore_data_usage::{
         apply_bucket_usage_memory_overlay, load_data_usage_from_backend, record_bucket_object_delete_memory,
         record_bucket_object_write_memory,
     };
@@ -82,12 +82,12 @@ mod ecstore_data_usage {
 
 #[cfg(test)]
 mod ecstore_global {
-    pub(crate) use rustfs_ecstore::api::global::GLOBAL_TierConfigMgr;
+    pub(crate) use crate::storage::ecstore_global::GLOBAL_TierConfigMgr;
 }
 
 #[allow(unused_imports)]
 mod ecstore_tier {
-    pub(crate) use rustfs_ecstore::api::tier::{tier, tier_config, warm_backend};
+    pub(crate) use crate::storage::ecstore_tier::{tier, tier_config, warm_backend};
 }
 
 pub(crate) const MIN_DISK_COMPRESSIBLE_SIZE: usize = ecstore_compression::MIN_DISK_COMPRESSIBLE_SIZE;

--- a/rustfs/src/storage/mod.rs
+++ b/rustfs/src/storage/mod.rs
@@ -71,7 +71,7 @@ pub(crate) use sse::{
 use std::sync::Arc;
 
 pub(crate) mod ecstore_admin {
-    pub(crate) use rustfs_ecstore::api::admin::get_local_server_property;
+    pub(crate) use rustfs_ecstore::api::admin::{get_local_server_property, get_server_info};
 }
 
 pub(crate) mod ecstore_bucket {
@@ -82,8 +82,18 @@ pub(crate) mod ecstore_bucket {
     pub(crate) use rustfs_ecstore::api::bucket::{quota, versioning, versioning_sys};
 }
 
+pub(crate) mod ecstore_capacity {
+    pub(crate) use rustfs_ecstore::api::capacity::{
+        PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
+    };
+}
+
 pub(crate) mod ecstore_client {
     pub(crate) use rustfs_ecstore::api::client::{object_api_utils, transition_api};
+}
+
+pub(crate) mod ecstore_compression {
+    pub(crate) use rustfs_ecstore::api::compression::{MIN_DISK_COMPRESSIBLE_SIZE, is_disk_compressible};
 }
 
 pub(crate) mod ecstore_cluster {
@@ -92,6 +102,13 @@ pub(crate) mod ecstore_cluster {
 
 pub(crate) mod ecstore_config {
     pub(crate) use rustfs_ecstore::api::config::{com, init, init_global_config_sys, storageclass, try_migrate_server_config};
+}
+
+pub(crate) mod ecstore_data_usage {
+    pub(crate) use rustfs_ecstore::api::data_usage::{
+        apply_bucket_usage_memory_overlay, load_data_usage_from_backend, record_bucket_object_delete_memory,
+        record_bucket_object_write_memory,
+    };
 }
 
 #[allow(unused_imports)]
@@ -166,6 +183,7 @@ pub(crate) mod ecstore_storage {
 
 pub(crate) mod ecstore_tier {
     pub(crate) use rustfs_ecstore::api::tier::tier::TierConfigMgr;
+    pub(crate) use rustfs_ecstore::api::tier::{tier, tier_config, warm_backend};
 }
 
 pub(crate) const BUCKET_ACCELERATE_CONFIG: &str = ecstore_bucket::metadata::BUCKET_ACCELERATE_CONFIG;

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -109,6 +109,7 @@ RUSTFS_ROOT_SERVER_OWNER_MODULE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_serve
 RUSTFS_TABLE_S3_OWNER_MODULE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_table_s3_owner_module_consumer_hits.txt"
 RUSTFS_APP_SHARED_OWNER_MODULE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_app_shared_owner_module_consumer_hits.txt"
 RUSTFS_APP_BUCKET_OWNER_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_bucket_owner_source_hits.txt"
+RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_ecstore_source_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
 RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE="${TMP_DIR}/rustfs_local_compat_owner_self_path_hits.txt"
 RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_compat_relative_consumer_hits.txt"
@@ -1236,6 +1237,16 @@ fi
 
 if [[ -s "$RUSTFS_APP_BUCKET_OWNER_SOURCE_HITS_FILE" ]]; then
   report_failure "RustFS app bucket facade must source completed bucket/client/config symbols through storage owner re-exports: $(paste -sd '; ' "$RUSTFS_APP_BUCKET_OWNER_SOURCE_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'rustfs_ecstore::api::' \
+    rustfs/src/app/mod.rs || true
+) >"$RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE"
+
+if [[ -s "$RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE" ]]; then
+  report_failure "RustFS app facade must source ECStore API symbols through storage owner re-exports: $(paste -sd '; ' "$RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Route the remaining RustFS app facade ECStore source imports through storage owner re-exports.
- Re-export app-needed admin, capacity, compression, data-usage, global, and tier modules from `rustfs/src/storage/mod.rs`.
- Extend `scripts/check_architecture_migration_rules.sh` to prevent any direct `rustfs_ecstore::api::` source path in `rustfs/src/app/mod.rs`.
- Record API-145 progress and verification in `docs/architecture/migration-progress.md`.

## Verification

- `cargo fmt --all`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo check --tests -p rustfs`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact

No runtime behavior change expected. Existing app facade paths remain in place while their remaining ECStore source modules now flow through the storage owner boundary.

## Additional Notes

Stacked on PR #3756.
