### PR TITLE
fix(ecstore): remove unused mirror fields

### DIFF
--- a/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
+++ b/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
@@ -2419,12 +2419,6 @@ async fn test_init_and_start_rebalance_rejects_second_start_after_gate() {
         decommission_cancelers: tokio::sync::RwLock::new(Vec::new()),
         start_gate: tokio::sync::Mutex::new(()),
         pool_meta_save_gate: tokio::sync::Mutex::new(()),
-        local_disk_map: crate::runtime::global::GLOBAL_LOCAL_DISK_MAP.clone(),
-        local_disk_id_map: crate::runtime::global::GLOBAL_LOCAL_DISK_ID_MAP.clone(),
-        local_disk_set_drives: crate::runtime::global::GLOBAL_LOCAL_DISK_SET_DRIVES.clone(),
-        tier_config_mgr: crate::services::tier::tier::TierConfigMgr::new(),
-        event_notifier: crate::services::event_notification::EventNotifier::new(),
-        bucket_monitor: std::sync::OnceLock::new(),
     });
 
     let err = store

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -317,13 +317,6 @@ impl ECStore {
             decommission_cancelers,
             start_gate: tokio::sync::Mutex::new(()),
             pool_meta_save_gate: tokio::sync::Mutex::new(()),
-
-            local_disk_map: runtime_sources::local_disk_map_handle(),
-            local_disk_id_map: runtime_sources::local_disk_id_map_handle(),
-            local_disk_set_drives: runtime_sources::local_disk_set_drives_handle(),
-            tier_config_mgr: runtime_sources::tier_config_mgr_handle(),
-            event_notifier: runtime_sources::event_notifier_handle(),
-            bucket_monitor: OnceLock::new(),
         });
 
         // Only set it when the global deployment ID is not yet configured
@@ -352,10 +345,6 @@ impl ECStore {
         }
 
         runtime_sources::publish_object_store(ec.clone()).await;
-
-        if let Some(monitor) = runtime_sources::bucket_monitor() {
-            let _ = ec.bucket_monitor.set(monitor);
-        }
 
         Ok(ec)
     }

--- a/crates/ecstore/src/store/mod.rs
+++ b/crates/ecstore/src/store/mod.rs
@@ -14,7 +14,6 @@
 
 #![allow(clippy::map_entry)]
 
-use crate::bucket::bandwidth::monitor::Monitor;
 use crate::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
 use crate::bucket::lifecycle::bucket_lifecycle_ops::{
     enqueue_immediate_expiry, enqueue_transition_immediate, init_background_expiry,
@@ -42,11 +41,9 @@ use crate::error::{
     StorageError, is_err_bucket_exists, is_err_bucket_not_found, is_err_invalid_upload_id, is_err_object_not_found,
     is_err_read_quorum, is_err_version_not_found, to_object_err,
 };
-use crate::runtime::global::{DISK_RESERVE_FRACTION, TypeLocalDiskSetDrives};
+use crate::runtime::global::DISK_RESERVE_FRACTION;
 use crate::runtime::sources as runtime_sources;
-use crate::services::event_notification::EventNotifier;
 use crate::services::rebalance::RebalanceMeta;
-use crate::services::tier::tier::TierConfigMgr;
 use crate::storage_api_contracts::{
     bucket::{BucketInfo, BucketOperations, BucketOptions, DeleteBucketOptions, MakeBucketOptions},
     list::{StorageListObjectVersionsInfo, StorageListObjectsV2Info, StorageObjectInfoOrErr, StorageWalkOptions},
@@ -75,11 +72,7 @@ use rustfs_utils::path::{decode_dir_object, encode_dir_object, path_join_buf};
 use s3s::dto::{BucketVersioningStatus, ObjectLockConfiguration, ObjectLockEnabled, VersioningConfiguration};
 use std::net::SocketAddr;
 use std::process::exit;
-use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use time::OffsetDateTime;
 use tokio::select;
 use tokio::sync::{Mutex, RwLock};
@@ -192,18 +185,6 @@ pub struct ECStore {
     /// The saver then clones the latest `pool_meta` under a short read lock and
     /// releases it before awaiting disk writes.
     pub(crate) pool_meta_save_gate: Mutex<()>,
-
-    // Phase 2 migration pending - do not use directly.
-    /// Local disk maps (migrated from GLOBAL_LOCAL_DISK_MAP/ID_MAP/SET_DRIVES)
-    pub(crate) local_disk_map: Arc<RwLock<HashMap<String, Option<DiskStore>>>>,
-    pub(crate) local_disk_id_map: Arc<RwLock<HashMap<Uuid, String>>>,
-    pub(crate) local_disk_set_drives: Arc<RwLock<TypeLocalDiskSetDrives>>,
-    /// Tier config manager (migrated from GLOBAL_TierConfigMgr)
-    pub(crate) tier_config_mgr: Arc<RwLock<TierConfigMgr>>,
-    /// Event notifier (migrated from GLOBAL_EventNotifier)
-    pub(crate) event_notifier: Arc<RwLock<EventNotifier>>,
-    /// Bucket monitor (migrated from GLOBAL_BUCKET_MONITOR)
-    pub(crate) bucket_monitor: OnceLock<Arc<Monitor>>,
 }
 
 impl std::fmt::Debug for ECStore {


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#730.

## Summary of Changes
- Remove unused `ECStore` mirror fields for local disk maps, local disk drive sets, tier config, event notifier, and bucket monitor.
- Keep global/runtime source ownership unchanged, including existing startup and fallback behavior.
- Update the rebalance unit-test store construction to match the smaller `ECStore` shape.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo check -p rustfs-ecstore --tests`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs-ecstore --lib test_init_and_start_rebalance_rejects_second_start_after_gate`
- `make pre-pr`

## Impact
Internal cleanup only. No user-facing, API, deployment, configuration, or documentation impact is expected.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
