### PR TITLE
fix(e2e): align KMS test helpers with server API field names and env requirements

### DIFF
--- a/crates/e2e_test/src/kms/common.rs
+++ b/crates/e2e_test/src/kms/common.rs
@@ -112,8 +112,8 @@ pub async fn create_default_key(
     secret_key: &str,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let create_key_body = serde_json::json!({
-        "KeyUsage": "ENCRYPT_DECRYPT",
-        "Description": "Default key for e2e testing"
+        "key_usage": "ENCRYPT_DECRYPT",
+        "description": "Default key for e2e testing"
     })
     .to_string();
 
@@ -296,8 +296,8 @@ pub async fn test_kms_key_management(
 
     // Test CreateKey
     let create_key_body = serde_json::json!({
-        "KeyUsage": "EncryptDecrypt",
-        "Description": "Test key for e2e testing"
+        "key_usage": "EncryptDecrypt",
+        "description": "Test key for e2e testing"
     })
     .to_string();
 
@@ -777,7 +777,9 @@ impl LocalKMSTestEnvironment {
             default_key_id,
         ];
 
-        self.base_env.start_rustfs_server(extra_args).await?;
+        self.base_env
+            .start_rustfs_server_with_env(extra_args, &[("RUSTFS_KMS_ALLOW_INSECURE_DEV_DEFAULTS", "true")])
+            .await?;
         Ok(default_key_id.to_string())
     }
 


### PR DESCRIPTION
## Problem

The hourly automated verification of `main` at `2214f67f` found that all lint/format/clippy checks passed, but 7 KMS e2e tests failed.

## Root Causes

### 1. Missing `RUSTFS_KMS_ALLOW_INSECURE_DEV_DEFAULTS` env var (6 tests)

The `LocalKMSTestEnvironment::start_rustfs_for_local_kms()` helper called `start_rustfs_server()` (no env vars) instead of `start_rustfs_server_with_env()` with `RUSTFS_KMS_ALLOW_INSECURE_DEV_DEFAULTS=true`. Since commit `c3055f93` (security(kms): require explicit dev defaults opt-in), the server requires this env var for local KMS backends.

**Affected tests:**
- `kms::bucket_default_encryption_test::test_bucket_default_encryption_multipart_upload`
- `kms::bucket_default_encryption_test::test_bucket_default_sse_s3_put_object`
- `kms::bucket_default_encryption_test::test_bucket_default_sse_kms_put_object`
- `kms::encryption_metadata_test::test_head_reports_managed_metadata_for_sse_s3`
- `kms::encryption_metadata_test::test_multipart_upload_writes_encrypted_data`
- `kms::kms_comprehensive_test::test_comprehensive_kms_full_workflow`

### 2. PascalCase field names in KMS key creation requests (1 test)

The `create_default_key()` and `test_kms_key_management()` functions sent JSON with `KeyUsage`/`Description` (PascalCase) but the server's `CreateKeyRequest` struct uses `#[serde(deny_unknown_fields)]` and expects `key_usage`/`description` (snake_case).

**Affected test:**
- `kms::kms_local_test::test_local_kms_end_to_end`

## Fix

Two changes in `crates/e2e_test/src/kms/common.rs`:

1. `start_rustfs_for_local_kms()`: changed `start_rustfs_server(extra_args)` → `start_rustfs_server_with_env(extra_args, &[("RUSTFS_KMS_ALLOW_INSECURE_DEV_DEFAULTS", "true")])`
2. Two JSON payloads: `"KeyUsage"` → `"key_usage"`, `"Description"` → `"description"`

## Verification

All 26 KMS e2e tests now pass:
- `kms::kms_local_test` (4 tests) ✅
- `kms::bucket_default_encryption_test` (5 tests) ✅
- `kms::encryption_metadata_test` (3 tests) ✅
- `kms::kms_comprehensive_test` (5 tests) ✅
- Other KMS test suites ✅

`make pre-commit` passes (fmt, clippy, unsafe-code, architecture-migration, logging-guardrails, doc-paths).

Note: `bucket_logging_test::tests::test_dummy_bucket_endpoints_http_contracts` also fails on main but is an unrelated environment issue (awscurl binary incompatibility on macOS).
