### PR TITLE
ci: close config model ownership guard

### DIFF
--- a/docs/architecture/crate-boundaries.md
+++ b/docs/architecture/crate-boundaries.md
@@ -78,10 +78,15 @@ or config-schema work. First inventory consumers, then decide whether existing
 
 The current decision is recorded in
 [`config-model-boundary-adr.md`](config-model-boundary-adr.md): use the existing
-`rustfs-config` package for the pure server-config model, keep persistence and
-global server-config state in `ecstore`, and preserve the old
-`rustfs_ecstore::config::*` path with a temporary compatibility marker during
-the first extraction.
+`rustfs-config` package for the pure server-config model and global
+server-config snapshot accessors, while ECStore keeps config persistence,
+storage-class global state, default wiring, and startup initialization.
+
+The old `rustfs_ecstore::config::{Config, KV, KVS, register_default_kvs,
+get_global_server_config, set_global_server_config}` compatibility path must
+not be restored after the Phase 1a cleanup. Consumers use
+`rustfs_config::server_config` for the moved model and accessors; ECStore public
+facades must not re-export those symbols.
 
 ## Loss-Prevention Coverage
 

--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,17 +5,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-external-storage-api-boundary-phase`
+- Branch: `overtrue/arch-config-model-phase`
 - Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/API-253/API-254/CTX-002`.
-- Current baseline also includes API-255 from PR #3923.
-- Current phase PR: API-256 external storage API boundary guard closure.
-- Based on: current `origin/main` after PR #3923 merged.
-- PR type for this branch: `consumer-migration`
-- Runtime behavior changes: none expected for API-256; this is a
-  loss-prevention guard and documentation closure for the completed external
-  storage API boundary migration.
+- Current baseline also includes API-255 from PR #3923 and API-256 from PR
+  #3925.
+- Current phase PR: CFG-009 config model ownership guard closure.
+- Based on: current `origin/main` after PR #3922 and PR #3925 merged.
+- PR type for this branch: `ci-gate`
+- Runtime behavior changes: none expected for CFG-009; this is a
+  loss-prevention guard and documentation closure for the completed config
+  model ownership migration.
 - Rust code changes: none expected.
-- CI/script changes: lock completed owner and test/fuzz boundaries against
+- CI/script changes: lock completed config model ownership against restoring
+  old `rustfs_ecstore::config` model/accessor compatibility paths, and lock
+  ECStore public facades against re-exporting the moved server-config symbols;
+  retain the existing completed owner and test/fuzz boundaries against
   bare/glob imports, scattered raw ECStore facade subpaths, and startup
   runtime/root-server/table/S3/app shared/app bucket/app ECStore/admin facade
   regressions, plus external runtime, test, fuzz, and storage-owner module
@@ -42,9 +46,10 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   `rustfs/src/storage` after API-253, reject restoring storage owner root
   wildcard re-exports after API-254, reject direct storage owner paths from the
   root/app/admin storage facades after API-255, reject restoring storage
-  root SSE re-exports after API-255, and reject direct external
+  root SSE re-exports after API-255, reject direct external
   `rustfs_ecstore::api` facade imports outside local `storage_api` boundary
-  files after API-256.
+  files after API-256, and reject restoring old ECStore server-config model or
+  global accessor compatibility paths after CFG-009.
 
 ## Phase 0 Tasks
 
@@ -1415,6 +1420,21 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     storage-class global state, default registration wiring, and startup
     initialization; global server-config reads and writes keep the same
     `std::sync::RwLock<Option<Config>>` clone semantics.
+- [x] `CFG-009` Close config model ownership guard coverage.
+  - Do: add one phase-level migration rule that rejects the removed
+    `rustfs_ecstore::config::{Config, KV, KVS, register_default_kvs,
+    get_global_server_config, set_global_server_config}` compatibility path and
+    rejects ECStore public facades re-exporting the moved server-config model
+    or global accessor symbols.
+  - Acceptance: moved server-config model symbols and global accessors stay
+    owned by `rustfs_config::server_config`; ECStore keeps persistence,
+    storage-class global state, default wiring, and startup initialization only.
+  - Must preserve: no Rust runtime behavior, config serialization, persisted
+    server-config shape, storage-class behavior, startup initialization, or
+    public API behavior change.
+  - Verification: architecture migration guard, shell syntax check, config
+    model residual scans, diff hygiene, full PR gate, and three-expert review
+    passed.
 
 ## Phase 1b Context Foundation Tasks
 
@@ -5709,12 +5729,15 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 1. `consumer-migration`: move to the next phase-level cleanup batch from the
    current handoff, keeping behavior-owned ECStore internals in ECStore until a
-   pure-move slice is concrete.
+   pure-move slice is concrete and verified.
 
 ## Pre-Push Review Log
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | CFG-009 closes the completed config model ownership phase with one guard over old ECStore config compatibility paths and ECStore facade re-exports. |
+| Migration preservation | pass | The slice only adds guard/documentation coverage; ECStore still owns persistence, storage-class state, default wiring, and startup initialization. |
+| Testing/verification | pass | Shell syntax, architecture migration guard, config residual scans, diff hygiene, script/docs risk review, and full PR gate passed. |
 | Quality/architecture | pass | API-256 closes external ECStore facade import coverage with one aggregate guard over runtime, test, e2e, and fuzz storage API boundaries. |
 | Migration preservation | pass | The slice only adds guard/documentation coverage and does not move runtime symbols or alter external storage behavior. |
 | Testing/verification | pass | Shell syntax, architecture migration guard, diff hygiene, script/docs risk review, and full PR gate passed. |

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -129,6 +129,7 @@ RUSTFS_APP_ADMIN_STORAGE_HELPER_ROOT_REEXPORT_HITS_FILE="${TMP_DIR}/rustfs_app_a
 EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_test_ecstore_compat_bypass_hits.txt"
 FUZZ_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/fuzz_ecstore_compat_bypass_hits.txt"
 EXTERNAL_ECSTORE_API_BOUNDARY_HITS_FILE="${TMP_DIR}/external_ecstore_api_boundary_hits.txt"
+LEGACY_ECSTORE_CONFIG_MODEL_HITS_FILE="${TMP_DIR}/legacy_ecstore_config_model_hits.txt"
 ALL_STORAGE_COMPAT_SELF_FACADE_PATH_HITS_FILE="${TMP_DIR}/all_storage_compat_self_facade_path_hits.txt"
 RUSTFS_LOCAL_COMPAT_OWNER_SELF_PATH_HITS_FILE="${TMP_DIR}/rustfs_local_compat_owner_self_path_hits.txt"
 RUSTFS_ROOT_COMPAT_RELATIVE_CONSUMER_HITS_FILE="${TMP_DIR}/rustfs_root_compat_relative_consumer_hits.txt"
@@ -2178,6 +2179,22 @@ fi
 
 if [[ -s "$EXTERNAL_ECSTORE_API_BOUNDARY_HITS_FILE" ]]; then
   report_failure "external ECStore API facade imports must stay in local storage_api boundary files: $(paste -sd '; ' "$EXTERNAL_ECSTORE_API_BOUNDARY_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  {
+    rg -n --with-filename 'rustfs_ecstore::config::(?:\{[^}]*\b(?:Config|KV|KVS|register_default_kvs|get_global_server_config|set_global_server_config)\b|(?:Config|KV|KVS|register_default_kvs|get_global_server_config|set_global_server_config)\b)' \
+      crates rustfs fuzz \
+      --glob '*.rs' || true
+    rg -n --with-filename 'pub(?:\([^)]*\))?\s+use\s+(?:crate::config|rustfs_config::server_config)::(?:\{[^}]*\b(?:Config|KV|KVS|register_default_kvs|get_global_server_config|set_global_server_config)\b|(?:Config|KV|KVS|register_default_kvs|get_global_server_config|set_global_server_config)\b)' \
+      crates/ecstore/src crates/ecstore/tests \
+      --glob '*.rs' || true
+  }
+) >"$LEGACY_ECSTORE_CONFIG_MODEL_HITS_FILE"
+
+if [[ -s "$LEGACY_ECSTORE_CONFIG_MODEL_HITS_FILE" ]]; then
+  report_failure "server-config model and global accessors must stay owned by rustfs_config::server_config, not ECStore compatibility paths: $(paste -sd '; ' "$LEGACY_ECSTORE_CONFIG_MODEL_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
- rustfs/backlog#660

## Summary of Changes
- Close the completed config model ownership phase with a migration guard against restoring the old `rustfs_ecstore::config` model/accessor compatibility path.
- Block ECStore public facades from re-exporting the moved server-config model and global accessor symbols.
- Update architecture boundary docs and migration progress for CFG-009.

## Verification
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- config model residual scans for old ECStore paths and facade re-exports
- `git diff --check`
- `make pre-pr`

## Impact
- No runtime behavior impact expected.
- No config serialization, persisted server-config shape, storage-class behavior, startup initialization, or public API behavior change expected.

## Additional Notes
- This is a loss-prevention guard and documentation closure for the completed config model ownership migration.
