### PR TITLE
fix(ecstore): replace unsafe k.unwrap() in bucket_target_sys (#729)

### DIFF
--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -1525,9 +1525,10 @@ impl TargetClient {
             .customize()
             .map_request(move |mut req| {
                 for (k, v) in headers.clone().into_iter() {
-                    let key_str = k.unwrap().as_str().to_string();
-                    let value_str = v.to_str().unwrap_or("").to_string();
-                    req.headers_mut().insert(key_str, value_str);
+                    if let Some(key_str) = k.map(|k| k.as_str().to_string()) {
+                        let value_str = v.to_str().unwrap_or("").to_string();
+                        req.headers_mut().insert(key_str, value_str);
+                    }
                 }
 
                 Result::<_, aws_smithy_types::error::operation::BuildError>::Ok(req)
@@ -1586,9 +1587,10 @@ impl TargetClient {
             .customize()
             .map_request(move |mut req| {
                 for (k, v) in headers.clone().into_iter() {
-                    let key_str = k.unwrap().as_str().to_string();
-                    let value_str = v.to_str().unwrap_or("").to_string();
-                    req.headers_mut().insert(key_str, value_str);
+                    if let Some(key_str) = k.map(|k| k.as_str().to_string()) {
+                        let value_str = v.to_str().unwrap_or("").to_string();
+                        req.headers_mut().insert(key_str, value_str);
+                    }
                 }
                 Result::<_, aws_smithy_types::error::operation::BuildError>::Ok(req)
             })
@@ -1625,9 +1627,10 @@ impl TargetClient {
             .customize()
             .map_request(move |mut req| {
                 for (k, v) in headers.clone().into_iter() {
-                    let key_str = k.unwrap().as_str().to_string();
-                    let value_str = v.to_str().unwrap_or("").to_string();
-                    req.headers_mut().insert(key_str, value_str);
+                    if let Some(key_str) = k.map(|k| k.as_str().to_string()) {
+                        let value_str = v.to_str().unwrap_or("").to_string();
+                        req.headers_mut().insert(key_str, value_str);
+                    }
                 }
                 Result::<_, aws_smithy_types::error::operation::BuildError>::Ok(req)
             })
@@ -1661,9 +1664,10 @@ impl TargetClient {
             .customize()
             .map_request(move |mut req| {
                 for (k, v) in headers.clone().into_iter() {
-                    let key_str = k.unwrap().as_str().to_string();
-                    let value_str = v.to_str().unwrap_or("").to_string();
-                    req.headers_mut().insert(key_str, value_str);
+                    if let Some(key_str) = k.map(|k| k.as_str().to_string()) {
+                        let value_str = v.to_str().unwrap_or("").to_string();
+                        req.headers_mut().insert(key_str, value_str);
+                    }
                 }
                 Result::<_, aws_smithy_types::error::operation::BuildError>::Ok(req)
             })
@@ -1694,9 +1698,10 @@ impl TargetClient {
             .customize()
             .map_request(move |mut req| {
                 for (k, v) in headers.clone().into_iter() {
-                    let key_str = k.unwrap().as_str().to_string();
-                    let value_str = v.to_str().unwrap_or("").to_string();
-                    req.headers_mut().insert(key_str, value_str);
+                    if let Some(key_str) = k.map(|k| k.as_str().to_string()) {
+                        let value_str = v.to_str().unwrap_or("").to_string();
+                        req.headers_mut().insert(key_str, value_str);
+                    }
                 }
                 Result::<_, aws_smithy_types::error::operation::BuildError>::Ok(req)
             })


### PR DESCRIPTION
## Summary

Replace unsafe `k.unwrap().as_str()` calls with safe `if let Some(key_str)` pattern in `bucket_target_sys.rs`.

Closes rustfs/backlog#729 (partial - first batch)

## Changes

5 locations where `HeaderMap` iterator yields `(Option<HeaderName>, Value)`:
- `k.unwrap()` → `if let Some(key_str) = k.map(|k| k.as_str().to_string())`

## Why

`HeaderMap::into_iter()` yields `Option<HeaderName>` because some headers may have invalid names. Using `unwrap()` could panic if an invalid header name is encountered. The safe pattern skips invalid headers gracefully.

## Testing

- Compilation passes
- All 6 bucket_target_sys tests pass