### PR TITLE
refactor: route readiness through app context

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,14 +5,13 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-app-context-runtime-resolvers`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155`.
-- Based on: `overtrue/arch-app-notify-compat-boundaries` after API-155.
+- Branch: `overtrue/arch-readiness-context-resolvers`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156`.
+- Based on: `main` after API-156.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: route selected KMS readiness, notification, and buffer
-  profile consumers through AppContext resolver helpers with legacy global
-  fallback.
+- Rust code changes: route server readiness IAM and endpoint consumers through
+  AppContext resolver helpers with legacy global fallback.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -20,7 +19,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   ECStore compatibility bypasses, plus runtime crate, owner crate, test/fuzz,
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4262,6 +4261,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     formatting, diff hygiene, Rust risk scan, branch freshness check,
     pre-commit, and three-expert review.
 
+- [x] `API-157` Route server readiness through AppContext resolvers.
+  - Do: add an IAM readiness resolver, use it for cached and uncached server
+    dependency readiness, and use the endpoints resolver for lock quorum
+    endpoint discovery.
+  - Acceptance: readiness no longer directly reads global IAM or endpoint state
+    when an AppContext resolver already owns that boundary.
+  - Must preserve: IAM-ready semantics, distributed lock quorum behavior, storage
+    readiness behavior, and legacy global fallback when AppContext is absent.
+  - Verification: RustFS compile coverage, targeted readiness/context tests,
+    migration guard, formatting, diff hygiene, Rust risk scan, branch freshness
+    check, pre-commit, and three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4285,10 +4296,30 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-156 centralizes selected app/server/storage runtime fallbacks behind AppContext resolver helpers without adding new abstractions. |
 | Migration preservation | pass | KMS readiness, notification dispatch, and ECFS buffer sizing keep existing global fallback semantics when no AppContext is available. |
 | Testing/verification | pass | RustFS focused compile, formatting, migration guard, shell syntax, diff hygiene, Rust risk scan, and pre-commit passed for API-156. |
+| Quality/architecture | pass | API-157 keeps readiness dependency checks behind AppContext-owned IAM and endpoints resolver boundaries. |
+| Migration preservation | pass | IAM readiness and lock quorum endpoint discovery keep legacy global fallback semantics when no AppContext is available. |
+| Testing/verification | pass | RustFS focused compile, targeted readiness/context tests, formatting, migration guard, diff hygiene, Rust risk scan, and pre-commit passed for API-157. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-157 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`:
+    passed.
+  - `cargo test -p rustfs readiness --lib`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `make pre-commit`: passed.
+  - AppContext readiness resolver scan: passed; server readiness uses IAM and
+    endpoints resolver helpers, with lock clients kept on the legacy global
+    boundary.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or
+    cast risks added.
 
 - Issue #660 API-156 current slice:
   - `cargo check --tests -p rustfs`: passed.

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -41,6 +41,13 @@ pub fn resolve_kms_runtime_service_manager() -> Option<Arc<KmsServiceManager>> {
     resolve_kms_runtime_service_manager_with(get_global_app_context(), || default_kms_runtime_interface().service_manager())
 }
 
+/// Resolve IAM readiness using AppContext-first precedence.
+pub fn resolve_iam_ready() -> bool {
+    resolve_iam_ready_with(get_global_app_context(), || {
+        rustfs_iam::get_global_iam_sys().is_some_and(|sys| sys.is_ready())
+    })
+}
+
 /// Resolve bucket metadata handle using AppContext-first precedence.
 pub fn resolve_bucket_metadata_handle() -> Option<Arc<RwLock<BucketMetadataSys>>> {
     resolve_bucket_metadata_handle_with(get_global_app_context(), || default_bucket_metadata_interface().handle())
@@ -91,6 +98,10 @@ fn resolve_kms_runtime_service_manager_with(
     context
         .and_then(|context| context.kms_runtime().service_manager())
         .or_else(fallback)
+}
+
+fn resolve_iam_ready_with(context: Option<Arc<AppContext>>, fallback: impl FnOnce() -> bool) -> bool {
+    context.map_or_else(fallback, |context| context.iam().is_ready())
 }
 
 fn resolve_bucket_metadata_handle_with(
@@ -154,7 +165,9 @@ mod tests {
     use tempfile::TempDir;
     use tokio_util::sync::CancellationToken;
 
-    struct TestIamInterface;
+    struct TestIamInterface {
+        ready: bool,
+    }
 
     impl IamInterface for TestIamInterface {
         fn handle(&self) -> Arc<IamSys<ObjectStore>> {
@@ -162,7 +175,7 @@ mod tests {
         }
 
         fn is_ready(&self) -> bool {
-            true
+            self.ready
         }
     }
 
@@ -299,7 +312,7 @@ mod tests {
         let context = Arc::new(AppContext::with_test_interfaces(
             object_store.clone(),
             AppContextTestInterfaces {
-                iam: Arc::new(TestIamInterface),
+                iam: Arc::new(TestIamInterface { ready: true }),
                 kms: Arc::new(TestKmsInterface {
                     kms: context_kms.clone(),
                 }),
@@ -329,6 +342,7 @@ mod tests {
                 .expect("context KMS runtime"),
             &context_kms
         ));
+        assert!(resolve_iam_ready_with(Some(context.clone()), || false));
         assert!(Arc::ptr_eq(
             &resolve_bucket_metadata_handle_with(Some(context.clone()), || None).expect("context bucket metadata"),
             &bucket_metadata
@@ -361,6 +375,7 @@ mod tests {
             &resolve_kms_runtime_service_manager_with(None, || Some(fallback_kms.clone())).expect("fallback KMS runtime"),
             &fallback_kms
         ));
+        assert!(!resolve_iam_ready_with(None, || false));
         assert!(Arc::ptr_eq(
             &resolve_bucket_metadata_handle_with(None, || Some(bucket_metadata.clone())).expect("fallback bucket metadata"),
             &bucket_metadata

--- a/rustfs/src/server/readiness.rs
+++ b/rustfs/src/server/readiness.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::app::context::{resolve_endpoints_handle, resolve_iam_ready};
 use crate::server::{ServiceState, ServiceStateManager};
 use crate::server::{has_path_prefix, is_table_catalog_path};
-use crate::storage::{
-    Endpoint, EndpointServerPools, get_global_endpoints_opt, get_global_lock_clients, is_dist_erasure,
-    resolve_object_store_handle,
-};
+use crate::storage::{Endpoint, EndpointServerPools, get_global_lock_clients, is_dist_erasure, resolve_object_store_handle};
 #[cfg(test)]
 use crate::storage::{Endpoints, PoolEndpoints};
 use bytes::Bytes;
@@ -27,7 +25,6 @@ use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use metrics::{counter, gauge};
 use rustfs_common::GlobalReadiness;
-use rustfs_iam::get_global_iam_sys;
 use rustfs_madmin::{Disk, StorageInfo};
 use rustfs_storage_api::StorageAdminApi;
 use std::future::Future;
@@ -441,7 +438,7 @@ pub async fn collect_dependency_readiness() -> DependencyReadiness {
 }
 
 pub async fn collect_dependency_readiness_report() -> DependencyReadinessReport {
-    let iam_ready_raw = get_global_iam_sys().is_some_and(|sys| sys.is_ready());
+    let iam_ready_raw = resolve_iam_ready();
     let storage_ready = if let Some(cached) = load_cached_storage_readiness().await {
         cached
     } else {
@@ -475,7 +472,7 @@ async fn collect_lock_quorum_status() -> LockQuorumStatus {
 }
 
 async fn collect_dependency_readiness_uncached() -> DependencyReadiness {
-    let iam_ready_raw = get_global_iam_sys().is_some_and(|sys| sys.is_ready());
+    let iam_ready_raw = resolve_iam_ready();
     let storage_ready = collect_storage_readiness_uncached().await;
     let lock_quorum_status = collect_lock_quorum_status_uncached().await;
 
@@ -584,7 +581,7 @@ async fn collect_lock_quorum_status_uncached() -> LockQuorumStatus {
         };
     }
 
-    let Some(pool_endpoints) = get_global_endpoints_opt() else {
+    let Some(pool_endpoints) = resolve_endpoints_handle() else {
         return LockQuorumStatus::default();
     };
     let Some(lock_clients) = get_global_lock_clients() else {


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary

- Added an AppContext IAM readiness resolver.
- Routed server dependency readiness through IAM and endpoints resolvers.
- Kept lock clients on the legacy global boundary until a dedicated AppContext lock interface exists.
- Updated architecture migration progress for API-157.

## Verification

- `cargo check --tests -p rustfs`
- `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`
- `cargo test -p rustfs readiness --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `make pre-commit`

## Impact

No runtime behavior change expected. Readiness prefers AppContext-owned IAM/endpoints when available and keeps legacy global fallback.

## Additional Notes

N/A.
