### PR TITLE
fix(server): normalize leading and duplicate slashes in object keys

### DIFF
--- a/crates/e2e_test/src/leading_slash_key_test.rs
+++ b/crates/e2e_test/src/leading_slash_key_test.rs
@@ -1,0 +1,144 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression tests for Issue #2427: object keys with a leading slash.
+//!
+//! AWS S3 accepts keys such as `/foo/bar` (request path `PUT /bucket//foo/bar`),
+//! and some SDK wrappers produce such keys. RustFS normalizes these MinIO-style:
+//! leading slashes are stripped and duplicate slashes after a leading slash are
+//! collapsed, so `//foo/bar` is stored and served as `foo/bar`.
+
+#[cfg(test)]
+mod tests {
+    use crate::common::{RustFSTestEnvironment, init_logging};
+    use aws_sdk_s3::Client;
+    use aws_sdk_s3::primitives::ByteStream;
+    use serial_test::serial;
+    use std::error::Error;
+    use tracing::info;
+
+    async fn create_bucket(client: &Client, bucket: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
+        client.create_bucket().bucket(bucket).send().await?;
+        Ok(())
+    }
+
+    /// PUT with a leading-slash key must succeed and the object must be
+    /// readable under the normalized key (leading slash stripped).
+    #[tokio::test]
+    #[serial]
+    async fn test_put_object_with_leading_slash_key() -> Result<(), Box<dyn Error + Send + Sync>> {
+        init_logging();
+        info!("Starting test: PUT object with leading slash in key (Issue #2427)");
+
+        let mut env = RustFSTestEnvironment::new().await?;
+        env.start_rustfs_server(vec![]).await?;
+
+        let client = env.create_s3_client();
+        let bucket = "test-leading-slash";
+        create_bucket(&client, bucket).await?;
+
+        // Key "/foo/bar" produces the request path "PUT /bucket//foo/bar".
+        let content = b"leading slash content";
+        client
+            .put_object()
+            .bucket(bucket)
+            .key("/foo/bar")
+            .body(ByteStream::from_static(content))
+            .send()
+            .await
+            .expect("PUT with leading-slash key must succeed");
+        info!("PUT with leading-slash key succeeded");
+
+        // The object is stored under the normalized key "foo/bar".
+        let output = client
+            .get_object()
+            .bucket(bucket)
+            .key("foo/bar")
+            .send()
+            .await
+            .expect("GET with normalized key must succeed");
+        let body = output.body.collect().await?.into_bytes();
+        assert_eq!(body.as_ref(), content, "content mismatch for normalized key");
+
+        // GET with the original leading-slash key is normalized to the same object.
+        let output = client
+            .get_object()
+            .bucket(bucket)
+            .key("/foo/bar")
+            .send()
+            .await
+            .expect("GET with leading-slash key must succeed");
+        let body = output.body.collect().await?.into_bytes();
+        assert_eq!(body.as_ref(), content, "content mismatch for leading-slash key");
+
+        // LIST must report the normalized key only.
+        let output = client.list_objects_v2().bucket(bucket).send().await?;
+        let keys: Vec<&str> = output.contents().iter().filter_map(|o| o.key()).collect();
+        assert_eq!(keys, vec!["foo/bar"], "LIST must contain only the normalized key");
+
+        env.stop_server();
+        info!("Test completed successfully");
+        Ok(())
+    }
+
+    /// Duplicate and repeated slashes after a leading slash collapse MinIO-style.
+    #[tokio::test]
+    #[serial]
+    async fn test_put_object_with_duplicate_slashes_normalized() -> Result<(), Box<dyn Error + Send + Sync>> {
+        init_logging();
+        info!("Starting test: duplicate slash normalization (Issue #2427)");
+
+        let mut env = RustFSTestEnvironment::new().await?;
+        env.start_rustfs_server(vec![]).await?;
+
+        let client = env.create_s3_client();
+        let bucket = "test-duplicate-slash";
+        create_bucket(&client, bucket).await?;
+
+        // (request key, normalized stored key)
+        let cases = [("//keyname", "keyname"), ("/dir///sub//file", "dir/sub/file")];
+
+        for (raw_key, normalized_key) in cases {
+            let content = format!("content for {raw_key}");
+            client
+                .put_object()
+                .bucket(bucket)
+                .key(raw_key)
+                .body(ByteStream::from(content.clone().into_bytes()))
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("PUT with key '{raw_key}' must succeed: {e:?}"));
+
+            let output = client
+                .get_object()
+                .bucket(bucket)
+                .key(normalized_key)
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("GET with normalized key '{normalized_key}' must succeed: {e:?}"));
+            let body = output.body.collect().await?.into_bytes();
+            assert_eq!(body.as_ref(), content.as_bytes(), "content mismatch for key '{raw_key}'");
+            info!("PUT '{}' stored and readable as '{}'", raw_key, normalized_key);
+        }
+
+        // DELETE through the raw key removes the normalized object.
+        client.delete_object().bucket(bucket).key("//keyname").send().await?;
+        let result = client.get_object().bucket(bucket).key("keyname").send().await;
+        assert!(result.is_err(), "object must be gone after DELETE with raw key");
+
+        env.stop_server();
+        info!("Test completed successfully");
+        Ok(())
+    }
+}

--- a/crates/e2e_test/src/lib.rs
+++ b/crates/e2e_test/src/lib.rs
@@ -61,6 +61,10 @@ mod anonymous_access_test;
 #[cfg(test)]
 mod special_chars_test;
 
+// Leading/duplicate slash key normalization tests (Issue #2427)
+#[cfg(test)]
+mod leading_slash_key_test;
+
 // Content-Encoding header preservation test
 #[cfg(test)]
 mod content_encoding_test;

--- a/rustfs/src/server/http.rs
+++ b/rustfs/src/server/http.rs
@@ -54,7 +54,12 @@ use rustfs_protocols::SwiftService;
 use rustfs_protos::proto_gen::node_service::node_service_server::NodeServiceServer;
 use rustfs_trusted_proxies::ClientInfo;
 use rustfs_utils::net::parse_and_resolve_address;
-use s3s::{host::MultiDomain, service::S3Service, service::S3ServiceBuilder};
+use s3s::{
+    config::{S3Config, StaticConfigProvider},
+    host::MultiDomain,
+    service::S3Service,
+    service::S3ServiceBuilder,
+};
 use socket2::{SockRef, TcpKeepalive};
 use std::io::{Error, Result};
 use std::net::SocketAddr;
@@ -528,6 +533,15 @@ pub async fn start_http_server(config: &config::Config, readiness: Arc<GlobalRea
         b.set_auth(IAMAuth::new(access_key, secret_key));
         b.set_access(store);
         b.set_route(admin::make_admin_route(config.console_enable)?);
+
+        // Normalize leading/duplicate forward slashes in object keys (MinIO parity).
+        // AWS S3 accepts keys such as "/foo/bar"; without this, requests like
+        // `PUT /bucket//foo/bar` are rejected downstream with InvalidArgument
+        // (ObjectNamePrefixAsSlash, issue #2427). MinIO collapses these slashes instead of preserving them,
+        // so `//foo/bar` is stored and served as `foo/bar`.
+        let mut s3_config = S3Config::default();
+        s3_config.normalize_forward_slash_path = true;
+        b.set_config(Arc::new(StaticConfigProvider::new(Arc::new(s3_config))));
 
         // Virtual-hosted-style requests are only set up for S3 API when server domains are configured and console is disabled
         if !config.server_domains.is_empty() && !config.console_enable {


### PR DESCRIPTION
## Related Issues

Fixes #2427

## Summary of Changes

For a path-style request like `PUT /bucket//foo/bar`, the object key extracted by the HTTP layer is `/foo/bar`. RustFS never enabled the s3s path-normalization option, so the raw key reached ecstore where `check_object_name_for_length_and_slash` (`crates/ecstore/src/bucket/utils.rs`) rejects keys starting with `/` (`ObjectNamePrefixAsSlash` -> `400 InvalidArgument`), and `is_valid_object_prefix` rejects keys containing `//`. AWS S3 accepts such keys, and some SDK wrappers produce them.

The pinned s3s fork already ships MinIO-style slash normalization behind `S3Config.normalize_forward_slash_path` (s3s-project/s3s#596), but it defaults to `false` and RustFS never set it.

**Fix**: enable `normalize_forward_slash_path` when building the S3 service in `rustfs/src/server/http.rs` via `S3ServiceBuilder::set_config(StaticConfigProvider)`. Keys whose raw form starts with `/` are normalized before any handler or ecstore validation runs:

- `/keyname` -> `keyname`
- `//keyname` -> `keyname`
- `/dir///sub//file` -> `dir/sub/file`
- keys not starting with `/` (e.g. `dir//file`) are left untouched

**Semantics (normalize vs preserve)**: AWS S3 technically preserves a leading slash as part of the key. MinIO instead normalizes such keys (collapses leading/duplicate slashes), which is what the s3s option implements. This PR follows MinIO parity: `PUT /bucket//foo/bar` succeeds and the object is stored and served as `foo/bar`. This is deliberate — literal leading-slash keys can never round-trip through the filesystem-backed layout, and MinIO-compatible behavior is what migrating clients expect. The ecstore-level checks stay in place as defense in depth.

New e2e regression tests in `crates/e2e_test/src/leading_slash_key_test.rs`:

- `test_put_object_with_leading_slash_key`: `PUT` with key `/foo/bar` (request path `/bucket//foo/bar`) succeeds; object is readable via both `foo/bar` and `/foo/bar`; `ListObjectsV2` reports only the normalized key.
- `test_put_object_with_duplicate_slashes_normalized`: `//keyname` -> `keyname`, `/dir///sub//file` -> `dir/sub/file`; `DELETE` through the raw key removes the normalized object.

## Verification

- `make pre-commit` — passed
- `cargo clippy -p rustfs -p e2e_test --all-targets -- -D warnings` — passed
- `cargo test -p e2e_test leading_slash` — 2 passed (both tests run against a locally started server; locally requires a `RUSTFS_CONSOLE_ADDRESS` override if port 9001 is occupied by another service)

## Impact

Behavior change: object keys with leading slashes (and duplicate slashes after a leading slash) are now accepted and normalized (MinIO parity) instead of being rejected with `InvalidArgument`. No API surface, configuration, or deployment changes.

## Additional Notes

The normalization itself is implemented upstream in s3s; this PR only opts in via `S3Config::normalize_forward_slash_path` and pins the behavior with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
