### PR TITLE
refactor(ecstore): scope dead code allowances

### DIFF
--- a/crates/ecstore/src/bucket/mod.rs
+++ b/crates/ecstore/src/bucket/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: bucket subsystems still contain staged ECStore migration code.
+#![allow(dead_code)]
+
 pub mod bandwidth;
 pub mod bucket_target_sys;
 pub mod error;

--- a/crates/ecstore/src/client/mod.rs
+++ b/crates/ecstore/src/client/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: S3 client compatibility models are kept while ECStore callers move to narrower facades.
+#![allow(dead_code)]
+
 pub mod admin_handler_utils;
 pub mod api_bucket_policy;
 pub mod api_error_response;

--- a/crates/ecstore/src/cluster/mod.rs
+++ b/crates/ecstore/src/cluster/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: cluster/RPC migration leaves transport capabilities staged for upcoming owners.
+#![allow(dead_code)]
+
 mod control_plane;
 pub(crate) mod rpc;
 

--- a/crates/ecstore/src/config/mod.rs
+++ b/crates/ecstore/src/config/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: configuration migration keeps legacy subsystem definitions available behind this module.
+#![allow(dead_code)]
+
 mod audit;
 pub mod com;
 #[allow(dead_code)]

--- a/crates/ecstore/src/core/mod.rs
+++ b/crates/ecstore/src/core/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: pool coordination helpers are being migrated behind runtime owners.
+#![allow(dead_code)]
+
 pub(crate) mod pools;
 pub(crate) mod sets;
 

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: data-movement migration keeps staged cleanup helpers until copy paths converge.
+#![allow(dead_code)]
+
 pub(crate) mod backpressure;
 
 use crate::error::{Error, Result, is_err_data_movement_overwrite, is_err_object_not_found, is_err_version_not_found};

--- a/crates/ecstore/src/data_usage/mod.rs
+++ b/crates/ecstore/src/data_usage/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: scanner/data-usage state is partially migrated and still owns staged cache helpers.
+#![allow(dead_code)]
+
 pub mod local_snapshot;
 
 use crate::storage_api_contracts::{

--- a/crates/ecstore/src/diagnostics/mod.rs
+++ b/crates/ecstore/src/diagnostics/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: diagnostics constants are staged for request-path telemetry migration.
+#![allow(dead_code)]
+
 pub(crate) mod admin_server_info;
 pub(crate) mod get;
 pub(crate) mod pool;

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: disk abstractions still carry staged health and direct-I/O migration paths.
+#![allow(dead_code)]
+
 pub mod disk_store;
 pub mod endpoint;
 pub mod error;

--- a/crates/ecstore/src/erasure/mod.rs
+++ b/crates/ecstore/src/erasure/mod.rs
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: erasure codec migration keeps staged streaming decode paths in this module.
+#![allow(dead_code)]
+
 pub(crate) mod codec;
 pub(crate) mod coding;

--- a/crates/ecstore/src/error/mod.rs
+++ b/crates/ecstore/src/error/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: error taxonomy still exposes compatibility variants while callers move to contracts.
+#![allow(dead_code)]
+
 use crate::bucket::error::BucketMetadataError;
 use crate::disk::error::DiskError;
 use crate::storage_api_contracts::{error::StorageErrorCode, range::HTTPRangeError};

--- a/crates/ecstore/src/event/mod.rs
+++ b/crates/ecstore/src/event/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: event target types are retained for notification owner migration.
+#![allow(dead_code)]
+
 pub mod name;
 pub mod targetid;
 pub mod targetlist;

--- a/crates/ecstore/src/io_support/mod.rs
+++ b/crates/ecstore/src/io_support/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: I/O backend selection keeps test-only and staged rio helpers scoped here.
+#![allow(dead_code)]
+
 pub(crate) mod bitrot;
 pub(crate) mod compress;
 pub(crate) mod rio;

--- a/crates/ecstore/src/layout/mod.rs
+++ b/crates/ecstore/src/layout/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: set-layout contracts are staged while ECStore ownership boundaries shrink.
+#![allow(dead_code)]
+
 //! Static ECStore layout boundaries.
 //!
 //! This module owns read-only layout descriptors used to keep static set

--- a/crates/ecstore/src/lib.rs
+++ b/crates/ecstore/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 // Copyright 2024 RustFS Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/crates/ecstore/src/object_api/mod.rs
+++ b/crates/ecstore/src/object_api/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: object API readers keep staged compatibility paths during facade migration.
+#![allow(dead_code)]
+
 use crate::bucket::metadata_sys::get_versioning_config;
 use crate::bucket::versioning::VersioningApi as _;
 use crate::config::storageclass;

--- a/crates/ecstore/src/runtime/mod.rs
+++ b/crates/ecstore/src/runtime/mod.rs
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: runtime source migration keeps fallback handles until all owners inject state.
+#![allow(dead_code)]
+
 pub(crate) mod global;
 pub(crate) mod sources;

--- a/crates/ecstore/src/services/mod.rs
+++ b/crates/ecstore/src/services/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: background service owners still contain staged notification/rebalance/tier paths.
+#![allow(dead_code)]
+
 pub(crate) mod batch_processor;
 pub(crate) mod event_notification;
 pub(crate) mod metrics_realtime;

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: SetDisks still hosts staged read/heal/write migration helpers.
+#![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 

--- a/crates/ecstore/src/storage_api_contracts/mod.rs
+++ b/crates/ecstore/src/storage_api_contracts/mod.rs
@@ -1,3 +1,6 @@
+// #730: storage contract traits are staged for facade migration and external owners.
+#![allow(dead_code)]
+
 use crate::error::Error;
 use crate::object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader};
 use rustfs_filemeta::FileInfo;

--- a/crates/ecstore/src/store/mod.rs
+++ b/crates/ecstore/src/store/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// #730: store startup/listing helpers are staged while global state is moved to owners.
+#![allow(dead_code)]
 #![allow(clippy::map_entry)]
 
 use crate::bucket::lifecycle::bucket_lifecycle_audit::LcEventSrc;

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -41,6 +41,10 @@ require_source_contains() {
   fi
 }
 
+if grep -Eq '^[[:space:]]*#!\[allow\([^]]*dead_code' "${ROOT_DIR}/crates/ecstore/src/lib.rs"; then
+  report_failure "ecstore crate root must not use allow(dead_code); scope temporary allowances to owning modules"
+fi
+
 require_source_contains "docs/architecture/overview.md" "## Baseline" "architecture overview baseline section"
 require_source_contains "docs/architecture/overview.md" "## Core Principle" "architecture overview core principle section"
 require_source_contains "docs/architecture/overview.md" "## Phase Order" "architecture overview phase order section"


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#730.

## Summary of Changes
- Removed the crate-level `#![allow(dead_code)]` from `rustfs-ecstore`.
- Scoped remaining staged dead-code allowances to owning ECStore modules with comments.
- Added an architecture guardrail to block reintroducing a crate-level dead-code allowance.

## Verification
- `cargo rustc -p rustfs-ecstore --lib -- -D dead_code`
- `cargo check -p rustfs-ecstore`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `make pre-commit`

## Impact
No runtime behavior or API changes; lint policy is narrower and guarded.

## Additional Notes
N/A
