### PR TITLE
chore: split pre-pr quality gate

### DIFF
--- a/.config/make/pre-commit.mak
+++ b/.config/make/pre-commit.mak
@@ -1,6 +1,6 @@
 ## —— Pre Commit Checks ----------------------------------------------------------------------------
 
-.NOTPARALLEL: pre-commit dev-check
+.NOTPARALLEL: pre-commit pre-pr dev-check
 
 .PHONY: setup-hooks
 setup-hooks: ## Set up git hooks
@@ -9,8 +9,12 @@ setup-hooks: ## Set up git hooks
 	@echo "✅ Git hooks setup complete!"
 
 .PHONY: pre-commit
-pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check clippy-check test ## Run full pre-commit checks
+pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check quick-check ## Run fast pre-commit checks
 	@echo "✅ All pre-commit checks passed!"
+
+.PHONY: pre-pr
+pre-pr: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check clippy-check test ## Run full pre-PR checks
+	@echo "✅ All pre-PR checks passed!"
 
 .PHONY: dev-check
 dev-check: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check quick-check ## Run fast local development checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,13 @@ Convert changes into independently verifiable outcomes. Prefer focused tests for
 For code changes, run and pass the following before opening a PR:
 
 ```bash
+make pre-pr
+```
+
+Before committing code changes, prefer focused verification for the touched
+surface and use the faster local gate when a broad smoke check is needed:
+
+```bash
 make pre-commit
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ How to use me:
 		make fmt                                 # Format code
 		make clippy                              # Run clippy checks
 		make test                                # Run tests
-		make pre-commit                          # Run all pre-commit checks
+		make pre-commit                          # Run fast pre-commit checks
+		make pre-pr                              # Run full pre-PR checks
 
 	🚀 Quick Start:
 		make build                               # Build RustFS binary
@@ -78,4 +79,3 @@ endef
 export HEADER
 
 -include $(addsuffix /*.mak, $(shell find .config/make -type d))
-


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Keep `make pre-commit` as a faster commit-time gate using formatting, safety, architecture, logging, and workspace compile checks.
- Add `make pre-pr` for the previous full gate with clippy and the full test suite.
- Update contributor guidance and Makefile help to use `make pre-pr` before opening Rust code PRs.

## Verification

- `make -n pre-commit`
- `make -n pre-pr`
- `make help | rg -n "pre-commit|pre-pr|Code Quality"`
- `make pre-commit`
- `git diff --check`

## Impact

No runtime behavior change. Local commit-time checks are faster; PR readiness keeps the full quality gate under `make pre-pr`.

## Additional Notes

Full `make pre-pr` was not run for this tooling-only change; its target expansion was verified and the new fast gate was executed.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
