### PR TITLE
refactor(lifecycle): add config persistence boundary

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/README.md
+++ b/crates/ecstore/src/bucket/lifecycle/README.md
@@ -13,7 +13,7 @@ and tier services.
 | `bucket_lifecycle_ops.rs` | Worker orchestration, expiry, transition, stale multipart cleanup, audit, replication delete scheduling, and queue state. | Depends on `ECStore`, `SetDisks`, runtime globals, bucket metadata/versioning/replication, disk internals, event notification, and tier services. |
 | `evaluator.rs` | Bucket lifecycle evaluation wrapper. | Reads object-lock and replication config from ECStore bucket modules. |
 | `rule.rs` | Lifecycle rule filter helpers. | Uses ECStore bucket tagging helpers. |
-| `tier_delete_journal.rs` | Remote tier delete journal persistence and recovery. | Depends on ECStore config storage, object IO contracts, metadata bucket paths, and `ECStore`. |
+| `tier_delete_journal.rs` | Remote tier delete journal persistence and recovery. | Uses lifecycle-local config persistence boundary, object IO contracts, metadata bucket paths, and `ECStore`. |
 | `tier_free_version_recovery.rs` | Free-version recovery queue and object restoration path. | Depends on `ECStore`, object metadata, storage-api contracts, and lifecycle queue callbacks. |
 | `tier_last_day_stats.rs` | Tier statistics helpers. | Pure data/stat logic, but still part of lifecycle worker reporting. |
 | `tier_sweeper.rs` | Remote tier deletion worker and transition cleanup. | Depends on runtime sources, `ECStore`, tier journal persistence, signer-error handling, and lifecycle object options. |
@@ -26,6 +26,7 @@ and tier services.
 | `LifecycleObjectStore` | Object stat, delete, transition, restore, multipart cleanup, and version-aware metadata operations. | Direct `ECStore`, `SetDisks`, disk, and object API access in worker paths. |
 | `LifecycleMetadataStore` | Lifecycle, object-lock, replication, bucket versioning, and stale multipart metadata reads. | Direct bucket metadata, object-lock, versioning, and replication module imports. |
 | `LifecycleRuntime` | Expiry state, transition state, tier config, deployment ID, local node name, queue metrics, cancellation, and worker sizing. | Direct runtime source/global access and process environment reads inside worker code. |
+| `LifecycleConfigStore` | Persist, read, and remove lifecycle-owned journal/config objects. | Direct ECStore config persistence helper imports from worker paths. |
 | `LifecycleReplicationSink` | Lifecycle-originated delete and version-purge replication scheduling. | Direct imports from bucket replication modules. |
 | `LifecycleAuditSink` | Lifecycle audit and notification event emission. | Direct event notification service calls and audit-side effects from worker code. |
 
@@ -52,3 +53,5 @@ unchanged. Do not start with a crate move.
 
 Current first boundary: `runtime_boundary.rs` centralizes lifecycle access to
 runtime state while preserving the existing ECStore-backed implementations.
+`config_boundary.rs` centralizes lifecycle-owned config object persistence for
+tier delete journal recovery while preserving the existing ECStore config store.

--- a/crates/ecstore/src/bucket/lifecycle/config_boundary.rs
+++ b/crates/ecstore/src/bucket/lifecycle/config_boundary.rs
@@ -1,0 +1,70 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use http::HeaderMap;
+use rustfs_filemeta::FileInfo;
+
+use crate::config::com;
+use crate::error::{Error, Result};
+use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
+use crate::storage_api_contracts::{
+    object::{DeletedObject, ObjectIO, ObjectOperations, ObjectToDelete},
+    range::HTTPRangeSpec,
+};
+
+pub(crate) async fn read_config<S>(api: Arc<S>, file: &str) -> Result<Vec<u8>>
+where
+    S: ObjectIO<
+            Error = Error,
+            RangeSpec = HTTPRangeSpec,
+            HeaderMap = HeaderMap,
+            ObjectOptions = ObjectOptions,
+            ObjectInfo = ObjectInfo,
+            GetObjectReader = GetObjectReader,
+            PutObjectReader = PutObjReader,
+        >,
+{
+    com::read_config(api, file).await
+}
+
+pub(crate) async fn save_config<S>(api: Arc<S>, file: &str, data: Vec<u8>) -> Result<()>
+where
+    S: ObjectIO<
+            Error = Error,
+            RangeSpec = HTTPRangeSpec,
+            HeaderMap = HeaderMap,
+            ObjectOptions = ObjectOptions,
+            ObjectInfo = ObjectInfo,
+            GetObjectReader = GetObjectReader,
+            PutObjectReader = PutObjReader,
+        >,
+{
+    com::save_config(api, file, data).await
+}
+
+pub(crate) async fn delete_config<S>(api: Arc<S>, file: &str) -> Result<()>
+where
+    S: ObjectOperations<
+            Error = Error,
+            ObjectInfo = ObjectInfo,
+            ObjectOptions = ObjectOptions,
+            FileInfo = FileInfo,
+            ObjectToDelete = ObjectToDelete,
+            DeletedObject = DeletedObject,
+        >,
+{
+    com::delete_config(api, file).await
+}

--- a/crates/ecstore/src/bucket/lifecycle/mod.rs
+++ b/crates/ecstore/src/bucket/lifecycle/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod bucket_lifecycle_audit;
 pub mod bucket_lifecycle_ops;
+mod config_boundary;
 pub mod core;
 pub mod evaluator;
 pub use self::core as lifecycle;

--- a/crates/ecstore/src/bucket/lifecycle/tier_delete_journal.rs
+++ b/crates/ecstore/src/bucket/lifecycle/tier_delete_journal.rs
@@ -19,8 +19,8 @@ use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
+use crate::bucket::lifecycle::config_boundary;
 use crate::bucket::lifecycle::tier_sweeper::{Jentry, delete_object_from_remote_tier_idempotent};
-use crate::config::com::{delete_config, read_config, save_config};
 use crate::disk::RUSTFS_META_BUCKET;
 use crate::error::{Error, Result};
 use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
@@ -120,7 +120,7 @@ where
         >,
 {
     let data = encode_tier_delete_journal_entry(je).map_err(std::io::Error::other)?;
-    save_config(api, &tier_delete_journal_object_name(je), data)
+    config_boundary::save_config(api, &tier_delete_journal_object_name(je), data)
         .await
         .map_err(std::io::Error::other)
 }
@@ -136,7 +136,7 @@ where
             DeletedObject = DeletedObject,
         >,
 {
-    match delete_config(api, &tier_delete_journal_object_name(je)).await {
+    match config_boundary::delete_config(api, &tier_delete_journal_object_name(je)).await {
         Ok(()) | Err(Error::ConfigNotFound) => Ok(()),
         Err(err) => Err(std::io::Error::other(err)),
     }
@@ -180,7 +180,7 @@ pub async fn recover_tier_delete_journal_entries(
 
     for object in list.objects {
         stats.scanned += 1;
-        let data = match read_config(api.clone(), &object.name).await {
+        let data = match config_boundary::read_config(api.clone(), &object.name).await {
             Ok(data) => data,
             Err(Error::ConfigNotFound) => continue,
             Err(err) => {

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -123,6 +123,7 @@ STORE_API_DELETE_DTO_INTERNAL_HITS_FILE="${TMP_DIR}/store_api_delete_dto_interna
 STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_definition_hits.txt"
 STORE_API_LIFECYCLE_HELPER_OLD_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_old_consumer_hits.txt"
 LIFECYCLE_AUDIT_SINK_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_audit_sink_bypass_hits.txt"
+LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_config_boundary_bypass_hits.txt"
 STORE_API_EXTERNAL_LIST_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_list_consumer_hits.txt"
 STORE_API_EXTERNAL_OPERATION_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_operation_consumer_hits.txt"
 STORE_API_OBJECT_OPERATION_LOCAL_METHOD_HITS_FILE="${TMP_DIR}/store_api_object_operation_local_method_hits.txt"
@@ -795,6 +796,18 @@ fi
 
 if [[ -s "$LIFECYCLE_AUDIT_SINK_BYPASS_HITS_FILE" ]]; then
   report_failure "lifecycle audit/event emission must stay behind bucket_lifecycle_audit sink: $(paste -sd '; ' "$LIFECYCLE_AUDIT_SINK_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::config::com::|use crate::config::com' \
+    crates/ecstore/src/bucket/lifecycle \
+    --glob '*.rs' |
+    rg -v '^crates/ecstore/src/bucket/lifecycle/config_boundary\.rs:' || true
+) >"$LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE"
+
+if [[ -s "$LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE" ]]; then
+  report_failure "lifecycle config persistence access must stay behind lifecycle config_boundary: $(paste -sd '; ' "$LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#749

## Summary of Changes
- Add a lifecycle-local `config_boundary` for tier delete journal config persistence.
- Route tier delete journal read/save/delete calls through the new boundary without changing journal behavior.
- Add an architecture guardrail that blocks lifecycle worker paths from reintroducing direct `crate::config::com` imports.
- Update the lifecycle split inventory with the config-store boundary.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `rg -n 'crate::config::com::|use crate::config::com' crates/ecstore/src/bucket/lifecycle --glob '*.rs'`
- `cargo test -p rustfs-ecstore tier_delete_journal --lib`
- `cargo check -p rustfs-ecstore --lib`
- `make pre-commit`

## Impact
No user-facing behavior change. Tier delete journal persistence keeps the same ECStore config-store implementation behind a lifecycle-local boundary.

## Additional Notes
`make pre-commit` passes. The logging guardrail still prints existing missing `crates/ecstore/src/tier/tier.rs` warnings before completing successfully.
