### PR TITLE
refactor(replication): add versioning boundary

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -15,6 +15,7 @@
 use super::replication_event_sink::{EventArgs, send_event};
 use super::replication_metadata_boundary as metadata_boundary;
 use super::replication_target_boundary as target_boundary;
+use super::replication_versioning_boundary as versioning_boundary;
 use super::runtime_boundary as runtime_sources;
 use crate::bucket::bandwidth::reader::{BucketOptions, MonitorReaderOptions, MonitoredReader};
 use crate::bucket::bucket_target_sys::{
@@ -25,7 +26,6 @@ use crate::bucket::replication::ResyncStatusType;
 use crate::bucket::replication::{ObjectOpts, ReplicationConfigurationExt as _};
 use crate::bucket::tagging::decode_tags_to_map;
 use crate::bucket::target::BucketTargets;
-use crate::bucket::versioning_sys::BucketVersioningSys;
 use crate::client::api_get_options::{AdvancedGetOptions, StatObjectOptions};
 use crate::config::com::save_config;
 use crate::disk::{BUCKET_META_PREFIX, RUSTFS_META_BUCKET};
@@ -1247,8 +1247,8 @@ pub async fn get_heal_replicate_object_info(oi: &ObjectInfo, rcfg: &ReplicationC
             },
             &oi,
             &ObjectOptions {
-                versioned: BucketVersioningSys::prefix_enabled(&oi.bucket, &oi.name).await,
-                version_suspended: BucketVersioningSys::prefix_suspended(&oi.bucket, &oi.name).await,
+                versioned: versioning_boundary::prefix_enabled(&oi.bucket, &oi.name).await,
+                version_suspended: versioning_boundary::prefix_suspended(&oi.bucket, &oi.name).await,
                 ..Default::default()
             },
             None,
@@ -1756,7 +1756,7 @@ pub async fn must_replicate(bucket: &str, object: &str, mopts: MustReplicateOpti
         return ReplicateDecision::default();
     }
 
-    if !BucketVersioningSys::prefix_enabled(bucket, object).await {
+    if !versioning_boundary::prefix_enabled(bucket, object).await {
         return ReplicateDecision::default();
     }
 
@@ -1892,8 +1892,8 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                 &dobj.delete_object.object_name,
                 &ObjectOptions {
                     version_id: Some(delete_marker_version_id.to_string()),
-                    versioned: BucketVersioningSys::prefix_enabled(&bucket, &dobj.delete_object.object_name).await,
-                    version_suspended: BucketVersioningSys::prefix_suspended(&bucket, &dobj.delete_object.object_name).await,
+                    versioned: versioning_boundary::prefix_enabled(&bucket, &dobj.delete_object.object_name).await,
+                    version_suspended: versioning_boundary::prefix_suspended(&bucket, &dobj.delete_object.object_name).await,
                     ..Default::default()
                 },
             )
@@ -2214,8 +2214,8 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
                 version_id: version_id.map(|v| v.to_string()),
                 mod_time: dobj.delete_object.delete_marker_mtime,
                 delete_replication: Some(drs),
-                versioned: BucketVersioningSys::prefix_enabled(&bucket, &dobj.delete_object.object_name).await,
-                version_suspended: BucketVersioningSys::prefix_suspended(&bucket, &dobj.delete_object.object_name).await,
+                versioned: versioning_boundary::prefix_enabled(&bucket, &dobj.delete_object.object_name).await,
+                version_suspended: versioning_boundary::prefix_suspended(&bucket, &dobj.delete_object.object_name).await,
                 ..Default::default()
             },
         )
@@ -2269,8 +2269,8 @@ async fn source_delete_marker_missing<S: EcstoreObjectOperations>(
             object_name,
             &ObjectOptions {
                 version_id: Some(delete_marker_version_id.to_string()),
-                versioned: BucketVersioningSys::prefix_enabled(bucket, object_name).await,
-                version_suspended: BucketVersioningSys::prefix_suspended(bucket, object_name).await,
+                versioned: versioning_boundary::prefix_enabled(bucket, object_name).await,
+                version_suspended: versioning_boundary::prefix_suspended(bucket, object_name).await,
                 ..Default::default()
             },
         )
@@ -3010,8 +3010,8 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
             return rinfo;
         }
 
-        let versioned = BucketVersioningSys::prefix_enabled(&bucket, &object).await;
-        let version_suspended = BucketVersioningSys::prefix_suspended(&bucket, &object).await;
+        let versioned = versioning_boundary::prefix_enabled(&bucket, &object).await;
+        let version_suspended = versioning_boundary::prefix_suspended(&bucket, &object).await;
 
         let obj_opts = ObjectOptions {
             version_id: self.version_id.map(|v| v.to_string()),
@@ -3297,8 +3297,8 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
             return rinfo;
         }
 
-        let versioned = BucketVersioningSys::prefix_enabled(&bucket, &object).await;
-        let version_suspended = BucketVersioningSys::prefix_suspended(&bucket, &object).await;
+        let versioned = versioning_boundary::prefix_enabled(&bucket, &object).await;
+        let version_suspended = versioning_boundary::prefix_suspended(&bucket, &object).await;
 
         let obj_opts = ObjectOptions {
             version_id: self.version_id.map(|v| v.to_string()),

--- a/crates/ecstore/src/bucket/replication/replication_versioning_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_versioning_boundary.rs
@@ -12,21 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod config;
-pub mod datatypes;
-mod replication_event_sink;
-mod replication_metadata_boundary;
-mod replication_pool;
-mod replication_resyncer;
-mod replication_state;
-mod replication_target_boundary;
-mod replication_versioning_boundary;
-mod rule;
-mod runtime_boundary;
+use crate::bucket::versioning_sys::BucketVersioningSys;
 
-pub use config::*;
-pub use datatypes::*;
-pub use replication_pool::*;
-pub use replication_resyncer::*;
-pub use replication_state::{BucketStats, ReplicationStats};
-pub use rule::*;
+pub(crate) async fn prefix_enabled(bucket: &str, prefix: &str) -> bool {
+    BucketVersioningSys::prefix_enabled(bucket, prefix).await
+}
+
+pub(crate) async fn prefix_suspended(bucket: &str, prefix: &str) -> bool {
+    BucketVersioningSys::prefix_suspended(bucket, prefix).await
+}

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -186,6 +186,7 @@ REPLICATION_FACADE_BYPASS_HITS_FILE="${TMP_DIR}/replication_facade_bypass_hits.t
 REPLICATION_EVENT_SINK_BYPASS_HITS_FILE="${TMP_DIR}/replication_event_sink_bypass_hits.txt"
 REPLICATION_METADATA_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_metadata_boundary_bypass_hits.txt"
 REPLICATION_TARGET_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_target_boundary_bypass_hits.txt"
+REPLICATION_VERSIONING_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_versioning_boundary_bypass_hits.txt"
 REPLICATION_RUNTIME_SOURCE_BYPASS_HITS_FILE="${TMP_DIR}/replication_runtime_source_bypass_hits.txt"
 GLOBAL_REPLICATION_STATE_BYPASS_HITS_FILE="${TMP_DIR}/global_replication_state_bypass_hits.txt"
 GLOBAL_BUCKET_MONITOR_BYPASS_HITS_FILE="${TMP_DIR}/global_bucket_monitor_bypass_hits.txt"
@@ -2375,6 +2376,18 @@ fi
 
 if [[ -s "$REPLICATION_METADATA_BOUNDARY_BYPASS_HITS_FILE" ]]; then
   report_failure "replication metadata access must stay behind replication metadata boundary: $(paste -sd '; ' "$REPLICATION_METADATA_BOUNDARY_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::bucket::versioning_sys|BucketVersioningSys::prefix_(enabled|suspended)' \
+    crates/ecstore/src/bucket/replication \
+    --glob '*.rs' |
+    rg -v '^crates/ecstore/src/bucket/replication/replication_versioning_boundary\.rs:' || true
+) >"$REPLICATION_VERSIONING_BOUNDARY_BYPASS_HITS_FILE"
+
+if [[ -s "$REPLICATION_VERSIONING_BOUNDARY_BYPASS_HITS_FILE" ]]; then
+  report_failure "replication versioning access must stay behind replication versioning boundary: $(paste -sd '; ' "$REPLICATION_VERSIONING_BOUNDARY_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#750.

## Summary of Changes
- Add a replication-local versioning boundary for prefix versioning checks.
- Route replication resyncer versioning lookups through that boundary without changing behavior.
- Add an architecture guardrail that blocks direct `BucketVersioningSys::prefix_*` access from replication modules outside the boundary.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo check -p rustfs-ecstore --lib`
- `make pre-commit`

## Impact
No user-facing behavior change. Replication versioning checks now have a local module boundary.

## Additional Notes
N/A

---

Thank you for contributing to RustFS! Please ensure your PR meets our contribution guidelines and includes appropriate tests.
