### PR TITLE
refactor: centralize ecstore replication runtime sources

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -28,6 +28,7 @@ use crate::config::com::{read_config, save_config};
 use crate::disk::BUCKET_META_PREFIX;
 use crate::error::Error as EcstoreError;
 use crate::object_api::{ObjectInfo, ObjectOptions};
+use crate::runtime_sources;
 use crate::storage_api_contracts::EcstoreObjectIO;
 use lazy_static::lazy_static;
 use rustfs_filemeta::MrfOpKind;
@@ -1399,12 +1400,11 @@ pub async fn init_background_replication<S: ReplicationStorage>(storage: Arc<S>)
         })
         .await;
 
-    assert!(GLOBAL_REPLICATION_STATS.get().is_some());
-    assert!(GLOBAL_REPLICATION_POOL.get().is_some());
+    assert!(runtime_sources::replication_runtime_initialized());
 }
 
 pub fn get_global_replication_pool() -> Option<Arc<DynReplicationPool>> {
-    GLOBAL_REPLICATION_POOL.get().cloned()
+    runtime_sources::replication_pool()
 }
 
 pub async fn schedule_replication<S: ReplicationStorage>(
@@ -1454,17 +1454,17 @@ pub async fn schedule_replication<S: ReplicationStorage>(
     }
     if dsc.is_synchronous() {
         replicate_object(ri, o).await
-    } else if let Some(pool) = GLOBAL_REPLICATION_POOL.get() {
+    } else if let Some(pool) = runtime_sources::replication_pool() {
         let _ = pool.queue_replica_task(ri).await;
     }
 }
 
 pub async fn schedule_replication_delete(dv: DeletedObjectReplicationInfo) {
-    if let Some(pool) = GLOBAL_REPLICATION_POOL.get() {
+    if let Some(pool) = runtime_sources::replication_pool() {
         let _ = pool.queue_replica_delete_task(dv.clone()).await;
     }
 
-    if let (Some(rs), Some(stats)) = (dv.delete_object.replication_state, GLOBAL_REPLICATION_STATS.get()) {
+    if let (Some(rs), Some(stats)) = (dv.delete_object.replication_state, runtime_sources::replication_stats()) {
         for (k, _v) in rs.targets.iter() {
             let ri = ReplicatedTargetInfo {
                 arn: k.clone(),
@@ -1600,7 +1600,7 @@ pub async fn queue_replication_heal_internal(
             || roi.version_purge_status == VersionPurgeStatusType::Failed
             || roi.version_purge_status == VersionPurgeStatusType::Pending
         {
-            let admission = if let Some(pool) = GLOBAL_REPLICATION_POOL.get() {
+            let admission = if let Some(pool) = runtime_sources::replication_pool() {
                 pool.queue_replica_delete_task(dv).await
             } else {
                 ReplicationQueueAdmission::Missed
@@ -1636,7 +1636,7 @@ pub async fn queue_replication_heal_internal(
     match roi.replication_status {
         ReplicationStatusType::Pending | ReplicationStatusType::Failed => {
             roi.event_type = REPLICATE_HEAL.to_string();
-            let admission = if let Some(pool) = GLOBAL_REPLICATION_POOL.get() {
+            let admission = if let Some(pool) = runtime_sources::replication_pool() {
                 pool.queue_replica_task(roi.clone()).await
             } else {
                 ReplicationQueueAdmission::Missed
@@ -1651,7 +1651,7 @@ pub async fn queue_replication_heal_internal(
 
     if roi.existing_obj_resync.must_resync() {
         roi.event_type = REPLICATE_EXISTING.to_string();
-        let admission = if let Some(pool) = GLOBAL_REPLICATION_POOL.get() {
+        let admission = if let Some(pool) = runtime_sources::replication_pool() {
             pool.queue_replica_task(roi.clone()).await
         } else {
             ReplicationQueueAdmission::Missed
@@ -1679,7 +1679,7 @@ async fn queue_replicate_deletes_wrapper(
             let mut dv = doi.clone();
             dv.reset_id = v.reset_id.clone();
             dv.target_arn = k.clone();
-            let target_admission = if let Some(pool) = GLOBAL_REPLICATION_POOL.get() {
+            let target_admission = if let Some(pool) = runtime_sources::replication_pool() {
                 pool.queue_replica_delete_task(dv).await
             } else {
                 ReplicationQueueAdmission::Missed

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -19,7 +19,6 @@ use crate::bucket::bucket_target_sys::{
 use crate::bucket::metadata_sys;
 use crate::bucket::msgp_decode::{read_msgp_ext8_time, skip_msgp_value, write_msgp_time};
 use crate::bucket::replication::ResyncStatusType;
-use crate::bucket::replication::replication_pool::GLOBAL_REPLICATION_STATS;
 use crate::bucket::replication::{ObjectOpts, ReplicationConfigurationExt as _};
 use crate::bucket::tagging::decode_tags_to_map;
 use crate::bucket::target::BucketTargets;
@@ -29,10 +28,10 @@ use crate::config::com::save_config;
 use crate::disk::{BUCKET_META_PREFIX, RUSTFS_META_BUCKET};
 use crate::error::{Error, Result, is_err_object_not_found, is_err_version_not_found};
 use crate::event_notification::{EventArgs, send_event};
-use crate::global::GLOBAL_LocalNodeName;
 use crate::global::get_global_bucket_monitor;
 use crate::global::resolve_object_store_handle;
 use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
+use crate::runtime_sources;
 use crate::set_disk::get_lock_acquire_timeout;
 use crate::storage_api_contracts::{EcstoreObjectIO, EcstoreObjectOperations};
 use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
@@ -226,7 +225,7 @@ fn is_head_proxy_failure(err: &SdkError<HeadObjectError>) -> bool {
 }
 
 async fn record_proxy_request(bucket: &str, api: &str, is_err: bool) {
-    if let Some(stats) = GLOBAL_REPLICATION_STATS.get() {
+    if let Some(stats) = runtime_sources::replication_stats() {
         stats.inc_proxy(bucket, api, is_err).await;
     }
 }
@@ -1857,7 +1856,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
 
@@ -1884,7 +1883,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -1983,7 +1982,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -2016,7 +2015,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -2047,7 +2046,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -2096,7 +2095,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             continue;
@@ -2189,7 +2188,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
         )
     };
 
-    if let Some(stats) = GLOBAL_REPLICATION_STATS.get() {
+    if let Some(stats) = runtime_sources::replication_stats() {
         for tgt in rinfos.targets.iter() {
             if tgt.replication_status != tgt.prev_replication_status {
                 stats
@@ -2348,7 +2347,7 @@ async fn replicate_force_delete_to_targets<S: ReplicationStorage>(dobj: &Deleted
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -2372,7 +2371,7 @@ async fn replicate_force_delete_to_targets<S: ReplicationStorage>(dobj: &Deleted
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -2404,7 +2403,7 @@ async fn replicate_force_delete_to_targets<S: ReplicationStorage>(dobj: &Deleted
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -2433,7 +2432,7 @@ async fn replicate_force_delete_to_targets<S: ReplicationStorage>(dobj: &Deleted
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             return;
@@ -2471,7 +2470,7 @@ async fn replicate_force_delete_to_targets<S: ReplicationStorage>(dobj: &Deleted
                     ..Default::default()
                 },
                 user_agent: "Internal: [Replication]".to_string(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 ..Default::default()
             });
             continue;
@@ -2501,7 +2500,7 @@ async fn replicate_force_delete_to_targets<S: ReplicationStorage>(dobj: &Deleted
                         ..Default::default()
                     },
                     user_agent: "Internal: [Replication]".to_string(),
-                    host: GLOBAL_LocalNodeName.to_string(),
+                    host: runtime_sources::default_local_node_name(),
                     ..Default::default()
                 });
                 return;
@@ -2544,7 +2543,7 @@ async fn replicate_force_delete_to_targets<S: ReplicationStorage>(dobj: &Deleted
                         ..Default::default()
                     },
                     user_agent: "Internal: [Replication]".to_string(),
-                    host: GLOBAL_LocalNodeName.to_string(),
+                    host: runtime_sources::default_local_node_name(),
                     ..Default::default()
                 });
             }
@@ -2738,7 +2737,7 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: roi.to_object_info(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -2758,7 +2757,7 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: roi.to_object_info(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -2797,7 +2796,7 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: roi.to_object_info(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -2821,7 +2820,7 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: roi.to_object_info(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -2846,7 +2845,7 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: roi.to_object_info(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -2889,7 +2888,7 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
                     event_name: EventName::ObjectReplicationNotTracked.to_string(),
                     bucket_name: bucket.clone(),
                     object: roi.to_object_info(),
-                    host: GLOBAL_LocalNodeName.to_string(),
+                    host: runtime_sources::default_local_node_name(),
                     user_agent: "Internal: [Replication]".to_string(),
                     ..Default::default()
                 });
@@ -2916,7 +2915,7 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
             object_info = u;
         }
 
-        if let Some(stats) = GLOBAL_REPLICATION_STATS.get() {
+        if let Some(stats) = runtime_sources::replication_stats() {
             for tgt in &rinfos.targets {
                 if tgt.replication_status != tgt.prev_replication_status {
                     stats
@@ -2937,14 +2936,14 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
         event_name,
         bucket_name: bucket.clone(),
         object: object_info,
-        host: GLOBAL_LocalNodeName.to_string(),
+        host: runtime_sources::default_local_node_name(),
         user_agent: "Internal: [Replication]".to_string(),
         ..Default::default()
     });
 
     if rinfos.replication_status() != ReplicationStatusType::Completed
         && roi.replication_status_internal == rinfos.replication_status_internal()
-        && let Some(stats) = GLOBAL_REPLICATION_STATS.get()
+        && let Some(stats) = runtime_sources::replication_stats()
     {
         for tgt in &rinfos.targets {
             if tgt.replication_status != tgt.prev_replication_status {
@@ -3005,7 +3004,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: self.to_object_info(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -3045,7 +3044,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                         event_name: EventName::ObjectReplicationNotTracked.to_string(),
                         bucket_name: bucket.clone(),
                         object: self.to_object_info(),
-                        host: GLOBAL_LocalNodeName.to_string(),
+                        host: runtime_sources::default_local_node_name(),
                         user_agent: "Internal: [Replication]".to_string(),
                         ..Default::default()
                     });
@@ -3076,7 +3075,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                     event_name: EventName::ObjectReplicationNotTracked.to_string(),
                     bucket_name: bucket.clone(),
                     object: object_info,
-                    host: GLOBAL_LocalNodeName.to_string(),
+                    host: runtime_sources::default_local_node_name(),
                     user_agent: "Internal: [Replication]".to_string(),
                     ..Default::default()
                 });
@@ -3098,7 +3097,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: object_info,
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -3193,7 +3192,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                     event_name: EventName::ObjectReplicationNotTracked.to_string(),
                     bucket_name: bucket.clone(),
                     object: object_info,
-                    host: GLOBAL_LocalNodeName.to_string(),
+                    host: runtime_sources::default_local_node_name(),
                     user_agent: "Internal: [Replication]".to_string(),
                     ..Default::default()
                 });
@@ -3292,7 +3291,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: self.to_object_info(),
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -3331,7 +3330,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                         event_name: EventName::ObjectReplicationNotTracked.to_string(),
                         bucket_name: bucket.clone(),
                         object: self.to_object_info(),
-                        host: GLOBAL_LocalNodeName.to_string(),
+                        host: runtime_sources::default_local_node_name(),
                         user_agent: "Internal: [Replication]".to_string(),
                         ..Default::default()
                     });
@@ -3371,7 +3370,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                     event_name: EventName::ObjectReplicationNotTracked.to_string(),
                     bucket_name: bucket.clone(),
                     object: object_info,
-                    host: GLOBAL_LocalNodeName.to_string(),
+                    host: runtime_sources::default_local_node_name(),
                     user_agent: "Internal: [Replication]".to_string(),
                     ..Default::default()
                 });
@@ -3395,7 +3394,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                 bucket_name: bucket.clone(),
                 object: object_info,
-                host: GLOBAL_LocalNodeName.to_string(),
+                host: runtime_sources::default_local_node_name(),
                 user_agent: "Internal: [Replication]".to_string(),
                 ..Default::default()
             });
@@ -3458,7 +3457,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                             event_name: EventName::ObjectReplicationNotTracked.to_string(),
                             bucket_name: bucket.clone(),
                             object: object_info.clone(),
-                            host: GLOBAL_LocalNodeName.to_string(),
+                            host: runtime_sources::default_local_node_name(),
                             user_agent: "Internal: [Replication]".to_string(),
                             ..Default::default()
                         });
@@ -3516,7 +3515,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                                 event_name: EventName::ObjectReplicationNotTracked.to_string(),
                                 bucket_name: bucket.clone(),
                                 object: object_info,
-                                host: GLOBAL_LocalNodeName.to_string(),
+                                host: runtime_sources::default_local_node_name(),
                                 user_agent: "Internal: [Replication]".to_string(),
                                 ..Default::default()
                             });
@@ -3543,7 +3542,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                         event_name: EventName::ObjectReplicationNotTracked.to_string(),
                         bucket_name: bucket.clone(),
                         object: object_info,
-                        host: GLOBAL_LocalNodeName.to_string(),
+                        host: runtime_sources::default_local_node_name(),
                         user_agent: "Internal: [Replication]".to_string(),
                         ..Default::default()
                     });
@@ -3579,7 +3578,7 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
                         event_name: EventName::ObjectReplicationNotTracked.to_string(),
                         bucket_name: bucket.clone(),
                         object: object_info,
-                        host: GLOBAL_LocalNodeName.to_string(),
+                        host: runtime_sources::default_local_node_name(),
                         user_agent: "Internal: [Replication]".to_string(),
                         ..Default::default()
                     });

--- a/crates/ecstore/src/runtime_sources.rs
+++ b/crates/ecstore/src/runtime_sources.rs
@@ -17,6 +17,7 @@ use std::{collections::HashMap, sync::Arc, time::SystemTime};
 use crate::bucket::bandwidth::monitor::Monitor;
 use crate::disk::endpoint::Endpoint;
 use crate::{
+    bucket::replication::{DynReplicationPool, GLOBAL_REPLICATION_POOL, GLOBAL_REPLICATION_STATS, ReplicationStats},
     config::get_global_storage_class,
     disk::{DiskAPI, DiskOption, DiskStore, new_disk},
     endpoints::EndpointServerPools,
@@ -24,7 +25,7 @@ use crate::{
     event_notification::EventNotifier,
     global::{
         GLOBAL_BOOT_TIME, GLOBAL_EventNotifier, GLOBAL_IsErasureSD, GLOBAL_LOCAL_DISK_ID_MAP, GLOBAL_LOCAL_DISK_MAP,
-        GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LifecycleSys, GLOBAL_RootDiskThreshold, GLOBAL_TierConfigMgr,
+        GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LifecycleSys, GLOBAL_LocalNodeName, GLOBAL_RootDiskThreshold, GLOBAL_TierConfigMgr,
         TypeLocalDiskSetDrives, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints,
         get_global_endpoints_opt, init_global_bucket_monitor, resolve_object_store_handle, set_global_deployment_id,
     },
@@ -58,6 +59,10 @@ pub(crate) fn endpoint_pools() -> Option<EndpointServerPools> {
 
 pub(crate) async fn local_node_name() -> String {
     GLOBAL_LOCAL_NODE_NAME.read().await.clone()
+}
+
+pub(crate) fn default_local_node_name() -> String {
+    GLOBAL_LocalNodeName.to_string()
 }
 
 pub(crate) async fn rustfs_addr() -> String {
@@ -115,6 +120,18 @@ pub(crate) fn deployment_upload_id(upload_id: &str) -> String {
 
 pub(crate) fn deployment_id() -> Option<String> {
     get_global_deployment_id()
+}
+
+pub(crate) fn replication_pool() -> Option<Arc<DynReplicationPool>> {
+    GLOBAL_REPLICATION_POOL.get().cloned()
+}
+
+pub(crate) fn replication_stats() -> Option<Arc<ReplicationStats>> {
+    GLOBAL_REPLICATION_STATS.get().cloned()
+}
+
+pub(crate) fn replication_runtime_initialized() -> bool {
+    GLOBAL_REPLICATION_STATS.get().is_some() && GLOBAL_REPLICATION_POOL.get().is_some()
 }
 
 pub(crate) fn ensure_deployment_id(deployment_id: Uuid) {

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,9 +5,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-observability-runtime-sources`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188`.
-- Based on: stacked on API-187 branch while PR #3798 is pending.
+- Branch: `overtrue/arch-ecstore-replication-runtime-sources`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189`.
+- Based on: stacked on API-188 branch while PR #3799 is pending.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
@@ -20,6 +20,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   data-plane KMS/storage-class/deployment-id/lock-manager/erasure metric reads,
   plus ECStore observability/status object-store, endpoint, node-name,
   boot-time, init-time, root-disk threshold, and cached RPC channel reads,
+  plus ECStore replication pool, replication stats, and event-host reads,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -29,7 +30,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136 through API-188 owner facade cleanup.
+- Docs changes: record the API-136 through API-189 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4733,6 +4734,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     runtime source scan, Rust risk scan, focused tests, migration/layer guards,
     PR-before-push pre-commit quality gate, and three-expert review.
 
+- [x] `API-189` Centralize ECStore replication runtime source reads.
+  - Do: route replication pool, replication stats, and replication event-host
+    runtime reads through the ECStore-owned runtime-source module.
+  - Acceptance: replication pool/resyncer code no longer reads those runtime
+    globals directly outside the owner runtime-source boundary.
+  - Must preserve: background replication initialization, async/sync queueing,
+    delete-task stats updates, proxy request stats, resync status updates, and
+    emitted replication event host values.
+  - Verification: ECStore compile coverage, formatting, diff hygiene, residual
+    replication runtime-source scan, Rust risk scan, focused tests,
+    migration/layer guards, PR-before-push pre-commit quality gate, and
+    three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4853,6 +4867,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 | Quality/architecture | pass | API-188 keeps ECStore observability/status runtime reads behind the ECStore runtime-source boundary without adding public APIs. |
 | Migration preservation | pass | Server info fields, metrics host fallback, data-usage cache refresh, root-disk checks, and cached RPC channel reuse keep existing semantics. |
 | Testing/verification | pass | ECStore compile/focused tests, formatting, migration/layer guards, residual scan, diff-only Rust risk scan, and pre-commit passed for API-188. |
+| Quality/architecture | pass | API-189 keeps ECStore replication runtime pool/stats/host reads behind the ECStore runtime-source boundary without adding public APIs. |
+| Migration preservation | pass | Replication initialization, queueing, delete stats, proxy stats, resync status updates, and emitted event host values keep existing semantics. |
+| Testing/verification | pass | ECStore compile/focused test, formatting, migration/layer guards, diff hygiene, residual scan, diff-only Rust risk scan, and pre-commit passed for API-189. |
 
 ## Verification Notes
 
@@ -4894,6 +4911,18 @@ Passed before push:
   - ECStore runtime source scan: passed for API-188 targets.
   - Rust risk scan: passed.
   - `make pre-commit`: passed.
+- Issue #660 API-189 current slice:
+  - `cargo check -p rustfs-ecstore --tests`: passed.
+  - `cargo test -p rustfs-ecstore --lib replication_queue_admission_combines_target_results -- --test-threads=1`:
+    passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Replication runtime-source scan: passed for API-189 targets.
+  - Diff-only Rust risk scan: passed.
+  - `make pre-commit`: passed, including 6552 nextest tests passed and
+    doctests passed; the existing OPA policy test took 603s.
 
 - Issue #660 API-186 current slice:
   - `cargo check -p rustfs-ecstore --tests`: passed.


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Centralize ECStore replication pool, replication stats, and replication event-host runtime source reads behind ECStore runtime source helpers.
- Keep replication initialization, queueing, stats updates, and emitted event host behavior unchanged.
- Update architecture migration progress through API-189.

## Verification
- `cargo check -p rustfs-ecstore --tests`
- `cargo test -p rustfs-ecstore --lib replication_queue_admission_combines_target_results -- --test-threads=1`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Diff-only Rust risk scan
- `make pre-commit`

## Impact
No expected user-facing behavior change. This narrows ECStore replication runtime-owner access boundaries for the architecture migration.

## Additional Notes
Stacked on #3799; retarget to `main` after #3799 merges.
