### PR TITLE
refactor: route site replication tls through app context

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -10,8 +10,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 - Based on: API-163 local branch stacked on API-162 PR #3776.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: route admin site-replication outbound TLS generation and
-  state reads through AppContext resolvers with legacy global fallback.
+- Rust code changes: route admin site-replication and TLS debug outbound TLS
+  generation/state reads through AppContext resolvers with legacy global
+  fallback.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -20,7 +21,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4371,6 +4372,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     TLS global-read scan, Rust risk scan, branch freshness check, and
     three-expert review.
 
+- [x] `API-165` Route admin TLS debug outbound TLS reads through AppContext.
+  - Do: route admin TLS debug status outbound TLS generation/state reads
+    through the AppContext outbound TLS runtime resolver.
+  - Acceptance: TLS debug status no longer directly calls outbound TLS global
+    summary helpers while preserving the same JSON status fields and consumer
+    generation flags.
+  - Must preserve: profile authorization, TLS source path reporting, reload
+    enable reporting, consumer labels, root CA status, mTLS identity status, and
+    legacy global fallback when AppContext is absent.
+  - Verification: RustFS compile coverage, targeted context resolver tests,
+    migration guard, layer guard, formatting, diff hygiene, residual outbound
+    TLS global-read scan, Rust risk scan, branch freshness check, and
+    three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4419,6 +4434,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-164 keeps admin site-replication outbound TLS generation/state reads behind AppContext resolver boundaries. |
 | Migration preservation | pass | Peer-client cache invalidation, root CA parsing, and published TLS-state fallback behavior are preserved. |
 | Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration/layer guards, diff hygiene, residual TLS scan, and Rust risk scan passed for API-164. |
+| Quality/architecture | pass | API-165 keeps admin TLS debug outbound TLS status reads behind the AppContext resolver boundary. |
+| Migration preservation | pass | TLS debug status JSON fields, consumer labels, reload/env reporting, and legacy fallback behavior are preserved. |
+| Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration/layer guards, diff hygiene, residual TLS scan, and Rust risk scan passed for API-165. |
 
 ## Verification Notes
 
@@ -4436,6 +4454,21 @@ Passed before push:
   - `./scripts/check_layer_dependencies.sh`: passed.
   - AppContext site-replication outbound TLS resolver scan: passed; direct admin
     site-replication TLS global reads are isolated to tests.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
+    risks added.
+
+- Issue #660 API-165 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - AppContext outbound TLS resolver scan: passed; direct admin outbound TLS
+    global reads are removed from production handlers.
   - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
     risks added.
 

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,13 +5,13 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-admin-site-replication-iam-context`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162`.
-- Based on: API-162 branch while PR #3776 is pending.
+- Branch: `overtrue/arch-admin-site-replication-tls-context`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163`.
+- Based on: API-163 local branch stacked on API-162 PR #3776.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: route admin site-replication IAM consumers through the
-  AppContext IAM resolver with legacy global fallback.
+- Rust code changes: route admin site-replication outbound TLS generation and
+  state reads through AppContext resolvers with legacy global fallback.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -20,7 +20,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4358,6 +4358,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration guard, formatting, diff hygiene, residual IAM global-read scan,
     Rust risk scan, branch freshness check, and three-expert review.
 
+- [x] `API-164` Route admin site-replication outbound TLS reads through AppContext.
+  - Do: add an outbound TLS runtime AppContext interface and route
+    site-replication peer-client TLS generation/state reads through resolvers.
+  - Acceptance: site-replication peer-client cache lookup and client rebuild
+    paths no longer directly call outbound TLS global loaders.
+  - Must preserve: peer-client cache invalidation by TLS generation, root CA
+    parsing, mTLS identity propagation via the published TLS state, and legacy
+    global fallback when AppContext is absent.
+  - Verification: RustFS compile coverage, targeted context resolver tests,
+    migration guard, layer guard, formatting, diff hygiene, residual outbound
+    TLS global-read scan, Rust risk scan, branch freshness check, and
+    three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4403,10 +4416,28 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-163 keeps admin site-replication IAM reads behind the AppContext IAM resolver boundary. |
 | Migration preservation | pass | Site-replicator service-account, IAM export/import, and peer-join service-account paths keep legacy fallback behavior. |
 | Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration guard, diff hygiene, residual IAM scan, and Rust risk scan passed for API-163. |
+| Quality/architecture | pass | API-164 keeps admin site-replication outbound TLS generation/state reads behind AppContext resolver boundaries. |
+| Migration preservation | pass | Peer-client cache invalidation, root CA parsing, and published TLS-state fallback behavior are preserved. |
+| Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration/layer guards, diff hygiene, residual TLS scan, and Rust risk scan passed for API-164. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-164 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - AppContext site-replication outbound TLS resolver scan: passed; direct admin
+    site-replication TLS global reads are isolated to tests.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
+    risks added.
 
 - Issue #660 API-163 current slice:
   - `cargo check --tests -p rustfs`: passed.

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -32,8 +32,9 @@ use crate::admin::site_replication_identity::{
 };
 use crate::admin::utils::{encode_compatible_admin_payload, read_compatible_admin_body};
 use crate::app::context::{
-    resolve_deployment_id, resolve_endpoints_handle, resolve_iam_handle, resolve_object_store_handle, resolve_region,
-    resolve_replication_pool_handle, resolve_runtime_port, resolve_server_config,
+    resolve_deployment_id, resolve_endpoints_handle, resolve_iam_handle, resolve_object_store_handle,
+    resolve_outbound_tls_generation, resolve_outbound_tls_state, resolve_region, resolve_replication_pool_handle,
+    resolve_runtime_port, resolve_server_config,
 };
 use crate::auth::{check_key_valid, get_session_token};
 use crate::config::get_config_snapshot;
@@ -71,7 +72,7 @@ use rustfs_policy::policy::{
 use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use rustfs_storage_api::{BucketOperations, BucketOptions, DeleteBucketOptions, MakeBucketOptions, SRBucketDeleteOp};
-use rustfs_tls_runtime::{GlobalPublishedOutboundTlsState, load_global_outbound_tls_generation, load_global_outbound_tls_state};
+use rustfs_tls_runtime::GlobalPublishedOutboundTlsState;
 use rustfs_utils::http::get_source_scheme;
 use rustls_pki_types::pem::PemObject;
 use s3s::dto::{
@@ -627,14 +628,14 @@ fn build_site_replication_peer_client(outbound_tls: &GlobalPublishedOutboundTlsS
 }
 
 async fn site_replication_peer_client() -> S3Result<reqwest::Client> {
-    let generation = load_global_outbound_tls_generation().0;
+    let generation = resolve_outbound_tls_generation().0;
     let cache = SITE_REPLICATION_PEER_CLIENT.lock().await;
     if let Some(hit) = site_replication_peer_client_cache_hit(&cache, generation) {
         return hit;
     }
     drop(cache);
 
-    let outbound_tls = load_global_outbound_tls_state().await;
+    let outbound_tls = resolve_outbound_tls_state().await;
     let built = build_site_replication_peer_client(&outbound_tls);
     let cache_entry = match &built {
         Ok(client) => SiteReplicationPeerClientCacheEntry::Ready(client.clone()),

--- a/rustfs/src/admin/handlers/tls_debug.rs
+++ b/rustfs/src/admin/handlers/tls_debug.rs
@@ -14,15 +14,13 @@
 
 use super::profile::authorize_profile_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
+use crate::app::context::resolve_outbound_tls_state;
 use crate::server::ADMIN_PREFIX;
 use http::StatusCode;
 use http::{HeaderMap, HeaderValue};
 use hyper::Method;
 use matchit::Params;
-use rustfs_tls_runtime::{
-    OutboundOnlySnapshotArgs, TlsConsumerStatusItem, TlsDebugStatusResponse, TlsRuntimeStatusSnapshot,
-    summarize_global_outbound_tls_state,
-};
+use rustfs_tls_runtime::{OutboundOnlySnapshotArgs, TlsConsumerStatusItem, TlsDebugStatusResponse, TlsRuntimeStatusSnapshot};
 use s3s::header::CONTENT_TYPE;
 use s3s::{Body, S3Error, S3ErrorCode, S3Request, S3Response, S3Result};
 
@@ -47,10 +45,13 @@ impl Operation for TlsStatusHandler {
         authorize_profile_request(&req).await?;
 
         let tls_path = rustfs_utils::get_env_opt_str(rustfs_config::ENV_RUSTFS_TLS_PATH).unwrap_or_default();
-        let outbound = summarize_global_outbound_tls_state().await;
+        let outbound = resolve_outbound_tls_state().await;
+        let generation = outbound.generation.0;
+        let has_root_ca = outbound.root_ca_pem.as_ref().is_some_and(|pem| !pem.is_empty());
+        let has_mtls_identity = outbound.mtls_identity.is_some();
         let status = TlsRuntimeStatusSnapshot::from_outbound_only(OutboundOnlySnapshotArgs {
             source_path: tls_path,
-            generation: outbound.generation.0,
+            generation,
             reload_enabled: rustfs_utils::get_env_bool(
                 rustfs_config::ENV_TLS_RELOAD_ENABLE,
                 rustfs_config::DEFAULT_TLS_RELOAD_ENABLE,
@@ -59,28 +60,28 @@ impl Operation for TlsStatusHandler {
             last_attempt_time: None,
             last_success_time: None,
             last_error: None,
-            has_roots: outbound.has_root_ca,
-            has_mtls_identity: outbound.has_mtls_identity,
+            has_roots: has_root_ca,
+            has_mtls_identity,
         });
         let payload = TlsDebugStatusResponse::builder(status)
             .push_consumers([
                 TlsConsumerStatusItem {
                     consumer: PROTOS_GRPC_CHANNEL_CONSUMER,
-                    generation: outbound.generation.0,
-                    has_root_ca: outbound.has_root_ca,
-                    has_mtls_identity: outbound.has_mtls_identity,
+                    generation,
+                    has_root_ca,
+                    has_mtls_identity,
                 },
                 TlsConsumerStatusItem {
                     consumer: RIO_HTTP_READER_CONSUMER,
-                    generation: outbound.generation.0,
-                    has_root_ca: outbound.has_root_ca,
-                    has_mtls_identity: outbound.has_mtls_identity,
+                    generation,
+                    has_root_ca,
+                    has_mtls_identity,
                 },
                 TlsConsumerStatusItem {
                     consumer: ECSTORE_TRANSITION_CLIENT_CONSUMER,
-                    generation: outbound.generation.0,
-                    has_root_ca: outbound.has_root_ca,
-                    has_mtls_identity: outbound.has_mtls_identity,
+                    generation,
+                    has_root_ca,
+                    has_mtls_identity,
                 },
             ])
             .build();

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -37,12 +37,23 @@ use rustfs_credentials::Credentials;
 use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
 use rustfs_kms::KmsServiceManager;
 use rustfs_lock::LockClient;
+use rustfs_tls_runtime::{GlobalPublishedOutboundTlsState, TlsGeneration};
 use std::{future::Future, sync::Arc};
 use tokio::sync::RwLock;
 
 /// Resolve KMS runtime service manager using AppContext-first precedence.
 pub fn resolve_kms_runtime_service_manager() -> Option<Arc<KmsServiceManager>> {
     resolve_kms_runtime_service_manager_with(get_global_app_context(), || default_kms_runtime_interface().service_manager())
+}
+
+/// Resolve outbound TLS generation using AppContext-first precedence.
+pub fn resolve_outbound_tls_generation() -> TlsGeneration {
+    resolve_outbound_tls_generation_with(get_global_app_context(), || default_outbound_tls_runtime_interface().generation())
+}
+
+/// Resolve outbound TLS state using AppContext-first precedence.
+pub async fn resolve_outbound_tls_state() -> GlobalPublishedOutboundTlsState {
+    resolve_outbound_tls_state_with(get_global_app_context()).await
 }
 
 /// Resolve IAM readiness using AppContext-first precedence.
@@ -152,6 +163,21 @@ fn resolve_kms_runtime_service_manager_with(
     context
         .and_then(|context| context.kms_runtime().service_manager())
         .or_else(fallback)
+}
+
+fn resolve_outbound_tls_generation_with(
+    context: Option<Arc<AppContext>>,
+    fallback: impl FnOnce() -> TlsGeneration,
+) -> TlsGeneration {
+    context.map_or_else(fallback, |context| context.outbound_tls_runtime().generation())
+}
+
+async fn resolve_outbound_tls_state_with(context: Option<Arc<AppContext>>) -> GlobalPublishedOutboundTlsState {
+    if let Some(context) = context {
+        return context.outbound_tls_runtime().state().await;
+    }
+
+    default_outbound_tls_runtime_interface().state().await
 }
 
 fn resolve_iam_ready_with(context: Option<Arc<AppContext>>, fallback: impl FnOnce() -> bool) -> bool {
@@ -291,8 +317,8 @@ mod tests {
     };
     use crate::app::context::interfaces::{
         ActionCredentialInterface, BucketMetadataInterface, BufferConfigInterface, DeploymentIdInterface, EndpointsInterface,
-        IamInterface, KmsInterface, KmsRuntimeInterface, LocalNodeNameInterface, LockClientInterface, RegionInterface,
-        RuntimePortInterface, ServerConfigInterface, TierConfigInterface,
+        IamInterface, KmsInterface, KmsRuntimeInterface, LocalNodeNameInterface, LockClientInterface,
+        OutboundTlsRuntimeInterface, RegionInterface, RuntimePortInterface, ServerConfigInterface, TierConfigInterface,
     };
     use crate::config::{RustFSBufferConfig, WorkloadProfile};
     use async_trait::async_trait;
@@ -333,6 +359,21 @@ mod tests {
     impl KmsRuntimeInterface for TestKmsRuntimeInterface {
         fn service_manager(&self) -> Option<Arc<KmsServiceManager>> {
             self.kms.clone()
+        }
+    }
+
+    struct TestOutboundTlsRuntimeInterface {
+        state: GlobalPublishedOutboundTlsState,
+    }
+
+    #[async_trait]
+    impl OutboundTlsRuntimeInterface for TestOutboundTlsRuntimeInterface {
+        fn generation(&self) -> TlsGeneration {
+            self.state.generation
+        }
+
+        async fn state(&self) -> GlobalPublishedOutboundTlsState {
+            self.state.clone()
         }
     }
 
@@ -514,6 +555,11 @@ mod tests {
         let fallback_deployment_id = "fallback-deployment".to_string();
         let context_runtime_port = 19000;
         let fallback_runtime_port = 29000;
+        let context_outbound_tls_state = GlobalPublishedOutboundTlsState {
+            generation: TlsGeneration(41),
+            root_ca_pem: Some(b"context-root-ca".to_vec()),
+            mtls_identity: None,
+        };
         let context_credentials = Credentials {
             access_key: "context-access-key".to_string(),
             ..Default::default()
@@ -534,6 +580,9 @@ mod tests {
                 }),
                 kms_runtime: Arc::new(TestKmsRuntimeInterface {
                     kms: Some(context_kms.clone()),
+                }),
+                outbound_tls_runtime: Arc::new(TestOutboundTlsRuntimeInterface {
+                    state: context_outbound_tls_state.clone(),
                 }),
                 notify: default_notify_interface(),
                 notification_system: default_notification_system_interface(),
@@ -578,6 +627,14 @@ mod tests {
                 .expect("context KMS runtime"),
             &context_kms
         ));
+        assert_eq!(
+            resolve_outbound_tls_generation_with(Some(context.clone()), || TlsGeneration(99)),
+            context_outbound_tls_state.generation
+        );
+        assert_eq!(
+            resolve_outbound_tls_state_with(Some(context.clone())).await.generation,
+            context_outbound_tls_state.generation
+        );
         assert!(resolve_iam_ready_with(Some(context.clone()), || false));
         assert!(Arc::ptr_eq(
             &resolve_bucket_metadata_handle_with(Some(context.clone()), || None).expect("context bucket metadata"),
@@ -638,6 +695,7 @@ mod tests {
             &resolve_kms_runtime_service_manager_with(None, || Some(fallback_kms.clone())).expect("fallback KMS runtime"),
             &fallback_kms
         ));
+        assert_eq!(resolve_outbound_tls_generation_with(None, || TlsGeneration(99)), TlsGeneration(99));
         assert!(!resolve_iam_ready_with(None, || false));
         assert!(resolve_iam_handle_with(None, || None).is_none());
         assert!(Arc::ptr_eq(

--- a/rustfs/src/app/context/global.rs
+++ b/rustfs/src/app/context/global.rs
@@ -17,15 +17,15 @@ use super::handles::{
     IamHandle, KmsHandle, default_action_credential_interface, default_bucket_metadata_interface,
     default_bucket_monitor_interface, default_buffer_config_interface, default_deployment_id_interface,
     default_endpoints_interface, default_kms_runtime_interface, default_local_node_name_interface, default_lock_client_interface,
-    default_notification_system_interface, default_notify_interface, default_region_interface,
-    default_replication_pool_interface, default_runtime_port_interface, default_server_config_interface,
-    default_tier_config_interface,
+    default_notification_system_interface, default_notify_interface, default_outbound_tls_runtime_interface,
+    default_region_interface, default_replication_pool_interface, default_runtime_port_interface,
+    default_server_config_interface, default_tier_config_interface,
 };
 use super::interfaces::{
     ActionCredentialInterface, BucketMetadataInterface, BucketMonitorInterface, BufferConfigInterface, DeploymentIdInterface,
     EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface, LocalNodeNameInterface, LockClientInterface,
-    NotificationSystemInterface, NotifyInterface, RegionInterface, ReplicationPoolInterface, RuntimePortInterface,
-    ServerConfigInterface, TierConfigInterface,
+    NotificationSystemInterface, NotifyInterface, OutboundTlsRuntimeInterface, RegionInterface, ReplicationPoolInterface,
+    RuntimePortInterface, ServerConfigInterface, TierConfigInterface,
 };
 use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
 use rustfs_kms::KmsServiceManager;
@@ -39,6 +39,7 @@ pub struct AppContext {
     #[allow(dead_code)]
     kms: Arc<dyn KmsInterface>,
     kms_runtime: Arc<dyn KmsRuntimeInterface>,
+    outbound_tls_runtime: Arc<dyn OutboundTlsRuntimeInterface>,
     notify: Arc<dyn NotifyInterface>,
     notification_system: Arc<dyn NotificationSystemInterface>,
     bucket_metadata: Arc<dyn BucketMetadataInterface>,
@@ -63,6 +64,7 @@ impl AppContext {
             iam,
             kms,
             kms_runtime: default_kms_runtime_interface(),
+            outbound_tls_runtime: default_outbound_tls_runtime_interface(),
             notify: default_notify_interface(),
             notification_system: default_notification_system_interface(),
             bucket_metadata: default_bucket_metadata_interface(),
@@ -104,6 +106,10 @@ impl AppContext {
 
     pub fn kms_runtime(&self) -> Arc<dyn KmsRuntimeInterface> {
         self.kms_runtime.clone()
+    }
+
+    pub fn outbound_tls_runtime(&self) -> Arc<dyn OutboundTlsRuntimeInterface> {
+        self.outbound_tls_runtime.clone()
     }
 
     pub fn notify(&self) -> Arc<dyn NotifyInterface> {
@@ -172,6 +178,7 @@ pub(super) struct AppContextTestInterfaces {
     pub(super) iam: Arc<dyn IamInterface>,
     pub(super) kms: Arc<dyn KmsInterface>,
     pub(super) kms_runtime: Arc<dyn KmsRuntimeInterface>,
+    pub(super) outbound_tls_runtime: Arc<dyn OutboundTlsRuntimeInterface>,
     pub(super) notify: Arc<dyn NotifyInterface>,
     pub(super) notification_system: Arc<dyn NotificationSystemInterface>,
     pub(super) bucket_metadata: Arc<dyn BucketMetadataInterface>,
@@ -197,6 +204,7 @@ impl AppContext {
             iam: interfaces.iam,
             kms: interfaces.kms,
             kms_runtime: interfaces.kms_runtime,
+            outbound_tls_runtime: interfaces.outbound_tls_runtime,
             notify: interfaces.notify,
             notification_system: interfaces.notification_system,
             bucket_metadata: interfaces.bucket_metadata,

--- a/rustfs/src/app/context/handles.rs
+++ b/rustfs/src/app/context/handles.rs
@@ -22,8 +22,8 @@ use super::super::{
 use super::interfaces::{
     ActionCredentialInterface, BucketMetadataInterface, BucketMonitorInterface, BufferConfigInterface, DeploymentIdInterface,
     EndpointsInterface, IamInterface, KmsInterface, KmsRuntimeInterface, LocalNodeNameInterface, LockClientInterface,
-    NotificationSystemInterface, NotifyInterface, RegionInterface, ReplicationPoolInterface, RuntimePortInterface,
-    ServerConfigInterface, TierConfigInterface,
+    NotificationSystemInterface, NotifyInterface, OutboundTlsRuntimeInterface, RegionInterface, ReplicationPoolInterface,
+    RuntimePortInterface, ServerConfigInterface, TierConfigInterface,
 };
 use crate::config::{RustFSBufferConfig, get_global_buffer_config};
 use async_trait::async_trait;
@@ -36,6 +36,9 @@ use rustfs_kms::{KmsServiceManager, get_global_kms_service_manager};
 use rustfs_lock::LockClient;
 use rustfs_notify::{EventArgs, NotificationError, notifier_global};
 use rustfs_targets::{EventName, arn::TargetID};
+use rustfs_tls_runtime::{
+    GlobalPublishedOutboundTlsState, TlsGeneration, load_global_outbound_tls_generation, load_global_outbound_tls_state,
+};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -86,6 +89,21 @@ pub struct KmsRuntimeHandle;
 impl KmsRuntimeInterface for KmsRuntimeHandle {
     fn service_manager(&self) -> Option<Arc<KmsServiceManager>> {
         get_global_kms_service_manager()
+    }
+}
+
+/// Default outbound TLS runtime interface adapter.
+#[derive(Default)]
+pub struct OutboundTlsRuntimeHandle;
+
+#[async_trait]
+impl OutboundTlsRuntimeInterface for OutboundTlsRuntimeHandle {
+    fn generation(&self) -> TlsGeneration {
+        load_global_outbound_tls_generation()
+    }
+
+    async fn state(&self) -> GlobalPublishedOutboundTlsState {
+        load_global_outbound_tls_state().await
     }
 }
 
@@ -264,6 +282,10 @@ pub fn default_notification_system_interface() -> Arc<dyn NotificationSystemInte
 
 pub fn default_kms_runtime_interface() -> Arc<dyn KmsRuntimeInterface> {
     Arc::new(KmsRuntimeHandle)
+}
+
+pub fn default_outbound_tls_runtime_interface() -> Arc<dyn OutboundTlsRuntimeInterface> {
+    Arc::new(OutboundTlsRuntimeHandle)
 }
 
 pub fn default_bucket_metadata_interface() -> Arc<dyn BucketMetadataInterface> {

--- a/rustfs/src/app/context/interfaces.rs
+++ b/rustfs/src/app/context/interfaces.rs
@@ -25,6 +25,7 @@ use rustfs_kms::KmsServiceManager;
 use rustfs_lock::LockClient;
 use rustfs_notify::{EventArgs, NotificationError};
 use rustfs_targets::{EventName, arn::TargetID};
+use rustfs_tls_runtime::{GlobalPublishedOutboundTlsState, TlsGeneration};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -44,6 +45,13 @@ pub trait KmsInterface: Send + Sync {
 /// KMS runtime interface for application-layer and admin handler integration.
 pub trait KmsRuntimeInterface: Send + Sync {
     fn service_manager(&self) -> Option<Arc<KmsServiceManager>>;
+}
+
+/// Outbound TLS runtime interface for client material consumers.
+#[async_trait]
+pub trait OutboundTlsRuntimeInterface: Send + Sync {
+    fn generation(&self) -> TlsGeneration;
+    async fn state(&self) -> GlobalPublishedOutboundTlsState;
 }
 
 /// Notify interface for application-layer use-cases.


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Route admin site-replication outbound TLS generation and state reads through AppContext resolvers with legacy global fallback.
- Route TLS debug status through the same AppContext outbound TLS state resolver.
- Update the architecture migration progress for API-164 and API-165.

## Verification
- `cargo check --tests -p rustfs`
- `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Residual outbound TLS global-read scan
- Rust risk scan

## Impact
No runtime behavior change expected. Existing outbound TLS fallback state, peer-client cache behavior, and TLS debug response fields are preserved.

## Additional Notes
N/A
