### PR TITLE
refactor(runtime): remove stale lifecycle global comment

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -2153,7 +2153,6 @@ pub async fn expire_transitioned_object(
     lc_event: &lifecycle::Event,
     _src: &LcEventSrc,
 ) -> Result<ObjectInfo, std::io::Error> {
-    //let traceFn = GLOBAL_LifecycleSys.trace(oi);
     let mut opts = ObjectOptions {
         versioned: BucketVersioningSys::prefix_enabled(&oi.bucket, &oi.name).await,
         version_suspended: BucketVersioningSys::prefix_suspended(&oi.bucket, &oi.name).await,


### PR DESCRIPTION
## Related Issues
rustfs/backlog#730

## Summary of Changes
- Remove a stale commented `GLOBAL_LifecycleSys` reference from lifecycle transition cleanup code.
- Keep lifecycle global references limited to the ECStore runtime-source boundary.

## Verification
- `cargo fmt --all --check`
- `rg -n --glob '*.rs' '\bGLOBAL_LifecycleSys\b' crates rustfs fuzz`
- `cargo check -p rustfs-ecstore --lib`
- `git diff --check`
- `make pre-commit`

## Impact
No behavior change. This only removes a dead comment that made global-state audits noisier.

## Additional Notes
N/A
