### PR TITLE
revert: restore #![allow(dead_code)] - CI clippy -D warnings conflict

### DIFF
--- a/crates/checksums/src/base64.rs
+++ b/crates/checksums/src/base64.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use base64_simd::STANDARD;
 use std::error::Error;

--- a/crates/ecstore/src/lib.rs
+++ b/crates/ecstore/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(dead_code)] // Gradually clean up dead code; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 // Copyright 2024 RustFS Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/crates/obs/src/metrics/collectors/audit.rs
+++ b/crates/obs/src/metrics/collectors/audit.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Audit metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_config.rs
+++ b/crates/obs/src/metrics/collectors/cluster_config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Cluster config metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/collectors/cluster_erasure_set.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Cluster erasure set metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_health.rs
+++ b/crates/obs/src/metrics/collectors/cluster_health.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Cluster health metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_iam.rs
+++ b/crates/obs/src/metrics/collectors/cluster_iam.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Cluster IAM metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/cluster_usage.rs
+++ b/crates/obs/src/metrics/collectors/cluster_usage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Cluster usage metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/dial9.rs
+++ b/crates/obs/src/metrics/collectors/dial9.rs
@@ -17,7 +17,7 @@
 //! This module provides metrics for monitoring the health and performance
 //! of the dial9 telemetry system itself.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::MetricType;
 use crate::metrics::report::PrometheusMetric;

--- a/crates/obs/src/metrics/collectors/ilm.rs
+++ b/crates/obs/src/metrics/collectors/ilm.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! ILM (Information Lifecycle Management) metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/notification.rs
+++ b/crates/obs/src/metrics/collectors/notification.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Notification metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/notification_target.rs
+++ b/crates/obs/src/metrics/collectors/notification_target.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::metrics::report::PrometheusMetric;
 use crate::metrics::schema::notification_target::{

--- a/crates/obs/src/metrics/collectors/replication.rs
+++ b/crates/obs/src/metrics/collectors/replication.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Replication metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/request.rs
+++ b/crates/obs/src/metrics/collectors/request.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! API request metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/scanner.rs
+++ b/crates/obs/src/metrics/collectors/scanner.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Scanner metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_cpu.rs
+++ b/crates/obs/src/metrics/collectors/system_cpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! System CPU metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_drive.rs
+++ b/crates/obs/src/metrics/collectors/system_drive.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! System drive metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_gpu.rs
+++ b/crates/obs/src/metrics/collectors/system_gpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! System GPU metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_memory.rs
+++ b/crates/obs/src/metrics/collectors/system_memory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! System memory metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_network.rs
+++ b/crates/obs/src/metrics/collectors/system_network.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! System network metrics collector.
 //!

--- a/crates/obs/src/metrics/collectors/system_process.rs
+++ b/crates/obs/src/metrics/collectors/system_process.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! System process metrics collector.
 //!

--- a/crates/obs/src/metrics/schema/audit.rs
+++ b/crates/obs/src/metrics/schema/audit.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/bucket.rs
+++ b/crates/obs/src/metrics/schema/bucket.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, new_histogram_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/bucket_replication.rs
+++ b/crates/obs/src/metrics/schema/bucket_replication.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster.rs
+++ b/crates/obs/src/metrics/schema/cluster.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_config.rs
+++ b/crates/obs/src/metrics/schema/cluster_config.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/schema/cluster_erasure_set.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_health.rs
+++ b/crates/obs/src/metrics/schema/cluster_health.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_iam.rs
+++ b/crates/obs/src/metrics/schema/cluster_iam.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_notification.rs
+++ b/crates/obs/src/metrics/schema/cluster_notification.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/cluster_usage.rs
+++ b/crates/obs/src/metrics/schema/cluster_usage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/ilm.rs
+++ b/crates/obs/src/metrics/schema/ilm.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/node_bucket.rs
+++ b/crates/obs/src/metrics/schema/node_bucket.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/node_disk.rs
+++ b/crates/obs/src/metrics/schema/node_disk.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_gauge_md};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/notification_target.rs
+++ b/crates/obs/src/metrics/schema/notification_target.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/process_resource.rs
+++ b/crates/obs/src/metrics/schema/process_resource.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_gauge_md};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/replication.rs
+++ b/crates/obs/src/metrics/schema/replication.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/request.rs
+++ b/crates/obs/src/metrics/schema/request.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/scanner.rs
+++ b/crates/obs/src/metrics/schema/scanner.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_cpu.rs
+++ b/crates/obs/src/metrics/schema/system_cpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 /// CPU system-related metric descriptors

--- a/crates/obs/src/metrics/schema/system_drive.rs
+++ b/crates/obs/src/metrics/schema/system_drive.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_gpu.rs
+++ b/crates/obs/src/metrics/schema/system_gpu.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! GPU-related metric descriptors.
 //!

--- a/crates/obs/src/metrics/schema/system_memory.rs
+++ b/crates/obs/src/metrics/schema/system_memory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_network.rs
+++ b/crates/obs/src/metrics/schema/system_network.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_network_host.rs
+++ b/crates/obs/src/metrics/schema/system_network_host.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_process.rs
+++ b/crates/obs/src/metrics/schema/system_process.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(dead_code)] // Gradually clean up; see https://github.com/rustfs/backlog/issues/742
+#![allow(dead_code)]
 
 //! Statistics collection functions for metrics.
 //!


### PR DESCRIPTION
## Summary

Revert the `#![warn(dead_code)]` changes from PR #3974. The CI runs clippy with `-D warnings` which turns warnings into errors, causing failures across all PRs.

## Problem

PR #3974 changed `#![allow(dead_code)]` to `#![warn(dead_code)]` in 47 files. However, CI runs:
```
cargo clippy --all-targets -- -D warnings
```

This means `#![warn(dead_code)]` + `-D warnings` = `#![deny(dead_code)]`, which fails compilation on any dead code.

## Solution

Revert to `#![allow(dead_code)]` until the dead code is actually cleaned up. The correct approach is:
1. Keep `#![allow(dead_code)]` to suppress warnings
2. Incrementally delete truly dead code
3. Add item-level `#[allow(dead_code)]` with descriptive comments for intentional items
4. Only change to `#![warn(dead_code)]` after all dead code is addressed

## Files Changed

47 files (ecstore, obs, checksums) - all reverted from `#![warn(dead_code)]` to `#![allow(dead_code)]`.

Exception: `crates/kms/src/encryption/dek.rs` retains `#![allow(dead_code)]` with comment (was not changed by #3974).