### PR TITLE
fix(storage): enrich versioning fallback log

### DIFF
--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -55,7 +55,11 @@ async fn bucket_versioning_config(bucket: &str) -> VersioningConfiguration {
     match BucketVersioningSys::get(bucket).await {
         Ok(cfg) => cfg,
         Err(err) => {
-            tracing::warn!("{:?}", err);
+            tracing::warn!(
+                bucket = %bucket,
+                error = ?err,
+                "failed to load bucket versioning configuration; using default configuration"
+            );
             VersioningConfiguration::default()
         }
     }


### PR DESCRIPTION
## Related Issues
Follow-up to #4237 review feedback.

## Summary of Changes
- Include the bucket name and fallback behavior when bucket versioning config lookup fails.
- Keep the existing default versioning fallback behavior unchanged.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p rustfs --lib`

## Impact
No API or compatibility impact. Improves warning diagnostics only.

## Additional Notes
N/A
