### PR TITLE
refactor: route app runtime consumers through context

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,14 +5,14 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-app-notify-compat-boundaries`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154`.
-- Based on: `overtrue/arch-test-fuzz-ecstore-thin-bridges` after API-154.
-- PR type for this branch: `pure-move`
+- Branch: `overtrue/arch-app-context-runtime-resolvers`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155`.
+- Based on: `overtrue/arch-app-notify-compat-boundaries` after API-155.
+- PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: remove the app context resolver compatibility module and
-  notify event-bridge re-export module, keeping their public symbols at the
-  owner roots.
+- Rust code changes: route selected KMS readiness, notification, and buffer
+  profile consumers through AppContext resolver helpers with legacy global
+  fallback.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -20,7 +20,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   ECStore compatibility bypasses, plus runtime crate, owner crate, test/fuzz,
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4247,9 +4247,24 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     syntax check, formatting, diff hygiene, Rust risk scan, branch freshness
     check, pre-commit, and three-expert review.
 
+- [x] `API-156` Route app runtime consumers through AppContext resolvers.
+  - Do: add notify and buffer profile resolver helpers, route bucket/object
+    notification users through the notify resolver, route ECFS buffer sizing
+    through the buffer resolver, and route public health KMS readiness through
+    the KMS runtime resolver.
+  - Acceptance: selected app/server/storage consumers no longer open-code
+    direct global notifier, buffer config, or KMS service manager fallback when
+    an AppContext resolver already owns the migration boundary.
+  - Must preserve: context-first behavior when an AppContext exists, legacy
+    global fallback when it does not, notification delivery semantics, buffer
+    opt-in behavior, and public health readiness behavior.
+  - Verification: RustFS compile coverage, migration guard, shell syntax check,
+    formatting, diff hygiene, Rust risk scan, branch freshness check,
+    pre-commit, and three-expert review.
+
 ## Next PRs
 
-1. `pure-move`: continue pruning remaining facade compatibility and owner boundaries.
+1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
 
 ## Pre-Push Review Log
 
@@ -4267,10 +4282,27 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-155 removes app context and notify thin compatibility modules while keeping owner-root exports. |
 | Migration preservation | pass | AppContext resolver precedence and notify pipeline public aliases keep the same public call paths. |
 | Testing/verification | pass | RustFS/notify focused compile, targeted tests, formatting, migration guard, shell syntax, diff hygiene, bridge scan, Rust risk scan, and pre-commit passed for API-155. |
+| Quality/architecture | pass | API-156 centralizes selected app/server/storage runtime fallbacks behind AppContext resolver helpers without adding new abstractions. |
+| Migration preservation | pass | KMS readiness, notification dispatch, and ECFS buffer sizing keep existing global fallback semantics when no AppContext is available. |
+| Testing/verification | pass | RustFS focused compile, formatting, migration guard, shell syntax, diff hygiene, Rust risk scan, and pre-commit passed for API-156. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-156 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `make pre-commit`: passed.
+  - AppContext runtime resolver scan: passed; selected bucket/object notify,
+    ECFS buffer sizing, and public health KMS readiness consumers use resolver
+    helpers.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or
+    cast risks added.
 
 - Issue #660 API-155 current slice:
   - `cargo check --tests -p rustfs -p rustfs-notify`: passed.

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -40,7 +40,7 @@ use crate::admin::handlers::site_replication::{
     site_replication_bucket_meta_hook, site_replication_delete_bucket_hook, site_replication_make_bucket_hook,
 };
 use crate::app::context::{
-    AppContext, default_notify_interface, get_global_app_context, resolve_object_store_handle_for_context,
+    AppContext, get_global_app_context, resolve_notify_interface_for_context, resolve_object_store_handle_for_context,
 };
 use crate::auth::get_condition_values_with_client_info;
 use crate::error::ApiError;
@@ -1712,11 +1712,7 @@ impl DefaultBucketUsecase {
             .map_err(ApiError::from)?;
 
         let region = resolve_notification_region(self.global_region(), request_region);
-        let notify = self
-            .context
-            .as_ref()
-            .map(|context| context.notify())
-            .unwrap_or_else(default_notify_interface);
+        let notify = resolve_notify_interface_for_context(self.context.as_deref());
         let clear_rules = notify.clear_bucket_notification_rules(&bucket);
         let parse_rules = async {
             let mut event_rules = Vec::new();

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -30,7 +30,6 @@ use super::EndpointServerPools;
 use super::TierConfigMgr;
 use super::metadata_sys::BucketMetadataSys;
 use super::new_object_layer_fn;
-#[cfg(test)]
 use crate::config::RustFSBufferConfig;
 use rustfs_config::server_config::Config;
 use rustfs_kms::KmsServiceManager;
@@ -58,6 +57,13 @@ pub fn resolve_object_store_handle_for_context(context: Option<&AppContext>) -> 
     context.map(|context| context.object_store()).or_else(new_object_layer_fn)
 }
 
+/// Resolve notify interface using an explicit AppContext, falling back to the legacy global notifier.
+pub fn resolve_notify_interface_for_context(context: Option<&AppContext>) -> Arc<dyn NotifyInterface> {
+    context
+        .map(|context| context.notify())
+        .unwrap_or_else(default_notify_interface)
+}
+
 /// Resolve endpoints using AppContext-first precedence.
 pub fn resolve_endpoints_handle() -> Option<EndpointServerPools> {
     resolve_endpoints_handle_with(get_global_app_context(), || default_endpoints_interface().handle())
@@ -71,6 +77,11 @@ pub fn resolve_tier_config_handle() -> Arc<RwLock<TierConfigMgr>> {
 /// Resolve server config using AppContext-first precedence.
 pub fn resolve_server_config() -> Option<Config> {
     resolve_server_config_with(get_global_app_context(), || default_server_config_interface().get())
+}
+
+/// Resolve buffer profile config using AppContext-first precedence.
+pub fn resolve_buffer_config() -> RustFSBufferConfig {
+    resolve_buffer_config_with(get_global_app_context(), || default_buffer_config_interface().get())
 }
 
 fn resolve_kms_runtime_service_manager_with(
@@ -117,7 +128,6 @@ fn resolve_server_config_with(context: Option<Arc<AppContext>>, fallback: impl F
     context.map_or_else(fallback, |context| context.server_config().get())
 }
 
-#[cfg(test)]
 fn resolve_buffer_config_with(
     context: Option<Arc<AppContext>>,
     fallback: impl FnOnce() -> RustFSBufferConfig,

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -15,7 +15,7 @@
 //! Object application use-case contracts.
 
 use crate::app::context::{
-    AppContext, default_notify_interface, get_global_app_context, resolve_object_store_handle_for_context,
+    AppContext, get_global_app_context, resolve_notify_interface_for_context, resolve_object_store_handle_for_context,
 };
 use crate::config::RustFSBufferConfig;
 use crate::delete_tail_activity::{DeleteTailActivityGuard, DeleteTailStage};
@@ -3707,11 +3707,7 @@ impl DefaultObjectUsecase {
         }
 
         let req_headers = req.headers.clone();
-        let notify = self
-            .context
-            .as_ref()
-            .map(|context| context.notify())
-            .unwrap_or_else(default_notify_interface);
+        let notify = resolve_notify_interface_for_context(self.context.as_deref());
         let request_context = req.extensions.get::<request_context::RequestContext>().cloned();
         let deleted_any = delete_results.iter().any(|result| result.delete_object.is_some());
         let notify_bucket = bucket.clone();
@@ -4712,11 +4708,7 @@ impl DefaultObjectUsecase {
             None => String::new(),
         };
 
-        let notify = self
-            .context
-            .as_ref()
-            .map(|context| context.notify())
-            .unwrap_or_else(default_notify_interface);
+        let notify = resolve_notify_interface_for_context(self.context.as_deref());
         let req_params = extract_params_header(&req.headers);
         let host = get_request_host(&req.headers);
         let port = get_request_port(&req.headers);

--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -14,6 +14,7 @@
 
 use crate::admin::console::is_console_path;
 use crate::admin::handlers::health::{HealthProbe, build_health_response_parts};
+use crate::app::context::resolve_kms_runtime_service_manager;
 use crate::error::ApiError;
 use crate::server::RemoteAddr;
 use crate::server::cors;
@@ -903,7 +904,7 @@ fn is_public_health_endpoint_request(method: &Method, path: &str) -> bool {
 }
 
 async fn health_kms_ready() -> bool {
-    let Some(service_manager) = rustfs_kms::get_global_kms_service_manager() else {
+    let Some(service_manager) = resolve_kms_runtime_service_manager() else {
         return true;
     };
 

--- a/rustfs/src/storage/ecfs_extend.rs
+++ b/rustfs/src/storage/ecfs_extend.rs
@@ -17,7 +17,8 @@ use super::{
     StorageError, add_object_lock_years, get_bucket_cors_config, get_bucket_object_lock_config, get_bucket_replication_config,
     resolve_object_store_handle,
 };
-use crate::config::{RustFSBufferConfig, WorkloadProfile, get_global_buffer_config, is_buffer_profile_enabled};
+use crate::app::context::resolve_buffer_config;
+use crate::config::{RustFSBufferConfig, WorkloadProfile, is_buffer_profile_enabled};
 use crate::error::ApiError;
 use crate::server::cors;
 use crate::storage::ecfs::ListObjectUnorderedQuery;
@@ -261,8 +262,8 @@ pub(crate) fn get_adaptive_buffer_size_with_profile(file_size: i64, profile: Opt
 /// ```
 pub(crate) fn get_buffer_size_opt_in(file_size: i64) -> usize {
     let buffer_size = if is_buffer_profile_enabled() {
-        // Use globally configured workload profile (enabled by default in Phase 3)
-        let config = get_global_buffer_config();
+        // Use the AppContext-owned profile when available, with global fallback during migration.
+        let config = resolve_buffer_config();
         config.get_buffer_size(file_size)
     } else {
         // Opt-out mode: Use GeneralPurpose profile for consistent behavior


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Added AppContext notify and buffer profile resolver helpers.
- Routed bucket/object notify consumers through the notify resolver, ECFS buffer sizing through the buffer resolver, and public health KMS readiness through the KMS runtime resolver.
- Updated architecture migration progress for API-156.

## Verification

- `cargo check --tests -p rustfs`
- `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `make pre-commit`

## Impact

No runtime behavior change expected. Selected app/server/storage consumers now prefer AppContext-owned dependencies when available and keep legacy global fallback.

## Additional Notes

N/A
