### PR TITLE
docs: update security advisory lessons

### DIFF
--- a/.agents/skills/security-advisory-lessons/SKILL.md
+++ b/.agents/skills/security-advisory-lessons/SKILL.md
@@ -101,6 +101,7 @@ For the full pattern map, read [advisory-patterns.md](references/advisory-patter
 - Do not reflect arbitrary `Origin` while also allowing credentials. Default CORS should be no CORS unless explicitly configured.
 - Do not render user-controlled object content in a same-origin iframe with console credentials available to JavaScript.
 - Prefer origin separation for object preview/download, `nosniff`, CSP, strict content-type handling, and avoiding durable credentials in `localStorage`.
+- Preview safety must be based on trusted content type and sandboxing, not object names or extensions such as `.pdf`.
 - Console license/version-like metadata endpoints should expose only coarse public data unless authenticated, especially subject names and expiration timestamps.
 
 ### Profiling, debug, and health endpoints
@@ -129,4 +130,5 @@ Use these prompts while reviewing a diff:
 - Does this response contain stored replication, remote target, or service credentials that need redaction or stricter authorization?
 - Is an archive entry, object key, or policy resource normalized differently between authorization and storage?
 - Is the same operation implemented in multiple paths, such as `CopyObject` vs `UploadPartCopy`, and do all paths enforce the same security contract?
+- Does a preview or browser-surface fix preserve the original security invariant when adding alternate viewers or file-type detection?
 - Does the test prove the exploit form is denied, or only that the intended form still works?

--- a/.agents/skills/security-advisory-lessons/references/advisory-patterns.md
+++ b/.agents/skills/security-advisory-lessons/references/advisory-patterns.md
@@ -68,6 +68,7 @@ Update this file only when an advisory adds or changes a reusable lesson, affect
 ### Browser, CORS, and console isolation
 
 - `GHSA-v9fg-3cr2-277j`: object preview rendered attacker-controlled HTML in a same-origin iframe, exposing console credentials stored in `localStorage`. Lesson: user content must be origin-isolated from the console and protected with `nosniff`, CSP, and strict content-type handling.
+- `GHSA-7gcx-wg4x-q9x6`: an incomplete preview fix reintroduced extension-based PDF detection and bypassed the sandboxed fallback for attacker-controlled content. Lesson: browser-surface fixes need regression tests for alternate viewers and file-type branches, and preview trust must come from validated content type plus sandboxing rather than object names.
 - `GHSA-x5xv-223c-8vm7`: default CORS reflected arbitrary origins with credentials. Lesson: never combine reflected origins with `Access-Control-Allow-Credentials: true`; default should be fail-closed.
 
 ### Trusted proxy and source IP conditions


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add the new GHSA-7gcx-wg4x-q9x6 preview-modal incomplete-fix lesson to the RustFS security advisory skill.
- Capture the reusable review prompt that browser-surface fixes must preserve content-type and sandboxing invariants across alternate viewers.

## Verification
- `git diff --check -- .agents/skills/security-advisory-lessons`
- `rg -n "TODO|TBD|PLACEHOLDER|FIXME" .agents/skills/security-advisory-lessons`
- Frontmatter name check for `.agents/skills/security-advisory-lessons/SKILL.md`
- Live advisory coverage check: 31 live GHSA IDs, 31 skill GHSA IDs, 0 missing

Full Rust gates were not run because this is an agent-instruction Markdown-only update.

## Impact
Updates local security-review guidance only. No product code, runtime behavior, API, or configuration changes.

## Additional Notes
Fetched live advisories with `gh api repos/rustfs/rustfs/security-advisories --paginate` and compared advisory IDs, states, titles, affected surface, and reusable lessons.
