### PR TITLE
fix: auto-repair clippy type_complexity failure from 83c32a7a

### DIFF
--- a/crates/object-capacity/src/capacity_manager.rs
+++ b/crates/object-capacity/src/capacity_manager.rs
@@ -1128,6 +1128,7 @@ mod tests {
     /// Table of env-configurable getters: (env var, getter normalized to u64,
     /// expected default, override string, expected override value).
     /// Durations are normalized to whole seconds.
+    #[allow(clippy::type_complexity)]
     fn config_getter_cases() -> Vec<(&'static str, fn() -> u64, u64, &'static str, u64)> {
         vec![
             (


### PR DESCRIPTION
## Problem

`make pre-pr` fails on `main` due to a clippy `type_complexity` error in `crates/object-capacity/src/capacity_manager.rs`:

```
error: very complex type used. Consider factoring parts into `type` definitions
    --> crates/object-capacity/src/capacity_manager.rs:1131:33
     |
1131 |     fn config_getter_cases() -> Vec<(&'static str, fn() -> u64, u64, &'static str, u64)> {
```

This was introduced by commit `9dfeffc4` (`test: prune redundant cases and add high-risk coverage across crates (#4208)`).

## Fix

Add `#[allow(clippy::type_complexity)]` on the `config_getter_cases()` test helper. The tuple type is intentionally explicit for test readability — no behavioral change.

## Verification

- ✅ `make pre-pr` — all checks pass (fmt, clippy, tests, doc-tests)
- ✅ `s3s-e2e` — all 26 S3 compatibility tests pass
