### PR TITLE
refactor: route admin context imports

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,9 +5,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-root-runtime-sources-batch`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206`.
-- Based on: stacked on PR #3845 head while PR #3845 is pending.
+- Branch: `overtrue/arch-admin-context-import-batch`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207`.
+- Based on: stacked on PR #3846 head while PR #3846 is pending.
 - PR type for this branch: `consumer-migration`
 - Runtime behavior changes: none.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
@@ -45,7 +45,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   readiness-time, observability, metrics, buffer, and TLS runtime source
   helpers, plus server readiness/audit/event/module-switch runtime source
   helpers, storage request/RPC/SSE runtime source helpers, and admin
-  handler/service/router runtime source helpers, plus root auth/init/config/protocol/workload, app usecase, and storage node-service runtime source helpers,
+  handler/service/router runtime source helpers, plus root auth/init/config/protocol/workload, app usecase, storage node-service, and remaining admin grouped context import runtime source helpers,
   through AppContext-first or owner-crate resolver boundaries.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
@@ -56,8 +56,8 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   event-bridge thin module regressions, plus IAM runtime-source bypasses;
   accept the reviewed AppContext resolver reverse dependencies in the layer
   baseline, and block direct admin AppContext resolver consumers outside the
-  admin runtime-source boundary, and block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries.
-- Docs changes: record the API-136 through API-206 owner facade and lifecycle
+  admin runtime-source boundary, block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries, and catch grouped AppContext imports.
+- Docs changes: record the API-136 through API-207 owner facade and lifecycle
   runtime-source cleanup.
 
 ## Phase 0 Tasks
@@ -4969,6 +4969,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     guards, diff hygiene, residual direct AppContext scan, Rust risk scan, fast
     PR gate, and full PR gate before PR.
 
+- [x] `API-207` Close remaining admin grouped AppContext imports.
+  - Do: route grouped admin handler AppContext resolver imports through the
+    admin runtime-source boundary and extend migration rules to catch grouped
+    `app::context` imports.
+  - Acceptance: admin handlers no longer import AppContext resolvers directly,
+    including grouped `crate::{ app::context::... }` imports, and migration
+    rules reject reintroducing them.
+  - Must preserve: admin credential checks, STS OIDC/token-signing lookups,
+    pool/rebalance notification and object-store behavior, tier stats/config
+    behavior, and bucket metadata object-store access.
+  - Verification: focused RustFS admin compile/tests, formatting, migration and
+    layer guards, diff hygiene, residual direct AppContext scan, Rust risk
+    scan, fast PR gate, and full PR gate before PR.
+
 ## Next PRs
 
 1. `consumer-migration`: continue reducing direct global reads behind AppContext resolver boundaries.
@@ -4977,6 +4991,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-207 closes the remaining grouped admin AppContext imports behind the admin runtime-source boundary and tightens guard coverage. |
+| Migration preservation | pass | Admin credentials, STS, pool/rebalance, tier, and bucket metadata resolver behavior preserve existing AppContext fallback semantics. |
+| Testing/verification | pass | Focused admin compile/tests, formatting, migration/layer guards, residual scan, fast PR gate, and full PR gate are planned before PR. |
 | Quality/architecture | pass | API-206 keeps root, app usecase, and storage node-service AppContext resolver consumers behind owner runtime-source boundaries and adds regression guards. |
 | Migration preservation | pass | Request credentials, IAM readiness, startup notify/region, buffer config, workload admission, S3 Select, app-context object-store/notify, and node-service IAM/lock behavior preserve existing semantics. |
 | Testing/verification | pass | Focused RustFS compile/tests, formatting, migration/layer guards, residual scan, fast PR gate, and full PR gate are planned before PR. |

--- a/rustfs/src/admin/handlers/bucket_meta.rs
+++ b/rustfs/src/admin/handlers/bucket_meta.rs
@@ -25,11 +25,11 @@ use super::super::{
     target::BucketTargets,
 };
 use crate::{
+    admin::runtime_sources::resolve_object_store_handle,
     admin::{
         auth::validate_admin_request,
         router::{AdminOperation, Operation, S3Router},
     },
-    app::context::resolve_object_store_handle,
     auth::{check_key_valid, get_session_token},
     server::{ADMIN_PREFIX, RemoteAddr},
 };

--- a/rustfs/src/admin/handlers/group.rs
+++ b/rustfs/src/admin/handlers/group.rs
@@ -14,13 +14,13 @@
 
 use super::iam_error::iam_error_to_s3_error;
 use crate::{
+    admin::runtime_sources::resolve_action_credentials,
     admin::{
         auth::validate_admin_request,
         handlers::site_replication::site_replication_iam_change_hook,
         router::{AdminOperation, Operation, S3Router},
         utils::has_space_be,
     },
-    app::context::resolve_action_credentials,
     auth::{check_key_valid, constant_time_eq, get_session_token},
     server::{ADMIN_PREFIX, RemoteAddr},
 };

--- a/rustfs/src/admin/handlers/policies.rs
+++ b/rustfs/src/admin/handlers/policies.rs
@@ -14,13 +14,13 @@
 
 use super::iam_error::iam_error_to_s3_error;
 use crate::{
+    admin::runtime_sources::resolve_action_credentials,
     admin::{
         auth::validate_admin_request,
         handlers::site_replication::site_replication_iam_change_hook,
         router::{AdminOperation, Operation, S3Router},
         utils::{encode_compatible_admin_payload, has_space_be, read_compatible_admin_body},
     },
-    app::context::resolve_action_credentials,
     auth::{check_key_valid, get_session_token},
     server::{ADMIN_PREFIX, RemoteAddr},
 };

--- a/rustfs/src/admin/handlers/pools.rs
+++ b/rustfs/src/admin/handlers/pools.rs
@@ -25,13 +25,13 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::{
+    admin::runtime_sources::{resolve_endpoints_handle, resolve_notification_system, resolve_object_store_handle},
     admin::{
         EndpointServerPools, PeerRestClient,
         auth::validate_admin_request,
         router::{AdminOperation, Operation, S3Router},
     },
     app::admin_usecase::{DefaultAdminUsecase, QueryPoolStatusRequest},
-    app::context::{resolve_endpoints_handle, resolve_notification_system, resolve_object_store_handle},
     auth::{check_key_valid, get_session_token},
     error::ApiError,
     server::{ADMIN_PREFIX, RemoteAddr},

--- a/rustfs/src/admin/handlers/rebalance.rs
+++ b/rustfs/src/admin/handlers/rebalance.rs
@@ -17,11 +17,11 @@ use super::super::{
     StorageError, decode_rebalance_stop_propagation_record,
 };
 use crate::{
+    admin::runtime_sources::{resolve_notification_system, resolve_object_store_handle},
     admin::{
         auth::validate_admin_request,
         router::{AdminOperation, Operation, S3Router},
     },
-    app::context::{resolve_notification_system, resolve_object_store_handle},
     auth::{check_key_valid, get_session_token},
     server::{ADMIN_PREFIX, RemoteAddr},
 };

--- a/rustfs/src/admin/handlers/sts.rs
+++ b/rustfs/src/admin/handlers/sts.rs
@@ -15,11 +15,11 @@
 use super::super::ecstore_utils::serialize;
 use super::is_admin::IsAdminHandler;
 use crate::{
+    admin::runtime_sources::{resolve_action_credentials, resolve_oidc_handle, resolve_token_signing_key},
     admin::{
         handlers::site_replication::site_replication_iam_change_hook,
         router::{AdminOperation, Operation, S3Router},
     },
-    app::context::{resolve_action_credentials, resolve_oidc_handle, resolve_token_signing_key},
     auth::{check_key_valid, extract_string_list_claim, get_session_token},
     server::ADMIN_PREFIX,
     server::RemoteAddr,

--- a/rustfs/src/admin/handlers/tier.rs
+++ b/rustfs/src/admin/handlers/tier.rs
@@ -19,12 +19,12 @@ use super::super::{
     ERR_TIER_NOT_FOUND, TierConfig, TierCreds, TierType, storageclass,
 };
 use crate::{
+    admin::runtime_sources::{
+        resolve_daily_tier_stats, resolve_notification_system, resolve_object_store_handle, resolve_tier_config_handle,
+    },
     admin::{
         auth::validate_admin_request,
         router::{AdminOperation, Operation, S3Router},
-    },
-    app::context::{
-        resolve_daily_tier_stats, resolve_notification_system, resolve_object_store_handle, resolve_tier_config_handle,
     },
     auth::{check_key_valid, get_session_token},
     server::{ADMIN_PREFIX, RemoteAddr},

--- a/rustfs/src/admin/handlers/user.rs
+++ b/rustfs/src/admin/handlers/user.rs
@@ -15,13 +15,13 @@
 use super::iam_error::iam_error_to_s3_error;
 use super::{account_info, group, service_account, user_iam, user_lifecycle, user_policy_binding};
 use crate::{
+    admin::runtime_sources::resolve_action_credentials,
     admin::{
         auth::validate_admin_request,
         handlers::site_replication::site_replication_iam_change_hook,
         router::{AdminOperation, Operation, S3Router},
         utils::{encode_compatible_admin_payload, has_space_be, read_compatible_admin_body},
     },
-    app::context::resolve_action_credentials,
     auth::{check_key_valid, constant_time_eq, get_session_token},
     server::RemoteAddr,
 };

--- a/rustfs/src/admin/runtime_sources.rs
+++ b/rustfs/src/admin/runtime_sources.rs
@@ -14,12 +14,13 @@
 
 pub(crate) use crate::app::context::{
     AppContext, get_global_app_context, publish_server_config, publish_storage_class_config, resolve_action_credentials,
-    resolve_boot_time, resolve_bucket_metadata_handle, resolve_bucket_monitor_handle, resolve_deployment_id,
-    resolve_endpoints_handle, resolve_iam_handle, resolve_kms_runtime_service_manager, resolve_notification_system,
-    resolve_object_store_handle, resolve_object_store_handle_for_context, resolve_oidc_handle,
+    resolve_boot_time, resolve_bucket_metadata_handle, resolve_bucket_monitor_handle, resolve_daily_tier_stats,
+    resolve_deployment_id, resolve_endpoints_handle, resolve_iam_handle, resolve_kms_runtime_service_manager,
+    resolve_notification_system, resolve_object_store_handle, resolve_object_store_handle_for_context, resolve_oidc_handle,
     resolve_or_init_kms_runtime_service_manager, resolve_outbound_tls_generation, resolve_outbound_tls_state,
     resolve_ready_iam_handle, resolve_region, resolve_replication_pool_handle, resolve_replication_stats_handle,
-    resolve_runtime_port, resolve_scanner_metrics_report, resolve_server_config, resolve_token_signing_key,
+    resolve_runtime_port, resolve_scanner_metrics_report, resolve_server_config, resolve_tier_config_handle,
+    resolve_token_signing_key,
 };
 
 #[cfg(test)]

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -1378,7 +1378,7 @@ fi
 
 (
   cd "$ROOT_DIR"
-  rg -n --with-filename 'crate::app::context::|use crate::app::context' rustfs/src/admin \
+  rg -n --with-filename 'crate::app::context::|use crate::app::context|app::context::' rustfs/src/admin \
     | rg -v '^rustfs/src/admin/runtime_sources\.rs:' || true
 ) >"$RUSTFS_ADMIN_RUNTIME_SOURCE_BYPASS_HITS_FILE"
 
@@ -1388,7 +1388,7 @@ fi
 
 (
   cd "$ROOT_DIR"
-  rg -n --with-filename 'crate::app::context::|use crate::app::context' rustfs/src --glob '*.rs' |
+  rg -n --with-filename 'crate::app::context::|use crate::app::context|app::context::' rustfs/src --glob '*.rs' |
     rg -v '^rustfs/src/app/context' |
     rg -v '(^rustfs/src/[^/]*runtime_sources\.rs:|/runtime_sources\.rs:)' || true
 ) >"$RUSTFS_APP_CONTEXT_DIRECT_BYPASS_HITS_FILE"
@@ -1399,7 +1399,7 @@ fi
 
 (
   cd "$ROOT_DIR"
-  rg -n --with-filename 'crate::app::context::|use crate::app::context' rustfs/src/app --glob '*.rs' |
+  rg -n --with-filename 'crate::app::context::|use crate::app::context|app::context::' rustfs/src/app --glob '*.rs' |
     rg -v '^rustfs/src/app/context' |
     rg -v '^rustfs/src/app/runtime_sources\.rs:' || true
 ) >"$RUSTFS_APP_USECASE_RUNTIME_SOURCE_BYPASS_HITS_FILE"
@@ -1410,7 +1410,7 @@ fi
 
 (
   cd "$ROOT_DIR"
-  rg -n --with-filename 'crate::app::context::|use crate::app::context' rustfs/src/storage --glob '*.rs' |
+  rg -n --with-filename 'crate::app::context::|use crate::app::context|app::context::' rustfs/src/storage --glob '*.rs' |
     rg -v '^rustfs/src/storage/runtime_sources\.rs:' || true
 ) >"$RUSTFS_STORAGE_DIRECT_APP_CONTEXT_BYPASS_HITS_FILE"
 


### PR DESCRIPTION
## Related Issues

rustfs/backlog#660

## Summary of Changes

- Routed the remaining grouped admin AppContext resolver imports through the admin runtime-source boundary.
- Added the missing admin runtime-source exports for tier stats and tier config access.
- Tightened migration guards so grouped `app::context` imports are rejected outside approved context/runtime-source modules.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo check --tests -p rustfs`
- `cargo test -p rustfs admin::handlers::group --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::policies --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::tier --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::sts --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::bucket_meta --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::rebalance --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::user --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::pools --lib -- --nocapture --test-threads=1`
- `cargo test -p rustfs admin::handlers::health::tests::test_build_health_payload_includes_degraded_reasons --lib -- --nocapture --test-threads=1`
- `make pre-pr`

## Impact

No runtime behavior change expected. This only changes owner-boundary imports and guard coverage.

## Additional Notes

N/A
