### PR TITLE
ci: add protocol feature test matrix (swift, sftp, no-default) (#736)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,44 @@ jobs:
       - name: Run rio-v2 clippy lints
         run: cargo clippy -p rustfs -p rustfs-ecstore --all-targets --features rio-v2 -- -D warnings
 
+  test-and-lint-protocols:
+    name: "Test and Lint (${{ matrix.features.name }})"
+    needs: skip-check
+    if: needs.skip-check.outputs.should_skip != 'true'
+    runs-on: ubicloud-standard-4
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - name: swift
+            flags: "--features swift"
+          - name: sftp
+            flags: "--features sftp"
+          - name: no-default
+            flags: "--no-default-features"
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Rust environment
+        uses: ./.github/actions/setup
+        with:
+          rust-version: stable
+          cache-shared-key: ci-test-${{ matrix.features.name }}-${{ hashFiles('**/Cargo.lock') }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run tests with ${{ matrix.features.name }}
+        run: |
+          cargo nextest run -p rustfs -p rustfs-protocols ${{ matrix.features.flags }}
+
+      - name: Run clippy with ${{ matrix.features.name }}
+        run: |
+          cargo clippy -p rustfs -p rustfs-protocols --all-targets ${{ matrix.features.flags }} -- -D warnings
+
   build-rustfs-debug-binary:
     name: Build RustFS Debug Binary
     needs: skip-check


### PR DESCRIPTION
## Summary

Add a new CI job `test-and-lint-protocols` that tests protocol features previously untested in CI.

Closes rustfs/backlog#736

## New CI Matrix

| Feature | Description | Status |
|---------|-------------|--------|
| `swift` | OpenStack Swift API | **NEW** — was never CI-tested |
| `sftp` | SFTP protocol | **NEW** — was never CI-tested |
| `no-default` | Pure S3 server (no default protocols) | **NEW** — was never CI-tested |

Each feature runs:
- `cargo nextest run -p rustfs -p rustfs-protocols`
- `cargo clippy -p rustfs -p rustfs-protocols --all-targets -- -D warnings`

## Why not `--all-features`?

The `metrics-gpu` feature requires NVIDIA hardware (`nvml-wrapper`), which is not available on CI runners. Testing `--all-features` would fail. Instead, we test individual features that are safe to compile on standard runners.

## Impact

- Catches compilation regressions in `swift` and `sftp` features before they reach users
- Tests the pure S3 server mode (`--no-default-features`) which disables ftps and webdav
- Adds ~15-20 minutes to CI (3 parallel jobs, each ~10 min)

## Testing

CI configuration change only — no code changes.