### PR TITLE
refactor: route admin facade through storage owner

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,18 +5,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-app-remaining-owner-symbols`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144`.
-- Based on: API-144 stacked slice.
+- Branch: `overtrue/arch-admin-ecstore-owner-symbols`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145`.
+- Based on: API-145 stacked slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: replace remaining RustFS app facade ECStore source imports
-  with storage-owner re-exports.
+- Rust code changes: replace RustFS admin facade ECStore source imports with
+  storage-owner re-exports.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
-  runtime/root-server/table/S3/app shared/app bucket/app ECStore facade
+  runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
   regressions.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4102,6 +4102,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     syntax check, formatting, diff hygiene, Rust risk scan, branch freshness
     check, pre-commit, and three-expert review.
 
+- [x] `API-146` Route admin facade ECStore source imports through storage owner re-exports.
+  - Do: expose admin-needed bucket, capacity, client, config, data-usage, disk,
+    error, global, layout, metrics, notification, rebalance, RPC, storage, and
+    tier symbols through storage owner re-exports, then source the admin facade
+    through `crate::storage`.
+  - Acceptance: `rustfs/src/admin/mod.rs` contains no direct
+    `rustfs_ecstore::api::` source imports; migration guards reject restoring
+    any direct ECStore API source path in the admin facade.
+  - Must preserve: admin handler utilities, bucket controls, storage class
+    updates, data usage reads, cluster/global metadata, metrics/notification
+    views, rebalance status, peer RPC, ECStore handle, and tier admin paths.
+  - Verification: focused RustFS test-target compile, migration guard, shell
+    syntax check, formatting, diff hygiene, Rust risk scan, branch freshness
+    check, pre-commit, and three-expert review.
+
 ## Next PRs
 
 1. `pure-move`: continue pruning remaining facade compatibility and owner boundaries.
@@ -4110,9 +4125,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-145 clears the remaining direct ECStore source imports from the app facade and guards the completed app boundary. |
-| Migration preservation | pass | App facade shape stays unchanged; server info, capacity, compression, data usage, global tier manager, and tier compatibility paths still delegate to the same ECStore backend modules through storage. |
-| Testing/verification | pass | Focused RustFS test-target compile, shell syntax, migration guard, formatting, diff hygiene, Rust risk scan, and pre-commit passed for API-145. |
+| Quality/architecture | pass | API-146 clears direct ECStore source imports from the admin facade and guards the completed admin boundary. |
+| Migration preservation | pass | Admin facade shape stays unchanged; bucket controls, config, data usage, global metadata, metrics, notification, rebalance, RPC, storage, and tier admin paths still delegate to the same ECStore backend modules through storage. |
+| Testing/verification | pass | Focused RustFS test-target compile, shell syntax, migration guard, formatting, diff hygiene, Rust risk scan, and pre-commit passed for API-146. |
 
 ## Verification Notes
 
@@ -4178,6 +4193,18 @@ Passed before push:
     textual matches were reported by the broad error-type scan.
 
 - Issue #660 API-145 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `make pre-commit`: passed.
+  - Rust risk scan: no new production unwrap/expect, casts, panic/todo/unsafe,
+    or error-type risks added; only existing `DiskResult<Vec<String>>`
+    textual matches were reported by the broad error-type scan.
+
+- Issue #660 API-146 current slice:
   - `cargo check --tests -p rustfs`: passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.

--- a/rustfs/src/admin/mod.rs
+++ b/rustfs/src/admin/mod.rs
@@ -104,39 +104,39 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 mod ecstore_bucket {
-    pub(crate) use rustfs_ecstore::api::bucket::{
+    pub(crate) use crate::storage::ecstore_bucket::{
         bandwidth, bucket_target_sys, lifecycle, metadata, metadata_sys, quota, replication, target, utils, versioning,
         versioning_sys,
     };
 }
 
 mod ecstore_capacity {
-    pub(crate) use rustfs_ecstore::api::capacity::is_reserved_or_invalid_bucket;
+    pub(crate) use crate::storage::ecstore_capacity::is_reserved_or_invalid_bucket;
 }
 
 mod ecstore_client {
-    pub(crate) use rustfs_ecstore::api::client::admin_handler_utils;
+    pub(crate) use crate::storage::ecstore_client::admin_handler_utils;
 }
 
 mod ecstore_config {
-    pub(crate) use rustfs_ecstore::api::config::{com, init, set_global_storage_class, storageclass};
+    pub(crate) use crate::storage::ecstore_config::{com, init, set_global_storage_class, storageclass};
 }
 
 mod ecstore_data_usage {
-    pub(crate) use rustfs_ecstore::api::data_usage::load_data_usage_from_backend;
+    pub(crate) use crate::storage::ecstore_data_usage::load_data_usage_from_backend;
 }
 
 #[allow(unused_imports)]
 mod ecstore_disk {
-    pub(crate) use rustfs_ecstore::api::disk::{RUSTFS_META_BUCKET, endpoint};
+    pub(crate) use crate::storage::ecstore_disk::{RUSTFS_META_BUCKET, endpoint};
 }
 
 mod ecstore_error {
-    pub(crate) use rustfs_ecstore::api::error::StorageError;
+    pub(crate) use crate::storage::ecstore_error::StorageError;
 }
 
 mod ecstore_global {
-    pub(crate) use rustfs_ecstore::api::global::{
+    pub(crate) use crate::storage::ecstore_global::{
         GLOBAL_BOOT_TIME, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints_opt, get_global_region,
         global_rustfs_port,
     };
@@ -144,20 +144,20 @@ mod ecstore_global {
 
 #[allow(unused_imports)]
 mod ecstore_layout {
-    pub(crate) use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
+    pub(crate) use crate::storage::ecstore_layout::{EndpointServerPools, Endpoints, PoolEndpoints};
 }
 
 mod ecstore_metrics {
-    pub(crate) use rustfs_ecstore::api::metrics::{CollectMetricsOpts, MetricType, collect_local_metrics};
+    pub(crate) use crate::storage::ecstore_metrics::{CollectMetricsOpts, MetricType, collect_local_metrics};
 }
 
 mod ecstore_notification {
-    pub(crate) use rustfs_ecstore::api::notification::{NotificationSys, get_global_notification_sys};
+    pub(crate) use crate::storage::ecstore_notification::{NotificationSys, get_global_notification_sys};
 }
 
 #[allow(unused_imports)]
 mod ecstore_rebalance {
-    pub(crate) use rustfs_ecstore::api::rebalance::{
+    pub(crate) use crate::storage::ecstore_rebalance::{
         DiskStat, RebalSaveOpt, RebalStatus, RebalanceCleanupWarningEntry, RebalanceCleanupWarnings, RebalanceInfo,
         RebalanceMeta, RebalanceStats, RebalanceStopPropagationRecord, decode_rebalance_stop_propagation_record,
         encode_rebalance_stop_propagation_record,
@@ -165,15 +165,15 @@ mod ecstore_rebalance {
 }
 
 mod ecstore_rpc {
-    pub(crate) use rustfs_ecstore::api::rpc::PeerRestClient;
+    pub(crate) use crate::storage::ecstore_rpc::PeerRestClient;
 }
 
 mod ecstore_storage {
-    pub(crate) use rustfs_ecstore::api::storage::ECStore;
+    pub(crate) use crate::storage::ecstore_storage::ECStore;
 }
 
 mod ecstore_tier {
-    pub(crate) use rustfs_ecstore::api::tier::{tier, tier_admin, tier_config, tier_handlers};
+    pub(crate) use crate::storage::ecstore_tier::{tier, tier_admin, tier_config, tier_handlers};
 }
 
 pub(crate) const RUSTFS_META_BUCKET: &str = ecstore_disk::RUSTFS_META_BUCKET;

--- a/rustfs/src/storage/mod.rs
+++ b/rustfs/src/storage/mod.rs
@@ -76,8 +76,8 @@ pub(crate) mod ecstore_admin {
 
 pub(crate) mod ecstore_bucket {
     pub(crate) use rustfs_ecstore::api::bucket::{
-        bucket_target_sys, lifecycle, metadata, metadata_sys, migration, object_lock, policy_sys, replication, tagging, target,
-        utils,
+        bandwidth, bucket_target_sys, lifecycle, metadata, metadata_sys, migration, object_lock, policy_sys, replication,
+        tagging, target, utils,
     };
     pub(crate) use rustfs_ecstore::api::bucket::{quota, versioning, versioning_sys};
 }
@@ -85,11 +85,12 @@ pub(crate) mod ecstore_bucket {
 pub(crate) mod ecstore_capacity {
     pub(crate) use rustfs_ecstore::api::capacity::{
         PoolDecommissionInfo, PoolStatus, get_total_usable_capacity, get_total_usable_capacity_free,
+        is_reserved_or_invalid_bucket,
     };
 }
 
 pub(crate) mod ecstore_client {
-    pub(crate) use rustfs_ecstore::api::client::{object_api_utils, transition_api};
+    pub(crate) use rustfs_ecstore::api::client::{admin_handler_utils, object_api_utils, transition_api};
 }
 
 pub(crate) mod ecstore_compression {
@@ -101,7 +102,9 @@ pub(crate) mod ecstore_cluster {
 }
 
 pub(crate) mod ecstore_config {
-    pub(crate) use rustfs_ecstore::api::config::{com, init, init_global_config_sys, storageclass, try_migrate_server_config};
+    pub(crate) use rustfs_ecstore::api::config::{
+        com, init, init_global_config_sys, set_global_storage_class, storageclass, try_migrate_server_config,
+    };
 }
 
 pub(crate) mod ecstore_data_usage {
@@ -133,9 +136,10 @@ pub(crate) mod ecstore_event {
 
 pub(crate) mod ecstore_global {
     pub(crate) use rustfs_ecstore::api::global::{
-        GLOBAL_TierConfigMgr, get_global_endpoints_opt, get_global_lock_client, get_global_lock_clients, get_global_region,
-        get_global_tier_config_mgr, is_dist_erasure, new_object_layer_fn, resolve_object_store_handle, set_global_endpoints,
-        set_global_region, set_global_rustfs_port, set_object_store_resolver, shutdown_background_services, update_erasure_type,
+        GLOBAL_BOOT_TIME, GLOBAL_TierConfigMgr, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints_opt,
+        get_global_lock_client, get_global_lock_clients, get_global_region, get_global_tier_config_mgr, global_rustfs_port,
+        is_dist_erasure, new_object_layer_fn, resolve_object_store_handle, set_global_endpoints, set_global_region,
+        set_global_rustfs_port, set_object_store_resolver, shutdown_background_services, update_erasure_type,
     };
 }
 
@@ -155,6 +159,15 @@ pub(crate) mod ecstore_notification {
     };
 }
 
+#[allow(unused_imports)]
+pub(crate) mod ecstore_rebalance {
+    pub(crate) use rustfs_ecstore::api::rebalance::{
+        DiskStat, RebalSaveOpt, RebalStatus, RebalanceCleanupWarningEntry, RebalanceCleanupWarnings, RebalanceInfo,
+        RebalanceMeta, RebalanceStats, RebalanceStopPropagationRecord, decode_rebalance_stop_propagation_record,
+        encode_rebalance_stop_propagation_record,
+    };
+}
+
 pub(crate) mod ecstore_rio {
     #[cfg(test)]
     pub(crate) use rustfs_ecstore::api::rio::{DecryptReader, EncryptReader, HardLimitReader, Reader, boxed_reader};
@@ -165,7 +178,7 @@ pub(crate) mod ecstore_rio {
 
 pub(crate) mod ecstore_rpc {
     pub(crate) use rustfs_ecstore::api::rpc::{
-        LocalPeerS3Client, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerS3Client, SERVICE_SIGNAL_REFRESH_CONFIG,
+        LocalPeerS3Client, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PeerRestClient, PeerS3Client, SERVICE_SIGNAL_REFRESH_CONFIG,
         SERVICE_SIGNAL_RELOAD_DYNAMIC, TONIC_RPC_PREFIX, verify_rpc_signature,
     };
 }
@@ -183,7 +196,7 @@ pub(crate) mod ecstore_storage {
 
 pub(crate) mod ecstore_tier {
     pub(crate) use rustfs_ecstore::api::tier::tier::TierConfigMgr;
-    pub(crate) use rustfs_ecstore::api::tier::{tier, tier_config, warm_backend};
+    pub(crate) use rustfs_ecstore::api::tier::{tier, tier_admin, tier_config, tier_handlers, warm_backend};
 }
 
 pub(crate) const BUCKET_ACCELERATE_CONFIG: &str = ecstore_bucket::metadata::BUCKET_ACCELERATE_CONFIG;

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -110,6 +110,7 @@ RUSTFS_TABLE_S3_OWNER_MODULE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_table_s3_owne
 RUSTFS_APP_SHARED_OWNER_MODULE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_app_shared_owner_module_consumer_hits.txt"
 RUSTFS_APP_BUCKET_OWNER_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_bucket_owner_source_hits.txt"
 RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_ecstore_source_hits.txt"
+RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_admin_ecstore_source_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
 RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE="${TMP_DIR}/rustfs_local_compat_owner_self_path_hits.txt"
 RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_compat_relative_consumer_hits.txt"
@@ -1247,6 +1248,16 @@ fi
 
 if [[ -s "$RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE" ]]; then
   report_failure "RustFS app facade must source ECStore API symbols through storage owner re-exports: $(paste -sd '; ' "$RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'rustfs_ecstore::api::' \
+    rustfs/src/admin/mod.rs || true
+) >"$RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE"
+
+if [[ -s "$RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE" ]]; then
+  report_failure "RustFS admin facade must source ECStore API symbols through storage owner re-exports: $(paste -sd '; ' "$RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Route the RustFS admin facade ECStore source imports through storage owner re-exports.
- Re-export admin-needed bucket, capacity, client, config, data-usage, disk, error, global, layout, metrics, notification, rebalance, RPC, storage, and tier symbols from `rustfs/src/storage/mod.rs`.
- Extend `scripts/check_architecture_migration_rules.sh` to prevent any direct `rustfs_ecstore::api::` source path in `rustfs/src/admin/mod.rs`.
- Record API-146 progress and verification in `docs/architecture/migration-progress.md`.

## Verification

- `cargo fmt --all`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo check --tests -p rustfs`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact

No runtime behavior change expected. Existing admin facade paths remain in place while their ECStore source modules now flow through the storage owner boundary.

## Additional Notes

Stacked on PR #3756.
