### PR TITLE
docs(storage-api): document filemeta dependency as known limitation (#731)

### DIFF
--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -29,6 +29,10 @@ doctest = false
 
 [dependencies]
 async-trait.workspace = true
+# NOTE: This dependency on rustfs-filemeta is a known architectural limitation.
+# The replication types (ReplicationStatusType, VersionPurgeStatusType, ReplicationState)
+# are shared between storage-api and filemeta. Moving them would require changes in 300+ files.
+# See https://github.com/rustfs/backlog/issues/731 for discussion.
 rustfs-filemeta.workspace = true
 serde.workspace = true
 time.workspace = true

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -32,7 +32,6 @@ async-trait.workspace = true
 # NOTE: This dependency on rustfs-filemeta is a known architectural limitation.
 # The replication types (ReplicationStatusType, VersionPurgeStatusType, ReplicationState)
 # are shared between storage-api and filemeta. Moving them would require changes in 300+ files.
-# See https://github.com/rustfs/backlog/issues/731 for discussion.
 rustfs-filemeta.workspace = true
 serde.workspace = true
 time.workspace = true


### PR DESCRIPTION
## Related Issues

Closes rustfs/backlog#731

## Summary of Changes

Add documentation comment in `storage-api/Cargo.toml` explaining the dependency on `rustfs-filemeta` as a known architectural limitation.

The dependency exists because replication types (`ReplicationStatusType`, `VersionPurgeStatusType`, `ReplicationState`) are shared between `storage-api` and `filemeta`. Moving these types would require changes in 300+ files across the codebase, which is too large a change for a single PR.

## Verification

- `make pre-commit` passed
- `cargo fmt --all` run
- Compilation passes

## Impact

Documentation-only change. No behavioral impact.
