### PR TITLE
refactor(runtime): remove stale lifecycle state comments

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -1140,7 +1140,6 @@ impl TransitionState {
             "Lifecycle worker configuration resolved"
         );
 
-        //let mut transition_state = GLOBAL_TransitionState.write().await;
         //self.objAPI = objAPI
         Self::update_workers(api, n).await;
     }
@@ -1364,7 +1363,6 @@ pub async fn init_background_expiry(api: Arc<ECStore>) {
         workers = get_env_usize("RUSTFS_DEFAULT_EXPIRY_WORKERS", 8);
     }
 
-    //let expiry_state = GLOBAL_ExpiryStSate.write().await;
     ExpiryState::resize_workers(workers, api.clone()).await;
     spawn_tier_free_version_recovery_once(api.clone());
     spawn_tier_delete_journal_recovery_once(api);


### PR DESCRIPTION
## Related Issues
rustfs/backlog#730

## Summary of Changes
- Remove stale commented lifecycle global-state references from lifecycle worker setup.
- Keep active lifecycle state access unchanged through the existing runtime-source helpers.

## Verification
- `rg -n "GLOBAL_TransitionState|GLOBAL_ExpiryStSate" crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs`
- `cargo fmt --all --check`
- `cargo check -p rustfs-ecstore --lib`
- `git diff --check`
- `make pre-commit`

## Impact
No behavior change. This only removes dead comments from lifecycle state setup code.

## Additional Notes
N/A
