### PR TITLE
test(s3tables): clarify durable draft failure test

### DIFF
--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -16510,7 +16510,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn strong_catalog_backing_rolls_back_cache_when_persist_and_reload_fail() {
+    async fn strong_catalog_backing_does_not_publish_draft_when_persist_and_reload_fail() {
         let backend = TestCatalogObjectBackend::default();
         let store = StrongTableCatalogStore::new(backend.clone());
         let bucket = "analytics";


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Rename the durable-strong S3 Tables persist/reload failure test so it describes the current draft-state behavior. The test now states that an unpersisted draft is not published when snapshot persistence and reload fail, rather than implying a live cache rollback implementation.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs strong_catalog_backing_does_not_publish_draft_when_persist_and_reload_fail --lib`
- `CARGO_BUILD_JOBS=2 TEST_THREADS=1 make pre-commit`
- `CARGO_BUILD_JOBS=2 TEST_THREADS=1 make pre-pr`

## Impact
No runtime behavior change. Test-only rename.

## Additional Notes
Follow-up cleanup after the durable-strong S3 Tables refresh landed.
