### PR TITLE
fix(heal): Add podAnnotations to statefulset and deployment templates

### DIFF
--- a/helm/rustfs/templates/deployment.yaml
+++ b/helm/rustfs/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "rustfs.serviceAccountName" . }}
       {{- with include "chart.imagePullSecrets" . }}

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -27,6 +27,10 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "rustfs.serviceAccountName" . }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
Fixes #3830

## Summary of Changes
Update Helm charts statefulset and deployment templates to use `podAnnotations` already present in [values.yaml](https://github.com/rustfs/rustfs/blob/ad6184b1266ef28c44d8201c25319c5b28cff2b2/helm/rustfs/values.yaml#L176)

## Verification

1. Deployed using Helm with minimally modified `values.yaml` to confirm no pod annotations are applied by default (only changed `secret.allowInsecureDefaults: true` to enable deployment)

1. Deployed using minimally modified `values.yaml` to confirm pod annotations are applied when added to `values.yaml` for both standalone and distributed mode

```YAML
secret:
  allowInsecureDefaults: true

podAnnotations:
  backup.velero.io/backup-volumes-excludes: rustfs
```

```YAML
secret:
  allowInsecureDefaults: true

podAnnotations:
  backup.velero.io/backup-volumes-excludes: rustfs

mode:
  standalone:
    enabled: true
  distributed:
    enabled: false
```

## Impact

Users' `podAnnotations` from [values.yaml](https://github.com/rustfs/rustfs/blob/ad6184b1266ef28c44d8201c25319c5b28cff2b2/helm/rustfs/values.yaml#L176), which are incorrectly not used today, might start being used as intended in future deployments

## Additional Notes


---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
