### PR TITLE
refactor: centralize runtime source boundaries

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5437,27 +5437,47 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     guards, diff hygiene, residual server AppContext entrypoint scan, Rust risk
     scan, and full PR gate before PR.
 
+- [x] `API-236` Route owner runtime-source AppContext reads through root entrypoints.
+  - Do: expose the remaining admin/app/storage AppContext resolver entrypoints
+    from `rustfs/src/runtime_sources.rs`, then route owner runtime-source
+    helpers through that root boundary instead of direct app-context imports.
+  - Acceptance: `rustfs/src/admin/runtime_sources.rs`,
+    `rustfs/src/app/runtime_sources.rs`, and
+    `rustfs/src/storage/runtime_sources.rs` no longer import
+    `crate::app::context`, and migration rules reject new owner runtime-source
+    AppContext bypasses.
+  - Must preserve: admin/object usecase construction, app usecase explicit
+    context fallback, storage RPC/storage helper runtime reads, IAM/KMS/TLS
+    resolver semantics, notification dispatch, and test-only TLS generation
+    hooks.
+  - Verification: focused admin/app/storage checks, formatting, migration and
+    layer guards, diff hygiene, residual owner runtime-source AppContext scan,
+    Rust risk scan, and full PR gate before PR.
+
 ## Next PRs
 
 1. `consumer-migration`: continue larger app/runtime global-source batches
-   after API-235.
+   after API-236.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-236 makes admin, app, and storage runtime sources consume root runtime-source entrypoints instead of importing app context directly. |
+| Migration preservation | pass | Admin/object usecase construction, app explicit-context fallback, storage runtime reads, IAM/KMS/TLS resolver behavior, notification dispatch, and test TLS hooks keep the same semantics. |
+| Testing/verification | pass | Focused admin/app/storage checks, formatting, migration/layer guards, residual owner runtime-source AppContext scan, diff hygiene, Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | API-235 makes server runtime sources consume root runtime-source entrypoints instead of importing app context directly. |
 | Migration preservation | pass | Server audit/event config reads, readiness checks, object-store lookups, KMS lookup, lock-client checks, and notify dispatch keep the same resolver semantics. |
-| Testing/verification | pass | Focused server checks, formatting, migration/layer guards, residual server AppContext scan, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
+| Testing/verification | pass | Focused server checks, formatting, migration/layer guards, residual server AppContext scan, diff hygiene, Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | API-234 removes the storage runtime-source re-export of the global AppContext getter and keeps startup AppContext reads behind root runtime-source entrypoints. |
 | Migration preservation | pass | Node RPC context fallback, object-store lookup, startup replication resync, and TLS generation math keep the same runtime handles and fallback behavior. |
-| Testing/verification | pass | Focused storage RPC/startup TLS checks, formatting, migration/layer guards, residual entrypoint scans, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
+| Testing/verification | pass | Focused storage RPC/startup TLS checks, formatting, migration/layer guards, residual entrypoint scans, diff hygiene, Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | API-233 moves ECFS S3 route bucket, multipart, and object usecase construction behind the storage S3 API boundary without introducing storage infra reverse dependencies. |
 | Migration preservation | pass | ECFS request forwarding, metrics recording, boxed recursive async handlers, and AppContext-backed usecase construction keep the same behavior. |
-| Testing/verification | pass | Focused storage ECFS tests, formatting, migration/layer guards, residual ECFS construction scan, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
+| Testing/verification | pass | Focused storage ECFS tests, formatting, migration/layer guards, residual ECFS construction scan, diff hygiene, Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | API-232 moves app usecase AppContext lookup behind the app runtime-source boundary instead of importing the global context getter in each usecase file. |
 | Migration preservation | pass | Bucket, multipart, admin, and object usecase constructors plus object buffer config fallback keep the same AppContext-first behavior. |
-| Testing/verification | pass | Focused app/admin tests, formatting, migration/layer guards, residual app global-entry scan, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
+| Testing/verification | pass | Focused app/admin tests, formatting, migration/layer guards, residual app global-entry scan, diff hygiene, Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | API-231 moves admin misc object-usecase construction and AppContext lookup behind the admin runtime-source boundary instead of keeping direct global entry points in router/service files. |
 | Migration preservation | pass | Object-lambda get execution, listen-notification bucket validation, dynamic config reload, runtime config snapshot reload, and site-replication normalization still use the same runtime handles. |
 | Testing/verification | pass | Focused admin router/service checks, formatting, migration/layer guards, residual admin global-entry scan, diff hygiene, Rust risk scan, and full PR gate passed before PR. |
@@ -5692,9 +5712,32 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 Passed before push:
 
+- Issue #660 API-236 current slice:
+  - Branch freshness check: rebased onto current `origin/main` after API-232
+    merged.
+  - `cargo test -p rustfs admin::router --lib`: passed, 61 passed.
+  - `cargo test -p rustfs app::bucket_usecase --lib`: passed, 64 passed.
+  - `cargo test -p rustfs app::object_usecase --lib`: passed, 102 passed
+    and 2 ignored.
+  - `cargo test -p rustfs storage::rpc --lib`: passed, 115 passed and 9
+    ignored.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed after deleting the stale
+    storage runtime-source AppContext baseline.
+  - Owner runtime-source AppContext residual scan: passed; admin, app, and
+    storage runtime sources no longer import `crate::app::context`.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
+    ordering lines.
+  - `make pre-pr`: passed on the combined API-233 through API-236 branch.
+  - Full PR gate: passed before PR.
+
 - Issue #660 API-235 current slice:
-  - Branch freshness check: stacked on API-234 local branch while API-231 PR
-    #3895 is pending.
+  - Branch freshness check: rebased onto current `origin/main` after API-232
+    merged.
   - `cargo test -p rustfs server:: --lib`: passed, 151 passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.
@@ -5707,11 +5750,12 @@ Passed before push:
   - Diff-added Rust risk scan: passed; no new production unwrap/expect,
     numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
     ordering lines.
-  - Full PR gate: planned before PR.
+  - `make pre-pr`: passed on the combined API-233 through API-236 branch.
+  - Full PR gate: passed before PR.
 
 - Issue #660 API-234 current slice:
-  - Branch freshness check: stacked on API-233 local branch while API-231 PR
-    #3895 is pending.
+  - Branch freshness check: rebased onto current `origin/main` after API-232
+    merged.
   - `cargo test -p rustfs storage::rpc --lib`: passed, 115 passed and 9
     ignored.
   - `cargo test -p rustfs startup_tls_material --lib`: passed, 3 passed.
@@ -5726,11 +5770,12 @@ Passed before push:
   - Diff-added Rust risk scan: passed; no new production unwrap/expect,
     numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
     ordering lines.
-  - Full PR gate: planned before PR.
+  - `make pre-pr`: passed on the combined API-233 through API-236 branch.
+  - Full PR gate: passed before PR.
 
 - Issue #660 API-233 current slice:
-  - Branch freshness check: stacked on API-232 local branch while API-231 PR
-    #3895 is pending.
+  - Branch freshness check: rebased onto current `origin/main` after API-232
+    merged.
   - `cargo test -p rustfs storage::ecfs --lib`: passed.
   - `cargo fmt --all`: passed.
   - `cargo fmt --all --check`: passed.
@@ -5742,7 +5787,8 @@ Passed before push:
     `rustfs/src/storage/s3_api/mod.rs`.
   - Diff-added Rust risk scan: passed; no new production unwrap/expect,
     numeric cast, Box dyn Error, print macro, or relaxed atomic ordering lines.
-  - Full PR gate: planned before PR.
+  - `make pre-pr`: passed on the combined API-233 through API-236 branch.
+  - Full PR gate: passed before PR.
 
 - Issue #660 API-232 current slice:
   - Branch freshness check: rebased onto current `origin/main` after API-231

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5422,15 +5422,33 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration and layer guards, diff hygiene, residual AppContext entrypoint
     scans, Rust risk scan, and full PR gate before PR.
 
+- [x] `API-235` Route server runtime-source reads through root entrypoints.
+  - Do: expose the server-needed AppContext resolver entrypoints from
+    `rustfs/src/runtime_sources.rs`, then route server runtime-source helpers
+    through those entrypoints instead of directly importing app context.
+  - Acceptance: `rustfs/src/server/runtime_sources.rs` no longer imports
+    `crate::app::context`, server consumers continue using the server-local
+    runtime-source helpers, and migration rules reject direct server
+    runtime-source AppContext imports.
+  - Must preserve: audit/event server config reads, module-switch object-store
+    lookup, readiness IAM/object-store/endpoints/lock-client checks, KMS
+    runtime lookup, and notify interface dispatch.
+  - Verification: focused server checks, formatting, migration and layer
+    guards, diff hygiene, residual server AppContext entrypoint scan, Rust risk
+    scan, and full PR gate before PR.
+
 ## Next PRs
 
 1. `consumer-migration`: continue larger app/runtime global-source batches
-   after API-234.
+   after API-235.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-235 makes server runtime sources consume root runtime-source entrypoints instead of importing app context directly. |
+| Migration preservation | pass | Server audit/event config reads, readiness checks, object-store lookups, KMS lookup, lock-client checks, and notify dispatch keep the same resolver semantics. |
+| Testing/verification | pass | Focused server checks, formatting, migration/layer guards, residual server AppContext scan, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
 | Quality/architecture | pass | API-234 removes the storage runtime-source re-export of the global AppContext getter and keeps startup AppContext reads behind root runtime-source entrypoints. |
 | Migration preservation | pass | Node RPC context fallback, object-store lookup, startup replication resync, and TLS generation math keep the same runtime handles and fallback behavior. |
 | Testing/verification | pass | Focused storage RPC/startup TLS checks, formatting, migration/layer guards, residual entrypoint scans, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
@@ -5673,6 +5691,23 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-235 current slice:
+  - Branch freshness check: stacked on API-234 local branch while API-231 PR
+    #3895 is pending.
+  - `cargo test -p rustfs server:: --lib`: passed, 151 passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed after deleting the stale
+    server runtime-source AppContext baseline.
+  - Server AppContext entrypoint residual scan: passed; server runtime sources
+    no longer import `crate::app::context`.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
+    ordering lines.
+  - Full PR gate: planned before PR.
 
 - Issue #660 API-234 current slice:
   - Branch freshness check: stacked on API-233 local branch while API-231 PR

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5407,15 +5407,33 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     guards, diff hygiene, residual ECFS usecase-construction scan, Rust risk
     scan, and full PR gate before PR.
 
+- [x] `API-234` Wrap runtime AppContext entrypoints behind owner sources.
+  - Do: replace storage RPC use of the re-exported global AppContext getter
+    with an owner-local `current_app_context()` helper, and route startup
+    replication-pool/TLS-generation reads through the root runtime-source
+    entrypoints.
+  - Acceptance: storage consumers no longer call or re-export
+    `get_global_app_context`, startup runtime sources no longer directly
+    reference `crate::app::context`, and migration rules reject both bypasses.
+  - Must preserve: node RPC server context fallback, object-store resolution,
+    startup bucket replication resync, TLS generation increments, outbound TLS
+    publication, and runtime-source visibility.
+  - Verification: focused storage RPC/startup TLS checks, formatting,
+    migration and layer guards, diff hygiene, residual AppContext entrypoint
+    scans, Rust risk scan, and full PR gate before PR.
+
 ## Next PRs
 
 1. `consumer-migration`: continue larger app/runtime global-source batches
-   after API-233.
+   after API-234.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-234 removes the storage runtime-source re-export of the global AppContext getter and keeps startup AppContext reads behind root runtime-source entrypoints. |
+| Migration preservation | pass | Node RPC context fallback, object-store lookup, startup replication resync, and TLS generation math keep the same runtime handles and fallback behavior. |
+| Testing/verification | pass | Focused storage RPC/startup TLS checks, formatting, migration/layer guards, residual entrypoint scans, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
 | Quality/architecture | pass | API-233 moves ECFS S3 route bucket, multipart, and object usecase construction behind the storage S3 API boundary without introducing storage infra reverse dependencies. |
 | Migration preservation | pass | ECFS request forwarding, metrics recording, boxed recursive async handlers, and AppContext-backed usecase construction keep the same behavior. |
 | Testing/verification | pass | Focused storage ECFS tests, formatting, migration/layer guards, residual ECFS construction scan, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
@@ -5655,6 +5673,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-234 current slice:
+  - Branch freshness check: stacked on API-233 local branch while API-231 PR
+    #3895 is pending.
+  - `cargo test -p rustfs storage::rpc --lib`: passed, 115 passed and 9
+    ignored.
+  - `cargo test -p rustfs startup_tls_material --lib`: passed, 3 passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - AppContext entrypoint residual scans: passed; storage consumers no longer
+    call or re-export `get_global_app_context`, and startup runtime sources no
+    longer reference `crate::app::context` directly.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
+    ordering lines.
+  - Full PR gate: planned before PR.
 
 - Issue #660 API-233 current slice:
   - Branch freshness check: stacked on API-232 local branch while API-231 PR

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,14 +5,15 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-app-usecase-context-boundary`
+- Branch: `overtrue/arch-storage-ecfs-usecase-boundary`
 - Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/CTX-002`.
-- Based on: stacked on API-231 local branch while API-230 PR #3894 is pending;
-  branch routes app usecase AppContext global lookups through the app
-  runtime-source boundary.
+- Based on: stacked on API-232 local branch while API-230 PR #3894 is pending;
+  branch routes storage ECFS S3 route app usecase construction through the
+  storage S3 API boundary.
 - PR type for this branch: `consumer-migration`
-- Runtime behavior changes: none expected for API-232; app usecase constructors
-  still use the same AppContext-backed handles.
+- Runtime behavior changes: none expected for API-233; storage ECFS S3 routes
+  still construct the same AppContext-backed bucket, multipart, and object
+  usecases.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
   region, KMS encryption service, runtime support handles, S3 Select DB,
   internode RPC metrics, IAM authorization/handler reads, notification
@@ -67,9 +68,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   aggregation through `rustfs/src/storage/storage_api.rs`, storage owner
   submodule storage contract imports through the same owner-local boundary,
   ECStore internal storage contract imports through the owner-local
-  `storage_api_contracts` boundary, and admin system, pool, cluster snapshot,
+  `storage_api_contracts` boundary, admin system, pool, cluster snapshot,
   plugin catalog, table catalog, module-switch, and console admin discovery
-  `DefaultAdminUsecase` construction through `admin::runtime_sources`.
+  `DefaultAdminUsecase` construction through `admin::runtime_sources`, and
+  storage ECFS S3 route app usecase construction through `storage::s3_api`.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -79,9 +81,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   event-bridge thin module regressions, plus IAM runtime-source bypasses;
   accept the reviewed AppContext resolver reverse dependencies in the layer
   baseline, and block direct admin AppContext resolver consumers outside the
-  admin runtime-source boundary, block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries, catch grouped AppContext imports, reject app usecase storage wildcard imports, reject app-layer S3 DTO and ECFS wildcard imports, narrow the object-usecase ECFS layer baseline entry to `FS`, reject direct storage S3 API helper imports from app usecase files, reject direct storage helper imports from app select/usecase files, reject completed app/admin storage helper bypasses, reject app usecase bypasses for migrated storage IO/compression/set-disk helpers, reject app usecase/test bypasses for migrated storage error, ETag, and storage-class helpers, reject app root bucket owner facade bypasses from migrated app consumers, reject app/admin runtime/data-usage root facade regressions, reject admin root storage facade regressions from migrated admin consumers, reject root/server/startup direct storage facade regressions from migrated outer consumers, reject root/server/startup direct storage contract imports from migrated outer consumers, reject app/admin direct storage contract imports from migrated owner consumers, keep app S3 helper imports routed through `app::storage_api`, reject scanner/heal direct ECStore or storage contract imports outside their local `storage_api` boundaries, reject external runtime/test/fuzz ECStore or storage contract imports outside their local `storage_api` boundaries, reject storage owner direct ECStore/storage-api imports outside the owner-local `storage_api` boundary, and reject ECStore internal direct storage-api imports outside the owner-local `storage_api_contracts` boundary.
+  admin runtime-source boundary, block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries, catch grouped AppContext imports, reject app usecase storage wildcard imports, reject app-layer S3 DTO and ECFS wildcard imports, narrow the object-usecase ECFS layer baseline entry to `FS`, reject direct storage S3 API helper imports from app usecase files, reject direct storage helper imports from app select/usecase files, reject completed app/admin storage helper bypasses, reject app usecase bypasses for migrated storage IO/compression/set-disk helpers, reject app usecase/test bypasses for migrated storage error, ETag, and storage-class helpers, reject app root bucket owner facade bypasses from migrated app consumers, reject app/admin runtime/data-usage root facade regressions, reject admin root storage facade regressions from migrated admin consumers, reject root/server/startup direct storage facade regressions from migrated outer consumers, reject root/server/startup direct storage contract imports from migrated outer consumers, reject app/admin direct storage contract imports from migrated owner consumers, keep app S3 helper imports routed through `app::storage_api`, reject scanner/heal direct ECStore or storage contract imports outside their local `storage_api` boundaries, reject external runtime/test/fuzz ECStore or storage contract imports outside their local `storage_api` boundaries, reject storage owner direct ECStore/storage-api imports outside the owner-local `storage_api` boundary, reject ECStore internal direct storage-api imports outside the owner-local `storage_api_contracts` boundary, and reject direct storage ECFS app usecase construction outside the storage S3 API boundary.
 - Docs changes: record the API-136 through API-226 owner facade and lifecycle
-  runtime-source cleanup.
+  runtime-source cleanup plus API-233 storage ECFS usecase construction
+  boundary.
 
 ## Phase 0 Tasks
 
@@ -5390,15 +5393,32 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     guards, diff hygiene, residual app global-entry scan, Rust risk scan, and
     full PR gate before PR.
 
+- [x] `API-233` Route storage ECFS app usecase construction through S3 API boundary.
+  - Do: expose bucket, multipart, and object usecase constructors from
+    `rustfs/src/storage/s3_api/mod.rs`, then route ECFS S3 bucket,
+    multipart, and object routes through those boundary helpers.
+  - Acceptance: `rustfs/src/storage/ecfs.rs` no longer imports app usecase
+    modules directly or calls `Default*Usecase::from_global()` directly, and
+    migration rules reject new direct construction.
+  - Must preserve: all ECFS S3 route request forwarding, metrics recording,
+    boxing behavior for recursive async route handlers, and AppContext-backed
+    usecase construction.
+  - Verification: focused storage ECFS checks, formatting, migration and layer
+    guards, diff hygiene, residual ECFS usecase-construction scan, Rust risk
+    scan, and full PR gate before PR.
+
 ## Next PRs
 
 1. `consumer-migration`: continue larger app/runtime global-source batches
-   after API-232.
+   after API-233.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-233 moves ECFS S3 route bucket, multipart, and object usecase construction behind the storage S3 API boundary without introducing storage infra reverse dependencies. |
+| Migration preservation | pass | ECFS request forwarding, metrics recording, boxed recursive async handlers, and AppContext-backed usecase construction keep the same behavior. |
+| Testing/verification | pass | Focused storage ECFS tests, formatting, migration/layer guards, residual ECFS construction scan, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
 | Quality/architecture | pass | API-232 moves app usecase AppContext lookup behind the app runtime-source boundary instead of importing the global context getter in each usecase file. |
 | Migration preservation | pass | Bucket, multipart, admin, and object usecase constructors plus object buffer config fallback keep the same AppContext-first behavior. |
 | Testing/verification | pass | Focused app/admin tests, formatting, migration/layer guards, residual app global-entry scan, diff hygiene, and Rust risk scan passed; full PR gate is planned before PR. |
@@ -5635,6 +5655,22 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-233 current slice:
+  - Branch freshness check: stacked on API-232 local branch while API-231 PR
+    #3895 is pending.
+  - `cargo test -p rustfs storage::ecfs --lib`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - ECFS usecase-construction residual scan: passed; remaining
+    `Default*Usecase::from_global()` references are confined to
+    `rustfs/src/storage/s3_api/mod.rs`.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    numeric cast, Box dyn Error, print macro, or relaxed atomic ordering lines.
+  - Full PR gate: planned before PR.
 
 - Issue #660 API-232 current slice:
   - Branch freshness check: rebased onto current `origin/main` after API-231

--- a/rustfs/src/admin/runtime_sources.rs
+++ b/rustfs/src/admin/runtime_sources.rs
@@ -15,8 +15,8 @@
 pub(crate) use crate::app::admin_usecase::{
     AdminPoolStatus, DefaultAdminUsecase, QueryPoolStatusRequest, QueryServerInfoRequest,
 };
-use crate::app::context::get_global_app_context;
-pub(crate) use crate::app::context::{
+use crate::app::object_usecase::DefaultObjectUsecase;
+pub(crate) use crate::runtime_sources::{
     AppContext, publish_server_config, publish_storage_class_config, resolve_action_credentials, resolve_boot_time,
     resolve_bucket_metadata_handle, resolve_bucket_monitor_handle, resolve_daily_tier_stats, resolve_deployment_id,
     resolve_endpoints_handle, resolve_iam_handle, resolve_kms_runtime_service_manager, resolve_notification_system,
@@ -26,11 +26,10 @@ pub(crate) use crate::app::context::{
     resolve_runtime_port, resolve_scanner_metrics_report, resolve_server_config, resolve_tier_config_handle,
     resolve_token_signing_key,
 };
-use crate::app::object_usecase::DefaultObjectUsecase;
 use std::sync::Arc;
 
 #[cfg(test)]
-pub(crate) use crate::app::context::set_test_outbound_tls_generation;
+pub(crate) use crate::runtime_sources::set_test_outbound_tls_generation;
 
 pub(crate) fn default_admin_usecase() -> DefaultAdminUsecase {
     DefaultAdminUsecase::from_global()
@@ -41,5 +40,5 @@ pub(crate) fn default_object_usecase() -> DefaultObjectUsecase {
 }
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
-    get_global_app_context()
+    crate::runtime_sources::current_app_context()
 }

--- a/rustfs/src/app/runtime_sources.rs
+++ b/rustfs/src/app/runtime_sources.rs
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::app::context::get_global_app_context;
-pub(crate) use crate::app::context::{
+pub(crate) use crate::runtime_sources::{
     AppContext, resolve_encryption_service, resolve_endpoints_handle, resolve_expiry_state_handle, resolve_notification_system,
     resolve_notify_interface_for_context, resolve_object_store_handle_for_context, resolve_s3select_db,
 };
 use std::sync::Arc;
 
 #[cfg(test)]
-pub(crate) use crate::app::context::resolve_tier_config_handle;
+pub(crate) use crate::runtime_sources::resolve_tier_config_handle;
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
-    get_global_app_context()
+    crate::runtime_sources::current_app_context()
 }

--- a/rustfs/src/runtime_sources.rs
+++ b/rustfs/src/runtime_sources.rs
@@ -15,6 +15,8 @@
 use crate::app::context;
 
 pub(crate) use context::{
-    AppContext, publish_oidc_handle, resolve_action_credentials, resolve_buffer_config, resolve_notify_interface,
-    resolve_outbound_tls_generation, resolve_ready_iam_handle, resolve_region, resolve_replication_pool_handle,
+    AppContext, NotifyInterface, publish_oidc_handle, resolve_action_credentials, resolve_buffer_config,
+    resolve_endpoints_handle, resolve_iam_ready, resolve_kms_runtime_service_manager, resolve_lock_clients_handle,
+    resolve_notify_interface, resolve_object_store_handle, resolve_outbound_tls_generation, resolve_ready_iam_handle,
+    resolve_region, resolve_replication_pool_handle, resolve_server_config,
 };

--- a/rustfs/src/runtime_sources.rs
+++ b/rustfs/src/runtime_sources.rs
@@ -13,10 +13,24 @@
 // limitations under the License.
 
 use crate::app::context;
+use std::sync::Arc;
 
 pub(crate) use context::{
-    AppContext, NotifyInterface, publish_oidc_handle, resolve_action_credentials, resolve_buffer_config,
-    resolve_endpoints_handle, resolve_iam_ready, resolve_kms_runtime_service_manager, resolve_lock_clients_handle,
-    resolve_notify_interface, resolve_object_store_handle, resolve_outbound_tls_generation, resolve_ready_iam_handle,
-    resolve_region, resolve_replication_pool_handle, resolve_server_config,
+    AppContext, NotifyInterface, publish_oidc_handle, publish_server_config, publish_storage_class_config,
+    resolve_action_credentials, resolve_boot_time, resolve_bucket_metadata_handle, resolve_bucket_monitor_handle,
+    resolve_buffer_config, resolve_daily_tier_stats, resolve_deployment_id, resolve_encryption_service, resolve_endpoints_handle,
+    resolve_expiry_state_handle, resolve_iam_handle, resolve_iam_ready, resolve_internode_metrics,
+    resolve_kms_runtime_service_manager, resolve_local_node_name, resolve_lock_client, resolve_lock_clients_handle,
+    resolve_notification_system, resolve_notify_interface, resolve_notify_interface_for_context, resolve_object_store_handle,
+    resolve_object_store_handle_for_context, resolve_oidc_handle, resolve_or_init_kms_runtime_service_manager,
+    resolve_outbound_tls_generation, resolve_outbound_tls_state, resolve_performance_metrics, resolve_ready_iam_handle,
+    resolve_region, resolve_replication_pool_handle, resolve_replication_stats_handle, resolve_runtime_port, resolve_s3select_db,
+    resolve_scanner_metrics_report, resolve_server_config, resolve_tier_config_handle, resolve_token_signing_key,
 };
+
+#[cfg(test)]
+pub(crate) use context::set_test_outbound_tls_generation;
+
+pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
+    context::get_global_app_context()
+}

--- a/rustfs/src/runtime_sources.rs
+++ b/rustfs/src/runtime_sources.rs
@@ -16,5 +16,5 @@ use crate::app::context;
 
 pub(crate) use context::{
     AppContext, publish_oidc_handle, resolve_action_credentials, resolve_buffer_config, resolve_notify_interface,
-    resolve_ready_iam_handle, resolve_region, resolve_replication_pool_handle,
+    resolve_outbound_tls_generation, resolve_ready_iam_handle, resolve_region, resolve_replication_pool_handle,
 };

--- a/rustfs/src/server/runtime_sources.rs
+++ b/rustfs/src/server/runtime_sources.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::app::context;
+use crate::runtime_sources::{
+    NotifyInterface, resolve_endpoints_handle, resolve_iam_ready, resolve_kms_runtime_service_manager,
+    resolve_lock_clients_handle, resolve_notify_interface, resolve_object_store_handle, resolve_server_config,
+};
 use crate::storage_api::{ECStore, EndpointServerPools};
 use rustfs_kms::KmsServiceManager;
 use rustfs_lock::LockClient;
@@ -20,29 +23,29 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 pub(crate) fn kms_runtime_service_manager() -> Option<Arc<KmsServiceManager>> {
-    context::resolve_kms_runtime_service_manager()
+    resolve_kms_runtime_service_manager()
 }
 
 pub(crate) fn server_config() -> Option<rustfs_config::server_config::Config> {
-    context::resolve_server_config()
+    resolve_server_config()
 }
 
-pub(crate) fn notify_interface() -> Arc<dyn context::NotifyInterface> {
-    context::resolve_notify_interface()
+pub(crate) fn notify_interface() -> Arc<dyn NotifyInterface> {
+    resolve_notify_interface()
 }
 
 pub(crate) fn object_store_handle() -> Option<Arc<ECStore>> {
-    context::resolve_object_store_handle()
+    resolve_object_store_handle()
 }
 
 pub(crate) fn iam_ready() -> bool {
-    context::resolve_iam_ready()
+    resolve_iam_ready()
 }
 
 pub(crate) fn endpoints_handle() -> Option<EndpointServerPools> {
-    context::resolve_endpoints_handle()
+    resolve_endpoints_handle()
 }
 
 pub(crate) fn lock_clients_handle() -> Option<HashMap<String, Arc<dyn LockClient>>> {
-    context::resolve_lock_clients_handle()
+    resolve_lock_clients_handle()
 }

--- a/rustfs/src/startup_runtime_sources.rs
+++ b/rustfs/src/startup_runtime_sources.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::config::RustFSBufferConfig;
+use crate::runtime_sources::{resolve_outbound_tls_generation, resolve_replication_pool_handle};
 use crate::storage_api::{DynReplicationPool, set_global_region, set_global_rustfs_port};
 use rustfs_kms::KmsServiceManager;
 use rustfs_obs::{GlobalError as ObservabilityError, OtelGuard};
@@ -72,7 +73,7 @@ pub(crate) fn init_metrics_runtime(ctx: CancellationToken) {
 }
 
 pub(crate) fn replication_pool_handle() -> Option<Arc<DynReplicationPool>> {
-    crate::app::context::resolve_replication_pool_handle()
+    resolve_replication_pool_handle()
 }
 
 pub(crate) fn set_put_stage_metrics_enabled(enabled: bool) {
@@ -84,7 +85,7 @@ pub(crate) fn init_tls_metrics() {
 }
 
 pub(crate) fn current_outbound_tls_generation() -> u64 {
-    crate::app::context::resolve_outbound_tls_generation().0
+    resolve_outbound_tls_generation().0
 }
 
 pub(crate) async fn publish_outbound_tls_state(generation: TlsGeneration, outbound: &OutboundTlsMaterial) {

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -22,15 +22,12 @@ use super::{
     update_bucket_metadata_config,
 };
 use super::{StorageReplicationConfigExt as _, StorageVersioningConfigExt as _};
-use crate::app::bucket_usecase::DefaultBucketUsecase;
-use crate::app::multipart_usecase::DefaultMultipartUsecase;
-use crate::app::object_usecase::DefaultObjectUsecase;
 use crate::error::ApiError;
 use crate::storage::access::has_bypass_governance_header;
 use crate::storage::helper::OperationHelper;
 use crate::storage::options::get_opts;
 use crate::storage::runtime_sources;
-use crate::storage::s3_api::acl;
+use crate::storage::s3_api::{self, acl};
 use crate::storage::{parse_object_lock_legal_hold, parse_object_lock_retention, validate_bucket_object_lock_enabled};
 use crate::table_catalog;
 use http::StatusCode;
@@ -243,7 +240,7 @@ impl S3 for FS {
         &self,
         req: S3Request<AbortMultipartUploadInput>,
     ) -> S3Result<S3Response<AbortMultipartUploadOutput>> {
-        let usecase = DefaultMultipartUsecase::from_global();
+        let usecase = s3_api::default_multipart_usecase();
         usecase.execute_abort_multipart_upload(req).await
     }
 
@@ -252,14 +249,14 @@ impl S3 for FS {
         &self,
         req: S3Request<CompleteMultipartUploadInput>,
     ) -> S3Result<S3Response<CompleteMultipartUploadOutput>> {
-        let usecase = DefaultMultipartUsecase::from_global();
+        let usecase = s3_api::default_multipart_usecase();
         Box::pin(usecase.execute_complete_multipart_upload(req)).await
     }
 
     /// Copy an object from one location to another
     #[instrument(level = "debug", skip(self, req))]
     async fn copy_object(&self, req: S3Request<CopyObjectInput>) -> S3Result<S3Response<CopyObjectOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         Box::pin(usecase.execute_copy_object(req)).await
     }
 
@@ -269,7 +266,7 @@ impl S3 for FS {
         fields(start_time=?time::OffsetDateTime::now_utc())
     )]
     async fn create_bucket(&self, req: S3Request<CreateBucketInput>) -> S3Result<S3Response<CreateBucketOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_create_bucket(req).await
     }
 
@@ -278,20 +275,20 @@ impl S3 for FS {
         &self,
         req: S3Request<CreateMultipartUploadInput>,
     ) -> S3Result<S3Response<CreateMultipartUploadOutput>> {
-        let usecase = DefaultMultipartUsecase::from_global();
+        let usecase = s3_api::default_multipart_usecase();
         usecase.execute_create_multipart_upload(req).await
     }
 
     /// Delete a bucket
     #[instrument(level = "debug", skip(self, req))]
     async fn delete_bucket(&self, req: S3Request<DeleteBucketInput>) -> S3Result<S3Response<DeleteBucketOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_bucket(req).await
     }
 
     #[instrument(level = "debug", skip(self))]
     async fn delete_bucket_cors(&self, req: S3Request<DeleteBucketCorsInput>) -> S3Result<S3Response<DeleteBucketCorsOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_bucket_cors(req).await
     }
 
@@ -299,7 +296,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketEncryptionInput>,
     ) -> S3Result<S3Response<DeleteBucketEncryptionOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_bucket_encryption(req).await
     }
 
@@ -308,7 +305,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketLifecycleInput>,
     ) -> S3Result<S3Response<DeleteBucketLifecycleOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_bucket_lifecycle(req).await
     }
 
@@ -316,7 +313,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketPolicyInput>,
     ) -> S3Result<S3Response<DeleteBucketPolicyOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_bucket_policy(req).await
     }
 
@@ -324,7 +321,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketReplicationInput>,
     ) -> S3Result<S3Response<DeleteBucketReplicationOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_bucket_replication(req).await
     }
 
@@ -333,7 +330,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketTaggingInput>,
     ) -> S3Result<S3Response<DeleteBucketTaggingOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_bucket_tagging(req).await
     }
 
@@ -362,14 +359,14 @@ impl S3 for FS {
         &self,
         req: S3Request<DeletePublicAccessBlockInput>,
     ) -> S3Result<S3Response<DeletePublicAccessBlockOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_delete_public_access_block(req).await
     }
 
     /// Delete an object
     #[instrument(level = "debug", skip(self, req))]
     async fn delete_object(&self, req: S3Request<DeleteObjectInput>) -> S3Result<S3Response<DeleteObjectOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         Box::pin(usecase.execute_delete_object(req)).await
     }
 
@@ -464,7 +461,7 @@ impl S3 for FS {
     /// Delete multiple objects
     #[instrument(level = "debug", skip(self, req))]
     async fn delete_objects(&self, req: S3Request<DeleteObjectsInput>) -> S3Result<S3Response<DeleteObjectsOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         usecase.execute_delete_objects(req).await
     }
 
@@ -510,7 +507,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self))]
     async fn get_bucket_cors(&self, req: S3Request<GetBucketCorsInput>) -> S3Result<S3Response<GetBucketCorsOutput>> {
         record_s3_op(S3Operation::GetBucketCors, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_cors(req).await
     }
 
@@ -519,7 +516,7 @@ impl S3 for FS {
         req: S3Request<GetBucketEncryptionInput>,
     ) -> S3Result<S3Response<GetBucketEncryptionOutput>> {
         record_s3_op(S3Operation::GetBucketEncryption, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_encryption(req).await
     }
 
@@ -529,7 +526,7 @@ impl S3 for FS {
         req: S3Request<GetBucketLifecycleConfigurationInput>,
     ) -> S3Result<S3Response<GetBucketLifecycleConfigurationOutput>> {
         record_s3_op(S3Operation::GetBucketLifecycleConfiguration, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_lifecycle_configuration(req).await
     }
 
@@ -537,7 +534,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self, req))]
     async fn get_bucket_location(&self, req: S3Request<GetBucketLocationInput>) -> S3Result<S3Response<GetBucketLocationOutput>> {
         record_s3_op(S3Operation::GetBucketLocation, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_location(req).await
     }
 
@@ -546,13 +543,13 @@ impl S3 for FS {
         req: S3Request<GetBucketNotificationConfigurationInput>,
     ) -> S3Result<S3Response<GetBucketNotificationConfigurationOutput>> {
         record_s3_op(S3Operation::GetBucketNotificationConfiguration, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_notification_configuration(req).await
     }
 
     async fn get_bucket_policy(&self, req: S3Request<GetBucketPolicyInput>) -> S3Result<S3Response<GetBucketPolicyOutput>> {
         record_s3_op(S3Operation::GetBucketPolicy, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_policy(req).await
     }
 
@@ -561,7 +558,7 @@ impl S3 for FS {
         req: S3Request<GetBucketPolicyStatusInput>,
     ) -> S3Result<S3Response<GetBucketPolicyStatusOutput>> {
         record_s3_op(S3Operation::GetBucketPolicyStatus, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_policy_status(req).await
     }
 
@@ -570,7 +567,7 @@ impl S3 for FS {
         req: S3Request<GetBucketReplicationInput>,
     ) -> S3Result<S3Response<GetBucketReplicationOutput>> {
         record_s3_op(S3Operation::GetBucketReplication, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_replication(req).await
     }
 
@@ -601,7 +598,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self))]
     async fn get_bucket_tagging(&self, req: S3Request<GetBucketTaggingInput>) -> S3Result<S3Response<GetBucketTaggingOutput>> {
         record_s3_op(S3Operation::GetBucketTagging, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_tagging(req).await
     }
 
@@ -611,7 +608,7 @@ impl S3 for FS {
         req: S3Request<GetPublicAccessBlockInput>,
     ) -> S3Result<S3Response<GetPublicAccessBlockOutput>> {
         record_s3_op(S3Operation::GetPublicAccessBlock, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_public_access_block(req).await
     }
 
@@ -621,7 +618,7 @@ impl S3 for FS {
         req: S3Request<GetBucketVersioningInput>,
     ) -> S3Result<S3Response<GetBucketVersioningOutput>> {
         record_s3_op(S3Operation::GetBucketVersioning, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_get_bucket_versioning(req).await
     }
 
@@ -654,7 +651,7 @@ impl S3 for FS {
         fields(start_time=?time::OffsetDateTime::now_utc())
     )]
     async fn get_object(&self, req: S3Request<GetObjectInput>) -> S3Result<S3Response<GetObjectOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         Box::pin(usecase.execute_get_object(req)).await
     }
 
@@ -680,7 +677,7 @@ impl S3 for FS {
         &self,
         req: S3Request<GetObjectAttributesInput>,
     ) -> S3Result<S3Response<GetObjectAttributesOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         usecase.execute_get_object_attributes(req).await
     }
 
@@ -932,13 +929,13 @@ impl S3 for FS {
 
     #[instrument(level = "debug", skip(self, req))]
     async fn head_bucket(&self, req: S3Request<HeadBucketInput>) -> S3Result<S3Response<HeadBucketOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_head_bucket(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn head_object(&self, req: S3Request<HeadObjectInput>) -> S3Result<S3Response<HeadObjectOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         usecase.execute_head_object(req).await
     }
 
@@ -946,7 +943,7 @@ impl S3 for FS {
     async fn list_buckets(&self, req: S3Request<ListBucketsInput>) -> S3Result<S3Response<ListBucketsOutput>> {
         // List buckets not associated with a bucket, give it bucket label "*" to denote "all".
         record_s3_op(S3Operation::ListBuckets, "*");
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_list_buckets(req).await
     }
 
@@ -955,7 +952,7 @@ impl S3 for FS {
         req: S3Request<ListMultipartUploadsInput>,
     ) -> S3Result<S3Response<ListMultipartUploadsOutput>> {
         record_s3_op(S3Operation::ListMultipartUploads, &req.input.bucket);
-        let usecase = DefaultMultipartUsecase::from_global();
+        let usecase = s3_api::default_multipart_usecase();
         usecase.execute_list_multipart_uploads(req).await
     }
 
@@ -964,7 +961,7 @@ impl S3 for FS {
         req: S3Request<ListObjectVersionsInput>,
     ) -> S3Result<S3Response<ListObjectVersionsOutput>> {
         record_s3_op(S3Operation::ListObjectVersions, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_list_object_versions(req).await
     }
 
@@ -973,35 +970,35 @@ impl S3 for FS {
         req: S3Request<ListObjectVersionsInput>,
     ) -> S3Result<S3Response<ListObjectVersionsMOutput>> {
         record_s3_op(S3Operation::ListObjectVersions, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_list_object_versions_m(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn list_objects(&self, req: S3Request<ListObjectsInput>) -> S3Result<S3Response<ListObjectsOutput>> {
         record_s3_op(S3Operation::ListObjects, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_list_objects(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn list_objects_v2(&self, req: S3Request<ListObjectsV2Input>) -> S3Result<S3Response<ListObjectsV2Output>> {
         record_s3_op(S3Operation::ListObjectsV2, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_list_objects_v2(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn list_objects_v2m(&self, req: S3Request<ListObjectsV2Input>) -> S3Result<S3Response<ListObjectsV2MOutput>> {
         record_s3_op(S3Operation::ListObjectsV2, &req.input.bucket);
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_list_objects_v2m(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn list_parts(&self, req: S3Request<ListPartsInput>) -> S3Result<S3Response<ListPartsOutput>> {
         record_s3_op(S3Operation::ListParts, &req.input.bucket);
-        let usecase = DefaultMultipartUsecase::from_global();
+        let usecase = s3_api::default_multipart_usecase();
         usecase.execute_list_parts(req).await
     }
 
@@ -1055,7 +1052,7 @@ impl S3 for FS {
 
     #[instrument(level = "debug", skip(self))]
     async fn put_bucket_cors(&self, req: S3Request<PutBucketCorsInput>) -> S3Result<S3Response<PutBucketCorsOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_cors(req).await
     }
 
@@ -1101,7 +1098,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketEncryptionInput>,
     ) -> S3Result<S3Response<PutBucketEncryptionOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_encryption(req).await
     }
 
@@ -1110,7 +1107,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketLifecycleConfigurationInput>,
     ) -> S3Result<S3Response<PutBucketLifecycleConfigurationOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_lifecycle_configuration(req).await
     }
 
@@ -1118,12 +1115,12 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketNotificationConfigurationInput>,
     ) -> S3Result<S3Response<PutBucketNotificationConfigurationOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_notification_configuration(req).await
     }
 
     async fn put_bucket_policy(&self, req: S3Request<PutBucketPolicyInput>) -> S3Result<S3Response<PutBucketPolicyOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_policy(req).await
     }
 
@@ -1131,7 +1128,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketReplicationInput>,
     ) -> S3Result<S3Response<PutBucketReplicationOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_replication(req).await
     }
 
@@ -1161,13 +1158,13 @@ impl S3 for FS {
         &self,
         req: S3Request<PutPublicAccessBlockInput>,
     ) -> S3Result<S3Response<PutPublicAccessBlockOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_public_access_block(req).await
     }
 
     #[instrument(level = "debug", skip(self))]
     async fn put_bucket_tagging(&self, req: S3Request<PutBucketTaggingInput>) -> S3Result<S3Response<PutBucketTaggingOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_tagging(req).await
     }
 
@@ -1176,7 +1173,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketVersioningInput>,
     ) -> S3Result<S3Response<PutBucketVersioningOutput>> {
-        let usecase = DefaultBucketUsecase::from_global();
+        let usecase = s3_api::default_bucket_usecase();
         usecase.execute_put_bucket_versioning(req).await
     }
 
@@ -1200,7 +1197,7 @@ impl S3 for FS {
 
     #[instrument(level = "debug", skip(self, req))]
     async fn put_object(&self, req: S3Request<PutObjectInput>) -> S3Result<S3Response<PutObjectOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         Box::pin(usecase.execute_put_object(self, req)).await
     }
 
@@ -1523,7 +1520,7 @@ impl S3 for FS {
     }
 
     async fn restore_object(&self, req: S3Request<RestoreObjectInput>) -> S3Result<S3Response<RestoreObjectOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         usecase.execute_restore_object(req).await
     }
 
@@ -1531,21 +1528,21 @@ impl S3 for FS {
         &self,
         req: S3Request<SelectObjectContentInput>,
     ) -> S3Result<S3Response<SelectObjectContentOutput>> {
-        let usecase = DefaultObjectUsecase::from_global();
+        let usecase = s3_api::default_object_usecase();
         usecase.execute_select_object_content(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn upload_part(&self, req: S3Request<UploadPartInput>) -> S3Result<S3Response<UploadPartOutput>> {
         record_s3_op(S3Operation::UploadPart, &req.input.bucket);
-        let usecase = DefaultMultipartUsecase::from_global();
+        let usecase = s3_api::default_multipart_usecase();
         usecase.execute_upload_part(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn upload_part_copy(&self, req: S3Request<UploadPartCopyInput>) -> S3Result<S3Response<UploadPartCopyOutput>> {
         record_s3_op(S3Operation::UploadPartCopy, &req.input.bucket);
-        let usecase = DefaultMultipartUsecase::from_global();
+        let usecase = s3_api::default_multipart_usecase();
         Box::pin(usecase.execute_upload_part_copy(req)).await
     }
 }

--- a/rustfs/src/storage/rpc/node_service.rs
+++ b/rustfs/src/storage/rpc/node_service.rs
@@ -186,7 +186,7 @@ impl std::fmt::Debug for NodeService {
 }
 
 pub fn make_server() -> NodeService {
-    let context = runtime_sources::get_global_app_context();
+    let context = runtime_sources::current_app_context();
     make_server_for_context(context)
 }
 
@@ -197,7 +197,7 @@ pub fn make_server_for_context(context: Option<Arc<runtime_sources::AppContext>>
 
 impl NodeService {
     fn resolve_object_store(&self) -> Option<Arc<crate::app::storage_api::ECStore>> {
-        let context = self.context.clone().or_else(runtime_sources::get_global_app_context);
+        let context = self.context.clone().or_else(runtime_sources::current_app_context);
         runtime_sources::object_store_handle_for_context(context.as_deref())
     }
 

--- a/rustfs/src/storage/runtime_sources.rs
+++ b/rustfs/src/storage/runtime_sources.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::app::context;
 use crate::config::RustFSBufferConfig;
+use crate::runtime_sources as root_runtime_sources;
 use crate::storage::ECStore;
 use rustfs_credentials::Credentials;
 use rustfs_iam::{error::Result as IamResult, store::object::ObjectStore, sys::IamSys};
@@ -22,60 +22,60 @@ use rustfs_kms::ObjectEncryptionService;
 use rustfs_lock::LockClient;
 use std::sync::Arc;
 
-pub(crate) use context::AppContext;
+pub(crate) use crate::runtime_sources::AppContext;
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
-    context::get_global_app_context()
+    root_runtime_sources::current_app_context()
 }
 
 pub(crate) fn object_store_handle() -> Option<Arc<ECStore>> {
-    context::resolve_object_store_handle()
+    root_runtime_sources::resolve_object_store_handle()
 }
 
 pub(crate) fn object_store_handle_for_context(context: Option<&AppContext>) -> Option<Arc<ECStore>> {
-    context::resolve_object_store_handle_for_context(context)
+    root_runtime_sources::resolve_object_store_handle_for_context(context)
 }
 
 pub(crate) fn buffer_config() -> RustFSBufferConfig {
-    context::resolve_buffer_config()
+    root_runtime_sources::resolve_buffer_config()
 }
 
 pub(crate) fn internode_metrics() -> Arc<InternodeMetrics> {
-    context::resolve_internode_metrics()
+    root_runtime_sources::resolve_internode_metrics()
 }
 
 pub(crate) async fn local_node_name() -> String {
-    context::resolve_local_node_name().await
+    root_runtime_sources::resolve_local_node_name().await
 }
 
 pub(crate) fn action_credentials() -> Option<Credentials> {
-    context::resolve_action_credentials()
+    root_runtime_sources::resolve_action_credentials()
 }
 
-pub(crate) fn notify_interface() -> Arc<dyn context::NotifyInterface> {
-    context::resolve_notify_interface()
+pub(crate) fn notify_interface() -> Arc<dyn root_runtime_sources::NotifyInterface> {
+    root_runtime_sources::resolve_notify_interface()
 }
 
 pub(crate) fn performance_metrics() -> Arc<PerformanceMetrics> {
-    context::resolve_performance_metrics()
+    root_runtime_sources::resolve_performance_metrics()
 }
 
 pub(crate) async fn encryption_service() -> Option<Arc<ObjectEncryptionService>> {
-    context::resolve_encryption_service().await
+    root_runtime_sources::resolve_encryption_service().await
 }
 
 pub(crate) fn region() -> Option<s3s::region::Region> {
-    context::resolve_region()
+    root_runtime_sources::resolve_region()
 }
 
 pub(crate) fn ready_iam_handle() -> IamResult<Arc<IamSys<ObjectStore>>> {
-    context::resolve_ready_iam_handle()
+    root_runtime_sources::resolve_ready_iam_handle()
 }
 
 pub(crate) fn iam_handle() -> Option<Arc<IamSys<ObjectStore>>> {
-    context::resolve_iam_handle()
+    root_runtime_sources::resolve_iam_handle()
 }
 
 pub(crate) fn lock_client() -> Option<Arc<dyn LockClient>> {
-    context::resolve_lock_client()
+    root_runtime_sources::resolve_lock_client()
 }

--- a/rustfs/src/storage/runtime_sources.rs
+++ b/rustfs/src/storage/runtime_sources.rs
@@ -22,7 +22,11 @@ use rustfs_kms::ObjectEncryptionService;
 use rustfs_lock::LockClient;
 use std::sync::Arc;
 
-pub(crate) use context::{AppContext, get_global_app_context};
+pub(crate) use context::AppContext;
+
+pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
+    context::get_global_app_context()
+}
 
 pub(crate) fn object_store_handle() -> Option<Arc<ECStore>> {
     context::resolve_object_store_handle()

--- a/rustfs/src/storage/s3_api/mod.rs
+++ b/rustfs/src/storage/s3_api/mod.rs
@@ -19,8 +19,24 @@
 //! This file intentionally starts as skeleton-only. Behavior remains in place
 //! until each helper is moved with dedicated small refactor steps.
 
+use crate::app::{
+    bucket_usecase::DefaultBucketUsecase, multipart_usecase::DefaultMultipartUsecase, object_usecase::DefaultObjectUsecase,
+};
+
 pub(crate) mod acl;
 pub(crate) mod bucket;
 pub(crate) mod common;
 pub(crate) mod multipart;
 pub(crate) mod tagging;
+
+pub(crate) fn default_bucket_usecase() -> DefaultBucketUsecase {
+    DefaultBucketUsecase::from_global()
+}
+
+pub(crate) fn default_multipart_usecase() -> DefaultMultipartUsecase {
+    DefaultMultipartUsecase::from_global()
+}
+
+pub(crate) fn default_object_usecase() -> DefaultObjectUsecase {
+    DefaultObjectUsecase::from_global()
+}

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -167,6 +167,7 @@ RUSTFS_APP_RUNTIME_STORAGE_API_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_runtime_s
 RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_startup_runtime_source_bypass_hits.txt"
 RUSTFS_SERVER_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_server_runtime_source_bypass_hits.txt"
 RUSTFS_STORAGE_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_runtime_source_bypass_hits.txt"
+RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_ecfs_usecase_bypass_hits.txt"
 RUSTFS_ADMIN_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_admin_runtime_source_bypass_hits.txt"
 RUSTFS_APP_CONTEXT_DIRECT_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_context_direct_bypass_hits.txt"
 RUSTFS_APP_USECASE_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_usecase_runtime_source_bypass_hits.txt"
@@ -1478,6 +1479,17 @@ fi
 
 if [[ -s "$RUSTFS_STORAGE_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
   report_failure "RustFS storage runtime source reads must stay behind rustfs/src/storage/runtime_sources.rs: $(paste -sd '; ' "$RUSTFS_STORAGE_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::app::(?:bucket_usecase|multipart_usecase|object_usecase)|Default(?:Bucket|Multipart|Object)Usecase::from_global\(\)' \
+    rustfs/src/storage/ecfs.rs \
+    --glob '*.rs' || true
+) >"$RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE"
+
+if [[ -s "$RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE" ]]; then
+  report_failure "RustFS storage ECFS S3 routes must construct app usecases through rustfs/src/storage/s3_api/mod.rs: $(paste -sd '; ' "$RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE")"
 fi
 
 (

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -167,6 +167,7 @@ RUSTFS_APP_RUNTIME_STORAGE_API_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_runtime_s
 RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_startup_runtime_source_bypass_hits.txt"
 RUSTFS_STARTUP_APP_CONTEXT_ENTRYPOINT_HITS_FILE="${TMP_DIR}/rustfs_startup_app_context_entrypoint_hits.txt"
 RUSTFS_SERVER_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_server_runtime_source_bypass_hits.txt"
+RUSTFS_SERVER_APP_CONTEXT_ENTRYPOINT_HITS_FILE="${TMP_DIR}/rustfs_server_app_context_entrypoint_hits.txt"
 RUSTFS_STORAGE_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_runtime_source_bypass_hits.txt"
 RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_ecfs_usecase_bypass_hits.txt"
 RUSTFS_STORAGE_GLOBAL_APP_CONTEXT_REEXPORT_HITS_FILE="${TMP_DIR}/rustfs_storage_global_app_context_reexport_hits.txt"
@@ -1473,6 +1474,17 @@ fi
 
 if [[ -s "$RUSTFS_SERVER_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
   report_failure "RustFS server runtime source reads must stay behind rustfs/src/server/runtime_sources.rs: $(paste -sd '; ' "$RUSTFS_SERVER_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::app::context::|use crate::app::context|app::context::' \
+    rustfs/src/server/runtime_sources.rs \
+    --glob '*.rs' || true
+) >"$RUSTFS_SERVER_APP_CONTEXT_ENTRYPOINT_HITS_FILE"
+
+if [[ -s "$RUSTFS_SERVER_APP_CONTEXT_ENTRYPOINT_HITS_FILE" ]]; then
+  report_failure "RustFS server AppContext reads must use rustfs/src/runtime_sources.rs entrypoints: $(paste -sd '; ' "$RUSTFS_SERVER_APP_CONTEXT_ENTRYPOINT_HITS_FILE")"
 fi
 
 (

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -168,6 +168,7 @@ RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_startup_runtim
 RUSTFS_STARTUP_APP_CONTEXT_ENTRYPOINT_HITS_FILE="${TMP_DIR}/rustfs_startup_app_context_entrypoint_hits.txt"
 RUSTFS_SERVER_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_server_runtime_source_bypass_hits.txt"
 RUSTFS_SERVER_APP_CONTEXT_ENTRYPOINT_HITS_FILE="${TMP_DIR}/rustfs_server_app_context_entrypoint_hits.txt"
+RUSTFS_OWNER_RUNTIME_APP_CONTEXT_ENTRYPOINT_HITS_FILE="${TMP_DIR}/rustfs_owner_runtime_app_context_entrypoint_hits.txt"
 RUSTFS_STORAGE_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_runtime_source_bypass_hits.txt"
 RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_ecfs_usecase_bypass_hits.txt"
 RUSTFS_STORAGE_GLOBAL_APP_CONTEXT_REEXPORT_HITS_FILE="${TMP_DIR}/rustfs_storage_global_app_context_reexport_hits.txt"
@@ -1485,6 +1486,19 @@ fi
 
 if [[ -s "$RUSTFS_SERVER_APP_CONTEXT_ENTRYPOINT_HITS_FILE" ]]; then
   report_failure "RustFS server AppContext reads must use rustfs/src/runtime_sources.rs entrypoints: $(paste -sd '; ' "$RUSTFS_SERVER_APP_CONTEXT_ENTRYPOINT_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::app::context::|use crate::app::context|app::context::' \
+    rustfs/src/admin/runtime_sources.rs \
+    rustfs/src/app/runtime_sources.rs \
+    rustfs/src/storage/runtime_sources.rs \
+    --glob '*.rs' || true
+) >"$RUSTFS_OWNER_RUNTIME_APP_CONTEXT_ENTRYPOINT_HITS_FILE"
+
+if [[ -s "$RUSTFS_OWNER_RUNTIME_APP_CONTEXT_ENTRYPOINT_HITS_FILE" ]]; then
+  report_failure "RustFS owner runtime AppContext reads must use rustfs/src/runtime_sources.rs entrypoints: $(paste -sd '; ' "$RUSTFS_OWNER_RUNTIME_APP_CONTEXT_ENTRYPOINT_HITS_FILE")"
 fi
 
 (

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -165,9 +165,11 @@ IAM_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/iam_runtime_source_bypass_hits.t
 RUSTFS_APP_CONTEXT_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_context_runtime_source_bypass_hits.txt"
 RUSTFS_APP_RUNTIME_STORAGE_API_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_runtime_storage_api_bypass_hits.txt"
 RUSTFS_STARTUP_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_startup_runtime_source_bypass_hits.txt"
+RUSTFS_STARTUP_APP_CONTEXT_ENTRYPOINT_HITS_FILE="${TMP_DIR}/rustfs_startup_app_context_entrypoint_hits.txt"
 RUSTFS_SERVER_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_server_runtime_source_bypass_hits.txt"
 RUSTFS_STORAGE_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_runtime_source_bypass_hits.txt"
 RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_storage_ecfs_usecase_bypass_hits.txt"
+RUSTFS_STORAGE_GLOBAL_APP_CONTEXT_REEXPORT_HITS_FILE="${TMP_DIR}/rustfs_storage_global_app_context_reexport_hits.txt"
 RUSTFS_ADMIN_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_admin_runtime_source_bypass_hits.txt"
 RUSTFS_APP_CONTEXT_DIRECT_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_context_direct_bypass_hits.txt"
 RUSTFS_APP_USECASE_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_usecase_runtime_source_bypass_hits.txt"
@@ -1449,6 +1451,17 @@ fi
 
 (
   cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::app::context::|use crate::app::context|app::context::' \
+    rustfs/src/startup_runtime_sources.rs \
+    --glob '*.rs' || true
+) >"$RUSTFS_STARTUP_APP_CONTEXT_ENTRYPOINT_HITS_FILE"
+
+if [[ -s "$RUSTFS_STARTUP_APP_CONTEXT_ENTRYPOINT_HITS_FILE" ]]; then
+  report_failure "RustFS startup AppContext reads must use rustfs/src/runtime_sources.rs entrypoints: $(paste -sd '; ' "$RUSTFS_STARTUP_APP_CONTEXT_ENTRYPOINT_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
   rg -n --with-filename 'crate::app::context::(?:\{[^}]*\b(?:resolve_server_config|resolve_notify_interface|resolve_object_store_handle|resolve_kms_runtime_service_manager|resolve_iam_ready|resolve_endpoints_handle|resolve_lock_clients_handle)\b|(?:resolve_server_config|resolve_notify_interface|resolve_object_store_handle|resolve_kms_runtime_service_manager|resolve_iam_ready|resolve_endpoints_handle|resolve_lock_clients_handle)\b)' \
     rustfs/src/server/audit.rs \
     rustfs/src/server/event.rs \
@@ -1490,6 +1503,17 @@ fi
 
 if [[ -s "$RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE" ]]; then
   report_failure "RustFS storage ECFS S3 routes must construct app usecases through rustfs/src/storage/s3_api/mod.rs: $(paste -sd '; ' "$RUSTFS_STORAGE_ECFS_USECASE_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'pub\(crate\) use .*get_global_app_context|get_global_app_context.*pub\(crate\) use' \
+    rustfs/src/storage/runtime_sources.rs \
+    --glob '*.rs' || true
+) >"$RUSTFS_STORAGE_GLOBAL_APP_CONTEXT_REEXPORT_HITS_FILE"
+
+if [[ -s "$RUSTFS_STORAGE_GLOBAL_APP_CONTEXT_REEXPORT_HITS_FILE" ]]; then
+  report_failure "RustFS storage AppContext lookup must stay wrapped by rustfs/src/storage/runtime_sources.rs: $(paste -sd '; ' "$RUSTFS_STORAGE_GLOBAL_APP_CONTEXT_REEXPORT_HITS_FILE")"
 fi
 
 (

--- a/scripts/layer-dependency-baseline.txt
+++ b/scripts/layer-dependency-baseline.txt
@@ -43,7 +43,6 @@ dep|rustfs/src/server/http.rs|infra->interface|crate::admin
 dep|rustfs/src/server/layer.rs|infra->interface|crate::admin::console::is_console_path
 dep|rustfs/src/server/layer.rs|infra->interface|crate::admin::handlers::health::HealthProbe
 dep|rustfs/src/server/layer.rs|infra->interface|crate::admin::handlers::health::build_health_response_parts
-dep|rustfs/src/server/runtime_sources.rs|infra->app|crate::app::context
 dep|rustfs/src/storage/ecfs_extend.rs|infra->interface|crate::storage::ecfs::ListObjectUnorderedQuery
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::ecfs::FS
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::ecfs::validate_object_lock_configuration_input

--- a/scripts/layer-dependency-baseline.txt
+++ b/scripts/layer-dependency-baseline.txt
@@ -48,7 +48,6 @@ dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::ecfs::FS
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::ecfs::validate_object_lock_configuration_input
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::s3_api::common::rustfs_initiator
 dep|rustfs/src/storage/ecfs_test.rs|infra->interface|crate::storage::s3_api::common::rustfs_owner
-dep|rustfs/src/storage/runtime_sources.rs|infra->app|crate::app::context
 dep|rustfs/src/storage/rpc/node_service.rs|infra->interface|crate::admin::service::config::reload_dynamic_config_runtime_state
 dep|rustfs/src/storage/rpc/node_service.rs|infra->interface|crate::admin::service::config::reload_runtime_config_snapshot
 dep|rustfs/src/storage/rpc/node_service.rs|infra->interface|crate::admin::service::site_replication::reload_site_replication_runtime_state


### PR DESCRIPTION
## Related Issues
Fixes #660

## Summary of Changes
- Route ECFS S3 route usecase construction through the storage S3 API boundary.
- Keep storage, startup, server, admin, and app runtime AppContext access behind runtime-source entrypoints.
- Add architecture guards for the migrated runtime-source boundaries and remove stale layer baselines.
- Update migration progress for API-233 through API-236.

## Verification
- `cargo test -p rustfs storage::ecfs --lib`
- `cargo test -p rustfs storage::rpc --lib`
- `cargo test -p rustfs startup_tls_material --lib`
- `cargo test -p rustfs server:: --lib`
- `cargo test -p rustfs admin::router --lib`
- `cargo test -p rustfs app::bucket_usecase --lib`
- `cargo test -p rustfs app::object_usecase --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `make pre-pr`

## Impact
No runtime behavior change expected. This is an internal architecture boundary cleanup.

## Additional Notes
N/A
