### PR TITLE
refactor(lifecycle): add replication sink boundary

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/README.md
+++ b/crates/ecstore/src/bucket/lifecycle/README.md
@@ -10,8 +10,8 @@ and tier services.
 | Module | Current role | Split blocker |
 |---|---|---|
 | `core.rs` | Lifecycle rule model, action evaluation, object options, and transition/expiry decisions. | Uses ECStore object metadata types and compatibility DTO re-exports. |
-| `bucket_lifecycle_ops.rs` | Worker orchestration, expiry, transition, stale multipart cleanup, audit, replication delete scheduling, and queue state. | Depends on `ECStore`, `SetDisks`, runtime globals, bucket metadata/versioning/replication, disk internals, event notification, and tier services. |
-| `evaluator.rs` | Bucket lifecycle evaluation wrapper. | Reads object-lock and replication config from ECStore bucket modules. |
+| `bucket_lifecycle_ops.rs` | Worker orchestration, expiry, transition, stale multipart cleanup, audit, replication delete scheduling, and queue state. | Depends on `ECStore`, `SetDisks`, runtime globals, bucket metadata/versioning, disk internals, event notification, tier services, and lifecycle-local replication sink. |
+| `evaluator.rs` | Bucket lifecycle evaluation wrapper. | Reads object-lock config from ECStore bucket modules and replication state through lifecycle-local replication sink. |
 | `rule.rs` | Lifecycle rule filter helpers. | Uses lifecycle-local tagging boundary. |
 | `tier_delete_journal.rs` | Remote tier delete journal persistence and recovery. | Uses lifecycle-local config persistence boundary, object IO contracts, metadata bucket paths, and `ECStore`. |
 | `tier_free_version_recovery.rs` | Free-version recovery queue and object restoration path. | Depends on `ECStore`, object metadata, storage-api contracts, and lifecycle queue callbacks. |
@@ -28,7 +28,7 @@ and tier services.
 | `LifecycleRuntime` | Expiry state, transition state, tier config, deployment ID, local node name, queue metrics, cancellation, and worker sizing. | Direct runtime source/global access and process environment reads inside worker code. |
 | `LifecycleConfigStore` | Persist, read, and remove lifecycle-owned journal/config objects. | Direct ECStore config persistence helper imports from worker paths. |
 | `LifecycleTagFilter` | Decode object tag strings for lifecycle rule matching. | Direct bucket tagging helper imports from lifecycle rule paths. |
-| `LifecycleReplicationSink` | Lifecycle-originated delete and version-purge replication scheduling. | Direct imports from bucket replication modules. |
+| `LifecycleReplicationSink` | Lifecycle-originated delete and version-purge replication scheduling. | Boundary is local, but still backed by ECStore bucket replication internals. |
 | `LifecycleAuditSink` | Lifecycle audit and notification event emission. | Direct event notification service calls and audit-side effects from worker code. |
 
 ## Migration Rules
@@ -56,3 +56,6 @@ Current first boundary: `runtime_boundary.rs` centralizes lifecycle access to
 runtime state while preserving the existing ECStore-backed implementations.
 `config_boundary.rs` centralizes lifecycle-owned config object persistence for
 tier delete journal recovery while preserving the existing ECStore config store.
+`replication_sink.rs` centralizes lifecycle-originated replication config checks
+and delete scheduling while preserving the existing ECStore replication worker
+path.

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -21,14 +21,12 @@ use crate::bucket::lifecycle::evaluator::Evaluator;
 use crate::bucket::lifecycle::lifecycle::{
     self, Lifecycle, ObjectOpts, TransitionOptions, abort_incomplete_multipart_upload_due,
 };
+use crate::bucket::lifecycle::replication_sink;
 use crate::bucket::lifecycle::tier_delete_journal::{process_tier_delete_journal_entry, run_tier_delete_journal_recovery_loop};
 use crate::bucket::lifecycle::tier_free_version_recovery::{DEFAULT_FREE_VERSION_RECOVERY_LIMIT, recover_tier_free_versions};
 use crate::bucket::lifecycle::tier_last_day_stats::{DailyAllTierStats, LastDayTierStats};
 use crate::bucket::lifecycle::tier_sweeper::{Jentry, delete_object_from_remote_tier_idempotent};
 use crate::bucket::object_lock::objectlock_sys::check_object_lock_for_deletion;
-use crate::bucket::replication::{
-    DeletedObjectReplicationInfo, ReplicationConfig, check_replicate_delete, schedule_replication_delete,
-};
 use crate::bucket::{metadata_sys, metadata_sys::get_lifecycle_config, versioning_sys::BucketVersioningSys};
 use crate::client::object_api_utils::new_getobjectreader;
 use crate::disk::error::DiskError;
@@ -62,8 +60,8 @@ use rustfs_config::{
 };
 use rustfs_data_usage::TierStats;
 use rustfs_filemeta::{
-    FileInfo, FileInfoOpts, NULL_VERSION_ID, REPLICATE_INCOMING_DELETE, ReplicateDecision, ReplicationState, RestoreStatusOps,
-    VersionPurgeStatusType, get_file_info, is_restored_object_on_disk,
+    FileInfo, FileInfoOpts, NULL_VERSION_ID, ReplicateDecision, ReplicationState, RestoreStatusOps, VersionPurgeStatusType,
+    get_file_info, is_restored_object_on_disk,
 };
 use rustfs_utils::{get_env_i64, get_env_usize, path::encode_dir_object, string::strings_has_prefix_fold};
 use s3s::dto::{
@@ -1949,7 +1947,7 @@ pub async fn enqueue_immediate_expiry(oi: &ObjectInfo, src: LcEventSrc) {
         Err(_) => None,
     };
     let replication = match metadata_sys::get_replication_config(&oi.bucket).await {
-        Ok((cfg, _)) if !cfg.rules.is_empty() => Some(Arc::new(ReplicationConfig::new(Some(cfg), None))),
+        Ok((cfg, _)) if !cfg.rules.is_empty() => Some(Arc::new(replication_sink::new_replication_config(cfg))),
         _ => None,
     };
 
@@ -2700,13 +2698,7 @@ async fn schedule_lifecycle_replication_delete_if_needed(oi: &ObjectInfo, dobj: 
 
     delete_object.replication_state = replication_state;
 
-    schedule_replication_delete(DeletedObjectReplicationInfo {
-        delete_object,
-        bucket: oi.bucket.clone(),
-        event_type: REPLICATE_INCOMING_DELETE.to_string(),
-        ..Default::default()
-    })
-    .await;
+    replication_sink::schedule_delete(oi.bucket.clone(), delete_object).await;
 }
 
 fn should_reuse_lifecycle_delete_replication_state(oi: &ObjectInfo, version_delete: bool) -> bool {
@@ -2749,9 +2741,9 @@ async fn lifecycle_delete_replication_state(oi: &ObjectInfo, version_id: Option<
         return Some(state);
     }
 
-    let dsc = check_replicate_delete(
+    let dsc = replication_sink::check_delete_replication(
         &oi.bucket,
-        &ObjectToDelete {
+        ObjectToDelete {
             object_name: oi.name.clone(),
             version_id,
             ..Default::default()
@@ -2762,7 +2754,6 @@ async fn lifecycle_delete_replication_state(oi: &ObjectInfo, version_id: Option<
             versioned: BucketVersioningSys::prefix_enabled(&oi.bucket, &oi.name).await,
             ..Default::default()
         },
-        None,
     )
     .await;
     if !dsc.replicate_any() {

--- a/crates/ecstore/src/bucket/lifecycle/evaluator.rs
+++ b/crates/ecstore/src/bucket/lifecycle/evaluator.rs
@@ -19,8 +19,8 @@ use time::OffsetDateTime;
 use tracing::info;
 
 use crate::bucket::lifecycle::lifecycle::{Event, Lifecycle, ObjectOpts};
+use crate::bucket::lifecycle::replication_sink::{self, LifecycleReplicationConfig};
 use crate::bucket::object_lock::objectlock_sys::is_object_locked_by_metadata;
-use crate::bucket::replication::ReplicationConfig;
 use rustfs_common::metrics::IlmAction;
 
 const LOG_COMPONENT_ECSTORE: &str = "ecstore";
@@ -32,7 +32,7 @@ const EVENT_LIFECYCLE_VERSION_SCAN_SKIPPED: &str = "lifecycle_version_scan_skipp
 pub struct Evaluator {
     policy: Arc<BucketLifecycleConfiguration>,
     lock_retention: Option<Arc<ObjectLockConfiguration>>,
-    repl_cfg: Option<Arc<ReplicationConfig>>,
+    repl_cfg: Option<Arc<LifecycleReplicationConfig>>,
 }
 
 impl Evaluator {
@@ -52,27 +52,16 @@ impl Evaluator {
     }
 
     /// WithReplicationConfig - sets the replication configuration for the evaluator
-    pub fn with_replication_config(mut self, rcfg: Option<Arc<ReplicationConfig>>) -> Self {
+    pub fn with_replication_config(mut self, rcfg: Option<Arc<LifecycleReplicationConfig>>) -> Self {
         self.repl_cfg = rcfg;
         self
     }
 
     /// IsPendingReplication checks if the object is pending replication.
     pub fn is_pending_replication(&self, obj: &ObjectOpts) -> bool {
-        use crate::bucket::replication::ReplicationConfigurationExt;
-        if self.repl_cfg.is_none() {
-            return false;
-        }
-        if let Some(rcfg) = &self.repl_cfg
-            && rcfg
-                .config
-                .as_ref()
-                .is_some_and(|config| config.has_active_rules(obj.name.as_str(), true))
-            && !obj.version_purge_status.is_empty()
-        {
-            return true;
-        }
-        false
+        self.repl_cfg
+            .as_ref()
+            .is_some_and(|rcfg| replication_sink::has_pending_version_purge(rcfg, obj))
     }
 
     /// IsObjectLocked checks if it is appropriate to remove an

--- a/crates/ecstore/src/bucket/lifecycle/mod.rs
+++ b/crates/ecstore/src/bucket/lifecycle/mod.rs
@@ -18,6 +18,7 @@ mod config_boundary;
 pub mod core;
 pub mod evaluator;
 pub use self::core as lifecycle;
+mod replication_sink;
 pub mod rule;
 mod runtime_boundary;
 mod tagging_boundary;

--- a/crates/ecstore/src/bucket/lifecycle/replication_sink.rs
+++ b/crates/ecstore/src/bucket/lifecycle/replication_sink.rs
@@ -1,0 +1,115 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rustfs_filemeta::{REPLICATE_INCOMING_DELETE, ReplicateDecision};
+use s3s::dto::ReplicationConfiguration;
+
+use crate::bucket::lifecycle::lifecycle::ObjectOpts;
+use crate::bucket::replication::{self, DeletedObjectReplicationInfo, ReplicationConfig, ReplicationConfigurationExt as _};
+use crate::object_api::{ObjectInfo, ObjectOptions};
+use crate::storage_api_contracts::object::{DeletedObject, ObjectToDelete};
+
+pub(crate) type LifecycleReplicationConfig = ReplicationConfig;
+
+pub(crate) fn new_replication_config(config: ReplicationConfiguration) -> LifecycleReplicationConfig {
+    ReplicationConfig::new(Some(config), None)
+}
+
+pub(crate) fn has_pending_version_purge(config: &LifecycleReplicationConfig, obj: &ObjectOpts) -> bool {
+    config
+        .config
+        .as_ref()
+        .is_some_and(|config| config.has_active_rules(obj.name.as_str(), true))
+        && !obj.version_purge_status.is_empty()
+}
+
+pub(crate) async fn check_delete_replication(
+    bucket: &str,
+    object: ObjectToDelete,
+    source: &ObjectInfo,
+    opts: &ObjectOptions,
+) -> ReplicateDecision {
+    replication::check_replicate_delete(bucket, &object, source, opts, None).await
+}
+
+pub(crate) async fn schedule_delete(bucket: String, delete_object: DeletedObject) {
+    replication::schedule_replication_delete(DeletedObjectReplicationInfo {
+        delete_object,
+        bucket,
+        event_type: REPLICATE_INCOMING_DELETE.to_string(),
+        ..Default::default()
+    })
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rustfs_filemeta::{ReplicationStatusType, VersionPurgeStatusType};
+    use s3s::dto::{Destination, ReplicationRule, ReplicationRuleStatus};
+
+    use super::*;
+
+    fn replication_rule() -> ReplicationRule {
+        ReplicationRule {
+            delete_marker_replication: None,
+            delete_replication: None,
+            destination: Destination {
+                bucket: "arn:aws:s3:::target-bucket".to_string(),
+                ..Default::default()
+            },
+            existing_object_replication: None,
+            filter: None,
+            id: Some("rule".to_string()),
+            prefix: Some(String::new()),
+            priority: Some(1),
+            source_selection_criteria: None,
+            status: ReplicationRuleStatus::from_static(ReplicationRuleStatus::ENABLED),
+        }
+    }
+
+    fn object_opts(version_purge_status: VersionPurgeStatusType) -> ObjectOpts {
+        ObjectOpts {
+            name: "logs/object".to_string(),
+            user_tags: String::new(),
+            mod_time: None,
+            size: 0,
+            version_id: None,
+            is_latest: true,
+            delete_marker: false,
+            num_versions: 1,
+            successor_mod_time: None,
+            transition_status: String::new(),
+            restore_ongoing: false,
+            restore_expires: None,
+            versioned: true,
+            version_suspended: false,
+            user_defined: HashMap::new(),
+            version_purge_status,
+            replication_status: ReplicationStatusType::default(),
+        }
+    }
+
+    #[test]
+    fn has_pending_version_purge_preserves_replication_active_rule_behavior() {
+        let config = new_replication_config(ReplicationConfiguration {
+            role: String::new(),
+            rules: vec![replication_rule()],
+        });
+
+        assert!(has_pending_version_purge(&config, &object_opts(VersionPurgeStatusType::Pending)));
+        assert!(!has_pending_version_purge(&config, &object_opts(VersionPurgeStatusType::default())));
+    }
+}

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -125,6 +125,7 @@ STORE_API_LIFECYCLE_HELPER_OLD_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_lifecycl
 LIFECYCLE_AUDIT_SINK_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_audit_sink_bypass_hits.txt"
 LIFECYCLE_CONFIG_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_config_boundary_bypass_hits.txt"
 LIFECYCLE_TAGGING_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_tagging_boundary_bypass_hits.txt"
+LIFECYCLE_REPLICATION_SINK_BYPASS_HITS_FILE="${TMP_DIR}/lifecycle_replication_sink_bypass_hits.txt"
 STORE_API_EXTERNAL_LIST_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_list_consumer_hits.txt"
 STORE_API_EXTERNAL_OPERATION_CONSUMER_HITS_FILE="${TMP_DIR}/store_api_external_operation_consumer_hits.txt"
 STORE_API_OBJECT_OPERATION_LOCAL_METHOD_HITS_FILE="${TMP_DIR}/store_api_object_operation_local_method_hits.txt"
@@ -826,6 +827,18 @@ fi
 
 if [[ -s "$LIFECYCLE_TAGGING_BOUNDARY_BYPASS_HITS_FILE" ]]; then
   report_failure "lifecycle tag decoding must stay behind lifecycle tagging_boundary: $(paste -sd '; ' "$LIFECYCLE_TAGGING_BOUNDARY_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'crate::bucket::replication' \
+    crates/ecstore/src/bucket/lifecycle \
+    --glob '*.rs' |
+    rg -v '^crates/ecstore/src/bucket/lifecycle/replication_sink\.rs:' || true
+) >"$LIFECYCLE_REPLICATION_SINK_BYPASS_HITS_FILE"
+
+if [[ -s "$LIFECYCLE_REPLICATION_SINK_BYPASS_HITS_FILE" ]]; then
+  report_failure "lifecycle replication scheduling must stay behind lifecycle replication_sink: $(paste -sd '; ' "$LIFECYCLE_REPLICATION_SINK_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#749.

## Summary of Changes
- Add a lifecycle-local replication sink for pending-replication checks, delete decisions, and lifecycle-originated delete scheduling.
- Route lifecycle evaluator and delete scheduling through the sink while keeping existing ECStore replication worker behavior.
- Add architecture guardrails preventing lifecycle modules from importing bucket replication directly.

## Verification
- `cargo test -p rustfs-ecstore has_pending_version_purge_preserves_replication_active_rule_behavior --lib`
- `cargo test -p rustfs-ecstore lifecycle_delete_replication_state --lib`
- `cargo fmt --all --check && git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `make pre-commit`

## Impact
No user-facing or API impact. This is an internal lifecycle split boundary.

## Additional Notes
N/A
