### PR TITLE
refactor: remove scalar runtime fallbacks

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,7 +5,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-runtime-default-resolver-fallback-removal`
+- Branch: `overtrue/arch-runtime-scalar-resolver-fallback-removal`
 - Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/API-253/API-254/CTX-002`.
 - Current baseline also includes API-255 from PR #3923, API-256 from PR
   #3925, CFG-009 from PR #3927, C-007/C-009 from PR #3935, C-008/C-010
@@ -22,22 +22,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   PR #3950, the GLOB-007 notification-system/server-config fallback removal
   from PR #3951, the GLOB-007 optional runtime handle fallback removal from
   PR #3952, the GLOB-007 AppContext-only fallback signature cleanup from
-  PR #3953, and the GLOB-007 runtime resolver fallback boundary cleanup from
-  PR #3954.
-- Current phase PR: GLOB-007 service/credential resolver fallback removal.
-- Based on: current `origin/main` after PR #3954 merged.
+  PR #3953, the GLOB-007 runtime resolver fallback boundary cleanup from
+  PR #3954, and the GLOB-007 service/credential resolver fallback removal from
+  PR #3955.
+- Current phase PR: GLOB-007 scalar/handle resolver fallback removal.
+- Based on: `origin/main` after PR #3955 merged.
 - PR type for this branch: `ci-gate`.
-- Runtime behavior changes: when no AppContext is published, service/credential
-  resolvers for KMS manager lookup, encryption service, IAM readiness/handle,
-  ready IAM handle, and action credentials now return their empty/error state
-  instead of consulting legacy globals.
-- Rust code changes: remove those public no-AppContext fallbacks, delete the
-  now-unused legacy runtime-source adapters, and pass object ZIP download token
-  signing credentials explicitly after resolving them at handler boundaries.
-  SSE/KMS tests now inject their test KMS service manager explicitly instead of
-  relying on no-AppContext fallback reads.
+- Runtime behavior changes: when no AppContext is published, scalar and handle
+  resolvers for outbound TLS generation, daily tier stats, runtime port,
+  metrics, local node name, tier config, expiry state, and buffer config now
+  return local empty/default values instead of consulting legacy globals.
+- Rust code changes: remove those public no-AppContext read fallbacks while
+  preserving the default AppContext interface sources used after startup.
 - CI/script changes: none intended.
-- Docs changes: update this progress ledger for the service/credential fallback
+- Docs changes: update this progress ledger for the scalar/handle fallback
   removal.
 
 ## Phase 0 Tasks
@@ -6103,6 +6101,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | GLOB-007 removes the scalar/handle fallback family while keeping concrete no-context defaults at the root runtime facade boundary. |
+| Migration preservation | pass | AppContext-backed behavior is unchanged; absent AppContext no longer consults legacy globals for TLS generation, tier stats, runtime port, metrics, local node name, tier config, expiry state, or buffer config. |
+| Testing/verification | pass | Focused resolver, site-replication, config, concurrency, and RPC tests passed; compile, formatting, architecture guard, scalar/handle fallback residual scan, diff hygiene, Rust risk scan, Rust quality scan, and full `make pre-pr` passed before PR. |
 | Quality/architecture | pass | GLOB-007 removes the next cohesive service/credential fallback family without changing public resolver signatures or caller-side error handling contracts. |
 | Migration preservation | pass | AppContext-backed behavior is unchanged; absent AppContext now returns `None`, `false`, or `IamSysNotInitialized` for the affected service/credential resolvers instead of consulting legacy globals. |
 | Testing/verification | pass | Focused resolver, object ZIP download, and SSE/KMS tests passed; compile, formatting, architecture guard, service/credential fallback residual scan, diff hygiene, Rust risk scan, Rust quality scan, and full `make pre-pr` are required before PR. |
@@ -9786,6 +9787,31 @@ Notes:
   - Rust risk scan: passed; no new unwrap/expect, numeric casts, string error
     public APIs, boxed public errors, production println/eprintln, or relaxed
     ordering introduced in changed Rust lines.
+
+- Issue #660 GLOB-007 scalar/handle resolver fallback removal:
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo test -p rustfs --lib app::context::tests::resolver_helpers_are_context_first_and_empty_when_context_is_absent`:
+    passed.
+  - `cargo test -p rustfs --lib admin::handlers::site_replication::tests::test_site_replication_peer_client_rebuilds_when_generation_changes`:
+    passed.
+  - `cargo test -p rustfs --lib test_site_replication_local_endpoint`:
+    passed, 4 passed.
+  - `cargo test -p rustfs --lib config::info::tests`: passed.
+  - `cargo test -p rustfs --lib storage::concurrency::manager`: passed, 17
+    passed.
+  - `cargo test -p rustfs --lib storage::rpc::http_service`: passed, 9
+    passed.
+  - `cargo fmt --all --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `git diff --check`: passed.
+  - Scalar/handle AppContext fallback residual scan: passed; public resolvers no
+    longer consult legacy global default interfaces when no AppContext exists.
+  - Rust risk scan: passed; no new production unwrap/expect, numeric casts,
+    string error public APIs, boxed public errors, or production
+    println/eprintln introduced in changed Rust files. Relaxed atomics are
+    limited to the test-only TLS generation override.
+  - `make pre-pr`: passed, including 6917 nextest tests passed, 112 skipped,
+    and doctests passed.
 
 ## Handoff Notes
 

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -62,9 +62,8 @@ pub async fn resolve_encryption_service() -> Option<Arc<ObjectEncryptionService>
 }
 
 /// Resolve outbound TLS generation using AppContext-first precedence.
-pub fn resolve_outbound_tls_generation() -> TlsGeneration {
+pub fn resolve_outbound_tls_generation() -> Option<TlsGeneration> {
     resolve_outbound_tls_generation_with(get_global_app_context())
-        .unwrap_or_else(|| default_outbound_tls_runtime_interface().generation())
 }
 
 #[cfg(test)]
@@ -176,8 +175,8 @@ pub fn resolve_boot_time() -> Option<SystemTime> {
 }
 
 /// Resolve daily tier transition statistics using AppContext-first precedence.
-pub fn resolve_daily_tier_stats() -> DailyAllTierStats {
-    resolve_daily_tier_stats_with(get_global_app_context()).unwrap_or_else(|| default_tier_stats_interface().daily_all())
+pub fn resolve_daily_tier_stats() -> Option<DailyAllTierStats> {
+    resolve_daily_tier_stats_with(get_global_app_context())
 }
 
 /// Resolve scanner metrics report using AppContext-first precedence.
@@ -195,8 +194,8 @@ pub fn resolve_deployment_id() -> Option<String> {
 }
 
 /// Resolve runtime port using AppContext-first precedence.
-pub fn resolve_runtime_port() -> u16 {
-    resolve_runtime_port_with(get_global_app_context()).unwrap_or_else(|| default_runtime_port_interface().get())
+pub fn resolve_runtime_port() -> Option<u16> {
+    resolve_runtime_port_with(get_global_app_context())
 }
 
 /// Resolve lock client using AppContext-first precedence.
@@ -210,13 +209,13 @@ pub fn resolve_lock_clients_handle() -> Option<HashMap<String, Arc<dyn LockClien
 }
 
 /// Resolve performance metrics using AppContext-first precedence.
-pub fn resolve_performance_metrics() -> Arc<PerformanceMetrics> {
-    resolve_performance_metrics_with(get_global_app_context()).unwrap_or_else(|| default_performance_metrics_interface().handle())
+pub fn resolve_performance_metrics() -> Option<Arc<PerformanceMetrics>> {
+    resolve_performance_metrics_with(get_global_app_context())
 }
 
 /// Resolve internode metrics using AppContext-first precedence.
-pub fn resolve_internode_metrics() -> Arc<InternodeMetrics> {
-    resolve_internode_metrics_with(get_global_app_context()).unwrap_or_else(|| default_internode_metrics_interface().handle())
+pub fn resolve_internode_metrics() -> Option<Arc<InternodeMetrics>> {
+    resolve_internode_metrics_with(get_global_app_context())
 }
 
 /// Resolve S3 Select database using AppContext-first precedence.
@@ -232,12 +231,8 @@ pub async fn resolve_s3select_db(
 }
 
 /// Resolve local node name using AppContext-first precedence.
-pub async fn resolve_local_node_name() -> String {
-    if let Some(node_name) = resolve_local_node_name_with(get_global_app_context()).await {
-        return node_name;
-    }
-
-    runtime_sources::local_node_name().await
+pub async fn resolve_local_node_name() -> Option<String> {
+    resolve_local_node_name_with(get_global_app_context()).await
 }
 
 /// Resolve action credentials using AppContext-first precedence.
@@ -251,13 +246,13 @@ pub fn resolve_region() -> Option<s3s::region::Region> {
 }
 
 /// Resolve tier config handle using AppContext-first precedence.
-pub fn resolve_tier_config_handle() -> Arc<RwLock<TierConfigMgr>> {
-    resolve_tier_config_handle_with(get_global_app_context()).unwrap_or_else(|| default_tier_config_interface().handle())
+pub fn resolve_tier_config_handle() -> Option<Arc<RwLock<TierConfigMgr>>> {
+    resolve_tier_config_handle_with(get_global_app_context())
 }
 
 /// Resolve lifecycle expiry state using AppContext-first precedence.
-pub fn resolve_expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
-    resolve_expiry_state_handle_with(get_global_app_context()).unwrap_or_else(|| default_expiry_state_interface().handle())
+pub fn resolve_expiry_state_handle() -> Option<Arc<RwLock<ExpiryState>>> {
+    resolve_expiry_state_handle_with(get_global_app_context())
 }
 
 /// Resolve server config using AppContext-first precedence.
@@ -283,8 +278,8 @@ pub fn publish_storage_class_config(config: StorageClassConfig) {
 }
 
 /// Resolve buffer profile config using AppContext-first precedence.
-pub fn resolve_buffer_config() -> RustFSBufferConfig {
-    resolve_buffer_config_with(get_global_app_context()).unwrap_or_else(|| default_buffer_config_interface().get())
+pub fn resolve_buffer_config() -> Option<RustFSBufferConfig> {
+    resolve_buffer_config_with(get_global_app_context())
 }
 
 fn resolve_kms_runtime_service_manager_with(context: Option<Arc<AppContext>>) -> Option<Arc<KmsServiceManager>> {

--- a/rustfs/src/runtime_sources.rs
+++ b/rustfs/src/runtime_sources.rs
@@ -13,19 +13,23 @@
 // limitations under the License.
 
 use crate::app::context;
+use crate::config::RustFSBufferConfig;
+use crate::storage_api::server::runtime_sources::{DailyAllTierStats, ExpiryState, TierConfigMgr};
+use rustfs_io_metrics::{PerformanceMetrics, internode_metrics::InternodeMetrics};
+use rustfs_tls_runtime::TlsGeneration;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::RwLock;
 
 pub(crate) use context::{
     AppContext, NotifyInterface, publish_oidc_handle, publish_server_config, publish_storage_class_config,
     resolve_action_credentials as current_action_credentials, resolve_boot_time as current_boot_time,
     resolve_bucket_metadata_handle as current_bucket_metadata_handle,
-    resolve_bucket_monitor_handle as current_bucket_monitor_handle, resolve_buffer_config as current_buffer_config,
-    resolve_daily_tier_stats as current_daily_tier_stats, resolve_deployment_id as current_deployment_id,
+    resolve_bucket_monitor_handle as current_bucket_monitor_handle, resolve_deployment_id as current_deployment_id,
     resolve_encryption_service as current_encryption_service, resolve_endpoints_handle as current_endpoints_handle,
-    resolve_expiry_state_handle as current_expiry_state_handle, resolve_iam_handle as current_iam_handle,
-    resolve_iam_ready as current_iam_ready, resolve_internode_metrics as current_internode_metrics,
-    resolve_kms_runtime_service_manager as current_kms_runtime_service_manager,
-    resolve_local_node_name as current_local_node_name, resolve_lock_client as current_lock_client,
+    resolve_iam_handle as current_iam_handle, resolve_iam_ready as current_iam_ready,
+    resolve_kms_runtime_service_manager as current_kms_runtime_service_manager, resolve_lock_client as current_lock_client,
     resolve_lock_clients_handle as current_lock_clients_handle, resolve_notification_system as current_notification_system,
     resolve_notification_system_for_context as current_notification_system_for_context,
     resolve_notify_interface as current_notify_interface,
@@ -34,18 +38,69 @@ pub(crate) use context::{
     resolve_object_store_handle_for_context as current_object_store_handle_for_context,
     resolve_oidc_handle as current_oidc_handle,
     resolve_or_init_kms_runtime_service_manager as current_or_init_kms_runtime_service_manager,
-    resolve_outbound_tls_generation as current_outbound_tls_generation, resolve_outbound_tls_state as current_outbound_tls_state,
-    resolve_performance_metrics as current_performance_metrics, resolve_ready_iam_handle as current_ready_iam_handle,
+    resolve_outbound_tls_state as current_outbound_tls_state, resolve_ready_iam_handle as current_ready_iam_handle,
     resolve_region as current_region, resolve_replication_pool_handle as current_replication_pool_handle,
-    resolve_replication_stats_handle as current_replication_stats_handle, resolve_runtime_port as current_runtime_port,
-    resolve_s3select_db as current_s3select_db, resolve_scanner_metrics_report as current_scanner_metrics_report,
-    resolve_server_config as current_server_config, resolve_server_config_for_context as current_server_config_for_context,
-    resolve_tier_config_handle as current_tier_config_handle, resolve_token_signing_key as current_token_signing_key,
+    resolve_replication_stats_handle as current_replication_stats_handle, resolve_s3select_db as current_s3select_db,
+    resolve_scanner_metrics_report as current_scanner_metrics_report, resolve_server_config as current_server_config,
+    resolve_server_config_for_context as current_server_config_for_context,
+    resolve_token_signing_key as current_token_signing_key,
 };
 
 #[cfg(test)]
-pub(crate) use context::set_test_outbound_tls_generation;
+static TEST_OUTBOUND_TLS_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn set_test_outbound_tls_generation(generation: u64) {
+    context::set_test_outbound_tls_generation(generation);
+    TEST_OUTBOUND_TLS_GENERATION.store(generation, Ordering::Relaxed);
+}
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
     context::get_global_app_context()
+}
+
+pub(crate) fn current_outbound_tls_generation() -> TlsGeneration {
+    context::resolve_outbound_tls_generation().unwrap_or_else(empty_outbound_tls_generation)
+}
+
+#[cfg(test)]
+fn empty_outbound_tls_generation() -> TlsGeneration {
+    TlsGeneration(TEST_OUTBOUND_TLS_GENERATION.load(Ordering::Relaxed))
+}
+
+#[cfg(not(test))]
+fn empty_outbound_tls_generation() -> TlsGeneration {
+    TlsGeneration(0)
+}
+
+pub(crate) fn current_daily_tier_stats() -> DailyAllTierStats {
+    context::resolve_daily_tier_stats().unwrap_or_default()
+}
+
+pub(crate) fn current_runtime_port() -> u16 {
+    context::resolve_runtime_port().unwrap_or(rustfs_config::DEFAULT_PORT)
+}
+
+pub(crate) fn current_performance_metrics() -> Arc<PerformanceMetrics> {
+    context::resolve_performance_metrics().unwrap_or_else(|| Arc::new(PerformanceMetrics::new()))
+}
+
+pub(crate) fn current_internode_metrics() -> Arc<InternodeMetrics> {
+    context::resolve_internode_metrics().unwrap_or_else(|| Arc::new(InternodeMetrics::default()))
+}
+
+pub(crate) async fn current_local_node_name() -> String {
+    context::resolve_local_node_name().await.unwrap_or_default()
+}
+
+pub(crate) fn current_tier_config_handle() -> Arc<RwLock<TierConfigMgr>> {
+    context::resolve_tier_config_handle().unwrap_or_else(TierConfigMgr::new)
+}
+
+pub(crate) fn current_expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
+    context::resolve_expiry_state_handle().unwrap_or_else(ExpiryState::new)
+}
+
+pub(crate) fn current_buffer_config() -> RustFSBufferConfig {
+    context::resolve_buffer_config().unwrap_or_default()
 }

--- a/rustfs/src/storage_api.rs
+++ b/rustfs/src/storage_api.rs
@@ -142,7 +142,9 @@ pub(crate) mod server {
     }
 
     pub(crate) mod runtime_sources {
-        pub(crate) use crate::storage::storage_api::{ECStore, EndpointServerPools};
+        pub(crate) use crate::storage::storage_api::{
+            DailyAllTierStats, ECStore, EndpointServerPools, ExpiryState, TierConfigMgr,
+        };
     }
 }
 


### PR DESCRIPTION
## Related Issues

rustfs/backlog#660

## Summary of Changes

- Remove legacy global fallback reads from scalar and handle AppContext resolvers.
- Keep concrete default values at the root runtime facade boundary for existing callers.
- Update the migration progress ledger and pre-push review log for this GLOB-007 batch.

## Verification

- `cargo check -p rustfs --lib`
- `cargo test -p rustfs --lib app::context::tests::resolver_helpers_are_context_first_and_empty_when_context_is_absent`
- `cargo test -p rustfs --lib admin::handlers::site_replication::tests::test_site_replication_peer_client_rebuilds_when_generation_changes`
- `cargo test -p rustfs --lib test_site_replication_local_endpoint`
- `cargo test -p rustfs --lib config::info::tests`
- `cargo test -p rustfs --lib storage::concurrency::manager`
- `cargo test -p rustfs --lib storage::rpc::http_service`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `git diff --check`
- `make pre-pr`

## Impact

No user-facing API or deployment change expected. No-AppContext resolver reads now stop at AppContext and root runtime facades supply local empty/default values for existing internal callers.

## Additional Notes

N/A
