### PR TITLE
ci: change runner from ubicloud to k8s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     name: Test and Lint
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: ubicloud-standard-4
+    runs-on: sm-standard-4
     timeout-minutes: 60
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -173,7 +173,7 @@ jobs:
     name: Test and Lint (rio-v2)
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: ubicloud-standard-4
+    runs-on: sm-standard-4
     timeout-minutes: 60
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -201,7 +201,7 @@ jobs:
     name: "Test and Lint (${{ matrix.features.name }})"
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
-    runs-on: ubicloud-standard-4
+    runs-on: sm-standard-4
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-s3tests.yml
+++ b/.github/workflows/e2e-s3tests.yml
@@ -99,7 +99,7 @@ defaults:
 
 jobs:
   s3tests:
-    runs-on: ubicloud-standard-4
+    runs-on: sm-standard-4
     timeout-minutes: 180
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently, we use ubicloud for Action Runner, now, migrating the runner from ubicloud to k8s.