### PR TITLE
refactor: route action credentials through app context

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,14 +5,13 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-admin-config-writes-context`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169`.
-- Based on: API-169 local branch after API-168 PR #3781 merged.
+- Branch: `overtrue/arch-auth-credentials-context`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170`.
+- Based on: API-169 PR #3782 after merge.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
-- Rust code changes: route admin server-config and storage-class runtime
-  publication through AppContext-first publish helpers, with legacy global
-  setters preserved as default adapters.
+- Rust code changes: route auth, protocol storage client, and storage helper
+  action-credential reads through the AppContext action-credential resolver.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -21,7 +20,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169 owner facade cleanup.
+- Docs changes: record the API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4446,6 +4445,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     config publication scan, Rust risk scan, branch freshness check, and
     three-expert review.
 
+- [x] `API-170` Route action credential reads through AppContext.
+  - Do: route auth validation, protocol storage-client owner checks, and
+    storage audit helper access-key enrichment through the AppContext
+    action-credential resolver.
+  - Acceptance: production auth/protocol/storage helper paths no longer read
+    action credentials directly from the credentials singleton, while the
+    AppContext default adapter preserves the legacy global fallback.
+  - Must preserve: owner detection, session-token claim validation, policy
+    principal type derivation, protocol request metadata, and audit access-key
+    enrichment.
+  - Verification: RustFS compile coverage, targeted context resolver tests,
+    migration guard, layer guard, formatting, diff hygiene, residual action
+    credential scan, Rust risk scan, branch freshness check, and three-expert
+    review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4509,10 +4523,29 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-169 keeps admin config runtime publication behind AppContext publish helpers with default global-setter adapters. |
 | Migration preservation | pass | Config writes, runtime reload, dynamic subsystem application, and storage-class parsing preserve existing persistence and runtime side effects. |
 | Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration/layer guards, diff hygiene, residual config publication scan, and Rust risk scan passed for API-169. |
+| Quality/architecture | pass | API-170 keeps action-credential reads behind the AppContext action-credential resolver across auth, protocols, and storage helper paths. |
+| Migration preservation | pass | Owner checks, claim validation, policy principal classification, protocol metadata, and audit access-key enrichment preserve existing fallback behavior. |
+| Testing/verification | pass | RustFS focused compile, targeted context tests, formatting, migration/layer guards, diff hygiene, residual action credential scan, and Rust risk scan passed for API-170. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-170 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - AppContext action credential scan: passed; direct production
+    `get_global_action_cred` and `get_global_access_key_opt` reads are removed
+    from auth, protocol client, and storage helper paths.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
+    risks added.
 
 - Issue #660 API-169 current slice:
   - `cargo check --tests -p rustfs`: passed.

--- a/rustfs/src/auth.rs
+++ b/rustfs/src/auth.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::app::context::resolve_action_credentials;
 use http::HeaderMap;
 use http::Uri;
-use rustfs_credentials::{Credentials, get_global_action_cred};
+use rustfs_credentials::Credentials;
 use rustfs_iam::error::Error as IamError;
 use rustfs_iam::sys::{
     SESSION_POLICY_NAME, get_claims_from_token_with_secret, get_claims_from_token_with_secret_allow_missing_exp,
@@ -330,7 +331,7 @@ pub async fn check_key_valid(session_token: &str, access_key: &str) -> S3Result<
         return Err(s3_error!(InvalidAccessKeyId, "Keystone authentication requires X-Auth-Token header"));
     }
 
-    let Some(mut cred) = get_global_action_cred() else {
+    let Some(mut cred) = resolve_action_credentials() else {
         return Err(S3Error::with_message(
             S3ErrorCode::InternalError,
             format!("get_global_action_cred {:?}", IamError::IamSysNotInitialized),
@@ -434,7 +435,7 @@ pub fn check_claims_from_token(token: &str, cred: &Credentials) -> S3Result<Hash
         return Err(s3_error!(InvalidRequest, "invalid access key is temp and expired"));
     }
 
-    let Some(sys_cred) = get_global_action_cred() else {
+    let Some(sys_cred) = resolve_action_credentials() else {
         return Err(s3_error!(InternalError, "action cred not init"));
     };
 
@@ -610,7 +611,7 @@ pub fn get_condition_values_with_query_and_client_info(
         cred.access_key.clone()
     };
 
-    let sys_cred = get_global_action_cred().unwrap_or_default();
+    let sys_cred = resolve_action_credentials().unwrap_or_default();
 
     let claims = &cred.claims;
 

--- a/rustfs/src/protocols/client.rs
+++ b/rustfs/src/protocols/client.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::app::context::resolve_action_credentials;
 use crate::storage::ecfs::FS;
 use http::{HeaderMap, Method};
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
@@ -139,7 +140,7 @@ impl ProtocolStorageClient {
     ) -> S3Result<S3Request<T>> {
         let mut extensions = http::Extensions::default();
 
-        let is_owner = if let Some(global_cred) = rustfs_credentials::get_global_action_cred() {
+        let is_owner = if let Some(global_cred) = resolve_action_credentials() {
             params.access_key == global_cred.access_key
         } else {
             false

--- a/rustfs/src/storage/helper.rs
+++ b/rustfs/src/storage/helper.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::app::context::resolve_action_credentials;
 use crate::server::{convert_ecstore_object_info, is_audit_module_enabled, is_notify_module_enabled};
 use crate::storage::access::{ReqInfo, request_context_from_req};
 use crate::storage::request_context::{RequestContext, extract_request_id_from_headers};
@@ -311,8 +312,8 @@ impl OperationHelper {
                 final_builder = final_builder.error(err);
             }
 
-            if let Some(sk) = rustfs_credentials::get_global_access_key_opt() {
-                final_builder = final_builder.access_key(&sk);
+            if let Some(cred) = resolve_action_credentials() {
+                final_builder = final_builder.access_key(&cred.access_key);
             }
 
             // Inject OpenTelemetry trace context into audit tags for distributed tracing correlation

--- a/scripts/layer-dependency-baseline.txt
+++ b/scripts/layer-dependency-baseline.txt
@@ -39,7 +39,9 @@ dep|rustfs/src/app/multipart_usecase.rs|app->interface|crate::storage::s3_api::m
 dep|rustfs/src/app/multipart_usecase.rs|app->interface|crate::storage::s3_api::multipart::parse_upload_part_number
 dep|rustfs/src/app/object_usecase.rs|app->interface|crate::storage::ecfs
 dep|rustfs/src/app/object_usecase.rs|app->interface|crate::storage::s3_api::multipart::parse_list_parts_params
+dep|rustfs/src/auth.rs|infra->app|crate::app::context::resolve_action_credentials
 dep|rustfs/src/init.rs|infra->interface|crate::admin
+dep|rustfs/src/protocols/client.rs|infra->app|crate::app::context::resolve_action_credentials
 dep|rustfs/src/protocols/client.rs|infra->interface|crate::storage::ecfs::FS
 dep|rustfs/src/server/audit.rs|infra->app|crate::app::context::resolve_server_config
 dep|rustfs/src/server/event.rs|infra->app|crate::app::context::resolve_server_config
@@ -57,6 +59,7 @@ dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::ecfs::FS
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::ecfs::validate_object_lock_configuration_input
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::s3_api::common::rustfs_initiator
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::s3_api::common::rustfs_owner
+dep|rustfs/src/storage/helper.rs|infra->app|crate::app::context::resolve_action_credentials
 dep|rustfs/src/storage/rpc/health.rs|infra->app|crate::app::context::resolve_local_node_name
 dep|rustfs/src/storage/rpc/node_service.rs|infra->app|crate::app::context::resolve_iam_handle
 dep|rustfs/src/storage/rpc/node_service.rs|infra->app|crate::app::context::resolve_lock_client


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Route auth action-credential reads through the AppContext resolver.
- Route protocol storage-client owner checks through the same resolver.
- Route storage audit access-key enrichment through the same resolver while preserving the legacy default adapter fallback.
- Record the API-170 migration slice and accepted layer-guard resolver edges.

## Verification

- `cargo check --tests -p rustfs`
- `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- AppContext action credential residual scan
- Rust risk scan

## Impact

No user-facing behavior change expected. Existing credential fallback behavior remains in the AppContext default adapter.

## Additional Notes

N/A
