### PR TITLE
fix: auto-repair clippy failures from d666028cdc

### DIFF
--- a/crates/replication/src/runtime.rs
+++ b/crates/replication/src/runtime.rs
@@ -84,10 +84,7 @@ pub fn resized_worker_counts(
 
 pub fn mrf_worker_size_to_count(size: i32) -> usize {
     let non_negative = size.max(0);
-    match usize::try_from(non_negative) {
-        Ok(size) => size,
-        Err(_) => 0,
-    }
+    usize::try_from(non_negative).unwrap_or_default()
 }
 
 pub fn worker_counts_for_priority(
@@ -145,10 +142,7 @@ fn auto_worker_count(current_workers: usize, auto_default: usize) -> usize {
 }
 
 fn usize_to_i32_saturating(value: usize) -> i32 {
-    match i32::try_from(value) {
-        Ok(value) => value,
-        Err(_) => i32::MAX,
-    }
+    i32::try_from(value).unwrap_or(i32::MAX)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

`make pre-pr` failed on `clippy-check` with 2 errors in `crates/replication/src/runtime.rs`:

1. **`manual-unwrap-or-default`** (line 87): `match usize::try_from(non_negative) { Ok(size) => size, Err(_) => 0 }` → `usize::try_from(non_negative).unwrap_or_default()`
2. **`manual-unwrap-or`** (line 148): `match i32::try_from(value) { Ok(value) => value, Err(_) => i32::MAX }` → `i32::try_from(value).unwrap_or(i32::MAX)`

Both were introduced in the latest `main` commit (`d666028cdc`) which added/refactored replication runtime code.

## Fix

Replaced the two verbose match expressions with their idiomatic clippy equivalents. No behavioral change — the semantics are identical.

## Verification

- ✅ `make clippy-check` — passes
- ✅ `make test` — 7237 passed, 113 skipped
- ✅ `s3s-e2e` — all S3 compatibility tests passed (Basic + Advanced suites)

## Baseline

`d666028cdc5167d608aaa0ce2c7af24718f29a13` (origin/main HEAD)
