### PR TITLE
refactor(obs): use lifecycle runtime facades

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -122,8 +122,8 @@ pub mod global {
 
 pub mod runtime {
     pub use crate::runtime::sources::{
-        bucket_monitor, first_cluster_node_is_local, global_tier_config_mgr, local_disk_map_read, object_store_handle,
-        setup_is_erasure, setup_is_erasure_sd,
+        bucket_monitor, expiry_state_handle, first_cluster_node_is_local, global_tier_config_mgr, local_disk_map_read,
+        object_store_handle, setup_is_erasure, setup_is_erasure_sd, transition_state_handle,
     };
 }
 

--- a/crates/ecstore/src/runtime/sources.rs
+++ b/crates/ecstore/src/runtime/sources.rs
@@ -379,11 +379,11 @@ pub(crate) fn tier_config_mgr_handle() -> Arc<RwLock<TierConfigMgr>> {
     GLOBAL_TierConfigMgr.clone()
 }
 
-pub(crate) fn expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
+pub fn expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
     GLOBAL_ExpiryState.clone()
 }
 
-pub(crate) fn transition_state_handle() -> Arc<TransitionState> {
+pub fn transition_state_handle() -> Arc<TransitionState> {
     GLOBAL_TransitionState.clone()
 }
 

--- a/crates/obs/src/metrics/mod.rs
+++ b/crates/obs/src/metrics/mod.rs
@@ -31,8 +31,8 @@ pub use scheduler::{
     init_metrics_runtime, metrics_runtime_controller_snapshot, metrics_runtime_status_snapshot,
 };
 pub(crate) use storage_api::metrics::{
-    BucketOperations, BucketOptions, OBS_GLOBAL_EXPIRY_STATE, OBS_GLOBAL_REPLICATION_STATS, OBS_GLOBAL_TRANSITION_STATE,
-    ObsBucketBandwidthMonitor, ObsEcstoreResult, ObsReplicationStats, ObsStore, StorageAdminApi, obs_get_global_bucket_monitor,
-    obs_get_quota_config, obs_get_total_usable_capacity, obs_get_total_usable_capacity_free, obs_load_data_usage_from_backend,
-    obs_resolve_object_store_handle,
+    BucketOperations, BucketOptions, OBS_GLOBAL_REPLICATION_STATS, ObsBucketBandwidthMonitor, ObsEcstoreResult,
+    ObsReplicationStats, ObsStore, StorageAdminApi, obs_expiry_state_handle, obs_get_global_bucket_monitor, obs_get_quota_config,
+    obs_get_total_usable_capacity, obs_get_total_usable_capacity_free, obs_load_data_usage_from_backend,
+    obs_resolve_object_store_handle, obs_transition_state_handle,
 };

--- a/crates/obs/src/metrics/runtime_sources.rs
+++ b/crates/obs/src/metrics/runtime_sources.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::metrics::{
-    OBS_GLOBAL_EXPIRY_STATE, OBS_GLOBAL_REPLICATION_STATS, OBS_GLOBAL_TRANSITION_STATE, ObsBucketBandwidthMonitor,
-    ObsReplicationStats, obs_get_global_bucket_monitor,
+    OBS_GLOBAL_REPLICATION_STATS, ObsBucketBandwidthMonitor, ObsReplicationStats, obs_expiry_state_handle,
+    obs_get_global_bucket_monitor, obs_transition_state_handle,
 };
 use rustfs_iam::{get_global_iam_sys, oidc::oidc_plugin_authn_metrics_snapshot};
 use std::sync::Arc;
@@ -68,17 +68,18 @@ pub(crate) fn replication_stats_handle() -> Option<ObsReplicationStatsHandle> {
 }
 
 pub(crate) async fn ilm_runtime_snapshot() -> ObsIlmRuntimeSnapshot {
+    let expiry_state = obs_expiry_state_handle();
+    let transition_state = obs_transition_state_handle();
+
     ObsIlmRuntimeSnapshot {
-        expiry_pending_tasks: usize_to_u64_saturating(OBS_GLOBAL_EXPIRY_STATE.read().await.pending_tasks()),
-        transition_active_tasks: i64_to_u64_floor_zero(OBS_GLOBAL_TRANSITION_STATE.active_tasks()),
-        transition_pending_tasks: usize_to_u64_saturating(OBS_GLOBAL_TRANSITION_STATE.pending_tasks()),
-        transition_missed_immediate_tasks: i64_to_u64_floor_zero(OBS_GLOBAL_TRANSITION_STATE.missed_immediate_tasks()),
-        transition_queue_full_tasks: i64_to_u64_floor_zero(OBS_GLOBAL_TRANSITION_STATE.queue_full_tasks()),
-        transition_queue_send_timeout_tasks: i64_to_u64_floor_zero(OBS_GLOBAL_TRANSITION_STATE.queue_send_timeout_tasks()),
-        transition_compensation_scheduled_tasks: i64_to_u64_floor_zero(
-            OBS_GLOBAL_TRANSITION_STATE.compensation_scheduled_tasks(),
-        ),
-        transition_compensation_running_tasks: i64_to_u64_floor_zero(OBS_GLOBAL_TRANSITION_STATE.compensation_running_tasks()),
+        expiry_pending_tasks: usize_to_u64_saturating(expiry_state.read().await.pending_tasks()),
+        transition_active_tasks: i64_to_u64_floor_zero(transition_state.active_tasks()),
+        transition_pending_tasks: usize_to_u64_saturating(transition_state.pending_tasks()),
+        transition_missed_immediate_tasks: i64_to_u64_floor_zero(transition_state.missed_immediate_tasks()),
+        transition_queue_full_tasks: i64_to_u64_floor_zero(transition_state.queue_full_tasks()),
+        transition_queue_send_timeout_tasks: i64_to_u64_floor_zero(transition_state.queue_send_timeout_tasks()),
+        transition_compensation_scheduled_tasks: i64_to_u64_floor_zero(transition_state.compensation_scheduled_tasks()),
+        transition_compensation_running_tasks: i64_to_u64_floor_zero(transition_state.compensation_running_tasks()),
     }
 }
 

--- a/crates/obs/src/metrics/storage_api.rs
+++ b/crates/obs/src/metrics/storage_api.rs
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 pub(crate) use rustfs_ecstore::api::bucket::bandwidth::monitor::Monitor as ObsBucketBandwidthMonitor;
-pub(crate) use rustfs_ecstore::api::bucket::lifecycle::bucket_lifecycle_ops::{
-    GLOBAL_ExpiryState as OBS_GLOBAL_EXPIRY_STATE, GLOBAL_TransitionState as OBS_GLOBAL_TRANSITION_STATE,
-};
 pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::get_quota_config as obs_get_quota_config;
 pub(crate) use rustfs_ecstore::api::bucket::replication::{
     GLOBAL_REPLICATION_STATS as OBS_GLOBAL_REPLICATION_STATS, ReplicationStats as ObsReplicationStats,
@@ -27,7 +24,8 @@ pub(crate) use rustfs_ecstore::api::capacity::{
 pub(crate) use rustfs_ecstore::api::data_usage::load_data_usage_from_backend as obs_load_data_usage_from_backend;
 pub(crate) use rustfs_ecstore::api::error::Result as ObsEcstoreResult;
 pub(crate) use rustfs_ecstore::api::runtime::{
-    bucket_monitor as obs_get_global_bucket_monitor, object_store_handle as obs_resolve_object_store_handle,
+    bucket_monitor as obs_get_global_bucket_monitor, expiry_state_handle as obs_expiry_state_handle,
+    object_store_handle as obs_resolve_object_store_handle, transition_state_handle as obs_transition_state_handle,
 };
 pub(crate) use rustfs_ecstore::api::storage::ECStore as ObsStore;
 use rustfs_storage_api as storage_contracts;
@@ -36,9 +34,9 @@ pub(crate) mod metrics {
     pub(crate) use super::storage_contracts::{BucketOperations, BucketOptions, StorageAdminApi};
 
     pub(crate) use super::{
-        OBS_GLOBAL_EXPIRY_STATE, OBS_GLOBAL_REPLICATION_STATS, OBS_GLOBAL_TRANSITION_STATE, ObsBucketBandwidthMonitor,
-        ObsEcstoreResult, ObsReplicationStats, ObsStore, obs_get_global_bucket_monitor, obs_get_quota_config,
-        obs_get_total_usable_capacity, obs_get_total_usable_capacity_free, obs_load_data_usage_from_backend,
-        obs_resolve_object_store_handle,
+        OBS_GLOBAL_REPLICATION_STATS, ObsBucketBandwidthMonitor, ObsEcstoreResult, ObsReplicationStats, ObsStore,
+        obs_expiry_state_handle, obs_get_global_bucket_monitor, obs_get_quota_config, obs_get_total_usable_capacity,
+        obs_get_total_usable_capacity_free, obs_load_data_usage_from_backend, obs_resolve_object_store_handle,
+        obs_transition_state_handle,
     };
 }

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -845,7 +845,7 @@ mod tests {
         };
         let endpoint_pools = EndpointServerPools(vec![pool_endpoints]);
 
-        if let Some(store) = crate::storage::storage_api::ecstore_global::new_object_layer_fn() {
+        if let Some(store) = runtime_sources::object_store() {
             return (temp_dir, store, endpoint_pools);
         }
 

--- a/rustfs/src/app/context/runtime_sources.rs
+++ b/rustfs/src/app/context/runtime_sources.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(test)]
+use super::super::storage_api::context::ECStore;
 use super::super::storage_api::context::EndpointServerPools;
 use super::super::storage_api::context::bucket::metadata_sys::BucketMetadataSys;
 use super::super::storage_api::context::runtime::{
@@ -176,6 +178,11 @@ pub fn tier_config() -> Arc<RwLock<TierConfigMgr>> {
 
 pub fn expiry_state() -> Arc<RwLock<ExpiryState>> {
     get_global_expiry_state()
+}
+
+#[cfg(test)]
+pub fn object_store() -> Option<Arc<ECStore>> {
+    super::super::storage_api::context::runtime::new_object_layer_fn()
 }
 
 pub fn server_config() -> Option<Config> {

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -171,6 +171,11 @@ pub(crate) mod runtime {
         crate::storage::storage_api::get_global_expiry_state()
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_object_layer_fn() -> Option<Arc<crate::storage::storage_api::ECStore>> {
+        crate::storage::storage_api::ecstore_global::new_object_layer_fn()
+    }
+
     pub(crate) fn set_object_store_resolver(resolver: Arc<ObjectStoreResolver>) -> bool {
         crate::storage::storage_api::set_object_store_resolver(resolver)
     }


### PR DESCRIPTION
## Related Issues
rustfs/backlog#730

## Summary of Changes
- Expose lifecycle runtime state handles through `rustfs_ecstore::api::runtime`.
- Route OBS ILM metrics through the runtime facade instead of re-exporting lifecycle globals.
- Keep the AppContext test fallback object-store access behind the app runtime source boundary.

## Verification
- `cargo test -p rustfs-obs --lib -- --nocapture`
- `cargo test -p rustfs --lib app::context -- --nocapture`
- `cargo check -p rustfs-obs --lib`
- `cargo check -p rustfs --lib`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
No user-facing behavior change. This narrows internal global-state access boundaries for observability and AppContext test fallback code.

## Additional Notes
N/A
