### PR TITLE
docs(ecstore): inventory lifecycle split blockers

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/README.md
+++ b/crates/ecstore/src/bucket/lifecycle/README.md
@@ -1,0 +1,51 @@
+# ECStore Lifecycle Split Inventory
+
+This directory still belongs to ECStore. It is not ready to become a standalone
+crate because lifecycle workers currently depend on ECStore runtime state,
+object IO, bucket metadata, replication scheduling, notification/audit sinks,
+and tier services.
+
+## Current Modules
+
+| Module | Current role | Split blocker |
+|---|---|---|
+| `core.rs` | Lifecycle rule model, action evaluation, object options, and transition/expiry decisions. | Uses ECStore object metadata types and compatibility DTO re-exports. |
+| `bucket_lifecycle_ops.rs` | Worker orchestration, expiry, transition, stale multipart cleanup, audit, replication delete scheduling, and queue state. | Depends on `ECStore`, `SetDisks`, runtime globals, bucket metadata/versioning/replication, disk internals, event notification, and tier services. |
+| `evaluator.rs` | Bucket lifecycle evaluation wrapper. | Reads object-lock and replication config from ECStore bucket modules. |
+| `rule.rs` | Lifecycle rule filter helpers. | Uses ECStore bucket tagging helpers. |
+| `tier_delete_journal.rs` | Remote tier delete journal persistence and recovery. | Depends on ECStore config storage, object IO contracts, metadata bucket paths, and `ECStore`. |
+| `tier_free_version_recovery.rs` | Free-version recovery queue and object restoration path. | Depends on `ECStore`, object metadata, storage-api contracts, and lifecycle queue callbacks. |
+| `tier_last_day_stats.rs` | Tier statistics helpers. | Pure data/stat logic, but still part of lifecycle worker reporting. |
+| `tier_sweeper.rs` | Remote tier deletion worker and transition cleanup. | Depends on runtime sources, `ECStore`, tier journal persistence, signer-error handling, and lifecycle object options. |
+| `bucket_lifecycle_audit.rs` | Lifecycle audit event source labels. | Must remain wired to lifecycle audit and notification sinks. |
+
+## Required Contracts
+
+| Contract | Responsibility | Current dependency to remove |
+|---|---|---|
+| `LifecycleObjectStore` | Object stat, delete, transition, restore, multipart cleanup, and version-aware metadata operations. | Direct `ECStore`, `SetDisks`, disk, and object API access in worker paths. |
+| `LifecycleMetadataStore` | Lifecycle, object-lock, replication, bucket versioning, and stale multipart metadata reads. | Direct bucket metadata, object-lock, versioning, and replication module imports. |
+| `LifecycleRuntime` | Expiry state, transition state, tier config, deployment ID, local node name, queue metrics, cancellation, and worker sizing. | Direct runtime source/global access and process environment reads inside worker code. |
+| `LifecycleReplicationSink` | Lifecycle-originated delete and version-purge replication scheduling. | Direct imports from bucket replication modules. |
+| `LifecycleAuditSink` | Lifecycle audit and notification event emission. | Direct event notification service calls and audit-side effects from worker code. |
+
+## Migration Rules
+
+1. Do not move `bucket/lifecycle` into a new crate while any worker imports
+   `crate::store::ECStore`, `crate::set_disk::SetDisks`, runtime globals, or
+   bucket replication internals directly.
+2. Extract pure contracts before runtime movement. The first code-bearing PR
+   should introduce one contract boundary and keep the old ECStore call path.
+3. Preserve lifecycle queue behavior, transition/expiry state, replication
+   delete scheduling, notification/audit events, scanner-visible metrics, and
+   stale multipart cleanup semantics.
+4. Keep `rustfs_ecstore::api::bucket::lifecycle` compatibility until scanner,
+   OBS, and test boundary files compile through replacement paths.
+5. Verify each code-bearing step with focused lifecycle tests before attempting
+   broad gates.
+
+## First Code-Bearing Step
+
+Start with `LifecycleRuntime` or `LifecycleAuditSink`. Both can be introduced
+as narrow internal contracts while keeping the current ECStore worker behavior
+unchanged. Do not start with a crate move.

--- a/docs/architecture/ecstore-module-split-plan.md
+++ b/docs/architecture/ecstore-module-split-plan.md
@@ -82,6 +82,9 @@ First safe PR:
   each dependency;
 - add no code movement and no behavior changes.
 
+The module-level inventory lives in
+`crates/ecstore/src/bucket/lifecycle/README.md`.
+
 Focused verification for the first code-bearing lifecycle PR:
 
 - `cargo test -p rustfs-ecstore lifecycle --lib`


### PR DESCRIPTION
## Related Issues

Related: rustfs/backlog#749
Epic: rustfs/backlog#728

## Summary of Changes

- Added `crates/ecstore/src/bucket/lifecycle/README.md` to document the current lifecycle module inventory, split blockers, required contracts, and first safe code-bearing step.
- Linked the lifecycle inventory from `docs/architecture/ecstore-module-split-plan.md`.
- Kept this as a documentation-only slice with no lifecycle crate movement or runtime behavior changes.

## Verification

- `./scripts/check_architecture_migration_rules.sh`
- `git diff --check`

## Impact

Documentation only. No runtime behavior, public API, deployment, or configuration changes.

## Additional Notes

This is the first safe slice for rustfs/backlog#749. The inventory records why lifecycle is not ready for a standalone crate and identifies the contracts needed before code movement.
