### PR TITLE
refactor: align app runtime facade helpers

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,7 +5,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-global-storage-runtime-consumer-batch`
+- Branch: `overtrue/arch-global-app-runtime-consumer-batch`
 - Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/API-253/API-254/CTX-002`.
 - Current baseline also includes API-255 from PR #3923, API-256 from PR
   #3925, CFG-009 from PR #3927, C-007/C-009 from PR #3935, C-008/C-010
@@ -14,18 +14,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   GLOB-005/CRATE-001/CRATE-002 from PR #3939, GLOB-006 from PR #3941,
   the first GLOB-007 admin runtime context handoff from PR #3942, and the
   GLOB-007 admin object-store/notification/server-config consumer batch from
-  PR #3943.
-- Current phase PR: GLOB-007 storage/server runtime facade consumer batch.
-- Based on: `origin/main` after PR #3944 merged.
+  PR #3943, the GLOB-007 admin runtime helper alias batch from PR #3944, and
+  the GLOB-007 storage/server runtime facade consumer batch from PR #3946.
+- Current phase PR: GLOB-007 app runtime facade consumer batch.
+- Based on: `origin/main` after PR #3946 merged.
 - PR type for this branch: `ci-gate`.
 - Runtime behavior changes: none intended.
-- Rust code changes: rename storage and server runtime facade accessors to
-  `current_*`, route storage access, ECFS extension, and node-service RPC
-  object-store lookups through the storage runtime facade, and remove the old
-  storage object-store resolver re-export.
+- Rust code changes: expose app runtime facade aliases as `current_*` and route
+  bucket, admin, object, multipart, select-object, and lifecycle test
+  consumers through those names while keeping the underlying root resolvers and
+  fallback behavior unchanged.
 - CI/script changes: none intended.
-- Docs changes: update this progress ledger for the storage/server runtime
-  facade consumer batch.
+- Docs changes: update this progress ledger for the app runtime facade consumer
+  batch.
 
 ## Phase 0 Tasks
 
@@ -2793,6 +2794,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   - Current slice: route storage and server runtime consumers through
     `current_*` facade helpers, remove the old storage object-store resolver
     re-export, and keep all resolver fallback behavior unchanged.
+  - Current slice: expose app runtime-source facade reads as `current_*`
+    aliases and move app bucket/admin/object/multipart/select-object consumers
+    plus the lifecycle transition test off direct resolver names.
   - Remaining work: remove one fallback family per PR only after scans prove no
     production caller depends on it; this slice keeps the fallback behavior
     because broader app/storage/server consumers still use the root resolvers.
@@ -6062,6 +6066,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | GLOB-007 exposes app runtime-source facade reads as `current_*` aliases and moves bucket, admin, object, multipart, select-object, and lifecycle test consumers off direct resolver names. |
+| Migration preservation | pass | The aliases delegate to the same root runtime resolvers, so AppContext object-store selection, notification dispatch, expiry/tier handles, endpoint snapshots, encryption service, and S3 Select DB behavior stay unchanged. |
+| Testing/verification | pass | Focused RustFS compile, formatting, architecture guard, app resolver residual scan, diff hygiene, and diff-added Rust risk scan are required before the full PR gate. |
 | Quality/architecture | pass | GLOB-007 renames storage and server runtime-source facade reads to `current_*`, moves remaining storage access/ECFS extension/RPC node-service object-store lookups behind the storage runtime facade, and removes the old storage object-store resolver re-export. |
 | Migration preservation | pass | The facade helpers still delegate to the same root runtime resolvers, so storage authorization, ECFS validation, decommission RPC, server readiness, audit, event, layer, and module-switch behavior stays unchanged. |
 | Testing/verification | pass | Focused compile, formatting, architecture guard, diff hygiene, storage/server resolver residual scan, and diff-added Rust risk scan are required before the full PR gate. |
@@ -6430,6 +6437,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 GLOB-007 app runtime facade consumer slice:
+  - Branch freshness check: rebased onto `origin/main` after PR #3946 merged.
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - App runtime resolver residual scan: passed.
+  - Diff-added Rust risk scan: passed; no new production unwrap/expect,
+    panic/todo/dbg, or ad-hoc stdout/stderr.
+  - Three-expert review: passed.
+  - `make pre-pr`: passed, including 6912 nextest tests passed, 112 skipped,
+    and doctests.
 
 - Issue #660 GLOB-007 storage/server runtime facade consumer slice:
   - Branch freshness check: rebased onto `origin/main` after PR #3944 merged.

--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -25,7 +25,7 @@ use super::storage_api::admin_usecase::data_usage::{
 };
 use super::storage_api::admin_usecase::{ECStore, EndpointServerPools};
 use crate::app::runtime_sources::{
-    AppContext, current_app_context, resolve_endpoints_handle, resolve_object_store_handle_for_context,
+    AppContext, current_app_context, current_endpoints_handle, current_object_store_handle_for_context,
 };
 use crate::capacity::resolve_admin_used_capacity;
 use crate::cluster_snapshot::{
@@ -196,7 +196,7 @@ impl DefaultAdminUsecase {
     }
 
     fn object_store(&self) -> Option<Arc<ECStore>> {
-        resolve_object_store_handle_for_context(self.context.as_deref())
+        current_object_store_handle_for_context(self.context.as_deref())
     }
 
     fn app_error(code: S3ErrorCode, message: impl Into<String>) -> ApiError {
@@ -583,7 +583,7 @@ impl DefaultAdminUsecase {
 
     pub async fn execute_collect_dependency_readiness(&self) -> DependencyReadiness {
         let report = collect_runtime_dependency_readiness_report().await;
-        if let Some(endpoint_pools) = resolve_endpoints_handle() {
+        if let Some(endpoint_pools) = current_endpoints_handle() {
             let runtime_status = ClusterRuntimeStatusSnapshot::from_readiness_report(report);
             return cluster_read_only_snapshot_from_endpoint_pools(&endpoint_pools, runtime_status)
                 .runtime_status
@@ -593,7 +593,7 @@ impl DefaultAdminUsecase {
     }
 
     pub async fn execute_collect_cluster_read_only_snapshot(&self) -> Option<ClusterReadOnlySnapshot> {
-        let endpoint_pools = resolve_endpoints_handle()?;
+        let endpoint_pools = current_endpoints_handle()?;
         collect_cluster_read_only_snapshot(&endpoint_pools).await
     }
 

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -60,8 +60,8 @@ use crate::admin::handlers::site_replication::{
     site_replication_bucket_meta_hook, site_replication_delete_bucket_hook, site_replication_make_bucket_hook,
 };
 use crate::app::runtime_sources::{
-    AppContext, current_app_context, resolve_encryption_service, resolve_notification_system,
-    resolve_notify_interface_for_context, resolve_object_store_handle_for_context,
+    AppContext, current_app_context, current_encryption_service, current_notification_system,
+    current_notify_interface_for_context, current_object_store_handle_for_context,
 };
 use crate::auth::get_condition_values_with_client_info;
 use crate::error::ApiError;
@@ -238,7 +238,7 @@ fn notify_bucket_metadata_reload(
     request_context: Option<request_context::RequestContext>,
 ) {
     spawn_background_with_context(request_context, async move {
-        if let Some(notification_sys) = resolve_notification_system()
+        if let Some(notification_sys) = current_notification_system()
             && let Err(err) = notification_sys.load_bucket_metadata(&bucket).await
         {
             warn!(bucket = %bucket, error = %err, "failed to notify peers after {operation}");
@@ -778,7 +778,7 @@ impl DefaultBucketUsecase {
     }
 
     fn object_store(&self) -> Option<Arc<ECStore>> {
-        resolve_object_store_handle_for_context(self.context.as_deref())
+        current_object_store_handle_for_context(self.context.as_deref())
     }
 
     #[instrument(
@@ -1594,7 +1594,7 @@ impl DefaultBucketUsecase {
             && by_default.sse_algorithm.as_str() == ServerSideEncryption::AWS_KMS
             && by_default.kms_master_key_id.as_deref().is_none_or(str::is_empty)
         {
-            let service = resolve_encryption_service()
+            let service = current_encryption_service()
                 .await
                 .ok_or_else(|| S3Error::with_message(S3ErrorCode::InternalError, "KMS service not initialized".to_string()))?;
             let default_key = service
@@ -1746,7 +1746,7 @@ impl DefaultBucketUsecase {
             .map_err(ApiError::from)?;
 
         let region = resolve_notification_region(self.global_region(), request_region);
-        let notify = resolve_notify_interface_for_context(self.context.as_deref());
+        let notify = current_notify_interface_for_context(self.context.as_deref());
         let clear_rules = notify.clear_bucket_notification_rules(&bucket);
         let parse_rules = async {
             let mut event_rules = Vec::new();

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -33,7 +33,7 @@ use super::storage_api::test::{
 };
 use super::{multipart_usecase::DefaultMultipartUsecase, object_usecase::DefaultObjectUsecase};
 use crate::app::bucket_usecase::DefaultBucketUsecase;
-use crate::app::runtime_sources::resolve_tier_config_handle;
+use crate::app::runtime_sources::current_tier_config_handle;
 use bytes::Bytes;
 use futures::FutureExt;
 use futures::stream;
@@ -343,7 +343,7 @@ impl AppWarmBackend for MockWarmBackend {
 
 async fn register_mock_tier(tier_name: &str) -> MockWarmBackend {
     let backend = MockWarmBackend::default();
-    let tier_config_mgr_handle = resolve_tier_config_handle();
+    let tier_config_mgr_handle = current_tier_config_handle();
     let mut tier_config_mgr = tier_config_mgr_handle.write().await;
     tier_config_mgr.tiers.insert(
         tier_name.to_string(),

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -56,7 +56,7 @@ use super::storage_api::multipart_usecase::sse::{
 };
 use super::storage_api::multipart_usecase::{StorageObjectOptions as ObjectOptions, StoragePutObjReader as PutObjReader};
 use crate::app::object_usecase::{build_put_like_object_lock_metadata, validate_existing_object_lock_for_write};
-use crate::app::runtime_sources::{AppContext, current_app_context, resolve_object_store_handle_for_context};
+use crate::app::runtime_sources::{AppContext, current_app_context, current_object_store_handle_for_context};
 use crate::capacity::record_capacity_write;
 use crate::error::ApiError;
 use crate::table_catalog;
@@ -295,7 +295,7 @@ impl DefaultMultipartUsecase {
     }
 
     fn object_store(&self) -> Option<Arc<ECStore>> {
-        resolve_object_store_handle_for_context(self.context.as_deref())
+        current_object_store_handle_for_context(self.context.as_deref())
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -90,8 +90,8 @@ use super::storage_api::object_usecase::{
     validate_sse_headers_for_write, validate_ssec_for_read, wrap_response_with_cors,
 };
 use crate::app::runtime_sources::{
-    AppContext, current_app_context, resolve_expiry_state_handle, resolve_notify_interface_for_context,
-    resolve_object_store_handle_for_context,
+    AppContext, current_app_context, current_expiry_state_handle, current_notify_interface_for_context,
+    current_object_store_handle_for_context,
 };
 use crate::config::RustFSBufferConfig;
 use crate::delete_tail_activity::{DeleteTailActivityGuard, DeleteTailStage};
@@ -376,7 +376,7 @@ async fn enqueue_transitioned_delete_cleanup(
 
     tier_delete_journal::persist_tier_delete_journal_entry(store, &je).await?;
 
-    let expiry_state = resolve_expiry_state_handle();
+    let expiry_state = current_expiry_state_handle();
     let mut expiry_state = expiry_state.write().await;
     if let Err(err) = expiry_state.enqueue_tier_journal_entry(&je).await {
         warn!(
@@ -1845,7 +1845,7 @@ impl DefaultObjectUsecase {
     }
 
     fn object_store(&self) -> Option<Arc<ECStore>> {
-        resolve_object_store_handle_for_context(self.context.as_deref())
+        current_object_store_handle_for_context(self.context.as_deref())
     }
 
     fn base_buffer_size(&self) -> usize {
@@ -4313,7 +4313,7 @@ impl DefaultObjectUsecase {
         }
 
         let req_headers = req.headers.clone();
-        let notify = resolve_notify_interface_for_context(self.context.as_deref());
+        let notify = current_notify_interface_for_context(self.context.as_deref());
         let request_context = req.extensions.get::<request_context::RequestContext>().cloned();
         let deleted_any = delete_results.iter().any(|result| result.delete_object.is_some());
         let notify_bucket = bucket.clone();
@@ -5318,7 +5318,7 @@ impl DefaultObjectUsecase {
             None => String::new(),
         };
 
-        let notify = resolve_notify_interface_for_context(self.context.as_deref());
+        let notify = current_notify_interface_for_context(self.context.as_deref());
         let req_params = extract_params_header(&req.headers);
         let host = get_request_host(&req.headers);
         let port = get_request_port(&req.headers);

--- a/rustfs/src/app/runtime_sources.rs
+++ b/rustfs/src/app/runtime_sources.rs
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 pub(crate) use crate::runtime_sources::{
-    AppContext, resolve_encryption_service, resolve_endpoints_handle, resolve_expiry_state_handle, resolve_notification_system,
-    resolve_notify_interface_for_context, resolve_object_store_handle_for_context, resolve_s3select_db,
+    AppContext, resolve_encryption_service as current_encryption_service, resolve_endpoints_handle as current_endpoints_handle,
+    resolve_expiry_state_handle as current_expiry_state_handle, resolve_notification_system as current_notification_system,
+    resolve_notify_interface_for_context as current_notify_interface_for_context,
+    resolve_object_store_handle_for_context as current_object_store_handle_for_context,
+    resolve_s3select_db as current_s3select_db,
 };
 use std::sync::Arc;
 
 #[cfg(test)]
-pub(crate) use crate::runtime_sources::resolve_tier_config_handle;
+pub(crate) use crate::runtime_sources::resolve_tier_config_handle as current_tier_config_handle;
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
     crate::runtime_sources::current_app_context()

--- a/rustfs/src/app/select_object.rs
+++ b/rustfs/src/app/select_object.rs
@@ -2,7 +2,7 @@ use super::storage_api::select_object::contract::object::ObjectOperations as _;
 use super::storage_api::select_object::options::get_opts;
 use super::storage_api::select_object::request_context::spawn_traced;
 use super::storage_api::select_object::{get_validated_store, validate_sse_headers_for_read, validate_ssec_for_read};
-use crate::app::runtime_sources::resolve_s3select_db;
+use crate::app::runtime_sources::current_s3select_db;
 use crate::error::ApiError;
 use bytes::Bytes;
 use datafusion::arrow::{
@@ -60,7 +60,7 @@ pub async fn execute_select_object_content(
     validate_scan_range_for_object_size(&input.request, metadata.size)?;
 
     let input = Arc::new(input);
-    let db = resolve_s3select_db((*input).clone(), false)
+    let db = current_s3select_db((*input).clone(), false)
         .await
         .map_err(map_query_error_to_s3)?;
     let query = Query::new(Context { input: input.clone() }, input.request.expression.clone());


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#660.

## Summary of Changes
- Expose app runtime-source facade reads as `current_*` aliases.
- Route app bucket, admin, object, multipart, select-object, and lifecycle test consumers through the app facade names.
- Update migration progress for this GLOB-007 app runtime facade consumer slice.

## Verification
- `cargo check -p rustfs --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- App runtime resolver residual scan
- Diff-added Rust risk scan
- `make pre-pr`

## Impact
No runtime behavior change; the facade aliases delegate to the same root runtime resolvers and preserve existing AppContext and fallback behavior.

## Additional Notes
N/A
