### PR TITLE
fix(object-capacity): resolve clippy type_complexity lint in test code

### DIFF
--- a/crates/object-capacity/src/capacity_manager.rs
+++ b/crates/object-capacity/src/capacity_manager.rs
@@ -1125,11 +1125,12 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    type ConfigGetterCase = (&'static str, fn() -> u64, u64, &'static str, u64);
+
     /// Table of env-configurable getters: (env var, getter normalized to u64,
     /// expected default, override string, expected override value).
     /// Durations are normalized to whole seconds.
-    #[allow(clippy::type_complexity)]
-    fn config_getter_cases() -> Vec<(&'static str, fn() -> u64, u64, &'static str, u64)> {
+    fn config_getter_cases() -> Vec<ConfigGetterCase> {
         vec![
             (
                 ENV_CAPACITY_SCHEDULED_INTERVAL,


### PR DESCRIPTION
## Related Issues
N/A — discovered by automated hourly verification.

## Summary of Changes
The `clippy-check` step of `make pre-pr` fails on `main` with a `type_complexity` lint error in `crates/object-capacity/src/capacity_manager.rs:1131`. The return type `Vec<(&'static str, fn() -> u64, u64, &'static str, u64)>` exceeds the complexity threshold.

Fix: introduce a `ConfigGetterCase` type alias in the test module to satisfy the lint, with zero runtime behavior change.

## Verification
- `make fmt-check` ✅
- `make unsafe-code-check` ✅
- `make architecture-migration-check` ✅
- `make logging-guardrails-check` ✅
- `make doc-paths-check` ✅
- `make clippy-check` ✅ (after fix)
- `make pre-commit` ✅ (full quick-check suite)
- `cargo test -p rustfs-object-capacity` — 36/38 passed; 2 flaky timing-sensitive tests fail (pre-existing on baseline, unrelated to this change)

## Impact
N/A — test-only code change, no runtime behavior change.

## Additional Notes
- Baseline: `83c32a7a407bc151f2107d535ba6a0334945b604`
- The 2 pre-existing flaky tests (`test_refresh_or_join_singleflight`, `test_spawn_refresh_if_needed_deduplicates_background_refresh`) fail intermittently due to timing sensitivity in singleflight/deduplication logic. Verified they also fail on the unmodified baseline.
- `s3s-e2e` could not be run: the installed version (rev `62cb4a71`) has a different CLI interface than expected by the verification script (`--endpoint`/`--rustfs-binary`/`--run-root` flags are absent).
