### PR TITLE
refactor(replication): add event sink boundary

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_event_sink.rs
+++ b/crates/ecstore/src/bucket/replication/replication_event_sink.rs
@@ -12,18 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod config;
-pub mod datatypes;
-mod replication_event_sink;
-mod replication_pool;
-mod replication_resyncer;
-mod replication_state;
-mod rule;
-mod runtime_boundary;
+pub(crate) use crate::services::event_notification::EventArgs;
 
-pub use config::*;
-pub use datatypes::*;
-pub use replication_pool::*;
-pub use replication_resyncer::*;
-pub use replication_state::{BucketStats, ReplicationStats};
-pub use rule::*;
+pub(crate) fn send_event(args: EventArgs) {
+    crate::services::event_notification::send_event(args);
+}

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::replication_event_sink::{EventArgs, send_event};
 use super::runtime_boundary as runtime_sources;
 use crate::bucket::bandwidth::reader::{BucketOptions, MonitorReaderOptions, MonitoredReader};
 use crate::bucket::bucket_target_sys::{
@@ -29,7 +30,6 @@ use crate::config::com::save_config;
 use crate::disk::{BUCKET_META_PREFIX, RUSTFS_META_BUCKET};
 use crate::error::{Error, Result, is_err_object_not_found, is_err_version_not_found};
 use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
-use crate::services::event_notification::{EventArgs, send_event};
 use crate::set_disk::get_lock_acquire_timeout;
 use crate::storage_api_contracts::{
     list::{ListOperations, StorageListObjectVersionsInfo, StorageListObjectsV2Info, StorageObjectInfoOrErr, StorageWalkOptions},

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -183,6 +183,7 @@ EXTERNAL_TEST_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/external_test_ecstore_
 FUZZ_ECSTORE_COMPAT_BYPASS_HITS_FILE="${TMP_DIR}/fuzz_ecstore_compat_bypass_hits.txt"
 EXTERNAL_ECSTORE_API_BOUNDARY_HITS_FILE="${TMP_DIR}/external_ecstore_api_boundary_hits.txt"
 REPLICATION_FACADE_BYPASS_HITS_FILE="${TMP_DIR}/replication_facade_bypass_hits.txt"
+REPLICATION_EVENT_SINK_BYPASS_HITS_FILE="${TMP_DIR}/replication_event_sink_bypass_hits.txt"
 REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/replication_runtime_source_bypass_hits.txt"
 GLOBAL_REPLICATION_STATE_BYPASS_HITS_FILE="${TMP_DIR}/global_replication_state_bypass_hits.txt"
 GLOBAL_BUCKET_MONITOR_BYPASS_HITS_FILE="${TMP_DIR}/global_bucket_monitor_bypass_hits.txt"
@@ -2336,6 +2337,18 @@ fi
 
 if [[ -s "$REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE" ]]; then
   report_failure "replication runtime-source access must stay behind replication runtime boundary: $(paste -sd '; ' "$REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::services::event_notification' \
+    crates/ecstore/src/bucket/replication \
+    --glob '*.rs' |
+    rg -v '^crates/ecstore/src/bucket/replication/replication_event_sink\.rs:' || true
+) >"$REPLICATION_EVENT_SINK_BYPASS_HITS_FILE"
+
+if [[ -s "$REPLICATION_EVENT_SINK_BYPASS_HITS_FILE" ]]; then
+  report_failure "replication event notification access must stay behind replication event sink: $(paste -sd '; ' "$REPLICATION_EVENT_SINK_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#750.

## Summary of Changes
- Add a replication-local event sink boundary for notification dispatch.
- Route replication resyncer event notification imports through that boundary without changing emitted event arguments.
- Add an architecture guardrail that blocks direct `event_notification` access from replication modules outside the sink.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo check -p rustfs-ecstore --lib`
- `make pre-commit`

## Impact
No user-facing behavior change. Replication event dispatch now has a local module boundary.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
