### PR TITLE
fix(iam): improve OIDC token exchange diagnostics

### DIFF
--- a/crates/iam/src/oidc.rs
+++ b/crates/iam/src/oidc.rs
@@ -22,7 +22,8 @@ use crate::oidc_state::{OidcAuthSession, OidcLogoutSession, OidcStateStore};
 use openidconnect::core::{CoreAuthenticationFlow, CoreClient, CoreIdToken};
 use openidconnect::{
     AsyncHttpClient, Audience, AuthType, AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, LogoutRequest, Nonce,
-    PkceCodeChallenge, PkceCodeVerifier, PostLogoutRedirectUrl, ProviderMetadataWithLogout, RedirectUrl, Scope,
+    PkceCodeChallenge, PkceCodeVerifier, PostLogoutRedirectUrl, ProviderMetadataWithLogout, RedirectUrl, RequestTokenError,
+    Scope,
 };
 use reqwest::Client;
 use rustfs_config::oidc::*;
@@ -569,7 +570,14 @@ impl OidcSys {
             .set_redirect_uri(Cow::Owned(redirect))
             .request_async(&self.http_client)
             .await
-            .map_err(|e| format!("token exchange failed: {e}"))?;
+            .map_err(|e| match &e {
+                RequestTokenError::Parse(parse_err, body) => format!(
+                    "token exchange failed: {e}: parse_error_path={}, response_body_len={}",
+                    parse_err.path(),
+                    body.len()
+                ),
+                _ => format!("token exchange failed: {e}"),
+            })?;
 
         // Verify the ID token (signature, issuer, audience, expiry, nonce)
         let id_token = token_response


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add parse-error context to OIDC authorization-code token exchange failures.
- When the OAuth/OIDC client cannot parse the token endpoint response, include the parse path and response body length in the existing error message.
- Keep the response body itself out of logs to avoid leaking token endpoint payloads.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-iam oidc --lib`
- `cargo check -p rustfs-iam`
- `make pre-commit`

## Impact
- No API, configuration, or compatibility changes.
- Operators get slightly more actionable diagnostics for malformed OIDC token endpoint responses.

## Additional Notes
`make pre-commit` passed. The logging guardrail script still prints stale missing-path warnings for `crates/ecstore/src/tier/tier.rs`, but exits successfully and reports the guardrail check as passed.