### PR TITLE
fix: bypass OnceLock in test for metadata early-stop gates

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -539,25 +539,48 @@ fn get_codec_streaming_multipart_max_parts() -> usize {
 }
 
 /// Check if metadata early-stop is enabled (base flag).
+///
+/// **Note**: Cached via `OnceLock` in production. In test builds the env var
+/// is read directly so that `temp_env` overrides take effect.
 fn is_get_metadata_early_stop_enabled() -> bool {
-    static CACHED: OnceLock<bool> = OnceLock::new();
-    *CACHED.get_or_init(|| {
+    #[cfg(test)]
+    {
         rustfs_utils::get_env_bool(ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE, DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE)
-    })
+    }
+    #[cfg(not(test))]
+    {
+        static CACHED: OnceLock<bool> = OnceLock::new();
+        *CACHED.get_or_init(|| {
+            rustfs_utils::get_env_bool(ENV_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE, DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ENABLE)
+        })
+    }
 }
 
 /// Check if version-aware early-stop is enabled.
 ///
 /// When enabled, versioned requests can early-stop when the requested
 /// version_id reaches quorum across disks.
+///
+/// **Note**: Cached via `OnceLock` in production. In test builds the env var
+/// is read directly so that `temp_env` overrides take effect.
 fn is_version_early_stop_enabled() -> bool {
-    static CACHED: OnceLock<bool> = OnceLock::new();
-    *CACHED.get_or_init(|| {
+    #[cfg(test)]
+    {
         rustfs_utils::get_env_bool(
             ENV_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE,
             DEFAULT_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE,
         )
-    })
+    }
+    #[cfg(not(test))]
+    {
+        static CACHED: OnceLock<bool> = OnceLock::new();
+        *CACHED.get_or_init(|| {
+            rustfs_utils::get_env_bool(
+                ENV_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE,
+                DEFAULT_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE,
+            )
+        })
+    }
 }
 
 // --- Rollout Percentage Functions ---


### PR DESCRIPTION
## Problem

The automated hourly verification detected a test failure introduced in `b16120dbc` (feat: optimize small GET read paths #4022):

```
test set_disk::read::tests::metadata_early_stop_rejects_data_reads ... FAILED
assertion failed: should_allow_metadata_early_stop(false, "", false, false)
```

The new test `metadata_early_stop_rejects_data_reads` uses `temp_env::with_vars` to set `RUSTFS_GET_METADATA_EARLY_STOP_ENABLE=true`, but `is_get_metadata_early_stop_enabled()` caches its value in a `OnceLock<bool>`. When another test (`metadata_early_stop_gate_defaults_to_disabled`) runs first, it initializes the `OnceLock` with the default value (`false`), and subsequent `temp_env` overrides cannot take effect.

## Fix

Applied the same `#[cfg(test)]` bypass pattern already established in commit `f401a4388` (fix(ecstore): tolerate OnceLock re-initialization in tests) for `is_lock_optimization_enabled()`:

- `is_get_metadata_early_stop_enabled()`: read env var directly in test builds, cache via `OnceLock` in production
- `is_version_early_stop_enabled()`: same pattern

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test -p rustfs-ecstore --lib` → 1787 passed, 0 failed ✅
- `cargo test --workspace --exclude e2e_test` → 1990 passed, 2 flaky (pre-existing) ✅

## Baseline

`b16120dbc` (feat: optimize small GET read paths #4022)
