### PR TITLE
refactor: isolate runtime ecstore facade imports

### DIFF
--- a/crates/heal/src/heal/ecstore_compat.rs
+++ b/crates/heal/src/heal/ecstore_compat.rs
@@ -1,0 +1,26 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) use rustfs_ecstore::api::data_usage::DATA_USAGE_CACHE_NAME as ECSTORE_DATA_USAGE_CACHE_NAME;
+pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint as EcstoreEndpoint;
+pub(crate) use rustfs_ecstore::api::disk::error::{DiskError as EcstoreDiskError, Result as EcstoreDiskResult};
+pub(crate) use rustfs_ecstore::api::disk::{
+    BUCKET_META_PREFIX as ECSTORE_BUCKET_META_PREFIX, Bytes as EcstoreDiskBytes, DeleteOptions as EcstoreDeleteOptions,
+    DiskAPI as EcstoreDiskAPI, DiskStore as EcstoreDiskStore, RUSTFS_META_BUCKET as ECSTORE_RUSTFS_META_BUCKET,
+};
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::disk::{DiskOption as EcstoreDiskOption, new_disk as ecstore_new_disk};
+pub(crate) use rustfs_ecstore::api::error::{Error as EcstoreErrorType, StorageError as EcstoreStorageError};
+pub(crate) use rustfs_ecstore::api::global::GLOBAL_LOCAL_DISK_MAP as ECSTORE_GLOBAL_LOCAL_DISK_MAP;
+pub(crate) use rustfs_ecstore::api::storage::ECStore as EcstoreStore;

--- a/crates/heal/src/heal/mod.rs
+++ b/crates/heal/src/heal/mod.rs
@@ -22,19 +22,15 @@ pub mod storage;
 pub mod task;
 pub mod utils;
 
-use rustfs_ecstore::api::data_usage::DATA_USAGE_CACHE_NAME as ECSTORE_DATA_USAGE_CACHE_NAME;
-use rustfs_ecstore::api::disk::endpoint::Endpoint as EcstoreEndpoint;
-use rustfs_ecstore::api::disk::error::{DiskError as EcstoreDiskError, Result as EcstoreDiskResult};
-use rustfs_ecstore::api::disk::{
-    BUCKET_META_PREFIX as ECSTORE_BUCKET_META_PREFIX, Bytes as EcstoreDiskBytes, DeleteOptions as EcstoreDeleteOptions,
-    DiskAPI as EcstoreDiskAPI, DiskStore as EcstoreDiskStore, RUSTFS_META_BUCKET as ECSTORE_RUSTFS_META_BUCKET,
+use ecstore_compat::{
+    ECSTORE_BUCKET_META_PREFIX, ECSTORE_DATA_USAGE_CACHE_NAME, ECSTORE_GLOBAL_LOCAL_DISK_MAP, ECSTORE_RUSTFS_META_BUCKET,
+    EcstoreDeleteOptions, EcstoreDiskAPI, EcstoreDiskBytes, EcstoreDiskError, EcstoreDiskResult, EcstoreDiskStore,
+    EcstoreEndpoint, EcstoreErrorType, EcstoreStorageError, EcstoreStore,
 };
 #[cfg(test)]
-use rustfs_ecstore::api::disk::{DiskOption as EcstoreDiskOption, new_disk as ecstore_new_disk};
-use rustfs_ecstore::api::error::{Error as EcstoreErrorType, StorageError as EcstoreStorageError};
-use rustfs_ecstore::api::global::GLOBAL_LOCAL_DISK_MAP as ECSTORE_GLOBAL_LOCAL_DISK_MAP;
-use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
+use ecstore_compat::{EcstoreDiskOption, ecstore_new_disk};
 
+mod ecstore_compat;
 pub use erasure_healer::ErasureSetHealer;
 pub use manager::{HealManager, HealOperationsSnapshot, HealPriorityCounts, HealSourceCounts};
 pub use resume::{CheckpointManager, ResumeCheckpoint, ResumeManager, ResumeState, ResumeUtils};

--- a/crates/iam/src/ecstore_compat.rs
+++ b/crates/iam/src/ecstore_compat.rs
@@ -1,0 +1,29 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) use rustfs_ecstore::api::config::RUSTFS_CONFIG_PREFIX as ECSTORE_RUSTFS_CONFIG_PREFIX;
+pub(crate) use rustfs_ecstore::api::config::com::{
+    delete_config as ecstore_delete_config, read_config_no_lock as ecstore_read_config_no_lock,
+    read_config_with_metadata as ecstore_read_config_with_metadata, save_config as ecstore_save_config,
+    save_config_with_opts as ecstore_save_config_with_opts,
+};
+pub(crate) use rustfs_ecstore::api::error::{
+    Error as EcstoreErrorType, Result as EcstoreResultType, StorageError as EcstoreStorageError,
+    classify_system_path_failure_reason as ecstore_classify_system_path_failure_reason,
+};
+pub(crate) use rustfs_ecstore::api::global::is_first_cluster_node_local as ecstore_is_first_cluster_node_local;
+pub(crate) use rustfs_ecstore::api::notification::{
+    NotificationPeerErr as EcstoreNotificationPeerErr, get_global_notification_sys as ecstore_get_global_notification_sys,
+};
+pub(crate) use rustfs_ecstore::api::storage::ECStore as EcstoreStore;

--- a/crates/iam/src/lib.rs
+++ b/crates/iam/src/lib.rs
@@ -13,23 +13,14 @@
 // limitations under the License.
 
 use crate::error::{Error, Result};
+use ecstore_compat::{
+    ECSTORE_RUSTFS_CONFIG_PREFIX, EcstoreErrorType, EcstoreNotificationPeerErr, EcstoreResultType, EcstoreStorageError,
+    EcstoreStore, ecstore_classify_system_path_failure_reason, ecstore_delete_config, ecstore_get_global_notification_sys,
+    ecstore_is_first_cluster_node_local, ecstore_read_config_no_lock, ecstore_read_config_with_metadata, ecstore_save_config,
+    ecstore_save_config_with_opts,
+};
 use manager::IamCache;
 use oidc::OidcSys;
-use rustfs_ecstore::api::config::RUSTFS_CONFIG_PREFIX as ECSTORE_RUSTFS_CONFIG_PREFIX;
-use rustfs_ecstore::api::config::com::{
-    delete_config as ecstore_delete_config, read_config_no_lock as ecstore_read_config_no_lock,
-    read_config_with_metadata as ecstore_read_config_with_metadata, save_config as ecstore_save_config,
-    save_config_with_opts as ecstore_save_config_with_opts,
-};
-use rustfs_ecstore::api::error::{
-    Error as EcstoreErrorType, Result as EcstoreResultType, StorageError as EcstoreStorageError,
-    classify_system_path_failure_reason as ecstore_classify_system_path_failure_reason,
-};
-use rustfs_ecstore::api::global::is_first_cluster_node_local as ecstore_is_first_cluster_node_local;
-use rustfs_ecstore::api::notification::{
-    NotificationPeerErr as EcstoreNotificationPeerErr, get_global_notification_sys as ecstore_get_global_notification_sys,
-};
-use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
 use std::sync::{Arc, OnceLock};
 use store::object::ObjectStore;
 use sys::IamSys;
@@ -42,6 +33,7 @@ const EVENT_IAM_STATE: &str = "iam_state";
 const EVENT_OIDC_STATE: &str = "oidc_state";
 
 pub mod cache;
+mod ecstore_compat;
 pub mod error;
 pub mod keyring;
 pub mod manager;

--- a/crates/notify/src/ecstore_compat.rs
+++ b/crates/notify/src/ecstore_compat.rs
@@ -1,0 +1,44 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rustfs_ecstore::api::config::com::{
+    read_config_without_migrate as read_notify_config_without_migrate_from_backend,
+    save_server_config as save_notify_server_config_to_backend,
+};
+use rustfs_ecstore::api::global::resolve_object_store_handle as resolve_notify_object_store_handle_from_backend;
+
+pub(crate) use rustfs_ecstore::api::storage::ECStore as NotifyStore;
+
+pub(crate) fn resolve_notify_object_store_handle() -> Option<Arc<NotifyStore>> {
+    resolve_notify_object_store_handle_from_backend()
+}
+
+pub(crate) async fn read_notify_server_config_without_migrate(
+    store: Arc<NotifyStore>,
+) -> Result<rustfs_config::server_config::Config, String> {
+    read_notify_config_without_migrate_from_backend(store)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+pub(crate) async fn save_notify_server_config(
+    store: Arc<NotifyStore>,
+    config: &rustfs_config::server_config::Config,
+) -> Result<(), String> {
+    save_notify_server_config_to_backend(store, config)
+        .await
+        .map_err(|err| err.to_string())
+}

--- a/crates/notify/src/lib.rs
+++ b/crates/notify/src/lib.rs
@@ -18,10 +18,9 @@
 //! It supports sending events to various targets
 //! (like Webhook and MQTT) and includes features like event persistence and retry on failure.
 
-use std::sync::Arc;
-
 mod bucket_config_manager;
 mod config_manager;
+mod ecstore_compat;
 mod error;
 mod event;
 mod event_bridge;
@@ -39,12 +38,9 @@ mod runtime_view;
 mod services;
 mod status_view;
 
-use rustfs_ecstore::api::config::com::{
-    read_config_without_migrate as read_notify_config_without_migrate_from_backend,
-    save_server_config as save_notify_server_config_to_backend,
+pub(crate) use ecstore_compat::{
+    read_notify_server_config_without_migrate, resolve_notify_object_store_handle, save_notify_server_config,
 };
-use rustfs_ecstore::api::global::resolve_object_store_handle as resolve_notify_object_store_handle_from_backend;
-pub(crate) use rustfs_ecstore::api::storage::ECStore as NotifyStore;
 
 pub use bucket_config_manager::NotifyBucketConfigManager;
 pub use config_manager::{NotifyConfigManager, runtime_target_id_for_subsystem};
@@ -63,24 +59,3 @@ pub use runtime_facade::NotifyRuntimeFacade;
 pub use runtime_view::NotifyRuntimeView;
 pub use services::NotifyServices;
 pub use status_view::NotifyStatusView;
-
-pub(crate) fn resolve_notify_object_store_handle() -> Option<Arc<NotifyStore>> {
-    resolve_notify_object_store_handle_from_backend()
-}
-
-pub(crate) async fn read_notify_server_config_without_migrate(
-    store: Arc<NotifyStore>,
-) -> Result<rustfs_config::server_config::Config, String> {
-    read_notify_config_without_migrate_from_backend(store)
-        .await
-        .map_err(|err| err.to_string())
-}
-
-pub(crate) async fn save_notify_server_config(
-    store: Arc<NotifyStore>,
-    config: &rustfs_config::server_config::Config,
-) -> Result<(), String> {
-    save_notify_server_config_to_backend(store, config)
-        .await
-        .map_err(|err| err.to_string())
-}

--- a/crates/obs/src/metrics/ecstore_compat.rs
+++ b/crates/obs/src/metrics/ecstore_compat.rs
@@ -1,0 +1,29 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
+    GLOBAL_ExpiryState as OBS_GLOBAL_EXPIRY_STATE, GLOBAL_TransitionState as OBS_GLOBAL_TRANSITION_STATE,
+};
+pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::get_quota_config as obs_get_quota_config;
+pub(crate) use rustfs_ecstore::api::bucket::replication::GLOBAL_REPLICATION_STATS as OBS_GLOBAL_REPLICATION_STATS;
+pub(crate) use rustfs_ecstore::api::capacity::{
+    get_total_usable_capacity as obs_get_total_usable_capacity,
+    get_total_usable_capacity_free as obs_get_total_usable_capacity_free,
+};
+pub(crate) use rustfs_ecstore::api::data_usage::load_data_usage_from_backend as obs_load_data_usage_from_backend;
+pub(crate) use rustfs_ecstore::api::error::Result as ObsEcstoreResult;
+pub(crate) use rustfs_ecstore::api::global::{
+    get_global_bucket_monitor as obs_get_global_bucket_monitor, resolve_object_store_handle as obs_resolve_object_store_handle,
+};
+pub(crate) use rustfs_ecstore::api::storage::ECStore as ObsStore;

--- a/crates/obs/src/metrics/mod.rs
+++ b/crates/obs/src/metrics/mod.rs
@@ -14,26 +14,17 @@
 
 pub mod collectors;
 pub mod config;
+mod ecstore_compat;
 pub mod report;
 pub mod scheduler;
 pub mod schema;
 pub mod stats_collector;
 
-pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
-    GLOBAL_ExpiryState as OBS_GLOBAL_EXPIRY_STATE, GLOBAL_TransitionState as OBS_GLOBAL_TRANSITION_STATE,
+pub(crate) use ecstore_compat::{
+    OBS_GLOBAL_EXPIRY_STATE, OBS_GLOBAL_REPLICATION_STATS, OBS_GLOBAL_TRANSITION_STATE, ObsEcstoreResult, ObsStore,
+    obs_get_global_bucket_monitor, obs_get_quota_config, obs_get_total_usable_capacity, obs_get_total_usable_capacity_free,
+    obs_load_data_usage_from_backend, obs_resolve_object_store_handle,
 };
-pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::get_quota_config as obs_get_quota_config;
-pub(crate) use rustfs_ecstore::api::bucket::replication::GLOBAL_REPLICATION_STATS as OBS_GLOBAL_REPLICATION_STATS;
-pub(crate) use rustfs_ecstore::api::capacity::{
-    get_total_usable_capacity as obs_get_total_usable_capacity,
-    get_total_usable_capacity_free as obs_get_total_usable_capacity_free,
-};
-pub(crate) use rustfs_ecstore::api::data_usage::load_data_usage_from_backend as obs_load_data_usage_from_backend;
-pub(crate) use rustfs_ecstore::api::error::Result as ObsEcstoreResult;
-pub(crate) use rustfs_ecstore::api::global::{
-    get_global_bucket_monitor as obs_get_global_bucket_monitor, resolve_object_store_handle as obs_resolve_object_store_handle,
-};
-pub(crate) use rustfs_ecstore::api::storage::ECStore as ObsStore;
 
 pub use collectors::*;
 pub use config::*;

--- a/crates/protocols/src/swift/ecstore_compat.rs
+++ b/crates/protocols/src/swift/ecstore_compat.rs
@@ -1,0 +1,36 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+pub(crate) use rustfs_ecstore::api::bucket::metadata::BucketMetadata as SwiftBucketMetadata;
+use rustfs_ecstore::api::bucket::metadata_sys::{
+    get as get_swift_bucket_metadata_from_backend, set_bucket_metadata as set_swift_bucket_metadata_in_backend,
+};
+pub(crate) use rustfs_ecstore::api::error::Result as SwiftStorageResult;
+pub(crate) use rustfs_ecstore::api::global::resolve_object_store_handle as resolve_swift_object_store_handle;
+use rustfs_ecstore::api::storage::ECStore as SwiftStore;
+
+pub type SwiftGetObjectReader = <SwiftStore as rustfs_storage_api::ObjectIO>::GetObjectReader;
+pub type SwiftObjectInfo = <SwiftStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
+pub type SwiftObjectOptions = <SwiftStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
+pub type SwiftPutObjReader = <SwiftStore as rustfs_storage_api::ObjectIO>::PutObjectReader;
+
+pub(crate) async fn get_swift_bucket_metadata(bucket: &str) -> SwiftStorageResult<Arc<SwiftBucketMetadata>> {
+    get_swift_bucket_metadata_from_backend(bucket).await
+}
+
+pub(crate) async fn set_swift_bucket_metadata(bucket: String, metadata: SwiftBucketMetadata) -> SwiftStorageResult<()> {
+    set_swift_bucket_metadata_in_backend(bucket, metadata).await
+}

--- a/crates/protocols/src/swift/mod.rs
+++ b/crates/protocols/src/swift/mod.rs
@@ -33,16 +33,6 @@
 //! and stores credentials in task-local storage, which Swift handlers access
 //! to enforce tenant isolation.
 
-use std::sync::Arc;
-
-use rustfs_ecstore::api::bucket::metadata::BucketMetadata as SwiftBucketMetadata;
-use rustfs_ecstore::api::bucket::metadata_sys::{
-    get as get_swift_bucket_metadata_from_backend, set_bucket_metadata as set_swift_bucket_metadata_in_backend,
-};
-use rustfs_ecstore::api::error::Result as SwiftStorageResult;
-use rustfs_ecstore::api::global::resolve_object_store_handle as resolve_swift_object_store_handle;
-use rustfs_ecstore::api::storage::ECStore as SwiftStore;
-
 pub mod account;
 pub mod acl;
 pub mod bulk;
@@ -67,21 +57,13 @@ pub mod tempurl;
 pub mod types;
 pub mod versioning;
 
+mod ecstore_compat;
+
 pub use errors::{SwiftError, SwiftResult};
 pub use router::{SwiftRoute, SwiftRouter};
 // Note: Container, Object, and SwiftMetadata types used by Swift implementation
 #[allow(unused_imports)]
 pub use types::{Container, Object, SwiftMetadata};
 
-pub type SwiftGetObjectReader = <SwiftStore as rustfs_storage_api::ObjectIO>::GetObjectReader;
-pub type SwiftObjectInfo = <SwiftStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
-pub type SwiftObjectOptions = <SwiftStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
-pub type SwiftPutObjReader = <SwiftStore as rustfs_storage_api::ObjectIO>::PutObjectReader;
-
-async fn get_swift_bucket_metadata(bucket: &str) -> SwiftStorageResult<Arc<SwiftBucketMetadata>> {
-    get_swift_bucket_metadata_from_backend(bucket).await
-}
-
-async fn set_swift_bucket_metadata(bucket: String, metadata: SwiftBucketMetadata) -> SwiftStorageResult<()> {
-    set_swift_bucket_metadata_in_backend(bucket, metadata).await
-}
+pub use ecstore_compat::{SwiftGetObjectReader, SwiftObjectInfo, SwiftObjectOptions, SwiftPutObjReader};
+pub(crate) use ecstore_compat::{get_swift_bucket_metadata, resolve_swift_object_store_handle, set_swift_bucket_metadata};

--- a/crates/s3select-api/src/ecstore_compat.rs
+++ b/crates/s3select-api/src/ecstore_compat.rs
@@ -1,0 +1,46 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rustfs_ecstore::api::error::{
+    is_err_bucket_not_found as select_is_err_bucket_not_found_from_backend,
+    is_err_object_not_found as select_is_err_object_not_found_from_backend,
+    is_err_version_not_found as select_is_err_version_not_found_from_backend,
+};
+use rustfs_ecstore::api::global::resolve_object_store_handle as resolve_select_object_store_handle_from_backend;
+
+pub(crate) use rustfs_ecstore::api::error::StorageError as SelectStorageError;
+pub(crate) use rustfs_ecstore::api::set_disk::DEFAULT_READ_BUFFER_SIZE as SELECT_DEFAULT_READ_BUFFER_SIZE;
+pub(crate) use rustfs_ecstore::api::storage::ECStore as SelectStore;
+
+pub(crate) type SelectGetObjectReader = <SelectStore as rustfs_storage_api::ObjectIO>::GetObjectReader;
+pub(crate) type SelectObjectInfo = <SelectStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
+pub(crate) type SelectObjectOptions = <SelectStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
+
+pub(crate) fn resolve_select_object_store_handle() -> Option<Arc<SelectStore>> {
+    resolve_select_object_store_handle_from_backend()
+}
+
+pub(crate) fn select_is_err_bucket_not_found(err: &SelectStorageError) -> bool {
+    select_is_err_bucket_not_found_from_backend(err)
+}
+
+pub(crate) fn select_is_err_object_not_found(err: &SelectStorageError) -> bool {
+    select_is_err_object_not_found_from_backend(err)
+}
+
+pub(crate) fn select_is_err_version_not_found(err: &SelectStorageError) -> bool {
+    select_is_err_version_not_found_from_backend(err)
+}

--- a/crates/s3select-api/src/lib.rs
+++ b/crates/s3select-api/src/lib.rs
@@ -13,20 +13,10 @@
 // limitations under the License.
 
 use datafusion::{common::DataFusionError, sql::sqlparser::parser::ParserError};
-use rustfs_ecstore::api::error::{
-    is_err_bucket_not_found as select_is_err_bucket_not_found_from_backend,
-    is_err_object_not_found as select_is_err_object_not_found_from_backend,
-    is_err_version_not_found as select_is_err_version_not_found_from_backend,
-};
-use rustfs_ecstore::api::global::resolve_object_store_handle as resolve_select_object_store_handle_from_backend;
 use snafu::{Backtrace, Location, Snafu};
 use std::fmt::Display;
-use std::sync::Arc;
 
-pub(crate) use rustfs_ecstore::api::error::StorageError as SelectStorageError;
-pub(crate) use rustfs_ecstore::api::set_disk::DEFAULT_READ_BUFFER_SIZE as SELECT_DEFAULT_READ_BUFFER_SIZE;
-pub(crate) use rustfs_ecstore::api::storage::ECStore as SelectStore;
-
+mod ecstore_compat;
 pub mod object_store;
 pub mod query;
 pub mod server;
@@ -36,25 +26,11 @@ mod test;
 
 pub type QueryResult<T> = Result<T, QueryError>;
 
-pub(crate) type SelectGetObjectReader = <SelectStore as rustfs_storage_api::ObjectIO>::GetObjectReader;
-pub(crate) type SelectObjectInfo = <SelectStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
-pub(crate) type SelectObjectOptions = <SelectStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
-
-pub(crate) fn resolve_select_object_store_handle() -> Option<Arc<SelectStore>> {
-    resolve_select_object_store_handle_from_backend()
-}
-
-pub(crate) fn select_is_err_bucket_not_found(err: &SelectStorageError) -> bool {
-    select_is_err_bucket_not_found_from_backend(err)
-}
-
-pub(crate) fn select_is_err_object_not_found(err: &SelectStorageError) -> bool {
-    select_is_err_object_not_found_from_backend(err)
-}
-
-pub(crate) fn select_is_err_version_not_found(err: &SelectStorageError) -> bool {
-    select_is_err_version_not_found_from_backend(err)
-}
+pub(crate) use ecstore_compat::{
+    SELECT_DEFAULT_READ_BUFFER_SIZE, SelectGetObjectReader, SelectObjectInfo, SelectObjectOptions, SelectStorageError,
+    SelectStore, resolve_select_object_store_handle, select_is_err_bucket_not_found, select_is_err_object_not_found,
+    select_is_err_version_not_found,
+};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/crates/scanner/src/ecstore_compat.rs
+++ b/crates/scanner/src/ecstore_compat.rs
@@ -1,0 +1,74 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) use rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys as EcstoreBucketTargetSys;
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc as EcstoreLcEventSrc;
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
+    GLOBAL_ExpiryState as ECSTORE_GLOBAL_EXPIRY_STATE, apply_expiry_rule as ecstore_apply_expiry_rule,
+    apply_transition_rule as ecstore_apply_transition_rule,
+};
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::evaluator::Evaluator as EcstoreEvaluator;
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::lifecycle::{
+    Event as EcstoreEvent, Lifecycle as EcstoreLifecycle, ObjectOpts as EcstoreObjectOpts,
+    TRANSITION_COMPLETE as ECSTORE_TRANSITION_COMPLETE,
+};
+pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::{
+    get_lifecycle_config as ecstore_get_lifecycle_config, get_object_lock_config as ecstore_get_object_lock_config,
+    get_replication_config as ecstore_get_replication_config,
+};
+pub(crate) use rustfs_ecstore::api::bucket::replication::{
+    ReplicationConfig as EcstoreReplicationConfig, ReplicationConfigurationExt as EcstoreReplicationConfigurationExt,
+    ReplicationHealQueueResult as EcstoreReplicationHealQueueResult,
+    ReplicationQueueAdmission as EcstoreReplicationQueueAdmission,
+    queue_replication_heal_internal as ecstore_queue_replication_heal_internal,
+};
+pub(crate) use rustfs_ecstore::api::bucket::versioning::VersioningApi as EcstoreVersioningApi;
+pub(crate) use rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys as EcstoreBucketVersioningSys;
+pub(crate) use rustfs_ecstore::api::cache::{
+    ListPathRawOptions as EcstoreListPathRawOptions, list_path_raw as ecstore_list_path_raw,
+};
+pub(crate) use rustfs_ecstore::api::capacity::{
+    is_reserved_or_invalid_bucket as ecstore_is_reserved_or_invalid_bucket, path2_bucket_object as ecstore_path2_bucket_object,
+    path2_bucket_object_with_base_path as ecstore_path2_bucket_object_with_base_path,
+};
+pub(crate) use rustfs_ecstore::api::config::com::{read_config as ecstore_read_config, save_config as ecstore_save_config};
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::config::init as ecstore_config_init;
+pub(crate) use rustfs_ecstore::api::config::storageclass::{
+    RRS as ECSTORE_STORAGECLASS_RRS, STANDARD as ECSTORE_STORAGECLASS_STANDARD,
+};
+pub(crate) use rustfs_ecstore::api::data_usage::replace_bucket_usage_memory_from_info as ecstore_replace_bucket_usage_memory_from_info;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint as EcstoreEndpoint;
+pub(crate) use rustfs_ecstore::api::disk::error::{DiskError as EcstoreDiskError, Result as EcstoreDiskResult};
+pub(crate) use rustfs_ecstore::api::disk::{
+    BUCKET_META_PREFIX as ECSTORE_BUCKET_META_PREFIX, Bytes as EcstoreDiskBytes, Disk as EcstoreDisk, DiskAPI as EcstoreDiskAPI,
+    DiskInfo as EcstoreDiskInfo, DiskInfoOptions as EcstoreDiskInfoOptions, DiskLocation as EcstoreDiskLocation,
+    RUSTFS_META_BUCKET as ECSTORE_RUSTFS_META_BUCKET, STORAGE_FORMAT_FILE as ECSTORE_STORAGE_FORMAT_FILE,
+    ScanGuard as EcstoreScanGuard,
+};
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::disk::{
+    DiskOption as EcstoreDiskOption, DiskStore as EcstoreDiskStore, new_disk as ecstore_new_disk,
+};
+pub(crate) use rustfs_ecstore::api::error::{
+    Error as EcstoreErrorType, Result as EcstoreResultType, StorageError as EcstoreStorageError,
+};
+pub(crate) use rustfs_ecstore::api::global::{
+    GLOBAL_TierConfigMgr as ECSTORE_GLOBAL_TIER_CONFIG_MGR, is_erasure as ecstore_is_erasure,
+    is_erasure_sd as ecstore_is_erasure_sd, resolve_object_store_handle as ecstore_resolve_object_store_handle,
+};
+pub(crate) use rustfs_ecstore::api::set_disk::SetDisks as EcstoreSetDisks;
+pub(crate) use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
+pub(crate) use rustfs_ecstore::api::tier::tier_config::TierConfig as EcstoreTierConfig;

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -20,59 +20,25 @@
     rust_2018_idioms
 )]
 
+mod ecstore_compat;
+
+use ecstore_compat::{
+    ECSTORE_BUCKET_META_PREFIX, ECSTORE_GLOBAL_EXPIRY_STATE, ECSTORE_GLOBAL_TIER_CONFIG_MGR, ECSTORE_RUSTFS_META_BUCKET,
+    ECSTORE_STORAGE_FORMAT_FILE, ECSTORE_STORAGECLASS_RRS, ECSTORE_STORAGECLASS_STANDARD, ECSTORE_TRANSITION_COMPLETE,
+    EcstoreBucketTargetSys, EcstoreBucketVersioningSys, EcstoreDisk, EcstoreDiskAPI, EcstoreDiskBytes, EcstoreDiskError,
+    EcstoreDiskInfo, EcstoreDiskInfoOptions, EcstoreDiskLocation, EcstoreDiskResult, EcstoreErrorType, EcstoreEvaluator,
+    EcstoreEvent, EcstoreLcEventSrc, EcstoreLifecycle, EcstoreListPathRawOptions, EcstoreObjectOpts, EcstoreReplicationConfig,
+    EcstoreReplicationConfigurationExt, EcstoreReplicationHealQueueResult, EcstoreReplicationQueueAdmission, EcstoreResultType,
+    EcstoreScanGuard, EcstoreSetDisks, EcstoreStorageError, EcstoreStore, EcstoreTierConfig, EcstoreVersioningApi,
+    ecstore_apply_expiry_rule, ecstore_apply_transition_rule, ecstore_get_lifecycle_config, ecstore_get_object_lock_config,
+    ecstore_get_replication_config, ecstore_is_erasure, ecstore_is_erasure_sd, ecstore_is_reserved_or_invalid_bucket,
+    ecstore_list_path_raw, ecstore_path2_bucket_object, ecstore_path2_bucket_object_with_base_path,
+    ecstore_queue_replication_heal_internal, ecstore_read_config, ecstore_replace_bucket_usage_memory_from_info,
+    ecstore_resolve_object_store_handle, ecstore_save_config,
+};
+#[cfg(test)]
+use ecstore_compat::{EcstoreDiskOption, EcstoreDiskStore, EcstoreEndpoint, ecstore_config_init, ecstore_new_disk};
 use http::HeaderMap;
-use rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys as EcstoreBucketTargetSys;
-use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc as EcstoreLcEventSrc;
-use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
-    GLOBAL_ExpiryState as ECSTORE_GLOBAL_EXPIRY_STATE, apply_expiry_rule as ecstore_apply_expiry_rule,
-    apply_transition_rule as ecstore_apply_transition_rule,
-};
-use rustfs_ecstore::api::bucket::lifecycle::evaluator::Evaluator as EcstoreEvaluator;
-use rustfs_ecstore::api::bucket::lifecycle::lifecycle::{
-    Event as EcstoreEvent, Lifecycle as EcstoreLifecycle, ObjectOpts as EcstoreObjectOpts,
-    TRANSITION_COMPLETE as ECSTORE_TRANSITION_COMPLETE,
-};
-use rustfs_ecstore::api::bucket::metadata_sys::{
-    get_lifecycle_config as ecstore_get_lifecycle_config, get_object_lock_config as ecstore_get_object_lock_config,
-    get_replication_config as ecstore_get_replication_config,
-};
-use rustfs_ecstore::api::bucket::replication::{
-    ReplicationConfig as EcstoreReplicationConfig, ReplicationConfigurationExt as EcstoreReplicationConfigurationExt,
-    ReplicationHealQueueResult as EcstoreReplicationHealQueueResult,
-    ReplicationQueueAdmission as EcstoreReplicationQueueAdmission,
-    queue_replication_heal_internal as ecstore_queue_replication_heal_internal,
-};
-use rustfs_ecstore::api::bucket::versioning::VersioningApi as EcstoreVersioningApi;
-use rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys as EcstoreBucketVersioningSys;
-use rustfs_ecstore::api::cache::{ListPathRawOptions as EcstoreListPathRawOptions, list_path_raw as ecstore_list_path_raw};
-use rustfs_ecstore::api::capacity::{
-    is_reserved_or_invalid_bucket as ecstore_is_reserved_or_invalid_bucket, path2_bucket_object as ecstore_path2_bucket_object,
-    path2_bucket_object_with_base_path as ecstore_path2_bucket_object_with_base_path,
-};
-use rustfs_ecstore::api::config::com::{read_config as ecstore_read_config, save_config as ecstore_save_config};
-#[cfg(test)]
-use rustfs_ecstore::api::config::init as ecstore_config_init;
-use rustfs_ecstore::api::config::storageclass::{RRS as ECSTORE_STORAGECLASS_RRS, STANDARD as ECSTORE_STORAGECLASS_STANDARD};
-use rustfs_ecstore::api::data_usage::replace_bucket_usage_memory_from_info as ecstore_replace_bucket_usage_memory_from_info;
-#[cfg(test)]
-use rustfs_ecstore::api::disk::endpoint::Endpoint as EcstoreEndpoint;
-use rustfs_ecstore::api::disk::error::{DiskError as EcstoreDiskError, Result as EcstoreDiskResult};
-use rustfs_ecstore::api::disk::{
-    BUCKET_META_PREFIX as ECSTORE_BUCKET_META_PREFIX, Bytes as EcstoreDiskBytes, Disk as EcstoreDisk, DiskAPI as EcstoreDiskAPI,
-    DiskInfo as EcstoreDiskInfo, DiskInfoOptions as EcstoreDiskInfoOptions, DiskLocation as EcstoreDiskLocation,
-    RUSTFS_META_BUCKET as ECSTORE_RUSTFS_META_BUCKET, STORAGE_FORMAT_FILE as ECSTORE_STORAGE_FORMAT_FILE,
-    ScanGuard as EcstoreScanGuard,
-};
-#[cfg(test)]
-use rustfs_ecstore::api::disk::{DiskOption as EcstoreDiskOption, DiskStore as EcstoreDiskStore, new_disk as ecstore_new_disk};
-use rustfs_ecstore::api::error::{Error as EcstoreErrorType, Result as EcstoreResultType, StorageError as EcstoreStorageError};
-use rustfs_ecstore::api::global::{
-    GLOBAL_TierConfigMgr as ECSTORE_GLOBAL_TIER_CONFIG_MGR, is_erasure as ecstore_is_erasure,
-    is_erasure_sd as ecstore_is_erasure_sd, resolve_object_store_handle as ecstore_resolve_object_store_handle,
-};
-use rustfs_ecstore::api::set_disk::SetDisks as EcstoreSetDisks;
-use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
-use rustfs_ecstore::api::tier::tier_config::TierConfig as EcstoreTierConfig;
 use rustfs_storage_api::{HTTPRangeSpec, ObjectIO, ObjectToDelete};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,18 +5,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-admin-ecstore-owner-symbols`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145`.
-- Based on: API-145 stacked slice.
+- Branch: `overtrue/arch-runtime-crate-ecstore-boundaries`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146`.
+- Based on: API-146 stacked slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: replace RustFS admin facade ECStore source imports with
-  storage-owner re-exports.
+- Rust code changes: move external runtime crate ECStore source imports into
+  crate-local `ecstore_compat` boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
-  regressions.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146 owner facade cleanup.
+  regressions, plus external runtime ECStore compatibility bypasses.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4117,6 +4117,23 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     syntax check, formatting, diff hygiene, Rust risk scan, branch freshness
     check, pre-commit, and three-expert review.
 
+- [x] `API-147` Route external runtime crate ECStore source imports through local compatibility boundaries.
+  - Do: move direct ECStore facade source imports in notify, observability
+    metrics, S3 Select, Swift, IAM, heal, and scanner runtime entry modules
+    into crate-local `ecstore_compat` modules while preserving existing
+    wrappers and aliases at each crate boundary.
+  - Acceptance: target runtime crate source directories contain no direct
+    `rustfs_ecstore::api::` source paths outside `ecstore_compat.rs`; migration
+    guards reject restoring those bypasses.
+  - Must preserve: notify config persistence and object-store resolution,
+    observability storage/ILM/replication metrics, S3 Select storage error
+    mapping and object reads, Swift metadata/object-store access, IAM config
+    and notification behavior, heal disk wrappers, and scanner lifecycle/disk
+    runtime wrappers.
+  - Verification: focused external crate compile, migration guard, shell syntax
+    check, formatting, diff hygiene, Rust risk scan, branch freshness check,
+    pre-commit, and three-expert review.
+
 ## Next PRs
 
 1. `pure-move`: continue pruning remaining facade compatibility and owner boundaries.
@@ -4125,9 +4142,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-146 clears direct ECStore source imports from the admin facade and guards the completed admin boundary. |
-| Migration preservation | pass | Admin facade shape stays unchanged; bucket controls, config, data usage, global metadata, metrics, notification, rebalance, RPC, storage, and tier admin paths still delegate to the same ECStore backend modules through storage. |
-| Testing/verification | pass | Focused RustFS test-target compile, shell syntax, migration guard, formatting, diff hygiene, Rust risk scan, and pre-commit passed for API-146. |
+| Quality/architecture | pass | API-147 moves selected external runtime crate ECStore source imports behind crate-local compatibility files and guards those boundaries. |
+| Migration preservation | pass | Notify, OBS metrics, S3 Select, Swift, IAM, heal, and scanner root APIs keep the same aliases/wrappers while only the ECStore source location changes. |
+| Testing/verification | pass | Focused external crate compile, formatting, migration guard, diff hygiene, Rust risk scan, and pre-commit passed for API-147. |
 
 ## Verification Notes
 
@@ -4215,6 +4232,21 @@ Passed before push:
   - Rust risk scan: no new production unwrap/expect, casts, panic/todo/unsafe,
     or error-type risks added; only existing `DiskResult<Vec<String>>`
     textual matches were reported by the broad error-type scan.
+
+- Issue #660 API-147 current slice:
+  - `cargo check -p rustfs-notify -p rustfs-obs -p rustfs-s3select-api -p rustfs-protocols -p rustfs-iam -p rustfs-heal -p rustfs-scanner`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `make pre-commit`: passed.
+  - Runtime crate ECStore source bypass scan: passed; target runtime crate
+    source paths now reference `rustfs_ecstore::api::` only inside
+    `ecstore_compat.rs`.
+  - Rust risk scan: no new production unwrap/expect, casts, panic/todo/unsafe,
+    or error-type risks added; changes only move import/source boundaries.
 
 - Issue #660 API-139 current slice:
   - `cargo check --tests -p rustfs`: passed.

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -111,6 +111,7 @@ RUSTFS_APP_SHARED_OWNER_MODULE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_app_shared_
 RUSTFS_APP_BUCKET_OWNER_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_bucket_owner_source_hits.txt"
 RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_ecstore_source_hits.txt"
 RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_admin_ecstore_source_hits.txt"
+EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_runtime_ecstore_compat_bypass_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
 RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE="${TMP_DIR}/rustfs_local_compat_owner_self_path_hits.txt"
 RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_compat_relative_consumer_hits.txt"
@@ -728,6 +729,7 @@ fi
     --glob '!crates/ecstore/**' \
     --glob '!**/storage_compat.rs' \
     --glob '!**/*storage_compat.rs' \
+    --glob '!**/ecstore_compat.rs' \
     --glob '!target/**' \
     | rg -v '^(rustfs/src/(admin/mod|app/mod|storage/mod)\.rs|crates/e2e_test/src/(replication_extension_test|reliant/(grpc_lock_client|node_interact_test))\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/(endpoint_index_test|heal_bug_fixes_test|heal_integration_test)\.rs|crates/iam/src/lib\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|fuzz/fuzz_targets/(bucket_validation|path_containment)\.rs):' || true
 ) |
@@ -1038,6 +1040,7 @@ fi
   rg -n --with-filename 'rustfs_ecstore::api::' rustfs/src crates fuzz \
     --glob '*storage_compat.rs' \
     --glob '*_compat.rs' \
+    --glob '!**/ecstore_compat.rs' \
     | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' || true
 ) >"$ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE"
 
@@ -1071,7 +1074,8 @@ fi
   cd "$ROOT_DIR"
   rg -n --with-filename 'rustfs_ecstore::api::[a-z_]+::' rustfs/src crates fuzz \
     --glob '*.rs' \
-    --glob '!crates/ecstore/**' |
+    --glob '!crates/ecstore/**' \
+    --glob '!**/ecstore_compat.rs' |
     rg -v '^(fuzz/fuzz_targets/bucket_validation\.rs|fuzz/fuzz_targets/path_containment\.rs|crates/e2e_test/src/reliant/grpc_lock_client\.rs|crates/e2e_test/src/reliant/node_interact_test\.rs|crates/e2e_test/src/replication_extension_test\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/endpoint_index_test\.rs|crates/heal/tests/heal_bug_fixes_test\.rs|crates/heal/tests/heal_integration_test\.rs|crates/iam/src/lib\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|rustfs/src/admin/mod\.rs|rustfs/src/app/mod\.rs|rustfs/src/storage/mod\.rs):' || true
 ) >"$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE"
 
@@ -1258,6 +1262,24 @@ fi
 
 if [[ -s "$RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE" ]]; then
   report_failure "RustFS admin facade must source ECStore API symbols through storage owner re-exports: $(paste -sd '; ' "$RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'rustfs_ecstore::api::' \
+    crates/heal/src/heal \
+    crates/iam/src \
+    crates/notify/src \
+    crates/obs/src/metrics \
+    crates/protocols/src/swift \
+    crates/s3select-api/src \
+    crates/scanner/src \
+    --glob '*.rs' \
+    --glob '!**/ecstore_compat.rs' || true
+) >"$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE"
+
+if [[ -s "$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE" ]]; then
+  report_failure "external runtime crates must source ECStore API symbols through their ecstore_compat boundary: $(paste -sd '; ' "$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Move direct ECStore facade source imports in notify, observability metrics, S3 Select, Swift, IAM, heal, and scanner runtime entry modules into crate-local `ecstore_compat` boundaries.
- Preserve the existing crate root aliases and wrapper functions so downstream call sites keep the same paths.
- Extend `scripts/check_architecture_migration_rules.sh` to reject direct `rustfs_ecstore::api::` bypasses in those runtime crate source directories outside `ecstore_compat.rs`.
- Record API-147 progress and verification in `docs/architecture/migration-progress.md`.

## Verification

- `cargo fmt --all`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo check -p rustfs-notify -p rustfs-obs -p rustfs-s3select-api -p rustfs-protocols -p rustfs-iam -p rustfs-heal -p rustfs-scanner`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact

No runtime behavior change expected. This only localizes ECStore facade source imports behind crate-local compatibility boundaries for the selected runtime crates.

## Additional Notes

Stacked on PR #3756.
