### PR TITLE
fix(ecstore): remove reachable panics in tiering, replication, and heal paths

### DIFF
--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -1254,6 +1254,17 @@ impl PutObjectOptions {
         }
     }
 
+    /// Insert `value` as header `name`, skipping values that are not valid
+    /// HTTP header values (with a warning) instead of panicking mid-replication.
+    fn insert_checked(header: &mut HeaderMap, name: &'static str, value: &str) {
+        match HeaderValue::from_str(value) {
+            Ok(v) => {
+                header.insert(name, v);
+            }
+            Err(_) => warn!("skipping header {} with invalid value", name),
+        }
+    }
+
     pub fn header(&self) -> HeaderMap {
         let mut header = HeaderMap::new();
 
@@ -1261,66 +1272,75 @@ impl PutObjectOptions {
         if content_type.is_empty() {
             content_type = "application/octet-stream".to_string();
         }
-        header.insert("Content-Type", HeaderValue::from_str(&content_type).expect("err"));
+        match HeaderValue::from_str(&content_type) {
+            Ok(v) => {
+                header.insert("Content-Type", v);
+            }
+            Err(_) => {
+                warn!("invalid Content-Type header value, falling back to application/octet-stream");
+                header.insert("Content-Type", HeaderValue::from_static("application/octet-stream"));
+            }
+        }
 
         if !self.content_encoding.is_empty() {
-            header.insert("Content-Encoding", HeaderValue::from_str(&self.content_encoding).expect("err"));
+            Self::insert_checked(&mut header, "Content-Encoding", &self.content_encoding);
         }
         if !self.content_disposition.is_empty() {
-            header.insert("Content-Disposition", HeaderValue::from_str(&self.content_disposition).expect("err"));
+            Self::insert_checked(&mut header, "Content-Disposition", &self.content_disposition);
         }
         if !self.content_language.is_empty() {
-            header.insert("Content-Language", HeaderValue::from_str(&self.content_language).expect("err"));
+            Self::insert_checked(&mut header, "Content-Language", &self.content_language);
         }
         if !self.cache_control.is_empty() {
-            header.insert("Cache-Control", HeaderValue::from_str(&self.cache_control).expect("err"));
+            Self::insert_checked(&mut header, "Cache-Control", &self.cache_control);
         }
 
         if self.expires.unix_timestamp() != 0 {
-            header.insert("Expires", HeaderValue::from_str(&self.expires.format(&Rfc3339).unwrap()).expect("err")); //rustfs invalid header
+            match self.expires.format(&Rfc3339) {
+                Ok(expires) => Self::insert_checked(&mut header, "Expires", &expires),
+                Err(err) => warn!("skipping Expires header, format failed: {}", err),
+            }
         }
 
         if let Some(mode) = &self.mode {
-            header.insert(AMZ_OBJECT_LOCK_MODE, HeaderValue::from_str(mode.as_str()).expect("err"));
+            Self::insert_checked(&mut header, AMZ_OBJECT_LOCK_MODE, mode.as_str());
         }
 
         if self.retain_until_date.unix_timestamp() != 0 {
-            header.insert(
-                AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE,
-                HeaderValue::from_str(&self.retain_until_date.format(&Rfc3339).unwrap()).expect("err"),
-            );
+            match self.retain_until_date.format(&Rfc3339) {
+                Ok(retain_until) => Self::insert_checked(&mut header, AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE, &retain_until),
+                Err(err) => warn!("skipping object-lock retain-until-date header, format failed: {}", err),
+            }
         }
 
         if let Some(legalhold) = &self.legalhold {
-            header.insert(AMZ_OBJECT_LOCK_LEGAL_HOLD, HeaderValue::from_str(legalhold.as_str()).expect("err"));
+            Self::insert_checked(&mut header, AMZ_OBJECT_LOCK_LEGAL_HOLD, legalhold.as_str());
         }
 
         if !self.storage_class.is_empty() {
-            header.insert(AMZ_STORAGE_CLASS, HeaderValue::from_str(&self.storage_class).expect("err"));
+            Self::insert_checked(&mut header, AMZ_STORAGE_CLASS, &self.storage_class);
         }
 
         if !self.website_redirect_location.is_empty() {
-            header.insert(
-                AMZ_WEBSITE_REDIRECT_LOCATION,
-                HeaderValue::from_str(&self.website_redirect_location).expect("err"),
-            );
+            Self::insert_checked(&mut header, AMZ_WEBSITE_REDIRECT_LOCATION, &self.website_redirect_location);
         }
 
         if !self.internal.replication_status.as_str().is_empty() {
-            header.insert(
-                AMZ_BUCKET_REPLICATION_STATUS,
-                HeaderValue::from_str(self.internal.replication_status.as_str()).expect("err"),
-            );
+            Self::insert_checked(&mut header, AMZ_BUCKET_REPLICATION_STATUS, self.internal.replication_status.as_str());
         }
 
         for (k, v) in &self.user_metadata {
+            let Ok(header_value) = HeaderValue::from_str(v) else {
+                warn!("skipping user metadata header with invalid value: {}", k);
+                continue;
+            };
             if is_amz_header(k) || is_standard_header(k) || is_storageclass_header(k) || is_rustfs_header(k) || is_minio_header(k)
             {
                 if let Ok(header_name) = HeaderName::from_bytes(k.as_bytes()) {
-                    header.insert(header_name, HeaderValue::from_str(v).unwrap());
+                    header.insert(header_name, header_value);
                 }
             } else if let Ok(header_name) = HeaderName::from_bytes(format!("x-amz-meta-{k}").as_bytes()) {
-                header.insert(header_name, HeaderValue::from_str(v).unwrap());
+                header.insert(header_name, header_value);
             }
         }
 

--- a/crates/ecstore/src/client/api_list.rs
+++ b/crates/ecstore/src/client/api_list.rs
@@ -133,7 +133,7 @@ impl TransitionClient {
                 body_vec.extend_from_slice(data);
             }
         }
-        let mut list_bucket_result = match quick_xml::de::from_str::<ListBucketV2Result>(&String::from_utf8(body_vec).unwrap()) {
+        let mut list_bucket_result = match quick_xml::de::from_str::<ListBucketV2Result>(&String::from_utf8_lossy(&body_vec)) {
             Ok(result) => result,
             Err(err) => {
                 return Err(std::io::Error::other(err.to_string()));

--- a/crates/ecstore/src/client/api_put_object.rs
+++ b/crates/ecstore/src/client/api_put_object.rs
@@ -234,13 +234,17 @@ impl PutObjectOptions {
         }
 
         for (k, v) in &self.user_metadata {
+            let Ok(header_value) = HeaderValue::from_str(v) else {
+                warn!("skipping user metadata header with invalid value: {}", k);
+                continue;
+            };
             if is_amz_header(k) || is_standard_header(k) || is_storageclass_header(k) || is_rustfs_header(k) || is_minio_header(k)
             {
                 if let Ok(header_name) = HeaderName::from_bytes(k.as_bytes()) {
-                    header.insert(header_name, HeaderValue::from_str(&v).expect("operation should succeed"));
+                    header.insert(header_name, header_value);
                 }
             } else if let Ok(header_name) = HeaderName::from_bytes(format!("x-amz-meta-{}", k).as_bytes()) {
-                header.insert(header_name, HeaderValue::from_str(&v).expect("operation should succeed"));
+                header.insert(header_name, header_value);
             }
         }
 

--- a/crates/ecstore/src/client/api_put_object_multipart.rs
+++ b/crates/ecstore/src/client/api_put_object_multipart.rs
@@ -388,14 +388,13 @@ impl TransitionClient {
 
         let complete_multipart_upload_result: CompleteMultipartUploadResult = CompleteMultipartUploadResult::default();
 
-        let (exp_time, rule_id) = if let Some(h_x_amz_expiration) = resp.headers().get(X_AMZ_EXPIRATION) {
-            (
-                OffsetDateTime::parse(h_x_amz_expiration.to_str().unwrap(), ISO8601_DATEFORMAT).unwrap(),
-                "".to_string(),
-            )
-        } else {
-            (OffsetDateTime::now_utc(), "".to_string())
-        };
+        let exp_time = resp
+            .headers()
+            .get(X_AMZ_EXPIRATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| OffsetDateTime::parse(s, ISO8601_DATEFORMAT).ok())
+            .unwrap_or_else(OffsetDateTime::now_utc);
+        let rule_id = "".to_string();
 
         Ok(UploadInfo {
             bucket: complete_multipart_upload_result.bucket,

--- a/crates/ecstore/src/client/api_put_object_streaming.rs
+++ b/crates/ecstore/src/client/api_put_object_streaming.rs
@@ -523,14 +523,13 @@ impl TransitionClient {
             )));
         }
 
-        let (exp_time, rule_id) = if let Some(h_x_amz_expiration) = resp.headers().get(X_AMZ_EXPIRATION) {
-            (
-                OffsetDateTime::parse(h_x_amz_expiration.to_str().unwrap(), ISO8601_DATEFORMAT).unwrap(),
-                "".to_string(),
-            )
-        } else {
-            (OffsetDateTime::now_utc(), "".to_string())
-        };
+        let exp_time = resp
+            .headers()
+            .get(X_AMZ_EXPIRATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| OffsetDateTime::parse(s, ISO8601_DATEFORMAT).ok())
+            .unwrap_or_else(OffsetDateTime::now_utc);
+        let rule_id = "".to_string();
         let h = resp.headers();
         Ok(UploadInfo {
             bucket: bucket_name.to_string(),

--- a/crates/ecstore/src/diagnostics/admin_server_info.rs
+++ b/crates/ecstore/src/diagnostics/admin_server_info.rs
@@ -79,7 +79,9 @@ async fn is_server_resolvable(endpoint: &Endpoint) -> Result<()> {
         "{}://{}:{}",
         endpoint.url.scheme(),
         endpoint.url.host_str().expect("URL should have host"),
-        endpoint.url.port().expect("URL should have port")
+        // `Url::port()` is None when the URL uses the scheme's default port
+        // (e.g. http on 80 / https on 443); fall back to the scheme default.
+        endpoint.url.port_or_known_default().expect("URL should have port")
     );
 
     let ping_task = async {

--- a/crates/ecstore/src/set_disk/heal.rs
+++ b/crates/ecstore/src/set_disk/heal.rs
@@ -352,11 +352,26 @@ impl SetDisks {
 
                         // We write at temporary location and then rename to final location.
                         let tmp_id = Uuid::new_v4().to_string();
-                        // Delete markers and remote (transitioned) objects carry no data_dir;
-                        // both are skipped by the `!latest_meta.deleted && !latest_meta.is_remote()`
-                        // guard below, so the placeholder values are never used.
-                        let src_data_dir = latest_meta.data_dir.map(|d| d.to_string()).unwrap_or_default();
-                        let dst_data_dir = latest_meta.data_dir.unwrap_or_default();
+                        // Delete markers and remote (transitioned) objects carry no data_dir and
+                        // skip the data-heal block below, so a nil placeholder is safe for them.
+                        // For a regular object a missing data_dir means the latest metadata is
+                        // corrupt; fail this object's heal with a clear error instead of building
+                        // part paths under a nil UUID directory.
+                        let data_dir = match latest_meta.data_dir {
+                            Some(data_dir) => data_dir,
+                            None => {
+                                if !latest_meta.deleted && !latest_meta.is_remote() {
+                                    error!(
+                                        "heal: latest metadata for {}/{} has no data_dir, cannot heal object data",
+                                        bucket, object
+                                    );
+                                    return Err(DiskError::FileCorrupt);
+                                }
+                                Uuid::nil()
+                            }
+                        };
+                        let src_data_dir = data_dir.to_string();
+                        let dst_data_dir = data_dir;
 
                         if !latest_meta.deleted && !latest_meta.is_remote() {
                             let erasure_info = latest_meta.erasure.clone();

--- a/crates/ecstore/src/set_disk/heal.rs
+++ b/crates/ecstore/src/set_disk/heal.rs
@@ -352,8 +352,11 @@ impl SetDisks {
 
                         // We write at temporary location and then rename to final location.
                         let tmp_id = Uuid::new_v4().to_string();
-                        let src_data_dir = latest_meta.data_dir.expect("operation should succeed").to_string();
-                        let dst_data_dir = latest_meta.data_dir.expect("operation should succeed");
+                        // Delete markers and remote (transitioned) objects carry no data_dir;
+                        // both are skipped by the `!latest_meta.deleted && !latest_meta.is_remote()`
+                        // guard below, so the placeholder values are never used.
+                        let src_data_dir = latest_meta.data_dir.map(|d| d.to_string()).unwrap_or_default();
+                        let dst_data_dir = latest_meta.data_dir.unwrap_or_default();
 
                         if !latest_meta.deleted && !latest_meta.is_remote() {
                             let erasure_info = latest_meta.erasure.clone();

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -4446,7 +4446,9 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
             if let Some(disk) = disk {
                 continue;
             }
-            let _ = self.add_partial(bucket, object, opts.version_id.as_ref().expect("err")).await;
+            let _ = self
+                .add_partial(bucket, object, opts.version_id.as_deref().unwrap_or_default())
+                .await;
             break;
         }
 

--- a/crates/ecstore/src/store/list_objects.rs
+++ b/crates/ecstore/src/store/list_objects.rs
@@ -1883,7 +1883,14 @@ impl ECStore {
             .instrument(tracing::Span::current()),
         );
 
-        tokio::spawn(async move { merge_entry_channels(rx, inputs, merge_tx, 1).await }.instrument(tracing::Span::current()));
+        tokio::spawn(
+            async move {
+                if let Err(err) = merge_entry_channels(rx, inputs, merge_tx, 1).await {
+                    error!("merge_entry_channels err {:?}", err)
+                }
+            }
+            .instrument(tracing::Span::current()),
+        );
 
         let walk_started = std::time::Instant::now();
         let walk_results = join_all(futures).await;
@@ -2952,7 +2959,14 @@ impl Sets {
             .instrument(tracing::Span::current()),
         );
 
-        tokio::spawn(async move { merge_entry_channels(rx, inputs, merge_tx, 1).await }.instrument(tracing::Span::current()));
+        tokio::spawn(
+            async move {
+                if let Err(err) = merge_entry_channels(rx, inputs, merge_tx, 1).await {
+                    error!("merge_entry_channels err {:?}", err)
+                }
+            }
+            .instrument(tracing::Span::current()),
+        );
 
         let walk_started = std::time::Instant::now();
         let walk_results = join_all(futures).await;


### PR DESCRIPTION
## Related Issues

N/A — found by an async/concurrency hygiene audit of production code paths in `rustfs-ecstore`.

## Summary of Changes

Removes 8 reachable `unwrap()`/`expect()` panics in background workers (ILM tiering, replication, heal) and one admin request path, plus adds error logging to 2 fire-and-forget merge tasks. All fixes are minimal and semantics-preserving: valid inputs behave exactly as before; the only behavior change is on inputs that previously panicked the worker.

**High severity (deterministic panics):**
- `client/api_put_object_streaming.rs`, `client/api_put_object_multipart.rs` — tier PUT / CompleteMultipartUpload responses parse the `x-amz-expiration` header as ISO8601 with `unwrap()`. S3/MinIO return `expiry-date="<RFC1123>", rule-id="..."` whenever the remote tier bucket has any lifecycle rule, so the parse deterministically panicked the ILM transition worker. Now falls back to `now_utc()` (same as when the header is absent).
- `client/api_put_object.rs` — `PutObjectOptions::header()` panicked via `expect()` on any user-metadata value that is not a valid HTTP header value (e.g. transitioning an object whose key contains non-ASCII characters, since the tiering flow stores the object key in metadata). Invalid values are now skipped with a warning, matching the existing idiom for header names in the same loop.
- `set_disk/heal.rs` — `latest_meta.data_dir.expect(...)` panicked when healing a delete marker (data_dir is `None`), a routine situation after node downtime on a versioned bucket. Both values are only consumed inside the `!deleted && !is_remote` guard, so placeholder defaults are never used for those metas.

**Medium severity:**
- `set_disk/mod.rs` (`transition_object`) — `opts.version_id.as_ref().expect("err")` panicked when transitioning an object in an unversioned bucket while a set disk is offline. `add_partial` only logs the version id, so an empty string is harmless.
- `bucket/bucket_target_sys.rs` — replication `PutObjectOptions::header()` had a dozen `expect("err")` calls on stored metadata (content-type, cache-control, object-lock dates, user metadata, ...). A single object with an invalid stored value re-panicked the replication worker on every retry. Invalid values are now skipped with a warning via a small `insert_checked` helper; invalid Content-Type falls back to `application/octet-stream`.
- `diagnostics/admin_server_info.rs` — `endpoint.url.port().expect(...)` panicked on every admin ServerInfo request in distributed clusters running on default ports, because the `url` crate normalizes port 80/443 to `None`. Now uses `port_or_known_default()`, which is identical for explicit non-default ports.

**Low severity:**
- `client/api_list.rs` — tier ListObjectsV2 response body decoded with `String::from_utf8(...).unwrap()`; a non-UTF-8 error page from a proxy panicked the admin tier verify path. Now `from_utf8_lossy`.
- `store/list_objects.rs` — two `walk_internal` spawns silently dropped the `merge_entry_channels` result; now logged, matching the logged variants of the same call elsewhere in the file.

Sites where an `unwrap()` is guarded by an invariant, or where the code is unreachable, were deliberately left untouched to keep the diff narrow.

## Verification

- `cargo fmt --all`
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`
- `cargo nextest run -p rustfs-ecstore` — 1874 passed, 1 skipped

## Impact

No API or configuration changes. Previously-panicking inputs now degrade gracefully (skip + `warn!`, or documented fallback values); all other inputs produce byte-identical behavior. Improves availability of ILM tiering, replication, heal, and admin ServerInfo in distributed deployments.

## Additional Notes

Part of a broader async/concurrency hygiene audit: `block_on` call sites and `std::sync` lock usage across `rustfs`/`ecstore` were also audited and found correct (test-only or properly `block_in_place`-wrapped; no locks held across `.await`), so no changes were needed there.
