### PR TITLE
refactor: clean app context fallback signatures

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,7 +5,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-runtime-optional-handle-fallback-removal`
+- Branch: `overtrue/arch-runtime-context-fallback-signature-cleanup`
 - Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/API-253/API-254/CTX-002`.
 - Current baseline also includes API-255 from PR #3923, API-256 from PR
   #3925, CFG-009 from PR #3927, C-007/C-009 from PR #3935, C-008/C-010
@@ -19,20 +19,19 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   GLOB-007 app runtime facade consumer batch from PR #3947, the GLOB-007 core
   runtime facade consumer batch from PR #3948, the GLOB-007 runtime facade
   alias sweep from PR #3949, the GLOB-007 object-store fallback removal from
-  PR #3950, and the GLOB-007 notification-system/server-config fallback
-  removal from PR #3951.
-- Current phase PR: GLOB-007 optional runtime handle fallback removal.
-- Based on: `origin/main` after PR #3951 merged.
+  PR #3950, the GLOB-007 notification-system/server-config fallback removal
+  from PR #3951, and the GLOB-007 optional runtime handle fallback removal
+  from PR #3952.
+- Current phase PR: GLOB-007 AppContext-only fallback signature cleanup.
+- Based on: `origin/main` after PR #3952 merged.
 - PR type for this branch: `ci-gate`.
-- Runtime behavior changes: optional runtime reads for token signing key,
-  bucket metadata, endpoint pools, bucket monitor, replication handles, boot
-  time, deployment ID, lock clients, and region now require AppContext instead
-  of falling back to legacy globals.
-- Rust code changes: remove the legacy global fallbacks from those optional
-  AppContext resolver families.
+- Runtime behavior changes: none intended beyond the PR #3952 optional
+  no-context behavior.
+- Rust code changes: remove stale fallback closure parameters from
+  AppContext-only resolver helpers for object-store, notification-system,
+  server-config, and optional runtime handles.
 - CI/script changes: none intended.
-- Docs changes: update this progress ledger for the optional handle fallback
-  removal.
+- Docs changes: update this progress ledger for the fallback signature cleanup.
 
 ## Phase 0 Tasks
 
@@ -2820,6 +2819,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
     handle/read resolvers for token signing key, bucket metadata, endpoints,
     bucket monitor, replication handles, boot time, deployment ID, lock
     clients, and region.
+  - Current slice: remove stale fallback closure parameters from
+    AppContext-only resolver helpers after their no-context behavior no longer
+    consults legacy globals.
   - Remaining work: remove the next fallback family per PR only after scans
     prove no production caller depends on it.
   - Verification: focused RustFS compile and admin test-target compile,
@@ -6088,6 +6090,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | GLOB-007 removes stale fallback closure parameters from resolver helpers whose no-context behavior is already AppContext-only, making hidden fallback reintroduction harder. |
+| Migration preservation | pass | Public runtime facade names and return types stay unchanged; this is a signature cleanup for private helper paths and test coverage after PR #3952. |
+| Testing/verification | pass | Focused resolver test passed; compile, formatting, architecture guard, fallback-parameter residual scan, diff hygiene, diff-added Rust risk scan, and full `make pre-pr` are required before PR. |
 | Quality/architecture | pass | GLOB-007 removes a broad optional-handle resolver fallback batch, keeping absent AppContext from consulting legacy globals for token signing key, bucket metadata, endpoints, bucket monitor, replication, boot, deployment, lock, and region reads. |
 | Migration preservation | pass | Action credentials, concrete default-returning runtime families, startup publishers, KMS/TLS/IAM readiness initialization, scanner metrics, S3 Select, local node name, tier config, expiry state, performance metrics, and buffer config fallbacks are intentionally left unchanged for later slices. |
 | Testing/verification | pass | Focused RustFS compile/test, formatting, architecture guard, optional-handle fallback residual scan, diff hygiene, diff-added Rust risk scan, and full `make pre-pr` are required before PR. |
@@ -6474,6 +6479,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Verification Notes
 
 Passed before push:
+
+- Issue #660 GLOB-007 AppContext-only fallback signature cleanup:
+  - Branch freshness check: rebased onto `origin/main` after PR #3952 merged.
+  - `cargo test -p rustfs --lib app::context::tests::resolver_helpers_are_context_first_and_fallback_when_context_is_absent`:
+    passed.
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo fmt --all`: passed.
+  - `cargo fmt --all --check`: passed.
+  - `git diff --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - AppContext-only fallback parameter residual scan: passed.
+  - Diff-added Rust risk scan: passed.
+  - Three-expert review: passed.
+  - `make pre-pr`: passed (`nextest`: 6917 passed, 112 skipped; doctests passed).
 
 - Issue #660 GLOB-007 optional runtime handle fallback removal:
   - Branch freshness check: rebased onto `origin/main` after PR #3951 merged.

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -102,12 +102,12 @@ pub fn resolve_ready_iam_handle() -> rustfs_iam::error::Result<Arc<IamSys<Object
 
 /// Resolve token signing key using AppContext-first precedence.
 pub fn resolve_token_signing_key() -> Option<String> {
-    resolve_token_signing_key_with(get_global_app_context(), || None)
+    resolve_token_signing_key_with(get_global_app_context())
 }
 
 /// Resolve bucket metadata handle using AppContext-first precedence.
 pub fn resolve_bucket_metadata_handle() -> Option<Arc<RwLock<BucketMetadataSys>>> {
-    resolve_bucket_metadata_handle_with(get_global_app_context(), || None)
+    resolve_bucket_metadata_handle_with(get_global_app_context())
 }
 
 /// Resolve object store handle using AppContext-first precedence.
@@ -136,7 +136,7 @@ pub fn resolve_notify_interface_for_context(context: Option<&AppContext>) -> Arc
 
 /// Resolve notification system handle using AppContext-first precedence.
 pub fn resolve_notification_system() -> Option<&'static NotificationSys> {
-    resolve_notification_system_with(get_global_app_context(), || None)
+    resolve_notification_system_with(get_global_app_context())
 }
 
 /// Resolve notification system handle using an explicit AppContext.
@@ -146,27 +146,27 @@ pub fn resolve_notification_system_for_context(context: Option<&AppContext>) -> 
 
 /// Resolve endpoints using AppContext-first precedence.
 pub fn resolve_endpoints_handle() -> Option<EndpointServerPools> {
-    resolve_endpoints_handle_with(get_global_app_context(), || None)
+    resolve_endpoints_handle_with(get_global_app_context())
 }
 
 /// Resolve bucket bandwidth monitor using AppContext-first precedence.
 pub fn resolve_bucket_monitor_handle() -> Option<Arc<BucketBandwidthMonitor>> {
-    resolve_bucket_monitor_handle_with(get_global_app_context(), || None)
+    resolve_bucket_monitor_handle_with(get_global_app_context())
 }
 
 /// Resolve replication pool handle using AppContext-first precedence.
 pub fn resolve_replication_pool_handle() -> Option<Arc<DynReplicationPool>> {
-    resolve_replication_pool_handle_with(get_global_app_context(), || None)
+    resolve_replication_pool_handle_with(get_global_app_context())
 }
 
 /// Resolve replication statistics handle using AppContext-first precedence.
 pub fn resolve_replication_stats_handle() -> Option<Arc<ReplicationStats>> {
-    resolve_replication_stats_handle_with(get_global_app_context(), || None)
+    resolve_replication_stats_handle_with(get_global_app_context())
 }
 
 /// Resolve boot time using AppContext-first precedence.
 pub fn resolve_boot_time() -> Option<SystemTime> {
-    resolve_boot_time_with(get_global_app_context(), || None)
+    resolve_boot_time_with(get_global_app_context())
 }
 
 /// Resolve daily tier transition statistics using AppContext-first precedence.
@@ -182,7 +182,7 @@ pub async fn resolve_scanner_metrics_report() -> ScannerMetricsReport {
 
 /// Resolve deployment identity using AppContext-first precedence.
 pub fn resolve_deployment_id() -> Option<String> {
-    resolve_deployment_id_with(get_global_app_context(), || None)
+    resolve_deployment_id_with(get_global_app_context())
 }
 
 /// Resolve runtime port using AppContext-first precedence.
@@ -192,12 +192,12 @@ pub fn resolve_runtime_port() -> u16 {
 
 /// Resolve lock client using AppContext-first precedence.
 pub fn resolve_lock_client() -> Option<Arc<dyn LockClient>> {
-    resolve_lock_client_with(get_global_app_context(), || None)
+    resolve_lock_client_with(get_global_app_context())
 }
 
 /// Resolve lock clients using AppContext-first precedence.
 pub fn resolve_lock_clients_handle() -> Option<HashMap<String, Arc<dyn LockClient>>> {
-    resolve_lock_clients_handle_with(get_global_app_context(), || None)
+    resolve_lock_clients_handle_with(get_global_app_context())
 }
 
 /// Resolve performance metrics using AppContext-first precedence.
@@ -233,7 +233,7 @@ pub fn resolve_action_credentials() -> Option<Credentials> {
 
 /// Resolve region using AppContext-first precedence.
 pub fn resolve_region() -> Option<s3s::region::Region> {
-    resolve_region_with(get_global_app_context(), || None)
+    resolve_region_with(get_global_app_context())
 }
 
 /// Resolve tier config handle using AppContext-first precedence.
@@ -248,7 +248,7 @@ pub fn resolve_expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
 
 /// Resolve server config using AppContext-first precedence.
 pub fn resolve_server_config() -> Option<Config> {
-    resolve_server_config_with(get_global_app_context(), || None)
+    resolve_server_config_with(get_global_app_context())
 }
 
 /// Resolve server config using an explicit AppContext.
@@ -355,52 +355,31 @@ fn resolve_ready_iam_handle_with(
     fallback()
 }
 
-fn resolve_token_signing_key_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<String>,
-) -> Option<String> {
+fn resolve_token_signing_key_with(context: Option<Arc<AppContext>>) -> Option<String> {
     context.and_then(|context| context.iam().token_signing_key())
 }
 
-fn resolve_bucket_metadata_handle_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<Arc<RwLock<BucketMetadataSys>>>,
-) -> Option<Arc<RwLock<BucketMetadataSys>>> {
+fn resolve_bucket_metadata_handle_with(context: Option<Arc<AppContext>>) -> Option<Arc<RwLock<BucketMetadataSys>>> {
     context.and_then(|context| context.bucket_metadata().handle())
 }
 
-fn resolve_notification_system_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<&'static NotificationSys>,
-) -> Option<&'static NotificationSys> {
+fn resolve_notification_system_with(context: Option<Arc<AppContext>>) -> Option<&'static NotificationSys> {
     context.and_then(|context| context.notification_system().handle())
 }
 
-fn resolve_bucket_monitor_handle_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<Arc<BucketBandwidthMonitor>>,
-) -> Option<Arc<BucketBandwidthMonitor>> {
+fn resolve_bucket_monitor_handle_with(context: Option<Arc<AppContext>>) -> Option<Arc<BucketBandwidthMonitor>> {
     context.and_then(|context| context.bucket_monitor().handle())
 }
 
-fn resolve_replication_pool_handle_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<Arc<DynReplicationPool>>,
-) -> Option<Arc<DynReplicationPool>> {
+fn resolve_replication_pool_handle_with(context: Option<Arc<AppContext>>) -> Option<Arc<DynReplicationPool>> {
     context.and_then(|context| context.replication_pool().handle())
 }
 
-fn resolve_replication_stats_handle_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<Arc<ReplicationStats>>,
-) -> Option<Arc<ReplicationStats>> {
+fn resolve_replication_stats_handle_with(context: Option<Arc<AppContext>>) -> Option<Arc<ReplicationStats>> {
     context.and_then(|context| context.replication_stats().handle())
 }
 
-fn resolve_boot_time_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<SystemTime>,
-) -> Option<SystemTime> {
+fn resolve_boot_time_with(context: Option<Arc<AppContext>>) -> Option<SystemTime> {
     context.and_then(|context| context.boot_time().get())
 }
 
@@ -424,21 +403,15 @@ where
 }
 
 #[cfg(test)]
-fn resolve_object_store_handle_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<Arc<ECStore>>,
-) -> Option<Arc<ECStore>> {
+fn resolve_object_store_handle_with(context: Option<Arc<AppContext>>) -> Option<Arc<ECStore>> {
     context.map(|context| context.object_store())
 }
 
-fn resolve_endpoints_handle_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<EndpointServerPools>,
-) -> Option<EndpointServerPools> {
+fn resolve_endpoints_handle_with(context: Option<Arc<AppContext>>) -> Option<EndpointServerPools> {
     context.and_then(|context| context.endpoints().handle())
 }
 
-fn resolve_deployment_id_with(context: Option<Arc<AppContext>>, _fallback: impl FnOnce() -> Option<String>) -> Option<String> {
+fn resolve_deployment_id_with(context: Option<Arc<AppContext>>) -> Option<String> {
     context.and_then(|context| context.deployment_id().get())
 }
 
@@ -446,17 +419,11 @@ fn resolve_runtime_port_with(context: Option<Arc<AppContext>>, fallback: impl Fn
     context.map_or_else(fallback, |context| context.runtime_port().get())
 }
 
-fn resolve_lock_client_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<Arc<dyn LockClient>>,
-) -> Option<Arc<dyn LockClient>> {
+fn resolve_lock_client_with(context: Option<Arc<AppContext>>) -> Option<Arc<dyn LockClient>> {
     context.and_then(|context| context.lock_client().handle())
 }
 
-fn resolve_lock_clients_handle_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<HashMap<String, Arc<dyn LockClient>>>,
-) -> Option<HashMap<String, Arc<dyn LockClient>>> {
+fn resolve_lock_clients_handle_with(context: Option<Arc<AppContext>>) -> Option<HashMap<String, Arc<dyn LockClient>>> {
     context.and_then(|context| context.lock_clients().handle())
 }
 
@@ -512,10 +479,7 @@ fn resolve_action_credentials_with(
         .unwrap_or_else(fallback)
 }
 
-fn resolve_region_with(
-    context: Option<Arc<AppContext>>,
-    _fallback: impl FnOnce() -> Option<s3s::region::Region>,
-) -> Option<s3s::region::Region> {
+fn resolve_region_with(context: Option<Arc<AppContext>>) -> Option<s3s::region::Region> {
     context.and_then(|context| context.region().get())
 }
 
@@ -535,7 +499,7 @@ fn resolve_expiry_state_handle_with(
         .unwrap_or_else(fallback)
 }
 
-fn resolve_server_config_with(context: Option<Arc<AppContext>>, _fallback: impl FnOnce() -> Option<Config>) -> Option<Config> {
+fn resolve_server_config_with(context: Option<Arc<AppContext>>) -> Option<Config> {
     context.and_then(|context| context.server_config().get())
 }
 
@@ -996,9 +960,7 @@ mod tests {
         let fallback_kms = Arc::new(KmsServiceManager::new());
         let bucket_metadata = Arc::new(RwLock::new(BucketMetadataSys::new(object_store.clone())));
         let context_replication_stats = Arc::new(ReplicationStats::new());
-        let fallback_replication_stats = Arc::new(ReplicationStats::new());
         let context_boot_time = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
-        let fallback_boot_time = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
         let mut context_daily_tier_stats = DailyAllTierStats::new();
         context_daily_tier_stats.insert("CONTEXT".to_string(), Default::default());
         let mut fallback_daily_tier_stats = DailyAllTierStats::new();
@@ -1021,17 +983,13 @@ mod tests {
         let fallback_storage_class_published = Arc::new(AtomicUsize::new(0));
         let buffer_config = RustFSBufferConfig::new(WorkloadProfile::AiTraining);
         let context_lock_client: Arc<dyn LockClient> = Arc::new(LocalClient::new());
-        let fallback_lock_client: Arc<dyn LockClient> = Arc::new(LocalClient::new());
         let context_node_name = "context-node".to_string();
         let fallback_node_name = "fallback-node".to_string();
         let context_deployment_id = "context-deployment".to_string();
-        let fallback_deployment_id = "fallback-deployment".to_string();
         let context_runtime_port = 19000;
         let fallback_runtime_port = 29000;
         let mut context_lock_clients = HashMap::new();
         context_lock_clients.insert("context-node:9000".to_string(), context_lock_client.clone());
-        let mut fallback_lock_clients = HashMap::new();
-        fallback_lock_clients.insert("fallback-node:9000".to_string(), fallback_lock_client.clone());
         let context_performance_metrics = Arc::new(PerformanceMetrics::new());
         let fallback_performance_metrics = Arc::new(PerformanceMetrics::new());
         let context_internode_metrics = Arc::new(InternodeMetrics::default());
@@ -1052,7 +1010,6 @@ mod tests {
             ..Default::default()
         };
         let context_region: s3s::region::Region = "context-region".parse().expect("test region");
-        let fallback_region: s3s::region::Region = "fallback-region".parse().expect("test region");
         let context_oidc_sys = match OidcSys::empty() {
             Ok(sys) => sys,
             Err(err) => unreachable!("test OIDC sys should initialize: {err}"),
@@ -1064,7 +1021,6 @@ mod tests {
         let context_oidc = Arc::new(context_oidc_sys);
         let fallback_oidc = Arc::new(fallback_oidc_sys);
         let context_token_signing_key = "context-token-signing-key".to_string();
-        let fallback_token_signing_key = "fallback-token-signing-key".to_string();
 
         let context = Arc::new(AppContext::with_test_interfaces(
             object_store.clone(),
@@ -1176,23 +1132,23 @@ mod tests {
         let resolved_oidc = resolve_oidc_handle_with(Some(context.clone()));
         assert!(resolved_oidc.as_ref().is_some_and(|oidc| Arc::ptr_eq(oidc, &fallback_oidc)));
         assert_eq!(
-            resolve_token_signing_key_with(Some(context.clone()), || Some(fallback_token_signing_key.clone())).as_deref(),
+            resolve_token_signing_key_with(Some(context.clone())).as_deref(),
             Some(context_token_signing_key.as_str())
         );
         assert!(Arc::ptr_eq(
-            &resolve_bucket_metadata_handle_with(Some(context.clone()), || None).expect("context bucket metadata"),
+            &resolve_bucket_metadata_handle_with(Some(context.clone())).expect("context bucket metadata"),
             &bucket_metadata
         ));
         assert!(Arc::ptr_eq(
-            &resolve_object_store_handle_with(Some(context.clone()), || None).expect("context object store"),
+            &resolve_object_store_handle_with(Some(context.clone())).expect("context object store"),
             &object_store
         ));
         assert!(Arc::ptr_eq(
-            &resolve_replication_stats_handle_with(Some(context.clone()), || None).expect("context replication stats"),
+            &resolve_replication_stats_handle_with(Some(context.clone())).expect("context replication stats"),
             &context_replication_stats
         ));
         assert_eq!(
-            resolve_boot_time_with(Some(context.clone()), || Some(fallback_boot_time)).expect("context boot time"),
+            resolve_boot_time_with(Some(context.clone())).expect("context boot time"),
             context_boot_time
         );
         assert!(
@@ -1205,15 +1161,14 @@ mod tests {
             context_scanner_metrics.current_cycle
         );
         assert_eq!(
-            resolve_endpoints_handle_with(Some(context.clone()), || None)
+            resolve_endpoints_handle_with(Some(context.clone()))
                 .expect("context endpoints")
                 .as_ref()[0]
                 .drives_per_set,
             endpoints.as_ref()[0].drives_per_set
         );
         assert_eq!(
-            resolve_deployment_id_with(Some(context.clone()), || Some(fallback_deployment_id.clone()))
-                .expect("context deployment id"),
+            resolve_deployment_id_with(Some(context.clone())).expect("context deployment id"),
             context_deployment_id
         );
         assert_eq!(
@@ -1221,11 +1176,11 @@ mod tests {
             context_runtime_port
         );
         assert!(Arc::ptr_eq(
-            &resolve_lock_client_with(Some(context.clone()), || None).expect("context lock client"),
+            &resolve_lock_client_with(Some(context.clone())).expect("context lock client"),
             &context_lock_client
         ));
         assert!(Arc::ptr_eq(
-            resolve_lock_clients_handle_with(Some(context.clone()), || None)
+            resolve_lock_clients_handle_with(Some(context.clone()))
                 .expect("context lock clients")
                 .get("context-node:9000")
                 .expect("context lock client entry"),
@@ -1257,10 +1212,7 @@ mod tests {
                 .access_key,
             context_credentials.access_key
         );
-        assert_eq!(
-            resolve_region_with(Some(context.clone()), || Some(fallback_region.clone())).expect("context region"),
-            context_region
-        );
+        assert_eq!(resolve_region_with(Some(context.clone())).expect("context region"), context_region);
         assert!(Arc::ptr_eq(
             &resolve_tier_config_handle_with(Some(context.clone()), TierConfigMgr::new),
             &tier_config
@@ -1270,7 +1222,7 @@ mod tests {
             &context_expiry_state
         ));
         assert_eq!(
-            resolve_server_config_with(Some(context.clone()), || None).expect("context server config"),
+            resolve_server_config_with(Some(context.clone())).expect("context server config"),
             server_config
         );
         publish_server_config_with(Some(context.clone()), Config::new(), |config| {
@@ -1302,14 +1254,14 @@ mod tests {
         assert!(!resolve_iam_ready_with(None, || false));
         assert!(resolve_iam_handle_with(None, || None).is_none());
         assert!(resolve_oidc_handle_with(None).is_none());
-        assert!(resolve_token_signing_key_with(None, || Some(fallback_token_signing_key.clone())).is_none());
+        assert!(resolve_token_signing_key_with(None).is_none());
         assert!(!publish_oidc_handle_with(None, context_oidc));
-        assert!(resolve_bucket_metadata_handle_with(None, || Some(bucket_metadata.clone())).is_none());
-        assert!(resolve_bucket_monitor_handle_with(None, || default_bucket_monitor_interface().handle()).is_none());
-        assert!(resolve_replication_pool_handle_with(None, || default_replication_pool_interface().handle()).is_none());
-        assert!(resolve_object_store_handle_with(None, || Some(object_store.clone())).is_none());
-        assert!(resolve_replication_stats_handle_with(None, || Some(fallback_replication_stats.clone())).is_none());
-        assert!(resolve_boot_time_with(None, || Some(fallback_boot_time)).is_none());
+        assert!(resolve_bucket_metadata_handle_with(None).is_none());
+        assert!(resolve_bucket_monitor_handle_with(None).is_none());
+        assert!(resolve_replication_pool_handle_with(None).is_none());
+        assert!(resolve_object_store_handle_with(None).is_none());
+        assert!(resolve_replication_stats_handle_with(None).is_none());
+        assert!(resolve_boot_time_with(None).is_none());
         assert!(resolve_daily_tier_stats_with(None, || fallback_daily_tier_stats.clone()).contains_key("FALLBACK"));
         assert_eq!(
             resolve_scanner_metrics_report_with(None, || async { fallback_scanner_metrics.clone() })
@@ -1317,11 +1269,11 @@ mod tests {
                 .current_cycle,
             fallback_scanner_metrics.current_cycle
         );
-        assert!(resolve_endpoints_handle_with(None, || Some(endpoints.clone())).is_none());
-        assert!(resolve_deployment_id_with(None, || Some(fallback_deployment_id.clone())).is_none());
+        assert!(resolve_endpoints_handle_with(None).is_none());
+        assert!(resolve_deployment_id_with(None).is_none());
         assert_eq!(resolve_runtime_port_with(None, || fallback_runtime_port), fallback_runtime_port);
-        assert!(resolve_lock_client_with(None, || Some(fallback_lock_client.clone())).is_none());
-        assert!(resolve_lock_clients_handle_with(None, || Some(fallback_lock_clients.clone())).is_none());
+        assert!(resolve_lock_client_with(None).is_none());
+        assert!(resolve_lock_clients_handle_with(None).is_none());
         assert!(Arc::ptr_eq(
             &resolve_performance_metrics_with(None, || fallback_performance_metrics.clone()),
             &fallback_performance_metrics
@@ -1348,13 +1300,13 @@ mod tests {
                 .access_key,
             fallback_credentials.access_key
         );
-        assert!(resolve_region_with(None, || Some(fallback_region.clone())).is_none());
+        assert!(resolve_region_with(None).is_none());
         assert!(Arc::ptr_eq(&resolve_tier_config_handle_with(None, || tier_config.clone()), &tier_config));
         assert!(Arc::ptr_eq(
             &resolve_expiry_state_handle_with(None, || fallback_expiry_state.clone()),
             &fallback_expiry_state
         ));
-        assert!(resolve_server_config_with(None, || Some(server_config.clone())).is_none());
+        assert!(resolve_server_config_with(None).is_none());
         publish_server_config_with(None, Config::new(), |config| {
             drop(config);
             fallback_server_config_published.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#660.

## Summary of Changes

- Remove stale fallback closure parameters from AppContext-only resolver helpers.
- Keep public runtime facade names, return types, and startup/default-returning fallback behavior unchanged.
- Update the migration ledger with the fallback signature cleanup review and verification result.

## Verification

- `cargo test -p rustfs --lib app::context::tests::resolver_helpers_are_context_first_and_fallback_when_context_is_absent`
- `cargo check -p rustfs --lib`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- AppContext-only fallback parameter residual scan
- Diff-added Rust risk scan
- Rust code quality scan
- `make pre-pr`

## Impact

Private helper signature cleanup only. Public runtime source facades keep their existing names and return types, and this PR does not add new runtime fallback behavior.

## Additional Notes

Rebased onto main after PR #3952 merged.
