### PR TITLE
fix(storage): tighten replication handle visibility

### DIFF
--- a/docs/architecture/ecstore-module-split-plan.md
+++ b/docs/architecture/ecstore-module-split-plan.md
@@ -196,7 +196,7 @@ Required contracts before crate movement:
   metrics through obs-local snapshot DTOs in
   `crates/obs/src/metrics/storage_api.rs` instead of carrying the ECStore
   replication stats handle through collectors.
-- `ReplicationPoolHandle` / `ReplicationStatsHandle`: RustFS app, admin,
+- `StorageReplicationPoolHandle` / `StorageReplicationStatsHandle`: RustFS app, admin,
   startup, and workload-admission code use storage-owner wrapper types from
   `rustfs/src/storage/storage_api.rs` for pool activity, resync, queue counts,
   proxy stats, and site metrics snapshots.

--- a/rustfs/src/app/context.rs
+++ b/rustfs/src/app/context.rs
@@ -157,12 +157,12 @@ pub fn resolve_bucket_monitor_handle() -> Option<Arc<BucketBandwidthMonitor>> {
 }
 
 /// Resolve replication pool handle using AppContext-first precedence.
-pub fn resolve_replication_pool_handle() -> Option<Arc<DynReplicationPool>> {
+pub(crate) fn resolve_replication_pool_handle() -> Option<Arc<DynReplicationPool>> {
     resolve_replication_pool_handle_with(get_global_app_context())
 }
 
 /// Resolve replication statistics handle using AppContext-first precedence.
-pub fn resolve_replication_stats_handle() -> Option<Arc<ReplicationStats>> {
+pub(crate) fn resolve_replication_stats_handle() -> Option<Arc<ReplicationStats>> {
     resolve_replication_stats_handle_with(get_global_app_context())
 }
 

--- a/rustfs/src/app/context/global.rs
+++ b/rustfs/src/app/context/global.rs
@@ -166,11 +166,11 @@ impl AppContext {
         self.bucket_monitor.clone()
     }
 
-    pub fn replication_pool(&self) -> Arc<dyn ReplicationPoolInterface> {
+    pub(crate) fn replication_pool(&self) -> Arc<dyn ReplicationPoolInterface> {
         self.replication_pool.clone()
     }
 
-    pub fn replication_stats(&self) -> Arc<dyn ReplicationStatsInterface> {
+    pub(crate) fn replication_stats(&self) -> Arc<dyn ReplicationStatsInterface> {
         self.replication_stats.clone()
     }
 

--- a/rustfs/src/app/context/handles.rs
+++ b/rustfs/src/app/context/handles.rs
@@ -452,11 +452,11 @@ pub fn default_bucket_monitor_interface() -> Arc<dyn BucketMonitorInterface> {
     Arc::new(BucketMonitorHandle)
 }
 
-pub fn default_replication_pool_interface() -> Arc<dyn ReplicationPoolInterface> {
+pub(crate) fn default_replication_pool_interface() -> Arc<dyn ReplicationPoolInterface> {
     Arc::new(ReplicationPoolHandle)
 }
 
-pub fn default_replication_stats_interface() -> Arc<dyn ReplicationStatsInterface> {
+pub(crate) fn default_replication_stats_interface() -> Arc<dyn ReplicationStatsInterface> {
     Arc::new(ReplicationStatsHandle)
 }
 

--- a/rustfs/src/app/context/interfaces.rs
+++ b/rustfs/src/app/context/interfaces.rs
@@ -101,12 +101,12 @@ pub trait BucketMonitorInterface: Send + Sync {
 }
 
 /// Replication pool interface for admin resync integration.
-pub trait ReplicationPoolInterface: Send + Sync {
+pub(crate) trait ReplicationPoolInterface: Send + Sync {
     fn handle(&self) -> Option<Arc<DynReplicationPool>>;
 }
 
 /// Replication statistics interface for admin metrics integration.
-pub trait ReplicationStatsInterface: Send + Sync {
+pub(crate) trait ReplicationStatsInterface: Send + Sync {
     fn handle(&self) -> Option<Arc<ReplicationStats>>;
 }
 

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -486,7 +486,7 @@ pub(crate) type DiskStore = ecstore_disk::DiskStore;
 pub(crate) type DisksLayout = ecstore_layout::DisksLayout;
 type EcstoreDynReplicationPool = ecstore_bucket::replication::DynReplicationPool;
 type EcstoreReplicationStats = ecstore_bucket::replication::ReplicationStats;
-pub(crate) type DynReplicationPool = ReplicationPoolHandle;
+pub(crate) type DynReplicationPool = StorageReplicationPoolHandle;
 pub(crate) type DynReader = ecstore_rio::DynReader;
 pub(crate) type ECStore = ecstore_storage::ECStore;
 pub(crate) type Endpoint = ecstore_disk::endpoint::Endpoint;
@@ -514,7 +514,7 @@ pub(crate) type ReadMultipleReq = ecstore_disk::ReadMultipleReq;
 pub(crate) type ReadMultipleResp = ecstore_disk::ReadMultipleResp;
 pub(crate) type ReadOptions = ecstore_disk::ReadOptions;
 pub(crate) type RenameDataResp = ecstore_disk::RenameDataResp;
-pub(crate) type ReplicationStats = ReplicationStatsHandle;
+pub(crate) type ReplicationStats = StorageReplicationStatsHandle;
 pub(crate) type SetupType = ecstore_layout::SetupType;
 pub(crate) type StorageError = ecstore_error::StorageError;
 pub(crate) type TierConfigMgr = ecstore_tier::TierConfigMgr;
@@ -535,11 +535,11 @@ pub(crate) type HardLimitReader<R> = ecstore_rio::HardLimitReader<R>;
 pub(crate) type NotificationSys = ecstore_notification::NotificationSys;
 
 #[derive(Debug, Clone)]
-pub struct ReplicationPoolHandle {
+pub(crate) struct StorageReplicationPoolHandle {
     inner: Arc<EcstoreDynReplicationPool>,
 }
 
-impl ReplicationPoolHandle {
+impl StorageReplicationPoolHandle {
     fn new(inner: Arc<EcstoreDynReplicationPool>) -> Arc<Self> {
         Arc::new(Self { inner })
     }
@@ -577,11 +577,11 @@ impl ReplicationPoolHandle {
 }
 
 #[derive(Debug, Clone)]
-pub struct ReplicationStatsHandle {
+pub(crate) struct StorageReplicationStatsHandle {
     inner: Arc<EcstoreReplicationStats>,
 }
 
-impl ReplicationStatsHandle {
+impl StorageReplicationStatsHandle {
     #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self {
@@ -689,11 +689,11 @@ pub(crate) fn disk_endpoint(disk: &DiskStore) -> String {
 }
 
 pub(crate) fn get_global_replication_pool() -> Option<Arc<DynReplicationPool>> {
-    ecstore_bucket::replication::get_global_replication_pool().map(ReplicationPoolHandle::new)
+    ecstore_bucket::replication::get_global_replication_pool().map(StorageReplicationPoolHandle::new)
 }
 
 pub(crate) fn get_global_replication_stats() -> Option<Arc<ReplicationStats>> {
-    ecstore_bucket::replication::get_global_replication_stats().map(ReplicationStatsHandle::from_ecstore)
+    ecstore_bucket::replication::get_global_replication_stats().map(StorageReplicationStatsHandle::from_ecstore)
 }
 
 pub(crate) fn get_global_boot_time() -> Option<std::time::SystemTime> {


### PR DESCRIPTION
## Related Issues
rustfs/backlog#750

## Summary of Changes
- Rename storage-owner replication runtime wrappers to avoid app context handle name collisions.
- Keep replication pool/stat wrapper types crate-visible and narrow replication-only app context APIs accordingly.
- Update the replication split plan with the explicit storage wrapper names.

## Verification
- `cargo check -p rustfs --lib`
- `cargo test -p rustfs app::context --lib`
- `cargo test -p rustfs workload_admission --lib`
- `cargo test -p rustfs replication_metrics --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `./scripts/check_architecture_migration_rules.sh`
- `make pre-commit`

## Impact
No user-facing API, deployment, or configuration impact expected.

## Additional Notes
Follow-up to rustfs/rustfs#4152 review feedback.
