### PR TITLE
refactor: remove storage owner wildcard imports

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,21 +5,22 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-storage-owner-rpc-domain-batch`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/CTX-002`.
-- Current prerequisite: API-251 is completed on
-  `overtrue/arch-storage-owner-runtime-domain-batch`.
-- Based on: stacked on `overtrue/arch-storage-owner-runtime-domain-batch`
+- Branch: `overtrue/arch-storage-owner-wildcard-domain-batch`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/CTX-002`.
+- Current prerequisite: API-252 is completed on
+  `overtrue/arch-storage-owner-rpc-domain-batch`.
+- Based on: stacked on `overtrue/arch-storage-owner-rpc-domain-batch`
   while prerequisite PRs are pending; rebase onto current `origin/main` after
   prerequisite PRs merge before opening this PR.
 - PR type for this branch: `consumer-migration`
-- Runtime behavior changes: none expected for API-252; storage-owner RPC
-  handlers and tests still use the same services, contracts, metrics, and
-  serialization helpers, now with explicit owner-domain imports instead of
-  parent wildcard imports.
-- Rust code changes: replace parent wildcard imports in storage-owner RPC
-  bucket, disk, event, health, HTTP service, lock, metrics, and msgpack tests;
-  prune the now-unused node-service aggregate imports.
+- Runtime behavior changes: none expected for API-253; storage-owner tests
+  still use the same storage, RPC, SSE, concurrency, timeout, helper, access,
+  and option paths, now with explicit imports instead of parent wildcard
+  imports.
+- Rust code changes: replace every remaining parent wildcard import under
+  `rustfs/src/storage` with explicit test imports across access, SSE, RPC,
+  concurrency, timeout, helper, backpressure, lock optimizer, options, request
+  context, and deadlock detector tests.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -42,8 +43,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   storage-owner internal consumer-domain cleanup; reject storage-owner internal
   root contract/object helper facade consumers after API-250, reject
   storage-owner runtime source, object-lock helper, RPC relative root, and ECFS
-  test root consumers after API-251, and reject restored RPC wildcard imports
-  after API-252.
+  test root consumers after API-251, reject restored RPC wildcard imports
+  after API-252, and reject restored parent wildcard imports anywhere under
+  `rustfs/src/storage` after API-253.
 
 ## Phase 0 Tasks
 
@@ -5645,15 +5647,33 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration/layer guards, storage-owner RPC wildcard scan, diff hygiene, and
     Rust risk scan passed; full PR gate is planned before PR.
 
+- [x] `API-253` Remove storage-owner test wildcard imports directory-wide.
+  - Do: replace every remaining `use super::*` under `rustfs/src/storage` with
+    explicit test imports across access, SSE, RPC, concurrency, timeout,
+    helper, backpressure, lock optimizer, options, request context, and
+    deadlock detector tests.
+  - Acceptance: `rustfs/src/storage` no longer contains parent wildcard
+    imports, and migration rules reject restored storage-wide parent wildcard
+    imports.
+  - Must preserve: storage access authorization tests, SSE/KMS tests, node RPC
+    tests, concurrency scheduling tests, timeout/backpressure helpers, option
+    parsing, request context extraction, and deadlock detector coverage.
+  - Verification: focused RustFS compile/test compile, formatting,
+    migration/layer guards, storage-wide wildcard scan, diff hygiene, and Rust
+    risk scan passed; full PR gate is planned before PR.
+
 ## Next PRs
 
-1. `consumer-migration`: continue larger owner boundary batches after API-252,
-   grouped by module family rather than single call-site cleanup.
+1. `consumer-migration`: continue larger owner boundary batches after API-253,
+   grouping multiple remaining storage-owner boundary families per PR.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-253 removes parent wildcard imports across the full storage-owner directory test surface and promotes the guard from RPC-only to storage-wide. |
+| Migration preservation | pass | Access, SSE, RPC, concurrency, timeout, helper, backpressure, lock optimizer, options, request context, and deadlock detector tests keep the same underlying symbols. |
+| Testing/verification | pass | RustFS compile/test compile, formatting, migration/layer guards, storage-wide wildcard scan, diff hygiene, and diff-added Rust risk scan passed; full PR gate is planned before PR. |
 | Quality/architecture | pass | API-252 replaces parent wildcard imports across the storage-owner RPC module family with explicit owner-domain imports. |
 | Migration preservation | pass | Node RPC handlers, HTTP RPC routing/streaming, metric serialization, lock mapping, bucket peer calls, and msgpack tests keep the same underlying symbols. |
 | Testing/verification | pass | Focused RustFS compile/test compile, formatting, migration/layer guards, storage-owner RPC wildcard scan, diff hygiene, and diff-added Rust risk scan passed; full PR gate is planned before PR. |
@@ -5950,6 +5970,23 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-253 current slice:
+  - Branch freshness check: stacked on `overtrue/arch-storage-owner-rpc-domain-batch`
+    while prerequisite PRs are pending.
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo test -p rustfs --lib storage --no-run`: passed with existing
+    `StorageObjectInfo` dead code warning.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Storage-wide parent wildcard import scan: passed.
+  - Diff-added Rust risk scan: passed.
+  - Full PR gate: pending before PR after prerequisite PRs merge and this
+    branch is rebased onto `origin/main`.
 
 - Issue #660 API-252 current slice:
   - Branch freshness check: stacked on `overtrue/arch-storage-owner-runtime-domain-batch`

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -2051,10 +2051,23 @@ impl S3Access for FS {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::{
+        AMZ_WRITE_OFFSET_BYTES_HEADER, BucketPolicyArgs, BucketPolicyExistingObjectTagHint, BucketPolicyRawLoadErrorKind, FS,
+        ObjectTagConditions, PostObjectRequestMarker, ReqInfo, S3Access, StorageError,
+        bucket_policy_needs_existing_object_tag_from_hint, classify_bucket_policy_raw_load_error,
+        complete_multipart_upload_authorize_action, get_bucket_policy_authorize_action, has_write_offset_bytes_header,
+        legal_hold_write_requested, list_parts_authorize_action, load_bucket_policy_existing_object_tag_hint,
+        merge_list_bucket_query_conditions, owner_can_bypass_policy_deny, post_object_authorize_action,
+        put_bucket_policy_authorize_action, request_context_from_req, retention_write_requested, secondary_tag_hint_action,
+        table_data_plane_admin_action, validate_post_object_success_controls,
+    };
+    use crate::error::ApiError;
     use http::{Extensions, HeaderMap, Method, Uri};
+    use rustfs_policy::policy::action::{Action, S3Action};
     use rustfs_policy::policy::{BucketPolicy, bucket_policy_uses_existing_object_tag_conditions};
+    use s3s::{S3ErrorCode, S3Request, dto::*};
     use std::collections::HashMap;
     use time::OffsetDateTime;
 

--- a/rustfs/src/storage/backpressure.rs
+++ b/rustfs/src/storage/backpressure.rs
@@ -483,8 +483,9 @@ impl Default for BackpressureMonitor {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::{BackpressureMonitor, BackpressurePipe, BackpressureState, ObjectPipeBackpressurePolicy};
 
     #[test]
     fn test_backpressure_config_default() {

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -1930,9 +1930,17 @@ pub fn get_buffer_size_opt_in(file_size: i64) -> usize {
 // ============================================
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::{
+        IoLoadLevel, IoPriority, IoPriorityMetrics, IoPriorityQueue, IoPriorityQueueConfig, IoSchedulerConfig,
+        IoSchedulingContext, IoStrategy, get_advanced_buffer_size, get_buffer_size_opt_in, get_concurrency_aware_buffer_size,
+    };
+    use rustfs_io_core::io_profile::{AccessPattern, StorageMedia};
+    use rustfs_io_metrics::bandwidth::{BandwidthSnapshot, BandwidthTier};
     use serial_test::serial;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
 
     #[tokio::test]
     #[serial]

--- a/rustfs/src/storage/concurrency/manager.rs
+++ b/rustfs/src/storage/concurrency/manager.rs
@@ -641,9 +641,16 @@ impl Default for ConcurrencyManager {
 // ============================================
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod integration_tests {
-    use super::*;
+    use super::super::io_schedule::{IoLoadLevel, IoPriority};
+    use super::super::request_guard::GetObjectGuard;
+    use super::ConcurrencyManager;
+    use rustfs_concurrency::{AdmissionState, WorkloadAdmissionSnapshotProvider, WorkloadClass};
+    use rustfs_config::MI_B;
+    use rustfs_io_core::io_profile::{AccessPattern, StorageMedia};
     use serial_test::serial;
+    use std::time::Duration;
 
     #[tokio::test]
     #[serial]

--- a/rustfs/src/storage/concurrency/request_guard.rs
+++ b/rustfs/src/storage/concurrency/request_guard.rs
@@ -173,7 +173,7 @@ impl Drop for PutObjectGuard {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{GetObjectGuard, PutObjectGuard};
 
     #[test]
     fn test_guard_increments_counter() {

--- a/rustfs/src/storage/deadlock_detector.rs
+++ b/rustfs/src/storage/deadlock_detector.rs
@@ -611,8 +611,10 @@ pub fn is_deadlock_detection_enabled() -> bool {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::{DeadlockDetector, LockInfo, LockType, RequestHangDetectionPolicy, RequestResourceTracker, WaitGraphEdge};
+    use std::time::{Duration, Instant};
 
     #[test]
     fn test_deadlock_detector_config_default() {

--- a/rustfs/src/storage/helper.rs
+++ b/rustfs/src/storage/helper.rs
@@ -391,12 +391,18 @@ impl Drop for OperationHelper {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::OperationHelper;
     use crate::server::{refresh_audit_module_enabled, refresh_notify_module_enabled};
+    use crate::storage::access::ReqInfo;
+    use crate::storage::request_context::RequestContext;
     use http::{Extensions, HeaderMap, HeaderValue, Method, Uri};
     use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, SharedString, Unit};
     use rustfs_credentials::Credentials;
+    use rustfs_s3_ops::S3Operation;
+    use rustfs_s3_types::EventName;
+    use s3s::S3Request;
     use s3s::dto::DeleteObjectTaggingInput;
     use std::sync::{Arc, Mutex};
     use temp_env::with_vars;

--- a/rustfs/src/storage/lock_optimizer.rs
+++ b/rustfs/src/storage/lock_optimizer.rs
@@ -381,9 +381,12 @@ pub fn is_lock_optimization_enabled() -> bool {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::{LockOptimizeConfig, LockOptimizer, LockStats, OptimizedLockGuard};
     use std::sync::Mutex;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
 
     #[test]
     fn test_lock_optimize_config_default() {

--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -46,9 +46,6 @@ use crate::auth::get_request_auth_type_with_query;
 use crate::auth::is_request_presigned_signature_v4_with_query;
 use crate::storage::storage_api::options_consumer::StorageObjectOptions as ObjectOptions;
 
-#[cfg(test)]
-use rustfs_utils::http::insert_header;
-
 /// Creates options for deleting an object in a bucket.
 pub async fn del_opts(
     bucket: &str,
@@ -782,12 +779,24 @@ fn get_content_sha256_cksum(headers: &HeaderMap<HeaderValue>, service_type: Serv
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use proptest::prelude::*;
     use temp_env;
 
-    use super::*;
+    use super::super::StorageError;
+    use super::{
+        ENV_REJECT_ARCHIVE_CONTENT_ENCODING, SUPPORTED_HEADERS, copy_dst_opts, copy_src_opts, del_opts,
+        detect_content_type_from_object_name, extract_metadata, extract_metadata_from_mime,
+        extract_metadata_from_mime_with_object_name, filter_object_metadata, get_default_opts, get_opts, parse_copy_source_range,
+        put_opts, put_opts_from_headers, validate_archive_content_encoding,
+    };
     use http::{HeaderMap, HeaderValue};
+    use rustfs_utils::http::{
+        AMZ_OBJECT_LOCK_LEGAL_HOLD_LOWER, AMZ_OBJECT_LOCK_MODE_LOWER, AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE_LOWER,
+        SUFFIX_FORCE_DELETE, SUFFIX_SOURCE_MTIME, SUFFIX_SOURCE_REPLICATION_REQUEST, insert_header,
+    };
+    use s3s::S3ErrorCode;
     use std::collections::HashMap;
     use uuid::Uuid;
 

--- a/rustfs/src/storage/request_context.rs
+++ b/rustfs/src/storage/request_context.rs
@@ -192,8 +192,11 @@ where
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::{RequestContext, extract_request_id_from_headers, extract_trace_context_ids_from_headers};
+    use http::HeaderMap;
+    use opentelemetry::global;
     use opentelemetry::trace::{SpanContext, TraceContextExt, TraceFlags, TraceId, TraceState, TracerProvider as _};
     use opentelemetry_sdk::propagation::TraceContextPropagator;
     use opentelemetry_sdk::trace::SdkTracerProvider;

--- a/rustfs/src/storage/rpc/node_service.rs
+++ b/rustfs/src/storage/rpc/node_service.rs
@@ -1212,26 +1212,33 @@ impl Node for NodeService {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    use super::*;
-    use Request;
+    use super::{
+        CollectMetricsOpts, Error, MetricType, Node as _, NodeService, PEER_RESTSIGNAL, PEER_RESTSUB_SYS,
+        SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC, STORAGE_CLASS_SUB_SYS,
+        background_rebalance_start_error_message, make_server, stop_rebalance_response,
+    };
+    use bytes::Bytes;
+    use rustfs_protos::models::PingBodyBuilder;
     use rustfs_protos::proto_gen::node_service::{
         BackgroundHealStatusRequest, CheckPartsRequest, DeleteBucketMetadataRequest, DeleteBucketRequest, DeletePathsRequest,
         DeletePolicyRequest, DeleteRequest, DeleteServiceAccountRequest, DeleteUserRequest, DeleteVersionRequest,
         DeleteVersionsRequest, DeleteVolumeRequest, DiskInfoRequest, DownloadProfileDataRequest, GenerallyLockRequest,
         GetAllBucketStatsRequest, GetBucketInfoRequest, GetBucketStatsDataRequest, GetCpusRequest, GetMemInfoRequest,
-        GetMetacacheListingRequest, GetNetInfoRequest, GetOsInfoRequest, GetPartitionsRequest, GetProcInfoRequest,
-        GetSeLinuxInfoRequest, GetSrMetricsDataRequest, GetSysConfigRequest, GetSysErrorsRequest, HealBucketRequest,
-        ListBucketRequest, ListDirRequest, ListVolumesRequest, LoadBucketMetadataRequest, LoadGroupRequest,
+        GetMetacacheListingRequest, GetMetricsRequest, GetNetInfoRequest, GetOsInfoRequest, GetPartitionsRequest,
+        GetProcInfoRequest, GetSeLinuxInfoRequest, GetSrMetricsDataRequest, GetSysConfigRequest, GetSysErrorsRequest,
+        HealBucketRequest, ListBucketRequest, ListDirRequest, ListVolumesRequest, LoadBucketMetadataRequest, LoadGroupRequest,
         LoadPolicyMappingRequest, LoadPolicyRequest, LoadRebalanceMetaRequest, LoadServiceAccountRequest,
         LoadTransitionTierConfigRequest, LoadUserRequest, LocalStorageInfoRequest, MakeBucketRequest, MakeVolumeRequest,
-        MakeVolumesRequest, PingRequest, ReadAllRequest, ReadAtRequest, ReadMultipleRequest, ReadVersionRequest, ReadXlRequest,
-        ReloadPoolMetaRequest, ReloadSiteReplicationConfigRequest, RenameDataRequest, RenameFileRequest, RenamePartRequest,
-        ServerInfoRequest, SignalServiceRequest, StartProfilingRequest, StatVolumeRequest, StopRebalanceRequest,
-        UpdateMetacacheListingRequest, UpdateMetadataRequest, VerifyFileRequest, WriteAllRequest, WriteMetadataRequest,
-        WriteRequest, node_service_client::NodeServiceClient, node_service_server::NodeServiceServer,
+        MakeVolumesRequest, Mss, PingRequest, ReadAllRequest, ReadAtRequest, ReadMultipleRequest, ReadVersionRequest,
+        ReadXlRequest, ReloadPoolMetaRequest, ReloadSiteReplicationConfigRequest, RenameDataRequest, RenameFileRequest,
+        RenamePartRequest, ServerInfoRequest, SignalServiceRequest, StartProfilingRequest, StatVolumeRequest,
+        StopRebalanceRequest, UpdateMetacacheListingRequest, UpdateMetadataRequest, VerifyFileRequest, WriteAllRequest,
+        WriteMetadataRequest, WriteRequest, node_service_client::NodeServiceClient, node_service_server::NodeServiceServer,
     };
+    use std::collections::HashMap;
     use tokio::net::TcpListener;
     use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::{Request, Response, Status};
 
     fn create_test_node_service() -> NodeService {
         make_server()

--- a/rustfs/src/storage/sse.rs
+++ b/rustfs/src/storage/sse.rs
@@ -2402,10 +2402,38 @@ fn ssec_invalid_request(message: &str) -> ApiError {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
-    use http::HeaderValue;
+    #[cfg(feature = "rio-v2")]
+    use super::{
+        DARE_CIPHER_AES_256_GCM, DARE_CIPHER_CHACHA20_POLY1305, MINIO_INTERNAL_ENCRYPTION_SEAL_ALGORITHM, SEALED_KEY_IV_SIZE,
+        SEALED_KEY_SIZE, is_legacy_rustfs_managed_metadata, is_supported_sealed_object_key_cipher,
+    };
+    use super::{
+        DecryptionRequest, EncryptionKeyKind, EncryptionMaterial, EncryptionRequest, INTERNAL_ENCRYPTION_ALGORITHM_HEADER,
+        INTERNAL_ENCRYPTION_IV_HEADER, INTERNAL_ENCRYPTION_KEY_HEADER, INTERNAL_ENCRYPTION_KEY_ID_HEADER, KmsSseDekProvider,
+        MINIO_INTERNAL_ENCRYPTION_ALGORITHM_HEADER, MINIO_INTERNAL_ENCRYPTION_IV_HEADER,
+        MINIO_INTERNAL_ENCRYPTION_KMS_CONTEXT_HEADER, MINIO_INTERNAL_ENCRYPTION_KMS_KEY_ID_HEADER,
+        MINIO_INTERNAL_ENCRYPTION_KMS_SEALED_KEY_HEADER, MINIO_INTERNAL_ENCRYPTION_MULTIPART_HEADER,
+        MINIO_INTERNAL_ENCRYPTION_S3_SEALED_KEY_HEADER, MINIO_INTERNAL_ENCRYPTION_SSEC_SEALED_KEY_HEADER,
+        PrepareEncryptionRequest, SSEC_ORIGINAL_SIZE_HEADER, SSEType, SseDekProvider, SsecParams, StorageError,
+        TestSseDekProvider, encryption_material_to_metadata, extract_server_side_encryption_from_headers,
+        extract_ssec_params_from_headers, extract_ssekms_context_from_headers, generate_ssec_nonce, is_managed_sse,
+        map_get_object_reader_error, mark_encrypted_multipart_metadata, normalize_managed_metadata, reset_sse_dek_provider,
+        resolve_effective_kms_key_id, sse_decryption, sse_encryption, sse_prepare_encryption, strip_managed_encryption_metadata,
+        validate_sse_headers_for_read, validate_sse_headers_for_write, validate_ssec_for_read, validate_ssec_params,
+        verify_ssec_key_match,
+    };
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Key, Nonce};
+    use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+    use http::{HeaderMap, HeaderValue};
+    use rustfs_kms::types::ObjectEncryptionContext;
     use rustfs_rio::{DecryptReader, EncryptReader};
+    use rustfs_utils::http::headers::AMZ_SERVER_SIDE_ENCRYPTION_KMS_CONTEXT;
+    use s3s::S3ErrorCode;
+    use s3s::dto::{SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5, ServerSideEncryption};
+    use std::collections::HashMap;
     use std::sync::OnceLock;
     use temp_env::async_with_vars;
     use tokio::sync::Mutex;

--- a/rustfs/src/storage/timeout_wrapper.rs
+++ b/rustfs/src/storage/timeout_wrapper.rs
@@ -462,8 +462,11 @@ pub fn get_io_buffer_size() -> usize {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
-    use super::*;
+    use super::{
+        GetObjectTimeoutPolicy, RequestTimeoutWrapper, TimedGetObjectResult, get_duplex_buffer_size, get_io_buffer_size,
+    };
     use std::time::Duration;
 
     #[test]

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -199,7 +199,7 @@ RUSTFS_STORAGE_OWNER_ROOT_FACADE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_o
 RUSTFS_STORAGE_OWNER_RUNTIME_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_runtime_root_consumer_hits.txt"
 RUSTFS_STORAGE_OWNER_HELPER_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_helper_root_consumer_hits.txt"
 RUSTFS_STORAGE_OWNER_RPC_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_rpc_root_consumer_hits.txt"
-RUSTFS_STORAGE_OWNER_RPC_WILDCARD_IMPORT_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_rpc_wildcard_import_hits.txt"
+RUSTFS_STORAGE_OWNER_WILDCARD_IMPORT_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_wildcard_import_hits.txt"
 RUSTFS_STORAGE_OWNER_TEST_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_test_root_consumer_hits.txt"
 RUSTFS_ADMIN_STORAGE_API_DOMAIN_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_admin_storage_api_domain_bypass_hits.txt"
 RUSTFS_APP_STORAGE_API_DOMAIN_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_storage_api_domain_bypass_hits.txt"
@@ -1929,11 +1929,12 @@ fi
   cd "$ROOT_DIR"
   rg -n --with-filename \
     '^[[:space:]]*use super::\*;' \
-    rustfs/src/storage/rpc/{bucket,disk,event,health,http_service,lock,metrics,mod}.rs || true
-) >"$RUSTFS_STORAGE_OWNER_RPC_WILDCARD_IMPORT_HITS_FILE"
+    rustfs/src/storage \
+    --glob '*.rs' || true
+) >"$RUSTFS_STORAGE_OWNER_WILDCARD_IMPORT_HITS_FILE"
 
-if [[ -s "$RUSTFS_STORAGE_OWNER_RPC_WILDCARD_IMPORT_HITS_FILE" ]]; then
-  report_failure "RustFS storage-owner RPC modules must use explicit imports instead of parent wildcard imports: $(paste -sd '; ' "$RUSTFS_STORAGE_OWNER_RPC_WILDCARD_IMPORT_HITS_FILE")"
+if [[ -s "$RUSTFS_STORAGE_OWNER_WILDCARD_IMPORT_HITS_FILE" ]]; then
+  report_failure "RustFS storage-owner modules must use explicit imports instead of parent wildcard imports: $(paste -sd '; ' "$RUSTFS_STORAGE_OWNER_WILDCARD_IMPORT_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Remove the remaining parent wildcard imports under `rustfs/src/storage`.
- Replace storage-owner test imports with explicit symbol lists across access, SSE, RPC, concurrency, timeout, helper, options, request-context, and deadlock detector coverage.
- Add an architecture migration guard that rejects restored parent wildcard imports in `rustfs/src/storage`.
- Update `docs/architecture/migration-progress.md` with API-253 status and review notes.

## Verification
- `cargo check -p rustfs --lib`
- `cargo test -p rustfs --lib storage --no-run`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Storage-wide parent wildcard import scan
- Diff-added Rust risk scan

## Impact
No runtime behavior change expected. This is an import-boundary cleanup and migration guard update.

## Additional Notes
Draft stacked PR. Full `make pre-pr` is pending after prerequisite branches merge and this branch is rebased onto `main`.
