### PR TITLE
build: pin rc crypto dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,19 +176,20 @@ serde_json = { version = "1.0.150", features = ["raw_value"] }
 serde_urlencoded = "0.7.1"
 
 # Cryptography and Security
-# NOTE: aes-gcm and chacha20poly1305 use RC versions because stable 0.11.0
-# has not been released yet. The previous stable versions (0.10.x) have
-# incompatible APIs. Monitor upstream for stable releases and upgrade promptly.
-aes-gcm = { version = "0.11.0-rc.4", features = ["rand_core"] }
-argon2 = { version = "0.6.0-rc.8" }
-blake2 = "0.11.0-rc.6"
-chacha20poly1305 = { version = "0.11.0-rc.3" }
+# NOTE: These direct cryptography dependencies use RC versions because the
+# matching stable releases are not available yet, while previous stable lines
+# have incompatible APIs. Keep them exact-pinned and monitor upstream for stable
+# releases.
+aes-gcm = { version = "=0.11.0-rc.4", features = ["rand_core"] }
+argon2 = { version = "=0.6.0-rc.8" }
+blake2 = "=0.11.0-rc.6"
+chacha20poly1305 = { version = "=0.11.0-rc.3" }
 crc-fast = "1.10.0"
 hmac = { version = "0.13.0" }
 jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"] }
 openidconnect = { version = "4.0", default-features = false }
 pbkdf2 = "0.13.0"
-rsa = { version = "0.10.0-rc.18" }
+rsa = { version = "=0.10.0-rc.18" }
 rustls = { version = "0.23.41", default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
 rustls-native-certs = "0.8"
 rustls-pki-types = "1.14.1"


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#732.

## Summary of Changes
- Exact-pin direct RC cryptography dependencies in the workspace manifest.
- Extend the existing RC-version comment to cover `aes-gcm`, `argon2`, `blake2`, `chacha20poly1305`, and `rsa`.
- Keep the current dependency lines and APIs unchanged while preventing semver drift to a newer prerelease.

## Verification
- `cargo metadata --no-deps --format-version 1`
- `cargo check -p rustfs-crypto --all-features`
- `cargo test -p rustfs-crypto --all-features`
- `cargo check -p rustfs-kms`
- `cargo test -p rustfs-kms`
- `cargo check -p rustfs-rio -p rustfs-rio-v2 -p rustfs-ecstore --tests`
- `cargo test -p rustfs --lib license`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_layer_dependencies.sh`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-pr`

## Impact
Dependency resolution now requires the reviewed RC versions exactly. No runtime, API, deployment, or configuration behavior is expected to change.

## Additional Notes
Stable releases for these dependency lines are not available yet or require incompatible API changes, so this keeps the current implementation stable until upstream stable releases can be adopted.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
