### PR TITLE
chore: replace blanket #![allow(dead_code)] with #![warn(dead_code)] (#742)

### DIFF
--- a/crates/checksums/src/base64.rs
+++ b/crates/checksums/src/base64.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use base64_simd::STANDARD;
 use std::error::Error;

--- a/crates/ecstore/src/lib.rs
+++ b/crates/ecstore/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up dead code; see https://github.com/rustfs/backlog/issues/742
 // Copyright 2024 RustFS Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/crates/obs/src/metrics/collectors/audit.rs
+++ b/crates/obs/src/metrics/collectors/audit.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Audit metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_config.rs
+++ b/crates/obs/src/metrics/collectors/cluster_config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Cluster config metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/collectors/cluster_erasure_set.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Cluster erasure set metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_health.rs
+++ b/crates/obs/src/metrics/collectors/cluster_health.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Cluster health metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_iam.rs
+++ b/crates/obs/src/metrics/collectors/cluster_iam.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Cluster IAM metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_usage.rs
+++ b/crates/obs/src/metrics/collectors/cluster_usage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Cluster usage metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/dial9.rs
+++ b/crates/obs/src/metrics/collectors/dial9.rs
@@ -17,7 +17,7 @@
 //! This module provides metrics for monitoring the health and performance
 //! of the dial9 telemetry system itself.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::MetricType;
 use crate::metrics::report::PrometheusMetric;

--- a/crates/obs/src/metrics/collectors/ilm.rs
+++ b/crates/obs/src/metrics/collectors/ilm.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! ILM (Information Lifecycle Management) metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/notification.rs
+++ b/crates/obs/src/metrics/collectors/notification.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Notification metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/notification_target.rs
+++ b/crates/obs/src/metrics/collectors/notification_target.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::metrics::report::PrometheusMetric;
 use crate::metrics::schema::notification_target::{

--- a/crates/obs/src/metrics/collectors/replication.rs
+++ b/crates/obs/src/metrics/collectors/replication.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Replication metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/request.rs
+++ b/crates/obs/src/metrics/collectors/request.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! API request metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/scanner.rs
+++ b/crates/obs/src/metrics/collectors/scanner.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Scanner metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_cpu.rs
+++ b/crates/obs/src/metrics/collectors/system_cpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! System CPU metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_drive.rs
+++ b/crates/obs/src/metrics/collectors/system_drive.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! System drive metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_gpu.rs
+++ b/crates/obs/src/metrics/collectors/system_gpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! System GPU metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_memory.rs
+++ b/crates/obs/src/metrics/collectors/system_memory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! System memory metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_network.rs
+++ b/crates/obs/src/metrics/collectors/system_network.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! System network metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_process.rs
+++ b/crates/obs/src/metrics/collectors/system_process.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! System process metrics collector.
 //!

--- a/crates/obs/src/metrics/schema/audit.rs
+++ b/crates/obs/src/metrics/schema/audit.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/bucket.rs
+++ b/crates/obs/src/metrics/schema/bucket.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, new_histogram_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/bucket_replication.rs
+++ b/crates/obs/src/metrics/schema/bucket_replication.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster.rs
+++ b/crates/obs/src/metrics/schema/cluster.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_config.rs
+++ b/crates/obs/src/metrics/schema/cluster_config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/schema/cluster_erasure_set.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_health.rs
+++ b/crates/obs/src/metrics/schema/cluster_health.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_iam.rs
+++ b/crates/obs/src/metrics/schema/cluster_iam.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_notification.rs
+++ b/crates/obs/src/metrics/schema/cluster_notification.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_usage.rs
+++ b/crates/obs/src/metrics/schema/cluster_usage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/ilm.rs
+++ b/crates/obs/src/metrics/schema/ilm.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/node_bucket.rs
+++ b/crates/obs/src/metrics/schema/node_bucket.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/node_disk.rs
+++ b/crates/obs/src/metrics/schema/node_disk.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_gauge_md};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/notification_target.rs
+++ b/crates/obs/src/metrics/schema/notification_target.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/process_resource.rs
+++ b/crates/obs/src/metrics/schema/process_resource.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_gauge_md};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/replication.rs
+++ b/crates/obs/src/metrics/schema/replication.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/request.rs
+++ b/crates/obs/src/metrics/schema/request.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/scanner.rs
+++ b/crates/obs/src/metrics/schema/scanner.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_cpu.rs
+++ b/crates/obs/src/metrics/schema/system_cpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 /// CPU system-related metric descriptors

--- a/crates/obs/src/metrics/schema/system_drive.rs
+++ b/crates/obs/src/metrics/schema/system_drive.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_gpu.rs
+++ b/crates/obs/src/metrics/schema/system_gpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! GPU-related metric descriptors.
 //!

--- a/crates/obs/src/metrics/schema/system_memory.rs
+++ b/crates/obs/src/metrics/schema/system_memory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_network.rs
+++ b/crates/obs/src/metrics/schema/system_network.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_network_host.rs
+++ b/crates/obs/src/metrics/schema/system_network_host.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_process.rs
+++ b/crates/obs/src/metrics/schema/system_process.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
+#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
 
 //! Statistics collection functions for metrics.
 //!


### PR DESCRIPTION
## Summary

Replace blanket `#![allow(dead_code)]` with `#![warn(dead_code)]` across ecstore, obs, and checksums crates. This surfaces 189 previously hidden dead_code warnings as a roadmap for incremental cleanup.

Closes rustfs/backlog#742

## Changes

- **`crates/ecstore/src/lib.rs`**: `#![allow(dead_code)]` → `#![warn(dead_code)]`
- **`crates/obs/src/metrics/collectors/*.rs`** (19 files): `#![allow(dead_code)]` → `#![warn(dead_code)]`
- **`crates/obs/src/metrics/schema/*.rs`** (15 files): `#![allow(dead_code)]` → `#![warn(dead_code)]`
- **`crates/obs/src/metrics/stats_collector.rs`**: `#![allow(dead_code)]` → `#![warn(dead_code)]`
- **`crates/checksums/src/base64.rs`**: `#![allow(dead_code)]` → `#![warn(dead_code)]`

## Why warn instead of remove?

Removing the allow entirely surfaces 189 warnings in ecstore alone. Using `#![warn(dead_code)]` makes these visible in CI output without blocking compilation, allowing incremental cleanup in follow-up PRs.

## Exception

`crates/kms/src/encryption/dek.rs` retains `#![allow(dead_code)]` because its trait methods are used by implementations outside the module — this is intentional.

## Next Steps

Follow-up PRs will address the 189 warnings by:
1. Deleting truly dead code (~60 items)
2. Adding item-level `#[allow(dead_code)]` with descriptive comments for migration leftovers and intentionally kept items

## Testing

- Compilation passes with warnings
- No behavior changes