### PR TITLE
refactor: centralize ecstore accessor runtime sources

### DIFF
--- a/crates/ecstore/src/runtime_sources.rs
+++ b/crates/ecstore/src/runtime_sources.rs
@@ -18,8 +18,9 @@ use crate::bucket::bandwidth::monitor::Monitor;
 use crate::disk::endpoint::Endpoint;
 use crate::{
     bucket::lifecycle::bucket_lifecycle_ops::{ExpiryState, GLOBAL_ExpiryState, GLOBAL_TransitionState, TransitionState},
+    bucket::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys},
     bucket::replication::{DynReplicationPool, GLOBAL_REPLICATION_POOL, GLOBAL_REPLICATION_STATS, ReplicationStats},
-    config::get_global_storage_class,
+    config::{get_global_storage_class, set_global_storage_class, storageclass},
     disk::{DiskAPI, DiskOption, DiskStore, new_disk},
     endpoints::EndpointServerPools,
     error::Result,
@@ -28,18 +29,21 @@ use crate::{
         GLOBAL_BOOT_TIME, GLOBAL_EventNotifier, GLOBAL_IsErasureSD, GLOBAL_LOCAL_DISK_ID_MAP, GLOBAL_LOCAL_DISK_MAP,
         GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LifecycleSys, GLOBAL_LocalNodeName, GLOBAL_RootDiskThreshold, GLOBAL_TierConfigMgr,
         TypeLocalDiskSetDrives, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints,
-        get_global_endpoints_opt, get_global_lock_clients, init_global_bucket_monitor, is_dist_erasure, is_erasure,
-        is_first_cluster_node_local, resolve_object_store_handle, set_global_deployment_id,
+        get_global_endpoints_opt, get_global_lock_clients, get_global_region, get_global_tier_config_mgr, global_rustfs_port,
+        init_global_bucket_monitor, is_dist_erasure, is_erasure, is_first_cluster_node_local, resolve_object_store_handle,
+        set_global_deployment_id, set_global_lock_client, set_global_lock_clients, set_object_layer,
     },
     notification_sys::{NotificationSys, get_global_notification_sys},
     store::ECStore,
     tier::tier::TierConfigMgr,
 };
-use rustfs_common::{GLOBAL_CONN_MAP, GLOBAL_LOCAL_NODE_NAME, GLOBAL_RUSTFS_ADDR};
+use rustfs_common::{GLOBAL_CONN_MAP, GLOBAL_LOCAL_NODE_NAME, GLOBAL_RUSTFS_ADDR, GLOBAL_RUSTFS_HOST};
+use rustfs_config::server_config::{Config, get_global_server_config, set_global_server_config};
 use rustfs_io_metrics::internode_metrics::global_internode_metrics;
 use rustfs_kms::{ObjectEncryptionService, get_global_encryption_service};
 use rustfs_lock::client::LockClient;
 use s3s::dto::BucketLifecycleConfiguration;
+use s3s::region::Region;
 use tokio::sync::RwLock;
 use tonic::transport::Channel;
 use uuid::Uuid;
@@ -95,8 +99,20 @@ pub(crate) async fn local_node_name() -> String {
     GLOBAL_LOCAL_NODE_NAME.read().await.clone()
 }
 
+pub(crate) async fn set_local_node_name(node_name: String) {
+    *GLOBAL_LOCAL_NODE_NAME.write().await = node_name;
+}
+
 pub(crate) fn default_local_node_name() -> String {
     GLOBAL_LocalNodeName.to_string()
+}
+
+pub(crate) fn rustfs_port() -> u16 {
+    global_rustfs_port()
+}
+
+pub(crate) async fn rustfs_host() -> String {
+    GLOBAL_RUSTFS_HOST.read().await.clone()
 }
 
 pub(crate) async fn rustfs_addr() -> String {
@@ -186,8 +202,50 @@ pub(crate) fn global_lock_clients() -> Option<&'static HashMap<String, Arc<dyn L
     get_global_lock_clients()
 }
 
+pub(crate) fn set_primary_lock_client(client: Arc<dyn LockClient>) -> std::result::Result<(), Arc<dyn LockClient>> {
+    set_global_lock_client(client)
+}
+
+pub(crate) fn set_lock_clients(
+    clients: HashMap<String, Arc<dyn LockClient>>,
+) -> std::result::Result<(), HashMap<String, Arc<dyn LockClient>>> {
+    set_global_lock_clients(clients)
+}
+
+pub(crate) async fn publish_object_store(store: Arc<ECStore>) {
+    set_object_layer(store).await;
+}
+
 pub(crate) fn notification_sys() -> Option<&'static NotificationSys> {
     get_global_notification_sys()
+}
+
+pub(crate) fn bucket_metadata_sys() -> Option<Arc<RwLock<BucketMetadataSys>>> {
+    get_global_bucket_metadata_sys()
+}
+
+pub(crate) fn region() -> Option<Region> {
+    get_global_region()
+}
+
+pub(crate) fn server_config() -> Option<Config> {
+    get_global_server_config()
+}
+
+pub(crate) fn set_server_config(config: Config) {
+    set_global_server_config(config);
+}
+
+pub(crate) fn storage_class_config() -> Option<storageclass::Config> {
+    get_global_storage_class()
+}
+
+pub(crate) fn set_storage_class_config(config: storageclass::Config) {
+    set_global_storage_class(config);
+}
+
+pub(crate) fn global_tier_config_mgr() -> Arc<RwLock<TierConfigMgr>> {
+    get_global_tier_config_mgr()
 }
 
 pub(crate) async fn bucket_lifecycle_config(bucket: &str) -> Option<BucketLifecycleConfiguration> {

--- a/crates/ecstore/src/store.rs
+++ b/crates/ecstore/src/store.rs
@@ -19,7 +19,6 @@ use crate::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
 use crate::bucket::lifecycle::bucket_lifecycle_ops::{
     enqueue_immediate_expiry, enqueue_transition_immediate, init_background_expiry,
 };
-use crate::bucket::metadata_sys::get_global_bucket_metadata_sys;
 use crate::bucket::metadata_sys::{self, set_bucket_metadata};
 use crate::bucket::utils::check_abort_multipart_args;
 use crate::bucket::utils::check_complete_multipart_args;
@@ -33,7 +32,6 @@ use crate::bucket::utils::check_object_args;
 use crate::bucket::utils::check_put_object_args;
 use crate::bucket::utils::check_put_object_part_args;
 use crate::bucket::utils::{check_valid_bucket_name, check_valid_bucket_name_strict, is_meta_bucketname};
-use crate::config::get_global_storage_class;
 use crate::config::storageclass;
 use crate::disk::endpoint::{Endpoint, EndpointType};
 use crate::disk::{DiskAPI, DiskInfo, DiskInfoOptions};
@@ -43,10 +41,7 @@ use crate::error::{
     is_err_read_quorum, is_err_version_not_found, to_object_err,
 };
 use crate::event_notification::EventNotifier;
-use crate::global::{
-    DISK_RESERVE_FRACTION, TypeLocalDiskSetDrives, get_global_region, get_global_tier_config_mgr, set_object_layer,
-};
-use crate::notification_sys::get_global_notification_sys;
+use crate::global::{DISK_RESERVE_FRACTION, TypeLocalDiskSetDrives};
 use crate::pools::PoolMeta;
 use crate::rebalance::RebalanceMeta;
 use crate::rpc::RemoteClient;
@@ -67,8 +62,7 @@ use http::HeaderMap;
 use lazy_static::lazy_static;
 use rand::RngExt as _;
 use rustfs_common::heal_channel::{HealItemType, HealOpts};
-use rustfs_common::{GLOBAL_LOCAL_NODE_NAME, GLOBAL_RUSTFS_ADDR, GLOBAL_RUSTFS_HOST, GLOBAL_RUSTFS_PORT};
-use rustfs_config::server_config::{Config, get_global_server_config, set_global_server_config};
+use rustfs_config::server_config::Config;
 use rustfs_filemeta::FileInfo;
 use rustfs_lock::{LocalClient, LockClient, NamespaceLockWrapper};
 use rustfs_madmin::heal_commands::HealResultItem;
@@ -229,22 +223,22 @@ impl std::fmt::Debug for ECStore {
 impl ECStore {
     /// Get server configuration (delegates to global)
     pub fn get_server_config(&self) -> Option<Config> {
-        get_global_server_config()
+        runtime_sources::server_config()
     }
 
     /// Set server configuration (delegates to global)
     pub fn set_server_config(&self, cfg: Config) {
-        set_global_server_config(cfg);
+        runtime_sources::set_server_config(cfg);
     }
 
     /// Get storage class configuration (delegates to global)
     pub fn get_storage_class(&self) -> Option<crate::config::storageclass::Config> {
-        crate::config::get_global_storage_class()
+        runtime_sources::storage_class_config()
     }
 
     /// Set storage class configuration (delegates to global)
     pub fn set_storage_class(&self, cfg: crate::config::storageclass::Config) {
-        crate::config::set_global_storage_class(cfg);
+        runtime_sources::set_storage_class_config(cfg);
     }
 }
 
@@ -254,12 +248,12 @@ impl ECStore {
 impl ECStore {
     /// Get the notification system
     pub fn notification_system(&self) -> Option<&'static crate::notification_sys::NotificationSys> {
-        get_global_notification_sys()
+        runtime_sources::notification_sys()
     }
 
     /// Get the bucket metadata system
     pub fn bucket_metadata_sys(&self) -> Option<Arc<tokio::sync::RwLock<crate::bucket::metadata_sys::BucketMetadataSys>>> {
-        get_global_bucket_metadata_sys()
+        runtime_sources::bucket_metadata_sys()
     }
 
     /// Get the global endpoints
@@ -269,22 +263,22 @@ impl ECStore {
 
     /// Get the global region
     pub fn region(&self) -> Option<s3s::region::Region> {
-        get_global_region()
+        runtime_sources::region()
     }
 
     /// Get the tier config manager
     pub fn tier_config_mgr(&self) -> Arc<tokio::sync::RwLock<crate::tier::tier::TierConfigMgr>> {
-        get_global_tier_config_mgr()
+        runtime_sources::global_tier_config_mgr()
     }
 
     /// Get the server configuration
     pub fn server_config(&self) -> Option<Config> {
-        get_global_server_config()
+        runtime_sources::server_config()
     }
 
     /// Get the storage class configuration
     pub fn storage_class(&self) -> Option<crate::config::storageclass::Config> {
-        get_global_storage_class()
+        runtime_sources::storage_class_config()
     }
 }
 
@@ -294,17 +288,17 @@ impl ECStore {
 impl ECStore {
     /// Get the server port
     pub fn port(&self) -> u16 {
-        crate::global::global_rustfs_port()
+        runtime_sources::rustfs_port()
     }
 
     /// Get the server host
     pub async fn host(&self) -> String {
-        GLOBAL_RUSTFS_HOST.read().await.clone()
+        runtime_sources::rustfs_host().await
     }
 
     /// Get the server address (host:port)
     pub async fn addr(&self) -> String {
-        GLOBAL_RUSTFS_ADDR.read().await.clone()
+        runtime_sources::rustfs_addr().await
     }
 }
 

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -168,11 +168,11 @@ impl ECStore {
         );
         let mut host = address.ip().to_string();
         if host.is_empty() {
-            host = GLOBAL_RUSTFS_HOST.read().await.to_string()
+            host = runtime_sources::rustfs_host().await
         }
         let mut port = address.port().to_string();
         if port.is_empty() {
-            port = GLOBAL_RUSTFS_PORT.read().await.to_string()
+            port = runtime_sources::rustfs_port().to_string()
         }
         debug!(
             event = EVENT_ECSTORE_INIT_STATUS,
@@ -351,7 +351,7 @@ impl ECStore {
             break;
         }
 
-        set_object_layer(ec.clone()).await;
+        runtime_sources::publish_object_store(ec.clone()).await;
 
         if let Some(monitor) = runtime_sources::bucket_monitor() {
             let _ = ec.bucket_monitor.set(monitor);

--- a/crates/ecstore/src/store/peer.rs
+++ b/crates/ecstore/src/store/peer.rs
@@ -113,7 +113,7 @@ pub fn init_lock_clients(endpoint_pools: EndpointServerPools) {
 
             // Store the first LocalClient globally for use by other modules
             if !first_local_client_set {
-                if let Err(e) = crate::global::set_global_lock_client(local_client.clone()) {
+                if let Err(e) = runtime_sources::set_primary_lock_client(local_client.clone()) {
                     // If already set, ignore the error (another thread may have set it)
                     debug!(
                         event = EVENT_LOCK_CLIENT_INITIALIZATION_FAILED,
@@ -135,7 +135,7 @@ pub fn init_lock_clients(endpoint_pools: EndpointServerPools) {
     }
 
     // Store the lock clients map globally
-    if crate::global::set_global_lock_clients(clients).is_err() {
+    if runtime_sources::set_lock_clients(clients).is_err() {
         error!(
             event = EVENT_LOCK_CLIENT_INITIALIZATION_FAILED,
             component = LOG_COMPONENT_ECSTORE,
@@ -158,15 +158,15 @@ pub(super) async fn init_local_peer(endpoint_pools: &EndpointServerPools, host: 
 
     if peer_set.is_empty() {
         if !host.is_empty() {
-            *GLOBAL_LOCAL_NODE_NAME.write().await = format!("{host}:{port}");
+            runtime_sources::set_local_node_name(format!("{host}:{port}")).await;
             return;
         }
 
-        *GLOBAL_LOCAL_NODE_NAME.write().await = format!("127.0.0.1:{port}");
+        runtime_sources::set_local_node_name(format!("127.0.0.1:{port}")).await;
         return;
     }
 
-    *GLOBAL_LOCAL_NODE_NAME.write().await = peer_set[0].clone();
+    runtime_sources::set_local_node_name(peer_set[0].clone()).await;
 }
 
 pub async fn get_disk_infos(disks: &[Option<DiskStore>]) -> Vec<Option<DiskInfo>> {

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,9 +5,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-ecstore-setup-runtime-sources-batch`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195`.
-- Based on: stacked on API-194 PR branch while PR #3811 is pending.
+- Branch: `overtrue/arch-ecstore-accessor-runtime-sources-batch`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196`.
+- Based on: stacked on API-195 PR branch while PR #3812 is pending.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
@@ -29,7 +29,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   pools/tier/notification owner-root runtime source reads, plus ECStore setup
   state, boot-time, endpoint snapshot, local node, local disk map, and lock
   client reads in store initialization, sets, set-disk, pool-space, and peer
-  client paths,
+  client paths, plus ECStore facade server-config, storage-class,
+  notification, bucket-metadata, endpoint, region, tier-config, server-address,
+  object-store publication, lock-client publication, and local-node publication
+  paths,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -39,7 +42,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   and storage owner thin bridge regressions, plus app context and notify
   event-bridge thin module regressions; accept the reviewed AppContext resolver
   reverse dependencies in the layer baseline.
-- Docs changes: record the API-136 through API-195 owner facade cleanup.
+- Docs changes: record the API-136 through API-196 owner facade cleanup.
 
 ## Phase 0 Tasks
 
@@ -4847,6 +4850,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration/layer guards, PR-before-push quality gate, and three-expert
     review.
 
+- [x] `API-196` Centralize ECStore accessor runtime source reads.
+  - Do: route ECStore server-config, storage-class, notification system,
+    bucket metadata system, endpoint, region, tier-config, host/address/port,
+    object-store publication, lock-client publication, and local-node
+    publication paths through the ECStore-owned runtime-source module.
+  - Acceptance: `store`, `store/init`, and `store/peer` no longer import or
+    call those process-global accessors directly outside the runtime-source
+    boundary.
+  - Must preserve: ECStore facade method signatures, default endpoint fallback,
+    object-layer publication, lock-client duplicate handling, local-node name
+    fallback construction, and server address reads.
+  - Verification: ECStore compile coverage, focused store init/accessor tests,
+    formatting, diff hygiene, residual runtime-source scan, migration/layer
+    guards, PR-before-push quality gate, and three-expert review.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4855,6 +4873,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-196 keeps ECStore facade, object-layer, lock-client, local-node, and server-address runtime access behind the runtime-source boundary. |
+| Migration preservation | pass | Facade signatures, endpoint fallback, object-store publication, lock-client duplicate handling, and local-node fallback behavior preserve existing semantics. |
+| Testing/verification | pass | ECStore compile and focused store-init/accessor tests have passed; formatting, migration/layer guards, residual scan, and PR gate are planned before PR. |
 | Quality/architecture | pass | API-195 keeps setup-state, boot-time, endpoint, local-node, local-disk, and lock-client reads behind the ECStore runtime-source boundary. |
 | Migration preservation | pass | Store init, local disk registration, distributed lock selection, recovered-disk map updates, pool-space inode checks, peer-client creation, and pool-meta persistence preserve existing behavior. |
 | Testing/verification | pass | ECStore compile, focused setup/set-disk tests, formatting, migration/layer guards, residual scan, Rust risk scan, and PR gate are planned for API-195. |


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#660.

## Summary of Changes

- Route ECStore facade server-config, storage-class, notification, bucket-metadata, endpoint, region, tier-config, and server-address accessors through the ECStore runtime-source boundary.
- Route object-store publication, lock-client publication, and local-node publication through runtime sources.
- Record API-196 migration progress and review notes.

## Verification

- `cargo check -p rustfs-ecstore --tests`
- `cargo nextest run -p rustfs app::capacity_dirty_scope_test::heal_object_marks_missing_shard_disk_dirty_for_capacity_manager app::context::tests::resolver_helpers_are_context_first_and_fallback_when_context_is_absent -p rustfs-ecstore bucket::lifecycle::bucket_lifecycle_ops::tests::cleanup_removes_empty_multipart_sha_dirs`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `make pre-pr`
- `make pre-commit`

## Impact

No intended runtime behavior change. ECStore facade and publication paths now flow through the owner runtime-source boundary.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
