### PR TITLE
refactor(runtime): guard endpoint port source

### DIFF
--- a/crates/ecstore/src/layout/endpoints.rs
+++ b/crates/ecstore/src/layout/endpoints.rs
@@ -17,7 +17,7 @@ use crate::{
         disks_layout::DisksLayout,
         endpoint::{Endpoint, EndpointType},
     },
-    runtime::global::global_rustfs_port,
+    runtime::sources as runtime_sources,
 };
 use rustfs_config::{DEFAULT_UNSAFE_BYPASS_DISK_CHECK, ENV_MINIO_CI, ENV_UNSAFE_BYPASS_DISK_CHECK};
 use rustfs_utils::{XHost, check_local_server_addr, get_host_ip, is_local_host};
@@ -811,7 +811,7 @@ impl EndpointServerPools {
                     continue;
                 }
                 let host = endpoint.host_port();
-                if endpoint.is_local && endpoint.url.port() == Some(global_rustfs_port()) && local.is_none() {
+                if endpoint.is_local && endpoint.url.port() == Some(runtime_sources::rustfs_port()) && local.is_none() {
                     local = Some(host.clone());
                 }
 

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -2482,10 +2482,10 @@ fi
 
 (
   cd "$ROOT_DIR"
-  rg -n --with-filename '\bGLOBAL_(REGION|RUSTFS_PORT)\b|\bglobalDeploymentIDPtr\b' \
+  rg -n --with-filename '\bGLOBAL_(REGION|RUSTFS_PORT)\b|\bglobalDeploymentIDPtr\b|\bruntime::global::global_rustfs_port\b' \
     crates rustfs fuzz \
     --glob '*.rs' |
-    rg -v '^(crates/common/src/globals|crates/ecstore/src/runtime/global)\.rs:' || true
+    rg -v '^(crates/common/src/globals|crates/ecstore/src/runtime/(global|sources))\.rs:' || true
 ) >"$GLOBAL_RUNTIME_SCALAR_BYPASS_HITS_FILE"
 
 if [[ -s "$GLOBAL_RUNTIME_SCALAR_BYPASS_HITS_FILE" ]]; then


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#730.

## Summary of Changes
- Route endpoint peer port matching through the ECStore runtime source helper.
- Extend the architecture migration guardrail to catch direct `runtime::global::global_rustfs_port` imports outside owner helpers.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo test -p rustfs-ecstore --lib layout::endpoints::test::test_create_server_endpoints`
- `make pre-commit`

## Impact
No user-facing behavior change. This keeps endpoint port reads behind the existing runtime source boundary.

## Additional Notes
N/A
