### PR TITLE
fix(ecstore): harden replication runtime guard

### DIFF
--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -2627,21 +2627,25 @@ fi
       $source = blank_block_comments($source);
       $source =~ s{//[^\n]*}{blank($&)}eg;
 
-      for my $statement (split /;/, $source) {
+      while ($source =~ /([^;]+)(?:;|$)/g) {
+        my $statement_start = $-[1];
+        my $statement = $1;
         my $normalized = $statement;
         $normalized =~ s/\s+//g;
 
         my $hits_ecstore =
-          $normalized =~ /\bECStore\b/
-          && $normalized =~ /crate::(?:store(?:::|::\{)|\{.*store(?:::|::\{))/s;
+          $normalized =~ /\bECStore(?:\b|as)/
+          && $normalized =~ /crate::(?:store::\{?|\{.*store::\{?)/s;
         my $hits_monitor =
-          $normalized =~ /\bMonitor\b/
-          && $normalized =~ /crate::(?:bucket(?:::|::\{)|\{.*bucket(?:::|::\{))/s
-          && $normalized =~ /bucket(?:::|::\{).*bandwidth(?:::|::\{).*monitor(?:::|::\{)/s;
+          $normalized =~ /\bMonitor(?:\b|as)/
+          && $normalized =~ /crate::(?:bucket::\{?|\{.*bucket::\{?)/s
+          && $normalized =~ /bucket::\{?.*bandwidth::\{?.*monitor::\{?/s;
 
         if ($hits_ecstore || $hits_monitor) {
-          my $prefix = substr($source, 0, index($source, $statement));
-          my $line = ($prefix =~ tr/\n//) + 1;
+          my $leading = $statement;
+          $leading =~ s/^(\s*).*$/$1/s;
+          my $prefix = substr($source, 0, $statement_start);
+          my $line = ($prefix =~ tr/\n//) + ($leading =~ tr/\n//) + 1;
           $normalized =~ s/\s+/ /g;
           print "$ARGV:$line:$normalized\n";
         }


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#750

## Summary of Changes
- Fix the replication runtime concrete-type guard so direct `crate::store::ECStore` and `crate::bucket::bandwidth::monitor::Monitor` imports are detected.
- Preserve correct line reporting for repeated import statements by tracking statement offsets.
- Keep grouped and nested import coverage while avoiding string and comment false positives.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `bash -n scripts/check_architecture_migration_rules.sh`
- `./scripts/check_architecture_migration_rules.sh`
- local negative smoke for direct, repeated, and nested runtime imports
- local smoke for string and comment false positives
- `make pre-commit`

## Impact
No runtime behavior change. This only hardens the architecture migration guard for replication runtime boundaries.

## Additional Notes
Follow-up to review feedback on #4131.
