### PR TITLE
refactor(ecstore): route replication filemeta contracts

### DIFF
--- a/crates/ecstore/src/bucket/replication/README.md
+++ b/crates/ecstore/src/bucket/replication/README.md
@@ -9,11 +9,11 @@ and lifecycle/heal scheduling paths.
 
 | Module | Current role | Split blocker |
 |---|---|---|
-| `config.rs` | Replication config helpers, rule matching, and tag filtering. | Uses replication-local tagging boundary and S3 DTOs directly. |
+| `config.rs` | Replication config helpers, rule matching, and tag filtering. | Uses replication-local filemeta/tagging boundaries and S3 DTOs directly. |
 | `datatypes.rs` | Replication status and operation DTOs. | Publicly re-exported through the ECStore replication facade. |
-| `replication_pool.rs` | Replication queue, worker pool, MRF persistence, bucket stats, and delete/object scheduling. | Depends on bucket target sys, bucket metadata sys and metadata paths through local boundaries, config storage, storage contracts through the replication storage boundary, runtime sources, and notification state. |
-| `replication_resyncer.rs` | Object replication, delete replication, resync, MRF encode/decode, target calls, and multipart target upload paths. | Depends on target calls and target config types through the replication target boundary, metadata paths and metadata systems through the replication metadata boundary, versioning systems, storage contracts through the replication storage boundary, runtime sources, notification events, bandwidth reader wrapping, and SetDisks lock timing. |
-| `replication_state.rs` | Replication queue/stat state and worker accounting. | Reads runtime sources and owns shared replication pool/stat state. |
+| `replication_pool.rs` | Replication queue, worker pool, MRF persistence, bucket stats, and delete/object scheduling. | Depends on bucket target sys, bucket metadata sys, metadata paths, and file metadata replication contracts through local boundaries, config storage, storage contracts through the replication storage boundary, runtime sources, and notification state. |
+| `replication_resyncer.rs` | Object replication, delete replication, resync, MRF encode/decode, target calls, and multipart target upload paths. | Depends on target calls and target config types through the replication target boundary, metadata paths and metadata systems through the replication metadata boundary, file metadata replication contracts through the filemeta boundary, versioning systems, storage contracts through the replication storage boundary, runtime sources, notification events, bandwidth reader wrapping, and SetDisks lock timing. |
+| `replication_state.rs` | Replication queue/stat state and worker accounting. | Reads runtime sources and file metadata replication contracts through local boundaries, and owns shared replication pool/stat state. |
 | `rule.rs` | Rule evaluation helpers for object replication options. | Depends on ECStore replication object option types. |
 | `mod.rs` | Compatibility re-export facade for the current ECStore owner. | Must stay stable until downstream scanner, lifecycle, heal, and metrics paths compile through replacement contracts. |
 
@@ -23,7 +23,8 @@ and lifecycle/heal scheduling paths.
 |---|---|---|
 | `ReplicationObjectIO` | Object read/write primitives used by config, MRF, resync status, and multipart replication paths. | ECStore object API reader/writer types and storage-api object IO contracts are concentrated in `replication_storage_boundary.rs`. |
 | `ReplicationStorage` | Object read/write/delete, object walk, metadata update, and target object IO. | ECStore object API, storage-api contracts, and read option types are concentrated in `replication_storage_boundary.rs`. |
-| `ReplicationMetadataStore` | Replication config, MRF/resync state, target reset headers, and status persistence. | Metadata sys access and replication metadata path constants are concentrated in `replication_metadata_boundary.rs`; versioning sys, config storage, and file metadata imports remain. |
+| `ReplicationMetadataStore` | Replication config, MRF/resync state, target reset headers, and status persistence. | Metadata sys access and replication metadata path constants are concentrated in `replication_metadata_boundary.rs`; versioning sys and config storage imports remain. |
+| `ReplicationFileMeta` | Replication status, decisions, MRF entries, resync decisions, and target reset helpers. | `rustfs_filemeta` replication contracts are concentrated in `replication_filemeta_boundary.rs`; `FileInfo` remains in the storage boundary for storage trait bindings and walk options. |
 | `ReplicationTargetStore` | Bucket target listing, target client lookup, target offline checks, target config types, and target operation option types. | Bucket target sys access, `BucketTargets`, and target operation types are concentrated in `replication_target_boundary.rs`. |
 | `ReplicationRuntime` | Worker pool, queue sizing, stats, bucket monitor, local node identity, cancellation, and admission state. | Direct runtime source/global access and shared replication pool/stat state. |
 | `ReplicationBandwidthLimiter` | Target reader wrapping for replication bandwidth accounting and throttling. | Direct bucket bandwidth reader imports from resyncer paths. |

--- a/crates/ecstore/src/bucket/replication/config.rs
+++ b/crates/ecstore/src/bucket/replication/config.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::replication_filemeta_boundary::ReplicationType;
 use super::replication_tagging_boundary as tagging_boundary;
 use crate::bucket::replication::ReplicationRuleExt as _;
-use rustfs_filemeta::ReplicationType;
 use s3s::dto::DeleteMarkerReplicationStatus;
 use s3s::dto::DeleteReplicationStatus;
 use s3s::dto::Destination;

--- a/crates/ecstore/src/bucket/replication/mod.rs
+++ b/crates/ecstore/src/bucket/replication/mod.rs
@@ -17,6 +17,7 @@ pub mod datatypes;
 mod replication_bandwidth_boundary;
 mod replication_config_store;
 mod replication_event_sink;
+mod replication_filemeta_boundary;
 mod replication_lock_boundary;
 mod replication_metadata_boundary;
 mod replication_msgp_boundary;

--- a/crates/ecstore/src/bucket/replication/replication_filemeta_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_filemeta_boundary.rs
@@ -1,0 +1,21 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) use rustfs_filemeta::{
+    MrfOpKind, MrfReplicateEntry, REPLICATE_EXISTING, REPLICATE_EXISTING_DELETE, REPLICATE_HEAL, REPLICATE_HEAL_DELETE,
+    ReplicateDecision, ReplicateObjectInfo, ReplicateTargetDecision, ReplicatedInfos, ReplicatedTargetInfo, ReplicationAction,
+    ReplicationState, ReplicationStatusType, ReplicationType, ReplicationWorkerOperation, ResyncDecision, ResyncTargetDecision,
+    VersionPurgeStatusType, get_replication_state, parse_replicate_decision, replication_statuses_map, target_reset_header,
+    version_purge_statuses_map,
+};

--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 use super::replication_config_store as config_store;
+use super::replication_filemeta_boundary::{
+    MrfOpKind, MrfReplicateEntry, REPLICATE_EXISTING, REPLICATE_HEAL, REPLICATE_HEAL_DELETE, ReplicateDecision,
+    ReplicateObjectInfo, ReplicatedTargetInfo, ReplicationStatusType, ReplicationType, ReplicationWorkerOperation,
+    ResyncDecision, VersionPurgeStatusType, replication_statuses_map, version_purge_statuses_map,
+};
 use super::replication_metadata_boundary as metadata_boundary;
 use super::replication_storage_boundary::{DeletedObject, ObjectInfo, ObjectOptions, ReplicationObjectIO, ReplicationStorage};
 use super::replication_target_boundary as target_boundary;
@@ -29,19 +34,6 @@ use crate::bucket::replication::replication_resyncer::{
 use crate::bucket::replication::replication_state::ReplicationStats;
 use crate::error::Error as EcstoreError;
 use lazy_static::lazy_static;
-use rustfs_filemeta::MrfOpKind;
-use rustfs_filemeta::MrfReplicateEntry;
-use rustfs_filemeta::ReplicateDecision;
-use rustfs_filemeta::ReplicateObjectInfo;
-use rustfs_filemeta::ReplicatedTargetInfo;
-use rustfs_filemeta::ReplicationStatusType;
-use rustfs_filemeta::ReplicationType;
-use rustfs_filemeta::ReplicationWorkerOperation;
-use rustfs_filemeta::ResyncDecision;
-use rustfs_filemeta::VersionPurgeStatusType;
-use rustfs_filemeta::replication_statuses_map;
-use rustfs_filemeta::version_purge_statuses_map;
-use rustfs_filemeta::{REPLICATE_EXISTING, REPLICATE_HEAL, REPLICATE_HEAL_DELETE};
 use rustfs_utils::http::{SUFFIX_REPLICATION_TIMESTAMP, get_str};
 use std::any::Any;
 use std::sync::Arc;

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -15,6 +15,12 @@
 use super::replication_bandwidth_boundary;
 use super::replication_config_store as config_store;
 use super::replication_event_sink::{EventArgs, send_event};
+use super::replication_filemeta_boundary::{
+    MrfOpKind, MrfReplicateEntry, REPLICATE_EXISTING, REPLICATE_EXISTING_DELETE, ReplicateDecision, ReplicateObjectInfo,
+    ReplicateTargetDecision, ReplicatedInfos, ReplicatedTargetInfo, ReplicationAction, ReplicationState, ReplicationStatusType,
+    ReplicationType, ReplicationWorkerOperation, ResyncDecision, ResyncTargetDecision, VersionPurgeStatusType,
+    get_replication_state, parse_replicate_decision, replication_statuses_map, target_reset_header, version_purge_statuses_map,
+};
 use super::replication_lock_boundary as lock_boundary;
 use super::replication_metadata_boundary as metadata_boundary;
 use super::replication_msgp_boundary::{read_msgp_ext8_time, skip_msgp_value, write_msgp_time};
@@ -49,12 +55,6 @@ use http_body::Frame;
 use http_body_util::StreamBody;
 use regex::Regex;
 use rmp_serde;
-use rustfs_filemeta::{
-    MrfReplicateEntry, REPLICATE_EXISTING, REPLICATE_EXISTING_DELETE, ReplicateDecision, ReplicateObjectInfo,
-    ReplicateTargetDecision, ReplicatedInfos, ReplicatedTargetInfo, ReplicationAction, ReplicationState, ReplicationStatusType,
-    ReplicationType, ReplicationWorkerOperation, ResyncDecision, ResyncTargetDecision, VersionPurgeStatusType,
-    get_replication_state, parse_replicate_decision, replication_statuses_map, target_reset_header, version_purge_statuses_map,
-};
 use rustfs_s3_types::EventName;
 use rustfs_utils::http::{
     AMZ_BUCKET_REPLICATION_STATUS, AMZ_OBJECT_TAGGING, AMZ_TAGGING_DIRECTIVE, CONTENT_ENCODING, HeaderExt as _,
@@ -1262,7 +1262,7 @@ impl ReplicationWorkerOperation for DeletedObjectReplicationInfo {
             version_id: self.delete_object.version_id,
             retry_count: 0,
             size: 0,
-            op: rustfs_filemeta::MrfOpKind::Delete,
+            op: MrfOpKind::Delete,
             delete_marker_version_id: self.delete_object.delete_marker_version_id,
             delete_marker: self.delete_object.delete_marker,
         }

--- a/crates/ecstore/src/bucket/replication/replication_state.rs
+++ b/crates/ecstore/src/bucket/replication/replication_state.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::replication_filemeta_boundary::{ReplicatedTargetInfo, ReplicationStatusType, ReplicationType};
 use super::runtime_boundary as runtime_sources;
 use crate::error::Error;
-use rustfs_filemeta::{ReplicatedTargetInfo, ReplicationStatusType, ReplicationType};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;

--- a/docs/architecture/ecstore-module-split-plan.md
+++ b/docs/architecture/ecstore-module-split-plan.md
@@ -103,7 +103,8 @@ Current coupling:
 
 - replication workers depend on `ReplicationStorage`, ECStore object APIs and
   storage-api contracts through the replication storage boundary, bucket target
-  clients, bucket metadata, file metadata replication state, scanner repair
+  clients, bucket metadata, file metadata replication state through the
+  filemeta boundary, scanner repair
   classification, runtime replication pool/stat handles, bucket monitor and
   bandwidth reader access through local boundaries, local node names, and
   notification events;
@@ -130,6 +131,12 @@ Required contracts before crate movement:
   MRF/resync state, and status persistence. Metadata sys access and replication
   metadata path constants are concentrated in
   `crates/ecstore/src/bucket/replication/replication_metadata_boundary.rs`.
+- `ReplicationFileMeta`: replication status, decisions, MRF entries, resync
+  decisions, and target reset helpers. `rustfs_filemeta` replication contracts
+  are concentrated in
+  `crates/ecstore/src/bucket/replication/replication_filemeta_boundary.rs`,
+  while `FileInfo` remains in the storage boundary for storage trait bindings
+  and walk options.
 - `ReplicationTargetStore`: bucket target listing, target client lookup,
   target offline checks, target config types, and target operation option
   types. Bucket target sys access, `BucketTargets`, and target operation types

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -201,6 +201,7 @@ REPLICATION_FACADE_BYPASS_HITS_FILE="${TMP_DIR}/replication_facade_bypass_hits.t
 REPLICATION_BANDWIDTH_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_bandwidth_boundary_bypass_hits.txt"
 REPLICATION_CONFIG_STORE_BYPASS_HITS_FILE="${TMP_DIR}/replication_config_store_bypass_hits.txt"
 REPLICATION_EVENT_SINK_BYPASS_HITS_FILE="${TMP_DIR}/replication_event_sink_bypass_hits.txt"
+REPLICATION_FILEMETA_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_filemeta_boundary_bypass_hits.txt"
 REPLICATION_LOCK_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_lock_boundary_bypass_hits.txt"
 REPLICATION_METADATA_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_metadata_boundary_bypass_hits.txt"
 REPLICATION_MSGP_BOUNDARY_BYPASS_HITS_FILE="${TMP_DIR}/replication_msgp_boundary_bypass_hits.txt"
@@ -2606,6 +2607,17 @@ fi
 
 if [[ -s "$REPLICATION_TAGGING_BOUNDARY_BYPASS_HITS_FILE" ]]; then
   report_failure "replication tag decoding must stay behind replication tagging boundary: $(paste -sd '; ' "$REPLICATION_TAGGING_BOUNDARY_BYPASS_HITS_FILE")"
+fi
+
+(
+  cd "$ROOT_DIR"
+  rg -n --with-filename 'rustfs_filemeta::' crates/ecstore/src/bucket/replication --glob '*.rs' |
+    rg -v '^crates/ecstore/src/bucket/replication/replication_filemeta_boundary\.rs:' |
+    rg -v '^crates/ecstore/src/bucket/replication/replication_storage_boundary\.rs:' || true
+) >"$REPLICATION_FILEMETA_BOUNDARY_BYPASS_HITS_FILE"
+
+if [[ -s "$REPLICATION_FILEMETA_BOUNDARY_BYPASS_HITS_FILE" ]]; then
+  report_failure "replication filemeta contracts must stay behind replication filemeta boundary: $(paste -sd '; ' "$REPLICATION_FILEMETA_BOUNDARY_BYPASS_HITS_FILE")"
 fi
 
 (


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#750

## Summary of Changes
- Add `replication_filemeta_boundary` for replication status, decision, MRF, resync, and target reset contracts from `rustfs_filemeta`.
- Route replication config, pool, state, and resyncer imports through the new local boundary without changing the underlying types.
- Extend architecture guardrails so new direct `rustfs_filemeta` replication imports stay behind the local filemeta boundary, with the existing storage `FileInfo` binding kept in the storage boundary.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `cargo test -p rustfs-ecstore replication --lib`
- `make pre-commit`
- Architecture guard negative smoke for direct `rustfs_filemeta::ReplicationStatusType` imports outside the boundary.
- Three independent read-only expert reviews passed.

## Impact
No user-facing behavior, serialization, storage semantics, API, or configuration changes expected. This is a replication boundary refactor for future crate extraction.

## Additional Notes
N/A
