### PR TITLE
refactor: route admin IAM globals through app context

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,16 +5,17 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-notify-dispatch-context`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179`.
-- Based on: API-178 prepared in PR #3786; this branch batches the next notify
-  dispatch consumer migration on top of that branch.
+- Branch: `overtrue/arch-admin-iam-oidc-context`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180`.
+- Based on: API-179 prepared in PR #3789; this branch batches admin IAM
+  OIDC and token-signing consumer migration on top of that branch.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
   region, KMS encryption service, runtime support handles, S3 Select DB,
-  internode RPC metrics, IAM authorization/handler reads, and notification
-  rules/event dispatch through AppContext-first resolvers.
+  internode RPC metrics, IAM authorization/handler reads, notification
+  rules/event dispatch, and admin OIDC/token-signing reads through
+  AppContext-first resolvers.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -23,7 +24,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136 through API-179 owner facade cleanup.
+- Docs changes: record the API-136 through API-180 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4586,6 +4587,22 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     dispatch scan, Rust risk scan, branch freshness check, and three-expert
     review.
 
+- [x] `API-180` Route admin OIDC and token-signing reads through AppContext.
+  - Do: expose AppContext-first resolvers for the OIDC system and token
+    signing key, then route console config, OIDC handlers, STS credential
+    generation, table credential vending, and site-replication STS validation
+    through those resolvers.
+  - Acceptance: targeted RustFS admin OIDC/token-signing consumers no longer
+    read IAM globals directly, while default adapters preserve the existing
+    global OIDC and action-credential fallback.
+  - Must preserve: OIDC provider listing, authorize/callback/logout behavior,
+    STS web-identity verification, STS/table credential claims, session-policy
+    handling, and site-replication STS token validation.
+  - Verification: RustFS compile coverage, targeted context resolver tests,
+    migration guard, layer guard, formatting, diff hygiene, residual
+    admin/global IAM scan, Rust risk scan, branch freshness check, and
+    three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4679,10 +4696,29 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-179 keeps notification rule registration and event dispatch behind the AppContext notify resolver. |
 | Migration preservation | pass | Startup rules, success-only storage events, replication suppression, ECStore hook conversion, and default notifier fallback are preserved. |
 | Testing/verification | pass | RustFS focused compile, targeted context resolver test, formatting, migration/layer guards, diff hygiene, residual notify dispatch scan, Rust risk scan, and pre-commit passed for API-179. |
+| Quality/architecture | pass | API-180 keeps admin OIDC and token-signing reads behind IAM/AppContext resolver methods without widening handler behavior. |
+| Migration preservation | pass | OIDC provider discovery, STS credential generation, table credential vending, and site-replication STS validation keep existing error mapping and fallback semantics. |
+| Testing/verification | pass | RustFS focused compile, targeted context resolver test, formatting/migration/layer guards, diff hygiene, residual admin IAM scan, and Rust risk scan passed for API-180. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-180 current slice:
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Admin IAM/OIDC scan: passed; targeted admin OIDC and token-signing reads
+    now go through AppContext IAM resolvers.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
+    risks added.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-179 current slice:
   - `cargo check --tests -p rustfs`: passed.

--- a/rustfs/src/admin/console.rs
+++ b/rustfs/src/admin/console.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::admin::handlers::health::{HealthProbe, build_health_response_parts, collect_dependency_readiness};
+use crate::app::context::resolve_oidc_handle;
 use crate::license::has_valid_license;
 use crate::server::has_path_prefix;
 use crate::server::{
@@ -134,7 +135,7 @@ impl Config {
         let http_prefix = rustfs_config::RUSTFS_HTTP_PREFIX;
 
         // Collect OIDC provider info if available
-        let oidc = rustfs_iam::get_oidc()
+        let oidc = resolve_oidc_handle()
             .map(|sys| {
                 sys.list_visible_providers()
                     .into_iter()

--- a/rustfs/src/admin/handlers/oidc.rs
+++ b/rustfs/src/admin/handlers/oidc.rs
@@ -16,7 +16,7 @@ use super::super::{read_admin_config_without_migrate, save_admin_server_config};
 use super::sts::create_oidc_sts_credentials;
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::app::context::{resolve_object_store_handle, resolve_server_config};
+use crate::app::context::{resolve_object_store_handle, resolve_oidc_handle, resolve_server_config};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, MINIO_ADMIN_PREFIX, RemoteAddr};
 use http::StatusCode;
@@ -268,7 +268,7 @@ pub struct ListOidcProvidersHandler {}
 #[async_trait::async_trait]
 impl Operation for ListOidcProvidersHandler {
     async fn call(&self, _req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
-        let oidc_sys = rustfs_iam::get_oidc().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+        let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
         let providers = oidc_sys.list_visible_providers();
         let json_body = serde_json::to_vec(&providers)
@@ -439,7 +439,7 @@ impl Operation for OidcAuthorizeHandler {
             return Err(s3_error!(InvalidRequest, "invalid provider_id"));
         }
 
-        let oidc_sys = rustfs_iam::get_oidc().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+        let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
         // Derive the callback redirect URI from the request
         let redirect_uri = derive_callback_uri(&req, provider_id)?;
@@ -512,7 +512,7 @@ impl Operation for OidcCallbackHandler {
             ));
         }
 
-        let oidc_sys = rustfs_iam::get_oidc().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+        let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
         let redirect_uri = derive_callback_uri(&req, provider_id)?;
 
@@ -599,7 +599,7 @@ impl Operation for OidcLogoutHandler {
             return redirect_response(&fallback_location);
         };
 
-        let location = match rustfs_iam::get_oidc() {
+        let location = match resolve_oidc_handle() {
             Some(oidc_sys) => match oidc_sys.build_logout_url(&logout_token, &fallback_location).await {
                 Ok(Some(url)) => url,
                 Ok(None) => fallback_location.clone(),
@@ -628,7 +628,7 @@ impl Operation for OidcLogoutHandler {
 /// an explicit redirect_uri is recommended to prevent header manipulation.
 fn derive_callback_uri(req: &S3Request<Body>, provider_id: &str) -> S3Result<String> {
     // Use explicitly configured redirect_uri if available
-    if let Some(oidc_sys) = rustfs_iam::get_oidc()
+    if let Some(oidc_sys) = resolve_oidc_handle()
         && let Some(config) = oidc_sys.get_provider_config(provider_id)
     {
         if let Some(ref uri) = config.redirect_uri {

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -34,7 +34,7 @@ use crate::admin::utils::{encode_compatible_admin_payload, read_compatible_admin
 use crate::app::context::{
     resolve_deployment_id, resolve_endpoints_handle, resolve_iam_handle, resolve_object_store_handle,
     resolve_outbound_tls_generation, resolve_outbound_tls_state, resolve_region, resolve_replication_pool_handle,
-    resolve_replication_stats_handle, resolve_runtime_port, resolve_server_config,
+    resolve_replication_stats_handle, resolve_runtime_port, resolve_server_config, resolve_token_signing_key,
 };
 use crate::auth::{check_key_valid, get_session_token};
 use crate::config::get_config_snapshot;
@@ -3557,7 +3557,7 @@ async fn apply_iam_item(item: SRIAMItem) -> S3Result<()> {
             let Some(sts_credential) = item.sts_credential else {
                 return Err(s3_error!(InvalidRequest, "stsCredential is required"));
             };
-            let Some(secret) = rustfs_iam::manager::get_token_signing_key() else {
+            let Some(secret) = resolve_token_signing_key() else {
                 return Err(s3_error!(InvalidRequest, "token signing key not initialized"));
             };
             let claims = get_claims_from_token_with_secret(&sts_credential.session_token, &secret)

--- a/rustfs/src/admin/handlers/sts.rs
+++ b/rustfs/src/admin/handlers/sts.rs
@@ -19,7 +19,7 @@ use crate::{
         handlers::site_replication::site_replication_iam_change_hook,
         router::{AdminOperation, Operation, S3Router},
     },
-    app::context::resolve_action_credentials,
+    app::context::{resolve_action_credentials, resolve_oidc_handle, resolve_token_signing_key},
     auth::{check_key_valid, extract_string_list_claim, get_session_token},
     server::ADMIN_PREFIX,
     server::RemoteAddr,
@@ -29,7 +29,7 @@ use http::header::HeaderValue;
 use hyper::Method;
 use matchit::Params;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
-use rustfs_iam::{manager::get_token_signing_key, oidc::OidcClaims, sys::SESSION_POLICY_NAME};
+use rustfs_iam::{oidc::OidcClaims, sys::SESSION_POLICY_NAME};
 use rustfs_madmin::{SITE_REPL_API_VERSION, SRIAMItem, SRSTSCredential};
 use rustfs_policy::{
     auth::get_new_credentials_with_metadata,
@@ -59,7 +59,7 @@ fn has_identity_authorization_context(policies: &[String], groups: &[String]) ->
 }
 
 fn configured_roles_claim_key(provider_id: &str) -> Option<String> {
-    rustfs_iam::get_oidc()
+    resolve_oidc_handle()
         .as_ref()
         .and_then(|oidc_sys| oidc_sys.get_provider_config(provider_id))
         .map(|cfg| cfg.roles_claim.trim().to_string())
@@ -239,7 +239,7 @@ async fn handle_assume_role(
         return Err(s3_error!(InvalidArgument, "invalid policy arg"));
     }
 
-    let Some(secret) = get_token_signing_key() else {
+    let Some(secret) = resolve_token_signing_key() else {
         return Err(s3_error!(InvalidArgument, "global active sk not init"));
     };
 
@@ -316,7 +316,7 @@ async fn handle_assume_role_with_web_identity(body: AssumeRoleRequest) -> S3Resu
     }
 
     // Verify the JWT and extract claims
-    let oidc_sys = rustfs_iam::get_oidc().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+    let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
     let (claims, provider_id) = oidc_sys
         .verify_web_identity_token(&body.web_identity_token)
@@ -429,7 +429,7 @@ pub async fn create_oidc_sts_credentials(
     }
 
     // Generate STS temp credentials
-    let secret = get_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
+    let secret = resolve_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
 
     let mut new_cred = get_new_credentials_with_metadata(&token_claims, &secret)
         .map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, format!("credential generation failed: {e}")))?;

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -17,7 +17,7 @@ use crate::admin::{
     auth::{AdminResourceScope, validate_admin_request, validate_admin_request_with_bucket_object},
     router::{AdminOperation, Operation, S3Router},
 };
-use crate::app::context::resolve_object_store_handle;
+use crate::app::context::{resolve_object_store_handle, resolve_token_signing_key};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{RemoteAddr, TABLE_CATALOG_COMPAT_PREFIX, TABLE_CATALOG_PREFIX};
 use crate::table_catalog::{DEFAULT_WAREHOUSE_ID, TableCatalogStore};
@@ -26,7 +26,7 @@ use hyper::Method;
 use matchit::Params;
 use metrics::{counter, histogram};
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
-use rustfs_iam::{manager::get_token_signing_key, sys::SESSION_POLICY_NAME};
+use rustfs_iam::sys::SESSION_POLICY_NAME;
 use rustfs_policy::{
     auth::get_new_credentials_with_metadata,
     policy::{
@@ -696,7 +696,7 @@ impl TableCredentialIssuer for IamTableCredentialIssuer {
             serde_json::Value::String(request.scope_prefix.clone()),
         );
 
-        let secret = get_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
+        let secret = resolve_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
         let mut credential = get_new_credentials_with_metadata(&claims, &secret)
             .map_err(|err| s3_error!(InternalError, "failed to generate table credentials: {}", err))?;
         bind_table_credential_parent(&mut credential, principal);

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -37,7 +37,7 @@ use super::{BucketBandwidthMonitor, DynReplicationPool, NotificationSys, Replica
 use crate::config::RustFSBufferConfig;
 use rustfs_config::server_config::Config;
 use rustfs_credentials::Credentials;
-use rustfs_iam::{error::Error as IamError, store::object::ObjectStore, sys::IamSys};
+use rustfs_iam::{error::Error as IamError, oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
 use rustfs_io_metrics::{PerformanceMetrics, internode_metrics::InternodeMetrics};
 use rustfs_kms::{KmsServiceManager, ObjectEncryptionService, init_global_kms_service_manager};
 use rustfs_lock::LockClient;
@@ -87,6 +87,16 @@ pub fn resolve_iam_handle() -> Option<Arc<IamSys<ObjectStore>>> {
 /// Resolve a ready IAM system handle using AppContext-first precedence.
 pub fn resolve_ready_iam_handle() -> rustfs_iam::error::Result<Arc<IamSys<ObjectStore>>> {
     resolve_ready_iam_handle_with(get_global_app_context(), rustfs_iam::get)
+}
+
+/// Resolve OIDC system handle using AppContext-first precedence.
+pub fn resolve_oidc_handle() -> Option<Arc<OidcSys>> {
+    resolve_oidc_handle_with(get_global_app_context(), rustfs_iam::get_oidc)
+}
+
+/// Resolve token signing key using AppContext-first precedence.
+pub fn resolve_token_signing_key() -> Option<String> {
+    resolve_token_signing_key_with(get_global_app_context(), rustfs_iam::manager::get_token_signing_key)
 }
 
 /// Resolve bucket metadata handle using AppContext-first precedence.
@@ -316,6 +326,19 @@ fn resolve_ready_iam_handle_with(
     fallback()
 }
 
+fn resolve_oidc_handle_with(
+    context: Option<Arc<AppContext>>,
+    fallback: impl FnOnce() -> Option<Arc<OidcSys>>,
+) -> Option<Arc<OidcSys>> {
+    context.and_then(|context| context.iam().oidc()).or_else(fallback)
+}
+
+fn resolve_token_signing_key_with(context: Option<Arc<AppContext>>, fallback: impl FnOnce() -> Option<String>) -> Option<String> {
+    context
+        .and_then(|context| context.iam().token_signing_key())
+        .or_else(fallback)
+}
+
 fn resolve_bucket_metadata_handle_with(
     context: Option<Arc<AppContext>>,
     fallback: impl FnOnce() -> Option<Arc<RwLock<BucketMetadataSys>>>,
@@ -539,7 +562,7 @@ mod tests {
     };
     use crate::config::{RustFSBufferConfig, WorkloadProfile};
     use async_trait::async_trait;
-    use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
+    use rustfs_iam::{oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
     use rustfs_io_metrics::{PerformanceMetrics, internode_metrics::InternodeMetrics};
     use rustfs_lock::{LocalClient, LockClient};
     use rustfs_s3select_api::{
@@ -555,6 +578,8 @@ mod tests {
 
     struct TestIamInterface {
         ready: bool,
+        oidc: Option<Arc<OidcSys>>,
+        token_signing_key: Option<String>,
     }
 
     impl IamInterface for TestIamInterface {
@@ -564,6 +589,14 @@ mod tests {
 
         fn is_ready(&self) -> bool {
             self.ready
+        }
+
+        fn oidc(&self) -> Option<Arc<OidcSys>> {
+            self.oidc.clone()
+        }
+
+        fn token_signing_key(&self) -> Option<String> {
+            self.token_signing_key.clone()
         }
     }
 
@@ -970,11 +1003,27 @@ mod tests {
         };
         let context_region: s3s::region::Region = "context-region".parse().expect("test region");
         let fallback_region: s3s::region::Region = "fallback-region".parse().expect("test region");
+        let context_oidc_sys = match OidcSys::empty() {
+            Ok(sys) => sys,
+            Err(err) => unreachable!("test OIDC sys should initialize: {err}"),
+        };
+        let fallback_oidc_sys = match OidcSys::empty() {
+            Ok(sys) => sys,
+            Err(err) => unreachable!("test OIDC fallback sys should initialize: {err}"),
+        };
+        let context_oidc = Arc::new(context_oidc_sys);
+        let fallback_oidc = Arc::new(fallback_oidc_sys);
+        let context_token_signing_key = "context-token-signing-key".to_string();
+        let fallback_token_signing_key = "fallback-token-signing-key".to_string();
 
         let context = Arc::new(AppContext::with_test_interfaces(
             object_store.clone(),
             AppContextTestInterfaces {
-                iam: Arc::new(TestIamInterface { ready: true }),
+                iam: Arc::new(TestIamInterface {
+                    ready: true,
+                    oidc: Some(context_oidc.clone()),
+                    token_signing_key: Some(context_token_signing_key.clone()),
+                }),
                 kms: Arc::new(TestKmsInterface {
                     kms: context_kms.clone(),
                 }),
@@ -1068,6 +1117,12 @@ mod tests {
             context_outbound_tls_state.generation
         );
         assert!(resolve_iam_ready_with(Some(context.clone()), || false));
+        let resolved_oidc = resolve_oidc_handle_with(Some(context.clone()), || Some(fallback_oidc.clone()));
+        assert!(resolved_oidc.as_ref().is_some_and(|oidc| Arc::ptr_eq(oidc, &context_oidc)));
+        assert_eq!(
+            resolve_token_signing_key_with(Some(context.clone()), || Some(fallback_token_signing_key.clone())).as_deref(),
+            Some(context_token_signing_key.as_str())
+        );
         assert!(Arc::ptr_eq(
             &resolve_bucket_metadata_handle_with(Some(context.clone()), || None).expect("context bucket metadata"),
             &bucket_metadata

--- a/rustfs/src/app/context/handles.rs
+++ b/rustfs/src/app/context/handles.rs
@@ -36,7 +36,7 @@ use rustfs_common::get_global_local_node_name;
 use rustfs_config::server_config::Config;
 use rustfs_config::server_config::{get_global_server_config, set_global_server_config};
 use rustfs_credentials::{Credentials, get_global_action_cred};
-use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
+use rustfs_iam::{oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
 use rustfs_io_metrics::{
     PerformanceMetrics,
     global_metrics::get_global_metrics,
@@ -73,6 +73,14 @@ impl IamInterface for IamHandle {
 
     fn is_ready(&self) -> bool {
         rustfs_iam::get().is_ok()
+    }
+
+    fn oidc(&self) -> Option<Arc<OidcSys>> {
+        rustfs_iam::get_oidc()
+    }
+
+    fn token_signing_key(&self) -> Option<String> {
+        rustfs_iam::manager::get_token_signing_key()
     }
 }
 

--- a/rustfs/src/app/context/interfaces.rs
+++ b/rustfs/src/app/context/interfaces.rs
@@ -23,7 +23,7 @@ use crate::config::RustFSBufferConfig;
 use async_trait::async_trait;
 use rustfs_config::server_config::Config;
 use rustfs_credentials::Credentials;
-use rustfs_iam::{store::object::ObjectStore, sys::IamSys};
+use rustfs_iam::{oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
 use rustfs_io_metrics::{PerformanceMetrics, internode_metrics::InternodeMetrics};
 use rustfs_kms::KmsServiceManager;
 use rustfs_lock::LockClient;
@@ -40,6 +40,12 @@ pub trait IamInterface: Send + Sync {
     #[allow(dead_code)]
     fn handle(&self) -> Arc<IamSys<ObjectStore>>;
     fn is_ready(&self) -> bool;
+    fn oidc(&self) -> Option<Arc<OidcSys>> {
+        None
+    }
+    fn token_signing_key(&self) -> Option<String> {
+        None
+    }
 }
 
 /// KMS interface for application-layer use-cases.


### PR DESCRIPTION
## Summary

- Route admin OIDC and token-signing reads through AppContext IAM resolvers.
- Keep default IAM adapters backed by the existing OIDC system and token signing key globals.
- Update migration progress for API-180.

## Related Issues

- rustfs/backlog#660

## Changes

- Added AppContext-first OIDC and token-signing resolver methods.
- Updated console config, OIDC admin handlers, STS credential generation, table credential vending, and site-replication STS validation to use those resolvers.
- Extended resolver coverage for context-first OIDC and token-signing behavior.

## Testing

- `cargo check --tests -p rustfs`
- `cargo test -p rustfs resolver_helpers_are_context_first_and_fallback_when_context_is_absent --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Admin IAM/OIDC residual scan
- Rust risk scan
- `make pre-commit`

## Notes

- Stacked on #3789 while that PR waits for remaining CI.
