### PR TITLE
refactor: make storage owner root exports explicit

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,22 +5,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-storage-owner-wildcard-domain-batch`
-- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/CTX-002`.
-- Current prerequisite: API-252 is completed on
-  `overtrue/arch-storage-owner-rpc-domain-batch`.
-- Based on: stacked on `overtrue/arch-storage-owner-rpc-domain-batch`
+- Branch: `overtrue/arch-storage-owner-root-export-cleanup`
+- Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/API-253/CTX-002`.
+- Current prerequisite: API-253 is completed on
+  `overtrue/arch-storage-owner-wildcard-domain-batch`.
+- Based on: stacked on `overtrue/arch-storage-owner-wildcard-domain-batch`
   while prerequisite PRs are pending; rebase onto current `origin/main` after
   prerequisite PRs merge before opening this PR.
 - PR type for this branch: `consumer-migration`
-- Runtime behavior changes: none expected for API-253; storage-owner tests
-  still use the same storage, RPC, SSE, concurrency, timeout, helper, access,
-  and option paths, now with explicit imports instead of parent wildcard
-  imports.
-- Rust code changes: replace every remaining parent wildcard import under
-  `rustfs/src/storage` with explicit test imports across access, SSE, RPC,
-  concurrency, timeout, helper, backpressure, lock optimizer, options, request
-  context, and deadlock detector tests.
+- Runtime behavior changes: none expected for API-254; storage owner root
+  still exposes the same crate-local owner API symbols, now as an explicit
+  export list instead of a wildcard re-export.
+- Rust code changes: make `rustfs/src/storage/storage_api.rs` a visible
+  crate-local owner boundary module and replace the storage root
+  `pub(crate) use storage_api::*` with an explicit re-export surface.
 - CI/script changes: lock completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
@@ -44,8 +42,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   root contract/object helper facade consumers after API-250, reject
   storage-owner runtime source, object-lock helper, RPC relative root, and ECFS
   test root consumers after API-251, reject restored RPC wildcard imports
-  after API-252, and reject restored parent wildcard imports anywhere under
-  `rustfs/src/storage` after API-253.
+  after API-252, reject restored parent wildcard imports anywhere under
+  `rustfs/src/storage` after API-253, and reject restoring storage owner root
+  wildcard re-exports after API-254.
 
 ## Phase 0 Tasks
 
@@ -5662,15 +5661,33 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     migration/layer guards, storage-wide wildcard scan, diff hygiene, and Rust
     risk scan passed; full PR gate is planned before PR.
 
+- [x] `API-254` Make storage-owner root exports explicit.
+  - Do: expose the storage-owner `storage_api` module as a crate-local boundary
+    and replace the storage root wildcard re-export with an explicit
+    re-export surface.
+  - Acceptance: `rustfs/src/storage/mod.rs` no longer uses
+    `pub(crate) use storage_api::*`, and migration rules reject restoring that
+    wildcard root export.
+  - Must preserve: all existing root, app, admin, storage, RPC, S3 API, ECFS,
+    SSE, startup, metrics, table, and test call paths that still consume the
+    storage owner crate-local API surface.
+  - Verification: focused RustFS compile, formatting, migration/layer guards,
+    root export wildcard scan, diff hygiene, and Rust risk scan passed; full PR
+    gate is planned before PR.
+
 ## Next PRs
 
-1. `consumer-migration`: continue larger owner boundary batches after API-253,
-   grouping multiple remaining storage-owner boundary families per PR.
+1. `consumer-migration`: migrate root, app, and admin facade users from the
+   storage root owner surface to explicit `storage::storage_api` paths in one
+   larger follow-up batch.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | API-254 removes the storage-owner root wildcard export and keeps the owner API surface explicit at the module boundary. |
+| Migration preservation | pass | Existing root, app, admin, storage, RPC, S3 API, ECFS, SSE, startup, metrics, table, and test consumers keep the same owner symbols. |
+| Testing/verification | pass | Focused RustFS compile, formatting, migration/layer guards, root export wildcard scan, diff hygiene, and diff-added Rust risk scan passed; full PR gate is planned before PR. |
 | Quality/architecture | pass | API-253 removes parent wildcard imports across the full storage-owner directory test surface and promotes the guard from RPC-only to storage-wide. |
 | Migration preservation | pass | Access, SSE, RPC, concurrency, timeout, helper, backpressure, lock optimizer, options, request context, and deadlock detector tests keep the same underlying symbols. |
 | Testing/verification | pass | RustFS compile/test compile, formatting, migration/layer guards, storage-wide wildcard scan, diff hygiene, and diff-added Rust risk scan passed; full PR gate is planned before PR. |
@@ -5970,6 +5987,24 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 API-254 current slice:
+  - Branch freshness check: stacked on
+    `overtrue/arch-storage-owner-wildcard-domain-batch` while prerequisite PRs
+    are pending.
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo test -p rustfs --lib storage --no-run`: passed with existing
+    `StorageObjectInfo` dead code warning.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `bash -n scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `./scripts/check_layer_dependencies.sh`: passed.
+  - Storage owner root export wildcard scan: passed.
+  - Diff-added Rust risk scan: passed.
+  - Full PR gate: pending before PR after prerequisite PRs merge and this
+    branch is rebased onto `origin/main`.
 
 - Issue #660 API-253 current slice:
   - Branch freshness check: stacked on `overtrue/arch-storage-owner-rpc-domain-batch`

--- a/rustfs/src/storage/mod.rs
+++ b/rustfs/src/storage/mod.rs
@@ -40,7 +40,7 @@ mod multi_factor_scheduler_integration_test;
 pub(crate) mod runtime_sources;
 #[cfg(test)]
 mod sse_test;
-mod storage_api;
+pub(crate) mod storage_api;
 
 pub(crate) use ecfs_extend::*;
 pub(crate) use sse::{
@@ -48,4 +48,48 @@ pub(crate) use sse::{
     sse_encryption, sse_prepare_encryption, strip_managed_encryption_metadata, validate_sse_headers_for_read,
     validate_sse_headers_for_write, validate_ssec_for_read,
 };
-pub(crate) use storage_api::*;
+#[allow(unused_imports)]
+pub(crate) use storage_api::{
+    BUCKET_ACCELERATE_CONFIG, BUCKET_LOGGING_CONFIG, BUCKET_REQUEST_PAYMENT_CONFIG, BUCKET_TABLE_CATALOG_META_PREFIX,
+    BUCKET_TABLE_CATALOG_TABLE_BUCKETS_PREFIX, BUCKET_TABLE_CONFIG, BUCKET_TABLE_RESERVED_PREFIX, BUCKET_VERSIONING_CONFIG,
+    BUCKET_WEBSITE_CONFIG, BucketBandwidthMonitor, BucketMetadata, BucketVersioningSys, CheckPartsResp, CollectMetricsOpts,
+    DEFAULT_READ_BUFFER_SIZE, DailyAllTierStats, DeleteOptions, DiskError, DiskInfo, DiskInfoOptions, DiskResult, DiskStore,
+    DynReader, DynReplicationPool, ECStore, Endpoint, EndpointServerPools, Error, EventArgs, ExpiryState, FS, FileInfoVersions,
+    FileReader, FileWriter, GetObjectReader, HashReader, LocalPeerS3Client, MetricType, NotificationSys, OBJECT_LOCK_CONFIG,
+    ObjectInfo, ObjectLockBlockReason, ObjectOptions, ObjectPartInfo, ObjectStoreResolver, PEER_RESTSIGNAL, PEER_RESTSUB_SYS,
+    PolicySys, PoolEndpoints, PutObjReader, QuotaError, RUSTFS_META_BUCKET, RawFileInfo, ReadMultipleReq, ReadMultipleResp,
+    ReadOptions, RenameDataResp, ReplicationStats, Result, SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC,
+    SetupType, StorageDeletedObject, StorageDiskRpcExt, StorageError, StorageGetObjectReader, StorageObjectInfo,
+    StorageObjectOptions, StorageObjectToDelete, StoragePeerS3ClientExt, StoragePutObjReader, StorageReplicationConfigExt,
+    StorageVersioningConfigExt, TONIC_RPC_PREFIX, TierConfigMgr, UpdateMetadataOpts, VolumeInfo, WalkDirOptions,
+    WorkloadAdmissionSnapshotProviderRef, WriteEncryption, WritePlan, access_consumer, add_object_lock_years, all_local_disk,
+    all_local_disk_path, bucket_metadata_runtime_initialized, check_retention_for_modification, collect_local_metrics,
+    compression_metadata_value, contract, decode_tags, decode_tags_to_map, delete_bucket_metadata_config, disk_drive_path,
+    disk_endpoint, ecfs_consumer, ecfs_extend_consumer, ecstore_admin, ecstore_bucket, ecstore_capacity, ecstore_client,
+    ecstore_cluster, ecstore_compression, ecstore_config, ecstore_data_usage, ecstore_disk, ecstore_error, ecstore_event,
+    ecstore_global, ecstore_layout, ecstore_metrics, ecstore_notification, ecstore_rebalance, ecstore_rio, ecstore_rpc,
+    ecstore_set_disk, ecstore_storage, ecstore_tier, encode_tags, find_local_disk_by_ref, get_bucket_accelerate_config,
+    get_bucket_cors_config, get_bucket_logging_config, get_bucket_metadata, get_bucket_notification_config,
+    get_bucket_object_lock_config, get_bucket_policy_raw, get_bucket_replication_config, get_bucket_request_payment_config,
+    get_bucket_sse_config, get_bucket_website_config, get_daily_all_tier_stats, get_global_boot_time, get_global_bucket_monitor,
+    get_global_deployment_id, get_global_endpoints_opt, get_global_expiry_state, get_global_lock_client, get_global_lock_clients,
+    get_global_notification_sys, get_global_region, get_global_replication_pool, get_global_replication_stats,
+    get_global_tier_config_mgr, get_local_server_property, get_lock_acquire_timeout, get_public_access_block_config,
+    global_rustfs_port, head_prefix_consumer, helper_consumer, init_background_replication, init_bucket_metadata_sys,
+    init_ecstore_config, init_global_config_sys, init_local_disks, init_lock_clients, is_all_buckets_not_found, is_dist_erasure,
+    is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found, is_valid_storage_class, load_bucket_metadata,
+    new_global_notification_sys, new_object_layer_fn, options_consumer, prewarm_local_disk_id_map, read_config,
+    record_replication_proxy, register_event_dispatch_hook, reload_transition_tier_config, replication_queue_current_count,
+    resolve_object_store_handle, rpc_consumer, runtime_sources_consumer, s3_api_consumer, save_config, serialize,
+    set_bucket_metadata, set_global_endpoints, set_global_region, set_global_rustfs_port, set_object_store_resolver,
+    set_workload_admission_snapshot_provider, shutdown_background_services, table_catalog_path_hash, to_s3s_etag,
+    topology_snapshot_from_endpoint_pools_with_capabilities, try_migrate_bucket_metadata, try_migrate_iam_config,
+    try_migrate_server_config, update_bucket_metadata_config, update_erasure_type, verify_rpc_signature, wrap_reader,
+};
+
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use storage_api::{
+    BucketMetadataSys, DecryptReader, DisksLayout, EncryptReader, Endpoints, HardLimitReader, STORAGE_CLASS_SUB_SYS,
+    boxed_reader, get_global_bucket_metadata_sys, test_consumer,
+};

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -200,6 +200,7 @@ RUSTFS_STORAGE_OWNER_RUNTIME_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_
 RUSTFS_STORAGE_OWNER_HELPER_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_helper_root_consumer_hits.txt"
 RUSTFS_STORAGE_OWNER_RPC_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_rpc_root_consumer_hits.txt"
 RUSTFS_STORAGE_OWNER_WILDCARD_IMPORT_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_wildcard_import_hits.txt"
+RUSTFS_STORAGE_OWNER_ROOT_EXPORT_GLOB_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_root_export_glob_hits.txt"
 RUSTFS_STORAGE_OWNER_TEST_ROOT_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_storage_owner_test_root_consumer_hits.txt"
 RUSTFS_ADMIN_STORAGE_API_DOMAIN_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_admin_storage_api_domain_bypass_hits.txt"
 RUSTFS_APP_STORAGE_API_DOMAIN_BYPASS_HITS_FILE="${TMP_DIR}/rustfs_app_storage_api_domain_bypass_hits.txt"
@@ -1935,6 +1936,17 @@ fi
 
 if [[ -s "$RUSTFS_STORAGE_OWNER_WILDCARD_IMPORT_HITS_FILE" ]]; then
   report_failure "RustFS storage-owner modules must use explicit imports instead of parent wildcard imports: $(paste -sd '; ' "$RUSTFS_STORAGE_OWNER_WILDCARD_IMPORT_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename \
+    '^pub\(crate\) use storage_api::\*;' \
+    rustfs/src/storage/mod.rs || true
+) >"$RUSTFS_STORAGE_OWNER_ROOT_EXPORT_GLOB_HITS_FILE"
+
+if [[ -s "$RUSTFS_STORAGE_OWNER_ROOT_EXPORT_GLOB_HITS_FILE" ]]; then
+  report_failure "RustFS storage owner root must explicitly list storage_api re-exports instead of using a wildcard: $(paste -sd '; ' "$RUSTFS_STORAGE_OWNER_ROOT_EXPORT_GLOB_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
rustfs/backlog#660

## Summary of Changes
- Make `rustfs/src/storage/storage_api.rs` the explicit crate-local owner boundary module.
- Replace the storage root `pub(crate) use storage_api::*` wildcard export with an explicit owner API export list.
- Add a migration guard that rejects restoring the storage owner root wildcard export.
- Update `docs/architecture/migration-progress.md` with API-254 status and review notes.

## Verification
- `cargo check -p rustfs --lib`
- `cargo test -p rustfs --lib storage --no-run`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- Storage owner root export wildcard scan
- Diff-added Rust risk scan

## Impact
No runtime behavior change expected. Existing root, app, admin, storage, RPC, S3 API, ECFS, SSE, startup, metrics, table, and test consumers keep the same owner symbols through an explicit export surface.

## Additional Notes
Draft stacked PR. Full `make pre-pr` is pending after prerequisite branches merge and this branch is rebased onto `main`.
