### PR TITLE
refactor: segment residual storage api boundaries

### DIFF
--- a/crates/ecstore/benches/comparison_benchmark.rs
+++ b/crates/ecstore/benches/comparison_benchmark.rs
@@ -36,7 +36,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 mod storage_api;
 use std::hint::black_box;
 use std::time::Duration;
-use storage_api::Erasure;
+use storage_api::comparison::Erasure;
 
 /// Performance test data configuration
 struct TestData {

--- a/crates/ecstore/benches/erasure_benchmark.rs
+++ b/crates/ecstore/benches/erasure_benchmark.rs
@@ -49,7 +49,7 @@ mod storage_api;
 use std::hint::black_box;
 use std::io::Cursor;
 use std::time::Duration;
-use storage_api::{BitrotReader, BitrotWriter, Erasure, calc_shard_size};
+use storage_api::erasure::{BitrotReader, BitrotWriter, Erasure, calc_shard_size};
 use tokio::runtime::Runtime;
 
 /// Benchmark configuration structure

--- a/crates/ecstore/benches/single_block_non_inline_benchmark.rs
+++ b/crates/ecstore/benches/single_block_non_inline_benchmark.rs
@@ -18,7 +18,7 @@ mod storage_api;
 use std::io::Cursor;
 use std::sync::Arc;
 use std::time::Duration;
-use storage_api::{BitrotWriterWrapper, CustomWriter, Erasure};
+use storage_api::single_block_non_inline::{BitrotWriterWrapper, CustomWriter, Erasure};
 
 #[derive(Clone, Debug)]
 struct BenchConfig {

--- a/crates/ecstore/benches/storage_api/mod.rs
+++ b/crates/ecstore/benches/storage_api/mod.rs
@@ -17,3 +17,15 @@
 pub(crate) use rustfs_ecstore::api::erasure::{
     BitrotReader, BitrotWriter, BitrotWriterWrapper, CustomWriter, Erasure, calc_shard_size,
 };
+
+pub(crate) mod comparison {
+    pub(crate) use super::Erasure;
+}
+
+pub(crate) mod erasure {
+    pub(crate) use super::{BitrotReader, BitrotWriter, Erasure, calc_shard_size};
+}
+
+pub(crate) mod single_block_non_inline {
+    pub(crate) use super::{BitrotWriterWrapper, CustomWriter, Erasure};
+}

--- a/crates/ecstore/tests/ecstore_contract_compat_test.rs
+++ b/crates/ecstore/tests/ecstore_contract_compat_test.rs
@@ -18,7 +18,7 @@ use rustfs_common::heal_channel::HealOpts;
 use rustfs_filemeta::FileInfo;
 use rustfs_lock::NamespaceLockWrapper;
 use rustfs_madmin::heal_commands::HealResultItem;
-use storage_api::{
+use storage_api::contract_compat::{
     CompletePart, DeletedObject, DiskStore, ECStore, Error, GetObjectReader, HTTPRangeSpec, ListMultipartsInfo, ListPartsInfo,
     MultipartInfo, MultipartUploadResult, ObjectInfo, ObjectOptions, ObjectToDelete, PartInfo, PutObjReader, StorageAdminApi,
     StorageHealOperations, StorageListObjectVersionsInfo, StorageListObjectsV2Info, StorageListOperations,

--- a/crates/ecstore/tests/legacy_bitrot_read_test.rs
+++ b/crates/ecstore/tests/legacy_bitrot_read_test.rs
@@ -32,7 +32,7 @@ mod storage_api;
 use rustfs_filemeta::{FileInfoOpts, get_file_info};
 use rustfs_utils::HashAlgorithm;
 use std::path::PathBuf;
-use storage_api::{DiskOption, Endpoint, STORAGE_FORMAT_FILE, create_bitrot_reader, new_disk};
+use storage_api::legacy_bitrot_read::{DiskOption, Endpoint, STORAGE_FORMAT_FILE, create_bitrot_reader, new_disk};
 use tokio::fs;
 
 fn workspace_root() -> PathBuf {

--- a/crates/ecstore/tests/minio_generated_read_test.rs
+++ b/crates/ecstore/tests/minio_generated_read_test.rs
@@ -9,7 +9,7 @@ mod storage_api;
 use rustfs_filemeta::{FileInfo, FileInfoOpts, get_file_info};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use storage_api::{
+use storage_api::minio_generated_read::{
     DiskAPI as _, DiskOption, Endpoint, Erasure, GetObjectReader, ObjectInfo, ObjectOptions, create_bitrot_reader, new_disk,
 };
 use temp_env::async_with_vars;

--- a/crates/ecstore/tests/storage_api.rs
+++ b/crates/ecstore/tests/storage_api.rs
@@ -13,3 +13,23 @@ pub(crate) use rustfs_storage_api::{
     ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations as StorageObjectOperations, ObjectToDelete, PartInfo,
     StorageAdminApi, WalkOptions as StorageWalkOptions,
 };
+
+pub(crate) mod contract_compat {
+    pub(crate) use super::{
+        CompletePart, DeletedObject, DiskStore, ECStore, Error, GetObjectReader, HTTPRangeSpec, ListMultipartsInfo,
+        ListPartsInfo, MultipartInfo, MultipartUploadResult, ObjectInfo, ObjectOptions, ObjectToDelete, PartInfo, PutObjReader,
+        StorageAdminApi, StorageHealOperations, StorageListObjectVersionsInfo, StorageListObjectsV2Info, StorageListOperations,
+        StorageMultipartOperations, StorageNamespaceLocking, StorageObjectIO, StorageObjectInfoOrErr, StorageObjectOperations,
+        StorageWalkOptions,
+    };
+}
+
+pub(crate) mod legacy_bitrot_read {
+    pub(crate) use super::{DiskOption, Endpoint, STORAGE_FORMAT_FILE, create_bitrot_reader, new_disk};
+}
+
+pub(crate) mod minio_generated_read {
+    pub(crate) use super::{
+        DiskAPI, DiskOption, Endpoint, Erasure, GetObjectReader, ObjectInfo, ObjectOptions, create_bitrot_reader, new_disk,
+    };
+}

--- a/crates/notify/src/lib.rs
+++ b/crates/notify/src/lib.rs
@@ -53,6 +53,6 @@ pub use runtime_facade::NotifyRuntimeFacade;
 pub use runtime_view::NotifyRuntimeView;
 pub use services::NotifyServices;
 pub use status_view::NotifyStatusView;
-pub(crate) use storage_api::{
+pub(crate) use storage_api::crate_boundary::{
     read_notify_server_config_without_migrate, resolve_notify_object_store_handle, save_notify_server_config,
 };

--- a/crates/notify/src/storage_api.rs
+++ b/crates/notify/src/storage_api.rs
@@ -41,3 +41,9 @@ pub(crate) async fn save_notify_server_config(
         .await
         .map_err(|err| err.to_string())
 }
+
+pub(crate) mod crate_boundary {
+    pub(crate) use super::{
+        read_notify_server_config_without_migrate, resolve_notify_object_store_handle, save_notify_server_config,
+    };
+}

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,13 +5,14 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-external-storage-api-domain-boundaries`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/CTX-002`.
-- Based on: rebased onto current `origin/main` after PR #3902 merged.
+- Branch: `overtrue/arch-residual-storage-api-domain-boundaries`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/CTX-002`.
+- Based on: rebased onto current `origin/main` after PR #3897 and PR #3900
+  merged on top of PR #3903.
 - PR type for this branch: `consumer-migration`
-- Runtime behavior changes: none expected for API-240; scanner, heal, IAM, OBS
-  metrics, S3 Select, Swift, e2e, and related tests still use the same owner
-  symbols through narrower domain modules.
+- Runtime behavior changes: none expected for API-241; residual notify,
+  ECStore test/bench, admin config, and storage RPC consumers still use the
+  same owner symbols through narrower local boundaries and aliases.
 - Rust code changes: route replication pool, outbound TLS generation, runtime
   region, KMS encryption service, runtime support handles, S3 Select DB,
   internode RPC metrics, IAM authorization/handler reads, notification
@@ -77,7 +78,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   tier boundaries, plus app storage API consumers through app domain modules
   for admin, bucket, object, multipart, select, context, and test boundaries,
   plus scanner, heal, IAM, OBS metrics, S3 Select, Swift, e2e, and related test
-  storage API consumers through external crate-local domain modules.
+  storage API consumers through external crate-local domain modules, plus
+  residual notify crate-boundary consumers, ECStore test/bench storage API
+  domain modules, and local ECStore type aliases for admin config and storage
+  RPC paths.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -87,11 +91,12 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   event-bridge thin module regressions, plus IAM runtime-source bypasses;
   accept the reviewed AppContext resolver reverse dependencies in the layer
   baseline, and block direct admin AppContext resolver consumers outside the
-  admin runtime-source boundary, block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries, catch grouped AppContext imports, reject app usecase storage wildcard imports, reject app-layer S3 DTO and ECFS wildcard imports, narrow the object-usecase ECFS layer baseline entry to `FS`, reject direct storage S3 API helper imports from app usecase files, reject direct storage helper imports from app select/usecase files, reject completed app/admin storage helper bypasses, reject app usecase bypasses for migrated storage IO/compression/set-disk helpers, reject app usecase/test bypasses for migrated storage error, ETag, and storage-class helpers, reject app root bucket owner facade bypasses from migrated app consumers, reject app/admin runtime/data-usage root facade regressions, reject admin root storage facade regressions from migrated admin consumers, reject root/server/startup direct storage facade regressions from migrated outer consumers, reject root/server/startup direct storage contract imports from migrated outer consumers, reject app/admin direct storage contract imports from migrated owner consumers, keep app S3 helper imports routed through `app::storage_api`, reject scanner/heal direct ECStore or storage contract imports outside their local `storage_api` boundaries, reject external runtime/test/fuzz ECStore or storage contract imports outside their local `storage_api` boundaries, reject storage owner direct ECStore/storage-api imports outside the owner-local `storage_api` boundary, reject ECStore internal direct storage-api imports outside the owner-local `storage_api_contracts` boundary, reject direct storage ECFS app usecase construction outside the storage S3 API boundary, reject flat root `storage_api` imports outside the new root-local domain modules, reject flat admin `storage_api` imports outside the new admin domain modules, reject flat app `storage_api` imports outside the new app consumer-domain modules, and reject flat external crate-local `storage_api` imports outside the new consumer-domain modules.
-- Docs changes: record the API-136 through API-240 owner facade,
+  admin runtime-source boundary, block root, app usecase, and storage direct AppContext resolver consumers outside their runtime-source boundaries, catch grouped AppContext imports, reject app usecase storage wildcard imports, reject app-layer S3 DTO and ECFS wildcard imports, narrow the object-usecase ECFS layer baseline entry to `FS`, reject direct storage S3 API helper imports from app usecase files, reject direct storage helper imports from app select/usecase files, reject completed app/admin storage helper bypasses, reject app usecase bypasses for migrated storage IO/compression/set-disk helpers, reject app usecase/test bypasses for migrated storage error, ETag, and storage-class helpers, reject app root bucket owner facade bypasses from migrated app consumers, reject app/admin runtime/data-usage root facade regressions, reject admin root storage facade regressions from migrated admin consumers, reject root/server/startup direct storage facade regressions from migrated outer consumers, reject root/server/startup direct storage contract imports from migrated outer consumers, reject app/admin direct storage contract imports from migrated owner consumers, keep app S3 helper imports routed through `app::storage_api`, reject scanner/heal direct ECStore or storage contract imports outside their local `storage_api` boundaries, reject external runtime/test/fuzz ECStore or storage contract imports outside their local `storage_api` boundaries, reject storage owner direct ECStore/storage-api imports outside the owner-local `storage_api` boundary, reject ECStore internal direct storage-api imports outside the owner-local `storage_api_contracts` boundary, reject direct storage ECFS app usecase construction outside the storage S3 API boundary, reject flat root `storage_api` imports outside the new root-local domain modules, reject flat admin `storage_api` imports outside the new admin domain modules, reject flat app `storage_api` imports outside the new app consumer-domain modules, reject flat external crate-local `storage_api` imports outside the new consumer-domain modules, and reject residual flat local `storage_api` imports from notify, ECStore tests/benches, and remaining RustFS app storage API type references.
+- Docs changes: record the API-136 through API-241 owner facade,
   runtime-source, ECFS usecase, root storage API domain-boundary, and admin
   storage API domain-boundary cleanup, and app storage API consumer-domain
-  cleanup, plus external crate-local storage API consumer-domain cleanup.
+  cleanup, plus external crate-local and residual local storage API
+  consumer-domain cleanup.
 
 ## Phase 0 Tasks
 
@@ -5528,14 +5533,31 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     layer guards, diff hygiene, residual flat external storage-api scan, Rust
     risk scan, and full PR gate passed before PR.
 
+- [x] `API-241` Segment residual storage API boundaries by consumer domain.
+  - Do: add residual notify crate-boundary, ECStore test/bench consumer-domain
+    modules, and local ECStore aliases for the remaining RustFS app storage API
+    type references.
+  - Acceptance: notify, ECStore tests/benches, admin config, and storage RPC no
+    longer import flat local storage API symbols for migrated residual
+    consumers; migration rules reject the old flat paths.
+  - Must preserve: notify config persistence, ECStore compatibility tests,
+    bitrot read tests, generated MinIO read fixtures, benchmark setup, admin
+    runtime config store resolution, and storage RPC object-store fallback.
+  - Verification: focused notify/ECStore/RustFS compile, formatting, migration
+    and layer guards, diff hygiene, residual flat local storage-api scan, Rust
+    risk scan, and full PR gate before PR.
+
 ## Next PRs
 
-1. `consumer-migration`: continue larger owner boundary batches after API-240.
+1. `consumer-migration`: continue larger owner boundary batches after API-241.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-241 segments residual local storage API imports into notify, ECStore test/bench, and RustFS local type boundaries. |
+| Migration preservation | pass | Notify config, ECStore contract/bitrot/read fixtures, benchmark setup, admin config, and storage RPC consumers keep the same owner symbols and call paths. |
+| Testing/verification | pass | Focused compile, formatting, migration/layer guards, residual flat local storage-api scan, diff hygiene, diff-added Rust risk scan, and full PR gate passed before PR. |
 | Quality/architecture | pass | API-240 segments external crate-local storage API boundaries into consumer domain modules instead of flat re-export surfaces. |
 | Migration preservation | pass | Scanner, heal, IAM, OBS metrics, S3 Select, Swift, e2e, and related test consumers keep the same owner symbols and call paths. |
 | Testing/verification | pass | Focused external crate compile, formatting, migration/layer guards, residual flat external storage-api scan, diff hygiene, diff-added Rust risk scan, and full PR gate passed before PR. |
@@ -5796,6 +5818,25 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-241 current slice:
+  - Branch freshness check: rebased onto current `origin/main` after PR #3897
+    and PR #3900 merged on top of PR #3903.
+  - `cargo check --tests --benches -p rustfs-ecstore -p rustfs-notify -p rustfs`:
+    passed.
+  - `cargo fmt --all`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Flat residual local storage-api scan: passed; notify, ECStore tests/benches,
+    admin config, and storage RPC residual consumers now use local
+    consumer-domain modules or aliases instead of flat imports.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    numeric cast, String error, Box dyn Error, print macro, or relaxed atomic
+    ordering lines.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `make pre-pr`: passed, including 6759 nextest tests passed, 112 skipped,
+    and doctests passed.
 
 - Issue #660 API-240 current slice:
   - Branch freshness check: rebased onto current `origin/main` after PR #3902

--- a/rustfs/src/admin/service/config.rs
+++ b/rustfs/src/admin/service/config.rs
@@ -18,6 +18,7 @@ use crate::admin::runtime_sources::{
 };
 use crate::admin::storage_api::config::{STORAGE_CLASS_SUB_SYS, read_admin_config_without_migrate, storageclass};
 use crate::admin::storage_api::contract::StorageAdminApi;
+use crate::admin::storage_api::runtime::ECStore;
 use rustfs_audit::reload_audit_config;
 use rustfs_config::audit::{AUDIT_MQTT_SUB_SYS, AUDIT_REDIS_DEFAULT_CHANNEL, AUDIT_WEBHOOK_SUB_SYS};
 use rustfs_config::notify::{NOTIFY_MQTT_SUB_SYS, NOTIFY_REDIS_DEFAULT_CHANNEL, NOTIFY_WEBHOOK_SUB_SYS};
@@ -66,9 +67,7 @@ fn invalid_request(message: impl Into<String>) -> S3Error {
     S3Error::with_message(S3ErrorCode::InvalidRequest, message.into())
 }
 
-fn resolve_runtime_config_store_for_context(
-    context: Option<&AppContext>,
-) -> S3Result<std::sync::Arc<crate::app::storage_api::ECStore>> {
+fn resolve_runtime_config_store_for_context(context: Option<&AppContext>) -> S3Result<std::sync::Arc<ECStore>> {
     resolve_object_store_handle_for_context(context).ok_or_else(|| internal_error("storage layer not initialized"))
 }
 

--- a/rustfs/src/storage/rpc/node_service.rs
+++ b/rustfs/src/storage/rpc/node_service.rs
@@ -196,7 +196,7 @@ pub fn make_server_for_context(context: Option<Arc<runtime_sources::AppContext>>
 }
 
 impl NodeService {
-    fn resolve_object_store(&self) -> Option<Arc<crate::app::storage_api::ECStore>> {
+    fn resolve_object_store(&self) -> Option<Arc<ECStore>> {
         let context = self.context.clone().or_else(runtime_sources::current_app_context);
         runtime_sources::object_store_handle_for_context(context.as_deref())
     }

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -1417,16 +1417,21 @@ fi
 
 (
   cd "$ROOT_DIR"
-  rg -n --with-filename 'use (crate::|super::)?storage_api::\{|use storage_api::\{|\b(crate::|super::)?storage_api::(BucketInfo|BucketOperations|BucketOptions|DeleteBucketOptions|DiskSetSelector|HTTPRangeSpec|ListOperations|MakeBucketOptions|NamespaceLocking|ObjectIO|ObjectOperations|StorageAdminApi|TonicInterceptor|BucketTargetSys)\b' \
+  rg -n --with-filename 'use (crate::|super::)?storage_api::\{|use storage_api::\{|\b(crate::|super::)?storage_api::(BucketInfo|BucketOperations|BucketOptions|DeleteBucketOptions|DiskSetSelector|ECStore|Erasure|HTTPRangeSpec|ListOperations|MakeBucketOptions|NamespaceLocking|ObjectIO|ObjectOperations|StorageAdminApi|TonicInterceptor|BucketTargetSys)\b' \
+    crates/ecstore/benches \
+    crates/ecstore/tests \
     crates/heal/src/heal \
     crates/heal/tests \
     crates/iam/src \
+    crates/notify/src \
     crates/obs/src/metrics \
     crates/protocols/src/swift \
     crates/s3select-api/src \
     crates/scanner/src \
     crates/scanner/tests \
     crates/e2e_test/src \
+    rustfs/src/admin/service/config.rs \
+    rustfs/src/storage/rpc/node_service.rs \
     --glob '*.rs' \
     --glob '!**/storage_api.rs' \
     --glob '!**/storage_api/mod.rs' || true


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#660

## Summary of Changes

- Segment residual flat local `storage_api` consumers through domain modules for notify and ECStore test/bench boundaries.
- Route remaining RustFS storage handle type references through local storage API aliases instead of direct app storage API paths.
- Extend migration guardrails to reject the residual flat storage API bypasses.

## Verification

- `make pre-pr`

## Impact

No expected runtime behavior change. This is an import-boundary refactor with additional migration guard coverage.

## Additional Notes

N/A
