### PR TITLE
refactor(ecstore): add lifecycle runtime boundary

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/README.md
+++ b/crates/ecstore/src/bucket/lifecycle/README.md
@@ -49,3 +49,6 @@ and tier services.
 Start with `LifecycleRuntime` or `LifecycleAuditSink`. Both can be introduced
 as narrow internal contracts while keeping the current ECStore worker behavior
 unchanged. Do not start with a crate move.
+
+Current first boundary: `runtime_boundary.rs` centralizes lifecycle access to
+runtime state while preserving the existing ECStore-backed implementations.

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::runtime_boundary as runtime_sources;
 use crate::bucket::lifecycle::bucket_lifecycle_audit::{LcAuditEvent, LcEventSrc};
 use crate::bucket::lifecycle::evaluator::Evaluator;
 use crate::bucket::lifecycle::lifecycle::{
@@ -33,7 +34,6 @@ use crate::error::Error;
 use crate::error::StorageError;
 use crate::error::{error_resp_to_object_err, is_err_object_not_found, is_err_version_not_found, is_network_or_host_down};
 use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions};
-use crate::runtime::sources as runtime_sources;
 use crate::services::event_notification::{EventArgs, send_event};
 use crate::services::tier::warm_backend::WarmBackendGetOpts;
 use crate::set_disk::{MAX_PARTS_COUNT, RUSTFS_MULTIPART_BUCKET_KEY, RUSTFS_MULTIPART_OBJECT_KEY, SetDisks};
@@ -2884,6 +2884,7 @@ mod tests {
         transitioned_cleanup_tuple,
     };
     use crate::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;
+    use crate::bucket::lifecycle::runtime_boundary as runtime_sources;
     use crate::bucket::lifecycle::tier_sweeper::Jentry;
     use crate::bucket::metadata::BUCKET_LIFECYCLE_CONFIG;
     use crate::bucket::metadata_sys;
@@ -2892,7 +2893,6 @@ mod tests {
     use crate::error::is_err_invalid_upload_id;
     use crate::layout::endpoints::{EndpointServerPools, Endpoints, PoolEndpoints};
     use crate::object_api::{ObjectInfo, ObjectOptions, PutObjReader};
-    use crate::runtime::sources as runtime_sources;
     use crate::set_disk::{RUSTFS_MULTIPART_BUCKET_KEY, RUSTFS_MULTIPART_OBJECT_KEY};
     use crate::storage_api_contracts::{
         bucket::{BucketOperations, BucketOptions, MakeBucketOptions},

--- a/crates/ecstore/src/bucket/lifecycle/mod.rs
+++ b/crates/ecstore/src/bucket/lifecycle/mod.rs
@@ -18,6 +18,7 @@ pub mod core;
 pub mod evaluator;
 pub use self::core as lifecycle;
 pub mod rule;
+mod runtime_boundary;
 pub mod tier_delete_journal;
 pub mod tier_free_version_recovery;
 pub mod tier_last_day_stats;

--- a/crates/ecstore/src/bucket/lifecycle/runtime_boundary.rs
+++ b/crates/ecstore/src/bucket/lifecycle/runtime_boundary.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use s3s::dto::BucketLifecycleConfiguration;
+use tokio::sync::RwLock;
+
+use crate::bucket::lifecycle::bucket_lifecycle_ops::{ExpiryState, TransitionState};
+use crate::runtime::sources;
+use crate::services::tier::tier::TierConfigMgr;
+use crate::store::ECStore;
+
+pub(crate) fn expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
+    sources::expiry_state_handle()
+}
+
+pub(crate) fn transition_state_handle() -> Arc<TransitionState> {
+    sources::transition_state_handle()
+}
+
+pub(crate) fn tier_config_mgr_handle() -> Arc<RwLock<TierConfigMgr>> {
+    sources::tier_config_mgr_handle()
+}
+
+pub(crate) fn object_store_handle() -> Option<Arc<ECStore>> {
+    sources::object_store_handle()
+}
+
+pub(crate) fn default_local_node_name() -> String {
+    sources::default_local_node_name()
+}
+
+pub(crate) fn deployment_id() -> Option<String> {
+    sources::deployment_id()
+}
+
+pub(crate) async fn bucket_lifecycle_config(bucket: &str) -> Option<BucketLifecycleConfiguration> {
+    sources::bucket_lifecycle_config(bucket).await
+}

--- a/crates/ecstore/src/bucket/lifecycle/tier_sweeper.rs
+++ b/crates/ecstore/src/bucket/lifecycle/tier_sweeper.rs
@@ -18,11 +18,11 @@
 #![allow(unused_must_use)]
 #![allow(clippy::all)]
 
+use super::runtime_boundary as runtime_sources;
 use crate::bucket::lifecycle::bucket_lifecycle_ops::ExpiryOp;
 use crate::bucket::lifecycle::lifecycle::{self, ObjectOpts};
 use crate::bucket::lifecycle::tier_delete_journal::persist_tier_delete_journal_entry;
 use crate::client::signer_error::error_chain_contains_signer_header_marker;
-use crate::runtime::sources as runtime_sources;
 use crate::storage_api_contracts::lifecycle::TransitionedObject;
 use crate::store::ECStore;
 use rustfs_utils::get_env_usize;


### PR DESCRIPTION
## Related Issues
rustfs/backlog#749

## Summary of Changes
- Add a lifecycle-local `runtime_boundary` module for runtime state access.
- Route lifecycle worker and tier sweeper runtime calls through that boundary.
- Document the new first boundary in the lifecycle split inventory.

## Verification
- `cargo test -p rustfs-ecstore lifecycle --lib -- --nocapture`
- `cargo check -p rustfs-ecstore --tests`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
No behavior change. Lifecycle still uses the existing ECStore-backed runtime state, but direct access is isolated behind an owner-local boundary for later crate split work.

## Additional Notes
N/A
