### PR TITLE
test: add insta snapshot test for storage error display format (#740)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3836,6 +3847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5286,6 +5303,19 @@ checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding 0.4.2",
  "hybrid-array",
+]
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -9282,6 +9312,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "insta",
  "lazy_static",
  "libc",
  "md-5 0.11.0",
@@ -10909,6 +10940,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,6 +333,8 @@ mimalloc = "0.1"
 tikv-jemallocator = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 # Used to control and obtain statistics for jemalloc at runtime
 tikv-jemalloc-ctl = { version = "0.6", features = ["use_std", "stats", "profiling"] }
+# Snapshot testing for output format regression detection
+insta = { version = "1.41", features = ["yaml", "json"] }
 # Used to generate pprof-compatible memory profiling data and support symbolization and flame graphs
 jemalloc_pprof = { version = "0.8.2", features = ["symbolize", "flamegraph"] }
 # Used to generate CPU performance analysis data and flame diagrams

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -145,6 +145,7 @@ serial_test = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 proptest = "1"
 rcgen.workspace = true
+insta = { workspace = true }
 
 [build-dependencies]
 shadow-rs = { workspace = true, features = ["build", "metadata"] }

--- a/crates/ecstore/src/error/mod.rs
+++ b/crates/ecstore/src/error/mod.rs
@@ -1448,4 +1448,34 @@ mod tests {
             assert_eq!(original_error, recovered_error);
         }
     }
+
+    #[test]
+    fn test_storage_error_display_snapshot() {
+        // Snapshot test to detect unexpected changes in error display format
+        let errors = vec![
+            StorageError::BucketNotFound("test-bucket".to_string()),
+            StorageError::ObjectNotFound("bucket".to_string(), "object".to_string()),
+            StorageError::VersionNotFound("bucket".to_string(), "object".to_string(), "v1".to_string()),
+            StorageError::InvalidUploadID("bucket".to_string(), "object".to_string(), "upload123".to_string()),
+            StorageError::DiskFull,
+            StorageError::FaultyDisk,
+            StorageError::FileNotFound,
+            StorageError::VolumeNotFound,
+            StorageError::ErasureReadQuorum,
+            StorageError::ErasureWriteQuorum,
+            StorageError::DecommissionAlreadyRunning,
+            StorageError::RebalanceAlreadyRunning,
+            StorageError::OperationCanceled,
+            StorageError::NamespaceLockQuorumUnavailable {
+                mode: "write",
+                bucket: "bucket".into(),
+                object: "object".into(),
+                required: 3,
+                achieved: 2,
+            },
+        ];
+
+        let error_messages: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+        insta::assert_yaml_snapshot!("storage_error_display", error_messages);
+    }
 }

--- a/crates/ecstore/src/error/snapshots/rustfs_ecstore__error__tests__storage_error_display.snap
+++ b/crates/ecstore/src/error/snapshots/rustfs_ecstore__error__tests__storage_error_display.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ecstore/src/error/mod.rs
+expression: error_messages
+---
+- "Bucket not found: test-bucket"
+- "Object not found: bucket/object"
+- "Version not found: bucket/object-v1"
+- "Invalid upload id: bucket/object-upload123"
+- Disk full
+- Faulty disk
+- File not found
+- Volume not found
+- erasure read quorum
+- erasure write quorum
+- Decommission already running
+- Rebalance already running
+- Operation canceled
+- "Namespace lock quorum unavailable for write lock on bucket/object: required 3, achieved 2"


### PR DESCRIPTION
## Related Issues

Refs #740

## Summary of Changes

Add `insta` snapshot testing framework and a snapshot test for `StorageError` display format. This catches output format regressions that traditional assert tests might miss.

## Changes

- Add `insta` to workspace dependencies
- Add `insta` to ecstore dev-dependencies
- Add snapshot test for `StorageError` display format

## Verification

- `make pre-commit` passed
- `cargo fmt --all` run
- Snapshot test passes

## Impact

Test-only change. No behavioral impact on production code.
