### PR TITLE
feat(get): add limited opt-in rollout gates

### DIFF
--- a/crates/ecstore/src/diagnostics/get.rs
+++ b/crates/ecstore/src/diagnostics/get.rs
@@ -22,6 +22,15 @@ pub(crate) const GET_OBJECT_PATH_CODEC_STREAMING_RUSTFS_ENGINE: &str = "codec_st
 pub(crate) const GET_OBJECT_PATH_EMPTY: &str = "empty";
 pub(crate) const GET_OBJECT_PATH_LEGACY_DUPLEX: &str = "legacy_duplex";
 pub(crate) const GET_OBJECT_PATH_REMOTE_TRANSITION: &str = "remote_transition";
+pub(crate) const GET_CODEC_STREAMING_DECISION_USE: &str = "use";
+pub(crate) const GET_CODEC_STREAMING_DECISION_FALLBACK: &str = "fallback";
+pub(crate) const GET_CODEC_STREAMING_REASON_NONE: &str = "none";
+pub(crate) const GET_CODEC_STREAMING_OBJECT_CLASS_PLAIN_SINGLE_PART: &str = "plain_single_part";
+pub(crate) const GET_CODEC_STREAMING_OBJECT_CLASS_RANGE: &str = "range";
+pub(crate) const GET_CODEC_STREAMING_OBJECT_CLASS_ENCRYPTED: &str = "encrypted";
+pub(crate) const GET_CODEC_STREAMING_OBJECT_CLASS_COMPRESSED: &str = "compressed";
+pub(crate) const GET_CODEC_STREAMING_OBJECT_CLASS_REMOTE: &str = "remote";
+pub(crate) const GET_CODEC_STREAMING_OBJECT_CLASS_MULTIPART: &str = "multipart";
 
 pub(crate) const GET_STAGE_DECODE: &str = "decode";
 pub(crate) const GET_STAGE_EMIT: &str = "emit";
@@ -220,6 +229,15 @@ mod tests {
         assert_eq!(GET_READER_BUFFER_PREFETCH, "prefetch");
         assert_eq!(GET_OBJECT_PATH_CODEC_STREAMING_LEGACY_ENGINE, "codec_streaming_legacy_engine");
         assert_eq!(GET_OBJECT_PATH_CODEC_STREAMING_RUSTFS_ENGINE, "codec_streaming_rustfs_engine");
+        assert_eq!(GET_CODEC_STREAMING_DECISION_USE, "use");
+        assert_eq!(GET_CODEC_STREAMING_DECISION_FALLBACK, "fallback");
+        assert_eq!(GET_CODEC_STREAMING_REASON_NONE, "none");
+        assert_eq!(GET_CODEC_STREAMING_OBJECT_CLASS_PLAIN_SINGLE_PART, "plain_single_part");
+        assert_eq!(GET_CODEC_STREAMING_OBJECT_CLASS_RANGE, "range");
+        assert_eq!(GET_CODEC_STREAMING_OBJECT_CLASS_ENCRYPTED, "encrypted");
+        assert_eq!(GET_CODEC_STREAMING_OBJECT_CLASS_COMPRESSED, "compressed");
+        assert_eq!(GET_CODEC_STREAMING_OBJECT_CLASS_REMOTE, "remote");
+        assert_eq!(GET_CODEC_STREAMING_OBJECT_CLASS_MULTIPART, "multipart");
         assert_eq!(GET_READER_PREFETCH_DIRECT, "direct");
         assert_eq!(GET_READER_PREFETCH_STORED, "stored");
         assert_eq!(GET_READER_PREFETCH_EOF, "eof");

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -316,6 +316,10 @@ const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENGINE: &str = GET_CODEC_STREAMING_ENGI
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ROLLOUT: &str = "off";
 const ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE: &str = "RUSTFS_GET_METADATA_EARLY_STOP_ENABLE";
 const DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE: bool = false;
+const ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT_PCT: &str = "RUSTFS_GET_CODEC_STREAMING_ROLLOUT_PCT";
+const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ROLLOUT_PCT: u32 = 100;
+const ENV_RUSTFS_GET_METADATA_EARLY_STOP_ROLLOUT_PCT: &str = "RUSTFS_GET_METADATA_EARLY_STOP_ROLLOUT_PCT";
+const DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ROLLOUT_PCT: u32 = 100;
 static OBJECT_LOCK_DIAG_ENABLED: OnceLock<bool> = OnceLock::new();
 
 mod heal;
@@ -399,15 +403,74 @@ fn is_get_codec_streaming_enabled() -> bool {
     #[cfg(not(test))]
     static CACHED: OnceLock<bool> = OnceLock::new();
     #[cfg(not(test))]
-    let enabled =
-        *CACHED.get_or_init(|| rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE));
+    let enabled = *CACHED.get_or_init(|| {
+        rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE)
+    });
     enabled
 }
 
 /// **Note**: Cached via `OnceLock` — env var changes require process restart.
 fn is_get_metadata_early_stop_enabled() -> bool {
     static CACHED: OnceLock<bool> = OnceLock::new();
-    *CACHED.get_or_init(|| rustfs_utils::get_env_bool(ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE, DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE))
+    *CACHED.get_or_init(|| {
+        rustfs_utils::get_env_bool(ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE, DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE)
+    })
+}
+
+/// Determine if an optimization should be enabled for a specific request.
+///
+/// Uses a stable hash of `(bucket, object)` to ensure the same object
+/// always gets consistent behavior. This enables percentage-based gradual rollout.
+///
+/// **Note**: `base_enabled` must be pre-cached (via `OnceLock`) to avoid
+/// per-request `std::env::var()` calls.
+fn is_optimization_enabled_for_request(base_enabled: bool, rollout_pct: u32, bucket: &str, object: &str) -> bool {
+    if !base_enabled || rollout_pct == 0 {
+        return false;
+    }
+    if rollout_pct >= 100 {
+        return true;
+    }
+
+    // Stable hash: same (bucket, object) always produces the same result
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bucket.hash(&mut hasher);
+    object.hash(&mut hasher);
+    let hash = hasher.finish() % 100;
+
+    (hash as u32) < rollout_pct
+}
+
+fn get_codec_streaming_rollout_pct() -> u32 {
+    static CACHED: OnceLock<u32> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        rustfs_utils::get_env_u32(ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT_PCT, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ROLLOUT_PCT)
+    })
+}
+
+fn get_metadata_early_stop_rollout_pct() -> u32 {
+    static CACHED: OnceLock<u32> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        rustfs_utils::get_env_u32(
+            ENV_RUSTFS_GET_METADATA_EARLY_STOP_ROLLOUT_PCT,
+            DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ROLLOUT_PCT,
+        )
+    })
+}
+
+/// Should this specific request use codec streaming?
+pub fn should_use_codec_streaming(bucket: &str, object: &str) -> bool {
+    let base = is_get_codec_streaming_enabled();
+    let pct = get_codec_streaming_rollout_pct();
+    is_optimization_enabled_for_request(base, pct, bucket, object)
+}
+
+/// Should this specific request use metadata early-stop?
+pub fn should_use_metadata_early_stop(bucket: &str, object: &str) -> bool {
+    let base = is_get_metadata_early_stop_enabled();
+    let pct = get_metadata_early_stop_rollout_pct();
+    is_optimization_enabled_for_request(base, pct, bucket, object)
 }
 
 fn get_codec_streaming_min_size() -> usize {
@@ -545,19 +608,15 @@ struct GetCodecStreamingGate {
     decision: GetCodecStreamingDecision,
 }
 
-fn record_get_codec_streaming_gate_decision(
-    object_class: GetCodecStreamingObjectClass,
-    decision: GetCodecStreamingDecision,
-) {
+fn record_get_codec_streaming_gate_decision(object_class: GetCodecStreamingObjectClass, decision: GetCodecStreamingDecision) {
     let (outcome, reason) = match decision {
         GetCodecStreamingDecision::Use => (
             crate::diagnostics::get::GET_CODEC_STREAMING_DECISION_USE,
             crate::diagnostics::get::GET_CODEC_STREAMING_REASON_NONE,
         ),
-        GetCodecStreamingDecision::Fallback(reason) => (
-            crate::diagnostics::get::GET_CODEC_STREAMING_DECISION_FALLBACK,
-            reason.as_str(),
-        ),
+        GetCodecStreamingDecision::Fallback(reason) => {
+            (crate::diagnostics::get::GET_CODEC_STREAMING_DECISION_FALLBACK, reason.as_str())
+        }
     };
     rustfs_io_metrics::record_get_object_codec_streaming_decision(outcome, object_class.as_str(), reason);
 }
@@ -1461,7 +1520,8 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                     self.pool_index,
                     opts.skip_verify_bitrot,
                 )
-                .await? {
+                .await?
+                {
                     read::GetCodecStreamingReaderBuildOutcome::Reader(stream) => {
                         record_get_codec_streaming_gate_decision(
                             codec_streaming_gate.object_class,

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -307,9 +307,13 @@ const GET_OBJECT_METADATA_CACHE_MAX_ENTRIES: usize = 1024;
 const ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE: &str = "RUSTFS_GET_CODEC_STREAMING_ENABLE";
 const ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE: &str = "RUSTFS_GET_CODEC_STREAMING_MIN_SIZE";
 const ENV_RUSTFS_GET_CODEC_STREAMING_ENGINE: &str = "RUSTFS_GET_CODEC_STREAMING_ENGINE";
+const ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT: &str = "RUSTFS_GET_CODEC_STREAMING_ROLLOUT";
+const ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED: &str = "RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED";
+const ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED: &str = "RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED";
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE: bool = false;
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE: usize = MI_B;
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENGINE: &str = GET_CODEC_STREAMING_ENGINE_LEGACY;
+const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ROLLOUT: &str = "off";
 const ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE: &str = "RUSTFS_GET_METADATA_EARLY_STOP_ENABLE";
 const DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE: bool = false;
 static OBJECT_LOCK_DIAG_ENABLED: OnceLock<bool> = OnceLock::new();
@@ -362,28 +366,48 @@ pub fn get_object_lock_diag_slow_hold_threshold() -> Duration {
 /// Check if lock optimization is enabled.
 /// When enabled, read locks are released after metadata read instead of
 /// being held for the entire data transfer duration.
+///
+/// **Note**: Cached via `OnceLock` — env var changes require process restart.
 pub fn is_lock_optimization_enabled() -> bool {
-    rustfs_utils::get_env_bool(
-        rustfs_config::ENV_OBJECT_LOCK_OPTIMIZATION_ENABLE,
-        rustfs_config::DEFAULT_OBJECT_LOCK_OPTIMIZATION_ENABLE,
-    )
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        rustfs_utils::get_env_bool(
+            rustfs_config::ENV_OBJECT_LOCK_OPTIMIZATION_ENABLE,
+            rustfs_config::DEFAULT_OBJECT_LOCK_OPTIMIZATION_ENABLE,
+        )
+    })
 }
 
 /// Check if deadlock detection is enabled.
 /// When enabled, lock operations are recorded for deadlock analysis.
+///
+/// **Note**: Cached via `OnceLock` — env var changes require process restart.
 pub fn is_deadlock_detection_enabled() -> bool {
-    rustfs_utils::get_env_bool(
-        rustfs_config::ENV_OBJECT_DEADLOCK_DETECTION_ENABLE,
-        rustfs_config::DEFAULT_OBJECT_DEADLOCK_DETECTION_ENABLE,
-    )
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        rustfs_utils::get_env_bool(
+            rustfs_config::ENV_OBJECT_DEADLOCK_DETECTION_ENABLE,
+            rustfs_config::DEFAULT_OBJECT_DEADLOCK_DETECTION_ENABLE,
+        )
+    })
 }
 
+/// **Note**: Cached via `OnceLock` — env var changes require process restart.
 fn is_get_codec_streaming_enabled() -> bool {
-    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE)
+    #[cfg(test)]
+    let enabled = rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE);
+    #[cfg(not(test))]
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    #[cfg(not(test))]
+    let enabled =
+        *CACHED.get_or_init(|| rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE));
+    enabled
 }
 
+/// **Note**: Cached via `OnceLock` — env var changes require process restart.
 fn is_get_metadata_early_stop_enabled() -> bool {
-    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE, DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE)
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| rustfs_utils::get_env_bool(ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE, DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE))
 }
 
 fn get_codec_streaming_min_size() -> usize {
@@ -403,6 +427,23 @@ fn get_codec_streaming_engine() -> GetCodecStreamingEngine {
         value if value.eq_ignore_ascii_case(GET_CODEC_STREAMING_ENGINE_LEGACY) => GetCodecStreamingEngine::Legacy,
         _ => GetCodecStreamingEngine::Legacy,
     }
+}
+
+fn get_codec_streaming_rollout() -> GetCodecStreamingRollout {
+    let rollout = rustfs_utils::get_env_str(ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ROLLOUT);
+    match rollout.trim() {
+        value if value.eq_ignore_ascii_case("internal") => GetCodecStreamingRollout::Internal,
+        value if value.eq_ignore_ascii_case("benchmark") => GetCodecStreamingRollout::Benchmark,
+        _ => GetCodecStreamingRollout::Off,
+    }
+}
+
+fn is_get_codec_streaming_body_compat_confirmed() -> bool {
+    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, false)
+}
+
+fn is_get_codec_streaming_header_compat_confirmed() -> bool {
+    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, false)
 }
 
 fn build_get_codec_streaming_decode_engine(erasure: coding::Erasure) -> std::io::Result<CodecStreamingDecodeEngine> {
@@ -426,8 +467,24 @@ enum GetCodecStreamingDecision {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GetCodecStreamingRollout {
+    Off,
+    Internal,
+    Benchmark,
+}
+
+impl GetCodecStreamingRollout {
+    const fn is_opted_in(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GetCodecStreamingFallbackReason {
     Disabled,
+    RolloutNotOptedIn,
+    BodyCompatibilityUnconfirmed,
+    HeaderCompatibilityUnconfirmed,
     LockOptimizationDisabled,
     Range,
     BelowMinSize,
@@ -436,12 +493,16 @@ enum GetCodecStreamingFallbackReason {
     Remote,
     Multipart,
     InvalidMinSize,
+    ReadQuorumNotSafe,
 }
 
 impl GetCodecStreamingFallbackReason {
     const fn as_str(self) -> &'static str {
         match self {
             Self::Disabled => "disabled",
+            Self::RolloutNotOptedIn => "rollout_not_opted_in",
+            Self::BodyCompatibilityUnconfirmed => "body_compatibility_unconfirmed",
+            Self::HeaderCompatibilityUnconfirmed => "header_compatibility_unconfirmed",
             Self::LockOptimizationDisabled => "lock_optimization_disabled",
             Self::Range => "range",
             Self::BelowMinSize => "below_min_size",
@@ -450,46 +511,166 @@ impl GetCodecStreamingFallbackReason {
             Self::Remote => "remote",
             Self::Multipart => "multipart",
             Self::InvalidMinSize => "invalid_min_size",
+            Self::ReadQuorumNotSafe => "read_quorum_not_safe",
         }
     }
 }
 
-fn get_codec_streaming_reader_decision(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GetCodecStreamingObjectClass {
+    PlainSinglePart,
+    Range,
+    Encrypted,
+    Compressed,
+    Remote,
+    Multipart,
+}
+
+impl GetCodecStreamingObjectClass {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::PlainSinglePart => crate::diagnostics::get::GET_CODEC_STREAMING_OBJECT_CLASS_PLAIN_SINGLE_PART,
+            Self::Range => crate::diagnostics::get::GET_CODEC_STREAMING_OBJECT_CLASS_RANGE,
+            Self::Encrypted => crate::diagnostics::get::GET_CODEC_STREAMING_OBJECT_CLASS_ENCRYPTED,
+            Self::Compressed => crate::diagnostics::get::GET_CODEC_STREAMING_OBJECT_CLASS_COMPRESSED,
+            Self::Remote => crate::diagnostics::get::GET_CODEC_STREAMING_OBJECT_CLASS_REMOTE,
+            Self::Multipart => crate::diagnostics::get::GET_CODEC_STREAMING_OBJECT_CLASS_MULTIPART,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GetCodecStreamingGate {
+    object_class: GetCodecStreamingObjectClass,
+    decision: GetCodecStreamingDecision,
+}
+
+fn record_get_codec_streaming_gate_decision(
+    object_class: GetCodecStreamingObjectClass,
+    decision: GetCodecStreamingDecision,
+) {
+    let (outcome, reason) = match decision {
+        GetCodecStreamingDecision::Use => (
+            crate::diagnostics::get::GET_CODEC_STREAMING_DECISION_USE,
+            crate::diagnostics::get::GET_CODEC_STREAMING_REASON_NONE,
+        ),
+        GetCodecStreamingDecision::Fallback(reason) => (
+            crate::diagnostics::get::GET_CODEC_STREAMING_DECISION_FALLBACK,
+            reason.as_str(),
+        ),
+    };
+    rustfs_io_metrics::record_get_object_codec_streaming_decision(outcome, object_class.as_str(), reason);
+}
+
+fn classify_get_codec_streaming_object_class(
+    range: &Option<HTTPRangeSpec>,
+    object_info: &ObjectInfo,
+    fi: &FileInfo,
+) -> GetCodecStreamingObjectClass {
+    if range.is_some() {
+        return GetCodecStreamingObjectClass::Range;
+    }
+    if object_info.is_encrypted() {
+        return GetCodecStreamingObjectClass::Encrypted;
+    }
+    if object_info.is_compressed() {
+        return GetCodecStreamingObjectClass::Compressed;
+    }
+    if object_info.is_remote() {
+        return GetCodecStreamingObjectClass::Remote;
+    }
+    if fi.parts.len() != 1 {
+        return GetCodecStreamingObjectClass::Multipart;
+    }
+    GetCodecStreamingObjectClass::PlainSinglePart
+}
+
+fn get_codec_streaming_reader_gate(
     range: &Option<HTTPRangeSpec>,
     object_info: &ObjectInfo,
     fi: &FileInfo,
     lock_optimization_enabled: bool,
-) -> GetCodecStreamingDecision {
+) -> GetCodecStreamingGate {
+    let object_class = classify_get_codec_streaming_object_class(range, object_info, fi);
+
     if !is_get_codec_streaming_enabled() {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Disabled);
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Disabled),
+        };
+    }
+    if !get_codec_streaming_rollout().is_opted_in() {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::RolloutNotOptedIn),
+        };
+    }
+    if !is_get_codec_streaming_body_compat_confirmed() {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::BodyCompatibilityUnconfirmed),
+        };
+    }
+    if !is_get_codec_streaming_header_compat_confirmed() {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::HeaderCompatibilityUnconfirmed),
+        };
+    }
+    if object_class == GetCodecStreamingObjectClass::Range {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Range),
+        };
     }
     if !lock_optimization_enabled {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::LockOptimizationDisabled);
-    }
-    if range.is_some() {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Range);
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::LockOptimizationDisabled),
+        };
     }
 
     let Ok(min_size) = i64::try_from(get_codec_streaming_min_size()) else {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::InvalidMinSize);
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::InvalidMinSize),
+        };
     };
     if object_info.size < min_size {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::BelowMinSize);
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::BelowMinSize),
+        };
     }
-    if object_info.is_encrypted() {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Encrypted);
+    if object_class == GetCodecStreamingObjectClass::Encrypted {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Encrypted),
+        };
     }
-    if object_info.is_compressed() {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Compressed);
+    if object_class == GetCodecStreamingObjectClass::Compressed {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Compressed),
+        };
     }
-    if object_info.is_remote() {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Remote);
+    if object_class == GetCodecStreamingObjectClass::Remote {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Remote),
+        };
     }
-    if fi.parts.len() != 1 {
-        return GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Multipart);
+    if object_class == GetCodecStreamingObjectClass::Multipart {
+        return GetCodecStreamingGate {
+            object_class,
+            decision: GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Multipart),
+        };
     }
 
-    GetCodecStreamingDecision::Use
+    GetCodecStreamingGate {
+        object_class,
+        decision: GetCodecStreamingDecision::Use,
+    }
 }
 
 fn is_confirmed_complete_part_missing(err: &str) -> bool {
@@ -1233,10 +1414,11 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
             return Ok(reader);
         }
 
-        let codec_streaming_decision = get_codec_streaming_reader_decision(&range, &object_info, &fi, lock_optimization_enabled);
+        let codec_streaming_gate = get_codec_streaming_reader_gate(&range, &object_info, &fi, lock_optimization_enabled);
 
         if object_info.is_remote() {
-            if let GetCodecStreamingDecision::Fallback(reason) = codec_streaming_decision {
+            if let GetCodecStreamingDecision::Fallback(reason) = codec_streaming_gate.decision {
+                record_get_codec_streaming_gate_decision(codec_streaming_gate.object_class, codec_streaming_gate.decision);
                 rustfs_io_metrics::record_get_object_codec_streaming_fallback(reason.as_str());
             }
             rustfs_io_metrics::record_get_object_reader_path(GET_OBJECT_PATH_REMOTE_TRANSITION);
@@ -1267,24 +1449,39 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
             read_lock_guard
         };
 
-        match codec_streaming_decision {
+        match codec_streaming_gate.decision {
             GetCodecStreamingDecision::Use => {
-                rustfs_io_metrics::record_get_object_reader_path(GET_OBJECT_PATH_CODEC_STREAMING);
-                let stream = Self::get_object_decode_reader_with_fileinfo(
+                match Self::get_object_decode_reader_with_fileinfo(
                     bucket,
                     object,
-                    fi,
-                    files,
+                    &fi,
+                    &files,
                     &disks,
                     self.set_index,
                     self.pool_index,
                     opts.skip_verify_bitrot,
                 )
-                .await?;
-                let (reader, _offset, _length) = GetObjectReader::new(stream, range, &object_info, opts, &h).await?;
-                return Ok(reader);
+                .await? {
+                    read::GetCodecStreamingReaderBuildOutcome::Reader(stream) => {
+                        record_get_codec_streaming_gate_decision(
+                            codec_streaming_gate.object_class,
+                            GetCodecStreamingDecision::Use,
+                        );
+                        rustfs_io_metrics::record_get_object_reader_path(GET_OBJECT_PATH_CODEC_STREAMING);
+                        let (reader, _offset, _length) = GetObjectReader::new(stream, range, &object_info, opts, &h).await?;
+                        return Ok(reader);
+                    }
+                    read::GetCodecStreamingReaderBuildOutcome::Fallback(reason) => {
+                        record_get_codec_streaming_gate_decision(
+                            codec_streaming_gate.object_class,
+                            GetCodecStreamingDecision::Fallback(reason),
+                        );
+                        rustfs_io_metrics::record_get_object_codec_streaming_fallback(reason.as_str());
+                    }
+                }
             }
             GetCodecStreamingDecision::Fallback(reason) => {
+                record_get_codec_streaming_gate_decision(codec_streaming_gate.object_class, codec_streaming_gate.decision);
                 rustfs_io_metrics::record_get_object_codec_streaming_fallback(reason.as_str());
             }
         }

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -48,6 +48,17 @@ const READ_REPAIR_HEAL_DEDUP_MAX_ENTRIES: usize = 4096;
 
 static READ_REPAIR_HEAL_CACHE: OnceLock<RwLock<HashMap<ReadRepairHealCacheKey, Instant>>> = OnceLock::new();
 
+pub(super) enum GetCodecStreamingReaderBuildOutcome {
+    Reader(Box<dyn AsyncRead + Unpin + Send + Sync>),
+    Fallback(GetCodecStreamingFallbackReason),
+}
+
+pub(super) fn codec_streaming_reader_setup_fallback_reason(
+    missing_shards: usize,
+) -> Option<GetCodecStreamingFallbackReason> {
+    (missing_shards > 0).then_some(GetCodecStreamingFallbackReason::ReadQuorumNotSafe)
+}
+
 #[derive(Clone, Copy, Debug)]
 struct MetadataFanoutObservation {
     outcome: &'static str,
@@ -1646,16 +1657,18 @@ impl SetDisks {
         opts: &ObjectOptions,
         read_data: bool,
     ) -> Result<(FileInfo, Vec<FileInfo>, Vec<Option<DiskStore>>)> {
+        let vid = opts.version_id.clone().unwrap_or_default();
+
         let use_metadata_cache = self.is_get_object_metadata_cache_enabled(bucket, opts, read_data).await;
-        if use_metadata_cache && let Some(cached) = self.cached_get_object_fileinfo(bucket, object).await {
-            return Ok((cached.fi, cached.parts_metadata, cached.online_disks));
+        if use_metadata_cache && vid.is_empty() {
+            if let Some(cached) = self.cached_get_object_fileinfo(bucket, object).await {
+                return Ok((cached.fi, cached.parts_metadata, cached.online_disks));
+            }
         }
 
         let disks = self.disks.read().await;
 
         let disks = disks.clone();
-
-        let vid = opts.version_id.clone().unwrap_or_default();
 
         // TODO: optimize concurrency and break once enough slots are available
         let (parts_metadata, errs, metadata_fanout_diagnostics) = Self::read_all_fileinfo_observed(
@@ -2186,13 +2199,13 @@ impl SetDisks {
     pub(super) async fn get_object_decode_reader_with_fileinfo(
         bucket: &str,
         object: &str,
-        fi: FileInfo,
-        files: Vec<FileInfo>,
+        fi: &FileInfo,
+        files: &[FileInfo],
         disks: &[Option<DiskStore>],
-        set_index: usize,
-        pool_index: usize,
+        _set_index: usize,
+        _pool_index: usize,
         skip_verify_bitrot: bool,
-    ) -> Result<Box<dyn AsyncRead + Unpin + Send + Sync>> {
+    ) -> Result<GetCodecStreamingReaderBuildOutcome> {
         let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index(disks, &files, &fi);
         if fi.parts.len() != 1 {
             return Err(Error::other("codec streaming reader only supports single-part plain objects"));
@@ -2263,18 +2276,8 @@ impl SetDisks {
         }
 
         let missing_shards = reader_setup.completed_failed_shards();
-        if missing_shards > 0 {
-            let version_id = fi.version_id.as_ref().map(ToString::to_string);
-            submit_read_repair_heal(
-                bucket,
-                object,
-                version_id.as_deref(),
-                pool_index,
-                set_index,
-                Some(part_number),
-                "missing_shards_streaming",
-            )
-            .await;
+        if let Some(reason) = codec_streaming_reader_setup_fallback_reason(missing_shards) {
+            return Ok(GetCodecStreamingReaderBuildOutcome::Fallback(reason));
         }
 
         let readers = reader_setup.readers;
@@ -2294,9 +2297,9 @@ impl SetDisks {
             part_length,
             metrics_path,
         )?;
-        Ok(Box::new(
+        Ok(GetCodecStreamingReaderBuildOutcome::Reader(Box::new(
             crate::erasure::coding::decode_reader::SyncErasureDecodeReader::new_with_metrics_path(reader, metrics_path),
-        ))
+        )))
     }
 }
 
@@ -3253,18 +3256,21 @@ mod tests {
         temp_env::with_vars(
             [
                 (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, Some("benchmark")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, Some("true")),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
             ],
             || {
                 let fi = codec_streaming_test_fileinfo(1024, 1);
                 let object_info = codec_streaming_test_object_info(&fi);
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &object_info, &fi, true),
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, true).decision,
                     GetCodecStreamingDecision::Use
                 );
 
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &object_info, &fi, false),
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, false).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::LockOptimizationDisabled)
                 );
 
@@ -3274,14 +3280,14 @@ mod tests {
                     end: 1,
                 });
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&range, &object_info, &fi, true),
+                    get_codec_streaming_reader_gate(&range, &object_info, &fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Range)
                 );
 
                 let multipart_fi = codec_streaming_test_fileinfo(1024, 2);
                 let multipart_object_info = codec_streaming_test_object_info(&multipart_fi);
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &multipart_object_info, &multipart_fi, true),
+                    get_codec_streaming_reader_gate(&None, &multipart_object_info, &multipart_fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Multipart)
                 );
 
@@ -3291,7 +3297,7 @@ mod tests {
                     .insert("x-amz-server-side-encryption".to_string(), "AES256".to_string());
                 let encrypted = codec_streaming_test_object_info(&encrypted_fi);
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &encrypted, &fi, true),
+                    get_codec_streaming_reader_gate(&None, &encrypted, &encrypted_fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Encrypted)
                 );
 
@@ -3299,14 +3305,14 @@ mod tests {
                 insert_str(&mut compressed_fi.metadata, SUFFIX_COMPRESSION, "lz4".to_string());
                 let compressed = codec_streaming_test_object_info(&compressed_fi);
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &compressed, &fi, true),
+                    get_codec_streaming_reader_gate(&None, &compressed, &compressed_fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Compressed)
                 );
 
                 let small_fi = codec_streaming_test_fileinfo(0, 1);
                 let small_object_info = codec_streaming_test_object_info(&small_fi);
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &small_object_info, &small_fi, true),
+                    get_codec_streaming_reader_gate(&None, &small_object_info, &small_fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::BelowMinSize)
                 );
 
@@ -3314,7 +3320,7 @@ mod tests {
                 remote_fi.transition_status = crate::bucket::lifecycle::lifecycle::TRANSITION_COMPLETE.to_string();
                 let remote = codec_streaming_test_object_info(&remote_fi);
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &remote, &remote_fi, true),
+                    get_codec_streaming_reader_gate(&None, &remote, &remote_fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Remote)
                 );
             },
@@ -3341,6 +3347,9 @@ mod tests {
         temp_env::with_vars(
             [
                 (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, Some("false")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, None::<&str>),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_ENGINE, Some(GET_CODEC_STREAMING_ENGINE_RUSTFS)),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
             ],
@@ -3349,7 +3358,7 @@ mod tests {
                 let object_info = codec_streaming_test_object_info(&fi);
 
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &object_info, &fi, true),
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Disabled)
                 );
             },
@@ -3386,6 +3395,15 @@ mod tests {
     #[test]
     fn codec_streaming_fallback_metric_labels_are_stable() {
         assert_eq!(GetCodecStreamingFallbackReason::Disabled.as_str(), "disabled");
+        assert_eq!(GetCodecStreamingFallbackReason::RolloutNotOptedIn.as_str(), "rollout_not_opted_in");
+        assert_eq!(
+            GetCodecStreamingFallbackReason::BodyCompatibilityUnconfirmed.as_str(),
+            "body_compatibility_unconfirmed"
+        );
+        assert_eq!(
+            GetCodecStreamingFallbackReason::HeaderCompatibilityUnconfirmed.as_str(),
+            "header_compatibility_unconfirmed"
+        );
         assert_eq!(
             GetCodecStreamingFallbackReason::LockOptimizationDisabled.as_str(),
             "lock_optimization_disabled"
@@ -3397,6 +3415,13 @@ mod tests {
         assert_eq!(GetCodecStreamingFallbackReason::Remote.as_str(), "remote");
         assert_eq!(GetCodecStreamingFallbackReason::Multipart.as_str(), "multipart");
         assert_eq!(GetCodecStreamingFallbackReason::InvalidMinSize.as_str(), "invalid_min_size");
+        assert_eq!(GetCodecStreamingFallbackReason::ReadQuorumNotSafe.as_str(), "read_quorum_not_safe");
+        assert_eq!(GetCodecStreamingObjectClass::PlainSinglePart.as_str(), "plain_single_part");
+        assert_eq!(GetCodecStreamingObjectClass::Range.as_str(), "range");
+        assert_eq!(GetCodecStreamingObjectClass::Encrypted.as_str(), "encrypted");
+        assert_eq!(GetCodecStreamingObjectClass::Compressed.as_str(), "compressed");
+        assert_eq!(GetCodecStreamingObjectClass::Remote.as_str(), "remote");
+        assert_eq!(GetCodecStreamingObjectClass::Multipart.as_str(), "multipart");
     }
 
     #[test]
@@ -3404,6 +3429,9 @@ mod tests {
         temp_env::with_vars(
             [
                 (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, None::<&str>),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
             ],
             || {
@@ -3411,10 +3439,118 @@ mod tests {
                 let object_info = codec_streaming_test_object_info(&fi);
 
                 assert_eq!(
-                    get_codec_streaming_reader_decision(&None, &object_info, &fi, true),
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, true).decision,
                     GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::Disabled)
                 );
             },
+        );
+    }
+
+    #[test]
+    fn codec_streaming_reader_gate_requires_explicit_rollout_and_compat_confirmation() {
+        temp_env::with_vars(
+            [
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, Some("off")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, None::<&str>),
+            ],
+            || {
+                let fi = codec_streaming_test_fileinfo(1024, 1);
+                let object_info = codec_streaming_test_object_info(&fi);
+
+                assert_eq!(
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, true).decision,
+                    GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::RolloutNotOptedIn)
+                );
+            },
+        );
+
+        temp_env::with_vars(
+            [
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, Some("benchmark")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, Some("false")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, Some("true")),
+            ],
+            || {
+                let fi = codec_streaming_test_fileinfo(1024, 1);
+                let object_info = codec_streaming_test_object_info(&fi);
+
+                assert_eq!(
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, true).decision,
+                    GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::BodyCompatibilityUnconfirmed)
+                );
+            },
+        );
+
+        temp_env::with_vars(
+            [
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, Some("benchmark")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, Some("false")),
+            ],
+            || {
+                let fi = codec_streaming_test_fileinfo(1024, 1);
+                let object_info = codec_streaming_test_object_info(&fi);
+
+                assert_eq!(
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, true).decision,
+                    GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::HeaderCompatibilityUnconfirmed)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn codec_streaming_reader_gate_records_object_classes() {
+        temp_env::with_vars(
+            [
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, Some("benchmark")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, Some("true")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
+            ],
+            || {
+                let fi = codec_streaming_test_fileinfo(1024, 1);
+                let object_info = codec_streaming_test_object_info(&fi);
+                assert_eq!(
+                    get_codec_streaming_reader_gate(&None, &object_info, &fi, true).object_class,
+                    GetCodecStreamingObjectClass::PlainSinglePart
+                );
+
+                let range = Some(HTTPRangeSpec {
+                    is_suffix_length: false,
+                    start: 0,
+                    end: 1,
+                });
+                assert_eq!(
+                    get_codec_streaming_reader_gate(&range, &object_info, &fi, true).object_class,
+                    GetCodecStreamingObjectClass::Range
+                );
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn codec_streaming_reader_build_falls_back_when_read_quorum_is_not_safe() {
+        let setup = setup_inline_bitrot_readers(
+            vec![None, Some(b"bbbb"), Some(b"cccc"), Some(b"dddd")],
+            2,
+            2,
+            BitrotReaderSetupMode::VerifyReconstruction,
+        )
+        .await;
+
+        assert_eq!(setup.completed_failed_shards(), 1);
+        assert_eq!(
+            codec_streaming_reader_setup_fallback_reason(setup.completed_failed_shards()),
+            Some(GetCodecStreamingFallbackReason::ReadQuorumNotSafe)
         );
     }
 

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -53,9 +53,7 @@ pub(super) enum GetCodecStreamingReaderBuildOutcome {
     Fallback(GetCodecStreamingFallbackReason),
 }
 
-pub(super) fn codec_streaming_reader_setup_fallback_reason(
-    missing_shards: usize,
-) -> Option<GetCodecStreamingFallbackReason> {
+pub(super) fn codec_streaming_reader_setup_fallback_reason(missing_shards: usize) -> Option<GetCodecStreamingFallbackReason> {
     (missing_shards > 0).then_some(GetCodecStreamingFallbackReason::ReadQuorumNotSafe)
 }
 
@@ -1660,10 +1658,11 @@ impl SetDisks {
         let vid = opts.version_id.clone().unwrap_or_default();
 
         let use_metadata_cache = self.is_get_object_metadata_cache_enabled(bucket, opts, read_data).await;
-        if use_metadata_cache && vid.is_empty() {
-            if let Some(cached) = self.cached_get_object_fileinfo(bucket, object).await {
-                return Ok((cached.fi, cached.parts_metadata, cached.online_disks));
-            }
+        if use_metadata_cache
+            && vid.is_empty()
+            && let Some(cached) = self.cached_get_object_fileinfo(bucket, object).await
+        {
+            return Ok((cached.fi, cached.parts_metadata, cached.online_disks));
         }
 
         let disks = self.disks.read().await;
@@ -2206,7 +2205,7 @@ impl SetDisks {
         _pool_index: usize,
         skip_verify_bitrot: bool,
     ) -> Result<GetCodecStreamingReaderBuildOutcome> {
-        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index(disks, &files, &fi);
+        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index(disks, files, fi);
         if fi.parts.len() != 1 {
             return Err(Error::other("codec streaming reader only supports single-part plain objects"));
         }

--- a/crates/io-metrics/src/lib.rs
+++ b/crates/io-metrics/src/lib.rs
@@ -597,6 +597,25 @@ pub fn record_get_object_codec_streaming_fallback(reason: &'static str) {
     counter!("rustfs_io_get_object_codec_streaming_fallback_total", "reason" => reason).increment(1);
 }
 
+/// Record the final codec-streaming rollout decision for a GET request.
+#[inline(always)]
+pub fn record_get_object_codec_streaming_decision(
+    outcome: &'static str,
+    object_class: &'static str,
+    reason: &'static str,
+) {
+    if !get_stage_metrics_enabled() {
+        return;
+    }
+    counter!(
+        "rustfs_io_get_object_codec_streaming_decision_total",
+        "outcome" => outcome,
+        "object_class" => object_class,
+        "reason" => reason
+    )
+    .increment(1);
+}
+
 /// Record one decoded reader stripe processed by a GetObject read path.
 #[inline(always)]
 pub fn record_get_object_reader_stripe(path: &'static str) {
@@ -1568,6 +1587,8 @@ mod tests {
         record_get_object_stage_duration("s3_handler", "request_context", 0.001);
         record_get_object_reader_path("codec_streaming");
         record_get_object_codec_streaming_fallback("range");
+        record_get_object_codec_streaming_decision("fallback", "range", "range");
+        record_get_object_codec_streaming_decision("use", "plain_single_part", "none");
         record_get_object_reader_stripe("codec_streaming");
         record_get_object_reader_bytes("codec_streaming", 1024);
         record_get_object_reader_buffer("codec_streaming", "output", 1024);

--- a/crates/io-metrics/src/lib.rs
+++ b/crates/io-metrics/src/lib.rs
@@ -599,11 +599,7 @@ pub fn record_get_object_codec_streaming_fallback(reason: &'static str) {
 
 /// Record the final codec-streaming rollout decision for a GET request.
 #[inline(always)]
-pub fn record_get_object_codec_streaming_decision(
-    outcome: &'static str,
-    object_class: &'static str,
-    reason: &'static str,
-) {
+pub fn record_get_object_codec_streaming_decision(outcome: &'static str, object_class: &'static str, reason: &'static str) {
     if !get_stage_metrics_enabled() {
         return;
     }

--- a/scripts/run_get_codec_streaming_smoke.sh
+++ b/scripts/run_get_codec_streaming_smoke.sh
@@ -18,14 +18,16 @@ SECRET_KEY="rustfsadmin"
 BUCKET="rustfs-get-codec-smoke"
 REGION="us-east-1"
 SIZES="1MiB,4MiB,10MiB"
-CONCURRENCY=32
-DURATION="15s"
+CONCURRENCY=16
+DURATION="30s"
 ROUNDS=3
 RETRY_PER_ROUND=1
-ROUND_COOLDOWN_SECS=0
+ROUND_COOLDOWN_SECS=20
 MODE="both"
 CODEC_ENGINES="legacy"
 CODEC_MAX_INFLIGHT=1
+METADATA_EARLY_STOP="off"
+SHARD_LOCALITY_PREFERENCE="off"
 OUTPUT_HANDOFF_ATTRIBUTION=false
 OUT_DIR=""
 RUSTFS_BIN="${PROJECT_ROOT}/target/release/rustfs"
@@ -38,6 +40,8 @@ COMPAT_OBJECT_KEY="__rustfs_get_v2_pr24_compat/object.bin"
 COMPAT_OBJECT_SIZE=65536
 DRY_RUN=false
 SKIP_BUILD=false
+PROFILE_FAILURES=0
+declare -a ORIGINAL_ARGS=()
 
 SERVER_PID=""
 
@@ -53,16 +57,19 @@ Purpose:
 Core options:
   --mode <legacy|codec|both>     Which profile(s) to run (default: both)
   --codec-engine <csv>           Codec engine(s) for codec profiles (default: legacy)
+  --metadata-early-stop <on|off> Enable metadata early-stop observe/opt-in env (default: off)
+  --shard-locality-preference <on|off>
+                                 Enable shard locality preference env (default: off)
   --codec-max-inflight <n>       RUSTFS_GET_CODEC_STREAMING_MAX_INFLIGHT (default: 1)
   --handoff-attribution          Enable output handoff attribution metrics
   --address <host:port>          RustFS listen address (default: 127.0.0.1:19030)
   --bucket <name>                Benchmark bucket (default: rustfs-get-codec-smoke)
   --sizes <csv>                  Object sizes (default: 1MiB,4MiB,10MiB)
-  --concurrency <n>              warp concurrency (default: 32)
-  --duration <duration>          warp duration per round (default: 15s)
+  --concurrency <n>              warp concurrency (default: 16)
+  --duration <duration>          warp duration per round (default: 30s)
   --rounds <n>                   rounds per size (default: 3)
   --retry-per-round <n>          failed-attempt retries per round (default: 1)
-  --round-cooldown-secs <n>      cooldown seconds after each completed round (default: 0)
+  --round-cooldown-secs <n>      cooldown seconds after each completed round (default: 20)
   --out-dir <path>               output directory (default: target/bench/get-codec-streaming-<timestamp>)
 
 Binary/options:
@@ -81,6 +88,9 @@ Credentials:
   --region <value>               S3 region (default: us-east-1)
 
 Output:
+  <out-dir>/environment.txt
+  <out-dir>/manifest.env
+  <out-dir>/baseline_compare.csv
   <out-dir>/legacy/warp/median_summary.csv
   <out-dir>/codec-legacy/warp/median_summary.csv
   <out-dir>/codec-rustfs/warp/median_summary.csv
@@ -99,6 +109,7 @@ Output:
   <out-dir>/<profile>/compat/response_headers.json
   <out-dir>/<profile>/compat/body_sha256.txt
   <out-dir>/<profile>/rustfs.log
+  <out-dir>/<profile>/warp/logs/*.log
 
 Example:
   scripts/run_get_codec_streaming_smoke.sh \
@@ -142,6 +153,8 @@ parse_args() {
     case "$1" in
       --mode) MODE="$2"; shift 2 ;;
       --codec-engine) CODEC_ENGINES="$2"; shift 2 ;;
+      --metadata-early-stop) METADATA_EARLY_STOP="$2"; shift 2 ;;
+      --shard-locality-preference) SHARD_LOCALITY_PREFERENCE="$2"; shift 2 ;;
       --codec-max-inflight) CODEC_MAX_INFLIGHT="$2"; shift 2 ;;
       --handoff-attribution) OUTPUT_HANDOFF_ATTRIBUTION=true; shift ;;
       --address) ADDRESS="$2"; shift 2 ;;
@@ -177,6 +190,16 @@ validate_args() {
   case "$MODE" in
     legacy|codec|both) ;;
     *) die "--mode must be legacy, codec, or both" ;;
+  esac
+
+  case "$METADATA_EARLY_STOP" in
+    on|off) ;;
+    *) die "--metadata-early-stop must be on or off" ;;
+  esac
+
+  case "$SHARD_LOCALITY_PREFERENCE" in
+    on|off) ;;
+    *) die "--shard-locality-preference must be on or off" ;;
   esac
 
   local raw engine
@@ -220,6 +243,111 @@ setup_output() {
     OUT_DIR="${PROJECT_ROOT}/target/bench/get-codec-streaming-$(date +%Y%m%d-%H%M%S)"
   fi
   mkdir -p "$OUT_DIR"
+}
+
+bool_from_on_off() {
+  case "$1" in
+    on) echo "true" ;;
+    off) echo "false" ;;
+    *) die "expected on/off value, got: $1" ;;
+  esac
+}
+
+command_line_string() {
+  printf '%q ' "${BASH_SOURCE[0]}" "${ORIGINAL_ARGS[@]}"
+}
+
+detect_cpu_summary() {
+  if command -v sysctl >/dev/null 2>&1; then
+    local brand logical
+    brand="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)"
+    logical="$(sysctl -n hw.logicalcpu 2>/dev/null || true)"
+    if [[ -n "$brand" && -n "$logical" ]]; then
+      printf '%s (%s logical cores)\n' "$brand" "$logical"
+      return
+    fi
+  fi
+
+  if command -v lscpu >/dev/null 2>&1; then
+    lscpu 2>/dev/null | awk -F: '
+      /^Model name:/ { model=$2 }
+      /^CPU\(s\):/ { cpus=$2 }
+      END {
+        gsub(/^[ \t]+|[ \t]+$/, "", model)
+        gsub(/^[ \t]+|[ \t]+$/, "", cpus)
+        if (model != "" && cpus != "") {
+          printf "%s (%s logical cores)\n", model, cpus
+        } else if (model != "") {
+          printf "%s\n", model
+        }
+      }
+    '
+    return
+  fi
+
+  echo "unknown"
+}
+
+write_root_environment() {
+  local branch git_head git_dirty_count rustc_version cargo_version command_line
+  branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
+  git_head="$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
+  git_dirty_count="$(git -C "$PROJECT_ROOT" status --porcelain | awk 'END { print NR + 0 }')"
+  rustc_version="$(rustc --version 2>/dev/null || echo unavailable)"
+  cargo_version="$(cargo --version 2>/dev/null || echo unavailable)"
+  command_line="$(command_line_string)"
+
+  cat >"${OUT_DIR}/environment.txt" <<EOF
+generated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+branch=${branch}
+git_head=${git_head}
+dirty_count=${git_dirty_count}
+rustc_version=${rustc_version}
+cargo_version=${cargo_version}
+os=$(uname -srmo 2>/dev/null || uname -a)
+cpu=$(detect_cpu_summary)
+command_line=${command_line% }
+EOF
+}
+
+write_root_manifest() {
+  local profiles_csv="$1"
+  local branch git_head git_dirty_count command_line
+  branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
+  git_head="$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
+  git_dirty_count="$(git -C "$PROJECT_ROOT" status --porcelain | awk 'END { print NR + 0 }')"
+  command_line="$(command_line_string)"
+
+  cat >"${OUT_DIR}/manifest.env" <<EOF
+branch=${branch}
+git_head=${git_head}
+git_dirty_count=${git_dirty_count}
+profiles=${profiles_csv}
+mode=${MODE}
+codec_engines=${CODEC_ENGINES}
+metadata_early_stop=${METADATA_EARLY_STOP}
+shard_locality_preference=${SHARD_LOCALITY_PREFERENCE}
+codec_max_inflight=${CODEC_MAX_INFLIGHT}
+output_handoff_attribution=${OUTPUT_HANDOFF_ATTRIBUTION}
+address=${ADDRESS}
+bucket=${BUCKET}
+region=${REGION}
+sizes=${SIZES}
+concurrency=${CONCURRENCY}
+duration=${DURATION}
+rounds=${ROUNDS}
+retry_per_round=${RETRY_PER_ROUND}
+round_cooldown_secs=${ROUND_COOLDOWN_SECS}
+skip_build=${SKIP_BUILD}
+dry_run=${DRY_RUN}
+rustfs_bin=${RUSTFS_BIN}
+warp_bin=${WARP_BIN}
+python_bin=${PYTHON_BIN}
+codec_min_size=${CODEC_MIN_SIZE}
+compat_object_key=${COMPAT_OBJECT_KEY}
+compat_object_size=${COMPAT_OBJECT_SIZE}
+command_line=${command_line% }
+EOF
 }
 
 build_rustfs_if_needed() {
@@ -308,6 +436,8 @@ compat_object_size=${COMPAT_OBJECT_SIZE}
 rustfs_volumes=${volumes}
 RUSTFS_GET_CODEC_STREAMING_ENABLE=${codec_enabled}
 RUSTFS_GET_CODEC_STREAMING_ENGINE=${codec_engine}
+RUSTFS_GET_METADATA_EARLY_STOP_ENABLE=$(bool_from_on_off "$METADATA_EARLY_STOP")
+RUSTFS_GET_SHARD_LOCALITY_PREFERENCE_ENABLE=$(bool_from_on_off "$SHARD_LOCALITY_PREFERENCE")
 RUSTFS_GET_CODEC_STREAMING_MAX_INFLIGHT=${CODEC_MAX_INFLIGHT}
 RUSTFS_GET_OUTPUT_HANDOFF_ATTRIBUTION_ENABLE=${OUTPUT_HANDOFF_ATTRIBUTION}
 RUSTFS_GET_CODEC_STREAMING_MIN_SIZE=${CODEC_MIN_SIZE}
@@ -387,6 +517,8 @@ start_server() {
     export RUSTFS_CONSOLE_ENABLE=false
     export RUSTFS_GET_CODEC_STREAMING_ENABLE="$codec_enabled"
     export RUSTFS_GET_CODEC_STREAMING_ENGINE="$codec_engine"
+    export RUSTFS_GET_METADATA_EARLY_STOP_ENABLE="$(bool_from_on_off "$METADATA_EARLY_STOP")"
+    export RUSTFS_GET_SHARD_LOCALITY_PREFERENCE_ENABLE="$(bool_from_on_off "$SHARD_LOCALITY_PREFERENCE")"
     export RUSTFS_GET_CODEC_STREAMING_MAX_INFLIGHT="$CODEC_MAX_INFLIGHT"
     export RUSTFS_GET_OUTPUT_HANDOFF_ATTRIBUTION_ENABLE="$OUTPUT_HANDOFF_ATTRIBUTION"
     export RUSTFS_GET_CODEC_STREAMING_MIN_SIZE="$CODEC_MIN_SIZE"
@@ -773,14 +905,15 @@ write_root_metrics_summary() {
 
   [[ "${#profile_dirs[@]}" -gt 0 ]] || return
 
-  "$PYTHON_BIN" - "${OUT_DIR}/metrics_summary.csv" "${OUT_DIR}/engine_compare.csv" "${profile_dirs[@]}" <<'PY'
+  "$PYTHON_BIN" - "${OUT_DIR}/metrics_summary.csv" "${OUT_DIR}/engine_compare.csv" "${OUT_DIR}/baseline_compare.csv" "${profile_dirs[@]}" <<'PY'
 import csv
 import pathlib
 import sys
 
 metrics_csv = pathlib.Path(sys.argv[1])
 engine_compare_csv = pathlib.Path(sys.argv[2])
-profile_dirs = [pathlib.Path(value) for value in sys.argv[3:]]
+baseline_compare_csv = pathlib.Path(sys.argv[3])
+profile_dirs = [pathlib.Path(value) for value in sys.argv[4:]]
 
 
 def load_manifest(path):
@@ -834,6 +967,12 @@ for profile_dir in profile_dirs:
                 "read_path": manifest.get("metrics_path", profile),
                 "codec_streaming_enabled": manifest.get("RUSTFS_GET_CODEC_STREAMING_ENABLE", ""),
                 "codec_engine": manifest.get("RUSTFS_GET_CODEC_STREAMING_ENGINE", ""),
+                "metadata_early_stop": manifest.get("RUSTFS_GET_METADATA_EARLY_STOP_ENABLE", ""),
+                "shard_locality_preference": manifest.get("RUSTFS_GET_SHARD_LOCALITY_PREFERENCE_ENABLE", ""),
+                "codec_max_inflight": manifest.get("RUSTFS_GET_CODEC_STREAMING_MAX_INFLIGHT", ""),
+                "output_handoff_attribution": manifest.get("RUSTFS_GET_OUTPUT_HANDOFF_ATTRIBUTION_ENABLE", ""),
+                "round_cooldown_secs": manifest.get("round_cooldown_secs", ""),
+                "duration": manifest.get("duration", ""),
                 "size": row["size"],
                 "tool": row["tool"],
                 "concurrency": row["concurrency"],
@@ -869,6 +1008,12 @@ fieldnames = [
     "read_path",
     "codec_streaming_enabled",
     "codec_engine",
+    "metadata_early_stop",
+    "shard_locality_preference",
+    "codec_max_inflight",
+    "output_handoff_attribution",
+    "round_cooldown_secs",
+    "duration",
     "size",
     "tool",
     "concurrency",
@@ -887,6 +1032,77 @@ with open(metrics_csv, "w", encoding="utf-8", newline="") as handle:
     writer = csv.DictWriter(handle, fieldnames=fieldnames)
     writer.writeheader()
     writer.writerows(rows)
+
+baseline_fields = [
+    "profile",
+    "read_path",
+    "codec_streaming_enabled",
+    "codec_engine",
+    "metadata_early_stop",
+    "shard_locality_preference",
+    "codec_max_inflight",
+    "output_handoff_attribution",
+    "round_cooldown_secs",
+    "duration",
+    "size",
+    "tool",
+    "concurrency",
+    "successful_rounds",
+    "failed_rounds",
+    "baseline_profile",
+    "new_median_reqps",
+    "baseline_median_reqps",
+    "delta_reqps_pct_vs_legacy",
+    "new_median_latency_ms",
+    "baseline_median_latency_ms",
+    "delta_latency_pct_vs_legacy",
+    "new_median_throughput_bps",
+    "baseline_median_throughput_bps",
+    "delta_throughput_pct_vs_legacy",
+    "performance_note",
+]
+baseline_rows = []
+for row in rows:
+    if row["profile"] == "legacy" or row["baseline_profile"] != "legacy":
+        continue
+    baseline = legacy_by_size.get(row["size"])
+    if baseline is None:
+        continue
+    baseline_rows.append(
+        {
+            "profile": row["profile"],
+            "read_path": row["read_path"],
+            "codec_streaming_enabled": row["codec_streaming_enabled"],
+            "codec_engine": row["codec_engine"],
+            "metadata_early_stop": row["metadata_early_stop"],
+            "shard_locality_preference": row["shard_locality_preference"],
+            "codec_max_inflight": row["codec_max_inflight"],
+            "output_handoff_attribution": row["output_handoff_attribution"],
+            "round_cooldown_secs": row["round_cooldown_secs"],
+            "duration": row["duration"],
+            "size": row["size"],
+            "tool": row["tool"],
+            "concurrency": row["concurrency"],
+            "successful_rounds": row["successful_rounds"],
+            "failed_rounds": row["failed_rounds"],
+            "baseline_profile": "legacy",
+            "new_median_reqps": row["median_reqps"],
+            "baseline_median_reqps": baseline.get("median_reqps", ""),
+            "delta_reqps_pct_vs_legacy": row["delta_reqps_pct_vs_legacy"],
+            "new_median_latency_ms": row["median_latency_ms"],
+            "baseline_median_latency_ms": baseline.get("median_latency_ms", ""),
+            "delta_latency_pct_vs_legacy": row["delta_latency_pct_vs_legacy"],
+            "new_median_throughput_bps": row["median_throughput_bps"],
+            "baseline_median_throughput_bps": baseline.get("median_throughput_bps", ""),
+            "delta_throughput_pct_vs_legacy": row["delta_throughput_pct_vs_legacy"],
+            "performance_note": row["performance_note"],
+        }
+    )
+
+with open(baseline_compare_csv, "w", encoding="utf-8", newline="") as handle:
+    writer = csv.DictWriter(handle, fieldnames=baseline_fields)
+    writer.writeheader()
+    writer.writerows(baseline_rows)
 
 codec_legacy_by_size = {row["size"]: row for row in by_profile.get("codec-legacy", [])}
 codec_rustfs_by_size = {row["size"]: row for row in by_profile.get("codec-rustfs", [])}
@@ -964,10 +1180,15 @@ PY
 run_profile() {
   local profile="$1"
   local baseline_csv="${2:-}"
+  local bench_rc=0
 
   stop_server
   start_server "$profile"
-  run_bench "$profile" "$baseline_csv"
+  if run_bench "$profile" "$baseline_csv"; then
+    :
+  else
+    bench_rc=$?
+  fi
   write_metrics_summary "$profile"
   run_compat_probe "$profile"
   stop_server
@@ -978,19 +1199,18 @@ run_profile() {
   if [[ -f "${OUT_DIR}/${profile}/warp/baseline_compare.csv" ]]; then
     log "Baseline compare: ${OUT_DIR}/${profile}/warp/baseline_compare.csv"
   fi
+
+  return "$bench_rc"
 }
 
 main() {
+  ORIGINAL_ARGS=("$@")
   parse_args "$@"
   validate_args
   setup_output
-  build_rustfs_if_needed
-
-  trap stop_server EXIT INT TERM
-
-  log "Output dir: $OUT_DIR"
   local codec_profiles=()
   local profiles=()
+  local profiles_csv=""
   local raw engine profile
   IFS=',' read -r -a engines <<< "$CODEC_ENGINES"
   for raw in "${engines[@]}"; do
@@ -1011,14 +1231,29 @@ main() {
       profiles=("legacy" "${codec_profiles[@]}")
       ;;
   esac
+  profiles_csv="$(IFS=,; echo "${profiles[*]}")"
+
+  write_root_environment
+  write_root_manifest "$profiles_csv"
+  build_rustfs_if_needed
+
+  trap stop_server EXIT INT TERM
+
+  log "Output dir: $OUT_DIR"
 
   local legacy_baseline_csv=""
   for profile in "${profiles[@]}"; do
     if [[ "$profile" == "legacy" ]]; then
-      run_profile "$profile"
-      legacy_baseline_csv="${OUT_DIR}/legacy/warp/median_summary.csv"
+      if ! run_profile "$profile"; then
+        PROFILE_FAILURES=$((PROFILE_FAILURES + 1))
+      fi
+      if [[ -f "${OUT_DIR}/legacy/warp/median_summary.csv" ]]; then
+        legacy_baseline_csv="${OUT_DIR}/legacy/warp/median_summary.csv"
+      fi
     else
-      run_profile "$profile" "$legacy_baseline_csv"
+      if ! run_profile "$profile" "$legacy_baseline_csv"; then
+        PROFILE_FAILURES=$((PROFILE_FAILURES + 1))
+      fi
     fi
     copy_profile_compat_artifacts "$profile" "${profile//-/_}"
   done
@@ -1034,6 +1269,12 @@ main() {
   fi
   if [[ -f "${OUT_DIR}/metrics_summary.csv" ]]; then
     log "Metrics summary: ${OUT_DIR}/metrics_summary.csv"
+  fi
+  if [[ -f "${OUT_DIR}/baseline_compare.csv" ]]; then
+    log "Baseline compare: ${OUT_DIR}/baseline_compare.csv"
+  fi
+  if [[ "$DRY_RUN" != "true" && "$PROFILE_FAILURES" -gt 0 ]]; then
+    die "one or more benchmark profiles reported failed rounds; see per-profile median/baseline outputs for details"
   fi
   log "GET codec streaming smoke finished."
 }

--- a/scripts/run_get_codec_streaming_smoke.sh
+++ b/scripts/run_get_codec_streaming_smoke.sh
@@ -328,6 +328,9 @@ codec_engines=${CODEC_ENGINES}
 metadata_early_stop=${METADATA_EARLY_STOP}
 shard_locality_preference=${SHARD_LOCALITY_PREFERENCE}
 codec_max_inflight=${CODEC_MAX_INFLIGHT}
+codec_rollout_codec_profile=benchmark
+codec_body_compat_confirmed_codec_profile=true
+codec_header_compat_confirmed_codec_profile=true
 output_handoff_attribution=${OUTPUT_HANDOFF_ATTRIBUTION}
 address=${ADDRESS}
 bucket=${BUCKET}
@@ -377,6 +380,33 @@ profile_codec_engine() {
   esac
 }
 
+profile_rollout_target() {
+  local profile="$1"
+  case "$profile" in
+    legacy) echo "off" ;;
+    codec-legacy|codec-rustfs) echo "benchmark" ;;
+    *) die "unknown profile: $profile" ;;
+  esac
+}
+
+profile_body_compat_confirmed() {
+  local profile="$1"
+  case "$profile" in
+    legacy) echo "false" ;;
+    codec-legacy|codec-rustfs) echo "true" ;;
+    *) die "unknown profile: $profile" ;;
+  esac
+}
+
+profile_header_compat_confirmed() {
+  local profile="$1"
+  case "$profile" in
+    legacy) echo "false" ;;
+    codec-legacy|codec-rustfs) echo "true" ;;
+    *) die "unknown profile: $profile" ;;
+  esac
+}
+
 profile_metrics_path() {
   local profile="$1"
   case "$profile" in
@@ -408,7 +438,11 @@ write_manifest() {
   local volumes="$4"
   local codec_engine="$5"
   local metrics_path="$6"
+  local rollout_target body_compat_confirmed header_compat_confirmed
   local git_head git_dirty_count
+  rollout_target="$(profile_rollout_target "$profile")"
+  body_compat_confirmed="$(profile_body_compat_confirmed "$profile")"
+  header_compat_confirmed="$(profile_header_compat_confirmed "$profile")"
 
   git_head="$(git -C "$PROJECT_ROOT" rev-parse HEAD)"
   git_dirty_count="$(git -C "$PROJECT_ROOT" status --porcelain | awk 'END { print NR + 0 }')"
@@ -436,6 +470,9 @@ compat_object_size=${COMPAT_OBJECT_SIZE}
 rustfs_volumes=${volumes}
 RUSTFS_GET_CODEC_STREAMING_ENABLE=${codec_enabled}
 RUSTFS_GET_CODEC_STREAMING_ENGINE=${codec_engine}
+RUSTFS_GET_CODEC_STREAMING_ROLLOUT=${rollout_target}
+RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED=${body_compat_confirmed}
+RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED=${header_compat_confirmed}
 RUSTFS_GET_METADATA_EARLY_STOP_ENABLE=$(bool_from_on_off "$METADATA_EARLY_STOP")
 RUSTFS_GET_SHARD_LOCALITY_PREFERENCE_ENABLE=$(bool_from_on_off "$SHARD_LOCALITY_PREFERENCE")
 RUSTFS_GET_CODEC_STREAMING_MAX_INFLIGHT=${CODEC_MAX_INFLIGHT}
@@ -489,6 +526,9 @@ start_server() {
   local codec_enabled
   local codec_engine
   local metrics_path
+  local rollout_target
+  local body_compat_confirmed
+  local header_compat_confirmed
   local rustfs_log
 
   data_root="$(profile_data_root "$profile")"
@@ -496,6 +536,9 @@ start_server() {
   codec_enabled="$(profile_codec_enabled "$profile")"
   codec_engine="$(profile_codec_engine "$profile")"
   metrics_path="$(profile_metrics_path "$profile")"
+  rollout_target="$(profile_rollout_target "$profile")"
+  body_compat_confirmed="$(profile_body_compat_confirmed "$profile")"
+  header_compat_confirmed="$(profile_header_compat_confirmed "$profile")"
   rustfs_log="${profile_dir}/rustfs.log"
 
   mkdir -p "${data_root}/disk1" "${data_root}/disk2" "${data_root}/disk3" "${data_root}/disk4"
@@ -517,6 +560,9 @@ start_server() {
     export RUSTFS_CONSOLE_ENABLE=false
     export RUSTFS_GET_CODEC_STREAMING_ENABLE="$codec_enabled"
     export RUSTFS_GET_CODEC_STREAMING_ENGINE="$codec_engine"
+    export RUSTFS_GET_CODEC_STREAMING_ROLLOUT="$rollout_target"
+    export RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED="$body_compat_confirmed"
+    export RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED="$header_compat_confirmed"
     export RUSTFS_GET_METADATA_EARLY_STOP_ENABLE="$(bool_from_on_off "$METADATA_EARLY_STOP")"
     export RUSTFS_GET_SHARD_LOCALITY_PREFERENCE_ENABLE="$(bool_from_on_off "$SHARD_LOCALITY_PREFERENCE")"
     export RUSTFS_GET_CODEC_STREAMING_MAX_INFLIGHT="$CODEC_MAX_INFLIGHT"

--- a/scripts/run_object_batch_bench_enhanced.sh
+++ b/scripts/run_object_batch_bench_enhanced.sh
@@ -37,6 +37,7 @@ RETRY_SLEEP_SECS=2
 COOLDOWN_SECS=0
 BASELINE_CSV=""
 EXTRA_ARGS=()
+FAILED_FINAL_ROUNDS=0
 
 usage() {
   cat <<'USAGE'
@@ -219,7 +220,7 @@ setup_output() {
   MEDIAN_CSV="$OUT_DIR/median_summary.csv"
   COMPARE_CSV="$OUT_DIR/baseline_compare.csv"
 
-  echo "size,tool,round,attempt,concurrency,status,throughput_human,throughput_bps,reqps,latency_human,latency_ms,log_file" > "$ROUND_CSV"
+  echo "size,tool,round,attempt,concurrency,status,exit_code,round_started_at_utc,round_finished_at_utc,throughput_human,throughput_bps,reqps,latency_human,latency_ms,log_file" > "$ROUND_CSV"
   echo "size,tool,concurrency,successful_rounds,failed_rounds,median_throughput_bps,median_reqps,median_latency_ms" > "$MEDIAN_CSV"
 }
 
@@ -342,6 +343,9 @@ run_one_attempt() {
   local attempt="$3"
   local log_file="$OUT_DIR/logs/${TOOL}_${size}_r${round}_a${attempt}.log"
   local status="ok"
+  local exit_code=0
+  local started_at_utc finished_at_utc
+  started_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   if [[ "$TOOL" == "warp" ]]; then
     local warp_host
@@ -369,7 +373,10 @@ run_one_attempt() {
       printf '\n'
       echo "dry run" > "$log_file"
     else
-      if ! "${cmd[@]}" 2>&1 | tee "$log_file" >&2; then
+      if "${cmd[@]}" 2>&1 | tee "$log_file" >&2; then
+        :
+      else
+        exit_code=$?
         status="failed"
       fi
     fi
@@ -397,27 +404,40 @@ run_one_attempt() {
       printf '\n'
       echo "dry run" > "$log_file"
     else
-      if ! "${cmd[@]}" 2>&1 | tee "$log_file" >&2; then
+      if "${cmd[@]}" 2>&1 | tee "$log_file" >&2; then
+        :
+      else
+        exit_code=$?
         status="failed"
       fi
     fi
   fi
+  finished_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   local metrics throughput_human reqps latency_human throughput_bps latency_ms
-  metrics="$(extract_metrics "$log_file")"
-  throughput_human="$(echo "$metrics" | cut -d',' -f1)"
-  reqps="$(echo "$metrics" | cut -d',' -f2)"
-  latency_human="$(echo "$metrics" | cut -d',' -f3)"
-  throughput_bps="$(to_bps "$throughput_human")"
-  latency_ms="$(to_ms "$latency_human")"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    throughput_human="N/A"
+    reqps="N/A"
+    latency_human="N/A"
+    throughput_bps="N/A"
+    latency_ms="N/A"
+  else
+    metrics="$(extract_metrics "$log_file")"
+    throughput_human="$(echo "$metrics" | cut -d',' -f1)"
+    reqps="$(echo "$metrics" | cut -d',' -f2)"
+    latency_human="$(echo "$metrics" | cut -d',' -f3)"
+    throughput_bps="$(to_bps "$throughput_human")"
+    latency_ms="$(to_ms "$latency_human")"
+  fi
 
   if [[ "$DRY_RUN" != "true" && "$status" == "ok" ]]; then
     if [[ "$throughput_bps" == "N/A" && "$reqps" == "N/A" ]]; then
       status="failed"
+      exit_code=1
     fi
   fi
 
-  echo "$size,$TOOL,$round,$attempt,$CONCURRENCY,$status,$throughput_human,$throughput_bps,$reqps,$latency_human,$latency_ms,$log_file" >> "$ROUND_CSV"
+  echo "$size,$TOOL,$round,$attempt,$CONCURRENCY,$status,$exit_code,$started_at_utc,$finished_at_utc,$throughput_human,$throughput_bps,$reqps,$latency_human,$latency_ms,$log_file" >> "$ROUND_CSV"
   echo "$status"
 }
 
@@ -437,12 +457,13 @@ run_size() {
       fi
       if (( attempt < RETRY_PER_ROUND+1 )); then
         echo "Round failed, retry in ${RETRY_SLEEP_SECS}s..."
-        sleep "$RETRY_SLEEP_SECS"
+        cooldown_sleep "$RETRY_SLEEP_SECS"
       fi
     done
 
     if [[ "$success" == "no" ]]; then
       echo "WARN: size=$size round=$round failed after retries."
+      FAILED_FINAL_ROUNDS=$((FAILED_FINAL_ROUNDS + 1))
     fi
 
     if (( COOLDOWN_SECS > 0 && round < ROUNDS )); then
@@ -464,9 +485,9 @@ build_median_summary() {
     ok_rounds="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6=="ok" {c++} END{print c+0}' "$ROUND_CSV")"
     fail_rounds="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6!="ok" {c++} END{print c+0}' "$ROUND_CSV")"
 
-    t_vals="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6=="ok" && $8!="N/A" {print $8}' "$ROUND_CSV")"
-    r_vals="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6=="ok" && $9!="N/A" {print $9}' "$ROUND_CSV")"
-    l_vals="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6=="ok" && $11!="N/A" {print $11}' "$ROUND_CSV")"
+    t_vals="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6=="ok" && $11!="N/A" {print $11}' "$ROUND_CSV")"
+    r_vals="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6=="ok" && $12!="N/A" {print $12}' "$ROUND_CSV")"
+    l_vals="$(awk -F',' -v s="$size" 'NR>1 && $1==s && $6=="ok" && $14!="N/A" {print $14}' "$ROUND_CSV")"
 
     local m_t m_r m_l
     m_t="$(median_from_numbers "$t_vals")"
@@ -558,6 +579,11 @@ main() {
     echo
     echo "=== Baseline Compare ==="
     cat "$COMPARE_CSV"
+  fi
+
+  if [[ "$DRY_RUN" != "true" && "$FAILED_FINAL_ROUNDS" -gt 0 ]]; then
+    echo "ERROR: ${FAILED_FINAL_ROUNDS} benchmark rounds failed after retries." >&2
+    exit 1
   fi
 }
 


### PR DESCRIPTION
## Related Issues
Fixes rustfs/backlog#726
Refs rustfs/backlog#715

## Summary of Changes
- centralize codec-streaming rollout gating so the new GET path stays opt-in and only admits eligible plain single-part objects
- require explicit rollout intent plus compatibility confirmation before the codec path can run, while keeping the default env behavior unchanged
- classify and record finite static fallback reasons and object classes for every codec-streaming decision
- treat degraded reader setup as `read_quorum_not_safe` and fall back to the legacy duplex path instead of extending the limited rollout to missing-shard scenarios
- wire the benchmark harness to set the benchmark rollout envs explicitly so cooled A/B runs continue to exercise the experimental path without changing defaults

## Verification
- `cargo check -p rustfs --lib`
- `cargo test -p rustfs-ecstore codec_streaming --lib`
- `cargo test -p rustfs-ecstore erasure_decode_reader --lib`
- `bash -n scripts/run_get_codec_streaming_smoke.sh`
- `bash scripts/run_get_codec_streaming_smoke.sh --dry-run --mode both --sizes 1MiB --concurrency 4 --duration 3s --rounds 1`
- `make pre-pr`

## Impact
- Default behavior remains unchanged:
  - `RUSTFS_GET_CODEC_STREAMING_ENABLE=false`
  - `RUSTFS_GET_METADATA_EARLY_STOP_ENABLE=false`
  - `RUSTFS_GET_SHARD_LOCALITY_PREFERENCE_ENABLE=false`
- New codec-streaming rollout now requires explicit opt-in (`benchmark` or `internal`) plus body/header compatibility confirmation.
- Degraded or otherwise ineligible objects continue to fall back to the legacy duplex path with recorded static fallback reasons.

## Additional Notes
- This PR does not default-enable any new GET path.
- Local untracked benchmark helper scripts were left untouched and are not part of this diff.
