### PR TITLE
refactor: centralize ecstore owner runtime sources

### DIFF
--- a/crates/ecstore/src/notification_sys.rs
+++ b/crates/ecstore/src/notification_sys.rs
@@ -15,10 +15,10 @@
 use crate::admin_server_info::get_commit_id;
 use crate::endpoints::EndpointServerPools;
 use crate::error::{Error, Result};
-use crate::global::{GLOBAL_BOOT_TIME, get_global_endpoints, resolve_object_store_handle};
 use crate::metrics_realtime::{CollectMetricsOpts, MetricType};
 use crate::rebalance::RebalSaveOpt;
 use crate::rpc::PeerRestClient;
+use crate::runtime_sources;
 use futures::future::join_all;
 use lazy_static::lazy_static;
 use rustfs_madmin::health::{Cpus, MemInfo, OsInfo, Partitions, ProcInfo, SysConfig, SysErrors, SysServices};
@@ -289,7 +289,7 @@ impl NotificationSys {
         S: StorageAdminApi<BackendInfo = rustfs_madmin::BackendInfo, StorageInfo = rustfs_madmin::StorageInfo>,
     {
         let mut futures = Vec::with_capacity(self.peer_clients.len());
-        let endpoints = get_global_endpoints();
+        let endpoints = runtime_sources::endpoint_pools().unwrap_or_else(|| Vec::new().into());
         let peer_timeout = Duration::from_secs(5);
 
         for (idx, client) in self.peer_clients.iter().enumerate() {
@@ -334,7 +334,7 @@ impl NotificationSys {
 
     pub async fn server_info(&self) -> Vec<ServerProperties> {
         let mut futures = Vec::with_capacity(self.peer_clients.len());
-        let endpoints = get_global_endpoints();
+        let endpoints = runtime_sources::endpoint_pools().unwrap_or_else(|| Vec::new().into());
         let peer_timeout = Duration::from_secs(5);
 
         for (idx, client) in self.peer_clients.iter().enumerate() {
@@ -595,7 +595,7 @@ impl NotificationSys {
             state = "started",
             "notification peer propagation"
         );
-        let Some(store) = resolve_object_store_handle() else {
+        let Some(store) = runtime_sources::object_store_handle() else {
             error!(
                 event = EVENT_NOTIFICATION_PEER_PROPAGATION,
                 component = LOG_COMPONENT_ECSTORE,
@@ -1107,11 +1107,7 @@ fn initializing_server_properties(host: &str) -> ServerProperties {
 
 fn offline_server_properties(host: &str, endpoints: &EndpointServerPools) -> ServerProperties {
     ServerProperties {
-        uptime: GLOBAL_BOOT_TIME
-            .get()
-            .and_then(|boot_time| SystemTime::now().duration_since(*boot_time).ok())
-            .unwrap_or_default()
-            .as_secs(),
+        uptime: runtime_sources::boot_uptime_secs(),
         version: get_commit_id(),
         endpoint: host.to_string(),
         state: ItemState::Offline.to_string().to_owned(),

--- a/crates/ecstore/src/pools.rs
+++ b/crates/ecstore/src/pools.rs
@@ -35,7 +35,6 @@ use crate::error::{Error, Result};
 use crate::error::{
     StorageError, is_err_bucket_exists, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found,
 };
-use crate::global::resolve_object_store_handle;
 use crate::object_api::{GetObjectReader, ObjectOptions};
 use crate::rebalance::{REBAL_META_NAME, RebalanceMeta, is_rebalance_conflicting_with_decommission};
 use crate::runtime_sources;
@@ -2420,7 +2419,7 @@ impl ECStore {
 
         self.ensure_decommission_rebalance_idle_after_refresh().await?;
 
-        let store = require_decommission_store(resolve_object_store_handle(), "start decommission")?;
+        let store = require_decommission_store(runtime_sources::object_store_handle(), "start decommission")?;
         let local_indices = local_decommission_queue_prefix(&self.endpoints(), &indices)?;
 
         self.start_decommission(indices.clone()).await?;

--- a/crates/ecstore/src/tier/tier.rs
+++ b/crates/ecstore/src/tier/tier.rs
@@ -38,7 +38,6 @@ use tracing::{debug, error, info, warn};
 
 use crate::client::admin_handler_utils::AdminError;
 use crate::error::{Error, Result, StorageError};
-use crate::global::resolve_object_store_handle;
 use crate::tier::{
     tier_admin::TierCreds,
     tier_config::{TierConfig, TierType},
@@ -1026,7 +1025,7 @@ impl TierConfigMgr {
 
     #[tracing::instrument(level = "debug", name = "tier_save", skip(self))]
     pub async fn save(&self) -> std::result::Result<(), std::io::Error> {
-        let Some(api) = resolve_object_store_handle() else {
+        let Some(api) = runtime_sources::object_store_handle() else {
             return Err(tier_config_not_initialized_error("save tiering config"));
         };
         //let (pr, opts) = GLOBAL_TierConfigMgr.write().config_reader()?;

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,9 +5,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-remaining-runtime-sources-batch`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193`.
-- Based on: latest default branch after merge 3808.
+- Branch: `overtrue/arch-ecstore-owner-runtime-sources-batch`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194`.
+- Based on: stacked on API-193 PR branch while PR #3810 is pending.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
@@ -25,7 +25,8 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   id, event-host reads, bucket monitor reads, replication worker pool reads,
   config/tier first-node checks, rebalance endpoint-locality checks, bucket
   metadata object-store reads, metadata endpoint/setup reads, lifecycle
-  object-store reads, and replication object-store readiness checks,
+  object-store reads, replication object-store readiness checks, and ECStore
+  pools/tier/notification owner-root runtime source reads,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -35,7 +36,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136 through API-193 owner facade cleanup.
+- Docs changes: record the API-136 through API-194 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4811,6 +4812,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration/layer guards, PR-before-push quality gate, and three-expert
     review.
 
+- [x] `API-194` Centralize ECStore owner-root runtime source reads.
+  - Do: route ECStore decommission object-store lookups, tier config save
+    object-store lookups, notification rebalance object-store lookups,
+    notification peer endpoint snapshots, and offline uptime reads through the
+    ECStore-owned runtime-source module.
+  - Acceptance: `pools`, `tier`, and `notification_sys` no longer import these
+    runtime globals directly outside the runtime-source boundary.
+  - Must preserve: decommission start validation and rollback behavior, tier
+    save initialization errors, notification stop-rebalance errors, peer
+    storage/server fallback behavior, and offline server uptime reporting.
+  - Verification: ECStore compile coverage, focused owner-root tests,
+    formatting, diff hygiene, residual runtime-source scan, Rust risk scan,
+    migration/layer guards, PR-before-push quality gate, and three-expert
+    review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4819,6 +4835,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-194 keeps pools, tier, and notification owner-root runtime reads behind the ECStore runtime-source boundary. |
+| Migration preservation | pass | Decommission, tier-save, notification rebalance, peer fallback, and offline uptime behavior preserve existing error/fallback semantics. |
+| Testing/verification | pass | ECStore compile, focused owner-root tests, formatting, migration/layer guards, residual scan, Rust risk scan, and PR gate are planned for API-194. |
 | Quality/architecture | pass | API-193 keeps remaining ECStore bucket metadata, lifecycle, and replication runtime reads behind the runtime-source boundary. |
 | Migration preservation | pass | Metadata fan-out, standalone fallback, lifecycle compensation/expiry, and replication readiness defaults preserve existing behavior. |
 | Testing/verification | pass | ECStore compile, focused scans, formatting, migration/layer guards, residual scan, Rust risk scan, and PR gate are planned for API-193. |


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Route ECStore decommission object-store lookups through the ECStore runtime-source boundary.
- Route tier config save object-store lookups through the same boundary.
- Route notification rebalance object-store lookups, peer endpoint snapshots, and offline uptime reads through the same boundary.
- Record API-194 migration progress and review notes.

## Verification

- `cargo check -p rustfs-ecstore --tests`
- `cargo test -p rustfs-ecstore --lib test_require_decommission_store_returns_error_when_missing -- --test-threads=1`
- `cargo test -p rustfs-ecstore --lib test_tier_config_not_initialized_error_formats_operation_context -- --test-threads=1`
- `cargo test -p rustfs-ecstore --lib handle_server_info_failure_returns_offline_after_threshold -- --test-threads=1`
- `cargo test -p rustfs-ecstore --lib handle_peer_failure_returns_offline_after_threshold_exceeded -- --test-threads=1`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `make pre-pr`
- `make pre-commit`

## Impact

No intended runtime behavior change. ECStore pools, tier, and notification owner-root runtime reads now go through the owner runtime-source boundary.

## Additional Notes

This branch was rebased onto `main` after PR #3810 merged.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
