### PR TITLE
refactor(runtime): remove unused node names global

### DIFF
--- a/crates/ecstore/src/runtime/global.rs
+++ b/crates/ecstore/src/runtime/global.rs
@@ -63,7 +63,6 @@ lazy_static! {
     pub static ref GLOBAL_BOOT_TIME: OnceCell<SystemTime> = OnceCell::new();
     pub static ref GLOBAL_LocalNodeName: String = "127.0.0.1:9000".to_string();
     pub static ref GLOBAL_LocalNodeNameHex: String = rustfs_utils::crypto::hex(GLOBAL_LocalNodeName.as_bytes());
-    pub static ref GLOBAL_NodeNamesHex: HashMap<String, ()> = HashMap::new();
     pub static ref GLOBAL_REGION: OnceLock<s3s::region::Region> = OnceLock::new();
     pub static ref GLOBAL_LOCAL_LOCK_CLIENT: OnceLock<Arc<dyn LockClient>> = OnceLock::new();
     pub static ref GLOBAL_LOCK_CLIENTS: OnceLock<HashMap<String, Arc<dyn LockClient>>> = OnceLock::new();

--- a/docs/architecture/global-state-inventory.md
+++ b/docs/architecture/global-state-inventory.md
@@ -13,11 +13,11 @@ caches separate from runtime migration targets.
 
 | Scope | Count | Command |
 |---|---:|---|
-| Rust source files | 1,237 | `rg --files -g '*.rs'` |
+| Rust source files | 1,252 | `rg --files -g '*.rs'` |
 | `OnceLock` references | 221 lines | `rg -n --glob '*.rs' 'OnceLock'` |
-| `GLOBAL_*` references | 302 lines | `rg -n --glob '*.rs' '\bGLOBAL_[A-Za-z0-9_]*\b'` |
+| `GLOBAL_*` references | 265 lines | `rg -n --glob '*.rs' '\bGLOBAL_[A-Za-z0-9_]*\b'` |
 | `static NAME:` definitions | 621 lines | `rg -n --glob '*.rs' '^\s*(pub(\([^)]*\))?\s+)?static(\s+mut)?\s+[A-Za-z_][A-Za-z0-9_]*\s*:'` |
-| `lazy_static!` `static ref` definitions | 59 lines | `rg -n --glob '*.rs' '^\s*(pub\s+)?static\s+ref\s+[A-Za-z_][A-Za-z0-9_]*\s*:'` |
+| `lazy_static!` `static ref` definitions | 58 lines | `rg -n --glob '*.rs' '^\s*(pub\s+)?static\s+ref\s+[A-Za-z_][A-Za-z0-9_]*\s*:'` |
 | `static mut` definitions | 0 lines | `rg -n --glob '*.rs' '^\s*(pub(\([^)]*\))?\s+)?static\s+mut\s+'` |
 
 ## Global State Classification


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#730.

## Summary of Changes
- Remove the unused `GLOBAL_NodeNamesHex` runtime singleton from the ECStore global compatibility layer.
- Refresh the global-state inventory counts after the latest merged guardrail batches.

## Verification
- `cargo test -p rustfs-ecstore runtime::sources::tests::lock_registry_selects_unique_clients_in_endpoint_order --lib`
- `cargo check -p rustfs-ecstore`
- `cargo fmt --all --check && git diff --check && ./scripts/check_architecture_migration_rules.sh`
- `make pre-commit`

## Impact
No user-facing behavior change. This removes unused runtime global state and keeps the #730 inventory current.

## Additional Notes
N/A
