### PR TITLE
fix: auto-repair breaking changes from a2ec13ab0

### DIFF
--- a/crates/e2e_test/src/admin_timeout_regression_test.rs
+++ b/crates/e2e_test/src/admin_timeout_regression_test.rs
@@ -20,6 +20,7 @@ use rustfs_madmin::{ITEM_OFFLINE, InfoMessage, StorageInfo};
 use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
+use serde::Deserialize;
 use serial_test::serial;
 use std::error::Error;
 use std::process::Command;
@@ -27,6 +28,11 @@ use tokio::time::{Duration, sleep, timeout};
 use uuid::Uuid;
 
 const BUCKET: &str = "issue-2525-admin-timeout";
+
+#[derive(Deserialize)]
+struct StorageInfoResponse {
+    info: StorageInfo,
+}
 
 async fn signed_admin_get(
     url: &str,
@@ -60,7 +66,8 @@ async fn fetch_info(cluster: &RustFSTestClusterEnvironment) -> Result<InfoMessag
 async fn fetch_storage_info(cluster: &RustFSTestClusterEnvironment) -> Result<StorageInfo, Box<dyn Error + Send + Sync>> {
     let url = format!("{}/rustfs/admin/v3/storageinfo", cluster.nodes[0].url);
     let response = signed_admin_get(&url, &cluster.access_key, &cluster.secret_key).await?;
-    parse_json_response(response, "storage info").await
+    let wrapper: StorageInfoResponse = parse_json_response(response, "storage info").await?;
+    Ok(wrapper.info)
 }
 
 async fn parse_json_response<T: serde::de::DeserializeOwned>(

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -72,6 +72,7 @@ use super::storage_api::object_usecase::object_utils::to_s3s_etag;
 use super::storage_api::object_usecase::options::{
     copy_dst_opts, copy_src_opts, del_opts, extract_metadata, extract_metadata_from_mime_with_object_name,
     filter_object_metadata, get_content_sha256_with_query, get_opts, normalize_content_encoding_for_storage, put_opts,
+    validate_archive_content_encoding,
 };
 use super::storage_api::object_usecase::request_context::{self, spawn_traced};
 use super::storage_api::object_usecase::s3_api::multipart::parse_list_parts_params;
@@ -2859,6 +2860,13 @@ impl DefaultObjectUsecase {
         // Validate object key
         validate_object_key(&key, request_method_name)?;
         validate_table_catalog_object_mutation(&bucket, &key).await?;
+
+        // Validate archive content encoding (reject when strict mode is enabled)
+        validate_archive_content_encoding(
+            &key,
+            req.headers.get("content-type").and_then(|value| value.to_str().ok()),
+            req.headers.get("content-encoding").and_then(|value| value.to_str().ok()),
+        )?;
 
         if let Some(size) = content_length {
             self.check_bucket_quota(&bucket, quota_operation, size as u64).await?;


### PR DESCRIPTION
## Problem

Automated hourly verification (`a2ec13ab0`) detected 3 test failures:

1. **`test_archive_put_rejects_content_encoding_when_strict_mode_enabled`** — Expected 400 BAD_REQUEST when `RUSTFS_REJECT_ARCHIVE_CONTENT_ENCODING=true`, got 200 OK.
2. **`test_archive_put_with_aws_chunked_and_effective_encoding_rejects_when_strict_mode_enabled`** — Same issue.
3. **`test_single_admin_timeout_does_not_immediately_mark_peer_offline`** — Serde deserialization error: `missing field 'disks'`.

## Root Cause

1. **Archive content encoding**: `validate_archive_content_encoding()` was only called in the multipart upload path (`multipart_usecase.rs`), not in the single-part `execute_put_object` path (`object_usecase.rs`). The function was originally added to both paths in `c9c242837` but removed from `object_usecase.rs` in the revert commit `642d83f0e`.

2. **Admin timeout test**: Commit `31b5db9a7` introduced a `StorageInfoResponse` wrapper around `StorageInfo` in the `/storageinfo` admin handler, but the e2e test still tried to deserialize the raw `StorageInfo` struct.

## Fix

1. **`rustfs/src/app/object_usecase.rs`**: Added `validate_archive_content_encoding()` call in `execute_put_object`, right after object key validation — matching the multipart path behavior.

2. **`crates/e2e_test/src/admin_timeout_regression_test.rs`**: Added `StorageInfoResponse` wrapper struct and updated `fetch_storage_info` to deserialize through it, extracting the `.info` field.

## Verification

- All 3 previously-failing tests now pass individually.
- `make pre-pr` passed: 7125 nextest tests passed, 113 skipped, doctests passed.
- `cargo fmt --all --check` clean.
