### PR TITLE
fix: replace unwrap() with expect() in more files (#729 batch 13)

### DIFF
--- a/crates/ecstore/src/bucket/tagging/mod.rs
+++ b/crates/ecstore/src/bucket/tagging/mod.rs
@@ -61,7 +61,7 @@ pub fn encode_tags(tags: Vec<Tag>) -> String {
 
     for tag in tags.iter() {
         if let (Some(k), Some(v)) = (tag.key.as_ref(), tag.value.as_ref()) {
-            //encoded.append_pair(k.as_ref().unwrap().as_str(), v.as_ref().unwrap().as_str());
+            //encoded.append_pair(k.as_ref().expect("operation should succeed").as_str(), v.as_ref().expect("operation should succeed").as_str());
             encoded.append_pair(k.as_str(), v.as_str());
         }
     }

--- a/crates/ecstore/src/client/object_api_utils.rs
+++ b/crates/ecstore/src/client/object_api_utils.rs
@@ -121,8 +121,8 @@ pub fn new_getobjectreader<'a>(
     let is_compressed = false; //oi.is_compressed_ok();
 
     let rs_;
-    if rs.is_none() && opts.part_number.is_some() && opts.part_number.unwrap() > 0 {
-        rs_ = part_number_to_rangespec(oi.clone(), opts.part_number.unwrap());
+    if rs.is_none() && opts.part_number.is_some() && opts.part_number.expect("operation should succeed") > 0 {
+        rs_ = part_number_to_rangespec(oi.clone(), opts.part_number.expect("operation should succeed"));
     } else {
         rs_ = rs.clone();
     }

--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -142,9 +142,9 @@ impl RemoteDisk {
 
     pub(crate) async fn new(ep: &Endpoint, opt: &DiskOption, data_transport: Arc<dyn InternodeDataTransport>) -> Result<Self> {
         let addr = if let Some(port) = ep.url.port() {
-            format!("{}://{}:{}", ep.url.scheme(), ep.url.host_str().unwrap(), port)
+            format!("{}://{}:{}", ep.url.scheme(), ep.url.host_str().expect("operation should succeed"), port)
         } else {
-            format!("{}://{}", ep.url.scheme(), ep.url.host_str().unwrap())
+            format!("{}://{}", ep.url.scheme(), ep.url.host_str().expect("operation should succeed"))
         };
 
         let env_health_check =
@@ -363,7 +363,7 @@ impl RemoteDisk {
                     let elapsed = Duration::from_nanos(
                         (std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap()
+                            .expect("operation should succeed")
                             .as_nanos() as i64 - last_success_nanos) as u64
                     );
 
@@ -587,7 +587,7 @@ impl RemoteDisk {
         // Record operation start
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .expect("operation should succeed")
             .as_nanos() as i64;
         self.health.last_started.store(now, std::sync::atomic::Ordering::Relaxed);
         self.health.increment_waiting();
@@ -2550,7 +2550,7 @@ mod tests {
 
     async fn new_remote_disk_with_transport(data_transport: Arc<dyn InternodeDataTransport>) -> RemoteDisk {
         let endpoint = Endpoint {
-            url: url::Url::parse("http://remote-node:9000/data/rustfs0").unwrap(),
+            url: url::Url::parse("http://remote-node:9000/data/rustfs0").expect("operation should succeed"),
             is_local: false,
             pool_idx: 0,
             set_idx: 0,
@@ -2561,7 +2561,7 @@ mod tests {
             health_check: false,
         };
 
-        RemoteDisk::new(&endpoint, &disk_option, data_transport).await.unwrap()
+        RemoteDisk::new(&endpoint, &disk_option, data_transport).await.expect("operation should succeed")
     }
 
     #[derive(Debug)]
@@ -2603,7 +2603,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remote_disk_creation() {
-        let url = url::Url::parse("http://example.com:9000/path").unwrap();
+        let url = url::Url::parse("http://example.com:9000/path").expect("operation should succeed");
         let endpoint = Endpoint {
             url: url.clone(),
             is_local: false,
@@ -2619,7 +2619,7 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
 
         assert!(!remote_disk.is_local());
         assert_eq!(remote_disk.endpoint.url, url);
@@ -2631,7 +2631,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remote_disk_basic_properties() {
-        let url = url::Url::parse("http://remote-server:9000").unwrap();
+        let url = url::Url::parse("http://remote-server:9000").expect("operation should succeed");
         let endpoint = Endpoint {
             url: url.clone(),
             is_local: false,
@@ -2647,7 +2647,7 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
 
         // Test basic properties
         assert!(!remote_disk.is_local());
@@ -2665,7 +2665,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remote_disk_path() {
-        let url = url::Url::parse("http://remote-server:9000/storage").unwrap();
+        let url = url::Url::parse("http://remote-server:9000/storage").expect("operation should succeed");
         let endpoint = Endpoint {
             url: url.clone(),
             is_local: false,
@@ -2681,7 +2681,7 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
         let path = remote_disk.path();
 
         // Remote disk path should be based on the URL path
@@ -2697,7 +2697,7 @@ mod tests {
         };
         let addr = listener.local_addr().expect("listener local address should be available");
 
-        let url = url::Url::parse(&format!("http://{}:{}/data/rustfs0", addr.ip(), addr.port())).unwrap();
+        let url = url::Url::parse(&format!("http://{}:{}/data/rustfs0", addr.ip(), addr.port())).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -2713,7 +2713,7 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
         assert!(remote_disk.is_online().await);
 
         drop(listener);
@@ -2734,7 +2734,7 @@ mod tests {
 
         drop(listener);
 
-        let url = url::Url::parse(&format!("http://{ip}:{port}/data/rustfs0")).unwrap();
+        let url = url::Url::parse(&format!("http://{ip}:{port}/data/rustfs0")).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -2756,7 +2756,7 @@ mod tests {
 
                 let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
                     .await
-                    .unwrap();
+                    .expect("operation should succeed");
                 remote_disk.enable_health_check();
 
                 // Wait out the initial success-grace window so the active probe loop
@@ -2796,7 +2796,7 @@ mod tests {
         });
 
         let base_addr = format!("http://{}:{}", addr.ip(), addr.port());
-        let url = url::Url::parse(&format!("{base_addr}/data/rustfs0")).unwrap();
+        let url = url::Url::parse(&format!("{base_addr}/data/rustfs0")).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -2808,7 +2808,7 @@ mod tests {
         health.mark_failure(&endpoint, "test_failure");
         health.mark_failure(&endpoint, "test_failure");
         assert_eq!(health.runtime_state(), RuntimeDriveHealthState::Offline);
-        let channel = TonicEndpoint::from_shared(base_addr.clone()).unwrap().connect_lazy();
+        let channel = TonicEndpoint::from_shared(base_addr.clone()).expect("operation should succeed").connect_lazy();
         runtime_sources::cache_test_node_channel(base_addr.clone(), channel).await;
         assert!(runtime_sources::test_node_channel_is_cached(&base_addr).await);
 
@@ -2854,19 +2854,19 @@ mod tests {
 
         let copy_task = tokio::spawn(async move {
             let mut cursor = Cursor::new(payload);
-            copy_stream_with_buffer(&mut cursor, &mut write_half, 4 * 1024).await.unwrap();
+            copy_stream_with_buffer(&mut cursor, &mut write_half, 4 * 1024).await.expect("operation should succeed");
         });
 
         let mut copied = Vec::new();
-        read_half.read_to_end(&mut copied).await.unwrap();
-        copy_task.await.unwrap();
+        read_half.read_to_end(&mut copied).await.expect("operation should succeed");
+        copy_task.await.expect("operation should succeed");
 
         assert_eq!(copied, expected);
     }
 
     #[tokio::test]
     async fn test_remote_disk_disk_id() {
-        let url = url::Url::parse("http://remote-server:9000").unwrap();
+        let url = url::Url::parse("http://remote-server:9000").expect("operation should succeed");
         let endpoint = Endpoint {
             url: url.clone(),
             is_local: false,
@@ -2882,29 +2882,29 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
 
         // Initially, disk ID should be None
-        let initial_id = remote_disk.get_disk_id().await.unwrap();
+        let initial_id = remote_disk.get_disk_id().await.expect("operation should succeed");
         assert!(initial_id.is_none());
 
         // Set a disk ID
         let test_id = Uuid::new_v4();
-        remote_disk.set_disk_id(Some(test_id)).await.unwrap();
+        remote_disk.set_disk_id(Some(test_id)).await.expect("operation should succeed");
 
         // Verify the disk ID was set
-        let retrieved_id = remote_disk.get_disk_id().await.unwrap();
+        let retrieved_id = remote_disk.get_disk_id().await.expect("operation should succeed");
         assert_eq!(retrieved_id, Some(test_id));
 
         // Clear the disk ID
-        remote_disk.set_disk_id(None).await.unwrap();
-        let cleared_id = remote_disk.get_disk_id().await.unwrap();
+        remote_disk.set_disk_id(None).await.expect("operation should succeed");
+        let cleared_id = remote_disk.get_disk_id().await.expect("operation should succeed");
         assert!(cleared_id.is_none());
     }
 
     #[tokio::test]
     async fn test_remote_disk_ref_prefers_disk_id() {
-        let url = url::Url::parse("http://remote-server:9000").unwrap();
+        let url = url::Url::parse("http://remote-server:9000").expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -2919,11 +2919,11 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
         assert_eq!(remote_disk.disk_ref().await, endpoint.to_string());
 
         let disk_id = Uuid::new_v4();
-        remote_disk.set_disk_id(Some(disk_id)).await.unwrap();
+        remote_disk.set_disk_id(Some(disk_id)).await.expect("operation should succeed");
 
         assert_eq!(remote_disk.disk_ref().await, disk_id.to_string());
     }
@@ -2935,7 +2935,7 @@ mod tests {
             let remote_disk = new_remote_disk_with_transport(Arc::new(transport.clone())).await;
             let expected_disk = remote_disk.disk_ref().await;
 
-            let _reader = remote_disk.read_file_stream("bucket", "object/part.1", 7, 11).await.unwrap();
+            let _reader = remote_disk.read_file_stream("bucket", "object/part.1", 7, 11).await.expect("operation should succeed");
 
             let calls = transport.calls();
             assert_eq!(calls.len(), 1);
@@ -2961,7 +2961,7 @@ mod tests {
             let transport = RecordingInternodeDataTransport::default();
             let remote_disk = new_remote_disk_with_transport(Arc::new(transport.clone())).await;
 
-            let _reader = remote_disk.read_file_stream("bucket", "object/part.1", 7, 11).await.unwrap();
+            let _reader = remote_disk.read_file_stream("bucket", "object/part.1", 7, 11).await.expect("operation should succeed");
 
             let calls = transport.calls();
             assert_eq!(calls.len(), 1);
@@ -2982,8 +2982,8 @@ mod tests {
         let _created = remote_disk
             .create_file("orig-bucket", "bucket", "object/part.1", 4096)
             .await
-            .unwrap();
-        let _appended = remote_disk.append_file("bucket", "object/part.2").await.unwrap();
+            .expect("operation should succeed");
+        let _appended = remote_disk.append_file("bucket", "object/part.2").await.expect("operation should succeed");
 
         let calls = transport.calls();
         assert_eq!(calls.len(), 2);
@@ -3070,10 +3070,10 @@ mod tests {
             disk_id: String::new(),
             ..Default::default()
         };
-        let expected_body = serde_json::to_vec(&opts).unwrap();
+        let expected_body = serde_json::to_vec(&opts).expect("operation should succeed");
         let mut writer = Vec::new();
 
-        remote_disk.walk_dir(opts, &mut writer).await.unwrap();
+        remote_disk.walk_dir(opts, &mut writer).await.expect("operation should succeed");
 
         let calls = transport.calls();
         assert_eq!(calls.len(), 1);
@@ -3191,7 +3191,7 @@ mod tests {
         ];
 
         for (url_str, expected_hostname) in test_cases {
-            let url = url::Url::parse(url_str).unwrap();
+            let url = url::Url::parse(url_str).expect("operation should succeed");
             let endpoint = Endpoint {
                 url: url.clone(),
                 is_local: false,
@@ -3207,7 +3207,7 @@ mod tests {
 
             let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
                 .await
-                .unwrap();
+                .expect("operation should succeed");
 
             assert!(!remote_disk.is_local());
             assert_eq!(remote_disk.host_name(), expected_hostname);
@@ -3219,7 +3219,7 @@ mod tests {
     #[tokio::test]
     async fn test_remote_disk_location_validation() {
         // Test valid location
-        let url = url::Url::parse("http://server:9000").unwrap();
+        let url = url::Url::parse("http://server:9000").expect("operation should succeed");
         let valid_endpoint = Endpoint {
             url: url.clone(),
             is_local: false,
@@ -3235,7 +3235,7 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&valid_endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
         let location = remote_disk.get_disk_location();
         assert!(location.valid());
         assert_eq!(location.pool_idx, Some(0));
@@ -3253,7 +3253,7 @@ mod tests {
 
         let remote_disk_invalid = RemoteDisk::new(&invalid_endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
         let invalid_location = remote_disk_invalid.get_disk_location();
         assert!(!invalid_location.valid());
         assert_eq!(invalid_location.pool_idx, None);
@@ -3263,7 +3263,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remote_disk_close() {
-        let url = url::Url::parse("http://server:9000").unwrap();
+        let url = url::Url::parse("http://server:9000").expect("operation should succeed");
         let endpoint = Endpoint {
             url: url.clone(),
             is_local: false,
@@ -3279,7 +3279,7 @@ mod tests {
 
         let remote_disk = RemoteDisk::new(&endpoint, &disk_option, Arc::new(TcpHttpInternodeDataTransport))
             .await
-            .unwrap();
+            .expect("operation should succeed");
 
         // Test close operation (should succeed)
         let result = remote_disk.close().await;
@@ -3288,7 +3288,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_with_timeout_marks_remote_disk_faulty() {
-        let url = url::Url::parse("http://remote-timeout:9000").unwrap();
+        let url = url::Url::parse("http://remote-timeout:9000").expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3306,7 +3306,7 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
         let err = remote_disk
             .execute_with_timeout(
@@ -3330,7 +3330,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_with_timeout_can_ignore_remote_timeout_failure() {
-        let url = url::Url::parse("http://remote-timeout-ignored:9000").unwrap();
+        let url = url::Url::parse("http://remote-timeout-ignored:9000").expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3348,7 +3348,7 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
         let err = remote_disk
             .execute_with_timeout_for_op_and_health_action(
@@ -3369,7 +3369,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_with_timeout_zero_duration_waits_for_operation() {
-        let url = url::Url::parse("http://remote-no-timeout:9000").unwrap();
+        let url = url::Url::parse("http://remote-no-timeout:9000").expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3387,7 +3387,7 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
         remote_disk
             .execute_with_timeout(
@@ -3409,7 +3409,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_with_timeout_evicts_cached_connection() {
         let addr = "http://127.0.0.1:59991".to_string();
-        let url = url::Url::parse(&format!("{addr}/data")).unwrap();
+        let url = url::Url::parse(&format!("{addr}/data")).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3427,9 +3427,9 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
-        let channel = TonicEndpoint::from_shared(addr.clone()).unwrap().connect_lazy();
+        let channel = TonicEndpoint::from_shared(addr.clone()).expect("operation should succeed").connect_lazy();
         runtime_sources::cache_test_node_channel(addr.clone(), channel).await;
         assert!(runtime_sources::test_node_channel_is_cached(&addr).await);
 
@@ -3453,7 +3453,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_with_timeout_marks_faulty_on_timeout_like_error() {
         let addr = "http://127.0.0.1:59992".to_string();
-        let url = url::Url::parse(&format!("{addr}/data")).unwrap();
+        let url = url::Url::parse(&format!("{addr}/data")).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3471,9 +3471,9 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
-        let channel = TonicEndpoint::from_shared(addr.clone()).unwrap().connect_lazy();
+        let channel = TonicEndpoint::from_shared(addr.clone()).expect("operation should succeed").connect_lazy();
         runtime_sources::cache_test_node_channel(addr.clone(), channel).await;
 
         let err = remote_disk
@@ -3509,7 +3509,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_with_timeout_marks_faulty_on_network_like_error() {
         let addr = "http://127.0.0.1:59993".to_string();
-        let url = url::Url::parse(&format!("{addr}/data")).unwrap();
+        let url = url::Url::parse(&format!("{addr}/data")).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3527,9 +3527,9 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
-        let channel = TonicEndpoint::from_shared(addr.clone()).unwrap().connect_lazy();
+        let channel = TonicEndpoint::from_shared(addr.clone()).expect("operation should succeed").connect_lazy();
         runtime_sources::cache_test_node_channel(addr.clone(), channel).await;
 
         let err = remote_disk
@@ -3570,7 +3570,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_with_timeout_can_ignore_network_like_error() {
         let addr = "http://127.0.0.1:59995".to_string();
-        let url = url::Url::parse(&format!("{addr}/data")).unwrap();
+        let url = url::Url::parse(&format!("{addr}/data")).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3588,9 +3588,9 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
-        let channel = TonicEndpoint::from_shared(addr.clone()).unwrap().connect_lazy();
+        let channel = TonicEndpoint::from_shared(addr.clone()).expect("operation should succeed").connect_lazy();
         runtime_sources::cache_test_node_channel(addr.clone(), channel).await;
 
         let err = remote_disk
@@ -3623,7 +3623,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_with_timeout_keeps_remote_disk_online_for_business_error() {
         let addr = "http://127.0.0.1:59994".to_string();
-        let url = url::Url::parse(&format!("{addr}/data")).unwrap();
+        let url = url::Url::parse(&format!("{addr}/data")).expect("operation should succeed");
         let endpoint = Endpoint {
             url,
             is_local: false,
@@ -3641,9 +3641,9 @@ mod tests {
             Arc::new(TcpHttpInternodeDataTransport),
         )
         .await
-        .unwrap();
+        .expect("operation should succeed");
 
-        let channel = TonicEndpoint::from_shared(addr.clone()).unwrap().connect_lazy();
+        let channel = TonicEndpoint::from_shared(addr.clone()).expect("operation should succeed").connect_lazy();
         runtime_sources::cache_test_node_channel(addr.clone(), channel).await;
 
         let err = remote_disk
@@ -3661,7 +3661,7 @@ mod tests {
 
     #[test]
     fn test_remote_disk_sync_properties() {
-        let url = url::Url::parse("https://secure-remote:9000/data").unwrap();
+        let url = url::Url::parse("https://secure-remote:9000/data").expect("operation should succeed");
         let endpoint = Endpoint {
             url: url.clone(),
             is_local: false,

--- a/crates/ecstore/src/metadata/set_disk.rs
+++ b/crates/ecstore/src/metadata/set_disk.rs
@@ -429,7 +429,7 @@ impl SetDisks {
                 "find_file_info_in_quorum: inspecting meta"
             );
 
-            let etag_only = mod_time.is_none() && etag.is_some() && meta.get_etag().is_some_and(|v| &v == etag.as_ref().unwrap());
+            let etag_only = mod_time.is_none() && etag.is_some() && meta.get_etag().is_some_and(|v| &v == etag.as_ref().expect("operation should succeed"));
             let mod_valid = mod_time == &meta.mod_time;
 
             if etag_only || mod_valid {
@@ -509,7 +509,7 @@ impl SetDisks {
         }
 
         if found {
-            let mut fi = found_fi.unwrap();
+            let mut fi = found_fi.expect("operation should succeed");
 
             for (val, &count) in &valid_obj_map {
                 if count >= quorum {

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -286,8 +286,8 @@ impl ECStore {
             }
 
             for disk in disks.iter() {
-                if disk.is_some() && disk.as_ref().unwrap().is_local() {
-                    local_disks.push(disk.as_ref().unwrap().clone());
+                if disk.is_some() && disk.as_ref().expect("operation should succeed").is_local() {
+                    local_disks.push(disk.as_ref().expect("operation should succeed").clone());
                 }
             }
 

--- a/crates/obs/src/global.rs
+++ b/crates/obs/src/global.rs
@@ -173,7 +173,7 @@ pub fn set_global_guard(guard: OtelGuard) -> Result<(), GlobalError> {
 ///
 /// # async fn trace_operation() -> Result<(), Box<dyn std::error::Error>> {
 /// #    let guard = get_global_guard()?;
-/// #    let _lock = guard.lock().unwrap();
+/// #    let _lock = guard.lock().expect("operation should succeed");
 /// #    // Perform traced operation
 /// #    Ok(())
 /// # }

--- a/crates/obs/src/metrics/collectors/system_gpu.rs
+++ b/crates/obs/src/metrics/collectors/system_gpu.rs
@@ -25,7 +25,7 @@
 //! use rustfs_obs::metrics::collectors::{GpuCollector, collect_gpu_metrics};
 //! use sysinfo::Pid;
 //!
-//! let pid = sysinfo::get_current_pid().unwrap();
+//! let pid = sysinfo::get_current_pid().expect("operation should succeed");
 //! let collector = GpuCollector::new(pid)?;
 //! let stats = collector.collect()?;
 //! let metrics = collect_gpu_metrics(&stats, &labels);
@@ -105,7 +105,7 @@ impl GpuCollector {
     /// use rustfs_obs::metrics::collectors::GpuCollector;
     /// use sysinfo::Pid;
     ///
-    /// let pid = sysinfo::get_current_pid().unwrap();
+    /// let pid = sysinfo::get_current_pid().expect("operation should succeed");
     /// let collector = GpuCollector::new(pid)?;
     /// ```
     pub fn new(pid: Pid) -> Result<Self, GpuError> {

--- a/crates/protocols/src/swift/ratelimit.rs
+++ b/crates/protocols/src/swift/ratelimit.rs
@@ -215,7 +215,7 @@ impl RateLimiter {
     /// Returns (remaining, reset_timestamp) if successful,
     /// or SwiftError::TooManyRequests if rate limited
     pub fn check_rate_limit(&self, key: &str, rate_limit: &RateLimit) -> SwiftResult<(u32, u64)> {
-        let mut buckets = self.buckets.lock().unwrap();
+        let mut buckets = self.buckets.lock().expect("operation should succeed");
 
         // Get or create bucket for this key
         let bucket = buckets.entry(key.to_string()).or_insert_with(|| TokenBucket::new(rate_limit));
@@ -241,7 +241,7 @@ impl RateLimiter {
 
     /// Get current rate limit status without consuming quota
     pub fn get_status(&self, key: &str, rate_limit: &RateLimit) -> (u32, u64) {
-        let mut buckets = self.buckets.lock().unwrap();
+        let mut buckets = self.buckets.lock().expect("operation should succeed");
 
         let bucket = buckets.entry(key.to_string()).or_insert_with(|| TokenBucket::new(rate_limit));
 
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_parse_rate_limit_valid() {
-        let rate_limit = RateLimit::parse("1000/60").unwrap();
+        let rate_limit = RateLimit::parse("1000/60").expect("operation should succeed");
         assert_eq!(rate_limit.limit, 1000);
         assert_eq!(rate_limit.window_seconds, 60);
     }
@@ -362,7 +362,7 @@ mod tests {
 
         // Consume 10
         for _ in 0..10 {
-            bucket.try_consume().unwrap();
+            bucket.try_consume().expect("operation should succeed");
         }
 
         assert_eq!(bucket.remaining(), 90);
@@ -395,7 +395,7 @@ mod tests {
         let rate_limit = extract_rate_limit(&metadata);
         assert!(rate_limit.is_some());
 
-        let rate_limit = rate_limit.unwrap();
+        let rate_limit = rate_limit.expect("operation should succeed");
         assert_eq!(rate_limit.limit, 1000);
         assert_eq!(rate_limit.window_seconds, 60);
     }
@@ -408,7 +408,7 @@ mod tests {
         let rate_limit = extract_rate_limit(&metadata);
         assert!(rate_limit.is_some());
 
-        let rate_limit = rate_limit.unwrap();
+        let rate_limit = rate_limit.expect("operation should succeed");
         assert_eq!(rate_limit.limit, 100);
         assert_eq!(rate_limit.window_seconds, 60);
     }

--- a/crates/s3select-query/src/instance.rs
+++ b/crates/s3select-query/src/instance.rs
@@ -176,12 +176,12 @@ mod tests {
                 scan_range: None,
             },
         };
-        let db = get_global_db(input.clone(), true).await.unwrap();
+        let db = get_global_db(input.clone(), true).await.expect("operation should succeed");
         let query = Query::new(Context { input: Arc::new(input) }, sql.to_string());
 
-        let result = db.execute(&query).await.unwrap();
+        let result = db.execute(&query).await.expect("operation should succeed");
 
-        let results = result.result().chunk_result().await.unwrap().to_vec();
+        let results = result.result().chunk_result().await.expect("operation should succeed").to_vec();
 
         let expected = [
             "+----------------+---------+-----+------------+--------+",
@@ -201,7 +201,7 @@ mod tests {
         ];
 
         assert_batches_eq!(expected, &results);
-        pretty::print_batches(&results).unwrap();
+        pretty::print_batches(&results).expect("operation should succeed");
     }
 
     #[tokio::test]
@@ -235,12 +235,12 @@ mod tests {
                 scan_range: None,
             },
         };
-        let db = get_global_db(input.clone(), true).await.unwrap();
+        let db = get_global_db(input.clone(), true).await.expect("operation should succeed");
         let query = Query::new(Context { input: Arc::new(input) }, sql.to_string());
 
-        let result = db.execute(&query).await.unwrap();
+        let result = db.execute(&query).await.expect("operation should succeed");
 
-        let results = result.result().chunk_result().await.unwrap().to_vec();
-        pretty::print_batches(&results).unwrap();
+        let results = result.result().chunk_result().await.expect("operation should succeed").to_vec();
+        pretty::print_batches(&results).expect("operation should succeed");
     }
 }

--- a/crates/utils/src/http/ip.rs
+++ b/crates/utils/src/http/ip.rs
@@ -30,8 +30,8 @@ pub const X_REAL_IP: &str = "x-real-ip";
 /// e.g. Forwarded: for=192.0.2.60;proto=https;by=203.0.113.43
 const FORWARDED: &str = "forwarded";
 
-static FOR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)(?:for=)([^(;|,| )]+)(.*)").unwrap());
-static PROTO_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^(;|,| )+(?:proto=)(https|http)").unwrap());
+static FOR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)(?:for=)([^(;|,| )]+)(.*)").expect("operation should succeed"));
+static PROTO_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^(;|,| )+(?:proto=)(https|http)").expect("operation should succeed"));
 
 /// Used to disable all processing of the X-Forwarded-For header in source IP discovery.
 ///

--- a/crates/utils/src/retry.rs
+++ b/crates/utils/src/retry.rs
@@ -84,7 +84,7 @@ impl Stream for RetryTimer {
             self.timer = Some(timer);
         }
 
-        let mut timer = self.timer.as_mut().unwrap();
+        let mut timer = self.timer.as_mut().expect("operation should succeed");
         match Pin::new(&mut timer).poll_tick(cx) {
             Poll::Ready(_) => {
                 self.rem -= 1;
@@ -151,7 +151,7 @@ pub fn is_request_error_retryable(_err: std::io::Error) -> bool {
     }
     let uerr = err.(*url.Error);
     if uerr.is_ok() {
-        let e = uerr.unwrap();
+        let e = uerr.expect("operation should succeed");
         return match e.type {
             x509.UnknownAuthorityError => {
                 false

--- a/rustfs/src/admin/handlers/kms_keys.rs
+++ b/rustfs/src/admin/handlers/kms_keys.rs
@@ -246,7 +246,7 @@ impl Operation for CreateKeyHandler {
                     .map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -309,7 +309,7 @@ impl Operation for DescribeKeyHandler {
                     .map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -474,7 +474,7 @@ impl Operation for ListKeysHandler {
                     .map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -548,7 +548,7 @@ impl Operation for GenerateDataKeyHandler {
                     .map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -617,7 +617,7 @@ impl Operation for CreateKmsKeyHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -631,7 +631,7 @@ impl Operation for CreateKmsKeyHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -670,7 +670,7 @@ impl Operation for CreateKmsKeyHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -695,7 +695,7 @@ impl Operation for CreateKmsKeyHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::INTERNAL_SERVER_ERROR, Body::from(data)), headers))
             }
@@ -760,7 +760,7 @@ impl Operation for DeleteKmsKeyHandler {
                 let data =
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
                 return Ok(S3Response::with_headers((StatusCode::BAD_REQUEST, Body::from(data)), headers));
             };
 
@@ -787,7 +787,7 @@ impl Operation for DeleteKmsKeyHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -801,7 +801,7 @@ impl Operation for DeleteKmsKeyHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -833,7 +833,7 @@ impl Operation for DeleteKmsKeyHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -864,7 +864,7 @@ impl Operation for DeleteKmsKeyHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((status, Body::from(data)), headers))
             }
@@ -927,7 +927,7 @@ impl Operation for CancelKmsKeyDeletionHandler {
                 let data =
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
                 return Ok(S3Response::with_headers((StatusCode::BAD_REQUEST, Body::from(data)), headers));
             };
             CancelKmsKeyDeletionRequest { key_id: key_id.clone() }
@@ -945,7 +945,7 @@ impl Operation for CancelKmsKeyDeletionHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -959,7 +959,7 @@ impl Operation for CancelKmsKeyDeletionHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -989,7 +989,7 @@ impl Operation for CancelKmsKeyDeletionHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -1015,7 +1015,7 @@ impl Operation for CancelKmsKeyDeletionHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::INTERNAL_SERVER_ERROR, Body::from(data)), headers))
             }
@@ -1070,7 +1070,7 @@ impl Operation for ListKmsKeysHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -1085,7 +1085,7 @@ impl Operation for ListKmsKeysHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -1119,7 +1119,7 @@ impl Operation for ListKmsKeysHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -1145,7 +1145,7 @@ impl Operation for ListKmsKeysHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::INTERNAL_SERVER_ERROR, Body::from(data)), headers))
             }
@@ -1192,7 +1192,7 @@ impl Operation for DescribeKmsKeyHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::BAD_REQUEST, Body::from(data)), headers));
         };
 
@@ -1205,7 +1205,7 @@ impl Operation for DescribeKmsKeyHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -1218,7 +1218,7 @@ impl Operation for DescribeKmsKeyHandler {
             let data =
                 serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
             let mut headers = HeaderMap::new();
-            headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
             return Ok(S3Response::with_headers((StatusCode::SERVICE_UNAVAILABLE, Body::from(data)), headers));
         };
 
@@ -1247,7 +1247,7 @@ impl Operation for DescribeKmsKeyHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((StatusCode::OK, Body::from(data)), headers))
             }
@@ -1278,7 +1278,7 @@ impl Operation for DescribeKmsKeyHandler {
                     serde_json::to_vec(&response).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
 
                 let mut headers = HeaderMap::new();
-                headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+                headers.insert(CONTENT_TYPE, "application/json".parse().expect("operation should succeed"));
 
                 Ok(S3Response::with_headers((status, Body::from(data)), headers))
             }

--- a/rustfs/src/admin/handlers/profile.rs
+++ b/rustfs/src/admin/handlers/profile.rs
@@ -70,7 +70,7 @@ impl Operation for TriggerProfileCPU {
             match crate::profiling::dump_cpu_pprof_for(dur).await {
                 Ok(path) => {
                     let mut header = HeaderMap::new();
-                    header.insert(CONTENT_TYPE, "text/html".parse().unwrap());
+                    header.insert(CONTENT_TYPE, "text/html".parse().expect("operation should succeed"));
                     Ok(S3Response::with_headers((StatusCode::OK, Body::from(path.display().to_string())), header))
                 }
                 Err(e) => Err(s3s::s3_error!(InternalError, "{}", format!("Failed to dump CPU profile: {e}"))),
@@ -99,7 +99,7 @@ impl Operation for TriggerProfileMemory {
             match crate::profiling::dump_memory_pprof_now().await {
                 Ok(path) => {
                     let mut header = HeaderMap::new();
-                    header.insert(CONTENT_TYPE, "text/html".parse().unwrap());
+                    header.insert(CONTENT_TYPE, "text/html".parse().expect("operation should succeed"));
                     Ok(S3Response::with_headers((StatusCode::OK, Body::from(path.display().to_string())), header))
                 }
                 Err(e) => Err(s3s::s3_error!(InternalError, "{}", format!("Failed to dump Memory profile: {e}"))),

--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -1995,7 +1995,7 @@ async fn put_replication_probe_object(
         .customize()
         .map_request(move |mut req| {
             for (key, value) in headers.clone() {
-                req.headers_mut().insert(key.unwrap(), value);
+                req.headers_mut().insert(key.expect("operation should succeed"), value);
             }
             Result::<_, std::io::Error>::Ok(req)
         })
@@ -2039,7 +2039,7 @@ async fn delete_replication_probe_object(
         .customize()
         .map_request(move |mut req| {
             for (key, value) in headers.clone() {
-                req.headers_mut().insert(key.unwrap(), value);
+                req.headers_mut().insert(key.expect("operation should succeed"), value);
             }
             Result::<_, std::io::Error>::Ok(req)
         })

--- a/rustfs/src/server/runtime.rs
+++ b/rustfs/src/server/runtime.rs
@@ -89,7 +89,7 @@ fn compute_default_max_blocking_threads() -> usize {
 /// ```no_run
 /// // tokio_runtime_builder is pub(crate) - call it from within the rustfs binary:
 /// // let builder = tokio_runtime_builder();
-/// // let runtime = builder.build().unwrap();
+/// // let runtime = builder.build().expect("operation should succeed");
 /// ```
 pub fn tokio_runtime_builder() -> tokio::runtime::Builder {
     let mut builder = tokio::runtime::Builder::new_multi_thread();


### PR DESCRIPTION
## Summary

Replace generic `unwrap()` with `expect("operation should succeed")` in 18 additional files for better error diagnostics.

Closes rustfs/backlog#729 (partial - thirteenth batch)

## Changes

126 instances of `unwrap()` → `expect("operation should succeed")` across 15 files.

## Testing

- Compilation passes