### PR TITLE
fix: suppress clippy type_complexity lint in capacity_manager test helper

### DIFF
--- a/crates/object-capacity/src/capacity_manager.rs
+++ b/crates/object-capacity/src/capacity_manager.rs
@@ -1128,6 +1128,7 @@ mod tests {
     /// Table of env-configurable getters: (env var, getter normalized to u64,
     /// expected default, override string, expected override value).
     /// Durations are normalized to whole seconds.
+    #[allow(clippy::type_complexity)]
     fn config_getter_cases() -> Vec<(&'static str, fn() -> u64, u64, &'static str, u64)> {
         vec![
             (


### PR DESCRIPTION
## Problem

`cargo clippy --all-targets --all-features -- -D warnings` fails on `main` (83c32a7a) with a `clippy::type_complexity` error in `crates/object-capacity/src/capacity_manager.rs:1131`, introduced by commit 9dfeffc4 ("test: prune redundant cases and add high-risk coverage across crates (#4208)").

The test helper `config_getter_cases()` returns `Vec<(&'static str, fn() -> u64, u64, &'static str, u64)>`, which exceeds the default type-complexity threshold.

## Fix

Added `#[allow(clippy::type_complexity)]` to the test-only function. This is the minimal fix — the tuple structure is clear in context and extracting a type alias would add indirection without improving readability.

## Verification

- ✅ `cargo fmt --all --check` — clean
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` — passes
- ✅ `cargo test -p rustfs-object-capacity` — 38/38 passed
- ✅ `cargo build -p rustfs` — builds successfully
- ✅ `s3s-e2e` — all 28 S3 compatibility tests passed (Basic + Advanced suites)

## Baseline

- Branch point: `83c32a7a` (fix(lifecycle): avoid blocking expiry enqueue #4197)
- Failing commit: `9dfeffc4` (test: prune redundant cases and add high-risk coverage across crates #4208)
