### PR TITLE
refactor(runtime): remove stale tier transport comments

### DIFF
--- a/crates/ecstore/src/services/tier/warm_backend_aliyun.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_aliyun.rs
@@ -68,7 +68,6 @@ impl WarmBackendAliyun {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,

--- a/crates/ecstore/src/services/tier/warm_backend_azure.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_azure.rs
@@ -68,7 +68,6 @@ impl WarmBackendAzure {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,

--- a/crates/ecstore/src/services/tier/warm_backend_huaweicloud.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_huaweicloud.rs
@@ -68,7 +68,6 @@ impl WarmBackendHuaweicloud {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,

--- a/crates/ecstore/src/services/tier/warm_backend_minio.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_minio.rs
@@ -68,7 +68,6 @@ impl WarmBackendMinIO {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             trailing_headers: true,
             region: conf.region.clone(),
             ..Default::default()

--- a/crates/ecstore/src/services/tier/warm_backend_r2.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_r2.rs
@@ -68,7 +68,6 @@ impl WarmBackendR2 {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             trailing_headers: true,
             region: conf.region.clone(),
             ..Default::default()

--- a/crates/ecstore/src/services/tier/warm_backend_rustfs.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_rustfs.rs
@@ -65,7 +65,6 @@ impl WarmBackendRustFS {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             trailing_headers: true,
             region: conf.region.clone(),
             ..Default::default()

--- a/crates/ecstore/src/services/tier/warm_backend_s3.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_s3.rs
@@ -93,7 +93,6 @@ impl WarmBackendS3 {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             region: conf.region.clone(),
             ..Default::default()
         };

--- a/crates/ecstore/src/services/tier/warm_backend_tencent.rs
+++ b/crates/ecstore/src/services/tier/warm_backend_tencent.rs
@@ -68,7 +68,6 @@ impl WarmBackendTencent {
         let opts = Options {
             creds,
             secure: u.scheme() == "https",
-            //transport: GLOBAL_RemoteTargetTransport,
             trailing_headers: true,
             region: conf.region.clone(),
             bucket_lookup: BucketLookupType::BucketLookupDNS,


### PR DESCRIPTION
## Related Issues
rustfs/backlog#730

## Summary of Changes
- Remove stale commented `GLOBAL_RemoteTargetTransport` references from tier warm backend option builders.
- Keep the active backend option construction unchanged.

## Verification
- `rg -n "GLOBAL_RemoteTargetTransport|transport:" crates/ecstore/src/services/tier`
- `cargo fmt --all --check`
- `cargo check -p rustfs-ecstore --lib`
- `git diff --check`
- `make pre-commit`

## Impact
No behavior change. This only removes dead comments from tier backend initialization code.

## Additional Notes
N/A
