### PR TITLE
refactor: route RPC IAM through app context

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,13 +5,13 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-readiness-context-resolvers`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156`.
-- Based on: `main` after API-156.
+- Branch: `overtrue/arch-rpc-iam-context-resolver`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157`.
+- Based on: `main` after API-157.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: route server readiness IAM and endpoint consumers through
-  AppContext resolver helpers with legacy global fallback.
+- Rust code changes: route RPC node IAM operation consumers through an
+  AppContext IAM handle resolver with legacy global fallback.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -19,7 +19,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   ECStore compatibility bypasses, plus runtime crate, owner crate, test/fuzz,
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4273,6 +4273,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration guard, formatting, diff hygiene, Rust risk scan, branch freshness
     check, pre-commit, and three-expert review.
 
+- [x] `API-158` Route RPC node IAM operations through AppContext resolver.
+  - Do: add an IAM handle resolver and use it for RPC node IAM policy, user,
+    group, and service-account reload/delete operations.
+  - Acceptance: RPC node IAM operations no longer directly read the global IAM
+    singleton when an AppContext resolver owns that boundary.
+  - Must preserve: request validation messages, `errServerNotInitialized`
+    fallback, IAM operation arguments, and legacy global fallback when
+    AppContext is absent.
+  - Verification: RustFS compile coverage, targeted context resolver tests,
+    migration guard, formatting, diff hygiene, Rust risk scan, branch freshness
+    check, pre-commit, and three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4299,10 +4311,28 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-157 keeps readiness dependency checks behind AppContext-owned IAM and endpoints resolver boundaries. |
 | Migration preservation | pass | IAM readiness and lock quorum endpoint discovery keep legacy global fallback semantics when no AppContext is available. |
 | Testing/verification | pass | RustFS focused compile, targeted readiness/context tests, formatting, migration guard, diff hygiene, Rust risk scan, and pre-commit passed for API-157. |
+| Quality/architecture | pass | API-158 keeps RPC node IAM operations behind the AppContext-owned IAM handle resolver boundary. |
+| Migration preservation | pass | RPC IAM policy, user, group, and service-account operations keep validation, arguments, and legacy fallback behavior. |
+| Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration guard, diff hygiene, Rust risk scan, and pre-commit passed for API-158. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-158 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `make pre-commit`: passed.
+  - AppContext IAM resolver scan: passed; RPC node IAM operations use the IAM
+    handle resolver, with lock clients kept on the legacy global boundary.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or
+    cast risks added.
 
 - Issue #660 API-157 current slice:
   - `cargo check --tests -p rustfs`: passed.

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -32,6 +32,7 @@ use super::metadata_sys::BucketMetadataSys;
 use super::new_object_layer_fn;
 use crate::config::RustFSBufferConfig;
 use rustfs_config::server_config::Config;
+use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
 use rustfs_kms::KmsServiceManager;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -46,6 +47,11 @@ pub fn resolve_iam_ready() -> bool {
     resolve_iam_ready_with(get_global_app_context(), || {
         rustfs_iam::get_global_iam_sys().is_some_and(|sys| sys.is_ready())
     })
+}
+
+/// Resolve IAM system handle using AppContext-first precedence.
+pub fn resolve_iam_handle() -> Option<Arc<IamSys<ObjectStore>>> {
+    resolve_iam_handle_with(get_global_app_context(), rustfs_iam::get_global_iam_sys)
 }
 
 /// Resolve bucket metadata handle using AppContext-first precedence.
@@ -102,6 +108,13 @@ fn resolve_kms_runtime_service_manager_with(
 
 fn resolve_iam_ready_with(context: Option<Arc<AppContext>>, fallback: impl FnOnce() -> bool) -> bool {
     context.map_or_else(fallback, |context| context.iam().is_ready())
+}
+
+fn resolve_iam_handle_with(
+    context: Option<Arc<AppContext>>,
+    fallback: impl FnOnce() -> Option<Arc<IamSys<ObjectStore>>>,
+) -> Option<Arc<IamSys<ObjectStore>>> {
+    context.map(|context| context.iam().handle()).or_else(fallback)
 }
 
 fn resolve_bucket_metadata_handle_with(
@@ -376,6 +389,7 @@ mod tests {
             &fallback_kms
         ));
         assert!(!resolve_iam_ready_with(None, || false));
+        assert!(resolve_iam_handle_with(None, || None).is_none());
         assert!(Arc::ptr_eq(
             &resolve_bucket_metadata_handle_with(None, || Some(bucket_metadata.clone())).expect("fallback bucket metadata"),
             &bucket_metadata

--- a/rustfs/src/storage/rpc/node_service.rs
+++ b/rustfs/src/storage/rpc/node_service.rs
@@ -23,13 +23,14 @@ use crate::admin::service::{
     config::{reload_dynamic_config_runtime_state, reload_runtime_config_snapshot},
     site_replication::reload_site_replication_runtime_state,
 };
+use crate::app::context::resolve_iam_handle;
 use bytes::Bytes;
 use futures::Stream;
 use futures_util::future::join_all;
 use rmp_serde::Deserializer;
 use rustfs_common::{get_global_local_node_name, heal_channel::HealOpts};
 use rustfs_filemeta::{FileInfo, MetacacheReader};
-use rustfs_iam::{get_global_iam_sys, store::UserType};
+use rustfs_iam::store::UserType;
 use rustfs_lock::{LockClient, LockRequest};
 use rustfs_madmin::health::{
     get_cpus, get_mem_info, get_os_info, get_partitions, get_proc_info, get_sys_config, get_sys_errors, get_sys_services,
@@ -632,7 +633,7 @@ impl Node for NodeService {
             }));
         }
 
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(DeletePolicyResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
@@ -661,7 +662,7 @@ impl Node for NodeService {
                 error_info: Some("policy name is missing".to_string()),
             }));
         }
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(LoadPolicyResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
@@ -700,7 +701,7 @@ impl Node for NodeService {
             }));
         };
         let is_group = request.is_group;
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(LoadPolicyMappingResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
@@ -728,7 +729,7 @@ impl Node for NodeService {
                 error_info: Some("access_key name is missing".to_string()),
             }));
         }
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(DeleteUserResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
@@ -760,7 +761,7 @@ impl Node for NodeService {
                 error_info: Some("access_key name is missing".to_string()),
             }));
         }
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(DeleteServiceAccountResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
@@ -790,7 +791,7 @@ impl Node for NodeService {
             }));
         }
 
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(LoadUserResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
@@ -826,7 +827,7 @@ impl Node for NodeService {
             }));
         }
 
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(LoadServiceAccountResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
@@ -857,7 +858,7 @@ impl Node for NodeService {
             }));
         }
 
-        let Some(iam_sys) = get_global_iam_sys() else {
+        let Some(iam_sys) = resolve_iam_handle() else {
             return Ok(Response::new(LoadGroupResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Added an AppContext-first IAM handle resolver with legacy global fallback.
- Routed RPC node IAM policy, user, group, and service-account operations through the resolver.
- Kept lock clients on the legacy global boundary until a dedicated AppContext lock interface exists.
- Updated architecture migration progress for API-158.

## Verification

- `cargo check --tests -p rustfs`
- `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `make pre-commit`

## Impact

No runtime behavior change expected. RPC IAM operations prefer the AppContext-owned IAM handle when available and keep legacy global fallback behavior when AppContext is absent.

## Additional Notes

N/A.
