### PR TITLE
refactor: isolate runtime test ecstore imports

### DIFF
--- a/crates/e2e_test/src/ecstore_test_compat.rs
+++ b/crates/e2e_test/src/ecstore_test_compat.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys as E2eBucketTargetSys;
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::disk::{VolumeInfo as E2eVolumeInfo, WalkDirOptions as E2eWalkDirOptions};
+pub(crate) use rustfs_ecstore::api::rpc::{
+    TonicInterceptor as E2eTonicInterceptor, node_service_time_out_client_no_auth as e2e_node_service_time_out_client_no_auth,
+};
+#[cfg(test)]
+pub(crate) use rustfs_ecstore::api::rpc::{
+    gen_tonic_signature_interceptor as gen_e2e_tonic_signature_interceptor,
+    node_service_time_out_client as e2e_node_service_time_out_client,
+};

--- a/crates/e2e_test/src/lib.rs
+++ b/crates/e2e_test/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod ecstore_test_compat;
 mod reliant;
 
 // Common utilities for all E2E tests

--- a/crates/e2e_test/src/reliant/grpc_lock_client.rs
+++ b/crates/e2e_test/src/reliant/grpc_lock_client.rs
@@ -15,8 +15,10 @@
 // Used by test_distributed_lock_4_nodes_grpc in lock.rs
 #![allow(dead_code)]
 
+use crate::ecstore_test_compat::{
+    E2eTonicInterceptor as TonicInterceptor, e2e_node_service_time_out_client_no_auth as node_service_time_out_client_no_auth,
+};
 use async_trait::async_trait;
-use rustfs_ecstore::api::rpc::{TonicInterceptor, node_service_time_out_client_no_auth};
 use rustfs_lock::{
     LockClient, LockError, LockId, LockInfo, LockRequest, LockResponse, LockStats, LockStatus, LockType, Result,
     types::{LockMetadata, LockPriority},

--- a/crates/e2e_test/src/reliant/node_interact_test.rs
+++ b/crates/e2e_test/src/reliant/node_interact_test.rs
@@ -14,10 +14,13 @@
 // limitations under the License.
 
 use crate::common::workspace_root;
+use crate::ecstore_test_compat::{
+    E2eTonicInterceptor as TonicInterceptor, E2eVolumeInfo as VolumeInfo, E2eWalkDirOptions as WalkDirOptions,
+    e2e_node_service_time_out_client as node_service_time_out_client,
+    gen_e2e_tonic_signature_interceptor as gen_tonic_signature_interceptor,
+};
 use futures::future::join_all;
 use rmp_serde::{Deserializer, Serializer};
-use rustfs_ecstore::api::disk::{VolumeInfo, WalkDirOptions};
-use rustfs_ecstore::api::rpc::{TonicInterceptor, gen_tonic_signature_interceptor, node_service_time_out_client};
 use rustfs_filemeta::{MetaCacheEntry, MetacacheReader, MetacacheWriter};
 use rustfs_protos::proto_gen::node_service::WalkDirRequest;
 use rustfs_protos::{

--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -15,6 +15,7 @@
 use crate::common::{
     RustFSTestEnvironment, awscurl_available, awscurl_post_sts_form_urlencoded, init_logging, local_http_client,
 };
+use crate::ecstore_test_compat::E2eBucketTargetSys as BucketTargetSys;
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::primitives::ByteStream;
@@ -22,7 +23,6 @@ use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
 use aws_sdk_s3::{Client, Config};
 use http::header::{CONTENT_TYPE, HOST};
 use reqwest::StatusCode;
-use rustfs_ecstore::api::bucket::bucket_target_sys::BucketTargetSys;
 use rustfs_madmin::{
     AddServiceAccountReq, ListServiceAccountsResp, PeerInfo, PeerSite, ReplicateAddStatus, ReplicateEditStatus,
     ReplicateRemoveStatus, SRRemoveReq, SRResyncOpStatus, SRStatusInfo, SiteReplicationInfo, SyncStatus,

--- a/crates/heal/tests/ecstore_test_compat/mod.rs
+++ b/crates/heal/tests/ecstore_test_compat/mod.rs
@@ -1,0 +1,7 @@
+#![allow(unused_imports)]
+
+pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::init_bucket_metadata_sys;
+pub(crate) use rustfs_ecstore::api::disk::DiskStore;
+pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint;
+pub(crate) use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
+pub(crate) use rustfs_ecstore::api::storage::{ECStore, init_local_disks};

--- a/crates/heal/tests/endpoint_index_test.rs
+++ b/crates/heal/tests/endpoint_index_test.rs
@@ -14,9 +14,9 @@
 
 //! test endpoint index settings
 
-use rustfs_ecstore::api::disk::endpoint::Endpoint;
-use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
-use rustfs_ecstore::api::storage::{ECStore, init_local_disks};
+mod ecstore_test_compat;
+
+use ecstore_test_compat::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_local_disks};
 use std::net::SocketAddr;
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;

--- a/crates/heal/tests/heal_bug_fixes_test.rs
+++ b/crates/heal/tests/heal_bug_fixes_test.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_ecstore::api::disk::{DiskStore, endpoint::Endpoint};
+mod ecstore_test_compat;
+
+use ecstore_test_compat::{DiskStore, Endpoint};
 use rustfs_heal::heal::{
     event::{HealEvent, Severity},
     task::{HealPriority, HealType},

--- a/crates/heal/tests/heal_integration_test.rs
+++ b/crates/heal/tests/heal_integration_test.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod ecstore_test_compat;
+
+use ecstore_test_compat::{
+    ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_bucket_metadata_sys, init_local_disks,
+};
 use http::HeaderMap;
 use rustfs_common::heal_channel::{HealOpts, HealScanMode};
-use rustfs_ecstore::api::bucket::metadata_sys::init_bucket_metadata_sys;
-use rustfs_ecstore::api::disk::endpoint::Endpoint;
-use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
-use rustfs_ecstore::api::storage::{ECStore, init_local_disks};
 use rustfs_heal::heal::{
     manager::{HealConfig, HealManager},
     storage::{ECStoreHealStorage, HealObjectOptions as ObjectOptions, HealPutObjReader as PutObjReader, HealStorageAPI},

--- a/crates/scanner/tests/ecstore_test_compat/mod.rs
+++ b/crates/scanner/tests/ecstore_test_compat/mod.rs
@@ -1,0 +1,20 @@
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
+    enqueue_transition_for_existing_objects, init_background_expiry,
+};
+pub(crate) use rustfs_ecstore::api::bucket::lifecycle::lifecycle::TransitionOptions;
+pub(crate) use rustfs_ecstore::api::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
+pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::{
+    get as get_bucket_metadata, init_bucket_metadata_sys, update as update_bucket_metadata,
+};
+pub(crate) use rustfs_ecstore::api::bucket::versioning_sys::BucketVersioningSys;
+pub(crate) use rustfs_ecstore::api::capacity::path2_bucket_object_with_base_path;
+pub(crate) use rustfs_ecstore::api::client::transition_api::{ReadCloser, ReaderImpl};
+pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint;
+pub(crate) use rustfs_ecstore::api::disk::{DiskAPI, DiskOption, STORAGE_FORMAT_FILE, new_disk};
+pub(crate) use rustfs_ecstore::api::global::GLOBAL_TierConfigMgr;
+pub(crate) use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
+pub(crate) use rustfs_ecstore::api::storage::{ECStore, init_local_disks};
+pub(crate) use rustfs_ecstore::api::tier::tier_config::{TierConfig, TierMinIO, TierType};
+pub(crate) use rustfs_ecstore::api::tier::warm_backend::{
+    WarmBackend as ScannerWarmBackend, WarmBackendGetOpts, build_transition_put_options,
+};

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -12,28 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod ecstore_test_compat;
+
+use ecstore_test_compat::{
+    BUCKET_LIFECYCLE_CONFIG, BucketVersioningSys, DiskAPI as _, DiskOption, ECStore, Endpoint, EndpointServerPools, Endpoints,
+    GLOBAL_TierConfigMgr, PoolEndpoints, ReadCloser, ReaderImpl, STORAGE_FORMAT_FILE, ScannerWarmBackend, TierConfig, TierMinIO,
+    TierType, TransitionOptions, WarmBackendGetOpts, build_transition_put_options, enqueue_transition_for_existing_objects,
+    get_bucket_metadata, init_background_expiry, init_bucket_metadata_sys, init_local_disks, new_disk,
+    path2_bucket_object_with_base_path, update_bucket_metadata,
+};
 use futures::FutureExt;
 use rustfs_config::ENV_TEST_FORCE_IMMEDIATE_TRANSITION_ENQUEUE_TIMEOUT;
-use rustfs_ecstore::api::bucket::{
-    lifecycle::{
-        bucket_lifecycle_ops::{enqueue_transition_for_existing_objects, init_background_expiry},
-        lifecycle::TransitionOptions,
-    },
-    metadata::BUCKET_LIFECYCLE_CONFIG,
-    metadata_sys::{get as get_bucket_metadata, init_bucket_metadata_sys, update as update_bucket_metadata},
-    versioning_sys::BucketVersioningSys,
-};
-use rustfs_ecstore::api::capacity::path2_bucket_object_with_base_path;
-use rustfs_ecstore::api::client::transition_api::{ReadCloser, ReaderImpl};
-use rustfs_ecstore::api::disk::endpoint::Endpoint;
-use rustfs_ecstore::api::disk::{DiskAPI as _, DiskOption, STORAGE_FORMAT_FILE, new_disk};
-use rustfs_ecstore::api::global::GLOBAL_TierConfigMgr;
-use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
-use rustfs_ecstore::api::storage::{ECStore, init_local_disks};
-use rustfs_ecstore::api::tier::{
-    tier_config::{TierConfig, TierMinIO, TierType},
-    warm_backend::{WarmBackend as ScannerWarmBackend, WarmBackendGetOpts, build_transition_put_options},
-};
 use rustfs_filemeta::FileMeta;
 use rustfs_scanner::scanner_folder::ScannerItem;
 use rustfs_scanner::scanner_io::ScannerIODisk;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,18 +5,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-runtime-crate-ecstore-boundaries`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146`.
-- Based on: API-146 stacked slice.
+- Branch: `overtrue/arch-runtime-test-ecstore-boundaries`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147`.
+- Based on: API-147 stacked slice.
 - PR type for this branch: `pure-move`
 - Runtime behavior changes: none.
-- Rust code changes: move external runtime crate ECStore source imports into
-  crate-local `ecstore_compat` boundaries.
+- Rust code changes: move external test/e2e ECStore source imports into
+  crate-local `ecstore_test_compat` boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
-  regressions, plus external runtime ECStore compatibility bypasses.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147 owner facade cleanup.
+  regressions, plus external runtime and test ECStore compatibility bypasses.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4134,6 +4134,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     check, formatting, diff hygiene, Rust risk scan, branch freshness check,
     pre-commit, and three-expert review.
 
+- [x] `API-148` Route external test ECStore source imports through local compatibility boundaries.
+  - Do: move direct ECStore facade source imports in heal integration tests,
+    scanner lifecycle tests, and e2e reliant/replication helpers into local
+    `ecstore_test_compat` modules while preserving existing test aliases and
+    helper call paths.
+  - Acceptance: target external test/e2e paths contain no direct
+    `rustfs_ecstore::api::` source paths outside `ecstore_test_compat.rs`;
+    migration guards reject restoring those bypasses.
+  - Must preserve: heal endpoint setup and resume disk types, scanner
+    lifecycle transition setup, e2e node RPC client helpers, and replication
+    bucket target cleanup behavior.
+  - Verification: focused test-target compile, migration guard, shell syntax
+    check, formatting, diff hygiene, Rust risk scan, branch freshness check,
+    pre-commit, and three-expert review.
+
 ## Next PRs
 
 1. `pure-move`: continue pruning remaining facade compatibility and owner boundaries.
@@ -4142,9 +4157,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
-| Quality/architecture | pass | API-147 moves selected external runtime crate ECStore source imports behind crate-local compatibility files and guards those boundaries. |
-| Migration preservation | pass | Notify, OBS metrics, S3 Select, Swift, IAM, heal, and scanner root APIs keep the same aliases/wrappers while only the ECStore source location changes. |
-| Testing/verification | pass | Focused external crate compile, formatting, migration guard, diff hygiene, Rust risk scan, and pre-commit passed for API-147. |
+| Quality/architecture | pass | API-148 moves selected external test/e2e ECStore source imports behind local compatibility files and guards those boundaries. |
+| Migration preservation | pass | Heal, scanner, and e2e tests keep the same aliases/helper calls while only the ECStore source location changes. |
+| Testing/verification | pass | Focused test-target compile, formatting, migration guard, diff hygiene, Rust risk scan, and pre-commit passed for API-148. |
 
 ## Verification Notes
 
@@ -4245,6 +4260,20 @@ Passed before push:
   - Runtime crate ECStore source bypass scan: passed; target runtime crate
     source paths now reference `rustfs_ecstore::api::` only inside
     `ecstore_compat.rs`.
+  - Rust risk scan: no new production unwrap/expect, casts, panic/todo/unsafe,
+    or error-type risks added; changes only move import/source boundaries.
+
+- Issue #660 API-148 current slice:
+  - `cargo check --tests -p rustfs-heal -p rustfs-scanner -p e2e_test`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `make pre-commit`: passed.
+  - External test ECStore source bypass scan: passed; target test/e2e paths now
+    reference `rustfs_ecstore::api::` only inside `ecstore_test_compat.rs`.
   - Rust risk scan: no new production unwrap/expect, casts, panic/todo/unsafe,
     or error-type risks added; changes only move import/source boundaries.
 

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -112,6 +112,7 @@ RUSTFS_APP_BUCKET_OWNER_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_bucket_owner_sou
 RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_ecstore_source_hits.txt"
 RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_admin_ecstore_source_hits.txt"
 EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_runtime_ecstore_compat_bypass_hits.txt"
+EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_test_ecstore_compat_bypass_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
 RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE="${TMP_DIR}/rustfs_local_compat_owner_self_path_hits.txt"
 RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_compat_relative_consumer_hits.txt"
@@ -730,6 +731,8 @@ fi
     --glob '!**/storage_compat.rs' \
     --glob '!**/*storage_compat.rs' \
     --glob '!**/ecstore_compat.rs' \
+    --glob '!**/ecstore_test_compat.rs' \
+    --glob '!**/ecstore_test_compat/**' \
     --glob '!target/**' \
     | rg -v '^(rustfs/src/(admin/mod|app/mod|storage/mod)\.rs|crates/e2e_test/src/(replication_extension_test|reliant/(grpc_lock_client|node_interact_test))\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/(endpoint_index_test|heal_bug_fixes_test|heal_integration_test)\.rs|crates/iam/src/lib\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|fuzz/fuzz_targets/(bucket_validation|path_containment)\.rs):' || true
 ) |
@@ -1041,6 +1044,8 @@ fi
     --glob '*storage_compat.rs' \
     --glob '*_compat.rs' \
     --glob '!**/ecstore_compat.rs' \
+    --glob '!**/ecstore_test_compat.rs' \
+    --glob '!**/ecstore_test_compat/**' \
     | rg -v '^[^:]+:[0-9]+:use rustfs_ecstore::api::[a-z_]+ as ecstore_[a-z_]+;' || true
 ) >"$ALL_STORAGE_COMPAT_RAW_FACADE_PATH_HITS_FILE"
 
@@ -1075,7 +1080,9 @@ fi
   rg -n --with-filename 'rustfs_ecstore::api::[a-z_]+::' rustfs/src crates fuzz \
     --glob '*.rs' \
     --glob '!crates/ecstore/**' \
-    --glob '!**/ecstore_compat.rs' |
+    --glob '!**/ecstore_compat.rs' \
+    --glob '!**/ecstore_test_compat.rs' \
+    --glob '!**/ecstore_test_compat/**' |
     rg -v '^(fuzz/fuzz_targets/bucket_validation\.rs|fuzz/fuzz_targets/path_containment\.rs|crates/e2e_test/src/reliant/grpc_lock_client\.rs|crates/e2e_test/src/reliant/node_interact_test\.rs|crates/e2e_test/src/replication_extension_test\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/endpoint_index_test\.rs|crates/heal/tests/heal_bug_fixes_test\.rs|crates/heal/tests/heal_integration_test\.rs|crates/iam/src/lib\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|rustfs/src/admin/mod\.rs|rustfs/src/app/mod\.rs|rustfs/src/storage/mod\.rs):' || true
 ) >"$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE"
 
@@ -1280,6 +1287,21 @@ fi
 
 if [[ -s "$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE" ]]; then
   report_failure "external runtime crates must source ECStore API symbols through their ecstore_compat boundary: $(paste -sd '; ' "$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'rustfs_ecstore::api::' \
+    crates/heal/tests \
+    crates/scanner/tests \
+    crates/e2e_test/src \
+    --glob '*.rs' \
+    --glob '!**/ecstore_test_compat.rs' \
+    --glob '!**/ecstore_test_compat/**' || true
+) >"$EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE"
+
+if [[ -s "$EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE" ]]; then
+  report_failure "external test crates must source ECStore API symbols through their ecstore_test_compat boundary: $(paste -sd '; ' "$EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Move direct ECStore facade source imports in heal, scanner, and e2e test paths into local `ecstore_test_compat` boundaries.
- Preserve existing test aliases and helper call paths so heal setup, scanner lifecycle tests, and e2e RPC/replication helpers keep the same behavior.
- Extend `scripts/check_architecture_migration_rules.sh` to reject direct `rustfs_ecstore::api::` bypasses in those external test/e2e paths outside `ecstore_test_compat`.
- Record API-148 progress and verification in `docs/architecture/migration-progress.md`.

## Verification

- `cargo fmt --all`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo check --tests -p rustfs-heal -p rustfs-scanner -p e2e_test`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact

No runtime behavior change expected. This only localizes external test and e2e ECStore facade source imports behind local compatibility boundaries.

## Additional Notes

Stacked on PR #3756 after PR #3760.
