### PR TITLE
fix(ci): pin protocol matrix checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Rust environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Pins the checkout action in the protocol feature matrix job to the same full-length SHA used by the rest of the CI workflow. This fixes the Security Audit workflow pin report failure introduced by the new matrix job.

## Verification
- `./scripts/security/check_workflow_pins.sh --enforce`
- `git diff --check --`

## Impact
CI-only change. No runtime, API, or user-facing impact.

## Additional Notes
N/A
