### PR TITLE
refactor: centralize app context runtime fallbacks

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,9 +5,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-iam-runtime-source-helpers`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201`.
-- Based on: latest main after PR #3827.
+- Branch: `overtrue/arch-app-context-runtime-source-fallbacks`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202`.
+- Based on: stacked on PR #3828 head after PR #3827.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
@@ -40,7 +40,8 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   stale RustFS tier-config and expiry-state test compat shims, plus scanner
   runtime config, erasure-mode, lifecycle queue, and tier runtime source helper
   names, plus IAM root-credential, server-config, and notification runtime
-  source helpers,
+  source helpers, plus AppContext fallback KMS/IAM/ECStore/config/metrics/TLS
+  runtime source helpers,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -51,7 +52,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   event-bridge thin module regressions, plus IAM runtime-source bypasses;
   accept the reviewed AppContext resolver reverse dependencies in the layer
   baseline.
-- Docs changes: record the API-136 through API-201 owner facade and lifecycle
+- Docs changes: record the API-136 through API-202 owner facade and lifecycle
   runtime-source cleanup.
 
 ## Phase 0 Tasks
@@ -5176,6 +5177,16 @@ Passed before push:
   - Branch freshness check: based on latest `origin/main` after PR #3795
     merged API-184.
   - `make pre-commit`: passed.
+
+- Issue #660 API-202 current slice:
+  - `cargo test -p rustfs app::context --lib -- --nocapture`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - AppContext fallback runtime source scan: passed; direct fallback global
+    reads should be isolated to `rustfs/src/app/context/runtime_sources.rs`.
+  - Verification: focused checks passed; full `make pre-pr` pending before PR.
 
 - Issue #660 API-184 current slice:
   - `cargo check -p rustfs-rio --tests`: passed.

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -19,6 +19,7 @@
 mod global;
 mod handles;
 mod interfaces;
+mod runtime_sources;
 mod startup;
 
 pub use global::*;
@@ -32,14 +33,13 @@ use super::ScannerMetricsReport;
 use super::StorageClassConfig;
 use super::TierConfigMgr;
 use super::metadata_sys::BucketMetadataSys;
-use super::new_object_layer_fn;
 use super::{BucketBandwidthMonitor, DynReplicationPool, ExpiryState, NotificationSys, ReplicationStats};
 use crate::config::RustFSBufferConfig;
 use rustfs_config::server_config::Config;
 use rustfs_credentials::Credentials;
 use rustfs_iam::{error::Error as IamError, oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
 use rustfs_io_metrics::{PerformanceMetrics, internode_metrics::InternodeMetrics};
-use rustfs_kms::{KmsServiceManager, ObjectEncryptionService, init_global_kms_service_manager};
+use rustfs_kms::{KmsServiceManager, ObjectEncryptionService};
 use rustfs_lock::LockClient;
 use rustfs_s3select_api::{QueryResult, server::dbms::DatabaseManagerSystem};
 use rustfs_tls_runtime::{GlobalPublishedOutboundTlsState, TlsGeneration};
@@ -54,12 +54,12 @@ pub fn resolve_kms_runtime_service_manager() -> Option<Arc<KmsServiceManager>> {
 
 /// Resolve or initialize the KMS runtime service manager using AppContext-first precedence.
 pub fn resolve_or_init_kms_runtime_service_manager() -> Arc<KmsServiceManager> {
-    resolve_or_init_kms_runtime_service_manager_with(get_global_app_context(), init_global_kms_service_manager)
+    resolve_or_init_kms_runtime_service_manager_with(get_global_app_context(), runtime_sources::init_kms_service_manager)
 }
 
 /// Resolve KMS encryption service using AppContext-first precedence.
 pub async fn resolve_encryption_service() -> Option<Arc<ObjectEncryptionService>> {
-    resolve_encryption_service_with(get_global_app_context(), rustfs_kms::get_global_encryption_service).await
+    resolve_encryption_service_with(get_global_app_context(), runtime_sources::encryption_service).await
 }
 
 /// Resolve outbound TLS generation using AppContext-first precedence.
@@ -69,7 +69,7 @@ pub fn resolve_outbound_tls_generation() -> TlsGeneration {
 
 #[cfg(test)]
 pub(crate) fn set_test_outbound_tls_generation(generation: u64) {
-    rustfs_common::set_global_outbound_tls_generation(generation);
+    runtime_sources::set_outbound_tls_generation(generation);
 }
 
 /// Resolve outbound TLS state using AppContext-first precedence.
@@ -79,29 +79,27 @@ pub async fn resolve_outbound_tls_state() -> GlobalPublishedOutboundTlsState {
 
 /// Resolve IAM readiness using AppContext-first precedence.
 pub fn resolve_iam_ready() -> bool {
-    resolve_iam_ready_with(get_global_app_context(), || {
-        rustfs_iam::get_global_iam_sys().is_some_and(|sys| sys.is_ready())
-    })
+    resolve_iam_ready_with(get_global_app_context(), runtime_sources::iam_is_ready)
 }
 
 /// Resolve IAM system handle using AppContext-first precedence.
 pub fn resolve_iam_handle() -> Option<Arc<IamSys<ObjectStore>>> {
-    resolve_iam_handle_with(get_global_app_context(), rustfs_iam::get_global_iam_sys)
+    resolve_iam_handle_with(get_global_app_context(), runtime_sources::iam_handle)
 }
 
 /// Resolve OIDC system handle using AppContext-first precedence.
 pub fn resolve_oidc_handle() -> Option<Arc<OidcSys>> {
-    resolve_oidc_handle_with(get_global_app_context(), rustfs_iam::get_oidc)
+    resolve_oidc_handle_with(get_global_app_context(), runtime_sources::oidc_handle)
 }
 
 /// Resolve a ready IAM system handle using AppContext-first precedence.
 pub fn resolve_ready_iam_handle() -> rustfs_iam::error::Result<Arc<IamSys<ObjectStore>>> {
-    resolve_ready_iam_handle_with(get_global_app_context(), rustfs_iam::get)
+    resolve_ready_iam_handle_with(get_global_app_context(), runtime_sources::ready_iam_handle)
 }
 
 /// Resolve token signing key using AppContext-first precedence.
 pub fn resolve_token_signing_key() -> Option<String> {
-    resolve_token_signing_key_with(get_global_app_context(), rustfs_iam::manager::get_token_signing_key)
+    resolve_token_signing_key_with(get_global_app_context(), runtime_sources::token_signing_key)
 }
 
 /// Resolve bucket metadata handle using AppContext-first precedence.
@@ -117,7 +115,9 @@ pub fn resolve_object_store_handle() -> Option<Arc<ECStore>> {
 
 /// Resolve object store handle using an explicit AppContext, falling back to the legacy global object layer.
 pub fn resolve_object_store_handle_for_context(context: Option<&AppContext>) -> Option<Arc<ECStore>> {
-    context.map(|context| context.object_store()).or_else(new_object_layer_fn)
+    context
+        .map(|context| context.object_store())
+        .or_else(runtime_sources::object_store)
 }
 
 /// Resolve notify interface using AppContext-first precedence.
@@ -217,7 +217,7 @@ pub async fn resolve_s3select_db(
 
 /// Resolve local node name using AppContext-first precedence.
 pub async fn resolve_local_node_name() -> String {
-    resolve_local_node_name_with(get_global_app_context(), rustfs_common::get_global_local_node_name).await
+    resolve_local_node_name_with(get_global_app_context(), runtime_sources::local_node_name).await
 }
 
 /// Resolve action credentials using AppContext-first precedence.
@@ -564,7 +564,6 @@ fn resolve_buffer_config_with(
 mod tests {
     use super::super::Endpoint;
     use super::super::init_local_disks;
-    use super::super::new_object_layer_fn;
     use super::super::{Endpoints, PoolEndpoints};
     use super::*;
     use crate::app::context::global::AppContextTestInterfaces;
@@ -912,7 +911,7 @@ mod tests {
     }
 
     async fn test_store() -> (TempDir, Arc<ECStore>, EndpointServerPools) {
-        if let Some(store) = new_object_layer_fn() {
+        if let Some(store) = runtime_sources::object_store() {
             let endpoints = EndpointServerPools(store.pools.iter().map(|pool| pool.endpoints.clone()).collect());
             return (tempfile::tempdir().expect("compat test temp dir"), store, endpoints);
         }
@@ -945,7 +944,7 @@ mod tests {
         };
         let endpoint_pools = EndpointServerPools(vec![pool_endpoints]);
 
-        if let Some(store) = new_object_layer_fn() {
+        if let Some(store) = runtime_sources::object_store() {
             return (temp_dir, store, endpoint_pools);
         }
 

--- a/rustfs/src/app/context/handles.rs
+++ b/rustfs/src/app/context/handles.rs
@@ -15,13 +15,7 @@
 use super::super::EndpointServerPools;
 use super::super::StorageClassConfig;
 use super::super::TierConfigMgr;
-use super::super::metadata_sys::{BucketMetadataSys, get_global_bucket_metadata_sys};
-use super::super::{
-    collect_scanner_metrics_report, get_daily_all_tier_stats, get_global_boot_time, get_global_bucket_monitor,
-    get_global_deployment_id, get_global_endpoints_opt, get_global_expiry_state, get_global_lock_client, get_global_lock_clients,
-    get_global_notification_sys, get_global_region, get_global_replication_pool, get_global_replication_stats,
-    get_global_tier_config_mgr, global_rustfs_port, set_global_storage_class,
-};
+use super::super::metadata_sys::BucketMetadataSys;
 use super::interfaces::{
     ActionCredentialInterface, BootTimeInterface, BucketMetadataInterface, BucketMonitorInterface, BufferConfigInterface,
     DeploymentIdInterface, EndpointsInterface, ExpiryStateInterface, IamInterface, InternodeMetricsInterface, KmsInterface,
@@ -30,26 +24,19 @@ use super::interfaces::{
     ReplicationPoolInterface, ReplicationStatsInterface, RuntimePortInterface, S3SelectDbInterface, ScannerMetricsInterface,
     ServerConfigInterface, StorageClassInterface, TierConfigInterface, TierStatsInterface,
 };
-use crate::config::{RustFSBufferConfig, get_global_buffer_config};
+use super::runtime_sources;
+use crate::config::RustFSBufferConfig;
 use async_trait::async_trait;
-use rustfs_common::get_global_local_node_name;
 use rustfs_config::server_config::Config;
-use rustfs_config::server_config::{get_global_server_config, set_global_server_config};
-use rustfs_credentials::{Credentials, get_global_action_cred};
-use rustfs_iam::{get_oidc, oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
-use rustfs_io_metrics::{
-    PerformanceMetrics,
-    global_metrics::get_global_metrics,
-    internode_metrics::{InternodeMetrics, global_internode_metrics},
-};
-use rustfs_kms::{KmsServiceManager, get_global_kms_service_manager};
+use rustfs_credentials::Credentials;
+use rustfs_iam::{oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
+use rustfs_io_metrics::{PerformanceMetrics, internode_metrics::InternodeMetrics};
+use rustfs_kms::KmsServiceManager;
 use rustfs_lock::LockClient;
-use rustfs_notify::{EventArgs, NotificationError, notifier_global};
+use rustfs_notify::{EventArgs, NotificationError};
 use rustfs_s3select_api::{QueryResult, server::dbms::DatabaseManagerSystem};
 use rustfs_targets::{EventName, arn::TargetID};
-use rustfs_tls_runtime::{
-    GlobalPublishedOutboundTlsState, TlsGeneration, load_global_outbound_tls_generation, load_global_outbound_tls_state,
-};
+use rustfs_tls_runtime::{GlobalPublishedOutboundTlsState, TlsGeneration};
 use s3s::dto::SelectObjectContentInput;
 use std::{collections::HashMap, sync::Arc, time::SystemTime};
 use tokio::sync::RwLock;
@@ -72,15 +59,15 @@ impl IamInterface for IamHandle {
     }
 
     fn is_ready(&self) -> bool {
-        rustfs_iam::get().is_ok()
+        runtime_sources::ready_iam_handle().is_ok()
     }
 
     fn oidc(&self) -> Option<Arc<OidcSys>> {
-        rustfs_iam::get_oidc()
+        runtime_sources::oidc_handle()
     }
 
     fn token_signing_key(&self) -> Option<String> {
-        rustfs_iam::manager::get_token_signing_key()
+        runtime_sources::token_signing_key()
     }
 }
 
@@ -90,7 +77,7 @@ pub struct OidcHandle;
 
 impl OidcInterface for OidcHandle {
     fn handle(&self) -> Option<Arc<OidcSys>> {
-        get_oidc()
+        runtime_sources::oidc_handle()
     }
 }
 
@@ -118,7 +105,7 @@ pub struct KmsRuntimeHandle;
 
 impl KmsRuntimeInterface for KmsRuntimeHandle {
     fn service_manager(&self) -> Option<Arc<KmsServiceManager>> {
-        get_global_kms_service_manager()
+        runtime_sources::kms_service_manager()
     }
 }
 
@@ -129,11 +116,11 @@ pub struct OutboundTlsRuntimeHandle;
 #[async_trait]
 impl OutboundTlsRuntimeInterface for OutboundTlsRuntimeHandle {
     fn generation(&self) -> TlsGeneration {
-        load_global_outbound_tls_generation()
+        runtime_sources::outbound_tls_generation()
     }
 
     async fn state(&self) -> GlobalPublishedOutboundTlsState {
-        load_global_outbound_tls_state().await
+        runtime_sources::outbound_tls_state().await
     }
 }
 
@@ -144,7 +131,7 @@ pub struct NotifyHandle;
 #[async_trait]
 impl NotifyInterface for NotifyHandle {
     async fn notify(&self, args: EventArgs) {
-        notifier_global::notify(args).await;
+        runtime_sources::notify(args).await;
     }
 
     async fn add_event_specific_rules(
@@ -153,11 +140,11 @@ impl NotifyInterface for NotifyHandle {
         region: &str,
         event_rules: &[(Vec<EventName>, String, String, Vec<TargetID>)],
     ) -> Result<(), NotificationError> {
-        notifier_global::add_event_specific_rules(bucket_name, region, event_rules).await
+        runtime_sources::add_event_specific_rules(bucket_name, region, event_rules).await
     }
 
     async fn clear_bucket_notification_rules(&self, bucket_name: &str) -> Result<(), NotificationError> {
-        notifier_global::clear_bucket_notification_rules(bucket_name).await
+        runtime_sources::clear_bucket_notification_rules(bucket_name).await
     }
 }
 
@@ -167,7 +154,7 @@ pub struct NotificationSystemHandle;
 
 impl NotificationSystemInterface for NotificationSystemHandle {
     fn handle(&self) -> Option<&'static super::super::NotificationSys> {
-        get_global_notification_sys()
+        runtime_sources::notification_system()
     }
 }
 
@@ -177,7 +164,7 @@ pub struct BucketMetadataHandle;
 
 impl BucketMetadataInterface for BucketMetadataHandle {
     fn handle(&self) -> Option<Arc<RwLock<BucketMetadataSys>>> {
-        get_global_bucket_metadata_sys()
+        runtime_sources::bucket_metadata()
     }
 }
 
@@ -187,7 +174,7 @@ pub struct BucketMonitorHandle;
 
 impl BucketMonitorInterface for BucketMonitorHandle {
     fn handle(&self) -> Option<Arc<super::super::BucketBandwidthMonitor>> {
-        get_global_bucket_monitor()
+        runtime_sources::bucket_monitor()
     }
 }
 
@@ -197,7 +184,7 @@ pub struct ReplicationPoolHandle;
 
 impl ReplicationPoolInterface for ReplicationPoolHandle {
     fn handle(&self) -> Option<Arc<super::super::DynReplicationPool>> {
-        get_global_replication_pool()
+        runtime_sources::replication_pool()
     }
 }
 
@@ -207,7 +194,7 @@ pub struct ReplicationStatsHandle;
 
 impl ReplicationStatsInterface for ReplicationStatsHandle {
     fn handle(&self) -> Option<Arc<super::super::ReplicationStats>> {
-        get_global_replication_stats()
+        runtime_sources::replication_stats()
     }
 }
 
@@ -217,7 +204,7 @@ pub struct BootTimeHandle;
 
 impl BootTimeInterface for BootTimeHandle {
     fn get(&self) -> Option<SystemTime> {
-        get_global_boot_time()
+        runtime_sources::boot_time()
     }
 }
 
@@ -227,7 +214,7 @@ pub struct TierStatsHandle;
 
 impl TierStatsInterface for TierStatsHandle {
     fn daily_all(&self) -> super::super::DailyAllTierStats {
-        get_daily_all_tier_stats()
+        runtime_sources::daily_tier_stats()
     }
 }
 
@@ -238,7 +225,7 @@ pub struct ScannerMetricsHandle;
 #[async_trait]
 impl ScannerMetricsInterface for ScannerMetricsHandle {
     async fn report(&self) -> super::super::ScannerMetricsReport {
-        collect_scanner_metrics_report().await
+        runtime_sources::scanner_metrics_report().await
     }
 }
 
@@ -248,7 +235,7 @@ pub struct EndpointsHandle;
 
 impl EndpointsInterface for EndpointsHandle {
     fn handle(&self) -> Option<EndpointServerPools> {
-        get_global_endpoints_opt()
+        runtime_sources::endpoints()
     }
 }
 
@@ -258,7 +245,7 @@ pub struct DeploymentIdHandle;
 
 impl DeploymentIdInterface for DeploymentIdHandle {
     fn get(&self) -> Option<String> {
-        get_global_deployment_id()
+        runtime_sources::deployment_id()
     }
 }
 
@@ -268,7 +255,7 @@ pub struct RuntimePortHandle;
 
 impl RuntimePortInterface for RuntimePortHandle {
     fn get(&self) -> u16 {
-        global_rustfs_port()
+        runtime_sources::runtime_port()
     }
 }
 
@@ -278,7 +265,7 @@ pub struct LockClientHandle;
 
 impl LockClientInterface for LockClientHandle {
     fn handle(&self) -> Option<Arc<dyn LockClient>> {
-        get_global_lock_client()
+        runtime_sources::lock_client()
     }
 }
 
@@ -288,7 +275,7 @@ pub struct LockClientsHandle;
 
 impl LockClientsInterface for LockClientsHandle {
     fn handle(&self) -> Option<HashMap<String, Arc<dyn LockClient>>> {
-        get_global_lock_clients().cloned()
+        runtime_sources::lock_clients()
     }
 }
 
@@ -298,7 +285,7 @@ pub struct PerformanceMetricsHandle;
 
 impl PerformanceMetricsInterface for PerformanceMetricsHandle {
     fn handle(&self) -> Arc<PerformanceMetrics> {
-        get_global_metrics()
+        runtime_sources::performance_metrics()
     }
 }
 
@@ -308,7 +295,7 @@ pub struct InternodeMetricsHandle;
 
 impl InternodeMetricsInterface for InternodeMetricsHandle {
     fn handle(&self) -> Arc<InternodeMetrics> {
-        global_internode_metrics().clone()
+        runtime_sources::internode_metrics()
     }
 }
 
@@ -323,7 +310,7 @@ impl S3SelectDbInterface for S3SelectDbHandle {
         input: SelectObjectContentInput,
         enable_debug: bool,
     ) -> QueryResult<Arc<dyn DatabaseManagerSystem + Send + Sync>> {
-        rustfs_s3select_query::get_global_db(input, enable_debug).await
+        runtime_sources::s3select_db(input, enable_debug).await
     }
 }
 
@@ -334,7 +321,7 @@ pub struct LocalNodeNameHandle;
 #[async_trait]
 impl LocalNodeNameInterface for LocalNodeNameHandle {
     async fn get(&self) -> String {
-        get_global_local_node_name().await
+        runtime_sources::local_node_name().await
     }
 }
 
@@ -344,7 +331,7 @@ pub struct ActionCredentialHandle;
 
 impl ActionCredentialInterface for ActionCredentialHandle {
     fn get(&self) -> Option<Credentials> {
-        get_global_action_cred()
+        runtime_sources::action_credentials()
     }
 }
 
@@ -354,7 +341,7 @@ pub struct RegionHandle;
 
 impl RegionInterface for RegionHandle {
     fn get(&self) -> Option<s3s::region::Region> {
-        get_global_region()
+        runtime_sources::region()
     }
 }
 
@@ -364,7 +351,7 @@ pub struct TierConfigHandle;
 
 impl TierConfigInterface for TierConfigHandle {
     fn handle(&self) -> Arc<RwLock<TierConfigMgr>> {
-        get_global_tier_config_mgr()
+        runtime_sources::tier_config()
     }
 }
 
@@ -374,7 +361,7 @@ pub struct ExpiryStateHandle;
 
 impl ExpiryStateInterface for ExpiryStateHandle {
     fn handle(&self) -> Arc<RwLock<super::super::ExpiryState>> {
-        get_global_expiry_state()
+        runtime_sources::expiry_state()
     }
 }
 
@@ -384,11 +371,11 @@ pub struct ServerConfigHandle;
 
 impl ServerConfigInterface for ServerConfigHandle {
     fn get(&self) -> Option<Config> {
-        get_global_server_config()
+        runtime_sources::server_config()
     }
 
     fn set(&self, config: Config) {
-        set_global_server_config(config);
+        runtime_sources::set_server_config(config);
     }
 }
 
@@ -398,7 +385,7 @@ pub struct StorageClassHandle;
 
 impl StorageClassInterface for StorageClassHandle {
     fn set(&self, config: StorageClassConfig) {
-        set_global_storage_class(config);
+        runtime_sources::set_storage_class(config);
     }
 }
 
@@ -408,7 +395,7 @@ pub struct BufferConfigHandle;
 
 impl BufferConfigInterface for BufferConfigHandle {
     fn get(&self) -> RustFSBufferConfig {
-        get_global_buffer_config().clone()
+        runtime_sources::buffer_config()
     }
 }
 

--- a/rustfs/src/app/context/runtime_sources.rs
+++ b/rustfs/src/app/context/runtime_sources.rs
@@ -1,0 +1,211 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::metadata_sys::BucketMetadataSys;
+use super::super::{
+    BucketBandwidthMonitor, DailyAllTierStats, DynReplicationPool, ECStore, EndpointServerPools, ExpiryState, NotificationSys,
+    ReplicationStats, ScannerMetricsReport, StorageClassConfig, TierConfigMgr, collect_scanner_metrics_report,
+    get_daily_all_tier_stats, get_global_boot_time, get_global_bucket_monitor, get_global_deployment_id,
+    get_global_endpoints_opt, get_global_expiry_state, get_global_lock_client, get_global_lock_clients,
+    get_global_notification_sys, get_global_region, get_global_replication_pool, get_global_replication_stats,
+    get_global_tier_config_mgr, global_rustfs_port, new_object_layer_fn, set_global_storage_class,
+};
+use crate::config::{RustFSBufferConfig, get_global_buffer_config};
+use rustfs_config::server_config::{Config, get_global_server_config, set_global_server_config};
+use rustfs_credentials::{Credentials, get_global_action_cred};
+use rustfs_iam::{error::Result as IamResult, oidc::OidcSys, store::object::ObjectStore, sys::IamSys};
+use rustfs_io_metrics::{
+    PerformanceMetrics,
+    global_metrics::get_global_metrics,
+    internode_metrics::{InternodeMetrics, global_internode_metrics},
+};
+use rustfs_kms::{KmsServiceManager, ObjectEncryptionService};
+use rustfs_lock::LockClient;
+use rustfs_notify::{EventArgs, NotificationError, notifier_global};
+use rustfs_s3select_api::{QueryResult, server::dbms::DatabaseManagerSystem};
+use rustfs_targets::{EventName, arn::TargetID};
+use rustfs_tls_runtime::{
+    GlobalPublishedOutboundTlsState, TlsGeneration, load_global_outbound_tls_generation, load_global_outbound_tls_state,
+};
+use s3s::dto::SelectObjectContentInput;
+use std::{collections::HashMap, sync::Arc, time::SystemTime};
+use tokio::sync::RwLock;
+
+pub fn kms_service_manager() -> Option<Arc<KmsServiceManager>> {
+    rustfs_kms::get_global_kms_service_manager()
+}
+
+pub fn init_kms_service_manager() -> Arc<KmsServiceManager> {
+    rustfs_kms::init_global_kms_service_manager()
+}
+
+pub async fn encryption_service() -> Option<Arc<ObjectEncryptionService>> {
+    rustfs_kms::get_global_encryption_service().await
+}
+
+pub fn outbound_tls_generation() -> TlsGeneration {
+    load_global_outbound_tls_generation()
+}
+
+#[cfg(test)]
+pub fn set_outbound_tls_generation(generation: u64) {
+    rustfs_common::set_global_outbound_tls_generation(generation);
+}
+
+pub async fn outbound_tls_state() -> GlobalPublishedOutboundTlsState {
+    load_global_outbound_tls_state().await
+}
+
+pub fn iam_is_ready() -> bool {
+    rustfs_iam::get_global_iam_sys().is_some_and(|sys| sys.is_ready())
+}
+
+pub fn iam_handle() -> Option<Arc<IamSys<ObjectStore>>> {
+    rustfs_iam::get_global_iam_sys()
+}
+
+pub fn ready_iam_handle() -> IamResult<Arc<IamSys<ObjectStore>>> {
+    rustfs_iam::get()
+}
+
+pub fn oidc_handle() -> Option<Arc<OidcSys>> {
+    rustfs_iam::get_oidc()
+}
+
+pub fn token_signing_key() -> Option<String> {
+    rustfs_iam::manager::get_token_signing_key()
+}
+
+pub async fn notify(args: EventArgs) {
+    notifier_global::notify(args).await;
+}
+
+pub async fn add_event_specific_rules(
+    bucket_name: &str,
+    region: &str,
+    event_rules: &[(Vec<EventName>, String, String, Vec<TargetID>)],
+) -> Result<(), NotificationError> {
+    notifier_global::add_event_specific_rules(bucket_name, region, event_rules).await
+}
+
+pub async fn clear_bucket_notification_rules(bucket_name: &str) -> Result<(), NotificationError> {
+    notifier_global::clear_bucket_notification_rules(bucket_name).await
+}
+
+pub fn notification_system() -> Option<&'static NotificationSys> {
+    get_global_notification_sys()
+}
+
+pub fn bucket_metadata() -> Option<Arc<RwLock<BucketMetadataSys>>> {
+    super::super::metadata_sys::get_global_bucket_metadata_sys()
+}
+
+pub fn bucket_monitor() -> Option<Arc<BucketBandwidthMonitor>> {
+    get_global_bucket_monitor()
+}
+
+pub fn replication_pool() -> Option<Arc<DynReplicationPool>> {
+    get_global_replication_pool()
+}
+
+pub fn replication_stats() -> Option<Arc<ReplicationStats>> {
+    get_global_replication_stats()
+}
+
+pub fn boot_time() -> Option<SystemTime> {
+    get_global_boot_time()
+}
+
+pub fn daily_tier_stats() -> DailyAllTierStats {
+    get_daily_all_tier_stats()
+}
+
+pub async fn scanner_metrics_report() -> ScannerMetricsReport {
+    collect_scanner_metrics_report().await
+}
+
+pub fn endpoints() -> Option<EndpointServerPools> {
+    get_global_endpoints_opt()
+}
+
+pub fn deployment_id() -> Option<String> {
+    get_global_deployment_id()
+}
+
+pub fn runtime_port() -> u16 {
+    global_rustfs_port()
+}
+
+pub fn lock_client() -> Option<Arc<dyn LockClient>> {
+    get_global_lock_client()
+}
+
+pub fn lock_clients() -> Option<HashMap<String, Arc<dyn LockClient>>> {
+    get_global_lock_clients().cloned()
+}
+
+pub fn performance_metrics() -> Arc<PerformanceMetrics> {
+    get_global_metrics()
+}
+
+pub fn internode_metrics() -> Arc<InternodeMetrics> {
+    global_internode_metrics().clone()
+}
+
+pub async fn s3select_db(
+    input: SelectObjectContentInput,
+    enable_debug: bool,
+) -> QueryResult<Arc<dyn DatabaseManagerSystem + Send + Sync>> {
+    rustfs_s3select_query::get_global_db(input, enable_debug).await
+}
+
+pub async fn local_node_name() -> String {
+    rustfs_common::get_global_local_node_name().await
+}
+
+pub fn action_credentials() -> Option<Credentials> {
+    get_global_action_cred()
+}
+
+pub fn region() -> Option<s3s::region::Region> {
+    get_global_region()
+}
+
+pub fn tier_config() -> Arc<RwLock<TierConfigMgr>> {
+    get_global_tier_config_mgr()
+}
+
+pub fn expiry_state() -> Arc<RwLock<ExpiryState>> {
+    get_global_expiry_state()
+}
+
+pub fn server_config() -> Option<Config> {
+    get_global_server_config()
+}
+
+pub fn set_server_config(config: Config) {
+    set_global_server_config(config);
+}
+
+pub fn set_storage_class(config: StorageClassConfig) {
+    set_global_storage_class(config);
+}
+
+pub fn buffer_config() -> RustFSBufferConfig {
+    get_global_buffer_config().clone()
+}
+
+pub fn object_store() -> Option<Arc<ECStore>> {
+    new_object_layer_fn()
+}

--- a/rustfs/src/app/context/startup.rs
+++ b/rustfs/src/app/context/startup.rs
@@ -14,6 +14,7 @@
 
 use super::super::ECStore;
 use super::global::{AppContext, get_global_app_context, init_global_app_context};
+use super::runtime_sources;
 use rustfs_kms::KmsServiceManager;
 use std::io::{Error, Result};
 use std::sync::Arc;
@@ -26,14 +27,15 @@ pub(crate) enum StartupAppContextBootstrap {
 
 impl AppContext {
     pub(crate) fn ensure_startup_kms_interface() -> Arc<KmsServiceManager> {
-        ensure_startup_kms_interface_with(rustfs_kms::get_global_kms_service_manager, rustfs_kms::init_global_kms_service_manager)
+        ensure_startup_kms_interface_with(runtime_sources::kms_service_manager, runtime_sources::init_kms_service_manager)
     }
 
     pub(crate) fn ensure_startup_after_iam(store: Arc<ECStore>, kms_interface: Arc<KmsServiceManager>) -> Result<()> {
         ensure_startup_app_context_after_iam_with(
             || get_global_app_context().is_some(),
             || {
-                let iam_interface = rustfs_iam::get().map_err(|_| Error::other("IAM is initialized but unavailable"))?;
+                let iam_interface =
+                    runtime_sources::ready_iam_handle().map_err(|_| Error::other("IAM is initialized but unavailable"))?;
                 init_global_app_context(AppContext::with_default_interfaces(store, iam_interface, kms_interface));
                 Ok(())
             },

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -152,6 +152,7 @@ ECSTORE_COMPAT_PASSTHROUGH_ACTUAL_FILE="${TMP_DIR}/ecstore_compat_passthrough_ac
 ECSTORE_COMPAT_PASSTHROUGH_DIFF_FILE="${TMP_DIR}/ecstore_compat_passthrough_diff.txt"
 RUSTFS_WORKLOAD_DIRECT_FOREGROUND_MAPPING_HITS_FILE="${TMP_DIR}/rustfs_workload_direct_foreground_mapping_hits.txt"
 IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/iam_runtime_source_bypass_hits.txt"
+RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_context_runtime_source_bypass_hits.txt"
 
 awk '
   /^## PR Types$/ {
@@ -1304,6 +1305,19 @@ fi
 
 if [[ -s "$IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
   report_failure "IAM runtime-source globals must stay behind crates/iam/src/runtime_sources.rs: $(paste -sd '; ' "$IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'get_global_(?:kms_service_manager|encryption_service|iam_sys|action_cred|server_config|notification_sys|bucket_metadata_sys|bucket_monitor|replication_pool|replication_stats|boot_time|endpoints_opt|deployment_id|lock_client|lock_clients|region|tier_config_mgr|expiry_state|local_node_name|buffer_config|db)|init_global_kms_service_manager|set_global_(?:server_config|storage_class|outbound_tls_generation)|load_global_outbound_tls_(?:generation|state)|global_(?:rustfs_port|internode_metrics)|get_daily_all_tier_stats|collect_scanner_metrics_report|new_object_layer_fn|notifier_global::' \
+    rustfs/src/app/context.rs \
+    rustfs/src/app/context \
+    --glob '*.rs' |
+    rg -v '^rustfs/src/app/context/runtime_sources\.rs:' || true
+) >"$RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE"
+
+if [[ -s "$RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
+  report_failure "RustFS AppContext fallback runtime globals must stay behind rustfs/src/app/context/runtime_sources.rs: $(paste -sd '; ' "$RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add an AppContext runtime source boundary for fallback global access.
- Route default AppContext adapters through the new boundary for KMS, IAM, ECStore, config, metrics, TLS, S3 Select, and credential sources.
- Extend migration guardrails and progress notes for the AppContext fallback boundary.

## Verification
- `cargo test -p rustfs app::context --lib -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `make pre-pr`

## Impact
No user-facing behavior change. This keeps AppContext fallback runtime access behind a single owner boundary.

## Additional Notes
N/A
