### PR TITLE
refactor: segment external storage api boundaries

### DIFF
--- a/crates/e2e_test/src/reliant/grpc_lock_client.rs
+++ b/crates/e2e_test/src/reliant/grpc_lock_client.rs
@@ -24,7 +24,7 @@ use rustfs_protos::proto_gen::node_service::{BatchGenerallyLockRequest, Generall
 use tonic::Request;
 use tracing::{info, warn};
 
-use crate::storage_api::{TonicInterceptor, node_service_time_out_client_no_auth};
+use crate::storage_api::grpc_lock::{TonicInterceptor, node_service_time_out_client_no_auth};
 
 /// gRPC lock client without authentication for testing
 /// Similar to RemoteClient but uses no_auth client

--- a/crates/e2e_test/src/reliant/node_interact_test.rs
+++ b/crates/e2e_test/src/reliant/node_interact_test.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::common::workspace_root;
-use crate::storage_api::{
+use crate::storage_api::node_interact::{
     TonicInterceptor, VolumeInfo, WalkDirOptions, gen_tonic_signature_interceptor, node_service_time_out_client,
 };
 use futures::future::join_all;

--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -16,7 +16,7 @@ use crate::common::{
     RustFSTestEnvironment, awscurl_available, awscurl_post_sts_form_urlencoded, init_logging, local_http_client,
     rustfs_binary_path,
 };
-use crate::storage_api::BucketTargetSys;
+use crate::storage_api::replication_extension::BucketTargetSys;
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::primitives::ByteStream;

--- a/crates/e2e_test/src/storage_api.rs
+++ b/crates/e2e_test/src/storage_api.rs
@@ -19,3 +19,19 @@ pub(crate) use rustfs_ecstore::api::disk::{VolumeInfo, WalkDirOptions};
 pub(crate) use rustfs_ecstore::api::rpc::{TonicInterceptor, node_service_time_out_client_no_auth};
 #[cfg(test)]
 pub(crate) use rustfs_ecstore::api::rpc::{gen_tonic_signature_interceptor, node_service_time_out_client};
+
+#[cfg(test)]
+pub(crate) mod node_interact {
+    pub(crate) use super::{
+        TonicInterceptor, VolumeInfo, WalkDirOptions, gen_tonic_signature_interceptor, node_service_time_out_client,
+    };
+}
+
+pub(crate) mod grpc_lock {
+    pub(crate) use super::{TonicInterceptor, node_service_time_out_client_no_auth};
+}
+
+#[cfg(test)]
+pub(crate) mod replication_extension {
+    pub(crate) use super::BucketTargetSys;
+}

--- a/crates/heal/src/heal/channel.rs
+++ b/crates/heal/src/heal/channel.rs
@@ -563,13 +563,13 @@ mod tests {
         async fn format_disk(&self, _endpoint: &Endpoint) -> crate::Result<()> {
             Ok(())
         }
-        async fn get_bucket_info(&self, _bucket: &str) -> crate::Result<Option<crate::heal::storage_api::BucketInfo>> {
+        async fn get_bucket_info(&self, _bucket: &str) -> crate::Result<Option<crate::heal::storage_api::status::BucketInfo>> {
             Ok(None)
         }
         async fn heal_bucket_metadata(&self, _bucket: &str) -> crate::Result<()> {
             Ok(())
         }
-        async fn list_buckets(&self) -> crate::Result<Vec<crate::heal::storage_api::BucketInfo>> {
+        async fn list_buckets(&self) -> crate::Result<Vec<crate::heal::storage_api::status::BucketInfo>> {
             Ok(vec![])
         }
         async fn object_exists(&self, _bucket: &str, _object: &str) -> crate::Result<bool> {

--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -2408,7 +2408,7 @@ mod tests {
     use rustfs_common::heal_channel::{HealOpts, HealRequestSource};
     use rustfs_madmin::heal_commands::HealResultItem;
 
-    use super::super::{DiskStore, Endpoint, storage_api::BucketInfo};
+    use super::super::{DiskStore, Endpoint, storage_api::status::BucketInfo};
 
     struct MockStorage;
 

--- a/crates/heal/src/heal/mod.rs
+++ b/crates/heal/src/heal/mod.rs
@@ -23,13 +23,13 @@ pub(crate) mod storage_api;
 pub mod task;
 pub mod utils;
 
-use storage_api::{
+use storage_api::owner::{
     ECSTORE_BUCKET_META_PREFIX, ECSTORE_DATA_USAGE_CACHE_NAME, ECSTORE_GLOBAL_LOCAL_DISK_MAP, ECSTORE_RUSTFS_META_BUCKET,
     EcstoreDeleteOptions, EcstoreDiskAPI, EcstoreDiskBytes, EcstoreDiskError, EcstoreDiskResult, EcstoreDiskStore,
     EcstoreEndpoint, EcstoreErrorType, EcstoreStorageError, EcstoreStore, ObjectIO, ObjectOperations,
 };
 #[cfg(test)]
-use storage_api::{EcstoreDiskOption, ecstore_new_disk};
+use storage_api::owner::{EcstoreDiskOption, ecstore_new_disk};
 
 pub use erasure_healer::ErasureSetHealer;
 pub use manager::{HealManager, HealOperationsSnapshot, HealPriorityCounts, HealSourceCounts};

--- a/crates/heal/src/heal/storage.rs
+++ b/crates/heal/src/heal/storage.rs
@@ -19,7 +19,7 @@ use rustfs_madmin::heal_commands::HealResultItem;
 use std::sync::Arc;
 use tracing::{debug, error, warn};
 
-use super::storage_api::{
+use super::storage_api::storage::{
     BucketInfo, BucketOperations, DiskSetSelector, HealOperations as _, ListOperations as _, ObjectIO as _,
     ObjectOperations as _, StorageAdminApi,
 };

--- a/crates/heal/src/heal/storage_api.rs
+++ b/crates/heal/src/heal/storage_api.rs
@@ -27,3 +27,26 @@ pub(crate) use rustfs_ecstore::api::storage::ECStore as EcstoreStore;
 pub(crate) use rustfs_storage_api::{
     BucketInfo, BucketOperations, DiskSetSelector, HealOperations, ListOperations, ObjectIO, ObjectOperations, StorageAdminApi,
 };
+
+pub(crate) mod owner {
+    pub(crate) use super::{
+        ECSTORE_BUCKET_META_PREFIX, ECSTORE_DATA_USAGE_CACHE_NAME, ECSTORE_GLOBAL_LOCAL_DISK_MAP, ECSTORE_RUSTFS_META_BUCKET,
+        EcstoreDeleteOptions, EcstoreDiskAPI, EcstoreDiskBytes, EcstoreDiskError, EcstoreDiskResult, EcstoreDiskStore,
+        EcstoreEndpoint, EcstoreErrorType, EcstoreStorageError, EcstoreStore, ObjectIO, ObjectOperations,
+    };
+
+    #[cfg(test)]
+    pub(crate) use super::{EcstoreDiskOption, ecstore_new_disk};
+}
+
+pub(crate) mod storage {
+    pub(crate) use super::{
+        BucketInfo, BucketOperations, DiskSetSelector, HealOperations, ListOperations, ObjectIO, ObjectOperations,
+        StorageAdminApi,
+    };
+}
+
+#[cfg(test)]
+pub(crate) mod status {
+    pub(crate) use super::BucketInfo;
+}

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -2208,7 +2208,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
 
-    use super::super::storage_api::BucketInfo;
+    use super::super::storage_api::status::BucketInfo;
     #[derive(Default)]
     struct MockStorage {
         listed: Mutex<bool>,

--- a/crates/heal/tests/endpoint_index_test.rs
+++ b/crates/heal/tests/endpoint_index_test.rs
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 #[path = "endpoint_index_test/storage_api.rs"]
 mod storage_api;
 
-use storage_api::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_local_disks};
+use storage_api::endpoint_index::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_local_disks};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_endpoint_index_settings() -> anyhow::Result<()> {

--- a/crates/heal/tests/endpoint_index_test/storage_api.rs
+++ b/crates/heal/tests/endpoint_index_test/storage_api.rs
@@ -15,3 +15,7 @@
 pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint;
 pub(crate) use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
 pub(crate) use rustfs_ecstore::api::storage::{ECStore, init_local_disks};
+
+pub(crate) mod endpoint_index {
+    pub(crate) use super::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_local_disks};
+}

--- a/crates/heal/tests/heal_bug_fixes_test.rs
+++ b/crates/heal/tests/heal_bug_fixes_test.rs
@@ -21,7 +21,7 @@ use rustfs_heal::heal::{
 #[path = "heal_bug_fixes_test/storage_api.rs"]
 mod storage_api;
 
-use storage_api::{BucketInfo, DiskStore, Endpoint};
+use storage_api::bug_fixes::{BucketInfo, DiskStore, Endpoint};
 
 #[test]
 fn test_heal_event_to_heal_request_no_panic() {

--- a/crates/heal/tests/heal_bug_fixes_test/storage_api.rs
+++ b/crates/heal/tests/heal_bug_fixes_test/storage_api.rs
@@ -14,3 +14,7 @@
 
 pub(crate) use rustfs_ecstore::api::disk::{DiskStore, endpoint::Endpoint};
 pub(crate) use rustfs_storage_api::BucketInfo;
+
+pub(crate) mod bug_fixes {
+    pub(crate) use super::{BucketInfo, DiskStore, Endpoint};
+}

--- a/crates/heal/tests/heal_integration_test.rs
+++ b/crates/heal/tests/heal_integration_test.rs
@@ -33,7 +33,7 @@ use walkdir::WalkDir;
 #[path = "heal_integration_test/storage_api.rs"]
 mod storage_api;
 
-use storage_api::{
+use storage_api::integration::{
     BucketOperations, BucketOptions, ECStore, Endpoint, EndpointServerPools, Endpoints, ObjectIO as _, ObjectOperations as _,
     PoolEndpoints, init_bucket_metadata_sys, init_local_disks,
 };

--- a/crates/heal/tests/heal_integration_test/storage_api.rs
+++ b/crates/heal/tests/heal_integration_test/storage_api.rs
@@ -17,3 +17,10 @@ pub(crate) use rustfs_ecstore::api::disk::endpoint::Endpoint;
 pub(crate) use rustfs_ecstore::api::layout::{EndpointServerPools, Endpoints, PoolEndpoints};
 pub(crate) use rustfs_ecstore::api::storage::{ECStore, init_local_disks};
 pub(crate) use rustfs_storage_api::{BucketOperations, BucketOptions, ObjectIO, ObjectOperations};
+
+pub(crate) mod integration {
+    pub(crate) use super::{
+        BucketOperations, BucketOptions, ECStore, Endpoint, EndpointServerPools, Endpoints, ObjectIO, ObjectOperations,
+        PoolEndpoints, init_bucket_metadata_sys, init_local_disks,
+    };
+}

--- a/crates/iam/src/lib.rs
+++ b/crates/iam/src/lib.rs
@@ -39,7 +39,7 @@ mod storage_api;
 pub mod store;
 pub mod sys;
 pub mod utils;
-pub(crate) use storage_api::{
+pub(crate) use storage_api::crate_boundary::{
     IAM_CONFIG_ROOT_PREFIX, IamEcstoreError, IamStorageError, IamStore, classify_iam_system_path_failure_reason,
     delete_iam_config, is_iam_first_cluster_node_local, read_iam_config_no_lock, read_iam_config_with_metadata, save_iam_config,
     save_iam_config_with_opts,
@@ -53,8 +53,8 @@ pub(crate) struct IamNotificationPeerErr {
     pub(crate) err: Option<IamEcstoreError>,
 }
 
-impl From<storage_api::IamEcstoreNotificationPeerErr> for IamNotificationPeerErr {
-    fn from(value: storage_api::IamEcstoreNotificationPeerErr) -> Self {
+impl From<storage_api::crate_boundary::IamEcstoreNotificationPeerErr> for IamNotificationPeerErr {
+    fn from(value: storage_api::crate_boundary::IamEcstoreNotificationPeerErr) -> Self {
         Self { err: value.err }
     }
 }

--- a/crates/iam/src/runtime_sources.rs
+++ b/crates/iam/src/runtime_sources.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::storage_api::{IamNotificationSys, notification_sys as ecstore_notification_sys};
+use crate::storage_api::runtime::{IamNotificationSys, notification_sys as ecstore_notification_sys};
 use rustfs_config::server_config::{Config as ServerConfig, get_global_server_config};
 use rustfs_credentials::{Credentials, get_global_action_cred};
 

--- a/crates/iam/src/storage_api.rs
+++ b/crates/iam/src/storage_api.rs
@@ -80,3 +80,19 @@ pub(crate) async fn is_iam_first_cluster_node_local() -> bool {
 pub(crate) fn notification_sys() -> Option<&'static IamNotificationSys> {
     get_global_notification_sys()
 }
+
+pub(crate) mod crate_boundary {
+    pub(crate) use super::{
+        IAM_CONFIG_ROOT_PREFIX, IamEcstoreError, IamEcstoreNotificationPeerErr, IamStorageError, IamStore,
+        classify_iam_system_path_failure_reason, delete_iam_config, is_iam_first_cluster_node_local, read_iam_config_no_lock,
+        read_iam_config_with_metadata, save_iam_config, save_iam_config_with_opts,
+    };
+}
+
+pub(crate) mod object_store {
+    pub(crate) use super::{HTTPPreconditions, ListOperations, ObjectInfoOrErr, ObjectOperations};
+}
+
+pub(crate) mod runtime {
+    pub(crate) use super::{IamNotificationSys, notification_sys};
+}

--- a/crates/iam/src/store/object.rs
+++ b/crates/iam/src/store/object.rs
@@ -37,7 +37,9 @@ use tokio::sync::mpsc::{self, Sender};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
-use crate::storage_api::{HTTPPreconditions, ListOperations as _, ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations};
+use crate::storage_api::object_store::{
+    HTTPPreconditions, ListOperations as _, ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations,
+};
 
 pub static IAM_CONFIG_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{IAM_CONFIG_ROOT_PREFIX}/iam"));
 pub static IAM_CONFIG_USERS_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{IAM_CONFIG_ROOT_PREFIX}/iam/users/"));

--- a/crates/obs/src/metrics/mod.rs
+++ b/crates/obs/src/metrics/mod.rs
@@ -30,7 +30,7 @@ pub use scheduler::{
     MetricsRuntimeShutdownHandle, MetricsRuntimeStatusSnapshot, MetricsRuntimeWorkerMutation, init_metrics_collectors,
     init_metrics_runtime, metrics_runtime_controller_snapshot, metrics_runtime_status_snapshot,
 };
-pub(crate) use storage_api::{
+pub(crate) use storage_api::metrics::{
     BucketOperations, BucketOptions, OBS_GLOBAL_EXPIRY_STATE, OBS_GLOBAL_REPLICATION_STATS, OBS_GLOBAL_TRANSITION_STATE,
     ObsBucketBandwidthMonitor, ObsEcstoreResult, ObsReplicationStats, ObsStore, StorageAdminApi, obs_get_global_bucket_monitor,
     obs_get_quota_config, obs_get_total_usable_capacity, obs_get_total_usable_capacity_free, obs_load_data_usage_from_backend,

--- a/crates/obs/src/metrics/storage_api.rs
+++ b/crates/obs/src/metrics/storage_api.rs
@@ -31,3 +31,12 @@ pub(crate) use rustfs_ecstore::api::global::{
 };
 pub(crate) use rustfs_ecstore::api::storage::ECStore as ObsStore;
 pub(crate) use rustfs_storage_api::{BucketOperations, BucketOptions, StorageAdminApi};
+
+pub(crate) mod metrics {
+    pub(crate) use super::{
+        BucketOperations, BucketOptions, OBS_GLOBAL_EXPIRY_STATE, OBS_GLOBAL_REPLICATION_STATS, OBS_GLOBAL_TRANSITION_STATE,
+        ObsBucketBandwidthMonitor, ObsEcstoreResult, ObsReplicationStats, ObsStore, StorageAdminApi,
+        obs_get_global_bucket_monitor, obs_get_quota_config, obs_get_total_usable_capacity, obs_get_total_usable_capacity_free,
+        obs_load_data_usage_from_backend, obs_resolve_object_store_handle,
+    };
+}

--- a/crates/protocols/src/swift/account.rs
+++ b/crates/protocols/src/swift/account.rs
@@ -14,7 +14,7 @@
 
 //! Swift account operations and validation
 
-use super::storage_api::{BucketOperations, MakeBucketOptions};
+use super::storage_api::account::{BucketOperations, MakeBucketOptions};
 use super::{SwiftError, SwiftResult};
 use super::{get_swift_bucket_metadata, resolve_swift_object_store_handle, set_swift_bucket_metadata};
 use rustfs_credentials::Credentials;

--- a/crates/protocols/src/swift/container.rs
+++ b/crates/protocols/src/swift/container.rs
@@ -17,7 +17,7 @@
 //! This module implements Swift container CRUD operations and container-bucket translation.
 
 use super::account::validate_account_access;
-use super::storage_api::{
+use super::storage_api::container::{
     BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, ListOperations as _, MakeBucketOptions,
 };
 use super::types::Container;

--- a/crates/protocols/src/swift/dlo.rs
+++ b/crates/protocols/src/swift/dlo.rs
@@ -18,7 +18,7 @@
 //! Segments are discovered at download time using lexicographic ordering
 //! based on a container metadata manifest pointer.
 
-use super::storage_api::HTTPRangeSpec;
+use super::storage_api::large_object::HTTPRangeSpec;
 use super::{SwiftError, container, object};
 use axum::http::{HeaderMap, Response, StatusCode};
 use rustfs_credentials::Credentials;

--- a/crates/protocols/src/swift/mod.rs
+++ b/crates/protocols/src/swift/mod.rs
@@ -61,7 +61,9 @@ pub mod versioning;
 pub use errors::{SwiftError, SwiftResult};
 pub use router::{SwiftRoute, SwiftRouter};
 // Note: Container, Object, and SwiftMetadata types used by Swift implementation
-pub use storage_api::{SwiftGetObjectReader, SwiftObjectInfo, SwiftObjectOptions, SwiftPutObjReader};
-pub(crate) use storage_api::{get_swift_bucket_metadata, resolve_swift_object_store_handle, set_swift_bucket_metadata};
+pub use storage_api::public_api::{SwiftGetObjectReader, SwiftObjectInfo, SwiftObjectOptions, SwiftPutObjReader};
+pub(crate) use storage_api::public_api::{
+    get_swift_bucket_metadata, resolve_swift_object_store_handle, set_swift_bucket_metadata,
+};
 #[allow(unused_imports)]
 pub use types::{Container, Object, SwiftMetadata};

--- a/crates/protocols/src/swift/object.rs
+++ b/crates/protocols/src/swift/object.rs
@@ -51,7 +51,7 @@
 
 use super::account::validate_account_access;
 use super::container::ContainerMapper;
-use super::storage_api::{BucketOperations, BucketOptions, HTTPRangeSpec, ObjectIO as _, ObjectOperations as _};
+use super::storage_api::object::{BucketOperations, BucketOptions, HTTPRangeSpec, ObjectIO as _, ObjectOperations as _};
 use super::{SwiftError, SwiftResult, resolve_swift_object_store_handle};
 use axum::http::HeaderMap;
 use rustfs_credentials::Credentials;

--- a/crates/protocols/src/swift/slo.rs
+++ b/crates/protocols/src/swift/slo.rs
@@ -18,7 +18,7 @@
 //! Large files (>5GB) are split into segments, and a manifest defines
 //! how segments are assembled on download.
 
-use super::storage_api::HTTPRangeSpec;
+use super::storage_api::large_object::HTTPRangeSpec;
 use super::{SwiftError, object};
 use axum::http::{HeaderMap, Response, StatusCode};
 use rustfs_credentials::Credentials;

--- a/crates/protocols/src/swift/storage_api.rs
+++ b/crates/protocols/src/swift/storage_api.rs
@@ -26,6 +26,31 @@ pub(crate) use rustfs_storage_api::{
     ObjectOperations,
 };
 
+pub(crate) mod account {
+    pub(crate) use super::{BucketOperations, MakeBucketOptions};
+}
+
+pub(crate) mod container {
+    pub(crate) use super::{BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, ListOperations, MakeBucketOptions};
+}
+
+pub(crate) mod large_object {
+    pub(crate) use super::HTTPRangeSpec;
+}
+
+pub(crate) mod object {
+    pub(crate) use super::{BucketOperations, BucketOptions, HTTPRangeSpec, ObjectIO, ObjectOperations};
+}
+
+pub(crate) mod public_api {
+    pub use super::{SwiftGetObjectReader, SwiftObjectInfo, SwiftObjectOptions, SwiftPutObjReader};
+    pub(crate) use super::{get_swift_bucket_metadata, resolve_swift_object_store_handle, set_swift_bucket_metadata};
+}
+
+pub(crate) mod versioning {
+    pub(crate) use super::{ListOperations, ObjectOperations};
+}
+
 pub type SwiftGetObjectReader = <SwiftStore as ObjectIO>::GetObjectReader;
 pub type SwiftObjectInfo = <SwiftStore as ObjectOperations>::ObjectInfo;
 pub type SwiftObjectOptions = <SwiftStore as ObjectOperations>::ObjectOptions;

--- a/crates/protocols/src/swift/versioning.rs
+++ b/crates/protocols/src/swift/versioning.rs
@@ -55,7 +55,7 @@ use super::account::validate_account_access;
 use super::container::ContainerMapper;
 use super::object::{ObjectKeyMapper, SwiftObjectOptions as ObjectOptions, head_object};
 use super::resolve_swift_object_store_handle;
-use super::storage_api::{ListOperations as _, ObjectOperations as _};
+use super::storage_api::versioning::{ListOperations as _, ObjectOperations as _};
 use super::{SwiftError, SwiftResult};
 use rustfs_credentials::Credentials;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/s3select-api/src/lib.rs
+++ b/crates/s3select-api/src/lib.rs
@@ -25,7 +25,7 @@ mod storage_api;
 mod test;
 
 pub type QueryResult<T> = Result<T, QueryError>;
-pub(crate) use storage_api::{
+pub(crate) use storage_api::crate_boundary::{
     SELECT_DEFAULT_READ_BUFFER_SIZE, SelectGetObjectReader, SelectObjectInfo, SelectObjectOptions, SelectStorageError,
     SelectStore, resolve_select_object_store_handle, select_is_err_bucket_not_found, select_is_err_object_not_found,
     select_is_err_version_not_found,

--- a/crates/s3select-api/src/object_store.rs
+++ b/crates/s3select-api/src/object_store.rs
@@ -48,7 +48,7 @@ use tokio::io::{AsyncRead, ReadBuf};
 use tokio_util::io::ReaderStream;
 use transform_stream::AsyncTryStream;
 
-use crate::storage_api::{HTTPRangeSpec, ObjectIO as _, ObjectOperations as _};
+use crate::storage_api::object_store::{HTTPRangeSpec, ObjectIO as _, ObjectOperations as _};
 
 fn select_default_read_buffer_size_u64() -> u64 {
     u64::try_from(SELECT_DEFAULT_READ_BUFFER_SIZE).unwrap_or(u64::MAX)

--- a/crates/s3select-api/src/storage_api.rs
+++ b/crates/s3select-api/src/storage_api.rs
@@ -25,6 +25,18 @@ pub(crate) use rustfs_ecstore::api::set_disk::DEFAULT_READ_BUFFER_SIZE as SELECT
 pub(crate) use rustfs_ecstore::api::storage::ECStore as SelectStore;
 pub(crate) use rustfs_storage_api::{HTTPRangeSpec, ObjectIO, ObjectOperations};
 
+pub(crate) mod object_store {
+    pub(crate) use super::{HTTPRangeSpec, ObjectIO, ObjectOperations};
+}
+
+pub(crate) mod crate_boundary {
+    pub(crate) use super::{
+        SELECT_DEFAULT_READ_BUFFER_SIZE, SelectGetObjectReader, SelectObjectInfo, SelectObjectOptions, SelectStorageError,
+        SelectStore, resolve_select_object_store_handle, select_is_err_bucket_not_found, select_is_err_object_not_found,
+        select_is_err_version_not_found,
+    };
+}
+
 pub(crate) type SelectGetObjectReader = <SelectStore as ObjectIO>::GetObjectReader;
 pub(crate) type SelectObjectInfo = <SelectStore as ObjectOperations>::ObjectInfo;
 pub(crate) type SelectObjectOptions = <SelectStore as ObjectOperations>::ObjectOptions;

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -24,7 +24,7 @@ use http::HeaderMap;
 use rustfs_config::server_config::{Config as ServerConfig, get_global_server_config as config_get_global_server_config};
 use std::path::PathBuf;
 use std::sync::Arc;
-use storage_api::{
+use storage_api::owner::{
     ECSTORE_BUCKET_META_PREFIX, ECSTORE_RUSTFS_META_BUCKET, ECSTORE_STORAGE_FORMAT_FILE, ECSTORE_STORAGECLASS_RRS,
     ECSTORE_STORAGECLASS_STANDARD, ECSTORE_TRANSITION_COMPLETE, EcstoreBucketTargetSys, EcstoreBucketVersioningSys, EcstoreDisk,
     EcstoreDiskAPI, EcstoreDiskBytes, EcstoreDiskError, EcstoreDiskInfo, EcstoreDiskInfoOptions, EcstoreDiskLocation,
@@ -40,7 +40,7 @@ use storage_api::{
     ecstore_resolve_object_store_handle, ecstore_save_config,
 };
 #[cfg(test)]
-use storage_api::{EcstoreDiskOption, EcstoreDiskStore, EcstoreEndpoint, ecstore_config_init, ecstore_new_disk};
+use storage_api::owner::{EcstoreDiskOption, EcstoreDiskStore, EcstoreEndpoint, ecstore_config_init, ecstore_new_disk};
 use tokio_util::sync::CancellationToken;
 
 pub mod data_usage_define;

--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -44,7 +44,7 @@ use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::storage_api::{BucketOperations, BucketOptions, NamespaceLocking as _};
+use crate::storage_api::scan::{BucketOperations, BucketOptions, NamespaceLocking as _};
 use crate::{
     ECStore, EcstoreError, RUSTFS_META_BUCKET, ScannerLifecycleConfigExt as _, ScannerReplicationConfigExt as _,
     get_lifecycle_config, get_replication_config, read_config, replace_bucket_usage_memory_from_info, save_config,
@@ -1148,9 +1148,9 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl crate::storage_api::ObjectIO for MemoryConfigStore {
+    impl crate::storage_api::scanner_io::ObjectIO for MemoryConfigStore {
         type Error = EcstoreError;
-        type RangeSpec = crate::storage_api::HTTPRangeSpec;
+        type RangeSpec = crate::storage_api::scanner_io::HTTPRangeSpec;
         type HeaderMap = http::HeaderMap;
         type ObjectOptions = ObjectOptions;
         type ObjectInfo = ObjectInfo;
@@ -1161,7 +1161,7 @@ mod tests {
             &self,
             bucket: &str,
             object: &str,
-            _range: Option<crate::storage_api::HTTPRangeSpec>,
+            _range: Option<crate::storage_api::scanner_io::HTTPRangeSpec>,
             _h: http::HeaderMap,
             _opts: &ObjectOptions,
         ) -> EcstoreResult<GetObjectReader> {

--- a/crates/scanner/src/scanner_io.rs
+++ b/crates/scanner/src/scanner_io.rs
@@ -42,7 +42,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
 use crate::ScannerObjectInfo as ObjectInfo;
-use crate::storage_api::{BucketInfo, BucketOperations, BucketOptions, DiskSetSelector, StorageAdminApi};
+use crate::storage_api::scanner_io::{BucketInfo, BucketOperations, BucketOptions, DiskSetSelector, StorageAdminApi};
 use crate::{
     BucketTargetSys, BucketVersioningSys, Disk, DiskError, ECStore, EcstoreError as Error, EcstoreResult as Result,
     ReplicationConfig, STORAGE_FORMAT_FILE, ScannerDiskExt as _, ScannerLifecycleConfigExt as _,

--- a/crates/scanner/src/storage_api.rs
+++ b/crates/scanner/src/storage_api.rs
@@ -76,3 +76,34 @@ pub(crate) use rustfs_storage_api::{
     BucketInfo, BucketOperations, BucketOptions, DiskSetSelector, HTTPRangeSpec, NamespaceLocking, ObjectIO, ObjectOperations,
     ObjectToDelete, StorageAdminApi,
 };
+
+pub(crate) mod owner {
+    pub(crate) use super::{
+        ECSTORE_BUCKET_META_PREFIX, ECSTORE_RUSTFS_META_BUCKET, ECSTORE_STORAGE_FORMAT_FILE, ECSTORE_STORAGECLASS_RRS,
+        ECSTORE_STORAGECLASS_STANDARD, ECSTORE_TRANSITION_COMPLETE, EcstoreBucketTargetSys, EcstoreBucketVersioningSys,
+        EcstoreDisk, EcstoreDiskAPI, EcstoreDiskBytes, EcstoreDiskError, EcstoreDiskInfo, EcstoreDiskInfoOptions,
+        EcstoreDiskLocation, EcstoreDiskResult, EcstoreErrorType, EcstoreEvaluator, EcstoreEvent, EcstoreLcEventSrc,
+        EcstoreLifecycle, EcstoreListPathRawOptions, EcstoreObjectOpts, EcstoreReplicationConfig,
+        EcstoreReplicationConfigurationExt, EcstoreReplicationHealQueueResult, EcstoreReplicationQueueAdmission,
+        EcstoreResultType, EcstoreScanGuard, EcstoreSetDisks, EcstoreStorageError, EcstoreStore, EcstoreTierConfig,
+        EcstoreVersioningApi, HTTPRangeSpec, ObjectIO, ObjectOperations, ObjectToDelete, ecstore_apply_expiry_rule,
+        ecstore_apply_transition_rule, ecstore_get_global_expiry_state, ecstore_get_global_tier_config_mgr,
+        ecstore_get_lifecycle_config, ecstore_get_object_lock_config, ecstore_get_replication_config, ecstore_is_erasure,
+        ecstore_is_erasure_sd, ecstore_is_reserved_or_invalid_bucket, ecstore_list_path_raw, ecstore_path2_bucket_object,
+        ecstore_path2_bucket_object_with_base_path, ecstore_queue_replication_heal_internal, ecstore_read_config,
+        ecstore_replace_bucket_usage_memory_from_info, ecstore_resolve_object_store_handle, ecstore_save_config,
+    };
+
+    #[cfg(test)]
+    pub(crate) use super::{EcstoreDiskOption, EcstoreDiskStore, EcstoreEndpoint, ecstore_config_init, ecstore_new_disk};
+}
+
+pub(crate) mod scan {
+    pub(crate) use super::{BucketOperations, BucketOptions, NamespaceLocking};
+}
+
+pub(crate) mod scanner_io {
+    pub(crate) use super::{BucketInfo, BucketOperations, BucketOptions, DiskSetSelector, StorageAdminApi};
+    #[cfg(test)]
+    pub(crate) use super::{HTTPRangeSpec, ObjectIO};
+}

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -41,7 +41,7 @@ use uuid::Uuid;
 
 mod storage_api;
 
-use storage_api::{
+use storage_api::lifecycle::{
     BUCKET_LIFECYCLE_CONFIG, BucketOperations, BucketOptions, BucketVersioningSys, CompletePart, DiskAPI as _, DiskOption,
     ECStore, Endpoint, EndpointServerPools, Endpoints, ListOperations as _, MakeBucketOptions, MultipartOperations as _,
     ObjectIO as _, ObjectOperations as _, PoolEndpoints, ReadCloser, ReaderImpl, STORAGE_FORMAT_FILE, ScannerWarmBackend,

--- a/crates/scanner/tests/storage_api/mod.rs
+++ b/crates/scanner/tests/storage_api/mod.rs
@@ -35,3 +35,14 @@ pub(crate) use rustfs_storage_api::{
     BucketOperations, BucketOptions, CompletePart, ListOperations, MakeBucketOptions, MultipartOperations, ObjectIO,
     ObjectOperations,
 };
+
+pub(crate) mod lifecycle {
+    pub(crate) use super::{
+        BUCKET_LIFECYCLE_CONFIG, BucketOperations, BucketOptions, BucketVersioningSys, CompletePart, DiskAPI, DiskOption,
+        ECStore, Endpoint, EndpointServerPools, Endpoints, ListOperations, MakeBucketOptions, MultipartOperations, ObjectIO,
+        ObjectOperations, PoolEndpoints, ReadCloser, ReaderImpl, STORAGE_FORMAT_FILE, ScannerWarmBackend, TierConfig, TierMinIO,
+        TierType, TransitionOptions, WarmBackendGetOpts, build_transition_put_options, enqueue_transition_for_existing_objects,
+        get_bucket_metadata, get_global_tier_config_mgr, init_background_expiry, init_bucket_metadata_sys, init_local_disks,
+        new_disk, path2_bucket_object_with_base_path, update_bucket_metadata,
+    };
+}

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,12 +5,12 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-app-storage-api-domain-boundary`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/CTX-002`.
-- Based on: rebased onto current `origin/main` after PR #3901 merged.
+- Branch: `overtrue/arch-external-storage-api-domain-boundaries`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/CTX-002`.
+- Based on: rebased onto current `origin/main` after PR #3902 merged.
 - PR type for this branch: `consumer-migration`
-- Runtime behavior changes: none expected for API-239; app bucket, object,
-  multipart, admin, select, context, and test consumers still use the same owner
+- Runtime behavior changes: none expected for API-240; scanner, heal, IAM, OBS
+  metrics, S3 Select, Swift, e2e, and related tests still use the same owner
   symbols through narrower domain modules.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
   region, KMS encryption service, runtime support handles, S3 Select DB,
@@ -75,7 +75,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   admin storage API consumers through admin domain modules for access, bucket,
   cluster, config, contract, error, metrics, object, rebalance, runtime, and
   tier boundaries, plus app storage API consumers through app domain modules
-  for admin, bucket, object, multipart, select, context, and test boundaries.
+  for admin, bucket, object, multipart, select, context, and test boundaries,
+  plus scanner, heal, IAM, OBS metrics, S3 Select, Swift, e2e, and related test
+  storage API consumers through external crate-local domain modules.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -85,11 +87,11 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   event-bridge thin module regressions, plus IAM runtime-source bypasses;
   accept the reviewed AppContext resolver reverse dependencies in the layer
   baseline, and block direct admin AppContext resolver consumers outside the
-  admin runtime-source boundary, block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries, catch grouped AppContext imports, reject app usecase storage wildcard imports, reject app-layer S3 DTO and ECFS wildcard imports, narrow the object-usecase ECFS layer baseline entry to `FS`, reject direct storage S3 API helper imports from app usecase files, reject direct storage helper imports from app select/usecase files, reject completed app/admin storage helper bypasses, reject app usecase bypasses for migrated storage IO/compression/set-disk helpers, reject app usecase/test bypasses for migrated storage error, ETag, and storage-class helpers, reject app root bucket owner facade bypasses from migrated app consumers, reject app/admin runtime/data-usage root facade regressions, reject admin root storage facade regressions from migrated admin consumers, reject root/server/startup direct storage facade regressions from migrated outer consumers, reject root/server/startup direct storage contract imports from migrated outer consumers, reject app/admin direct storage contract imports from migrated owner consumers, keep app S3 helper imports routed through `app::storage_api`, reject scanner/heal direct ECStore or storage contract imports outside their local `storage_api` boundaries, reject external runtime/test/fuzz ECStore or storage contract imports outside their local `storage_api` boundaries, reject storage owner direct ECStore/storage-api imports outside the owner-local `storage_api` boundary, reject ECStore internal direct storage-api imports outside the owner-local `storage_api_contracts` boundary, reject direct storage ECFS app usecase construction outside the storage S3 API boundary, reject flat root `storage_api` imports outside the new root-local domain modules, reject flat admin `storage_api` imports outside the new admin domain modules, and reject flat app `storage_api` imports outside the new app consumer-domain modules.
-- Docs changes: record the API-136 through API-239 owner facade,
+  admin runtime-source boundary, block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries, catch grouped AppContext imports, reject app usecase storage wildcard imports, reject app-layer S3 DTO and ECFS wildcard imports, narrow the object-usecase ECFS layer baseline entry to `FS`, reject direct storage S3 API helper imports from app usecase files, reject direct storage helper imports from app select/usecase files, reject completed app/admin storage helper bypasses, reject app usecase bypasses for migrated storage IO/compression/set-disk helpers, reject app usecase/test bypasses for migrated storage error, ETag, and storage-class helpers, reject app root bucket owner facade bypasses from migrated app consumers, reject app/admin runtime/data-usage root facade regressions, reject admin root storage facade regressions from migrated admin consumers, reject root/server/startup direct storage facade regressions from migrated outer consumers, reject root/server/startup direct storage contract imports from migrated outer consumers, reject app/admin direct storage contract imports from migrated owner consumers, keep app S3 helper imports routed through `app::storage_api`, reject scanner/heal direct ECStore or storage contract imports outside their local `storage_api` boundaries, reject external runtime/test/fuzz ECStore or storage contract imports outside their local `storage_api` boundaries, reject storage owner direct ECStore/storage-api imports outside the owner-local `storage_api` boundary, reject ECStore internal direct storage-api imports outside the owner-local `storage_api_contracts` boundary, reject direct storage ECFS app usecase construction outside the storage S3 API boundary, reject flat root `storage_api` imports outside the new root-local domain modules, reject flat admin `storage_api` imports outside the new admin domain modules, reject flat app `storage_api` imports outside the new app consumer-domain modules, and reject flat external crate-local `storage_api` imports outside the new consumer-domain modules.
+- Docs changes: record the API-136 through API-240 owner facade,
   runtime-source, ECFS usecase, root storage API domain-boundary, and admin
   storage API domain-boundary cleanup, and app storage API consumer-domain
-  cleanup.
+  cleanup, plus external crate-local storage API consumer-domain cleanup.
 
 ## Phase 0 Tasks
 
@@ -5510,15 +5512,33 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     guards, diff hygiene, residual flat app storage-api scan, Rust risk scan,
     and full PR gate passed before PR.
 
+- [x] `API-240` Segment external storage API boundaries by consumer domain.
+  - Do: add scanner, heal, IAM, OBS metrics, S3 Select, Swift, e2e, and related
+    test consumer-domain modules, then migrate those consumers away from flat
+    local `storage_api` imports.
+  - Acceptance: external crate-local consumers no longer import flat storage
+    facade symbols, storage contracts, ECStore helpers, runtime handles, or test
+    fixtures directly from local storage API roots; migration rules reject the
+    old flat paths.
+  - Must preserve: scanner data usage and lifecycle scan behavior, heal storage
+    and status fixtures, IAM object-store/runtime notification semantics, OBS
+    metrics collection, S3 Select object reads, Swift account/container/object
+    large-object/versioning behavior, and e2e RPC helper semantics.
+  - Verification: focused external crate compile, formatting, migration and
+    layer guards, diff hygiene, residual flat external storage-api scan, Rust
+    risk scan, and full PR gate passed before PR.
+
 ## Next PRs
 
-1. `consumer-migration`: continue larger root and owner boundary batches after
-   API-239.
+1. `consumer-migration`: continue larger owner boundary batches after API-240.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-240 segments external crate-local storage API boundaries into consumer domain modules instead of flat re-export surfaces. |
+| Migration preservation | pass | Scanner, heal, IAM, OBS metrics, S3 Select, Swift, e2e, and related test consumers keep the same owner symbols and call paths. |
+| Testing/verification | pass | Focused external crate compile, formatting, migration/layer guards, residual flat external storage-api scan, diff hygiene, diff-added Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | API-239 segments the app-local storage API boundary into app consumer domain modules instead of a flat re-export surface. |
 | Migration preservation | pass | App admin, bucket, object, multipart, select, context, lifecycle-transition, and capacity dirty-scope consumers keep the same owner symbols and call paths. |
 | Testing/verification | pass | RustFS focused compile, formatting, migration/layer guards, residual flat app storage-api scan, diff hygiene, diff-added Rust risk scan, and full PR gate passed before PR. |
@@ -5776,6 +5796,23 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-240 current slice:
+  - Branch freshness check: rebased onto current `origin/main` after PR #3902
+    merged.
+  - `cargo check --tests -p rustfs-scanner -p rustfs-heal -p rustfs-iam -p rustfs-obs -p rustfs-s3select-api -p rustfs-protocols -p e2e_test -F rustfs-protocols/swift`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Flat external storage-api residual scan: passed; scanner, heal, IAM, OBS
+    metrics, S3 Select, Swift, e2e, and related test consumers now use
+    `storage_api` consumer-domain modules instead of flat imports.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
+    ordering lines.
+  - `make pre-pr`: passed.
 
 - Issue #660 API-239 current slice:
   - Branch freshness check: rebased onto current `origin/main` after PR #3901

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -118,6 +118,7 @@ RUSTFS_APP_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_app_ecstore_source_hits.t
 RUSTFS_ADMIN_ECSTORE_SOURCE_HITS_FILE="${TMP_DIR}/rustfs_admin_ecstore_source_hits.txt"
 EXTERNAL_RUNTIME_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_runtime_ecstore_compat_bypass_hits.txt"
 EXTERNAL_RUNTIME_STORAGE_API_BYPASS_HITS_FILE="${TMP_DIR}/external_runtime_storage_api_bypass_hits.txt"
+EXTERNAL_STORAGE_API_DOMAIN_BYPASS_HITS_FILE="${TMP_DIR}/external_storage_api_domain_bypass_hits.txt"
 EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_test_ecstore_compat_bypass_hits.txt"
 FUZZ_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/fuzz_ecstore_compat_bypass_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
@@ -1412,6 +1413,27 @@ fi
 
 if [[ -s "$EXTERNAL_RUNTIME_STORAGE_API_BYPASS_HITS_FILE" ]]; then
   report_failure "external runtime crates must source storage-api contracts through their local storage_api boundary: $(paste -sd '; ' "$EXTERNAL_RUNTIME_STORAGE_API_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'use (crate::|super::)?storage_api::\{|use storage_api::\{|\b(crate::|super::)?storage_api::(BucketInfo|BucketOperations|BucketOptions|DeleteBucketOptions|DiskSetSelector|HTTPRangeSpec|ListOperations|MakeBucketOptions|NamespaceLocking|ObjectIO|ObjectOperations|StorageAdminApi|TonicInterceptor|BucketTargetSys)\b' \
+    crates/heal/src/heal \
+    crates/heal/tests \
+    crates/iam/src \
+    crates/obs/src/metrics \
+    crates/protocols/src/swift \
+    crates/s3select-api/src \
+    crates/scanner/src \
+    crates/scanner/tests \
+    crates/e2e_test/src \
+    --glob '*.rs' \
+    --glob '!**/storage_api.rs' \
+    --glob '!**/storage_api/mod.rs' || true
+) >"$EXTERNAL_STORAGE_API_DOMAIN_BYPASS_HITS_FILE"
+
+if [[ -s "$EXTERNAL_STORAGE_API_DOMAIN_BYPASS_HITS_FILE" ]]; then
+  report_failure "external local storage_api consumers must use domain modules instead of flat imports: $(paste -sd '; ' "$EXTERNAL_STORAGE_API_DOMAIN_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#660

## Summary of Changes

- Segment external crate-local `storage_api` boundaries into consumer-domain modules for scanner, heal, IAM, OBS metrics, S3 Select, Swift, e2e, and related tests.
- Route external consumers through the new domain modules instead of flat local storage API imports.
- Extend migration guardrails to reject flat external local storage API consumer bypasses.

## Verification

- `make pre-pr`

## Impact

No expected runtime behavior change. This is an import-boundary refactor with additional migration guard coverage.

## Additional Notes

N/A
