### PR TITLE
refactor: move runtime fallback defaults to owners

### DIFF
--- a/docs/architecture/migration-progress.md
+++ b/docs/architecture/migration-progress.md
@@ -5,7 +5,7 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 ## Current Context
 
 - Issue: [`rustfs/backlog#660`](https://github.com/rustfs/backlog/issues/660)
-- Branch: `overtrue/arch-runtime-specialized-fallback-boundary`
+- Branch: `overtrue/arch-runtime-root-fallback-facade-cleanup`
 - Baseline: completed `C-011/C-012/C-013/API-055/API-059/API-079/API-080/API-081/API-082/API-083/API-084/API-085/API-086/API-087/API-088/API-089/API-090/API-091/API-092/API-093/API-094/API-095/API-096/API-097/API-098/API-099/API-100/API-101/API-102/API-103/API-104/API-105/API-106/API-107/API-108/API-109/API-110/API-111/API-112/API-113/API-114/API-115/API-116/API-117/API-118/API-119/API-120/API-121/API-122/API-123/API-124/API-125/API-126/API-127/API-128/API-129/API-130/API-131/API-132/API-133/API-134/API-135/API-136/API-137/API-138/API-139/API-140/API-141/API-142/API-143/API-144/API-145/API-146/API-147/API-148/API-149/API-150/API-151/API-152/API-153/API-154/API-155/API-156/API-157/API-158/API-159/API-160/API-161/API-162/API-163/API-164/API-165/API-166/API-167/API-168/API-169/API-170/API-171/API-172/API-173/API-174/API-175/API-176/API-177/API-178/API-179/API-180/API-181/API-182/API-183/API-184/API-185/API-186/API-187/API-188/API-189/API-190/API-191/API-192/API-193/API-194/API-195/API-196/API-197/API-198/API-199/API-200/API-201/API-202/API-203/API-204/API-205/API-206/API-207/API-208/API-209/API-210/API-211/API-212/API-213/API-214/API-215/API-216/API-217/API-218/API-219/API-220/API-221/API-222/API-223/API-224/API-225/API-226/API-227/API-228/API-229/API-230/API-231/API-232/API-233/API-234/API-235/API-236/API-237/API-238/API-239/API-240/API-241/API-242/API-243/API-244/API-245/API-246/API-247/API-248/API-249/API-250/API-251/API-252/API-253/API-254/CTX-002`.
 - Current baseline also includes API-255 from PR #3923, API-256 from PR
   #3925, CFG-009 from PR #3927, C-007/C-009 from PR #3935, C-008/C-010
@@ -24,21 +24,20 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
   PR #3952, the GLOB-007 AppContext-only fallback signature cleanup from
   PR #3953, the GLOB-007 runtime resolver fallback boundary cleanup from
   PR #3954, the GLOB-007 service/credential resolver fallback removal from
-  PR #3955, and the GLOB-007 scalar/handle resolver fallback removal from
-  PR #3957.
-- Current phase PR: GLOB-007 specialized resolver fallback boundary.
-- Based on: `origin/main` after PR #3957 merged.
+  PR #3955, the GLOB-007 scalar/handle resolver fallback removal from PR #3957,
+  and the GLOB-007 specialized resolver fallback boundary from PR #3958.
+- Current phase PR: GLOB-007 root runtime fallback facade cleanup.
+- Based on: `origin/main` after PR #3958 merged.
 - PR type for this branch: `ci-gate`.
-- Runtime behavior changes: AppContext specialized resolver helpers for KMS
-  initialization, notify interface, outbound TLS state, scanner metrics, S3
-  Select DB, server-config publish, and storage-class publish now stop at the
-  AppContext boundary, while root runtime facades preserve the existing
-  no-AppContext fallback contracts for callers.
-- Rust code changes: move those specialized no-AppContext fallbacks out of
-  `app::context` public resolvers and into the root `runtime_sources` facade.
+- Runtime behavior changes: no intended behavior change; admin, app, storage,
+  server, startup, and config owner facades preserve their existing
+  no-AppContext defaults.
+- Rust code changes: remove concrete default fallback wrappers from the root
+  `runtime_sources` facade and move those defaults to the owner facades that
+  consume them.
 - CI/script changes: none intended.
-- Docs changes: update this progress ledger for the specialized fallback
-  boundary.
+- Docs changes: update this progress ledger for the root fallback facade
+  cleanup.
 
 ## Phase 0 Tasks
 
@@ -6107,6 +6106,9 @@ Status values: `[ ]` not started, `[~]` in progress, `[x]` complete, `[!]` block
 
 | Expert | Status | Notes |
 |---|---|---|
+| Quality/architecture | pass | GLOB-007 removes concrete fallback composition from the root runtime facade; owner facades now decide when to apply fallback factories. |
+| Migration preservation | pass | Existing admin, app, storage, server, startup, and config no-AppContext defaults are preserved at their consuming owner boundaries. |
+| Testing/verification | pass | Focused resolver, TLS, S3 Select, config, and config-info tests passed; compile, formatting, architecture guard, residual scans, diff hygiene, Rust risk scan, and full `make pre-pr` passed before PR. |
 | Quality/architecture | pass | GLOB-007 moves specialized no-AppContext fallback behavior from AppContext public resolvers to root runtime facade wrappers, keeping resolver helpers context-only. |
 | Migration preservation | pass | Existing callers keep concrete root facade return contracts for KMS initialization, notify interface, outbound TLS state, scanner metrics, S3 Select DB, server-config publish, and storage-class publish. |
 | Testing/verification | pass | Focused resolver, site-replication TLS, S3 Select, and config tests passed; compile, formatting, architecture guard, specialized fallback residual scan, diff hygiene, Rust risk scan, Rust quality scan, and full `make pre-pr` passed before PR. |
@@ -9846,6 +9848,35 @@ Notes:
     println/eprintln introduced in changed Rust files. Relaxed atomics are
     limited to the test-only TLS generation override.
   - `make pre-pr`: passed, including 6917 nextest tests passed, 112 skipped,
+    and doctests passed.
+
+- Issue #660 GLOB-007 root runtime fallback facade cleanup:
+  - `cargo check -p rustfs --lib`: passed.
+  - `cargo test -p rustfs --lib app::context::tests::resolver_helpers_are_context_first_and_empty_when_context_is_absent`:
+    passed.
+  - `cargo test -p rustfs --lib admin::handlers::site_replication::tests::test_site_replication_peer_client_rebuilds_when_generation_changes`:
+    passed.
+  - `cargo test -p rustfs --lib admin::handlers::site_replication::tests::test_site_replication_local_endpoint`:
+    passed, 4 passed.
+  - `cargo test -p rustfs --lib app::select_object::tests`: passed, 19
+    passed.
+  - `cargo test -p rustfs --lib admin::handlers::config_admin::tests`: passed,
+    29 passed.
+  - `cargo test -p rustfs --lib admin::service::config::tests`: passed, 7
+    passed.
+  - `cargo test -p rustfs --lib config::info::tests`: passed, 5 passed.
+  - `cargo fmt --all --check`: passed.
+  - `./scripts/check_architecture_migration_rules.sh`: passed.
+  - `git diff --check`: passed.
+  - Root runtime fallback composition residual scan: passed; the root runtime
+    facade no longer owns concrete no-AppContext default composition.
+  - Owner AppContext bypass scan: passed; owner runtime facades use root
+    runtime entrypoints instead of direct AppContext access.
+  - Rust risk scan: passed; no new production unwrap/expect, numeric casts,
+    boxed public errors, or production println/eprintln introduced in changed
+    Rust files. Relaxed atomics are limited to the test-only TLS generation
+    override.
+  - `make pre-pr`: passed, including 6918 nextest tests passed, 112 skipped,
     and doctests passed.
 
 ## Handoff Notes

--- a/rustfs/src/admin/runtime_sources.rs
+++ b/rustfs/src/admin/runtime_sources.rs
@@ -12,25 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::storage_api::runtime::{ECStore, NotificationSys};
+use crate::admin::storage_api::runtime_sources::{
+    DailyAllTierStats, ECStore, NotificationSys, ScannerMetricsReport, StorageClassConfig, TierConfigMgr,
+};
 pub(crate) use crate::app::admin_usecase::{
     AdminPoolStatus, DefaultAdminUsecase, QueryPoolStatusRequest, QueryServerInfoRequest,
 };
 use crate::app::object_usecase::DefaultObjectUsecase;
+use crate::runtime_sources as root_runtime_sources;
 pub(crate) use crate::runtime_sources::{
     AppContext, current_action_credentials, current_boot_time, current_bucket_metadata_handle, current_bucket_monitor_handle,
-    current_daily_tier_stats, current_deployment_id, current_endpoints_handle, current_iam_handle,
-    current_kms_runtime_service_manager, current_notification_system_for_context, current_object_store_handle_for_context,
-    current_oidc_handle, current_or_init_kms_runtime_service_manager, current_outbound_tls_generation,
-    current_outbound_tls_state, current_ready_iam_handle, current_region, current_replication_pool_handle,
-    current_replication_stats_handle, current_runtime_port, current_scanner_metrics_report, current_server_config_for_context,
-    current_tier_config_handle, current_token_signing_key, publish_server_config, publish_storage_class_config,
+    current_deployment_id, current_endpoints_handle, current_iam_handle, current_kms_runtime_service_manager,
+    current_notification_system_for_context, current_object_store_handle_for_context, current_oidc_handle,
+    current_ready_iam_handle, current_region, current_replication_pool_handle, current_replication_stats_handle,
+    current_server_config_for_context, current_token_signing_key,
 };
 use rustfs_config::server_config::Config;
+use rustfs_kms::KmsServiceManager;
+use rustfs_tls_runtime::{GlobalPublishedOutboundTlsState, TlsGeneration};
 use std::sync::Arc;
-
 #[cfg(test)]
-pub(crate) use crate::runtime_sources::set_test_outbound_tls_generation;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::RwLock;
 
 pub(crate) fn default_admin_usecase() -> DefaultAdminUsecase {
     DefaultAdminUsecase::from_global()
@@ -57,4 +60,72 @@ pub(crate) fn current_notification_system() -> Option<&'static NotificationSys> 
 pub(crate) fn current_server_config() -> Option<Config> {
     let context = current_app_context();
     current_server_config_for_context(context.as_deref())
+}
+
+pub(crate) fn current_or_init_kms_runtime_service_manager() -> Arc<KmsServiceManager> {
+    root_runtime_sources::current_or_init_kms_runtime_service_manager()
+        .unwrap_or_else(rustfs_kms::init_global_kms_service_manager)
+}
+
+#[cfg(test)]
+static TEST_OUTBOUND_TLS_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn set_test_outbound_tls_generation(generation: u64) {
+    root_runtime_sources::set_test_outbound_tls_generation(generation);
+    TEST_OUTBOUND_TLS_GENERATION.store(generation, Ordering::Relaxed);
+}
+
+pub(crate) fn current_outbound_tls_generation() -> TlsGeneration {
+    root_runtime_sources::current_outbound_tls_generation().unwrap_or_else(empty_outbound_tls_generation)
+}
+
+#[cfg(test)]
+fn empty_outbound_tls_generation() -> TlsGeneration {
+    TlsGeneration(TEST_OUTBOUND_TLS_GENERATION.load(Ordering::Relaxed))
+}
+
+#[cfg(not(test))]
+fn empty_outbound_tls_generation() -> TlsGeneration {
+    TlsGeneration(0)
+}
+
+pub(crate) async fn current_outbound_tls_state() -> GlobalPublishedOutboundTlsState {
+    if let Some(state) = root_runtime_sources::current_outbound_tls_state().await {
+        return state;
+    }
+
+    root_runtime_sources::fallback_outbound_tls_runtime_interface().state().await
+}
+
+pub(crate) fn current_daily_tier_stats() -> DailyAllTierStats {
+    root_runtime_sources::current_daily_tier_stats().unwrap_or_default()
+}
+
+pub(crate) fn current_runtime_port() -> u16 {
+    root_runtime_sources::current_runtime_port().unwrap_or(rustfs_config::DEFAULT_PORT)
+}
+
+pub(crate) async fn current_scanner_metrics_report() -> ScannerMetricsReport {
+    if let Some(report) = root_runtime_sources::current_scanner_metrics_report().await {
+        return report;
+    }
+
+    root_runtime_sources::fallback_scanner_metrics_interface().report().await
+}
+
+pub(crate) fn current_tier_config_handle() -> Arc<RwLock<TierConfigMgr>> {
+    root_runtime_sources::current_tier_config_handle().unwrap_or_else(TierConfigMgr::new)
+}
+
+pub(crate) fn publish_server_config(config: Config) {
+    if !root_runtime_sources::publish_server_config(config.clone()) {
+        root_runtime_sources::fallback_server_config_interface().set(config);
+    }
+}
+
+pub(crate) fn publish_storage_class_config(config: StorageClassConfig) {
+    if !root_runtime_sources::publish_storage_class_config(config.clone()) {
+        root_runtime_sources::fallback_storage_class_interface().set(config);
+    }
 }

--- a/rustfs/src/admin/storage_api.rs
+++ b/rustfs/src/admin/storage_api.rs
@@ -110,6 +110,15 @@ pub(crate) type TierConfig = ecstore_tier::tier_config::TierConfig;
 pub(crate) type TierCreds = ecstore_tier::tier_admin::TierCreds;
 pub(crate) type TierType = ecstore_tier::tier_config::TierType;
 
+pub(crate) mod runtime_sources {
+    pub(crate) type DailyAllTierStats = super::DailyAllTierStats;
+    pub(crate) type ECStore = super::ECStore;
+    pub(crate) type NotificationSys = super::NotificationSys;
+    pub(crate) type ScannerMetricsReport = rustfs_common::metrics::ScannerMetricsReport;
+    pub(crate) type StorageClassConfig = crate::storage::storage_api::ecstore_config::storageclass::Config;
+    pub(crate) type TierConfigMgr = crate::storage::storage_api::TierConfigMgr;
+}
+
 #[cfg(test)]
 pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
 #[cfg(test)]

--- a/rustfs/src/app/runtime_sources.rs
+++ b/rustfs/src/app/runtime_sources.rs
@@ -12,15 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) use crate::runtime_sources::{
-    AppContext, current_encryption_service, current_endpoints_handle, current_expiry_state_handle, current_notification_system,
-    current_notify_interface_for_context, current_object_store_handle_for_context, current_s3select_db,
-};
-use std::sync::Arc;
-
+use crate::app::storage_api::runtime_sources::ExpiryState;
 #[cfg(test)]
-pub(crate) use crate::runtime_sources::current_tier_config_handle;
+use crate::app::storage_api::runtime_sources::TierConfigMgr;
+use crate::runtime_sources as root_runtime_sources;
+pub(crate) use crate::runtime_sources::{
+    AppContext, current_encryption_service, current_endpoints_handle, current_notification_system,
+    current_object_store_handle_for_context,
+};
+use rustfs_s3select_api::{QueryResult, server::dbms::DatabaseManagerSystem};
+use s3s::dto::SelectObjectContentInput;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
     crate::runtime_sources::current_app_context()
+}
+
+pub(crate) fn current_notify_interface_for_context(
+    app_context: Option<&AppContext>,
+) -> Arc<dyn root_runtime_sources::NotifyInterface> {
+    root_runtime_sources::current_notify_interface_for_context(app_context)
+        .unwrap_or_else(root_runtime_sources::fallback_notify_interface)
+}
+
+pub(crate) async fn current_s3select_db(
+    input: SelectObjectContentInput,
+    enable_debug: bool,
+) -> QueryResult<Arc<dyn DatabaseManagerSystem + Send + Sync>> {
+    if let Some(result) = root_runtime_sources::current_s3select_db(input.clone(), enable_debug).await {
+        return result;
+    }
+
+    root_runtime_sources::fallback_s3select_db_interface()
+        .get(input, enable_debug)
+        .await
+}
+
+pub(crate) fn current_expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
+    root_runtime_sources::current_expiry_state_handle().unwrap_or_else(ExpiryState::new)
+}
+
+#[cfg(test)]
+pub(crate) fn current_tier_config_handle() -> Arc<RwLock<TierConfigMgr>> {
+    root_runtime_sources::current_tier_config_handle().unwrap_or_else(TierConfigMgr::new)
 }

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -211,6 +211,12 @@ pub(crate) mod runtime {
     }
 }
 
+pub(crate) mod runtime_sources {
+    pub(crate) type ExpiryState = super::runtime::ExpiryState;
+    #[cfg(test)]
+    pub(crate) type TierConfigMgr = super::runtime::TierConfigMgr;
+}
+
 pub(crate) mod access {
     pub(crate) use crate::storage::storage_api::access_consumer::{
         PostObjectRequestMarker, ReqInfo, authorize_request, has_bypass_governance_header, req_info_mut, req_info_ref,

--- a/rustfs/src/config/info.rs
+++ b/rustfs/src/config/info.rs
@@ -546,7 +546,7 @@ fn collect_config_info_json() -> ConfigInfoJson {
     let workload_profile = {
         use super::workload_profiles::is_buffer_profile_enabled;
         if is_buffer_profile_enabled() {
-            let config = current_buffer_config();
+            let config = current_buffer_config().unwrap_or_default();
             let profile = config.workload_profile();
             let buffer_config = profile.config();
             Some(WorkloadProfileJson {
@@ -870,7 +870,7 @@ fn get_workload_profile_info() -> String {
         return "| Workload Profile | (disabled) |".to_string();
     }
 
-    let config = current_buffer_config();
+    let config = current_buffer_config().unwrap_or_default();
     let profile = config.workload_profile();
     let name = config.workload_name();
     let buffer_config = profile.config();

--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::runtime_sources::{current_notify_interface, current_region};
+use crate::runtime_sources::current_region;
 use crate::server::ShutdownHandle;
+use crate::server::runtime_sources::current_notify_interface;
 use crate::storage_api::startup::init::{
     get_bucket_notification_config, process_lambda_configurations, process_queue_configurations, process_topic_configurations,
 };

--- a/rustfs/src/runtime_sources.rs
+++ b/rustfs/src/runtime_sources.rs
@@ -13,144 +13,46 @@
 // limitations under the License.
 
 use crate::app::context;
-use crate::app::storage_api::runtime::{ScannerMetricsReport, StorageClassConfig};
-use crate::config::RustFSBufferConfig;
-use crate::storage_api::server::runtime_sources::{DailyAllTierStats, ExpiryState, TierConfigMgr};
-use rustfs_config::server_config::Config;
-use rustfs_io_metrics::{PerformanceMetrics, internode_metrics::InternodeMetrics};
-use rustfs_kms::KmsServiceManager;
-use rustfs_s3select_api::{QueryResult, server::dbms::DatabaseManagerSystem};
-use rustfs_tls_runtime::TlsGeneration;
-use s3s::dto::SelectObjectContentInput;
 use std::sync::Arc;
-#[cfg(test)]
-use std::sync::atomic::{AtomicU64, Ordering};
-use tokio::sync::RwLock;
 
 pub(crate) use context::{
-    AppContext, NotifyInterface, publish_oidc_handle, resolve_action_credentials as current_action_credentials,
+    AppContext, NotifyInterface, default_notify_interface as fallback_notify_interface,
+    default_outbound_tls_runtime_interface as fallback_outbound_tls_runtime_interface,
+    default_s3select_db_interface as fallback_s3select_db_interface,
+    default_scanner_metrics_interface as fallback_scanner_metrics_interface,
+    default_server_config_interface as fallback_server_config_interface,
+    default_storage_class_interface as fallback_storage_class_interface, publish_oidc_handle, publish_server_config,
+    publish_storage_class_config, resolve_action_credentials as current_action_credentials,
     resolve_boot_time as current_boot_time, resolve_bucket_metadata_handle as current_bucket_metadata_handle,
-    resolve_bucket_monitor_handle as current_bucket_monitor_handle, resolve_deployment_id as current_deployment_id,
+    resolve_bucket_monitor_handle as current_bucket_monitor_handle, resolve_buffer_config as current_buffer_config,
+    resolve_daily_tier_stats as current_daily_tier_stats, resolve_deployment_id as current_deployment_id,
     resolve_encryption_service as current_encryption_service, resolve_endpoints_handle as current_endpoints_handle,
-    resolve_iam_handle as current_iam_handle, resolve_iam_ready as current_iam_ready,
-    resolve_kms_runtime_service_manager as current_kms_runtime_service_manager, resolve_lock_client as current_lock_client,
+    resolve_expiry_state_handle as current_expiry_state_handle, resolve_iam_handle as current_iam_handle,
+    resolve_iam_ready as current_iam_ready, resolve_internode_metrics as current_internode_metrics,
+    resolve_kms_runtime_service_manager as current_kms_runtime_service_manager,
+    resolve_local_node_name as current_local_node_name, resolve_lock_client as current_lock_client,
     resolve_lock_clients_handle as current_lock_clients_handle, resolve_notification_system as current_notification_system,
     resolve_notification_system_for_context as current_notification_system_for_context,
+    resolve_notify_interface as current_notify_interface,
+    resolve_notify_interface_for_context as current_notify_interface_for_context,
     resolve_object_store_handle as current_object_store_handle,
     resolve_object_store_handle_for_context as current_object_store_handle_for_context,
-    resolve_oidc_handle as current_oidc_handle, resolve_ready_iam_handle as current_ready_iam_handle,
+    resolve_oidc_handle as current_oidc_handle,
+    resolve_or_init_kms_runtime_service_manager as current_or_init_kms_runtime_service_manager,
+    resolve_outbound_tls_generation as current_outbound_tls_generation, resolve_outbound_tls_state as current_outbound_tls_state,
+    resolve_performance_metrics as current_performance_metrics, resolve_ready_iam_handle as current_ready_iam_handle,
     resolve_region as current_region, resolve_replication_pool_handle as current_replication_pool_handle,
-    resolve_replication_stats_handle as current_replication_stats_handle, resolve_server_config as current_server_config,
-    resolve_server_config_for_context as current_server_config_for_context,
-    resolve_token_signing_key as current_token_signing_key,
+    resolve_replication_stats_handle as current_replication_stats_handle, resolve_runtime_port as current_runtime_port,
+    resolve_s3select_db as current_s3select_db, resolve_scanner_metrics_report as current_scanner_metrics_report,
+    resolve_server_config as current_server_config, resolve_server_config_for_context as current_server_config_for_context,
+    resolve_tier_config_handle as current_tier_config_handle, resolve_token_signing_key as current_token_signing_key,
 };
-
-#[cfg(test)]
-static TEST_OUTBOUND_TLS_GENERATION: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(test)]
 pub(crate) fn set_test_outbound_tls_generation(generation: u64) {
     context::set_test_outbound_tls_generation(generation);
-    TEST_OUTBOUND_TLS_GENERATION.store(generation, Ordering::Relaxed);
 }
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
     context::get_global_app_context()
-}
-
-pub(crate) fn current_or_init_kms_runtime_service_manager() -> Arc<KmsServiceManager> {
-    context::resolve_or_init_kms_runtime_service_manager().unwrap_or_else(rustfs_kms::init_global_kms_service_manager)
-}
-
-pub(crate) fn current_notify_interface() -> Arc<dyn NotifyInterface> {
-    context::resolve_notify_interface().unwrap_or_else(context::default_notify_interface)
-}
-
-pub(crate) fn current_notify_interface_for_context(context: Option<&AppContext>) -> Arc<dyn NotifyInterface> {
-    context::resolve_notify_interface_for_context(context).unwrap_or_else(context::default_notify_interface)
-}
-
-pub(crate) fn current_outbound_tls_generation() -> TlsGeneration {
-    context::resolve_outbound_tls_generation().unwrap_or_else(empty_outbound_tls_generation)
-}
-
-pub(crate) async fn current_outbound_tls_state() -> rustfs_tls_runtime::GlobalPublishedOutboundTlsState {
-    if let Some(state) = context::resolve_outbound_tls_state().await {
-        return state;
-    }
-
-    context::default_outbound_tls_runtime_interface().state().await
-}
-
-#[cfg(test)]
-fn empty_outbound_tls_generation() -> TlsGeneration {
-    TlsGeneration(TEST_OUTBOUND_TLS_GENERATION.load(Ordering::Relaxed))
-}
-
-#[cfg(not(test))]
-fn empty_outbound_tls_generation() -> TlsGeneration {
-    TlsGeneration(0)
-}
-
-pub(crate) fn current_daily_tier_stats() -> DailyAllTierStats {
-    context::resolve_daily_tier_stats().unwrap_or_default()
-}
-
-pub(crate) fn current_runtime_port() -> u16 {
-    context::resolve_runtime_port().unwrap_or(rustfs_config::DEFAULT_PORT)
-}
-
-pub(crate) fn current_performance_metrics() -> Arc<PerformanceMetrics> {
-    context::resolve_performance_metrics().unwrap_or_else(|| Arc::new(PerformanceMetrics::new()))
-}
-
-pub(crate) fn current_internode_metrics() -> Arc<InternodeMetrics> {
-    context::resolve_internode_metrics().unwrap_or_else(|| Arc::new(InternodeMetrics::default()))
-}
-
-pub(crate) async fn current_scanner_metrics_report() -> ScannerMetricsReport {
-    if let Some(report) = context::resolve_scanner_metrics_report().await {
-        return report;
-    }
-
-    context::default_scanner_metrics_interface().report().await
-}
-
-pub(crate) async fn current_s3select_db(
-    input: SelectObjectContentInput,
-    enable_debug: bool,
-) -> QueryResult<Arc<dyn DatabaseManagerSystem + Send + Sync>> {
-    if let Some(result) = context::resolve_s3select_db(input.clone(), enable_debug).await {
-        return result;
-    }
-
-    context::default_s3select_db_interface().get(input, enable_debug).await
-}
-
-pub(crate) async fn current_local_node_name() -> String {
-    context::resolve_local_node_name().await.unwrap_or_default()
-}
-
-pub(crate) fn current_tier_config_handle() -> Arc<RwLock<TierConfigMgr>> {
-    context::resolve_tier_config_handle().unwrap_or_else(TierConfigMgr::new)
-}
-
-pub(crate) fn current_expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
-    context::resolve_expiry_state_handle().unwrap_or_else(ExpiryState::new)
-}
-
-pub(crate) fn current_buffer_config() -> RustFSBufferConfig {
-    context::resolve_buffer_config().unwrap_or_default()
-}
-
-pub(crate) fn publish_server_config(config: Config) {
-    if !context::publish_server_config(config.clone()) {
-        context::default_server_config_interface().set(config);
-    }
-}
-
-pub(crate) fn publish_storage_class_config(config: StorageClassConfig) {
-    if !context::publish_storage_class_config(config.clone()) {
-        context::default_storage_class_interface().set(config);
-    }
 }

--- a/rustfs/src/server/runtime_sources.rs
+++ b/rustfs/src/server/runtime_sources.rs
@@ -28,7 +28,7 @@ pub(crate) fn current_server_config() -> Option<rustfs_config::server_config::Co
 }
 
 pub(crate) fn current_notify_interface() -> Arc<dyn NotifyInterface> {
-    crate::runtime_sources::current_notify_interface()
+    crate::runtime_sources::current_notify_interface().unwrap_or_else(crate::runtime_sources::fallback_notify_interface)
 }
 
 pub(crate) fn current_object_store_handle() -> Option<Arc<ECStore>> {

--- a/rustfs/src/startup_runtime_sources.rs
+++ b/rustfs/src/startup_runtime_sources.rs
@@ -91,7 +91,9 @@ pub(crate) fn init_tls_metrics() {
 }
 
 pub(crate) fn current_outbound_tls_generation() -> u64 {
-    runtime_current_outbound_tls_generation().0
+    runtime_current_outbound_tls_generation()
+        .map(|generation| generation.0)
+        .unwrap_or_default()
 }
 
 pub(crate) async fn publish_outbound_tls_state(generation: TlsGeneration, outbound: &OutboundTlsMaterial) {

--- a/rustfs/src/storage/runtime_sources.rs
+++ b/rustfs/src/storage/runtime_sources.rs
@@ -37,15 +37,15 @@ pub(crate) fn current_object_store_handle_for_context(context: Option<&AppContex
 }
 
 pub(crate) fn current_buffer_config() -> RustFSBufferConfig {
-    root_runtime_sources::current_buffer_config()
+    root_runtime_sources::current_buffer_config().unwrap_or_default()
 }
 
 pub(crate) fn current_internode_metrics() -> Arc<InternodeMetrics> {
-    root_runtime_sources::current_internode_metrics()
+    root_runtime_sources::current_internode_metrics().unwrap_or_else(|| Arc::new(InternodeMetrics::default()))
 }
 
 pub(crate) async fn current_local_node_name() -> String {
-    root_runtime_sources::current_local_node_name().await
+    root_runtime_sources::current_local_node_name().await.unwrap_or_default()
 }
 
 pub(crate) fn current_action_credentials() -> Option<Credentials> {
@@ -53,11 +53,11 @@ pub(crate) fn current_action_credentials() -> Option<Credentials> {
 }
 
 pub(crate) fn current_notify_interface() -> Arc<dyn root_runtime_sources::NotifyInterface> {
-    root_runtime_sources::current_notify_interface()
+    root_runtime_sources::current_notify_interface().unwrap_or_else(root_runtime_sources::fallback_notify_interface)
 }
 
 pub(crate) fn current_performance_metrics() -> Arc<PerformanceMetrics> {
-    root_runtime_sources::current_performance_metrics()
+    root_runtime_sources::current_performance_metrics().unwrap_or_else(|| Arc::new(PerformanceMetrics::new()))
 }
 
 pub(crate) async fn current_encryption_service() -> Option<Arc<ObjectEncryptionService>> {

--- a/rustfs/src/storage_api.rs
+++ b/rustfs/src/storage_api.rs
@@ -142,9 +142,7 @@ pub(crate) mod server {
     }
 
     pub(crate) mod runtime_sources {
-        pub(crate) use crate::storage::storage_api::{
-            DailyAllTierStats, ECStore, EndpointServerPools, ExpiryState, TierConfigMgr,
-        };
+        pub(crate) use crate::storage::storage_api::{ECStore, EndpointServerPools};
     }
 }
 


### PR DESCRIPTION
## Related Issues
- Part of rustfs/backlog#660

## Summary of Changes
- Remove concrete no-AppContext fallback composition from the root runtime facade.
- Move fallback decisions into the admin, app, storage, server, startup, and config owner facades that consume them.
- Add narrow runtime-source domain exports for admin/app storage boundary usage and update the migration progress ledger.

## Verification
- `cargo check -p rustfs --lib`
- `cargo test -p rustfs --lib app::context::tests::resolver_helpers_are_context_first_and_empty_when_context_is_absent`
- `cargo test -p rustfs --lib admin::handlers::site_replication::tests::test_site_replication_peer_client_rebuilds_when_generation_changes`
- `cargo test -p rustfs --lib admin::handlers::site_replication::tests::test_site_replication_local_endpoint`
- `cargo test -p rustfs --lib app::select_object::tests`
- `cargo test -p rustfs --lib admin::handlers::config_admin::tests`
- `cargo test -p rustfs --lib admin::service::config::tests`
- `cargo test -p rustfs --lib config::info::tests`
- `cargo fmt --all --check`
- `./scripts/check_architecture_migration_rules.sh`
- `git diff --check`
- Root runtime fallback composition residual scan
- Owner AppContext bypass residual scan
- Rust risk scan
- `make pre-pr`

## Impact
No intended runtime behavior change. Existing no-AppContext defaults remain at the consuming owner boundaries while the root runtime facade stops composing concrete fallback defaults.

## Additional Notes
- `make pre-pr` passed with 6918 nextest tests passed, 112 skipped, and doctests passed.
