### PR TITLE
fix(replication): address resync review follow-up

### DIFF
--- a/crates/replication/src/resync.rs
+++ b/crates/replication/src/resync.rs
@@ -453,8 +453,8 @@ fn skip_msgp_value<R: Read>(rd: &mut R) -> Result<()> {
         Marker::FixExt8 => 8,
         Marker::FixExt16 => 16,
         Marker::Ext8 => 1 + read_skip_len(rd, 1)?,
-        Marker::Ext16 => 2 + read_skip_len(rd, 2)?,
-        Marker::Ext32 => 4 + read_skip_len(rd, 4)?,
+        Marker::Ext16 => 1 + read_skip_len(rd, 2)?,
+        Marker::Ext32 => 1 + read_skip_len(rd, 4)?,
         Marker::Reserved => 0,
     };
     if skip_len > 0 {
@@ -532,5 +532,16 @@ mod tests {
         assert_eq!(got.targets_map["arn:replication:a"].resync_id, "rid-1");
         assert_eq!(got.targets_map["arn:replication:a"].resync_status, ResyncStatusType::ResyncStarted);
         assert_eq!(got.targets_map["arn:replication:a"].replicated_count, 7);
+    }
+
+    #[test]
+    fn skip_msgp_value_consumes_ext_type_and_payload() {
+        let mut ext16 = Cursor::new(vec![0xc8, 0, 2, MSGP_TIME_EXT_TYPE as u8, 0xaa, 0xbb, 0x01]);
+        skip_msgp_value(&mut ext16).expect("ext16 should skip");
+        assert!(matches!(rmp::decode::read_marker(&mut ext16), Ok(Marker::FixPos(1))));
+
+        let mut ext32 = Cursor::new(vec![0xc9, 0, 0, 0, 2, MSGP_TIME_EXT_TYPE as u8, 0xaa, 0xbb, 0x01]);
+        skip_msgp_value(&mut ext32).expect("ext32 should skip");
+        assert!(matches!(rmp::decode::read_marker(&mut ext32), Ok(Marker::FixPos(1))));
     }
 }

--- a/crates/replication/src/resync.rs
+++ b/crates/replication/src/resync.rs
@@ -558,7 +558,7 @@ mod tests {
     fn skip_msgp_value_consumes_fixext_type_and_payload() {
         for (marker, payload_len) in [(0xd4, 1), (0xd5, 2), (0xd6, 4), (0xd7, 8), (0xd8, 16)] {
             let mut data = vec![marker, MSGP_TIME_EXT_TYPE as u8];
-            data.extend(std::iter::repeat(0xaa).take(payload_len));
+            data.resize(data.len() + payload_len, 0xaa);
             data.push(0x01);
 
             let mut cursor = Cursor::new(data);

--- a/crates/replication/src/resync.rs
+++ b/crates/replication/src/resync.rs
@@ -447,19 +447,28 @@ fn skip_msgp_value<R: Read>(rd: &mut R) -> Result<()> {
             }
             return Ok(());
         }
-        Marker::FixExt1 => 1,
-        Marker::FixExt2 => 2,
-        Marker::FixExt4 => 4,
-        Marker::FixExt8 => 8,
-        Marker::FixExt16 => 16,
+        Marker::FixExt1 => 1 + 1,
+        Marker::FixExt2 => 1 + 2,
+        Marker::FixExt4 => 1 + 4,
+        Marker::FixExt8 => 1 + 8,
+        Marker::FixExt16 => 1 + 16,
         Marker::Ext8 => 1 + read_skip_len(rd, 1)?,
         Marker::Ext16 => 1 + read_skip_len(rd, 2)?,
         Marker::Ext32 => 1 + read_skip_len(rd, 4)?,
         Marker::Reserved => 0,
     };
     if skip_len > 0 {
-        let mut buf = vec![0u8; skip_len];
-        rd.read_exact(&mut buf)?;
+        skip_exact(rd, skip_len)?;
+    }
+    Ok(())
+}
+
+fn skip_exact<R: Read>(rd: &mut R, mut len: usize) -> Result<()> {
+    let mut buf = [0u8; 1024];
+    while len > 0 {
+        let take = len.min(buf.len());
+        rd.read_exact(&mut buf[..take])?;
+        len -= take;
     }
     Ok(())
 }
@@ -543,5 +552,18 @@ mod tests {
         let mut ext32 = Cursor::new(vec![0xc9, 0, 0, 0, 2, MSGP_TIME_EXT_TYPE as u8, 0xaa, 0xbb, 0x01]);
         skip_msgp_value(&mut ext32).expect("ext32 should skip");
         assert!(matches!(rmp::decode::read_marker(&mut ext32), Ok(Marker::FixPos(1))));
+    }
+
+    #[test]
+    fn skip_msgp_value_consumes_fixext_type_and_payload() {
+        for (marker, payload_len) in [(0xd4, 1), (0xd5, 2), (0xd6, 4), (0xd7, 8), (0xd8, 16)] {
+            let mut data = vec![marker, MSGP_TIME_EXT_TYPE as u8];
+            data.extend(std::iter::repeat(0xaa).take(payload_len));
+            data.push(0x01);
+
+            let mut cursor = Cursor::new(data);
+            skip_msgp_value(&mut cursor).expect("fixext should skip");
+            assert!(matches!(rmp::decode::read_marker(&mut cursor), Ok(Marker::FixPos(1))));
+        }
     }
 }

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -2543,7 +2543,7 @@ fi
 
 (
   cd "$ROOT_DIR"
-  rg -n --with-filename 'pub\s+(?:struct|enum)\s+(ResyncOpts|TargetReplicationResyncStatus|BucketReplicationResyncStatus|ResyncStatusType)\b' \
+  rg -n --with-filename 'pub\s+(struct|enum)\s+(ResyncOpts|TargetReplicationResyncStatus|BucketReplicationResyncStatus|ResyncStatusType)\b' \
     crates/ecstore/src/bucket/replication \
     --glob '*.rs' || true
 ) >"$REPLICATION_RESYNC_CONTRACT_BACKSLIDE_HITS_FILE"


### PR DESCRIPTION
## Related Issues
rustfs/backlog#750

## Summary of Changes
- Use a supported ripgrep regex in the resync contract backslide guard.
- Fix MessagePack Ext16/Ext32 skipping to consume the extension type byte plus payload.
- Add a regression test for skipping ext fields before the next marker.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-replication`
- `./scripts/check_architecture_migration_rules.sh`
- `git diff --check origin/main...HEAD`
- `make pre-commit`

## Impact
No API or configuration changes. This preserves resync metadata forward compatibility.

## Additional Notes
Follow-up to #4154 after review fixes missed the merged commit.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
