### PR TITLE
fix: collapse nested if to satisfy clippy::collapsible_if lint

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
@@ -98,10 +98,8 @@ pub(crate) fn replication_put_object_options(sc: &str, object_info: &ObjectInfo)
     for (key, value) in object_info.user_defined.iter() {
         let has_valid_sse_header = valid_sse_replication_header(key).is_some();
 
-        if !is_ssec || !has_valid_sse_header {
-            if is_internal_key(key) || is_standard_header(key) {
-                continue;
-            }
+        if (!is_ssec || !has_valid_sse_header) && (is_internal_key(key) || is_standard_header(key)) {
+            continue;
         }
 
         if let Some(replication_header) = valid_sse_replication_header(key) {


### PR DESCRIPTION
## Problem

`make pre-pr` failed on `main` at commit `3533080d4` due to a `clippy::collapsible_if` lint error in `crates/ecstore/src/bucket/replication/replication_target_boundary.rs`.

**Error:**
```
error: this `if` statement can be collapsed
  --> crates/ecstore/src/bucket/replication/replication_target_boundary.rs:101:9
    |
101 |         if !is_ssec || !has_valid_sse_header {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Fix

Collapsed the nested `if` into a single combined condition:

```rust
// Before
if !is_ssec || !has_valid_sse_header {
    if is_internal_key(key) || is_standard_header(key) {
        continue;
    }
}

// After
if (!is_ssec || !has_valid_sse_header) && (is_internal_key(key) || is_standard_header(key)) {
    continue;
}
```

## Verification

- ✅ `cargo fmt --all --check` — passes
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passes
- ✅ `cargo test -p rustfs-ecstore` — passes (1839 passed, 1 flaky ignored)
- ✅ s3s-e2e — all 15 tests PASSED (5.9s)
