### PR TITLE
fix(ecstore): scope replication boundary etag import to test module

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
@@ -20,8 +20,7 @@ use aws_sdk_s3::operation::head_object::HeadObjectOutput;
 use aws_sdk_s3::types::{ObjectLockLegalHoldStatus, ObjectLockRetentionMode};
 use http::HeaderMap;
 use rustfs_replication::{
-    ReplicationSourceObject, ReplicationTargetObject, content_matches_by_etag, replication_action_for_target,
-    target_is_newer_than_source_null_version,
+    ReplicationSourceObject, ReplicationTargetObject, replication_action_for_target, target_is_newer_than_source_null_version,
 };
 use rustfs_utils::http::{
     AMZ_BUCKET_REPLICATION_STATUS, AMZ_OBJECT_LOCK_LEGAL_HOLD, AMZ_OBJECT_LOCK_MODE, AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE,
@@ -365,6 +364,7 @@ fn valid_sse_replication_header(key: &str) -> Option<&str> {
 mod tests {
     use super::*;
     use aws_smithy_types::DateTime;
+    use rustfs_replication::content_matches_by_etag;
     use rustfs_utils::http::{
         SSEC_ALGORITHM_HEADER, SUFFIX_REPLICATION_ACTUAL_OBJECT_SIZE, SUFFIX_REPLICATION_SSEC_CRC, get_header_map,
     };


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Fixes a workspace-wide `cargo clippy -D warnings` failure introduced by #4211: `content_matches_by_etag` is imported at lib scope in `crates/ecstore/src/bucket/replication/replication_target_boundary.rs` but only used inside the `#[cfg(test)]` module, so non-test builds fail with `unused import`. The import is moved into the test module. No behavior change.

## Verification

- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `cargo test -p rustfs-ecstore --lib bucket::replication::replication_target_boundary` (9 tests pass)
- `cargo fmt --all`

## Impact

N/A (test-only import scoping; no behavior change)

## Additional Notes

Unblocks `make pre-pr` / CI clippy for all branches based on current `main`.
