### PR TITLE
refactor: route admin runtime sources through current helpers

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,24 +5,26 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-global-admin-context-consumer-batch`
+- Branch: `overtrue/arch-global-runtime-owner-consumer-batch`
 - Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/API-253/API-254/CTX-002`.
 - Current baseline also includes API-255 from PR #3923, API-256 from PR
   #3925, CFG-009 from PR #3927, C-007/C-009 from PR #3935, C-008/C-010
   from PR #3936, and DOC-001/DOC-002/DOC-003/DOC-004/DOC-005/
   TEST-DOC-001 from PR #3938, GLOB-001/GLOB-002/GLOB-003/GLOB-004/
   GLOB-005/CRATE-001/CRATE-002 from PR #3939, GLOB-006 from PR #3941,
-  and the first GLOB-007 admin runtime context handoff from PR #3942.
-- Current phase PR: GLOB-007 admin context consumer batch.
-- Based on: `origin/main` after PR #3942 merged.
+  the first GLOB-007 admin runtime context handoff from PR #3942, and the
+  GLOB-007 admin object-store/notification/server-config consumer batch from
+  PR #3943.
+- Current phase PR: GLOB-007 admin runtime helper alias batch.
+- Based on: `origin/main` after PR #3943 merged.
 - PR type for this branch: `ci-gate`.
 - Runtime behavior changes: none intended.
-- Rust code changes: add admin current-runtime resolver helpers and route the
-  remaining admin handler/router object-store, notification-system, and
-  server-config consumers through AppContext-aware boundaries before legacy
-  fallbacks.
+- Rust code changes: route remaining admin IAM, KMS, OIDC, action-credential,
+  region, endpoint, replication, tier, scanner, TLS, and system runtime-source
+  reads through admin `current_*` helper names while preserving the existing
+  AppContext-first resolver behavior and fallback boundaries.
 - CI/script changes: none intended.
-- Docs changes: update this progress ledger for the admin context consumer
+- Docs changes: update this progress ledger for the admin runtime helper alias
   batch.
 
 ## Phase 0 Tasks
@@ -2785,6 +2787,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     object-store, notification-system, and server-config consumers through
     admin current-runtime helpers backed by AppContext-aware resolver
     boundaries.
+  - Current slice: route remaining admin runtime-source reads for IAM, KMS,
+    OIDC, action credentials, region, endpoint, replication, tier, scanner,
+    TLS, and system runtime handles through admin `current_*` helper names.
   - Remaining work: remove one fallback family per PR only after scans prove no
     production caller depends on it; this slice keeps the fallback behavior
     because broader app/storage/server consumers still use the root resolvers.
@@ -6054,6 +6059,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | GLOB-007 adds admin `current_*` helper aliases for the remaining runtime-source families and moves admin IAM, KMS, OIDC, action-credential, region, endpoint, replication, tier, scanner, TLS, and system consumers off direct root resolver names. |
+| Migration preservation | pass | The helper aliases delegate to the same AppContext-first runtime resolvers and keep all existing fallback paths, so this is a naming/boundary cleanup with no admin auth, IAM, KMS, replication, tier, scanner, TLS, or route behavior change. |
+| Testing/verification | pass | RustFS lib compile, formatting, architecture guard, diff hygiene, admin resolver residual scan, and diff-added Rust risk scan passed before the full PR gate. |
 | Quality/architecture | pass | GLOB-007 adds admin current-runtime resolver helpers and moves remaining admin handler/router object-store, notification-system, and server-config consumers off direct root resolver calls without changing owner boundaries. |
 | Migration preservation | pass | The helpers call `current_app_context()` and delegate to the same AppContext-aware resolver/fallback paths from PR #3942, so account, bucket metadata, heal, zip download, pool, quota, rebalance, replication, site replication, table catalog, tier, and router behavior stays unchanged. |
 | Testing/verification | pass | Focused RustFS compile/tests, admin test-target compile, admin resolver residual scan, formatting, architecture guard, diff hygiene, Rust risk scan, and full `make pre-pr` passed before PR. |
@@ -6416,6 +6424,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 GLOB-007 admin runtime helper alias slice:
+  - Branch freshness check: created from `origin/main` after PR #3943 merged.
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - Admin resolver residual scan: passed.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    unchecked narrow casts, stringly errors, or ad-hoc stdout/stderr.
+  - Three-expert review: passed.
+  - `make pre-pr`: passed, including 6912 nextest tests passed, 112 skipped,
+    and doctests.
 
 - Issue #660 GLOB-007 admin context consumer slice:
   - Branch freshness check: rebased onto `origin/main` after PR #3942 merged.

--- a/rustfs/src/admin/auth.rs
+++ b/rustfs/src/admin/auth.rs
@@ -56,7 +56,7 @@ pub async fn validate_admin_request(
     actions: Vec<Action>,
     remote_addr: Option<std::net::SocketAddr>,
 ) -> S3Result<()> {
-    let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+    let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
         return Err(s3_error!(InternalError, "iam not init"));
     };
     let ctx = AuthContext {
@@ -146,7 +146,7 @@ pub async fn validate_admin_request_with_bucket_object(
     remote_addr: Option<std::net::SocketAddr>,
     resource: AdminResourceScope<'_>,
 ) -> S3Result<()> {
-    let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+    let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
         return Err(s3_error!(InternalError, "iam not init"));
     };
     let ctx = AuthContext {

--- a/rustfs/src/admin/console.rs
+++ b/rustfs/src/admin/console.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::runtime_sources::{default_admin_usecase, resolve_oidc_handle};
+use crate::admin::runtime_sources::{current_oidc_handle, default_admin_usecase};
 use crate::admin::storage_api::access::RequestContext;
 use crate::license::has_valid_license;
 use crate::server::has_path_prefix;
@@ -134,7 +134,7 @@ impl Config {
         let http_prefix = rustfs_config::RUSTFS_HTTP_PREFIX;
 
         // Collect OIDC provider info if available
-        let oidc = resolve_oidc_handle()
+        let oidc = current_oidc_handle()
             .map(|sys| {
                 sys.list_visible_providers()
                     .into_iter()

--- a/rustfs/src/admin/handlers/account_info.rs
+++ b/rustfs/src/admin/handlers/account_info.rs
@@ -14,7 +14,7 @@
 
 use crate::admin::auth::authenticate_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::{current_object_store_handle, resolve_action_credentials};
+use crate::admin::runtime_sources::{current_action_credentials, current_object_store_handle};
 use crate::admin::storage_api::bucket::versioning_sys::BucketVersioningSys;
 use crate::admin::storage_api::contract::admin::StorageAdminApi;
 use crate::admin::storage_api::contract::bucket::{BucketOperations, BucketOptions};
@@ -70,7 +70,7 @@ impl Operation for AccountInfoHandler {
 
         let (cred, owner) = authenticate_request(&req.headers, &req.uri, &input_cred).await?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -145,7 +145,7 @@ impl Operation for AccountInfoHandler {
             cred.access_key.clone()
         };
 
-        let Some(admin_cred) = resolve_action_credentials() else {
+        let Some(admin_cred) = current_action_credentials() else {
             return Err(S3Error::with_message(
                 S3ErrorCode::InternalError,
                 "action credentials are not initialized".to_string(),

--- a/rustfs/src/admin/handlers/group.rs
+++ b/rustfs/src/admin/handlers/group.rs
@@ -14,7 +14,7 @@
 
 use super::iam_error::iam_error_to_s3_error;
 use crate::{
-    admin::runtime_sources::resolve_action_credentials,
+    admin::runtime_sources::current_action_credentials,
     admin::{
         auth::validate_admin_request,
         handlers::site_replication::site_replication_iam_change_hook,
@@ -115,7 +115,7 @@ impl Operation for ListGroups {
         )
         .await?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -180,7 +180,7 @@ impl Operation for GetGroup {
                 GroupQuery::default()
             }
         };
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -256,7 +256,7 @@ impl Operation for DeleteGroup {
 
         let group = decode_delete_group_name(&params)?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -394,7 +394,7 @@ impl Operation for SetGroupStatus {
             return Err(s3_error!(InvalidArgument, "group is required"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -537,7 +537,7 @@ impl Operation for UpdateGroupMembers {
             "admin group state"
         );
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -551,7 +551,7 @@ impl Operation for UpdateGroupMembers {
                         ));
                     }
 
-                    resolve_action_credentials()
+                    current_action_credentials()
                         .map(|cred| {
                             if constant_time_eq(&cred.access_key, member) {
                                 return Err(S3Error::with_message(

--- a/rustfs/src/admin/handlers/is_admin.rs
+++ b/rustfs/src/admin/handlers/is_admin.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::router::Operation;
-use crate::admin::runtime_sources::resolve_action_credentials;
+use crate::admin::runtime_sources::current_action_credentials;
 use crate::auth::{check_key_valid, constant_time_eq, get_condition_values, get_session_token};
 use http::{HeaderMap, HeaderValue};
 use hyper::StatusCode;
@@ -47,7 +47,7 @@ impl Operation for IsAdminHandler {
         let access_key_to_check = input_cred.access_key.clone();
 
         // Check if the user is admin: root user check, then evaluate through the policy engine
-        let is_admin = if let Some(sys_cred) = resolve_action_credentials() {
+        let is_admin = if let Some(sys_cred) = current_action_credentials() {
             constant_time_eq(&access_key_to_check, &sys_cred.access_key)
                 || constant_time_eq(&cred.parent_user, &sys_cred.access_key)
         } else {
@@ -58,7 +58,7 @@ impl Operation for IsAdminHandler {
             true
         } else {
             let empty_claims = HashMap::new();
-            let iam_store = crate::admin::runtime_sources::resolve_ready_iam_handle()
+            let iam_store = crate::admin::runtime_sources::current_ready_iam_handle()
                 .map_err(|_| s3_error!(InternalError, "iam not init"))?;
             let conditions = get_condition_values(&req.headers, &cred, None, None, None);
             iam_store

--- a/rustfs/src/admin/handlers/kms_dynamic.rs
+++ b/rustfs/src/admin/handlers/kms_dynamic.rs
@@ -17,8 +17,8 @@
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::runtime_sources::{
-    current_app_context, resolve_kms_runtime_service_manager, resolve_object_store_handle_for_context,
-    resolve_or_init_kms_runtime_service_manager,
+    current_app_context, current_kms_runtime_service_manager, current_or_init_kms_runtime_service_manager,
+    resolve_object_store_handle_for_context,
 };
 use crate::admin::storage_api::config::{read_admin_config, save_admin_config};
 use crate::auth::{check_key_valid, get_session_token};
@@ -41,7 +41,7 @@ const LOG_SUBSYSTEM_KMS: &str = "kms";
 const EVENT_ADMIN_KMS_DYNAMIC_STATE: &str = "admin_kms_dynamic_state";
 
 fn kms_service_manager_from_context() -> std::sync::Arc<rustfs_kms::KmsServiceManager> {
-    resolve_kms_runtime_service_manager().unwrap_or_else(|| {
+    current_kms_runtime_service_manager().unwrap_or_else(|| {
         warn!(
             component = LOG_COMPONENT_ADMIN,
             subsystem = LOG_SUBSYSTEM_KMS,
@@ -49,7 +49,7 @@ fn kms_service_manager_from_context() -> std::sync::Arc<rustfs_kms::KmsServiceMa
             result = "service_manager_fallback_initialized",
             "admin kms dynamic state"
         );
-        resolve_or_init_kms_runtime_service_manager()
+        current_or_init_kms_runtime_service_manager()
     })
 }
 

--- a/rustfs/src/admin/handlers/kms_keys.rs
+++ b/rustfs/src/admin/handlers/kms_keys.rs
@@ -16,7 +16,7 @@
 
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::{resolve_kms_runtime_service_manager, resolve_or_init_kms_runtime_service_manager};
+use crate::admin::runtime_sources::{current_kms_runtime_service_manager, current_or_init_kms_runtime_service_manager};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use base64::Engine;
@@ -117,11 +117,11 @@ fn extract_key_id(uri: &hyper::Uri) -> Option<String> {
 }
 
 fn kms_service_manager_from_context() -> Option<std::sync::Arc<rustfs_kms::KmsServiceManager>> {
-    resolve_kms_runtime_service_manager()
+    current_kms_runtime_service_manager()
 }
 
 async fn kms_encryption_service_from_context() -> Option<std::sync::Arc<rustfs_kms::ObjectEncryptionService>> {
-    let manager = resolve_or_init_kms_runtime_service_manager();
+    let manager = current_or_init_kms_runtime_service_manager();
     manager.get_encryption_service().await
 }
 

--- a/rustfs/src/admin/handlers/kms_management.rs
+++ b/rustfs/src/admin/handlers/kms_management.rs
@@ -17,7 +17,7 @@
 use super::kms_keys::{CreateKeyHandler, DescribeKeyHandler, GenerateDataKeyHandler, ListKeysHandler};
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::{resolve_kms_runtime_service_manager, resolve_or_init_kms_runtime_service_manager};
+use crate::admin::runtime_sources::{current_kms_runtime_service_manager, current_or_init_kms_runtime_service_manager};
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use hyper::{HeaderMap, Method, StatusCode};
@@ -35,11 +35,11 @@ async fn kms_encryption_service_from_context() -> Option<std::sync::Arc<rustfs_k
 }
 
 fn kms_service_manager_from_context() -> std::sync::Arc<rustfs_kms::KmsServiceManager> {
-    match resolve_kms_runtime_service_manager() {
+    match current_kms_runtime_service_manager() {
         Some(manager) => manager,
         None => {
             warn!("KMS service manager not initialized, initializing now as fallback");
-            resolve_or_init_kms_runtime_service_manager()
+            current_or_init_kms_runtime_service_manager()
         }
     }
 }

--- a/rustfs/src/admin/handlers/object_zip_download.rs
+++ b/rustfs/src/admin/handlers/object_zip_download.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::router::{ADMIN_OBJECT_ZIP_DOWNLOADS_PATH, AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::{current_object_store_handle, resolve_action_credentials, resolve_region};
+use crate::admin::runtime_sources::{current_action_credentials, current_object_store_handle, current_region};
 use crate::admin::storage_api::access::{ReqInfo, authorize_request};
 use crate::admin::storage_api::contract::bucket::{BucketOperations, BucketOptions};
 use crate::admin::storage_api::contract::list::ListOperations as _;
@@ -205,7 +205,7 @@ impl From<ObjectZipDownloadReqInfoSnapshot> for ReqInfo {
             bucket: snapshot.bucket,
             object: snapshot.object,
             version_id: snapshot.version_id,
-            region: resolve_region(),
+            region: current_region(),
             request_context: None,
         }
     }
@@ -283,7 +283,7 @@ impl From<ClientInfoSnapshot> for ClientInfo {
 
 fn download_token_encryption_key() -> S3Result<[u8; 32]> {
     let credentials =
-        resolve_action_credentials().ok_or_else(|| s3_error!(InternalError, "global action credentials are not initialized"))?;
+        current_action_credentials().ok_or_else(|| s3_error!(InternalError, "global action credentials are not initialized"))?;
     if credentials.secret_key.is_empty() {
         return Err(s3_error!(InternalError, "global action credentials are not initialized"));
     }
@@ -400,7 +400,7 @@ async fn authenticate_object_zip_download_request(req: &mut S3Request<Body>) -> 
     req.extensions.insert(ReqInfo {
         cred: Some(cred),
         is_owner: owner,
-        region: resolve_region(),
+        region: current_region(),
         request_context: req.extensions.get().cloned(),
         ..Default::default()
     });
@@ -697,7 +697,7 @@ async fn authorize_zip_items_for_download(record: &ObjectZipDownloadToken, items
                 extensions
             },
             credentials: None,
-            region: resolve_region(),
+            region: current_region(),
             service: None,
             trailing_headers: None,
         };
@@ -1092,7 +1092,7 @@ mod tests {
             "object ZIP download token should carry an authenticated payload"
         );
         assert!(
-            src.contains("resolve_action_credentials"),
+            src.contains("current_action_credentials"),
             "object ZIP download token should be verifiable by any node sharing global credentials"
         );
         assert!(
@@ -1377,7 +1377,7 @@ mod tests {
     }
 
     fn ensure_test_signing_credentials() {
-        if resolve_action_credentials().is_none() {
+        if current_action_credentials().is_none() {
             let _ = init_global_action_credentials(
                 Some("TESTROOTACCESSKEY".to_string()),
                 Some("TESTROOTSECRET1234567890".to_string()),
@@ -1400,7 +1400,7 @@ mod tests {
             bucket: Some("photos".to_string()),
             object: None,
             version_id: None,
-            region: resolve_region(),
+            region: current_region(),
             request_context: None,
         }
     }

--- a/rustfs/src/admin/handlers/oidc.rs
+++ b/rustfs/src/admin/handlers/oidc.rs
@@ -16,7 +16,7 @@ use super::sts::create_oidc_sts_credentials;
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::runtime_sources::{
-    current_app_context, resolve_object_store_handle_for_context, resolve_oidc_handle, resolve_server_config_for_context,
+    current_app_context, current_oidc_handle, resolve_object_store_handle_for_context, resolve_server_config_for_context,
 };
 use crate::admin::storage_api::config::{read_admin_config_without_migrate, save_admin_server_config};
 use crate::auth::{check_key_valid, get_session_token};
@@ -270,7 +270,7 @@ pub struct ListOidcProvidersHandler {}
 #[async_trait::async_trait]
 impl Operation for ListOidcProvidersHandler {
     async fn call(&self, _req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
-        let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+        let oidc_sys = current_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
         let providers = oidc_sys.list_visible_providers();
         let json_body = serde_json::to_vec(&providers)
@@ -441,7 +441,7 @@ impl Operation for OidcAuthorizeHandler {
             return Err(s3_error!(InvalidRequest, "invalid provider_id"));
         }
 
-        let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+        let oidc_sys = current_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
         // Derive the callback redirect URI from the request
         let redirect_uri = derive_callback_uri(&req, provider_id)?;
@@ -514,7 +514,7 @@ impl Operation for OidcCallbackHandler {
             ));
         }
 
-        let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+        let oidc_sys = current_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
         let redirect_uri = derive_callback_uri(&req, provider_id)?;
 
@@ -601,7 +601,7 @@ impl Operation for OidcLogoutHandler {
             return redirect_response(&fallback_location);
         };
 
-        let location = match resolve_oidc_handle() {
+        let location = match current_oidc_handle() {
             Some(oidc_sys) => match oidc_sys.build_logout_url(&logout_token, &fallback_location).await {
                 Ok(Some(url)) => url,
                 Ok(None) => fallback_location.clone(),
@@ -630,7 +630,7 @@ impl Operation for OidcLogoutHandler {
 /// an explicit redirect_uri is recommended to prevent header manipulation.
 fn derive_callback_uri(req: &S3Request<Body>, provider_id: &str) -> S3Result<String> {
     // Use explicitly configured redirect_uri if available
-    if let Some(oidc_sys) = resolve_oidc_handle()
+    if let Some(oidc_sys) = current_oidc_handle()
         && let Some(config) = oidc_sys.get_provider_config(provider_id)
     {
         if let Some(ref uri) = config.redirect_uri {

--- a/rustfs/src/admin/handlers/policies.rs
+++ b/rustfs/src/admin/handlers/policies.rs
@@ -14,7 +14,7 @@
 
 use super::iam_error::iam_error_to_s3_error;
 use crate::{
-    admin::runtime_sources::resolve_action_credentials,
+    admin::runtime_sources::current_action_credentials,
     admin::{
         auth::validate_admin_request,
         handlers::site_replication::site_replication_iam_change_hook,
@@ -144,7 +144,7 @@ impl Operation for ListCannedPolicies {
             }
         };
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -252,7 +252,7 @@ impl Operation for AddCannedPolicy {
         if policy.version.is_empty() {
             return Err(s3_error!(InvalidArgument, "policy version is required"));
         }
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -340,7 +340,7 @@ impl Operation for InfoCannedPolicy {
             return Err(s3_error!(InvalidArgument, "too many policies"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -401,7 +401,7 @@ impl Operation for RemoveCannedPolicy {
             return Err(s3_error!(InvalidArgument, "policy name is required"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -492,7 +492,7 @@ impl Operation for SetPolicyForUserOrGroup {
             return Err(s3_error!(InvalidArgument, "user or group is required"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -520,7 +520,7 @@ impl Operation for SetPolicyForUserOrGroup {
                 }
             };
 
-            let Some(sys_cred) = resolve_action_credentials() else {
+            let Some(sys_cred) = current_action_credentials() else {
                 return Err(s3_error!(InternalError, "failed to load global credentials"));
             };
 
@@ -825,7 +825,7 @@ async fn handle_builtin_policy_entities(req: S3Request<Body>) -> S3Result<S3Resp
 
     let query = parse_policy_entities_query(req.uri.query());
 
-    let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+    let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
         return Err(s3_error!(InternalError, "iam not init"));
     };
 
@@ -961,7 +961,7 @@ async fn handle_builtin_policy_association(req: S3Request<Body>, is_attach: bool
         .map_err(|e| s3_error!(InvalidRequest, "unmarshal policy association body failed, e: {:?}", e))?;
     validate_policy_association_req(&assoc_req)?;
 
-    let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+    let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
         return Err(s3_error!(InternalError, "iam not init"));
     };
 
@@ -986,7 +986,7 @@ async fn handle_builtin_policy_association(req: S3Request<Body>, is_attach: bool
             }
         }
 
-        let Some(sys_cred) = resolve_action_credentials() else {
+        let Some(sys_cred) = current_action_credentials() else {
             return Err(s3_error!(InternalError, "get global action cred failed"));
         };
 

--- a/rustfs/src/admin/handlers/pools.rs
+++ b/rustfs/src/admin/handlers/pools.rs
@@ -26,8 +26,8 @@ use tracing::{error, info, warn};
 
 use crate::{
     admin::runtime_sources::{
-        AdminPoolStatus, QueryPoolStatusRequest, current_notification_system, current_object_store_handle, default_admin_usecase,
-        resolve_endpoints_handle,
+        AdminPoolStatus, QueryPoolStatusRequest, current_endpoints_handle, current_notification_system,
+        current_object_store_handle, default_admin_usecase,
     },
     admin::{
         auth::validate_admin_request,
@@ -214,7 +214,7 @@ macro_rules! log_pool_response_emitted {
 }
 
 fn endpoints_from_context() -> Option<crate::admin::storage_api::runtime::EndpointServerPools> {
-    resolve_endpoints_handle()
+    current_endpoints_handle()
 }
 
 fn validate_start_decommission_guards(decommission_running: bool, rebalance_running: bool) -> s3s::S3Result<()> {

--- a/rustfs/src/admin/handlers/quota.rs
+++ b/rustfs/src/admin/handlers/quota.rs
@@ -16,7 +16,7 @@
 
 use crate::admin::auth::{validate_admin_request, validate_admin_request_with_bucket};
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::{current_object_store_handle, resolve_bucket_metadata_handle};
+use crate::admin::runtime_sources::{current_bucket_metadata_handle, current_object_store_handle};
 use crate::admin::storage_api::bucket::metadata_sys::BucketMetadataSys;
 use crate::admin::storage_api::bucket::quota::checker::QuotaChecker;
 use crate::admin::storage_api::bucket::quota::{BucketQuota, QuotaError, QuotaOperation};
@@ -167,7 +167,7 @@ pub struct GetBucketQuotaStatsHandler;
 pub struct CheckBucketQuotaHandler;
 
 fn bucket_metadata_from_context() -> Option<Arc<RwLock<BucketMetadataSys>>> {
-    resolve_bucket_metadata_handle()
+    current_bucket_metadata_handle()
 }
 
 async fn current_usage_from_context(bucket: &str) -> u64 {

--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -15,7 +15,7 @@
 use crate::admin::auth::validate_admin_request;
 use crate::admin::handlers::site_replication::site_replication_peer_deployment_id_for_endpoint;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::{current_object_store_handle, resolve_replication_stats_handle, resolve_runtime_port};
+use crate::admin::runtime_sources::{current_object_store_handle, current_replication_stats_handle, current_runtime_port};
 use crate::admin::storage_api::bucket::metadata::BUCKET_TARGETS_FILE;
 use crate::admin::storage_api::bucket::metadata_sys;
 use crate::admin::storage_api::bucket::metadata_sys::get_replication_config;
@@ -175,7 +175,7 @@ impl Operation for GetReplicationMetricsHandler {
         // TODO cluster cache
         // In actual implementation, statistics would be obtained from cluster
         // This is simplified to get from local cache
-        let bucket_stats = match resolve_replication_stats_handle() {
+        let bucket_stats = match current_replication_stats_handle() {
             Some(s) => s.get_latest_replication_stats(bucket).await,
             None => BucketStats::default(),
         };
@@ -240,7 +240,7 @@ impl Operation for SetRemoteTargetHandler {
         let same_target = rustfs_utils::net::is_local_host(
             target_url.host().unwrap_or(Host::Domain("localhost")),
             target_url.port().unwrap_or(80),
-            resolve_runtime_port(),
+            current_runtime_port(),
         )
         .unwrap_or_default();
 

--- a/rustfs/src/admin/handlers/scanner.rs
+++ b/rustfs/src/admin/handlers/scanner.rs
@@ -14,7 +14,7 @@
 
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::resolve_scanner_metrics_report;
+use crate::admin::runtime_sources::current_scanner_metrics_report;
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
 use http::{HeaderMap, HeaderValue};
@@ -85,7 +85,7 @@ impl Operation for ScannerStatusHandler {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let _cred = validate_scanner_status_request(&req).await?;
         let response = ScannerStatusResponse {
-            metrics: resolve_scanner_metrics_report().await,
+            metrics: current_scanner_metrics_report().await,
             runtime_config: rustfs_scanner::scanner_runtime_config_status(),
         };
         let body = serde_json::to_vec(&response).map_err(|err| {

--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -15,7 +15,7 @@
 use super::iam_error::iam_error_to_s3_error;
 use crate::admin::access_key_identity;
 use crate::admin::handlers::site_replication::site_replication_iam_change_hook;
-use crate::admin::runtime_sources::resolve_action_credentials;
+use crate::admin::runtime_sources::current_action_credentials;
 use crate::admin::utils::{encode_compatible_admin_payload, has_space_be, is_compat_admin_request, read_compatible_admin_body};
 use crate::auth::{constant_time_eq, get_condition_values, get_session_token};
 use crate::server::{ADMIN_PREFIX, RemoteAddr};
@@ -268,7 +268,7 @@ impl Operation for AddServiceAccount {
             None
         };
 
-        let Some(sys_cred) = resolve_action_credentials() else {
+        let Some(sys_cred) = current_action_credentials() else {
             return Err(s3_error!(InvalidRequest, "get sys cred failed"));
         };
 
@@ -292,7 +292,7 @@ impl Operation for AddServiceAccount {
             req_is_derived_cred = true;
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -513,7 +513,7 @@ impl Operation for UpdateServiceAccount {
             return Err(s3_error!(InvalidRequest, "get cred failed"));
         };
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -642,7 +642,7 @@ impl Operation for InfoServiceAccount {
 
         let access_key = query.access_key;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -719,7 +719,7 @@ impl Operation for TemporaryAccountInfo {
         let (cred, owner) =
             check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -789,7 +789,7 @@ impl Operation for InfoAccessKey {
             query.access_key
         };
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -912,7 +912,7 @@ impl Operation for ListServiceAccount {
         //     cred.parent_user
         // };
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -1049,7 +1049,7 @@ impl Operation for ListAccessKeysBulk {
         let (cred, owner) =
             check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -1121,7 +1121,7 @@ impl Operation for ListAccessKeysBulk {
                 .into_keys()
                 .collect::<Vec<_>>();
 
-            if let Some(sys_cred) = resolve_action_credentials() {
+            if let Some(sys_cred) = current_action_credentials() {
                 users.push(sys_cred.access_key);
             }
             users
@@ -1252,7 +1252,7 @@ impl Operation for DeleteServiceAccount {
             return Err(s3_error!(InvalidArgument, "access key is empty"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -15,9 +15,9 @@
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::runtime_sources::{
-    current_object_store_handle, current_server_config, resolve_deployment_id, resolve_endpoints_handle, resolve_iam_handle,
-    resolve_oidc_handle, resolve_outbound_tls_generation, resolve_outbound_tls_state, resolve_region,
-    resolve_replication_pool_handle, resolve_replication_stats_handle, resolve_runtime_port, resolve_token_signing_key,
+    current_deployment_id, current_endpoints_handle, current_iam_handle, current_object_store_handle, current_oidc_handle,
+    current_outbound_tls_generation, current_outbound_tls_state, current_region, current_replication_pool_handle,
+    current_replication_stats_handle, current_runtime_port, current_server_config, current_token_signing_key,
 };
 use crate::admin::site_replication_identity::{
     canonical_endpoint, deployment_id_for_endpoint, normalize_peer_map_by_identity_with, same_identity_endpoint,
@@ -687,14 +687,14 @@ fn build_site_replication_peer_client(outbound_tls: &GlobalPublishedOutboundTlsS
 }
 
 async fn site_replication_peer_client() -> S3Result<reqwest::Client> {
-    let generation = resolve_outbound_tls_generation().0;
+    let generation = current_outbound_tls_generation().0;
     let cache = SITE_REPLICATION_PEER_CLIENT.lock().await;
     if let Some(hit) = site_replication_peer_client_cache_hit(&cache, generation) {
         return hit;
     }
     drop(cache);
 
-    let outbound_tls = resolve_outbound_tls_state().await;
+    let outbound_tls = current_outbound_tls_state().await;
     let built = build_site_replication_peer_client(&outbound_tls);
     let cache_entry = match &built {
         Ok(client) => SiteReplicationPeerClientCacheEntry::Ready(client.clone()),
@@ -732,7 +732,7 @@ fn runtime_tls_enabled_with(endpoints: Option<&crate::admin::storage_api::runtim
 }
 
 fn runtime_tls_enabled() -> bool {
-    let endpoints = resolve_endpoints_handle();
+    let endpoints = current_endpoints_handle();
     runtime_tls_enabled_with(endpoints.as_ref())
 }
 
@@ -883,7 +883,7 @@ fn request_endpoint(uri: &Uri, headers: &HeaderMap) -> String {
         .map(str::to_string)
         .or_else(|| uri.authority().map(|value| value.as_str().to_string()))
         .or_else(|| {
-            resolve_endpoints_handle().and_then(|endpoints| {
+            current_endpoints_handle().and_then(|endpoints| {
                 endpoints
                     .as_ref()
                     .iter()
@@ -892,7 +892,7 @@ fn request_endpoint(uri: &Uri, headers: &HeaderMap) -> String {
                     .map(|endpoint| endpoint.host_port())
             })
         })
-        .unwrap_or_else(|| format!("127.0.0.1:{}", resolve_runtime_port()));
+        .unwrap_or_else(|| format!("127.0.0.1:{}", current_runtime_port()));
 
     format!("{scheme}://{host}")
 }
@@ -920,7 +920,7 @@ fn site_replication_local_endpoint(uri: &Uri, headers: &HeaderMap) -> String {
             if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
                 return request_endpoint(&Uri::from_static("/"), &HeaderMap::new());
             }
-            if parsed.port_or_known_default() == runtime_console_port() && parsed.set_port(Some(resolve_runtime_port())).is_ok() {
+            if parsed.port_or_known_default() == runtime_console_port() && parsed.set_port(Some(current_runtime_port())).is_ok() {
                 parsed.to_string().trim_end_matches('/').to_string()
             } else {
                 endpoint
@@ -960,7 +960,7 @@ fn non_negative_u64(value: i64) -> u64 {
 
 fn current_local_peer(req: &S3Request<Body>, state: &SiteReplicationState) -> PeerInfo {
     let endpoint = site_replication_local_endpoint(&req.uri, &req.headers);
-    let deployment_id = resolve_deployment_id().unwrap_or_else(|| deployment_id_for_endpoint(&endpoint));
+    let deployment_id = current_deployment_id().unwrap_or_else(|| deployment_id_for_endpoint(&endpoint));
     let stored_peer = state.peers.get(&deployment_id);
 
     PeerInfo {
@@ -984,7 +984,7 @@ fn current_local_peer(req: &S3Request<Body>, state: &SiteReplicationState) -> Pe
 
 fn current_local_runtime_peer(state: &SiteReplicationState) -> PeerInfo {
     let endpoint = current_local_runtime_endpoint();
-    let deployment_id = resolve_deployment_id().unwrap_or_else(|| deployment_id_for_endpoint(&endpoint));
+    let deployment_id = current_deployment_id().unwrap_or_else(|| deployment_id_for_endpoint(&endpoint));
     let stored_peer = state.peers.get(&deployment_id);
 
     PeerInfo {
@@ -1567,7 +1567,7 @@ fn reconcile_peer_with_actual_identity(mut state: SiteReplicationState, actual_p
 }
 
 async fn site_replicator_service_account_secret(access_key: &str) -> S3Result<String> {
-    let Some(iam_sys) = resolve_iam_handle() else {
+    let Some(iam_sys) = current_iam_handle() else {
         return Err(s3_error!(InvalidRequest, "iam not init"));
     };
 
@@ -1584,7 +1584,7 @@ fn legacy_site_replicator_state_secret(state: &SiteReplicationState) -> Option<S
 }
 
 async fn set_site_replicator_service_account_secret(parent_user: &str, secret_key: String) -> S3Result<String> {
-    let Some(iam_sys) = resolve_iam_handle() else {
+    let Some(iam_sys) = current_iam_handle() else {
         return Err(s3_error!(InvalidRequest, "iam not init"));
     };
 
@@ -1630,7 +1630,7 @@ async fn set_site_replicator_service_account_secret(parent_user: &str, secret_ke
 }
 
 async fn ensure_site_replicator_service_account(parent_user: &str, rotate_secret: bool) -> S3Result<(String, String)> {
-    let Some(iam_sys) = resolve_iam_handle() else {
+    let Some(iam_sys) = current_iam_handle() else {
         return Err(s3_error!(InvalidRequest, "iam not init"));
     };
 
@@ -1716,7 +1716,7 @@ async fn send_peer_admin_request<T: Serialize>(
         access_key,
         secret_key,
         "",
-        resolve_region()
+        current_region()
             .map(|region| region.to_string())
             .as_deref()
             .unwrap_or("us-east-1"),
@@ -1830,7 +1830,7 @@ async fn send_peer_admin_get_request(endpoint: &str, path: &str, access_key: &st
         access_key,
         secret_key,
         "",
-        resolve_region()
+        current_region()
             .map(|region| region.to_string())
             .as_deref()
             .unwrap_or("us-east-1"),
@@ -2204,7 +2204,7 @@ async fn build_sr_info(state: &SiteReplicationState, local_peer: &PeerInfo) -> S
         let mut entry = SRBucketInfo {
             bucket: bucket.name.clone(),
             created_at: bucket.created,
-            location: resolve_region().map(|region| region.to_string()).unwrap_or_default(),
+            location: current_region().map(|region| region.to_string()).unwrap_or_default(),
             api_version: Some(SITE_REPL_API_VERSION.to_string()),
             ..Default::default()
         };
@@ -2233,7 +2233,7 @@ async fn build_sr_info(state: &SiteReplicationState, local_peer: &PeerInfo) -> S
         info.buckets.insert(bucket.name, entry);
     }
 
-    if let Some(iam_sys) = resolve_iam_handle() {
+    if let Some(iam_sys) = current_iam_handle() {
         for (name, policy_doc) in iam_sys.list_policy_docs("").await.map_err(ApiError::from)? {
             info.policies.insert(
                 name,
@@ -2292,10 +2292,10 @@ async fn build_sr_info(state: &SiteReplicationState, local_peer: &PeerInfo) -> S
 
 fn local_idp_settings() -> IDPSettings {
     let mut settings = IDPSettings::default();
-    if let Some(oidc) = resolve_oidc_handle() {
+    if let Some(oidc) = current_oidc_handle() {
         let providers = oidc.list_providers();
         settings.open_id.enabled = !providers.is_empty();
-        settings.open_id.region = resolve_region().map(|region| region.to_string()).unwrap_or_default();
+        settings.open_id.region = current_region().map(|region| region.to_string()).unwrap_or_default();
 
         for provider in providers {
             let Some(config) = oidc.get_provider_config(&provider.provider_id) else {
@@ -2391,7 +2391,7 @@ fn filter_sr_info(mut info: SRInfo, opts: &SRStatusOptions) -> SRInfo {
 }
 
 async fn build_metrics_summary(local_peer: &PeerInfo) -> SRMetricsSummary {
-    let Some(stats) = resolve_replication_stats_handle() else {
+    let Some(stats) = current_replication_stats_handle() else {
         return SRMetricsSummary::default();
     };
 
@@ -3608,7 +3608,7 @@ fn site_replication_bucket_target_for_peer(
     let port = parsed.port_or_known_default().ok_or_else(|| {
         S3Error::with_message(S3ErrorCode::InvalidRequest, format!("peer endpoint missing port: {}", peer.endpoint))
     })?;
-    let region = resolve_region()
+    let region = current_region()
         .map(|region| region.to_string())
         .filter(|region| !region.is_empty())
         .unwrap_or_else(|| "us-east-1".to_string());
@@ -4282,7 +4282,7 @@ async fn start_site_bucket_resync(bucket: &str, peer: &PeerInfo, resync_id: &str
     }
     BucketTargetSys::get().update_all_targets(bucket, Some(&targets)).await;
 
-    let Some(pool) = resolve_replication_pool_handle() else {
+    let Some(pool) = current_replication_pool_handle() else {
         bucket_status.status = "failed".to_string();
         bucket_status.err_detail = "replication pool is not initialized".to_string();
         return bucket_status;
@@ -4350,7 +4350,7 @@ async fn cancel_site_bucket_resync(bucket: &str, peer: &PeerInfo, resync_id: &st
     }
     BucketTargetSys::get().update_all_targets(bucket, Some(&targets)).await;
 
-    let Some(pool) = resolve_replication_pool_handle() else {
+    let Some(pool) = current_replication_pool_handle() else {
         bucket_status.status = "failed".to_string();
         bucket_status.err_detail = "replication pool is not initialized".to_string();
         return bucket_status;
@@ -4569,7 +4569,7 @@ fn group_info_requires_upsert(update: &rustfs_madmin::GroupAddRemove) -> bool {
 }
 
 async fn apply_iam_item(item: SRIAMItem) -> S3Result<()> {
-    let Some(iam_sys) = resolve_iam_handle() else {
+    let Some(iam_sys) = current_iam_handle() else {
         return Err(s3_error!(InvalidRequest, "iam not init"));
     };
     let incoming_updated_at = item.updated_at;
@@ -4623,7 +4623,7 @@ async fn apply_iam_item(item: SRIAMItem) -> S3Result<()> {
             let Some(sts_credential) = item.sts_credential else {
                 return Err(s3_error!(InvalidRequest, "stsCredential is required"));
             };
-            let Some(secret) = resolve_token_signing_key() else {
+            let Some(secret) = current_token_signing_key() else {
                 return Err(s3_error!(InvalidRequest, "token signing key not initialized"));
             };
             let claims = get_claims_from_token_with_secret(&sts_credential.session_token, &secret)
@@ -5109,7 +5109,7 @@ impl Operation for SRPeerJoinHandler {
         }
 
         if !join_req.svc_acct_access_key.is_empty() && !join_req.svc_acct_secret_key.is_empty() {
-            let Some(iam_sys) = resolve_iam_handle() else {
+            let Some(iam_sys) = current_iam_handle() else {
                 return Err(s3_error!(InvalidRequest, "iam not init"));
             };
 
@@ -5353,7 +5353,7 @@ impl Operation for SiteReplicationEditHandler {
             };
 
             for target in current_state.peers.values() {
-                let local_target = resolve_deployment_id()
+                let local_target = current_deployment_id()
                     .as_ref()
                     .is_some_and(|deployment_id| deployment_id == &target.deployment_id);
                 if local_target {
@@ -5726,7 +5726,7 @@ impl Operation for SRRotateServiceAccountHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::admin::runtime_sources::{resolve_outbound_tls_generation, set_test_outbound_tls_generation};
+    use crate::admin::runtime_sources::{current_outbound_tls_generation, set_test_outbound_tls_generation};
     use crate::admin::storage_api::runtime::Endpoint;
     use crate::admin::storage_api::runtime::{EndpointServerPools, Endpoints, PoolEndpoints};
     use http::{HeaderMap, HeaderValue, Uri};
@@ -7566,7 +7566,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_site_replication_peer_client_rebuilds_when_generation_changes() {
-        let previous_generation = resolve_outbound_tls_generation().0;
+        let previous_generation = current_outbound_tls_generation().0;
         let previous_cache = {
             let mut cache = SITE_REPLICATION_PEER_CLIENT.lock().await;
             let snapshot = cache.clone();

--- a/rustfs/src/admin/handlers/sts.rs
+++ b/rustfs/src/admin/handlers/sts.rs
@@ -15,7 +15,7 @@
 use super::is_admin::IsAdminHandler;
 use crate::admin::storage_api::bucket::utils::serialize;
 use crate::{
-    admin::runtime_sources::{resolve_action_credentials, resolve_oidc_handle, resolve_token_signing_key},
+    admin::runtime_sources::{current_action_credentials, current_oidc_handle, current_token_signing_key},
     admin::{
         handlers::site_replication::site_replication_iam_change_hook,
         router::{AdminOperation, Operation, S3Router},
@@ -59,7 +59,7 @@ fn has_identity_authorization_context(policies: &[String], groups: &[String]) ->
 }
 
 fn configured_roles_claim_key(provider_id: &str) -> Option<String> {
-    resolve_oidc_handle()
+    current_oidc_handle()
         .as_ref()
         .and_then(|oidc_sys| oidc_sys.get_provider_config(provider_id))
         .map(|cfg| cfg.roles_claim.trim().to_string())
@@ -187,7 +187,7 @@ async fn handle_assume_role(
         return Err(s3_error!(InvalidRequest, "AccessDenied"));
     }
 
-    let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+    let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
         return Err(s3_error!(InvalidRequest, "iam not init"));
     };
     let conditions = crate::auth::get_condition_values(&headers, &cred, None, None, remote_addr);
@@ -239,7 +239,7 @@ async fn handle_assume_role(
         return Err(s3_error!(InvalidArgument, "invalid policy arg"));
     }
 
-    let Some(secret) = resolve_token_signing_key() else {
+    let Some(secret) = current_token_signing_key() else {
         return Err(s3_error!(InvalidArgument, "global active sk not init"));
     };
 
@@ -262,7 +262,7 @@ async fn handle_assume_role(
         .await
         .map_err(|_| s3_error!(InternalError, "set_temp_user failed"))?;
 
-    let root_access_key = resolve_action_credentials().map(|cred| cred.access_key);
+    let root_access_key = current_action_credentials().map(|cred| cred.access_key);
     if root_access_key.as_deref() != Some(new_cred.parent_user.as_str())
         && let Err(err) = site_replication_iam_change_hook(SRIAMItem {
             r#type: "sts-credential".to_string(),
@@ -316,7 +316,7 @@ async fn handle_assume_role_with_web_identity(body: AssumeRoleRequest) -> S3Resu
     }
 
     // Verify the JWT and extract claims
-    let oidc_sys = resolve_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
+    let oidc_sys = current_oidc_handle().ok_or_else(|| s3_error!(InternalError, "OIDC not initialized"))?;
 
     let (claims, provider_id) = oidc_sys
         .verify_web_identity_token(&body.web_identity_token)
@@ -429,7 +429,7 @@ pub async fn create_oidc_sts_credentials(
     }
 
     // Generate STS temp credentials
-    let secret = resolve_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
+    let secret = current_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
 
     let mut new_cred = get_new_credentials_with_metadata(&token_claims, &secret)
         .map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, format!("credential generation failed: {e}")))?;
@@ -439,7 +439,7 @@ pub async fn create_oidc_sts_credentials(
 
     // Store temp user in IAM
     let iam_store =
-        crate::admin::runtime_sources::resolve_ready_iam_handle().map_err(|_| s3_error!(InternalError, "IAM not initialized"))?;
+        crate::admin::runtime_sources::current_ready_iam_handle().map_err(|_| s3_error!(InternalError, "IAM not initialized"))?;
 
     let updated_at = iam_store
         .set_temp_user(&new_cred.access_key, &new_cred, None)

--- a/rustfs/src/admin/handlers/system.rs
+++ b/rustfs/src/admin/handlers/system.rs
@@ -16,7 +16,7 @@ use super::{cluster_snapshot, metrics};
 use crate::admin::auth::validate_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::runtime_sources::{
-    DefaultAdminUsecase, QueryServerInfoRequest, default_admin_usecase, resolve_endpoints_handle,
+    DefaultAdminUsecase, QueryServerInfoRequest, current_endpoints_handle, default_admin_usecase,
 };
 use crate::admin::storage_api::cluster::{
     CapabilityState, CapabilityStatus, ObservabilitySnapshotProvider, TopologySnapshot, TopologySnapshotProvider,
@@ -314,7 +314,7 @@ pub(crate) async fn build_runtime_capabilities_response()
     let workload_admission = workload_admission_registry_snapshot();
     let cluster_snapshot_discovery = cluster_snapshot::build_cluster_snapshot_discovery_response().await;
 
-    let (topology, topology_status) = if let Some(endpoint_pools) = resolve_endpoints_handle() {
+    let (topology, topology_status) = if let Some(endpoint_pools) = current_endpoints_handle() {
         let topology_provider = EndpointTopologySnapshotProvider::new(endpoint_pools);
         let topology = topology_provider.topology_snapshot().await?;
         (Some(topology), CapabilityStatus::supported())

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::runtime_sources::default_admin_usecase;
-use crate::admin::runtime_sources::{current_object_store_handle, resolve_token_signing_key};
+use crate::admin::runtime_sources::{current_object_store_handle, current_token_signing_key};
 use crate::admin::storage_api::bucket::{metadata::table_catalog_path_hash, metadata_sys};
 use crate::admin::storage_api::runtime::ECStore;
 use crate::admin::{
@@ -709,13 +709,13 @@ impl TableCredentialIssuer for IamTableCredentialIssuer {
             serde_json::Value::String(request.scope_prefix.clone()),
         );
 
-        let secret = resolve_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
+        let secret = current_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
         let mut credential = get_new_credentials_with_metadata(&claims, &secret)
             .map_err(|err| s3_error!(InternalError, "failed to generate table credentials: {}", err))?;
         bind_table_credential_parent(&mut credential, principal);
 
         let iam_store =
-            crate::admin::runtime_sources::resolve_ready_iam_handle().map_err(|_| s3_error!(InternalError, "iam not init"))?;
+            crate::admin::runtime_sources::current_ready_iam_handle().map_err(|_| s3_error!(InternalError, "iam not init"))?;
         iam_store
             .set_temp_user(&credential.access_key, &credential, None)
             .await

--- a/rustfs/src/admin/handlers/tier.rs
+++ b/rustfs/src/admin/handlers/tier.rs
@@ -20,7 +20,7 @@ use crate::admin::storage_api::tier::{
 };
 use crate::{
     admin::runtime_sources::{
-        current_notification_system, current_object_store_handle, resolve_daily_tier_stats, resolve_tier_config_handle,
+        current_daily_tier_stats, current_notification_system, current_object_store_handle, current_tier_config_handle,
     },
     admin::{
         auth::validate_admin_request,
@@ -297,7 +297,7 @@ impl Operation for AddTier {
         };
 
         {
-            let tier_config_mgr_handle = resolve_tier_config_handle();
+            let tier_config_mgr_handle = current_tier_config_handle();
             let mut tier_config_mgr = tier_config_mgr_handle.write().await;
             if let Err(err) = tier_config_mgr.reload(store).await {
                 warn!(
@@ -444,7 +444,7 @@ impl Operation for EditTier {
         };
 
         {
-            let tier_config_mgr_handle = resolve_tier_config_handle();
+            let tier_config_mgr_handle = current_tier_config_handle();
             let mut tier_config_mgr = tier_config_mgr_handle.write().await;
             if let Err(err) = tier_config_mgr.reload(store).await {
                 warn!(
@@ -545,7 +545,7 @@ impl Operation for ListTiers {
         )
         .await?;
 
-        let tier_config_mgr_handle = resolve_tier_config_handle();
+        let tier_config_mgr_handle = current_tier_config_handle();
         let tier_config_mgr = tier_config_mgr_handle.read().await;
         let tiers = tier_config_mgr.list_tiers();
 
@@ -614,7 +614,7 @@ impl Operation for RemoveTier {
         };
 
         {
-            let tier_config_mgr_handle = resolve_tier_config_handle();
+            let tier_config_mgr_handle = current_tier_config_handle();
             let mut tier_config_mgr = tier_config_mgr_handle.write().await;
             if let Err(err) = tier_config_mgr.reload(store).await {
                 warn!(
@@ -702,7 +702,7 @@ impl Operation for VerifyTier {
         .await?;
 
         let tier = resolve_tier_name(&req.uri, &params)?;
-        let tier_config_mgr_handle = resolve_tier_config_handle();
+        let tier_config_mgr_handle = current_tier_config_handle();
         let mut tier_config_mgr = tier_config_mgr_handle.write().await;
         tier_config_mgr.verify(&tier).await.map_err(map_tier_verify_error)?;
 
@@ -749,7 +749,7 @@ impl Operation for GetTierInfo {
         } else {
             None
         };
-        let info = filter_tier_stats(resolve_daily_tier_stats(), tier_name);
+        let info = filter_tier_stats(current_daily_tier_stats(), tier_name);
 
         let data = serde_json::to_vec(&info)
             .map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, format!("marshal tier err {e}")))?;
@@ -891,7 +891,7 @@ impl Operation for ClearTier {
             return Err(s3_error!(InvalidRequest, "invalid clear-tier confirmation token"));
         };
 
-        let tier_config_mgr_handle = resolve_tier_config_handle();
+        let tier_config_mgr_handle = current_tier_config_handle();
         let mut tier_config_mgr = tier_config_mgr_handle.write().await;
         //tier_config_mgr.reload(api);
         if let Err(err) = tier_config_mgr.clear_tier(force).await {

--- a/rustfs/src/admin/handlers/tls_debug.rs
+++ b/rustfs/src/admin/handlers/tls_debug.rs
@@ -14,7 +14,7 @@
 
 use super::profile::authorize_profile_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
-use crate::admin::runtime_sources::resolve_outbound_tls_state;
+use crate::admin::runtime_sources::current_outbound_tls_state;
 use crate::server::ADMIN_PREFIX;
 use http::StatusCode;
 use http::{HeaderMap, HeaderValue};
@@ -45,7 +45,7 @@ impl Operation for TlsStatusHandler {
         authorize_profile_request(&req).await?;
 
         let tls_path = rustfs_utils::get_env_opt_str(rustfs_config::ENV_RUSTFS_TLS_PATH).unwrap_or_default();
-        let outbound = resolve_outbound_tls_state().await;
+        let outbound = current_outbound_tls_state().await;
         let generation = outbound.generation.0;
         let has_root_ca = outbound.root_ca_pem.as_ref().is_some_and(|pem| !pem.is_empty());
         let has_mtls_identity = outbound.mtls_identity.is_some();

--- a/rustfs/src/admin/handlers/trace.rs
+++ b/rustfs/src/admin/handlers/trace.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::router::Operation;
-use crate::admin::runtime_sources::resolve_endpoints_handle;
+use crate::admin::runtime_sources::current_endpoints_handle;
 use crate::admin::storage_api::runtime::PeerRestClient;
 use http::StatusCode;
 use hyper::Uri;
@@ -40,7 +40,7 @@ impl Operation for Trace {
         let _trace_opts = extract_trace_options(&req.uri)?;
 
         // let (tx, rx) = mpsc::channel(10000);
-        let _peers = match resolve_endpoints_handle() {
+        let _peers = match current_endpoints_handle() {
             Some(ep) => PeerRestClient::new_clients(ep.clone()).await,
             None => (Vec::new(), Vec::new()),
         };

--- a/rustfs/src/admin/handlers/user.rs
+++ b/rustfs/src/admin/handlers/user.rs
@@ -15,7 +15,7 @@
 use super::iam_error::iam_error_to_s3_error;
 use super::{account_info, group, service_account, user_iam, user_lifecycle, user_policy_binding};
 use crate::{
-    admin::runtime_sources::resolve_action_credentials,
+    admin::runtime_sources::current_action_credentials,
     admin::{
         auth::validate_admin_request,
         handlers::site_replication::site_replication_iam_change_hook,
@@ -221,13 +221,13 @@ impl Operation for AddUser {
             return Err(s3_error!(InvalidArgument, "secret key is required"));
         }
 
-        if let Some(sys_cred) = resolve_action_credentials()
+        if let Some(sys_cred) = current_action_credentials()
             && constant_time_eq(&sys_cred.access_key, ak)
         {
             return Err(s3_error!(InvalidArgument, "cannot create a user with the system access key"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -356,7 +356,7 @@ impl Operation for SetUserStatus {
         let status = AccountStatus::try_from(query.status.as_deref().unwrap_or_default())
             .map_err(|e| S3Error::with_message(S3ErrorCode::InvalidArgument, e))?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -408,7 +408,7 @@ impl Operation for ListUsers {
             }
         };
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -474,14 +474,14 @@ impl Operation for RemoveUser {
             return Err(s3_error!(InvalidArgument, "access key is empty"));
         }
 
-        let sys_cred = resolve_action_credentials()
+        let sys_cred = current_action_credentials()
             .ok_or_else(|| S3Error::with_message(S3ErrorCode::InternalError, "failed to load global credentials"))?;
 
         if ak == sys_cred.access_key || ak == cred.access_key || cred.parent_user == ak {
             return Err(s3_error!(InvalidArgument, "cannot remove the current user"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -558,7 +558,7 @@ impl Operation for GetUserInfo {
             return Err(s3_error!(InvalidArgument, "access key is empty"));
         }
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
@@ -654,7 +654,7 @@ impl Operation for ExportIam {
         )
         .await?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -888,7 +888,7 @@ impl Operation for ImportIam {
         let mut zip_reader =
             ZipArchive::new(Cursor::new(body)).map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, e.to_string()))?;
 
-        let Ok(iam_store) = crate::admin::runtime_sources::resolve_ready_iam_handle() else {
+        let Ok(iam_store) = crate::admin::runtime_sources::current_ready_iam_handle() else {
             return Err(s3_error!(InvalidRequest, "iam not init"));
         };
 
@@ -933,7 +933,7 @@ impl Operation for ImportIam {
             }
         }
 
-        let Some(sys_cred) = resolve_action_credentials() else {
+        let Some(sys_cred) = current_action_credentials() else {
             return Err(s3_error!(InvalidRequest, "get sys cred failed"));
         };
 

--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -28,9 +28,9 @@ use super::storage_api::runtime::PeerRestClient;
 use crate::admin::console::{is_console_path, make_console_server};
 use crate::admin::handlers::oidc::is_oidc_path;
 use crate::admin::runtime_sources::{
-    current_notification_system, current_object_store_handle, current_server_config, default_object_usecase, resolve_boot_time,
-    resolve_bucket_monitor_handle, resolve_deployment_id, resolve_region, resolve_replication_pool_handle,
-    resolve_replication_stats_handle,
+    current_boot_time, current_bucket_monitor_handle, current_deployment_id, current_notification_system,
+    current_object_store_handle, current_region, current_replication_pool_handle, current_replication_stats_handle,
+    current_server_config, default_object_usecase,
 };
 use crate::admin::storage_api::access::{ReqInfo, authorize_request, spawn_traced};
 use crate::admin::storage_api::contract::bucket::{BucketOperations, BucketOptions};
@@ -750,7 +750,7 @@ fn build_object_lambda_source_url(req: &S3Request<Body>) -> S3Result<String> {
     let region = req
         .region
         .clone()
-        .or_else(resolve_region)
+        .or_else(current_region)
         .map(|value| value.as_str().to_string())
         .unwrap_or_else(|| "us-east-1".to_string());
     let session_token = get_session_token(&req.uri, &req.headers).unwrap_or_default().to_string();
@@ -1422,7 +1422,7 @@ async fn ensure_replication_config_exists(bucket: &str) -> S3Result<()> {
 }
 
 async fn build_replication_metrics_response(bucket: &str, route: ReplicationExtRoute) -> S3Result<S3Response<Body>> {
-    let bucket_stats = match resolve_replication_stats_handle() {
+    let bucket_stats = match current_replication_stats_handle() {
         Some(stats) => stats.get_latest_replication_stats(bucket).await,
         None => BucketStats::default(),
     };
@@ -1438,14 +1438,14 @@ async fn build_replication_metrics_response(bucket: &str, route: ReplicationExtR
 }
 
 fn replication_metrics_uptime_seconds() -> i64 {
-    resolve_boot_time()
+    current_boot_time()
         .and_then(|boot_time| SystemTime::now().duration_since(boot_time).ok())
         .map(|uptime| uptime.as_secs() as i64)
         .unwrap_or_default()
 }
 
 fn collect_replication_metrics_bandwidth(bucket: &str) -> HashMap<String, BandwidthDetails> {
-    resolve_bucket_monitor_handle()
+    current_bucket_monitor_handle()
         .map(|monitor| {
             monitor
                 .get_report(|name| name == bucket)
@@ -1513,7 +1513,7 @@ async fn authorize_replication_extension_request(req: &mut S3Request<Body>, ext_
         bucket: Some(ext_req.bucket.clone()),
         object: None,
         version_id: None,
-        region: resolve_region(),
+        region: current_region(),
         ..Default::default()
     });
 
@@ -1828,7 +1828,7 @@ async fn check_replication_target(bucket: &str, target: &BucketTarget) -> Replic
 
     if target.target_bucket == bucket
         && !target.deployment_id.is_empty()
-        && resolve_deployment_id().as_deref() == Some(target.deployment_id.as_str())
+        && current_deployment_id().as_deref() == Some(target.deployment_id.as_str())
     {
         result.status = "FAILED".to_string();
         result.error = Some("target bucket must not match source bucket on the same deployment".to_string());
@@ -2149,7 +2149,7 @@ async fn start_replication_resync(bucket: &str, reset: &ReplicationResetStartReq
         .map_err(ApiError::from)?;
     BucketTargetSys::get().update_all_targets(bucket, Some(&targets)).await;
 
-    let Some(pool) = resolve_replication_pool_handle() else {
+    let Some(pool) = current_replication_pool_handle() else {
         return Err(s3_error!(InternalError, "replication pool is not initialized"));
     };
 
@@ -2169,7 +2169,7 @@ async fn start_replication_resync(bucket: &str, reset: &ReplicationResetStartReq
 }
 
 async fn load_replication_resync_status(bucket: &str) -> S3Result<BucketReplicationResyncStatus> {
-    let Some(pool) = resolve_replication_pool_handle() else {
+    let Some(pool) = current_replication_pool_handle() else {
         return Err(s3_error!(InternalError, "replication pool is not initialized"));
     };
 
@@ -2242,7 +2242,7 @@ async fn authorize_misc_extension_request(req: &mut S3Request<Body>, route: &Mis
         bucket,
         object,
         version_id: None,
-        region: resolve_region(),
+        region: current_region(),
         ..Default::default()
     });
 
@@ -3661,7 +3661,7 @@ mod tests {
                 access_key: "rustfsadmin".to_string(),
                 secret_key: s3s::auth::SecretKey::from("rustfssecret"),
             }),
-            region: resolve_region(),
+            region: current_region(),
             service: None,
             trailing_headers: None,
         };

--- a/rustfs/src/admin/runtime_sources.rs
+++ b/rustfs/src/admin/runtime_sources.rs
@@ -18,13 +18,19 @@ pub(crate) use crate::app::admin_usecase::{
 };
 use crate::app::object_usecase::DefaultObjectUsecase;
 pub(crate) use crate::runtime_sources::{
-    AppContext, publish_server_config, publish_storage_class_config, resolve_action_credentials, resolve_boot_time,
-    resolve_bucket_metadata_handle, resolve_bucket_monitor_handle, resolve_daily_tier_stats, resolve_deployment_id,
-    resolve_endpoints_handle, resolve_iam_handle, resolve_kms_runtime_service_manager, resolve_notification_system_for_context,
-    resolve_object_store_handle_for_context, resolve_oidc_handle, resolve_or_init_kms_runtime_service_manager,
-    resolve_outbound_tls_generation, resolve_outbound_tls_state, resolve_ready_iam_handle, resolve_region,
-    resolve_replication_pool_handle, resolve_replication_stats_handle, resolve_runtime_port, resolve_scanner_metrics_report,
-    resolve_server_config_for_context, resolve_tier_config_handle, resolve_token_signing_key,
+    AppContext, publish_server_config, publish_storage_class_config, resolve_action_credentials as current_action_credentials,
+    resolve_boot_time as current_boot_time, resolve_bucket_metadata_handle as current_bucket_metadata_handle,
+    resolve_bucket_monitor_handle as current_bucket_monitor_handle, resolve_daily_tier_stats as current_daily_tier_stats,
+    resolve_deployment_id as current_deployment_id, resolve_endpoints_handle as current_endpoints_handle,
+    resolve_iam_handle as current_iam_handle, resolve_kms_runtime_service_manager as current_kms_runtime_service_manager,
+    resolve_notification_system_for_context, resolve_object_store_handle_for_context, resolve_oidc_handle as current_oidc_handle,
+    resolve_or_init_kms_runtime_service_manager as current_or_init_kms_runtime_service_manager,
+    resolve_outbound_tls_generation as current_outbound_tls_generation, resolve_outbound_tls_state as current_outbound_tls_state,
+    resolve_ready_iam_handle as current_ready_iam_handle, resolve_region as current_region,
+    resolve_replication_pool_handle as current_replication_pool_handle,
+    resolve_replication_stats_handle as current_replication_stats_handle, resolve_runtime_port as current_runtime_port,
+    resolve_scanner_metrics_report as current_scanner_metrics_report, resolve_server_config_for_context,
+    resolve_tier_config_handle as current_tier_config_handle, resolve_token_signing_key as current_token_signing_key,
 };
 use rustfs_config::server_config::Config;
 use std::sync::Arc;


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#660.

## Summary of Changes
- Add admin `current_*` helper aliases for the remaining runtime-source families.
- Route admin IAM, KMS, OIDC, action-credential, region, endpoint, replication, tier, scanner, TLS, and system consumers through the admin runtime boundary.
- Update migration progress with the GLOB-007 admin runtime helper alias slice.

## Verification
- `cargo check -p rustfs --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- Admin resolver residual scan
- Diff-added Rust risk scan
- `make pre-pr`

## Impact
No runtime behavior change; existing AppContext-first fallback behavior is preserved.

## Additional Notes
N/A
