### PR TITLE
refactor: route admin usecase construction boundary

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,11 +5,14 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-oidc-app-context-ownership`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229`.
-- Based on: API-229 branch; branch retires the CTX-002 OIDC resolver fallback by publishing the initialized OIDC handle into AppContext.
+- Branch: `overtrue/arch-admin-usecase-runtime-boundary`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/CTX-002`.
+- Based on: latest `origin/main` after CTX-002 PR #3893 merged; branch routes
+  admin `DefaultAdminUsecase` construction through the admin runtime-source
+  boundary.
 - PR type for this branch: `consumer-migration`
-- Runtime behavior changes: admin OIDC resolution is now AppContext-owned after startup publishes the initialized OIDC handle; endpoint behavior and non-fatal OIDC initialization semantics remain unchanged.
+- Runtime behavior changes: none expected for API-230; admin handlers still use
+  the same `DefaultAdminUsecase` implementation and AppContext-backed handles.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
   region, KMS encryption service, runtime support handles, S3 Select DB,
   internode RPC metrics, IAM authorization/handler reads, notification
@@ -63,8 +66,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   boundaries, plus storage owner root ECStore facade and storage contract
   aggregation through `rustfs/src/storage/storage_api.rs`, storage owner
   submodule storage contract imports through the same owner-local boundary,
-  and ECStore internal storage contract imports through the owner-local
-  `storage_api_contracts` boundary.
+  ECStore internal storage contract imports through the owner-local
+  `storage_api_contracts` boundary, and admin system, pool, cluster snapshot,
+  plugin catalog, table catalog, module-switch, and console admin discovery
+  `DefaultAdminUsecase` construction through `admin::runtime_sources`.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -5341,14 +5346,34 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration and layer guards, diff hygiene, residual ECStore bench API scan,
     Rust risk scan, and full PR gate before PR.
 
+- [x] `API-230` Route admin usecase construction through runtime boundary.
+  - Do: expose admin usecase construction and required admin DTO types from
+    `rustfs/src/admin/runtime_sources.rs`, then route system, pool, cluster
+    snapshot, plugin catalog, table catalog, module-switch, and console admin
+    discovery paths through that boundary.
+  - Acceptance: migrated admin handler sources no longer import
+    `crate::app::admin_usecase` directly, and the server-info route guard
+    requires the admin runtime-source constructor.
+  - Must preserve: admin authentication and authorization checks, admin
+    discovery route values, storage/data-usage/pool/decommission responses,
+    cluster snapshot collection, plugin catalog payloads, table catalog config
+    payloads, module switch responses, and console config discovery.
+  - Verification: focused admin tests, formatting, migration and layer guards,
+    diff hygiene, residual admin usecase import scan, Rust risk scan, and full
+    PR gate passed before PR.
+
 ## Next PRs
 
-1. `consumer-migration`: continue larger owner/external crate storage-boundary batches after API-229.
+1. `consumer-migration`: continue larger admin/app/runtime global-source
+   batches after API-230.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-230 moves admin handler `DefaultAdminUsecase` construction behind the admin runtime-source boundary instead of letting each handler import the app usecase directly. |
+| Migration preservation | pass | Admin auth checks, discovery URLs, system info, pool/decommission, cluster snapshot, plugin catalog, table catalog, module-switch, and console responses keep the same usecase implementation. |
+| Testing/verification | pass | Focused admin tests, formatting, migration/layer guards, direct app-usecase import scan, diff hygiene, Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | CTX-002 cleanup makes OIDC resolution AppContext-owned and removes the unused IAM-to-OIDC shortcut instead of keeping a hidden global bypass. |
 | Migration preservation | pass | Startup still treats OIDC initialization as non-fatal and publishes the initialized handle when available; admin OIDC, STS, and console consumers keep the same response behavior. |
 | Testing/verification | pass | Focused app::context tests, formatting, compatibility marker scan, and Rust risk scan passed; full PR gate is planned before PR. |
@@ -5576,6 +5601,26 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-230 current slice:
+  - Branch freshness check: based on CTX-002 PR #3893 head while #3893 was
+    pending, then rebased onto latest `origin/main` after #3893 merged.
+  - `cargo test -p rustfs admin::handlers::system --lib`: passed.
+  - `cargo test -p rustfs admin::handlers::pools --lib`: passed.
+  - `cargo test -p rustfs admin::route_registration_test::test_phase5_admin_info_contract --lib`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Admin usecase import residual scan: passed; remaining
+    `crate::app::admin_usecase` and `DefaultAdminUsecase::from_global()`
+    references are confined to `rustfs/src/admin/runtime_sources.rs`.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
+    ordering lines.
+  - `make pre-pr`: passed.
 
 - Issue #660 API-187 current slice:
   - `cargo check -p rustfs-ecstore --tests`: passed.

--- a/rustfs/src/admin/console.rs
+++ b/rustfs/src/admin/console.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use crate::admin::handlers::health::{HealthProbe, build_health_response_parts, collect_dependency_readiness};
-use crate::admin::runtime_sources::resolve_oidc_handle;
+use crate::admin::runtime_sources::{default_admin_usecase, resolve_oidc_handle};
 use crate::admin::storage_api::RequestContext;
-use crate::app::admin_usecase::DefaultAdminUsecase;
 use crate::license::has_valid_license;
 use crate::server::has_path_prefix;
 use crate::server::{
@@ -224,7 +223,7 @@ struct ApiDiscovery {
 }
 
 fn console_api_discovery() -> ApiDiscovery {
-    let usecase = DefaultAdminUsecase::from_global();
+    let usecase = default_admin_usecase();
     ApiDiscovery {
         runtime_capabilities: usecase.runtime_capabilities_route().to_string(),
         cluster_snapshot: usecase.cluster_snapshot_route().to_string(),

--- a/rustfs/src/admin/handlers/cluster_snapshot.rs
+++ b/rustfs/src/admin/handlers/cluster_snapshot.rs
@@ -16,6 +16,7 @@ use crate::admin::storage_api::{CapabilityState, CapabilityStatus, Observability
 use crate::admin::{
     auth::validate_admin_request,
     router::{AdminOperation, Operation, S3Router},
+    runtime_sources::default_admin_usecase,
     storage_api::ecstore_cluster::{
         ClusterDriveMembership, ClusterEndpointType, ClusterLocalNodeStorage, ClusterLocalNodeStorageSnapshot,
         ClusterMembershipSnapshot, ClusterNodeMembership, ClusterPeerHealth, ClusterPeerHealthSnapshot, ClusterPoolState,
@@ -23,7 +24,6 @@ use crate::admin::{
     },
     system,
 };
-use crate::app::admin_usecase::DefaultAdminUsecase;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::cluster_snapshot::{
     ClusterReadOnlySnapshot, ClusterRuntimeReadinessState, ClusterRuntimeStatusSnapshot, cluster_has_actionable_pressure,
@@ -103,7 +103,7 @@ pub struct GetClusterSnapshotHandler {}
 impl Operation for GetClusterSnapshotHandler {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         authorize_cluster_snapshot_request(&req).await?;
-        let snapshot = DefaultAdminUsecase::from_global()
+        let snapshot = default_admin_usecase()
             .execute_collect_cluster_read_only_snapshot()
             .await
             .map(ClusterSnapshotView::from);
@@ -112,7 +112,7 @@ impl Operation for GetClusterSnapshotHandler {
 }
 
 pub(crate) async fn build_cluster_snapshot_discovery_response() -> ClusterSnapshotDiscoveryResponse {
-    let usecase = DefaultAdminUsecase::from_global();
+    let usecase = default_admin_usecase();
     let path = usecase.cluster_snapshot_route().to_string();
     let snapshot = usecase.execute_collect_cluster_read_only_snapshot().await;
 

--- a/rustfs/src/admin/handlers/module_switch.rs
+++ b/rustfs/src/admin/handlers/module_switch.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::admin::runtime_sources::default_admin_usecase;
 use crate::admin::{
     auth::validate_admin_request,
     router::{AdminOperation, Operation, S3Router},
 };
-use crate::app::admin_usecase::DefaultAdminUsecase;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{
     ADMIN_PREFIX, ModuleSwitchSnapshot, ModuleSwitchSource, PersistedModuleSwitches, RemoteAddr, current_module_switch_snapshot,
@@ -78,7 +78,7 @@ struct ModuleSwitchDiscovery {
 
 impl From<ModuleSwitchSnapshot> for ModuleSwitchesResponse {
     fn from(value: ModuleSwitchSnapshot) -> Self {
-        let usecase = DefaultAdminUsecase::from_global();
+        let usecase = default_admin_usecase();
         Self {
             notify_enabled: value.notify_enabled,
             audit_enabled: value.audit_enabled,

--- a/rustfs/src/admin/handlers/plugins_catalog.rs
+++ b/rustfs/src/admin/handlers/plugins_catalog.rs
@@ -19,8 +19,8 @@ use crate::admin::{
         PluginContractEntrypointKind, PluginContractPackaging, PluginDistributionContract, PluginRuntimeContract,
     },
     router::{AdminOperation, Operation, S3Router},
+    runtime_sources::default_admin_usecase,
 };
-use crate::app::admin_usecase::DefaultAdminUsecase;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use http::{HeaderMap, HeaderValue, StatusCode};
@@ -58,7 +58,7 @@ fn target_domain_name_from_subsystem(subsystem: &str) -> PluginContractDomain {
 }
 
 fn build_catalog_response() -> PluginCatalogResponse {
-    let usecase = DefaultAdminUsecase::from_global();
+    let usecase = default_admin_usecase();
     let mut plugins: HashMap<&'static str, PluginCatalogEntry> = HashMap::new();
 
     for descriptor in builtin_notify_target_admin_descriptors()

--- a/rustfs/src/admin/handlers/pools.rs
+++ b/rustfs/src/admin/handlers/pools.rs
@@ -25,13 +25,15 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::{
-    admin::runtime_sources::{resolve_endpoints_handle, resolve_notification_system, resolve_object_store_handle},
+    admin::runtime_sources::{
+        AdminPoolStatus, QueryPoolStatusRequest, default_admin_usecase, resolve_endpoints_handle, resolve_notification_system,
+        resolve_object_store_handle,
+    },
     admin::{
         auth::validate_admin_request,
         router::{AdminOperation, Operation, S3Router},
         storage_api::{EndpointServerPools, PeerRestClient},
     },
-    app::admin_usecase::{DefaultAdminUsecase, QueryPoolStatusRequest},
     auth::{check_key_valid, get_session_token},
     error::ApiError,
     server::{ADMIN_PREFIX, RemoteAddr},
@@ -52,7 +54,7 @@ struct PoolAdminDiscovery {
 
 #[derive(Debug, Clone, serde::Serialize)]
 struct PoolStatusResponse {
-    pool: crate::app::admin_usecase::AdminPoolStatus,
+    pool: AdminPoolStatus,
     admin_discovery: PoolAdminDiscovery,
 }
 
@@ -413,7 +415,7 @@ fn parse_pool_idx_by_id(pool: &str, endpoint_count: usize) -> Option<usize> {
 }
 
 fn pool_admin_discovery() -> PoolAdminDiscovery {
-    let usecase = DefaultAdminUsecase::from_global();
+    let usecase = default_admin_usecase();
     PoolAdminDiscovery {
         runtime_capabilities: usecase.runtime_capabilities_route().to_string(),
         cluster_snapshot: usecase.cluster_snapshot_route().to_string(),
@@ -498,7 +500,7 @@ impl Operation for ListPools {
         )
         .await?;
 
-        let usecase = DefaultAdminUsecase::from_global();
+        let usecase = default_admin_usecase();
         let pool_items = usecase.execute_list_pools().await.map_err(S3Error::from)?;
 
         let data = serde_json::to_vec(&pool_items).map_err(|e| {
@@ -597,7 +599,7 @@ impl Operation for StatusPool {
 
         let query = parse_status_pool_query(&req.uri).map_err(|_| pool_admin_query_parse_error("load pool status"))?;
 
-        let usecase = DefaultAdminUsecase::from_global();
+        let usecase = default_admin_usecase();
         let pools_status = usecase
             .execute_query_pool_status(QueryPoolStatusRequest {
                 pool: query.pool,
@@ -652,7 +654,7 @@ impl Operation for StatusDecommission {
 
         let query = parse_status_pool_query(&req.uri).map_err(|_| pool_admin_query_parse_error("load decommission status"))?;
 
-        let usecase = DefaultAdminUsecase::from_global();
+        let usecase = default_admin_usecase();
         let data = if query.pool.is_empty() {
             let status = usecase.execute_list_decommission_status().await.map_err(S3Error::from)?;
             serde_json::to_vec(&status)
@@ -1071,12 +1073,12 @@ impl Operation for ClearDecommission {
 #[cfg(test)]
 mod pools_handler_tests {
     use super::{
-        PoolAuditContext, contextualize_admin_pool_api_error, decommission_admin_not_initialized_error_with_audit,
-        decommission_peer_target, has_duplicate_indices, parse_mutation_pool_query, parse_pool_idx_by_id,
-        parse_status_pool_query, pool_admin_missing_credentials_error, pool_admin_missing_credentials_error_with_request,
-        pool_admin_pool_index_error_with_audit, pool_admin_pool_not_found_error_with_audit,
-        pool_admin_pool_parse_error_with_audit, pool_admin_query_parse_error, pool_admin_query_parse_error_with_audit,
-        validate_pool_mutation_leader, validate_start_decommission_guards,
+        AdminPoolStatus, PoolAuditContext, contextualize_admin_pool_api_error,
+        decommission_admin_not_initialized_error_with_audit, decommission_peer_target, has_duplicate_indices,
+        parse_mutation_pool_query, parse_pool_idx_by_id, parse_status_pool_query, pool_admin_missing_credentials_error,
+        pool_admin_missing_credentials_error_with_request, pool_admin_pool_index_error_with_audit,
+        pool_admin_pool_not_found_error_with_audit, pool_admin_pool_parse_error_with_audit, pool_admin_query_parse_error,
+        pool_admin_query_parse_error_with_audit, validate_pool_mutation_leader, validate_start_decommission_guards,
     };
     use crate::admin::storage_api::{Endpoint, EndpointServerPools, Endpoints, PoolEndpoints};
 
@@ -1353,7 +1355,7 @@ mod pools_handler_tests {
     #[test]
     fn test_pool_status_response_exposes_admin_discovery_paths() {
         let response = super::PoolStatusResponse {
-            pool: crate::app::admin_usecase::AdminPoolStatus {
+            pool: AdminPoolStatus {
                 id: 0,
                 cmd_line: "pool-0".to_string(),
                 last_update: time::OffsetDateTime::UNIX_EPOCH,

--- a/rustfs/src/admin/handlers/system.rs
+++ b/rustfs/src/admin/handlers/system.rs
@@ -15,11 +15,12 @@
 use super::{cluster_snapshot, metrics};
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::resolve_endpoints_handle;
+use crate::admin::runtime_sources::{
+    DefaultAdminUsecase, QueryServerInfoRequest, default_admin_usecase, resolve_endpoints_handle,
+};
 use crate::admin::storage_api::{
     CapabilityState, CapabilityStatus, ObservabilitySnapshotProvider, TopologySnapshot, TopologySnapshotProvider,
 };
-use crate::app::admin_usecase::{DefaultAdminUsecase, QueryServerInfoRequest};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::runtime_capabilities::{EndpointTopologySnapshotProvider, RustFsObservabilitySnapshotProvider};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
@@ -202,7 +203,7 @@ impl Operation for ServerInfoHandler {
         )
         .await?;
 
-        let usecase = DefaultAdminUsecase::from_global();
+        let usecase = default_admin_usecase();
         let info = usecase
             .execute_query_server_info(QueryServerInfoRequest { include_pools: true })
             .await
@@ -260,7 +261,7 @@ impl Operation for StorageInfoHandler {
         )
         .await?;
 
-        let usecase = DefaultAdminUsecase::from_global();
+        let usecase = default_admin_usecase();
         let info = usecase.execute_query_storage_info().await.map_err(S3Error::from)?;
         let response = StorageInfoResponse {
             info,
@@ -307,7 +308,7 @@ pub struct RuntimeCapabilitiesHandler {}
 
 pub(crate) async fn build_runtime_capabilities_response()
 -> Result<RuntimeCapabilitiesResponse, crate::admin::storage_api::CapabilitySnapshotError> {
-    let usecase = DefaultAdminUsecase::from_global();
+    let usecase = default_admin_usecase();
     let observability_provider = RustFsObservabilitySnapshotProvider;
     let observability = observability_provider.observability_snapshot().await?;
     let workload_admission = workload_admission_registry_snapshot();
@@ -493,7 +494,7 @@ impl Operation for DataUsageInfoHandler {
         )
         .await?;
 
-        let usecase = DefaultAdminUsecase::from_global();
+        let usecase = default_admin_usecase();
         let info = usecase.execute_query_data_usage_info().await.map_err(S3Error::from)?;
 
         let data = serde_json::to_vec(&info).map_err(|e| {
@@ -515,11 +516,11 @@ mod tests {
         OBSERVABILITY_SUMMARY_RESOLVED, ServerInfoResponse, TOPOLOGY_SNAPSHOT_NOT_AVAILABLE, TOPOLOGY_SUMMARY_RESOLVED,
         build_runtime_capabilities_response, build_runtime_capabilities_summary, system_admin_discovery,
     };
+    use crate::admin::runtime_sources::DefaultAdminUsecase;
     use crate::admin::storage_api::{
         CapabilityState, CapabilityStatus, MemorySamplingState, ObservabilitySnapshot, PlatformSupport, TopologyCapabilities,
         TopologySnapshot, UserspaceProfilingCapability,
     };
-    use crate::app::admin_usecase::DefaultAdminUsecase;
     use rustfs_concurrency::{AdmissionState, WorkloadClass};
     use rustfs_madmin::{InfoMessage, StorageInfo};
 

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::admin::runtime_sources::default_admin_usecase;
 use crate::admin::runtime_sources::{resolve_object_store_handle, resolve_token_signing_key};
 use crate::admin::storage_api::{ECStore, metadata::table_catalog_path_hash, metadata_sys};
 use crate::admin::{
     auth::{AdminResourceScope, validate_admin_request, validate_admin_request_with_bucket_object},
     router::{AdminOperation, Operation, S3Router},
 };
-use crate::app::admin_usecase::DefaultAdminUsecase;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{RemoteAddr, TABLE_CATALOG_COMPAT_PREFIX, TABLE_CATALOG_PREFIX};
 use crate::table_catalog::{DEFAULT_WAREHOUSE_ID, TableCatalogStore};
@@ -988,7 +988,7 @@ fn register_table_catalog_prefix_routes(r: &mut S3Router<AdminOperation>, prefix
 }
 
 fn catalog_config_response() -> CatalogConfigResponse {
-    let usecase = DefaultAdminUsecase::from_global();
+    let usecase = default_admin_usecase();
     CatalogConfigResponse {
         defaults: BTreeMap::from([
             (WAREHOUSE_PROPERTY, DEFAULT_WAREHOUSE_ID),

--- a/rustfs/src/admin/route_registration_test.rs
+++ b/rustfs/src/admin/route_registration_test.rs
@@ -1223,9 +1223,9 @@ fn test_phase5_admin_info_contract() {
     let server_info_impl_block = &system_src[server_info_impl_start..];
 
     assert!(
-        server_info_impl_block.contains("DefaultAdminUsecase::from_global()")
+        server_info_impl_block.contains("default_admin_usecase()")
             && server_info_impl_block.contains("execute_query_server_info(QueryServerInfoRequest { include_pools: true })"),
-        "admin server info path must be served through DefaultAdminUsecase::execute_query_server_info"
+        "admin server info path must be served through admin runtime-source DefaultAdminUsecase::execute_query_server_info"
     );
 }
 

--- a/rustfs/src/admin/runtime_sources.rs
+++ b/rustfs/src/admin/runtime_sources.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) use crate::app::admin_usecase::{
+    AdminPoolStatus, DefaultAdminUsecase, QueryPoolStatusRequest, QueryServerInfoRequest,
+};
 pub(crate) use crate::app::context::{
     AppContext, get_global_app_context, publish_server_config, publish_storage_class_config, resolve_action_credentials,
     resolve_boot_time, resolve_bucket_metadata_handle, resolve_bucket_monitor_handle, resolve_daily_tier_stats,
@@ -25,3 +28,7 @@ pub(crate) use crate::app::context::{
 
 #[cfg(test)]
 pub(crate) use crate::app::context::set_test_outbound_tls_generation;
+
+pub(crate) fn default_admin_usecase() -> DefaultAdminUsecase {
+    DefaultAdminUsecase::from_global()
+}


### PR DESCRIPTION
## Related Issues

rustfs/backlog#660

## Summary of Changes

- route admin DefaultAdminUsecase construction through the admin runtime-source boundary
- migrate system, pool, cluster snapshot, plugin catalog, table catalog, module-switch, and console discovery paths to the boundary
- update migration progress for API-230 after the CTX-002 cleanup

## Verification

- `cargo test -p rustfs admin::handlers::system --lib`
- `cargo test -p rustfs admin::handlers::pools --lib`
- `cargo test -p rustfs admin::route_registration_test::test_phase5_admin_info_contract --lib`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `git diff --check`
- `make pre-pr`

## Impact

No runtime behavior change is expected. Admin handlers still use the same DefaultAdminUsecase implementation and AppContext-backed handles; this change centralizes construction behind the admin runtime-source boundary.

## Additional Notes

N/A
