### PR TITLE
test(ecstore): cover SetDisks storage contracts

### DIFF
--- a/crates/ecstore/tests/ecstore_contract_compat_test.rs
+++ b/crates/ecstore/tests/ecstore_contract_compat_test.rs
@@ -20,10 +20,10 @@ use rustfs_lock::NamespaceLockWrapper;
 use rustfs_madmin::heal_commands::HealResultItem;
 use storage_api::contract_compat::{
     CompletePart, DeletedObject, DiskStore, ECStore, Error, GetObjectReader, HTTPRangeSpec, ListMultipartsInfo, ListPartsInfo,
-    MultipartInfo, MultipartUploadResult, ObjectInfo, ObjectOptions, ObjectToDelete, PartInfo, PutObjReader, StorageAdminApi,
-    StorageHealOperations, StorageListObjectVersionsInfo, StorageListObjectsV2Info, StorageListOperations,
-    StorageMultipartOperations, StorageNamespaceLocking, StorageObjectIO, StorageObjectInfoOrErr, StorageObjectOperations,
-    StorageWalkOptions,
+    MultipartInfo, MultipartUploadResult, ObjectInfo, ObjectOptions, ObjectToDelete, PartInfo, PutObjReader, SetDisks,
+    StorageAdminApi, StorageBucketOperations, StorageHealOperations, StorageListObjectVersionsInfo, StorageListObjectsV2Info,
+    StorageListOperations, StorageMultipartOperations, StorageNamespaceLocking, StorageObjectIO, StorageObjectInfoOrErr,
+    StorageObjectOperations, StorageWalkOptions,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -62,6 +62,13 @@ where
             GetObjectReader = GetObjectReader,
             PutObjectReader = PutObjReader,
         >,
+{
+    std::any::type_name::<T>()
+}
+
+fn storage_bucket_operations_type_name<T>() -> &'static str
+where
+    T: StorageBucketOperations<Error = Error>,
 {
     std::any::type_name::<T>()
 }
@@ -136,6 +143,11 @@ fn ecstore_implements_storage_object_io_contract() {
 }
 
 #[test]
+fn ecstore_implements_storage_bucket_operations_contract() {
+    assert!(storage_bucket_operations_type_name::<ECStore>().ends_with("::ECStore"));
+}
+
+#[test]
 fn ecstore_implements_storage_object_operations_contract() {
     assert!(storage_object_operations_type_name::<ECStore>().ends_with("::ECStore"));
 }
@@ -153,4 +165,39 @@ fn ecstore_implements_storage_multipart_operations_contract() {
 #[test]
 fn ecstore_implements_storage_heal_operations_contract() {
     assert!(storage_heal_operations_type_name::<ECStore>().ends_with("::ECStore"));
+}
+
+#[test]
+fn set_disks_implements_storage_namespace_locking_contract() {
+    assert!(storage_namespace_locking_type_name::<SetDisks>().ends_with("::SetDisks"));
+}
+
+#[test]
+fn set_disks_implements_storage_object_io_contract() {
+    assert!(storage_object_io_type_name::<SetDisks>().ends_with("::SetDisks"));
+}
+
+#[test]
+fn set_disks_implements_storage_bucket_operations_contract() {
+    assert!(storage_bucket_operations_type_name::<SetDisks>().ends_with("::SetDisks"));
+}
+
+#[test]
+fn set_disks_implements_storage_object_operations_contract() {
+    assert!(storage_object_operations_type_name::<SetDisks>().ends_with("::SetDisks"));
+}
+
+#[test]
+fn set_disks_implements_storage_list_operations_contract() {
+    assert!(storage_list_operations_type_name::<SetDisks>().ends_with("::SetDisks"));
+}
+
+#[test]
+fn set_disks_implements_storage_multipart_operations_contract() {
+    assert!(storage_multipart_operations_type_name::<SetDisks>().ends_with("::SetDisks"));
+}
+
+#[test]
+fn set_disks_implements_storage_heal_operations_contract() {
+    assert!(storage_heal_operations_type_name::<SetDisks>().ends_with("::SetDisks"));
 }

--- a/crates/ecstore/tests/storage_api.rs
+++ b/crates/ecstore/tests/storage_api.rs
@@ -4,20 +4,20 @@ pub(crate) use rustfs_ecstore::api::bitrot::create_bitrot_reader;
 pub(crate) use rustfs_ecstore::api::disk::{DiskAPI, DiskOption, DiskStore, STORAGE_FORMAT_FILE, endpoint::Endpoint, new_disk};
 pub(crate) use rustfs_ecstore::api::erasure::Erasure;
 pub(crate) use rustfs_ecstore::api::object::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
-pub(crate) use rustfs_ecstore::api::{error::Error, storage::ECStore};
+pub(crate) use rustfs_ecstore::api::{error::Error, set_disk::SetDisks, storage::ECStore};
 use rustfs_storage_api as storage_contracts;
 
 pub(crate) mod contract_compat {
     pub(crate) use super::storage_contracts::{
-        CompletePart, DeletedObject, HTTPRangeSpec, HealOperations as StorageHealOperations, ListMultipartsInfo,
-        ListObjectVersionsInfo as StorageListObjectVersionsInfo, ListObjectsV2Info as StorageListObjectsV2Info,
-        ListOperations as StorageListOperations, ListPartsInfo, MultipartInfo, MultipartOperations as StorageMultipartOperations,
-        MultipartUploadResult, NamespaceLocking as StorageNamespaceLocking, ObjectIO as StorageObjectIO,
-        ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations as StorageObjectOperations, ObjectToDelete, PartInfo,
-        StorageAdminApi, WalkOptions as StorageWalkOptions,
+        BucketOperations as StorageBucketOperations, CompletePart, DeletedObject, HTTPRangeSpec,
+        HealOperations as StorageHealOperations, ListMultipartsInfo, ListObjectVersionsInfo as StorageListObjectVersionsInfo,
+        ListObjectsV2Info as StorageListObjectsV2Info, ListOperations as StorageListOperations, ListPartsInfo, MultipartInfo,
+        MultipartOperations as StorageMultipartOperations, MultipartUploadResult, NamespaceLocking as StorageNamespaceLocking,
+        ObjectIO as StorageObjectIO, ObjectInfoOrErr as StorageObjectInfoOrErr, ObjectOperations as StorageObjectOperations,
+        ObjectToDelete, PartInfo, StorageAdminApi, WalkOptions as StorageWalkOptions,
     };
 
-    pub(crate) use super::{DiskStore, ECStore, Error, GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
+    pub(crate) use super::{DiskStore, ECStore, Error, GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader, SetDisks};
 }
 
 pub(crate) mod legacy_bitrot_read {

--- a/docs/architecture/ecstore-api-facade-inventory.md
+++ b/docs/architecture/ecstore-api-facade-inventory.md
@@ -42,6 +42,10 @@ local boundary or storage-api contract first, then route consumers through it.
 | Replication | Bucket target and metadata systems, bucket target client config, disk, object API, runtime sources, notification, and SetDisks lock timing. | `ReplicationStorage`, `ReplicationMetadataStore`, `ReplicationRuntime`, `ReplicationEventSink`, and `ReplicationLifecycleBridge`. |
 | SetDisks | Shared disks, endpoints, format state, namespace locks, cache, and implementations for object IO, namespace locking, bucket, object, list, multipart, and heal operations. | Pure shard source, disk error, bitrot IO, namespace lock, metrics label, and file metadata contracts before any operation family moves. |
 
+`crates/ecstore/tests/ecstore_contract_compat_test.rs` keeps compile-time
+coverage for `ECStore` and `SetDisks` storage-api trait compatibility before
+any facade shrink or operation-family movement.
+
 ## Shrink Rules
 
 1. Do not remove a facade item until its downstream boundary has compile-time


### PR DESCRIPTION
## Related Issues
rustfs/backlog#734

## Summary of Changes
- Add compile-time contract coverage for `SetDisks` storage-api compatibility.
- Cover the bucket operations contract for both `ECStore` and `SetDisks`.
- Document the contract guard before future facade shrink or operation-family movement.

## Verification
- `cargo test -p rustfs-ecstore --test ecstore_contract_compat_test -- --nocapture`
- `cargo check -p rustfs-ecstore --tests`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
No runtime behavior changes. This strengthens compatibility coverage before future ECStore facade narrowing or SetDisks operation-family migration.

## Additional Notes
N/A
