### PR TITLE
refactor: centralize IAM root credential access

### DIFF
--- a/crates/iam/src/lib.rs
+++ b/crates/iam/src/lib.rs
@@ -47,6 +47,7 @@ pub mod keyring;
 pub mod manager;
 pub mod oidc;
 pub mod oidc_state;
+mod root_credentials;
 pub mod store;
 pub mod sys;
 pub mod utils;
@@ -59,6 +60,10 @@ pub(crate) type IamStorageResult<T> = EcstoreResultType<T>;
 pub(crate) type IamStore = EcstoreStore;
 pub(crate) type IamConfigObjectInfo = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectInfo;
 pub(crate) type IamConfigObjectOptions = <IamStore as rustfs_storage_api::ObjectOperations>::ObjectOptions;
+
+pub fn is_root_access_key(access_key: &str) -> bool {
+    root_credentials::is_root_access_key(access_key)
+}
 
 pub(crate) async fn read_iam_config_no_lock(api: Arc<IamStore>, file: &str) -> IamStorageResult<Vec<u8>> {
     ecstore_read_config_no_lock(api, file).await

--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -25,7 +25,7 @@ use crate::{
     },
 };
 use futures::future::join_all;
-use rustfs_credentials::{Credentials, EMBEDDED_POLICY_TYPE, INHERITED_POLICY_TYPE, get_global_action_cred};
+use rustfs_credentials::{Credentials, EMBEDDED_POLICY_TYPE, INHERITED_POLICY_TYPE};
 use rustfs_madmin::{AccountStatus, AddOrUpdateUserReq, GroupDesc};
 use rustfs_policy::{
     arn::ARN,
@@ -2137,11 +2137,7 @@ fn set_default_canned_policies(policies: &mut HashMap<String, PolicyDoc>) {
 }
 
 pub fn get_token_signing_key() -> Option<String> {
-    if let Some(s) = get_global_action_cred() {
-        Some(s.secret_key)
-    } else {
-        None
-    }
+    crate::root_credentials::token_signing_key()
 }
 
 pub fn extract_jwt_claims(u: &UserIdentity) -> Result<HashMap<String, Value>> {

--- a/crates/iam/src/root_credentials.rs
+++ b/crates/iam/src/root_credentials.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rustfs_credentials::{Credentials, get_global_action_cred};
+
+pub(crate) fn credentials() -> Option<Credentials> {
+    get_global_action_cred()
+}
+
+pub(crate) fn credentials_or_default() -> Credentials {
+    credentials().unwrap_or_default()
+}
+
+pub(crate) fn token_signing_key() -> Option<String> {
+    credentials().map(|cred| cred.secret_key)
+}
+
+pub(crate) fn is_root_access_key(access_key: &str) -> bool {
+    credentials().is_some_and(|cred| cred.access_key == access_key)
+}

--- a/crates/iam/src/store/object.rs
+++ b/crates/iam/src/store/object.rs
@@ -23,9 +23,9 @@ use crate::{
     error::{is_err_no_such_policy, is_err_no_such_user},
     keyring,
     manager::{extract_jwt_claims, extract_jwt_claims_allow_missing_exp, get_default_policyes},
+    root_credentials,
 };
 use futures::future::join_all;
-use rustfs_credentials::get_global_action_cred;
 use rustfs_io_metrics::record_system_path_failure;
 use rustfs_policy::{auth::UserIdentity, policy::PolicyDoc};
 use rustfs_storage_api::{HTTPPreconditions, ListOperations as _, ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations};
@@ -165,7 +165,7 @@ impl ObjectStore {
         }
 
         const STREAM_IO_HEADER_LEN: usize = 41;
-        let cred = get_global_action_cred().unwrap_or_default();
+        let cred = root_credentials::credentials_or_default();
         let mut last_err = None;
 
         let mut try_decrypt_with_key = |key: &[u8], source: DecryptSource| -> Option<DecryptOutcome> {
@@ -1273,16 +1273,16 @@ impl Store for ObjectStore {
 mod tests {
     use super::{DecryptSource, ObjectStore};
     use crate::keyring;
-    use rustfs_credentials::{Credentials, get_global_action_cred, init_global_action_credentials};
+    use rustfs_credentials::{Credentials, init_global_action_credentials};
     use serial_test::serial;
     use temp_env::with_vars;
 
     fn test_cred() -> Credentials {
-        if let Some(cred) = get_global_action_cred() {
+        if let Some(cred) = crate::root_credentials::credentials() {
             return cred;
         }
         let _ = init_global_action_credentials(Some("COMPATTESTAK".to_string()), Some("COMPATTESTSK1234567890".to_string()));
-        get_global_action_cred().unwrap_or_default()
+        crate::root_credentials::credentials_or_default()
     }
 
     #[test]

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -28,7 +28,7 @@ use crate::{
     notify_iam_delete_policy, notify_iam_delete_service_account, notify_iam_delete_user, notify_iam_load_group,
     notify_iam_load_policy, notify_iam_load_policy_mapping, notify_iam_load_service_account, notify_iam_load_user,
 };
-use rustfs_credentials::{Credentials, EMBEDDED_POLICY_TYPE, INHERITED_POLICY_TYPE, get_global_action_cred};
+use rustfs_credentials::{Credentials, EMBEDDED_POLICY_TYPE, INHERITED_POLICY_TYPE};
 use rustfs_madmin::AddOrUpdateUserReq;
 use rustfs_madmin::GroupDesc;
 use rustfs_policy::arn::ARN;
@@ -748,7 +748,7 @@ impl<T: Store> IamSys<T> {
     }
 
     pub async fn check_key(&self, access_key: &str) -> Result<(Option<UserIdentity>, bool)> {
-        if let Some(sys_cred) = get_global_action_cred()
+        if let Some(sys_cred) = crate::root_credentials::credentials()
             && sys_cred.access_key == access_key
         {
             return Ok((Some(UserIdentity::new(sys_cred)), true));
@@ -1010,7 +1010,7 @@ impl<T: Store> IamSys<T> {
     }
 
     pub(crate) async fn prepare_sts_auth(&self, args: &Args<'_>, parent_user: &str) -> PreparedIamAuth {
-        let is_owner = matches!(get_global_action_cred(), Some(cred) if cred.access_key == parent_user);
+        let is_owner = crate::is_root_access_key(parent_user);
         let role_arn = args.get_role_arn();
 
         let (effective_groups, groups_source, policies) = if is_owner {
@@ -1162,7 +1162,7 @@ impl<T: Store> IamSys<T> {
             && matches!(mode, PreparedServicePolicyMode::SessionBound)
             && matches!(session_policy, PreparedSessionPolicy::Policy(_));
 
-        let is_owner = matches!(get_global_action_cred(), Some(cred) if cred.access_key == parent_user);
+        let is_owner = crate::is_root_access_key(parent_user);
         let role_arn = args.get_role_arn();
 
         let svc_policies = if is_owner || bypass_parent_policy {
@@ -1352,7 +1352,7 @@ mod tests {
     use crate::error::Error;
     use crate::manager::get_default_policyes;
     use crate::store::{GroupInfo, MappedPolicy, Store, UserType};
-    use rustfs_credentials::{Credentials, get_global_action_cred, init_global_action_credentials};
+    use rustfs_credentials::{Credentials, init_global_action_credentials};
     use rustfs_policy::auth::{UserIdentity, get_new_credentials_with_metadata};
     use rustfs_policy::policy::Args;
     use rustfs_policy::policy::action::{Action, AdminAction, S3Action};
@@ -1660,7 +1660,7 @@ mod tests {
     }
 
     fn ensure_test_global_credentials() {
-        if get_global_action_cred().is_none() {
+        if crate::root_credentials::credentials().is_none() {
             let _ = init_global_action_credentials(Some("TESTROOTACCESSKEY".to_string()), Some("TESTROOTSECRET123".to_string()));
         }
     }
@@ -1940,9 +1940,8 @@ mod tests {
         let iam_sys = IamSys::new(cache_manager);
 
         let parent_user = "sts-fallback-test-parent";
-        let token_secret = get_global_action_cred()
-            .expect("global action credentials should be initialized")
-            .secret_key;
+        let token_secret = crate::root_credentials::token_signing_key()
+            .unwrap_or_else(|| unreachable!("global action credentials should be initialized"));
         let mut claims = HashMap::new();
         claims.insert("parent".to_string(), Value::String(parent_user.to_string()));
         claims.insert(

--- a/crates/protocols/src/common/gateway.rs
+++ b/crates/protocols/src/common/gateway.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_credentials;
 use rustfs_policy::policy::action::S3Action as PolicyS3Action;
 use serde_json;
 use std::collections::HashMap;
@@ -299,11 +298,7 @@ pub async fn is_authorized(
     let policy_action: rustfs_policy::policy::action::Action = action.clone().into();
 
     // Check if user is the owner (admin)
-    let is_owner = if let Some(global_cred) = rustfs_credentials::get_global_action_cred() {
-        session_context.principal.access_key() == global_cred.access_key
-    } else {
-        false
-    };
+    let is_owner = rustfs_iam::is_root_access_key(session_context.principal.access_key());
 
     let args = rustfs_policy::policy::Args {
         account: session_context.principal.access_key(),

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,18 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-admin-iam-oidc-context`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180`.
-- Based on: API-179 prepared in PR #3789; this branch batches admin IAM
-  OIDC and token-signing consumer migration on top of that branch.
+- Branch: `overtrue/arch-iam-credential-boundary`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181`.
+- Based on: API-180 prepared in PR #3791; this branch batches IAM root
+  credential boundary cleanup on top of that branch.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
   region, KMS encryption service, runtime support handles, S3 Select DB,
   internode RPC metrics, IAM authorization/handler reads, notification
-  rules/event dispatch, and admin OIDC/token-signing reads through
-  AppContext-first resolvers.
+  rules/event dispatch, admin OIDC/token-signing reads, and IAM root
+  credential consumers through AppContext-first or IAM-owned resolver
+  boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -24,7 +25,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136 through API-180 owner facade cleanup.
+- Docs changes: record the API-136 through API-181 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4603,6 +4604,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     admin/global IAM scan, Rust risk scan, branch freshness check, and
     three-expert review.
 
+- [x] `API-181` Centralize IAM root credential reads behind IAM boundary.
+  - Do: add an IAM-owned root credential helper, route IAM store/sys/token
+    signing consumers through it, and make protocol gateway owner checks call an
+    IAM predicate instead of reading credentials directly.
+  - Acceptance: production IAM and protocol gateway paths no longer call the
+    action credential global directly outside the IAM boundary module, while
+    root user detection, legacy IAM decrypt fallback, and token-signing behavior
+    remain unchanged.
+  - Must preserve: root credential lookup, owner-policy bypass decisions,
+    legacy secret-key decrypt fallback, STS token signing key selection,
+    service-account/STSes authorization, and protocol gateway policy args.
+  - Verification: IAM/protocol compile coverage, IAM focused tests, formatting,
+    migration guard, layer guard, diff hygiene, residual direct credential scan,
+    Rust risk scan, branch freshness check, and three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4699,10 +4715,29 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-180 keeps admin OIDC and token-signing reads behind IAM/AppContext resolver methods without widening handler behavior. |
 | Migration preservation | pass | OIDC provider discovery, STS credential generation, table credential vending, and site-replication STS validation keep existing error mapping and fallback semantics. |
 | Testing/verification | pass | RustFS focused compile, targeted context resolver test, formatting/migration/layer guards, diff hygiene, residual admin IAM scan, and Rust risk scan passed for API-180. |
+| Quality/architecture | pass | API-181 keeps IAM root credential reads centralized in an IAM-owned helper and exposes only a root access-key predicate to protocol code. |
+| Migration preservation | pass | Root owner checks, legacy IAM decrypt fallback, token signing, and gateway policy args preserve existing credential semantics. |
+| Testing/verification | pass | IAM/protocol compile, IAM unit tests, formatting, migration/layer guards, diff hygiene, residual credential scan, and Rust risk scan passed for API-181. |
 
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-181 current slice:
+  - `cargo check -p rustfs-iam -p rustfs-protocols --tests`: passed.
+  - `cargo test -p rustfs-iam --lib`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - IAM/protocol credential scan: passed; production direct
+    `get_global_action_cred` calls are isolated to the IAM root credential
+    boundary.
+  - Rust risk scan: no new production unwrap/expect, panic/todo/unsafe, or cast
+    risks added.
+  - `make pre-commit`: passed.
 
 - Issue #660 API-180 current slice:
   - `cargo check --tests -p rustfs`: passed.


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Add an IAM-owned root credential boundary helper.
- Route IAM store/sys/token-signing consumers through that boundary.
- Make protocol gateway owner checks call the IAM root access-key predicate instead of reading credentials directly.
- Record API-181 migration progress and verification.

## Verification
- `cargo check -p rustfs-iam -p rustfs-protocols --tests`
- `cargo test -p rustfs-iam --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- IAM/protocol credential scan
- Rust risk scan
- `make pre-commit`

## Impact
No runtime behavior change expected. Root credential lookup, legacy IAM decrypt fallback, token signing, and gateway owner policy arguments keep their existing semantics.

## Additional Notes
Stacked on `overtrue/arch-notify-dispatch-context` while PR #3789 is still open.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
