### PR TITLE
refactor: centralize startup runtime sources

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,8 +5,8 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-app-context-runtime-source-fallbacks`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202`.
+- Branch: `overtrue/arch-startup-runtime-sources`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203`.
 - Based on: stacked on PR #3828 head after PR #3827.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
@@ -41,7 +41,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   runtime config, erasure-mode, lifecycle queue, and tier runtime source helper
   names, plus IAM root-credential, server-config, and notification runtime
   source helpers, plus AppContext fallback KMS/IAM/ECStore/config/metrics/TLS
-  runtime source helpers,
+  runtime source helpers, plus startup/root KMS, credentials, region,
+  readiness-time, observability, metrics, buffer, and TLS runtime source
+  helpers,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -52,7 +54,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   event-bridge thin module regressions, plus IAM runtime-source bypasses;
   accept the reviewed AppContext resolver reverse dependencies in the layer
   baseline.
-- Docs changes: record the API-136 through API-202 owner facade and lifecycle
+- Docs changes: record the API-136 through API-203 owner facade and lifecycle
   runtime-source cleanup.
 
 ## Phase 0 Tasks
@@ -5178,7 +5180,29 @@ Passed before push:
     merged API-184.
   - `make pre-commit`: passed.
 
-- Issue #660 API-202 current slice:
+- Issue #660 API-203 current slice:
+  - Do: centralize startup/root runtime global publication and initialization
+    behind `rustfs/src/startup_runtime_sources.rs`, including action
+    credentials, runtime region/port/address, init time, KMS manager,
+    observability guard, metrics runtime, buffer profile, and outbound TLS
+    generation/state metrics.
+  - Must preserve: startup ordering, embedded startup semantics, KMS
+    configuration behavior, observability guard error classification, buffer
+    profile fallback behavior, TLS startup publish behavior, and TLS reload
+    loop behavior.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - `cargo check --tests -p rustfs`: passed.
+  - `cargo test -p rustfs startup --lib -- --nocapture`: passed.
+  - `git diff --check`: passed.
+  - Rust risk scan: passed; no new production unwrap/expect, unchecked narrow
+    casts, stringly errors, or ad-hoc stdout/stderr.
+  - `make pre-pr`: passed after rebasing onto current `origin/main`.
+  - Verification: focused checks and full `make pre-pr` passed before PR.
+
+- Issue #660 API-202 prior slice:
   - `cargo test -p rustfs app::context --lib -- --nocapture`: passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.
@@ -5186,7 +5210,7 @@ Passed before push:
   - `./scripts/check_layer_dependencies.sh`: passed.
   - AppContext fallback runtime source scan: passed; direct fallback global
     reads should be isolated to `rustfs/src/app/context/runtime_sources.rs`.
-  - Verification: focused checks passed; full `make pre-pr` pending before PR.
+  - Verification: focused checks and full `make pre-pr` passed before PR.
 
 - Issue #660 API-184 current slice:
   - `cargo check -p rustfs-rio --tests`: passed.

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -17,7 +17,7 @@ use crate::server::ShutdownHandle;
 use crate::storage::{
     get_bucket_notification_config, process_lambda_configurations, process_queue_configurations, process_topic_configurations,
 };
-use crate::{admin, config, version};
+use crate::{admin, config, startup_runtime_sources, version};
 use rustfs_config::{
     DEFAULT_BUFFER_MAX_SIZE, DEFAULT_BUFFER_MIN_SIZE, DEFAULT_BUFFER_PROFILE, DEFAULT_BUFFER_UNKNOWN_SIZE, DEFAULT_UPDATE_CHECK,
     ENV_RUSTFS_BUFFER_DEFAULT_SIZE, ENV_RUSTFS_BUFFER_MAX_SIZE, ENV_RUSTFS_BUFFER_MIN_SIZE, ENV_UPDATE_CHECK, RUSTFS_REGION,
@@ -403,7 +403,7 @@ async fn configure_and_start_kms(
 #[instrument(skip(config))]
 pub async fn init_kms_system(config: &config::Config) -> std::io::Result<()> {
     // Initialize global KMS service manager (starts in NotConfigured state)
-    let service_manager = rustfs_kms::init_global_kms_service_manager();
+    let service_manager = startup_runtime_sources::init_kms_service_manager();
 
     // If KMS is enabled in configuration, configure and start the service
     if config.kms_enable {
@@ -491,7 +491,7 @@ pub async fn init_kms_system(config: &config::Config) -> std::io::Result<()> {
 /// # Arguments
 /// * `config` - The application configuration options
 pub fn init_buffer_profile_system(config: &config::Config) {
-    use crate::config::{WorkloadProfile, init_global_buffer_config, set_buffer_profile_enabled};
+    use crate::config::WorkloadProfile;
 
     // Whether buffer profiling is disabled or not, it is enabled by default, unless the user explicitly sets '--buffer-profile-disable' or 'RUSTFS_BUFFER_PROFILE_DISABLE=true'
     if config.buffer_profile_disable {
@@ -506,7 +506,7 @@ pub fn init_buffer_profile_system(config: &config::Config) {
             reason = "flag_override",
             "Buffer profile state changed"
         );
-        set_buffer_profile_enabled(false);
+        startup_runtime_sources::set_buffer_profile_enabled(false);
     } else {
         // Enabled by default: use configured workload profile
         info!(
@@ -574,7 +574,7 @@ pub fn init_buffer_profile_system(config: &config::Config) {
                 fallback_profile = DEFAULT_BUFFER_PROFILE,
                 "Buffer profile initialization disabled after validation failures"
             );
-            set_buffer_profile_enabled(false);
+            startup_runtime_sources::set_buffer_profile_enabled(false);
             return;
         };
 
@@ -590,10 +590,10 @@ pub fn init_buffer_profile_system(config: &config::Config) {
         );
 
         // Initialize the global buffer configuration
-        init_global_buffer_config(buffer_config);
+        startup_runtime_sources::init_buffer_config(buffer_config);
 
         // Enable buffer profiling globally
-        set_buffer_profile_enabled(true);
+        startup_runtime_sources::set_buffer_profile_enabled(true);
 
         info!(
             target: "rustfs::init",

--- a/rustfs/src/lib.rs
+++ b/rustfs/src/lib.rs
@@ -87,6 +87,7 @@ pub(crate) mod startup_preflight;
 pub(crate) mod startup_protocols;
 pub(crate) mod startup_runtime;
 pub(crate) mod startup_runtime_hooks;
+pub(crate) mod startup_runtime_sources;
 pub(crate) mod startup_server;
 pub(crate) mod startup_services;
 pub(crate) mod startup_shutdown;

--- a/rustfs/src/server/tls_material.rs
+++ b/rustfs/src/server/tls_material.rs
@@ -20,7 +20,7 @@
 //! (system roots, leaf-as-CA, mTLS env-var path overrides) and builds the server
 //! TLS acceptor directly from the pre-loaded server material — no double reads.
 
-use crate::app::context::resolve_outbound_tls_generation;
+use crate::startup_runtime_sources;
 use rustfs_common::MtlsIdentityPem;
 use rustfs_config::{
     DEFAULT_SERVER_MTLS_ENABLE, DEFAULT_TLS_KEYLOG, DEFAULT_TLS_RELOAD_ENABLE, DEFAULT_TLS_RELOAD_INTERVAL,
@@ -30,8 +30,7 @@ use rustfs_config::{
 };
 use rustfs_tls_runtime::{
     ServerTlsMaterial as RuntimeServerTlsMaterial, TlsGeneration, TlsSource, WebPkiClientVerifierOptions,
-    build_webpki_client_verifier, create_multi_cert_resolver, publish_global_outbound_tls_state, record_tls_generation,
-    record_tls_reload_result, record_tls_reload_skipped,
+    build_webpki_client_verifier, create_multi_cert_resolver,
 };
 use rustfs_utils::{get_env_bool, get_env_opt_str};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
@@ -541,7 +540,7 @@ pub(crate) fn spawn_reload_loop(tls_path: String, holder: Arc<TlsAcceptorHolder>
             match rustfs_tls_runtime::TlsMaterialSnapshot::load(&tls_source).await {
                 Ok(mut snapshot) => {
                     if let Err(e) = enrich_outbound(&mut snapshot.outbound, &tls_dir).await {
-                        record_tls_reload_result("rustfs_server_reload_loop", "enrich_err", None, None);
+                        startup_runtime_sources::record_tls_reload_result("rustfs_server_reload_loop", "enrich_err", None, None);
                         warn!(
                             component = LOG_COMPONENT_TLS,
                             subsystem = LOG_SUBSYSTEM_TLS,
@@ -553,9 +552,9 @@ pub(crate) fn spawn_reload_loop(tls_path: String, holder: Arc<TlsAcceptorHolder>
                         continue;
                     }
 
-                    let generation = resolve_outbound_tls_generation().0.saturating_add(1);
-                    publish_global_outbound_tls_state(TlsGeneration(generation), &snapshot.outbound).await;
-                    record_tls_generation("rustfs_server_reload_loop", generation);
+                    let generation = startup_runtime_sources::current_outbound_tls_generation().saturating_add(1);
+                    startup_runtime_sources::publish_outbound_tls_state(TlsGeneration(generation), &snapshot.outbound).await;
+                    startup_runtime_sources::record_tls_generation("rustfs_server_reload_loop", generation);
                     if !snapshot.outbound.root_ca_pem.is_empty() {
                         info!(
                             component = LOG_COMPONENT_TLS,
@@ -578,10 +577,15 @@ pub(crate) fn spawn_reload_loop(tls_path: String, holder: Arc<TlsAcceptorHolder>
                                 "TLS reload state changed"
                             );
                             holder.swap(&new_holder);
-                            record_tls_reload_result("rustfs_server_reload_loop", "ok", None, Some(generation));
+                            startup_runtime_sources::record_tls_reload_result(
+                                "rustfs_server_reload_loop",
+                                "ok",
+                                None,
+                                Some(generation),
+                            );
                         }
                         Ok(None) => {
-                            record_tls_reload_skipped("rustfs_server_reload_loop", "no_acceptor");
+                            startup_runtime_sources::record_tls_reload_skipped("rustfs_server_reload_loop", "no_acceptor");
                             warn!(
                                 component = LOG_COMPONENT_TLS,
                                 subsystem = LOG_SUBSYSTEM_TLS,
@@ -592,7 +596,12 @@ pub(crate) fn spawn_reload_loop(tls_path: String, holder: Arc<TlsAcceptorHolder>
                             )
                         }
                         Err(e) => {
-                            record_tls_reload_result("rustfs_server_reload_loop", "acceptor_err", None, Some(generation));
+                            startup_runtime_sources::record_tls_reload_result(
+                                "rustfs_server_reload_loop",
+                                "acceptor_err",
+                                None,
+                                Some(generation),
+                            );
                             warn!(
                                 component = LOG_COMPONENT_TLS,
                                 subsystem = LOG_SUBSYSTEM_TLS,
@@ -606,7 +615,7 @@ pub(crate) fn spawn_reload_loop(tls_path: String, holder: Arc<TlsAcceptorHolder>
                     }
                 }
                 Err(e) => {
-                    record_tls_reload_result("rustfs_server_reload_loop", "load_err", None, None);
+                    startup_runtime_sources::record_tls_reload_result("rustfs_server_reload_loop", "load_err", None, None);
                     warn!(
                         component = LOG_COMPONENT_TLS,
                         subsystem = LOG_SUBSYSTEM_TLS,

--- a/rustfs/src/startup_lifecycle.rs
+++ b/rustfs/src/startup_lifecycle.rs
@@ -16,6 +16,7 @@ use crate::storage::ECStore;
 use crate::{
     server::{ServiceStateManager, ShutdownHandle, wait_for_shutdown},
     startup_iam::{IamBootstrapDisposition, publish_ready_for_iam_bootstrap},
+    startup_runtime_sources,
     startup_services::StartupServiceRuntime,
     startup_shutdown::run_startup_shutdown_sequence,
 };
@@ -122,7 +123,7 @@ pub(crate) async fn run_startup_runtime_lifecycle(lifecycle: StartupRuntimeLifec
         "RustFS server ready"
     );
     publish_ready_for_iam_bootstrap(iam_bootstrap, readiness.as_ref(), Some(state_manager.as_ref())).await?;
-    rustfs_common::set_global_init_time_now().await;
+    startup_runtime_sources::publish_init_time_now().await;
 
     if enable_scanner {
         init_data_scanner(shutdown_token.clone(), store).await;
@@ -156,7 +157,7 @@ pub(crate) async fn publish_embedded_startup_ready(
     readiness: &GlobalReadiness,
 ) -> Result<()> {
     publish_ready_for_iam_bootstrap(iam_bootstrap, readiness, None).await?;
-    rustfs_common::set_global_init_time_now().await;
+    startup_runtime_sources::publish_init_time_now().await;
     Ok(())
 }
 

--- a/rustfs/src/startup_observability.rs
+++ b/rustfs/src/startup_observability.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::init::{init_auto_tuner, init_update_check, print_server_info};
-use rustfs_obs::init_metrics_runtime;
+use crate::startup_runtime_sources;
 use tokio_util::sync::CancellationToken;
 
 pub(crate) async fn init_observability_runtime(ctx: CancellationToken) {
@@ -21,9 +21,9 @@ pub(crate) async fn init_observability_runtime(ctx: CancellationToken) {
     init_update_check();
     crate::allocator_reclaim::init_allocator_reclaim(ctx.clone());
 
-    if rustfs_obs::observability_metric_enabled() {
-        rustfs_io_metrics::set_put_stage_metrics_enabled(true);
-        init_metrics_runtime(ctx.clone());
+    if startup_runtime_sources::observability_metric_enabled() {
+        startup_runtime_sources::set_put_stage_metrics_enabled(true);
+        startup_runtime_sources::init_metrics_runtime(ctx.clone());
         crate::memory_observability::init_memory_observability(ctx.clone());
         init_auto_tuner(ctx).await;
     }

--- a/rustfs/src/startup_preflight.rs
+++ b/rustfs/src/startup_preflight.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{config::Config, license::init_license, startup_runtime::init_startup_runtime_foundation};
-use rustfs_obs::{init_obs, set_global_guard};
+use crate::{config::Config, license::init_license, startup_runtime::init_startup_runtime_foundation, startup_runtime_sources};
 use rustfs_utils::{ExternalEnvCompatReport, apply_external_env_compat};
 use std::{
     fmt,
@@ -73,11 +72,11 @@ pub(crate) async fn init_startup_server_preflight(
 }
 
 async fn init_startup_observability(obs_endpoint: String) -> std::result::Result<(), StartupServerPreflightError> {
-    let guard = init_obs(Some(obs_endpoint))
+    let guard = startup_runtime_sources::init_observability_guard(obs_endpoint)
         .await
         .map_err(|err| StartupServerPreflightError::ObservabilityInit(Error::other(err)))?;
 
-    match set_global_guard(guard).map_err(Error::other) {
+    match startup_runtime_sources::set_observability_guard(guard).map_err(Error::other) {
         Ok(_) => {
             debug!(
                 target: "rustfs::main",

--- a/rustfs/src/startup_runtime_hooks.rs
+++ b/rustfs/src/startup_runtime_hooks.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::license::license_status;
+use crate::startup_runtime_sources;
 use rustls::crypto::aws_lc_rs::default_provider;
 use std::future::Future;
 use std::io::{Error, Result};
@@ -104,10 +105,10 @@ pub(crate) fn install_default_crypto_provider() {
 }
 
 pub(crate) async fn init_embedded_runtime_hooks(obs_endpoint: String) -> Result<()> {
-    let guard = rustfs_obs::init_obs(Some(obs_endpoint))
+    let guard = startup_runtime_sources::init_observability_guard(obs_endpoint)
         .await
         .map_err(|err| Error::other(format!("init_obs: {err}")))?;
-    rustfs_obs::set_global_guard(guard).map_err(|err| Error::other(format!("set_global_guard: {err}")))?;
+    startup_runtime_sources::set_observability_guard(guard).map_err(|err| Error::other(format!("set_global_guard: {err}")))?;
 
     install_embedded_default_crypto_provider();
     rustfs_trusted_proxies::init();

--- a/rustfs/src/startup_runtime_sources.rs
+++ b/rustfs/src/startup_runtime_sources.rs
@@ -1,0 +1,105 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::RustFSBufferConfig;
+use crate::storage::{set_global_region, set_global_rustfs_port};
+use rustfs_kms::KmsServiceManager;
+use rustfs_obs::{GlobalError as ObservabilityError, OtelGuard};
+use rustfs_tls_runtime::{OutboundTlsMaterial, TlsGeneration};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+pub(crate) fn init_action_credentials(
+    access_key: String,
+    secret_key: String,
+) -> Result<(), rustfs_credentials::CredentialsError> {
+    rustfs_credentials::init_global_action_credentials(Some(access_key), Some(secret_key))
+}
+
+pub(crate) fn publish_region(region: s3s::region::Region) {
+    set_global_region(region);
+}
+
+pub(crate) fn publish_server_port(port: u16) {
+    set_global_rustfs_port(port);
+}
+
+pub(crate) async fn publish_server_addr(addr: &str) {
+    rustfs_common::set_global_addr(addr).await;
+}
+
+pub(crate) async fn publish_init_time_now() {
+    rustfs_common::set_global_init_time_now().await;
+}
+
+pub(crate) fn init_kms_service_manager() -> Arc<KmsServiceManager> {
+    rustfs_kms::init_global_kms_service_manager()
+}
+
+pub(crate) fn init_buffer_config(buffer_config: RustFSBufferConfig) {
+    crate::config::init_global_buffer_config(buffer_config);
+}
+
+pub(crate) fn set_buffer_profile_enabled(enabled: bool) {
+    crate::config::set_buffer_profile_enabled(enabled);
+}
+
+pub(crate) async fn init_observability_guard(obs_endpoint: String) -> Result<OtelGuard, ObservabilityError> {
+    rustfs_obs::init_obs(Some(obs_endpoint)).await
+}
+
+pub(crate) fn set_observability_guard(guard: OtelGuard) -> Result<(), ObservabilityError> {
+    rustfs_obs::set_global_guard(guard)
+}
+
+pub(crate) fn observability_metric_enabled() -> bool {
+    rustfs_obs::observability_metric_enabled()
+}
+
+pub(crate) fn init_metrics_runtime(ctx: CancellationToken) {
+    rustfs_obs::init_metrics_runtime(ctx);
+}
+
+pub(crate) fn set_put_stage_metrics_enabled(enabled: bool) {
+    rustfs_io_metrics::set_put_stage_metrics_enabled(enabled);
+}
+
+pub(crate) fn init_tls_metrics() {
+    rustfs_tls_runtime::init_tls_metrics();
+}
+
+pub(crate) fn current_outbound_tls_generation() -> u64 {
+    crate::app::context::resolve_outbound_tls_generation().0
+}
+
+pub(crate) async fn publish_outbound_tls_state(generation: TlsGeneration, outbound: &OutboundTlsMaterial) {
+    rustfs_tls_runtime::publish_global_outbound_tls_state(generation, outbound).await;
+}
+
+pub(crate) fn record_tls_generation(consumer: &'static str, generation: u64) {
+    rustfs_tls_runtime::record_tls_generation(consumer, generation);
+}
+
+pub(crate) fn record_tls_reload_result(
+    consumer: &'static str,
+    result: &'static str,
+    duration_secs: Option<f64>,
+    generation: Option<u64>,
+) {
+    rustfs_tls_runtime::record_tls_reload_result(consumer, result, duration_secs, generation);
+}
+
+pub(crate) fn record_tls_reload_skipped(consumer: &'static str, reason: &'static str) {
+    rustfs_tls_runtime::record_tls_reload_skipped(consumer, reason);
+}

--- a/rustfs/src/startup_server.rs
+++ b/rustfs/src/startup_server.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage::{set_global_region, set_global_rustfs_port};
 use crate::{
     capacity::capacity_integration::init_capacity_management,
     config::Config,
     server::{ServiceState, ServiceStateManager, ShutdownHandle, start_http_server},
+    startup_runtime_sources,
 };
-use rustfs_common::{GlobalReadiness, set_global_addr};
-use rustfs_credentials::init_global_action_credentials;
+use rustfs_common::GlobalReadiness;
 use rustfs_utils::net::parse_and_resolve_address;
 use std::{
     io::{Error, ErrorKind, Result},
@@ -84,7 +83,7 @@ pub(crate) async fn init_startup_listen_context(config: &Config) -> Result<Start
     if let Some(region_str) = &config.region {
         region_str
             .parse::<s3s::region::Region>()
-            .map(set_global_region)
+            .map(startup_runtime_sources::publish_region)
             .map_err(|err| Error::other(format!("invalid region '{}': {}", region_str, err)))?;
     }
 
@@ -116,8 +115,8 @@ pub(crate) async fn init_startup_listen_context(config: &Config) -> Result<Start
     );
 
     init_startup_action_credentials(config)?;
-    set_global_rustfs_port(server_port);
-    set_global_addr(&config.address).await;
+    startup_runtime_sources::publish_server_port(server_port);
+    startup_runtime_sources::publish_server_addr(&config.address).await;
 
     Ok(StartupListenContext {
         readiness,
@@ -205,18 +204,18 @@ pub(crate) async fn init_embedded_startup_listen_context(config: &Config) -> Res
         ));
     }
 
-    init_global_action_credentials(Some(config.access_key.clone()), Some(config.secret_key.clone()))
+    startup_runtime_sources::init_action_credentials(config.access_key.clone(), config.secret_key.clone())
         .map_err(|err| Error::other(format!("credentials: {err:?}")))?;
 
     if let Some(region_str) = &config.region {
         region_str
             .parse::<s3s::region::Region>()
-            .map(set_global_region)
+            .map(startup_runtime_sources::publish_region)
             .map_err(|err| Error::other(format!("invalid region '{region_str}': {err}")))?;
     }
 
-    set_global_rustfs_port(server_addr.port());
-    set_global_addr(&config.address).await;
+    startup_runtime_sources::publish_server_port(server_addr.port());
+    startup_runtime_sources::publish_server_addr(&config.address).await;
 
     Ok(EmbeddedStartupListenContext {
         readiness,
@@ -276,7 +275,7 @@ fn log_sanitized_server_config(config: &Config) {
 }
 
 fn init_startup_action_credentials(config: &Config) -> Result<()> {
-    match init_global_action_credentials(Some(config.access_key.clone()), Some(config.secret_key.clone())) {
+    match startup_runtime_sources::init_action_credentials(config.access_key.clone(), config.secret_key.clone()) {
         Ok(_) => {
             debug!(
                 target: "rustfs::main::run",

--- a/rustfs/src/startup_tls_material.rs
+++ b/rustfs/src/startup_tls_material.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::app::context::resolve_outbound_tls_generation;
 use crate::config::Config;
+use crate::startup_runtime_sources;
 use std::io::{Error, Result};
 use tracing::{error, info};
 
@@ -27,11 +27,9 @@ pub(crate) async fn init_outbound_tls_material(config: &Config) -> Result<()> {
     if let Some(tls_path) = normalized_tls_path(config.tls_path.as_deref()) {
         match crate::server::tls_material::load_tls_material(tls_path).await {
             Ok(snapshot) => {
-                use rustfs_tls_runtime::{publish_global_outbound_tls_state, record_tls_generation};
-
-                let generation = next_tls_generation(resolve_outbound_tls_generation().0);
-                publish_global_outbound_tls_state(generation, &snapshot.outbound).await;
-                record_tls_generation(TLS_STARTUP_GENERATION_CONSUMER, generation.0);
+                let generation = next_tls_generation(startup_runtime_sources::current_outbound_tls_generation());
+                startup_runtime_sources::publish_outbound_tls_state(generation, &snapshot.outbound).await;
+                startup_runtime_sources::record_tls_generation(TLS_STARTUP_GENERATION_CONSUMER, generation.0);
                 info!(
                     target: "rustfs::main",
                     event = EVENT_TLS_OUTBOUND_INITIALIZED,
@@ -55,8 +53,8 @@ pub(crate) async fn init_outbound_tls_material(config: &Config) -> Result<()> {
                 return Err(Error::other(err.to_string()));
             }
         }
-        if rustfs_obs::observability_metric_enabled() {
-            rustfs_tls_runtime::init_tls_metrics();
+        if startup_runtime_sources::observability_metric_enabled() {
+            startup_runtime_sources::init_tls_metrics();
         }
     }
 

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -153,6 +153,7 @@ ECSTORE_COMPAT_PASSTHROUGH_DIFF_FILE="${TMP_DIR}/ecstore_compat_passthrough_diff
 RUSTFS_WORKLOAD_DIRECT_FOREGROUND_MAPPING_HITS_FILE="${TMP_DIR}/rustfs_workload_direct_foreground_mapping_hits.txt"
 IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/iam_runtime_source_bypass_hits.txt"
 RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_context_runtime_source_bypass_hits.txt"
+RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_startup_runtime_source_bypass_hits.txt"
 
 awk '
   /^## PR Types$/ {
@@ -1318,6 +1319,21 @@ fi
 
 if [[ -s "$RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
   report_failure "RustFS AppContext fallback runtime globals must stay behind rustfs/src/app/context/runtime_sources.rs: $(paste -sd '; ' "$RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename '\b(?:init_global_action_credentials|set_global_region|set_global_rustfs_port|set_global_addr|set_global_init_time_now|init_global_kms_service_manager|init_global_buffer_config|set_buffer_profile_enabled)\b|rustfs_obs::(?:\{[^}]*\b(?:init_obs|set_global_guard)\b|(?:init_obs|set_global_guard|observability_metric_enabled|init_metrics_runtime)\b)|rustfs_io_metrics::set_put_stage_metrics_enabled\b|\b(?:publish_global_outbound_tls_state|record_tls_generation|record_tls_reload_result|record_tls_reload_skipped|init_tls_metrics)\b' \
+    rustfs/src/init.rs \
+    rustfs/src/startup_*.rs \
+    rustfs/src/server/tls_material.rs \
+    --glob '*.rs' |
+    rg -v 'startup_runtime_sources::' |
+    rg -v '^rustfs/src/startup_runtime_sources\.rs:' || true
+) >"$RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE"
+
+if [[ -s "$RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
+  report_failure "RustFS startup runtime globals must stay behind rustfs/src/startup_runtime_sources.rs: $(paste -sd '; ' "$RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
 fi
 
 (

--- a/scripts/layer-dependency-baseline.txt
+++ b/scripts/layer-dependency-baseline.txt
@@ -59,9 +59,7 @@ dep|rustfs/src/server/readiness.rs|infra->app|crate::app::context::resolve_endpo
 dep|rustfs/src/server/readiness.rs|infra->app|crate::app::context::resolve_iam_ready
 dep|rustfs/src/server/readiness.rs|infra->app|crate::app::context::resolve_lock_clients_handle
 dep|rustfs/src/server/readiness.rs|infra->app|crate::app::context::resolve_object_store_handle
-dep|rustfs/src/server/tls_material.rs|infra->app|crate::app::context::resolve_outbound_tls_generation
 dep|rustfs/src/startup_bucket_metadata.rs|infra->app|crate::app::context::resolve_replication_pool_handle
-dep|rustfs/src/startup_tls_material.rs|infra->app|crate::app::context::resolve_outbound_tls_generation
 dep|rustfs/src/startup_iam.rs|infra->app|crate::app::context::AppContext
 dep|rustfs/src/storage/ecfs_extend.rs|infra->app|crate::app::context::resolve_buffer_config
 dep|rustfs/src/storage/ecfs_extend.rs|infra->interface|crate::storage::ecfs::ListObjectUnorderedQuery


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add a startup runtime source boundary for root global publication and initialization.
- Route startup KMS, credentials, region/address/port, init time, observability, metrics, buffer, and outbound TLS runtime access through the new boundary.
- Extend migration guardrails and progress notes for the startup runtime source boundary.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo check --tests -p rustfs`
- `cargo test -p rustfs startup --lib -- --nocapture`
- `git diff --check`
- `make pre-pr`

## Impact
No user-facing behavior change. Startup ordering, embedded startup behavior, KMS setup, observability setup, buffer profiling, and TLS publish/reload behavior are preserved.

## Additional Notes
N/A
