### PR TITLE
refactor: centralize iam runtime source helpers

### DIFF
--- a/crates/iam/src/lib.rs
+++ b/crates/iam/src/lib.rs
@@ -26,9 +26,7 @@ use rustfs_ecstore::api::error::{
     classify_system_path_failure_reason as ecstore_classify_system_path_failure_reason,
 };
 use rustfs_ecstore::api::global::is_first_cluster_node_local as ecstore_is_first_cluster_node_local;
-use rustfs_ecstore::api::notification::{
-    NotificationPeerErr as EcstoreNotificationPeerErr, get_global_notification_sys as ecstore_get_global_notification_sys,
-};
+use rustfs_ecstore::api::notification::NotificationPeerErr as EcstoreNotificationPeerErr;
 use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
 use std::sync::{Arc, OnceLock};
 use store::object::ObjectStore;
@@ -48,6 +46,7 @@ pub mod manager;
 pub mod oidc;
 pub mod oidc_state;
 mod root_credentials;
+mod runtime_sources;
 mod server_config;
 pub mod store;
 pub mod sys;
@@ -114,7 +113,7 @@ impl From<EcstoreNotificationPeerErr> for IamNotificationPeerErr {
 }
 
 pub(crate) async fn notify_iam_delete_policy(policy_name: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_policy(policy_name)
             .await
@@ -126,7 +125,7 @@ pub(crate) async fn notify_iam_delete_policy(policy_name: &str) -> Vec<IamNotifi
 }
 
 pub(crate) async fn notify_iam_load_policy(policy_name: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys
             .load_policy(policy_name)
             .await
@@ -138,7 +137,7 @@ pub(crate) async fn notify_iam_load_policy(policy_name: &str) -> Vec<IamNotifica
 }
 
 pub(crate) async fn notify_iam_delete_user(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_user(access_key)
             .await
@@ -150,7 +149,7 @@ pub(crate) async fn notify_iam_delete_user(access_key: &str) -> Vec<IamNotificat
 }
 
 pub(crate) async fn notify_iam_load_user(access_key: &str, temp: bool) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys
             .load_user(access_key, temp)
             .await
@@ -162,7 +161,7 @@ pub(crate) async fn notify_iam_load_user(access_key: &str, temp: bool) -> Vec<Ia
 }
 
 pub(crate) async fn notify_iam_load_service_account(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys
             .load_service_account(access_key)
             .await
@@ -174,7 +173,7 @@ pub(crate) async fn notify_iam_load_service_account(access_key: &str) -> Vec<Iam
 }
 
 pub(crate) async fn notify_iam_delete_service_account(access_key: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys
             .delete_service_account(access_key)
             .await
@@ -186,7 +185,7 @@ pub(crate) async fn notify_iam_delete_service_account(access_key: &str) -> Vec<I
 }
 
 pub(crate) async fn notify_iam_load_group(group: &str) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys.load_group(group).await.into_iter().map(Into::into).collect(),
         None => Vec::new(),
     }
@@ -197,7 +196,7 @@ pub(crate) async fn notify_iam_load_policy_mapping(
     user_type: u64,
     is_group: bool,
 ) -> Vec<IamNotificationPeerErr> {
-    match ecstore_get_global_notification_sys() {
+    match runtime_sources::notification_sys() {
         Some(notification_sys) => notification_sys
             .load_policy_mapping(user_or_group, user_type, is_group)
             .await

--- a/crates/iam/src/runtime_sources.rs
+++ b/crates/iam/src/runtime_sources.rs
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_credentials::Credentials;
+use rustfs_config::server_config::{Config as ServerConfig, get_global_server_config};
+use rustfs_credentials::{Credentials, get_global_action_cred};
+use rustfs_ecstore::api::notification::{NotificationSys, get_global_notification_sys};
 
-pub(crate) fn credentials() -> Option<Credentials> {
-    crate::runtime_sources::action_credentials()
+pub(crate) fn action_credentials() -> Option<Credentials> {
+    get_global_action_cred()
 }
 
-pub(crate) fn credentials_or_default() -> Credentials {
-    credentials().unwrap_or_default()
+pub(crate) fn current_server_config() -> Option<ServerConfig> {
+    get_global_server_config()
 }
 
-pub(crate) fn token_signing_key() -> Option<String> {
-    credentials().map(|cred| cred.secret_key)
-}
-
-pub(crate) fn is_root_access_key(access_key: &str) -> bool {
-    credentials().is_some_and(|cred| cred.access_key == access_key)
+pub(crate) fn notification_sys() -> Option<&'static NotificationSys> {
+    get_global_notification_sys()
 }

--- a/crates/iam/src/server_config.rs
+++ b/crates/iam/src/server_config.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_config::server_config::{Config as ServerConfig, get_global_server_config};
+use rustfs_config::server_config::Config as ServerConfig;
 
 pub(crate) fn current_server_config() -> Option<ServerConfig> {
-    get_global_server_config()
+    crate::runtime_sources::current_server_config()
 }

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,9 +5,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-scanner-runtime-source-resolvers`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200`.
-- Based on: stacked on API-199 PR branch while PR #3826 is pending.
+- Branch: `overtrue/arch-iam-runtime-source-helpers`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201`.
+- Based on: latest main after PR #3827.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
@@ -39,7 +39,8 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   runtime-source helpers, scanner lifecycle/tier runtime source reads, and the
   stale RustFS tier-config and expiry-state test compat shims, plus scanner
   runtime config, erasure-mode, lifecycle queue, and tier runtime source helper
-  names,
+  names, plus IAM root-credential, server-config, and notification runtime
+  source helpers,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -47,9 +48,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   regressions, plus external runtime, test, fuzz, and storage-owner module
   ECStore compatibility bypasses, plus runtime crate, owner crate, test/fuzz,
   and storage owner thin bridge regressions, plus app context and notify
-  event-bridge thin module regressions; accept the reviewed AppContext resolver
-  reverse dependencies in the layer baseline.
-- Docs changes: record the API-136 through API-200 owner facade and lifecycle
+  event-bridge thin module regressions, plus IAM runtime-source bypasses;
+  accept the reviewed AppContext resolver reverse dependencies in the layer
+  baseline.
+- Docs changes: record the API-136 through API-201 owner facade and lifecycle
   runtime-source cleanup.
 
 ## Phase 0 Tasks

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -151,6 +151,7 @@ ECSTORE_COMPAT_PASSTHROUGH_EXPECTED_FILE="${TMP_DIR}/ecstore_compat_passthrough_
 ECSTORE_COMPAT_PASSTHROUGH_ACTUAL_FILE="${TMP_DIR}/ecstore_compat_passthrough_actual.txt"
 ECSTORE_COMPAT_PASSTHROUGH_DIFF_FILE="${TMP_DIR}/ecstore_compat_passthrough_diff.txt"
 RUSTFS_WORKLOAD_DIRECT_FOREGROUND_MAPPING_HITS_FILE="${TMP_DIR}/rustfs_workload_direct_foreground_mapping_hits.txt"
+IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/iam_runtime_source_bypass_hits.txt"
 
 awk '
   /^## PR Types$/ {
@@ -737,7 +738,7 @@ fi
     --glob '!**/ecstore_test_compat/**' \
     --glob '!**/ecstore_fuzz_compat.rs' \
     --glob '!target/**' \
-    | rg -v '^(rustfs/src/(admin/mod|app/mod|storage/mod)\.rs|crates/e2e_test/src/(replication_extension_test|reliant/(grpc_lock_client|node_interact_test))\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/(endpoint_index_test|heal_bug_fixes_test|heal_integration_test)\.rs|crates/iam/src/lib\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|fuzz/fuzz_targets/(bucket_validation|path_containment)\.rs):' || true
+    | rg -v '^(rustfs/src/(admin/mod|app/mod|storage/mod)\.rs|crates/e2e_test/src/(replication_extension_test|reliant/(grpc_lock_client|node_interact_test))\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/(endpoint_index_test|heal_bug_fixes_test|heal_integration_test)\.rs|crates/iam/src/(lib|runtime_sources)\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|fuzz/fuzz_targets/(bucket_validation|path_containment)\.rs):' || true
 ) |
   cat >"$DIRECT_ECSTORE_IMPORT_HITS_FILE"
 
@@ -1086,7 +1087,7 @@ fi
     --glob '!**/ecstore_compat.rs' \
     --glob '!**/ecstore_test_compat.rs' \
     --glob '!**/ecstore_test_compat/**' |
-    rg -v '^(fuzz/fuzz_targets/bucket_validation\.rs|fuzz/fuzz_targets/path_containment\.rs|crates/e2e_test/src/reliant/grpc_lock_client\.rs|crates/e2e_test/src/reliant/node_interact_test\.rs|crates/e2e_test/src/replication_extension_test\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/endpoint_index_test\.rs|crates/heal/tests/heal_bug_fixes_test\.rs|crates/heal/tests/heal_integration_test\.rs|crates/iam/src/lib\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|rustfs/src/admin/mod\.rs|rustfs/src/app/mod\.rs|rustfs/src/storage/mod\.rs):' || true
+    rg -v '^(fuzz/fuzz_targets/bucket_validation\.rs|fuzz/fuzz_targets/path_containment\.rs|crates/e2e_test/src/reliant/grpc_lock_client\.rs|crates/e2e_test/src/reliant/node_interact_test\.rs|crates/e2e_test/src/replication_extension_test\.rs|crates/heal/src/heal/mod\.rs|crates/heal/tests/endpoint_index_test\.rs|crates/heal/tests/heal_bug_fixes_test\.rs|crates/heal/tests/heal_integration_test\.rs|crates/iam/src/(lib|runtime_sources)\.rs|crates/notify/src/lib\.rs|crates/obs/src/metrics/mod\.rs|crates/protocols/src/swift/mod\.rs|crates/s3select-api/src/lib\.rs|crates/scanner/src/lib\.rs|crates/scanner/tests/lifecycle_integration_test\.rs|rustfs/src/admin/mod\.rs|rustfs/src/app/mod\.rs|rustfs/src/storage/mod\.rs):' || true
 ) >"$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE"
 
 if [[ -s "$ALL_ECSTORE_API_RAW_SUBPATH_HITS_FILE" ]]; then
@@ -1286,11 +1287,23 @@ fi
     crates/scanner/src \
     --glob '*.rs' \
     --glob '!**/ecstore_compat.rs' |
-    rg -v '^(crates/heal/src/heal/mod.rs|crates/iam/src/lib.rs|crates/notify/src/lib.rs|crates/obs/src/metrics/mod.rs|crates/protocols/src/swift/mod.rs|crates/s3select-api/src/lib.rs|crates/scanner/src/lib.rs):' || true
+    rg -v '^(crates/heal/src/heal/mod.rs|crates/iam/src/(lib|runtime_sources).rs|crates/notify/src/lib.rs|crates/obs/src/metrics/mod.rs|crates/protocols/src/swift/mod.rs|crates/s3select-api/src/lib.rs|crates/scanner/src/lib.rs):' || true
 ) >"$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE"
 
 if [[ -s "$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE" ]]; then
   report_failure "external runtime crates must source ECStore API symbols through their owner root or ecstore_compat boundary: $(paste -sd '; ' "$EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'get_global_(?:action_cred|server_config|notification_sys)' \
+    crates/iam/src \
+    --glob '*.rs' |
+    rg -v '^crates/iam/src/runtime_sources\.rs:' || true
+) >"$IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE"
+
+if [[ -s "$IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
+  report_failure "IAM runtime-source globals must stay behind crates/iam/src/runtime_sources.rs: $(paste -sd '; ' "$IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add IAM-owned runtime source helpers for credentials, server config, and notification runtime access.
- Route IAM call sites through the new helper module.
- Extend migration guardrails and progress notes for the IAM runtime source boundary.

## Verification
- `cargo test -p rustfs-iam -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `make pre-pr`

## Impact
No user-facing behavior change. This narrows runtime source access behind the IAM owner boundary.

## Additional Notes
N/A
