### PR TITLE
refactor: route admin kms manager through app context

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,14 +5,14 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-admin-status-metrics-context`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166`.
-- Based on: API-166 local branch stacked on API-164/API-165 local branch after API-163 PR #3777 merged.
+- Branch: `overtrue/arch-admin-kms-manager-context`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168`.
+- Based on: API-168 local branch stacked on API-167 local branch after API-163 PR #3777 merged.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: route admin status and metrics reads for boot time, tier
-  transition stats, and scanner metrics through AppContext resolvers with
-  legacy global fallback.
+- Rust code changes: route admin KMS service-manager initialization fallback
+  through an AppContext-first resolver with legacy global initialization
+  preserved when no manager is available.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -21,7 +21,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4417,6 +4417,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     status global-read scan, Rust risk scan, branch freshness check, and
     three-expert review.
 
+- [x] `API-168` Route admin KMS manager initialization through AppContext.
+  - Do: add an AppContext-first KMS runtime resolver that initializes the
+    legacy global manager only after context/default lookup misses, then route
+    admin KMS key, management, and dynamic handlers through it.
+  - Acceptance: admin production handlers no longer directly initialize the
+    global KMS service manager, while the AppContext default path preserves
+    legacy global initialization fallback.
+  - Must preserve: KMS key encryption-service lookup, KMS status/config/cache
+    handlers, dynamic KMS configure/start/stop/reconfigure behavior, and
+    existing fallback warning logs.
+  - Verification: RustFS compile coverage, targeted context resolver tests,
+    migration guard, layer guard, formatting, diff hygiene, residual admin KMS
+    init scan, Rust risk scan, branch freshness check, and three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4474,6 +4488,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-167 keeps admin boot-time, tier-transition, and scanner metrics reads behind AppContext resolver boundaries. |
 | Migration preservation | pass | Replication uptime enrichment, tier stats filtering, scanner metrics JSON, and scanner runtime-config reporting are preserved. |
 | Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration/layer guards, diff hygiene, residual admin status scan, and Rust risk scan passed for API-167. |
+| Quality/architecture | pass | API-168 keeps admin KMS service-manager initialization behind the AppContext resolver boundary. |
+| Migration preservation | pass | KMS key, management, and dynamic handlers preserve legacy initialization fallback and existing fallback logs. |
+| Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration/layer guards, diff hygiene, residual KMS init scan, and Rust risk scan passed for API-168. |
 
 ## Verification Notes
 
@@ -4537,6 +4554,21 @@ Passed before push:
   - AppContext admin status resolver scan: passed; direct admin production
     `GLOBAL_BOOT_TIME`, `GLOBAL_TransitionState`, and scanner `global_metrics`
     reads are removed.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
+    risks added.
+
+- Issue #660 API-168 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - AppContext admin KMS init resolver scan: passed; direct admin production
+    `init_global_kms_service_manager` calls are removed.
   - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
     risks added.
 

--- a/rustfs/src/admin/handlers/kms_dynamic.rs
+++ b/rustfs/src/admin/handlers/kms_dynamic.rs
@@ -17,7 +17,9 @@
 use super::super::{read_admin_config, save_admin_config};
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::app::context::{resolve_kms_runtime_service_manager, resolve_object_store_handle};
+use crate::app::context::{
+    resolve_kms_runtime_service_manager, resolve_object_store_handle, resolve_or_init_kms_runtime_service_manager,
+};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use hyper::{Method, StatusCode};
@@ -46,7 +48,7 @@ fn kms_service_manager_from_context() -> std::sync::Arc<rustfs_kms::KmsServiceMa
             result = "service_manager_fallback_initialized",
             "admin kms dynamic state"
         );
-        rustfs_kms::init_global_kms_service_manager()
+        resolve_or_init_kms_runtime_service_manager()
     })
 }
 

--- a/rustfs/src/admin/handlers/kms_keys.rs
+++ b/rustfs/src/admin/handlers/kms_keys.rs
@@ -16,14 +16,14 @@
 
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::app::context::resolve_kms_runtime_service_manager;
+use crate::app::context::{resolve_kms_runtime_service_manager, resolve_or_init_kms_runtime_service_manager};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use base64::Engine;
 use hyper::{HeaderMap, Method, StatusCode};
 use matchit::Params;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
-use rustfs_kms::{KmsError, init_global_kms_service_manager, types::*};
+use rustfs_kms::{KmsError, types::*};
 use rustfs_policy::policy::action::{Action, KmsAction};
 use s3s::header::CONTENT_TYPE;
 use s3s::{Body, S3Request, S3Response, S3Result, s3_error};
@@ -121,7 +121,7 @@ fn kms_service_manager_from_context() -> Option<std::sync::Arc<rustfs_kms::KmsSe
 }
 
 async fn kms_encryption_service_from_context() -> Option<std::sync::Arc<rustfs_kms::ObjectEncryptionService>> {
-    let manager = kms_service_manager_from_context().unwrap_or_else(init_global_kms_service_manager);
+    let manager = resolve_or_init_kms_runtime_service_manager();
     manager.get_encryption_service().await
 }
 

--- a/rustfs/src/admin/handlers/kms_management.rs
+++ b/rustfs/src/admin/handlers/kms_management.rs
@@ -17,12 +17,12 @@
 use super::kms_keys::{CreateKeyHandler, DescribeKeyHandler, GenerateDataKeyHandler, ListKeysHandler};
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::app::context::resolve_kms_runtime_service_manager;
+use crate::app::context::{resolve_kms_runtime_service_manager, resolve_or_init_kms_runtime_service_manager};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use hyper::{HeaderMap, Method, StatusCode};
 use matchit::Params;
-use rustfs_kms::{KmsBackend, init_global_kms_service_manager};
+use rustfs_kms::KmsBackend;
 use rustfs_policy::policy::action::{Action, KmsAction};
 use s3s::header::CONTENT_TYPE;
 use s3s::{Body, S3Request, S3Response, S3Result, s3_error};
@@ -39,7 +39,7 @@ fn kms_service_manager_from_context() -> std::sync::Arc<rustfs_kms::KmsServiceMa
         Some(manager) => manager,
         None => {
             warn!("KMS service manager not initialized, initializing now as fallback");
-            init_global_kms_service_manager()
+            resolve_or_init_kms_runtime_service_manager()
         }
     }
 }

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -37,7 +37,7 @@ use crate::config::RustFSBufferConfig;
 use rustfs_config::server_config::Config;
 use rustfs_credentials::Credentials;
 use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
-use rustfs_kms::KmsServiceManager;
+use rustfs_kms::{KmsServiceManager, init_global_kms_service_manager};
 use rustfs_lock::LockClient;
 use rustfs_tls_runtime::{GlobalPublishedOutboundTlsState, TlsGeneration};
 use std::{future::Future, sync::Arc, time::SystemTime};
@@ -46,6 +46,11 @@ use tokio::sync::RwLock;
 /// Resolve KMS runtime service manager using AppContext-first precedence.
 pub fn resolve_kms_runtime_service_manager() -> Option<Arc<KmsServiceManager>> {
     resolve_kms_runtime_service_manager_with(get_global_app_context(), || default_kms_runtime_interface().service_manager())
+}
+
+/// Resolve or initialize the KMS runtime service manager using AppContext-first precedence.
+pub fn resolve_or_init_kms_runtime_service_manager() -> Arc<KmsServiceManager> {
+    resolve_or_init_kms_runtime_service_manager_with(get_global_app_context(), init_global_kms_service_manager)
 }
 
 /// Resolve outbound TLS generation using AppContext-first precedence.
@@ -186,6 +191,15 @@ fn resolve_kms_runtime_service_manager_with(
     context
         .and_then(|context| context.kms_runtime().service_manager())
         .or_else(fallback)
+}
+
+fn resolve_or_init_kms_runtime_service_manager_with(
+    context: Option<Arc<AppContext>>,
+    fallback: impl FnOnce() -> Arc<KmsServiceManager>,
+) -> Arc<KmsServiceManager> {
+    context
+        .and_then(|context| context.kms_runtime().service_manager())
+        .unwrap_or_else(fallback)
 }
 
 fn resolve_outbound_tls_generation_with(
@@ -753,6 +767,10 @@ mod tests {
                 .expect("context KMS runtime"),
             &context_kms
         ));
+        assert!(Arc::ptr_eq(
+            &resolve_or_init_kms_runtime_service_manager_with(Some(context.clone()), || fallback_kms.clone()),
+            &context_kms
+        ));
         assert_eq!(
             resolve_outbound_tls_generation_with(Some(context.clone()), || TlsGeneration(99)),
             context_outbound_tls_state.generation
@@ -836,6 +854,10 @@ mod tests {
 
         assert!(Arc::ptr_eq(
             &resolve_kms_runtime_service_manager_with(None, || Some(fallback_kms.clone())).expect("fallback KMS runtime"),
+            &fallback_kms
+        ));
+        assert!(Arc::ptr_eq(
+            &resolve_or_init_kms_runtime_service_manager_with(None, || fallback_kms.clone()),
             &fallback_kms
         ));
         assert_eq!(resolve_outbound_tls_generation_with(None, || TlsGeneration(99)), TlsGeneration(99));


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Added an AppContext-first KMS resolver that initializes the legacy global manager only after context/default lookup misses.
- Routed admin KMS key, management, and dynamic handlers through that resolver.
- Updated `docs/architecture/migration-progress.md` for API-168.

## Verification

- `cargo check --tests -p rustfs`
- `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `bash -n scripts/check_architecture_migration_rules.sh && ./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Residual admin KMS init scan
- Rust risk scan

## Impact

No user-facing API or runtime behavior change expected. Legacy KMS manager initialization fallback remains available when AppContext is absent.

## Additional Notes

N/A
