### PR TITLE
refactor: centralize ecstore bucket runtime sources

### DIFF
--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -21,7 +21,7 @@ use crate::bucket::target::ARN;
 use crate::bucket::target::BucketTargetType;
 use crate::bucket::target::{self, BucketTarget, BucketTargets, Credentials};
 use crate::bucket::versioning_sys::BucketVersioningSys;
-use crate::global::get_global_bucket_monitor;
+use crate::runtime_sources;
 use aws_credential_types::Credentials as SdkCredentials;
 use aws_sdk_s3::config::Region as SdkRegion;
 use aws_sdk_s3::error::ProvideErrorMetadata;
@@ -698,7 +698,7 @@ impl BucketTargetSys {
     }
 
     fn update_bandwidth_limit(&self, bucket: &str, arn: &str, limit: i64) {
-        if let Some(bucket_monitor) = get_global_bucket_monitor() {
+        if let Some(bucket_monitor) = runtime_sources::bucket_monitor() {
             if limit == 0 {
                 bucket_monitor.delete_bucket_throttle(bucket, arn);
                 return;

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -28,7 +28,6 @@ use crate::config::com::save_config;
 use crate::disk::{BUCKET_META_PREFIX, RUSTFS_META_BUCKET};
 use crate::error::{Error, Result, is_err_object_not_found, is_err_version_not_found};
 use crate::event_notification::{EventArgs, send_event};
-use crate::global::get_global_bucket_monitor;
 use crate::global::resolve_object_store_handle;
 use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
 use crate::runtime_sources;
@@ -3698,7 +3697,7 @@ fn wrap_with_bandwidth_monitor_with_header(
     arn: &str,
     header_size: usize,
 ) -> Box<dyn AsyncRead + Unpin + Send + Sync> {
-    if let Some(monitor) = get_global_bucket_monitor() {
+    if let Some(monitor) = runtime_sources::bucket_monitor() {
         Box::new(MonitoredReader::new(
             monitor,
             stream,

--- a/crates/ecstore/src/bucket/replication/replication_state.rs
+++ b/crates/ecstore/src/bucket/replication/replication_state.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bucket::replication::get_global_replication_pool;
 use crate::error::Error;
-use crate::global::get_global_bucket_monitor;
+use crate::runtime_sources;
 use rustfs_filemeta::{ReplicatedTargetInfo, ReplicationStatusType, ReplicationType};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -887,7 +886,7 @@ impl ReplicationStats {
             let mut interval = interval(Duration::from_secs(2));
             loop {
                 interval.tick().await;
-                let current = get_global_replication_pool()
+                let current = runtime_sources::replication_pool()
                     .map(|pool| pool.active_workers() + pool.active_lrg_workers() + pool.active_mrf_workers())
                     .unwrap_or(0);
                 let mut workers = workers_clone.lock().await;
@@ -1246,7 +1245,7 @@ impl ReplicationStats {
         };
         drop(cache);
 
-        if let Some(monitor) = get_global_bucket_monitor() {
+        if let Some(monitor) = runtime_sources::bucket_monitor() {
             let bw_report = monitor.get_report(|name| name == bucket);
             for (opts, bw) in bw_report.bucket_stats {
                 let stat = replication_stats

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,9 +5,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-lifecycle-runtime-sources-batch`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190`.
-- Based on: latest default branch after merge 3802.
+- Branch: `overtrue/arch-ecstore-bucket-runtime-sources-batch`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191`.
+- Based on: latest default branch after merge 3805.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
@@ -22,7 +22,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   boot-time, init-time, root-disk threshold, and cached RPC channel reads,
   plus ECStore replication pool, replication stats, and event-host reads,
   plus ECStore lifecycle queue state, tier config, lifecycle config, deployment
-  id, and event-host reads,
+  id, event-host reads, bucket monitor reads, and replication worker pool reads,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -32,7 +32,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136 through API-190 owner facade cleanup.
+- Docs changes: record the API-136 through API-191 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4765,6 +4765,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     scan, migration/layer guards, PR-before-push pre-commit quality gate, and
     three-expert review.
 
+- [x] `API-191` Centralize ECStore bucket runtime source reads.
+  - Do: route bucket monitor reads and replication worker pool reads through the
+    ECStore-owned runtime-source module.
+  - Acceptance: bucket target bandwidth updates, replication resync bandwidth
+    wrappers, and replication state stats no longer read those runtime globals
+    directly outside the owner runtime-source boundary.
+  - Must preserve: bandwidth limit updates, uninitialized-monitor warnings,
+    monitored resync readers, active worker statistics, and bucket replication
+    bandwidth reports.
+  - Verification: ECStore compile coverage, focused replication-state test,
+    formatting, diff hygiene, residual bucket runtime-source scan, Rust risk
+    scan, migration/layer guards, PR-before-push pre-commit quality gate, and
+    three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4773,6 +4787,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-191 keeps bucket monitor and replication worker pool reads behind the ECStore runtime-source boundary without adding new public APIs. |
+| Migration preservation | pass | Bandwidth limit updates, monitored resync readers, active worker statistics, and bucket replication bandwidth reports keep existing fallback behavior. |
+| Testing/verification | pass | ECStore compile, focused replication-state test, formatting, migration/layer guards, residual scan, Rust risk scan, and pre-commit planned before PR. |
 | Quality/architecture | pass | API-152 removes thin test/fuzz ECStore bridge files and keeps direct imports in owner test/fuzz files. |
 | Migration preservation | pass | E2E, heal, scanner, and fuzz consumers keep the same ECStore API symbols and call paths. |
 | Testing/verification | pass | Focused test/fuzz compile, formatting, migration guard, shell syntax, diff hygiene, Rust risk scan, and pre-commit passed for API-152. |


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Route ECStore bucket monitor reads through the ECStore runtime source module for bucket target bandwidth updates and replication resync monitoring.
- Route replication active-worker stats through the ECStore replication pool runtime source accessor.
- Record API-191 migration progress.

## Verification

- `cargo check -p rustfs-ecstore --tests`
- `cargo test -p rustfs-ecstore --lib test_active_worker_stat_update_tracks_rolling_avg_and_max -- --test-threads=1`
- `cargo test -p rustfs-ecstore --lib build_remove_object_headers_includes_internal_version_id_for_replication_delete -- --test-threads=1`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- bucket runtime-source residual scan
- diff-only Rust risk scan
- `make pre-commit`

## Impact

No runtime behavior change expected. This keeps existing bandwidth limit updates, uninitialized-monitor warnings, monitored resync readers, active worker statistics, and bucket replication bandwidth reports while centralizing runtime source reads.

## Additional Notes

Built after the ECStore lifecycle runtime-source PR merged.
