### PR TITLE
fix: auto-repair breaking changes from 48b70f6e

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
@@ -19,8 +19,6 @@ use crate::bucket::bucket_target_sys::{BucketTargetError, BucketTargetSys};
 use aws_sdk_s3::operation::head_object::HeadObjectOutput;
 use aws_sdk_s3::types::{ObjectLockLegalHoldStatus, ObjectLockRetentionMode};
 use http::HeaderMap;
-#[cfg(test)]
-use rustfs_replication::content_matches_by_etag;
 use rustfs_replication::{
     ReplicationSourceObject, ReplicationTargetObject, replication_action_for_target, target_is_newer_than_source_null_version,
 };


### PR DESCRIPTION
## Auto-repair: unused import in replication_target_boundary.rs

### Problem
`clippy --workspace --all-targets --all-features -- -D warnings` failed on commit `48b70f6e` (latest `main`) due to an unused import:

```
error: unused import: `rustfs_replication::content_matches_by_etag`
  --> crates/ecstore/src/bucket/replication/replication_target_boundary.rs:23:5
```

The `#[cfg(test)] use content_matches_by_etag` at module level (line 22-23) was redundant — the test module already imports it locally at line 369.

### Fix
Removed the duplicate `#[cfg(test)] use` at lines 22-23 (2-line diff).

### Verification
- ✅ `cargo fmt --all --check` — clean
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passes
- ✅ `cargo test -p rustfs-ecstore` — all tests pass
- ✅ `scripts/check_architecture_migration_rules.sh` — passes
- ✅ `s3s-e2e` — all 25 S3 compatibility tests pass
