### PR TITLE
refactor(lifecycle): add tagging boundary

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/README.md
+++ b/crates/ecstore/src/bucket/lifecycle/README.md
@@ -12,7 +12,7 @@ and tier services.
 | `core.rs` | Lifecycle rule model, action evaluation, object options, and transition/expiry decisions. | Uses ECStore object metadata types and compatibility DTO re-exports. |
 | `bucket_lifecycle_ops.rs` | Worker orchestration, expiry, transition, stale multipart cleanup, audit, replication delete scheduling, and queue state. | Depends on `ECStore`, `SetDisks`, runtime globals, bucket metadata/versioning/replication, disk internals, event notification, and tier services. |
 | `evaluator.rs` | Bucket lifecycle evaluation wrapper. | Reads object-lock and replication config from ECStore bucket modules. |
-| `rule.rs` | Lifecycle rule filter helpers. | Uses ECStore bucket tagging helpers. |
+| `rule.rs` | Lifecycle rule filter helpers. | Uses lifecycle-local tagging boundary. |
 | `tier_delete_journal.rs` | Remote tier delete journal persistence and recovery. | Uses lifecycle-local config persistence boundary, object IO contracts, metadata bucket paths, and `ECStore`. |
 | `tier_free_version_recovery.rs` | Free-version recovery queue and object restoration path. | Depends on `ECStore`, object metadata, storage-api contracts, and lifecycle queue callbacks. |
 | `tier_last_day_stats.rs` | Tier statistics helpers. | Pure data/stat logic, but still part of lifecycle worker reporting. |
@@ -27,6 +27,7 @@ and tier services.
 | `LifecycleMetadataStore` | Lifecycle, object-lock, replication, bucket versioning, and stale multipart metadata reads. | Direct bucket metadata, object-lock, versioning, and replication module imports. |
 | `LifecycleRuntime` | Expiry state, transition state, tier config, deployment ID, local node name, queue metrics, cancellation, and worker sizing. | Direct runtime source/global access and process environment reads inside worker code. |
 | `LifecycleConfigStore` | Persist, read, and remove lifecycle-owned journal/config objects. | Direct ECStore config persistence helper imports from worker paths. |
+| `LifecycleTagFilter` | Decode object tag strings for lifecycle rule matching. | Direct bucket tagging helper imports from lifecycle rule paths. |
 | `LifecycleReplicationSink` | Lifecycle-originated delete and version-purge replication scheduling. | Direct imports from bucket replication modules. |
 | `LifecycleAuditSink` | Lifecycle audit and notification event emission. | Direct event notification service calls and audit-side effects from worker code. |
 

--- a/crates/ecstore/src/bucket/lifecycle/rule.rs
+++ b/crates/ecstore/src/bucket/lifecycle/rule.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::bucket::tagging::decode_tags_to_map;
+use super::tagging_boundary;
 use s3s::dto::{LifecycleRuleAndOperator, LifecycleRuleFilter, Tag, Transition};
 
 const _ERR_TRANSITION_INVALID_DAYS: &str = "Days must be 0 or greater when used with Transition";
@@ -31,7 +31,7 @@ impl Filter for LifecycleRuleFilter {
             return true;
         }
 
-        let user_tags = decode_tags_to_map(user_tags);
+        let user_tags = tagging_boundary::decode_tags_to_map(user_tags);
 
         self.tag.as_ref().is_none_or(|tag| tag_matches(tag, &user_tags))
             && self.and.as_ref().is_none_or(|and| and_tags_match(and, &user_tags))

--- a/crates/ecstore/src/bucket/lifecycle/tagging_boundary.rs
+++ b/crates/ecstore/src/bucket/lifecycle/tagging_boundary.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod bucket_lifecycle_audit;
-pub mod bucket_lifecycle_ops;
-mod config_boundary;
-pub mod core;
-pub mod evaluator;
-pub use self::core as lifecycle;
-pub mod rule;
-mod runtime_boundary;
-mod tagging_boundary;
-pub mod tier_delete_journal;
-pub mod tier_free_version_recovery;
-pub mod tier_last_day_stats;
-pub mod tier_sweeper;
+use std::collections::HashMap;
+
+pub(crate) fn decode_tags_to_map(tags: &str) -> HashMap<String, String> {
+    crate::bucket::tagging::decode_tags_to_map(tags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_tags_to_map;
+
+    #[test]
+    fn decode_tags_to_map_preserves_bucket_tagging_parser_behavior() {
+        let tags = decode_tags_to_map("env=prod&encoded=a%2Fb&=ignored");
+
+        assert_eq!(tags.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(tags.get("encoded").map(String::as_str), Some("a/b"));
+        assert!(!tags.contains_key(""));
+    }
+}

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -124,6 +124,7 @@ STORE_API_LIFECYCLE_HELPER_DEFINITION_HITS_FILE="${TMP_DIR}/store_api_lifecycle_
 STORE_API_LIFECYCLE_HELPER_OLD_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_lifecycle_helper_old_consumer_hits.txt"
 LIFECYCLE_AUDIT_SINK_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_audit_sink_bypass_hits.txt"
 LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_config_boundary_bypass_hits.txt"
+LIFECYCLE_TAGGING_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_tagging_boundary_bypass_hits.txt"
 STORE_API_EXTERNAL_LIST_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_list_consumer_hits.txt"
 STORE_API_EXTERNAL_OPERATION_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_operation_consumer_hits.txt"
 STORE_API_OBJECT_OPERATION_LOCAL_METHOD_HITS_FILE="${TMP_DIR}/store_api_object_operation_local_method_hits.txt"
@@ -811,6 +812,18 @@ fi
 
 if [[ -s "$LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE" ]]; then
   report_failure "lifecycle config persistence access must stay behind lifecycle config_boundary: $(paste -sd '; ' "$LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::bucket::tagging::decode_tags_to_map|use crate::bucket::tagging' \
+    crates/ecstore/src/bucket/lifecycle \
+    --glob '*.rs' |
+    rg -v '^crates/ecstore/src/bucket/lifecycle/tagging_boundary\.rs:' || true
+) >"$LIFECYCLE_TAGGING_BOUNDARY_BYPASS_HITS_FILE"
+
+if [[ -s "$LIFECYCLE_TAGGING_BOUNDARY_BYPASS_HITS_FILE" ]]; then
+  report_failure "lifecycle tag decoding must stay behind lifecycle tagging_boundary: $(paste -sd '; ' "$LIFECYCLE_TAGGING_BOUNDARY_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#749

## Summary of Changes

- Add a lifecycle-local tagging boundary for lifecycle rule tag matching.
- Route lifecycle rule tag decoding through the boundary.
- Add a guardrail against direct bucket tagging imports from lifecycle code.
- Update the lifecycle split inventory.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `rg -n --with-filename 'crate::bucket::tagging::decode_tags_to_map|use crate::bucket::tagging' crates/ecstore/src/bucket/lifecycle --glob '*.rs' | rg -v '^crates/ecstore/src/bucket/lifecycle/tagging_boundary\.rs:'`
- `cargo test -p rustfs-ecstore decode_tags_to_map_preserves_bucket_tagging_parser_behavior --lib`
- `cargo test -p rustfs-ecstore lifecycle_rule_filter --lib`
- `cargo check -p rustfs-ecstore --lib`
- `make pre-commit`

## Impact

No user-facing behavior change.

## Additional Notes

`make pre-commit` passes; the logging guardrail still prints the existing missing `crates/ecstore/src/tier/tier.rs` scan warnings.
