### PR TITLE
fix(lock): respect requested acquire timeout

### DIFF
--- a/crates/lock/src/fast_lock/shard.rs
+++ b/crates/lock/src/fast_lock/shard.rs
@@ -416,9 +416,10 @@ impl LockShard {
         let adaptive_timeout_secs =
             (base_timeout.as_secs_f64() * total_multiplier).min(crate::fast_lock::MAX_ACQUIRE_TIMEOUT.as_secs_f64());
 
-        // Ensure minimum reasonable timeout even for low priority
+        // Keep the caller-provided and global acquire timeouts as hard deadlines.
         let min_timeout_secs = base_timeout.as_secs_f64() * 0.8;
-        Duration::from_secs_f64(adaptive_timeout_secs.max(min_timeout_secs))
+        let adaptive_timeout = Duration::from_secs_f64(adaptive_timeout_secs.max(min_timeout_secs));
+        adaptive_timeout.min(base_timeout.min(crate::fast_lock::MAX_ACQUIRE_TIMEOUT))
     }
 
     /// Batch acquire locks with ordering to prevent deadlocks
@@ -753,6 +754,50 @@ mod tests {
 
         // Release first lock
         assert!(shard.release_lock(&key, &owner1, LockMode::Exclusive));
+    }
+
+    #[test]
+    fn test_adaptive_timeout_does_not_exceed_request_acquire_timeout() {
+        let shard = LockShard::new(0);
+        let key = ObjectKey::new("bucket", "object");
+        let owner: Arc<str> = Arc::from("owner");
+        let acquire_timeout = Duration::from_millis(500);
+
+        for priority in [LockPriority::Normal, LockPriority::High, LockPriority::Critical] {
+            let request = ObjectLockRequest {
+                key: key.clone(),
+                mode: LockMode::Exclusive,
+                owner: owner.clone(),
+                acquire_timeout,
+                lock_timeout: Duration::from_secs(30),
+                priority,
+            };
+
+            assert_eq!(
+                shard.calculate_adaptive_timeout(&request),
+                acquire_timeout,
+                "adaptive timeout must not extend the requested acquire timeout for {priority:?} priority"
+            );
+        }
+    }
+
+    #[test]
+    fn test_adaptive_timeout_does_not_exceed_global_max_acquire_timeout() {
+        let shard = LockShard::new(0);
+        let request = ObjectLockRequest {
+            key: ObjectKey::new("bucket", "object"),
+            mode: LockMode::Exclusive,
+            owner: Arc::from("owner"),
+            acquire_timeout: crate::fast_lock::MAX_ACQUIRE_TIMEOUT + Duration::from_secs(60),
+            lock_timeout: Duration::from_secs(30),
+            priority: LockPriority::Critical,
+        };
+
+        assert_eq!(
+            shard.calculate_adaptive_timeout(&request),
+            crate::fast_lock::MAX_ACQUIRE_TIMEOUT,
+            "adaptive timeout must not extend the global max acquire timeout"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`ObjectLockRequest::acquire_timeout` is the timeout budget provided by the caller, so it should act as the hard deadline for acquiring an object lock.

The fast lock slow path currently derives its wait deadline from `calculate_adaptive_timeout()`. Before this change, that adaptive timeout multiplied `request.acquire_timeout` by priority and shard-load factors, then capped part of the calculation by the global `MAX_ACQUIRE_TIMEOUT`.

That creates a deadline mismatch:

- callers may request a 5s acquire timeout
- the fast lock shard may internally wait longer than 5s because of the adaptive multiplier
- other lock paths and log/error context still treat the request's `acquire_timeout` as the expected caller budget

There was also a related cap-ordering issue: when `request.acquire_timeout` is larger than `MAX_ACQUIRE_TIMEOUT`, the `base_timeout * 0.8` minimum could raise the final value above the global max after the earlier partial cap was applied.

In other words, the local fast-lock wait deadline can become longer than the timeout contract carried by the request, and in large-budget cases it can also exceed the global max acquire timeout. This makes timeout behavior inconsistent and can hide contention behind a wait that exceeded the intended budget.

## Fix

- keep the existing priority/load adaptive calculation
- cap the final adaptive timeout at `min(request.acquire_timeout, MAX_ACQUIRE_TIMEOUT)`
- keep both the caller-provided acquire timeout and global max acquire timeout as hard deadlines
- add regression tests for normal, high, and critical priority requests, plus a large caller timeout above `MAX_ACQUIRE_TIMEOUT`

## Testing

- `cargo fmt --all`
- `git diff --check`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p rustfs-lock test_adaptive_timeout_does_not_exceed_request_acquire_timeout`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p rustfs-lock`
