### PR TITLE
fix(replication): avoid target status map allocation

### DIFF
--- a/crates/ecstore/src/object_api/types.rs
+++ b/crates/ecstore/src/object_api/types.rs
@@ -748,9 +748,14 @@ impl ObjectInfo {
     }
 
     pub fn target_replication_status(&self, arn: &str) -> ReplicationStatusType {
-        replication_statuses_map(self.replication_status_internal.as_deref().unwrap_or_default())
-            .get(arn)
-            .cloned()
+        self.replication_status_internal
+            .as_deref()
+            .unwrap_or_default()
+            .split(';')
+            .find_map(|entry| {
+                let (target_arn, status) = entry.split_once('=')?;
+                (!target_arn.is_empty() && target_arn == arn).then(|| ReplicationStatusType::from(status))
+            })
             .unwrap_or_default()
     }
 
@@ -843,6 +848,7 @@ mod tests {
         let state = object.replication_state();
 
         assert_eq!(object.target_replication_status("arn:target-a"), ReplicationStatusType::Completed);
+        assert_eq!(object.target_replication_status("arn:target-b"), ReplicationStatusType::Failed);
         assert_eq!(object.target_replication_status("arn:missing"), ReplicationStatusType::Empty);
         assert_eq!(state.targets.get("arn:target-b"), Some(&ReplicationStatusType::Failed));
         assert_eq!(state.purge_targets.get("arn:target-a"), Some(&VersionPurgeStatusType::Pending));


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#750.

## Summary of Changes
- Parse `ObjectInfo::target_replication_status()` by scanning the status string directly instead of allocating a full target-status map per call.
- Keep target-status behavior covered for completed, failed, and missing targets.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore object_info_replication_helpers_parse_target_status_and_reset_headers --lib`
- `git diff --check`
- `make pre-commit`

## Impact
No user-facing behavior, deployment, or configuration impact. This reduces avoidable allocation work on repeated per-object target-status lookups.

## Additional Notes
Follows up review feedback from rustfs/rustfs#4158.
