### PR TITLE
chore(deps): update bytesize and s3s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "bytestring"
@@ -8154,9 +8154,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
 dependencies = [
  "rustversion",
 ]
@@ -10157,8 +10157,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3s"
-version = "0.14.0"
-source = "git+https://github.com/rustfs/s3s?rev=b365107038a633ce0f7a199f507507a8c5e64665#b365107038a633ce0f7a199f507507a8c5e64665"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe1bd31748cb69848c2cf4028cecdadf5f8299ef3b02a83e21b20e7bda3aba9"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10157,9 +10157,8 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3s"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe1bd31748cb69848c2cf4028cecdadf5f8299ef3b02a83e21b20e7bda3aba9"
+version = "0.14.0"
+source = "git+https://github.com/rustfs/s3s?rev=b365107038a633ce0f7a199f507507a8c5e64665#b365107038a633ce0f7a199f507507a8c5e64665"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ redis = { version = "1.3.0", features = ["connection-manager", "tokio-rustls-com
 rustix = { version = "1.1.4", features = ["fs"] }
 rust-embed = { version = "8.11.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { version = "0.14.1", features = ["minio"] }
+s3s = { git = "https://github.com/rustfs/s3s", rev = "b365107038a633ce0f7a199f507507a8c5e64665", features = ["minio"] }
 serial_test = "3.5.0"
 shadow-rs = { version = "2.0.0", default-features = false }
 siphasher = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ tower-http = { version = "0.7.0", features = ["cors"] }
 # Serialization and Data Formats
 apache-avro = "0.21.0"
 bytes = { version = "1.12.0", features = ["serde"] }
-bytesize = "2.4.0"
+bytesize = "2.4.2"
 byteorder = "1.5.0"
 flatbuffers = "25.12.19"
 form_urlencoded = "1.2.2"
@@ -281,7 +281,7 @@ redis = { version = "1.3.0", features = ["connection-manager", "tokio-rustls-com
 rustix = { version = "1.1.4", features = ["fs"] }
 rust-embed = { version = "8.11.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { git = "https://github.com/rustfs/s3s", rev = "b365107038a633ce0f7a199f507507a8c5e64665", features = ["minio"] }
+s3s = { version = "0.14.1", features = ["minio"] }
 serial_test = "3.5.0"
 shadow-rs = { version = "2.0.0", default-features = false }
 siphasher = "1.0.3"


### PR DESCRIPTION
## Related Issues

Related to s3s-project/s3s#523 comment: https://github.com/s3s-project/s3s/issues/523#issuecomment-4875102994

## Summary of Changes

- Update `bytesize` from `2.4.0` to `2.4.2`.
- Replace the pinned `rustfs/s3s` git revision with the published crates.io `s3s = 0.14.1` release.
- Refresh `Cargo.lock` for the resulting dependency resolution.

## Verification

- `cargo fmt --all --check`
- `cargo metadata --locked --format-version 1 --no-deps`
- `git diff --check HEAD~1..HEAD`

## Impact

This keeps RustFS on the upstream `s3s` dependency security update release while using the published crate instead of a git revision. No RustFS API or configuration changes are expected.

## Additional Notes

The linked upstream comment notes that `s3s` v0.14.1 was published for dependency security updates.