### PR TITLE
fix(ecstore): surface multipart cleanup delete errors

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -1658,6 +1658,9 @@ async fn cleanup_stale_multipart_uploads_in_set(set: &Arc<SetDisks>, now: Offset
     let mut deleted = 0usize;
     let mut candidates = HashMap::new();
 
+    // Discovery is intentionally local-owner based: each server lists the disks
+    // it owns locally. Once a stale upload path is found, delete_all fans out
+    // idempotently across the set to remove matching shards on every disk.
     for disk in set.get_local_disks().await.into_iter().flatten() {
         if !disk.is_online().await {
             continue;

--- a/crates/ecstore/src/set_disk/list.rs
+++ b/crates/ecstore/src/set_disk/list.rs
@@ -54,6 +54,18 @@ impl SetDisks {
             }
         }
 
+        let failed = errors.iter().filter(|err| err.is_some()).count();
+        if failed > 0 {
+            debug!(
+                bucket = %bucket,
+                prefix = %prefix,
+                failed,
+                total = errors.len(),
+                errors = ?errors,
+                "delete_all completed with disk errors"
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Document the stale multipart cleanup ownership model as local-owner discovery with set-wide idempotent deletion.
- Log partial disk failures from `SetDisks::delete_all` instead of silently discarding the collected errors.
- Preserve existing delete semantics while making cleanup gaps observable during stale multipart cleanup and other recursive delete-all callers.

## Verification
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p rustfs-ecstore stale_multipart_cleanup --lib`

Full `make pre-commit` was not run per task instruction; this PR used focused verification for the stale multipart cleanup surface.

## Impact
No API or compatibility impact. Operators now get debug diagnostics when recursive set-wide cleanup encounters disk-level delete errors.

## Additional Notes
This keeps RustFS's local-owner cleanup design instead of changing each node to enumerate remote disks.
