### PR TITLE
refactor(replication): add runtime boundary

### DIFF
--- a/crates/ecstore/src/bucket/replication/mod.rs
+++ b/crates/ecstore/src/bucket/replication/mod.rs
@@ -18,6 +18,7 @@ mod replication_pool;
 mod replication_resyncer;
 mod replication_state;
 mod rule;
+mod runtime_boundary;
 
 pub use config::*;
 pub use datatypes::*;

--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::runtime_boundary as runtime_sources;
 use crate::bucket::bucket_target_sys::BucketTargetSys;
 use crate::bucket::metadata_sys;
 use crate::bucket::replication::ResyncOpts;
@@ -28,7 +29,6 @@ use crate::config::com::{read_config, save_config};
 use crate::disk::BUCKET_META_PREFIX;
 use crate::error::Error as EcstoreError;
 use crate::object_api::{ObjectInfo, ObjectOptions};
-use crate::runtime::sources as runtime_sources;
 use crate::storage_api_contracts::object::DeletedObject;
 use crate::storage_api_contracts::object::EcstoreObjectIO;
 use lazy_static::lazy_static;

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::runtime_boundary as runtime_sources;
 use crate::bucket::bandwidth::reader::{BucketOptions, MonitorReaderOptions, MonitoredReader};
 use crate::bucket::bucket_target_sys::{
     AdvancedPutOptions, BucketTargetSys, PutObjectOptions, PutObjectPartOptions, RemoveObjectOptions, TargetClient,
@@ -28,7 +29,6 @@ use crate::config::com::save_config;
 use crate::disk::{BUCKET_META_PREFIX, RUSTFS_META_BUCKET};
 use crate::error::{Error, Result, is_err_object_not_found, is_err_version_not_found};
 use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
-use crate::runtime::sources as runtime_sources;
 use crate::services::event_notification::{EventArgs, send_event};
 use crate::set_disk::get_lock_acquire_timeout;
 use crate::storage_api_contracts::{

--- a/crates/ecstore/src/bucket/replication/replication_state.rs
+++ b/crates/ecstore/src/bucket/replication/replication_state.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::runtime_boundary as runtime_sources;
 use crate::error::Error;
-use crate::runtime::sources as runtime_sources;
 use rustfs_filemeta::{ReplicatedTargetInfo, ReplicationStatusType, ReplicationType};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};

--- a/crates/ecstore/src/bucket/replication/runtime_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/runtime_boundary.rs
@@ -1,0 +1,45 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::bucket::bandwidth::monitor::Monitor;
+use crate::bucket::replication::replication_pool::DynReplicationPool;
+use crate::bucket::replication::replication_state::ReplicationStats;
+use crate::runtime::sources;
+use crate::store::ECStore;
+
+pub(crate) fn object_store_handle() -> Option<Arc<ECStore>> {
+    sources::object_store_handle()
+}
+
+pub(crate) fn default_local_node_name() -> String {
+    sources::default_local_node_name()
+}
+
+pub(crate) fn replication_pool() -> Option<Arc<DynReplicationPool>> {
+    sources::replication_pool()
+}
+
+pub(crate) fn replication_stats() -> Option<Arc<ReplicationStats>> {
+    sources::replication_stats()
+}
+
+pub(crate) fn replication_runtime_initialized() -> bool {
+    sources::replication_runtime_initialized()
+}
+
+pub(crate) fn bucket_monitor() -> Option<Arc<Monitor>> {
+    sources::bucket_monitor()
+}

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -183,6 +183,7 @@ EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_test_ecstore_
 FUZZ_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/fuzz_ecstore_compat_bypass_hits.txt"
 EXTERNAL_ECSTORE_API_BOUNDARY_HITS_FILE="${TMP_DIR}/external_ecstore_api_boundary_hits.txt"
 REPLICATION_FACADE_BYPASS_HITS_FILE="${TMP_DIR}/replication_facade_bypass_hits.txt"
+REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/replication_runtime_source_bypass_hits.txt"
 GLOBAL_REPLICATION_STATE_BYPASS_HITS_FILE="${TMP_DIR}/global_replication_state_bypass_hits.txt"
 GLOBAL_BUCKET_MONITOR_BYPASS_HITS_FILE="${TMP_DIR}/global_bucket_monitor_bypass_hits.txt"
 GLOBAL_ENDPOINTS_BYPASS_HITS_FILE="${TMP_DIR}/global_endpoints_bypass_hits.txt"
@@ -2323,6 +2324,18 @@ fi
 
 if [[ -s "$REPLICATION_FACADE_BYPASS_HITS_FILE" ]]; then
   report_failure "replication facade imports must stay in local storage_api boundaries: $(paste -sd '; ' "$REPLICATION_FACADE_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::runtime::sources(\s+as\s+runtime_sources|::)' \
+    crates/ecstore/src/bucket/replication \
+    --glob '*.rs' |
+    rg -v '^crates/ecstore/src/bucket/replication/runtime_boundary\.rs:' || true
+) >"$REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE"
+
+if [[ -s "$REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
+  report_failure "replication runtime-source access must stay behind replication runtime boundary: $(paste -sd '; ' "$REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#750.

## Summary of Changes
- Add a replication-local runtime boundary for object-store, local-node, replication pool/stat, and bucket-monitor reads.
- Route replication pool/state/resyncer runtime lookups through that boundary.
- Add an architecture guardrail that blocks direct `crate::runtime::sources` imports from replication modules outside the boundary.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo check -p rustfs-ecstore --lib`
- `make pre-commit`

## Impact
No user-facing behavior change. Replication runtime-source access is now routed through a local boundary.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
