### PR TITLE
refactor(deps): replace snafu and heal anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7837,7 +7837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e50c72c21c738f5c5f350cc33640aee30bf7cd20f9d9da20ed41bce2671d532"
 dependencies = [
  "bytes",
- "snafu 0.6.10",
+ "snafu",
 ]
 
 [[package]]
@@ -9170,7 +9170,6 @@ dependencies = [
 name = "rustfs-heal"
 version = "1.0.0-beta.8"
 dependencies = [
- "anyhow",
  "async-trait",
  "futures",
  "http 1.4.2",
@@ -9741,7 +9740,7 @@ dependencies = [
  "rustfs-storage-api",
  "s3s",
  "serde_json",
- "snafu 0.9.1",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -9761,7 +9760,6 @@ dependencies = [
  "parking_lot",
  "rustfs-s3select-api",
  "s3s",
- "snafu 0.9.1",
  "tokio",
  "tracing",
 ]
@@ -10828,16 +10826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "doc-comment",
- "snafu-derive 0.6.10",
-]
-
-[[package]]
-name = "snafu"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
-dependencies = [
- "snafu-derive 0.9.1",
+ "snafu-derive",
 ]
 
 [[package]]
@@ -10849,18 +10838,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,6 @@ shadow-rs = { version = "2.0.0", default-features = false }
 siphasher = "1.0.3"
 smallvec = { version = "1.15.2", features = ["serde"] }
 smartstring = "1.0.1"
-snafu = "0.9.1"
 snap = "1.1.1"
 starshard = { version = "2.2.1", features = ["rayon", "async", "serde"] }
 strum = { version = "0.28.0", features = ["derive"] }

--- a/crates/heal/Cargo.toml
+++ b/crates/heal/Cargo.toml
@@ -41,7 +41,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
-anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 metrics = { workspace = true }

--- a/crates/heal/src/error.rs
+++ b/crates/heal/src/error.rs
@@ -40,9 +40,6 @@ pub enum Error {
     #[error("Other error: {0}")]
     Other(String),
 
-    #[error(transparent)]
-    Anyhow(#[from] anyhow::Error),
-
     #[error("Serialization error: {0}")]
     Serialization(String),
 
@@ -94,11 +91,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 impl Error {
     /// Create an Other error from any error type
-    pub fn other<E>(error: E) -> Self
-    where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>,
-    {
-        Error::Other(error.into().to_string())
+    pub fn other(error: impl std::fmt::Display) -> Self {
+        Error::Other(error.to_string())
     }
 
     /// Create a transient skip error for retryable background heal checks.

--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -588,7 +588,7 @@ fn is_recoverable_heal_error(err: &Error, error: &str) -> bool {
         Error::TaskTimeout | Error::TransientSkip { .. } => true,
         Error::Storage(err) => is_recoverable_storage_heal_error(err) || is_recoverable_heal_error_message(error),
         Error::Disk(err) => is_recoverable_disk_heal_error(err) || is_recoverable_heal_error_message(error),
-        Error::TaskExecutionFailed { .. } | Error::Io(_) | Error::IO(_) | Error::Anyhow(_) | Error::Other(_) => {
+        Error::TaskExecutionFailed { .. } | Error::Io(_) | Error::IO(_) | Error::Other(_) => {
             is_recoverable_heal_error_message(error)
         }
         _ => false,

--- a/crates/heal/tests/endpoint_index_test.rs
+++ b/crates/heal/tests/endpoint_index_test.rs
@@ -24,7 +24,7 @@ mod storage_api;
 use storage_api::endpoint_index::{ECStore, Endpoint, EndpointServerPools, Endpoints, PoolEndpoints, init_local_disks};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_endpoint_index_settings() -> anyhow::Result<()> {
+async fn test_endpoint_index_settings() -> rustfs_heal::Result<()> {
     let temp_dir = TempDir::new()?;
 
     // create test disk paths

--- a/crates/s3select-api/Cargo.toml
+++ b/crates/s3select-api/Cargo.toml
@@ -40,7 +40,7 @@ http.workspace = true
 pin-project-lite.workspace = true
 s3s.workspace = true
 serde_json = { workspace = true }
-snafu = { workspace = true, features = ["backtrace"] }
+thiserror = { workspace = true }
 parking_lot.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/s3select-api/src/lib.rs
+++ b/crates/s3select-api/src/lib.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use datafusion::{common::DataFusionError, sql::sqlparser::parser::ParserError};
-use snafu::{Backtrace, Location, Snafu};
 use std::fmt::Display;
+use thiserror::Error;
 
 pub mod object_store;
 pub mod query;
@@ -31,52 +31,49 @@ pub(crate) use storage_api::crate_boundary::{
     select_is_err_version_not_found,
 };
 
-#[derive(Debug, Snafu)]
-#[snafu(visibility(pub))]
+#[derive(Debug, Error)]
 pub enum QueryError {
-    #[snafu(display("DataFusion error: {}", source))]
-    Datafusion {
-        source: Box<DataFusionError>,
-        location: Location,
-        backtrace: Backtrace,
-    },
+    #[error("DataFusion error: {source}")]
+    Datafusion { source: Box<DataFusionError> },
 
-    #[snafu(display("This feature is not implemented: {}", err))]
+    #[error("This feature is not implemented: {err}")]
     NotImplemented { err: String },
 
-    #[snafu(display("Multi-statement not allow, found num:{}, sql:{}", num, sql))]
+    #[error("Multi-statement not allow, found num:{num}, sql:{sql}")]
     MultiStatement { num: usize, sql: String },
 
-    #[snafu(display("Failed to build QueryDispatcher. err: {}", err))]
+    #[error("Failed to build QueryDispatcher. err: {err}")]
     BuildQueryDispatcher { err: String },
 
-    #[snafu(display("The query has been canceled"))]
+    #[error("The query has been canceled")]
     Cancel,
 
-    #[snafu(display("{}", source))]
-    Parser { source: ParserError },
+    #[error("{source}")]
+    Parser {
+        #[from]
+        source: ParserError,
+    },
 
-    #[snafu(display("Udf not exists, name:{}.", name))]
+    #[error("Udf not exists, name:{name}.")]
     FunctionNotExists { name: String },
 
-    #[snafu(display("Udf already exists, name:{}.", name))]
+    #[error("Udf already exists, name:{name}.")]
     FunctionExists { name: String },
 
-    #[snafu(display("Store Error, e:{}.", e))]
+    #[error("Store Error, e:{e}.")]
     StoreError { e: String },
 }
 
 impl From<DataFusionError> for QueryError {
-    #[track_caller]
     fn from(value: DataFusionError) -> Self {
         match value {
-            DataFusionError::External(e) if e.downcast_ref::<QueryError>().is_some() => *e.downcast::<QueryError>().unwrap(),
-
-            v => Self::Datafusion {
-                source: Box::new(v),
-                location: std::panic::Location::caller(),
-                backtrace: Backtrace::capture(),
+            DataFusionError::External(e) => match e.downcast::<QueryError>() {
+                Ok(query_error) => *query_error,
+                Err(e) => Self::Datafusion {
+                    source: Box::new(DataFusionError::External(e)),
+                },
             },
+            v => Self::Datafusion { source: Box::new(v) },
         }
     }
 }

--- a/crates/s3select-query/Cargo.toml
+++ b/crates/s3select-query/Cargo.toml
@@ -34,7 +34,6 @@ derive_builder = { workspace = true }
 futures = { workspace = true }
 parking_lot = { workspace = true }
 s3s.workspace = true
-snafu = { workspace = true, features = ["backtrace"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/s3select-query/src/sql/parser.rs
+++ b/crates/s3select-query/src/sql/parser.rs
@@ -20,10 +20,9 @@ use datafusion::sql::sqlparser::{
     tokenizer::{Token, Tokenizer},
 };
 use rustfs_s3select_api::{
-    ParserSnafu,
+    QueryError,
     query::{ast::ExtStatement, parser::Parser as RustFsParser},
 };
-use snafu::ResultExt;
 
 use super::dialect::RustFsDialect;
 
@@ -41,7 +40,7 @@ pub struct DefaultParser {}
 
 impl RustFsParser for DefaultParser {
     fn parse(&self, sql: &str) -> rustfs_s3select_api::QueryResult<VecDeque<ExtStatement>> {
-        ExtParser::parse_sql(sql).context(ParserSnafu)
+        ExtParser::parse_sql(sql).map_err(QueryError::from)
     }
 }
 


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#633

## Summary of Changes
- Replace the remaining direct SNAFU-based `QueryError` implementation in `rustfs-s3select-api` with `thiserror` while preserving existing display messages and DataFusion error unwrapping behavior.
- Remove `snafu` usage from `rustfs-s3select-query` by mapping parser errors through the typed `QueryError` conversion path.
- Remove the `anyhow` dependency from `rustfs-heal`, including the transparent `Error::Anyhow` variant, and keep heal fallback errors represented by the existing typed `Error::Other` path.
- Update Cargo manifests and lockfile entries so the workspace no longer carries a direct `snafu` dependency for these crates.

## Verification
- `cargo check -p rustfs-s3select-api -p rustfs-s3select-query -p rustfs-heal`
- `cargo test -p rustfs-s3select-api test_query_error --lib`
- `cargo test -p rustfs-s3select-query test_default_parser --lib`
- `cargo test -p rustfs-heal --test endpoint_index_test`
- `cargo fmt --all --check`
- `make pre-commit`
- `make pre-pr`

## Impact
- Library-facing error handling in the touched crates now follows the repository-preferred `thiserror` pattern.
- Existing parser and DataFusion error display text is preserved for compatibility.
- No runtime configuration, deployment, storage format, or API wire-format changes are expected.

## Additional Notes
- `snafu` can still appear as a transitive dependency through third-party crates, but it is no longer a direct workspace dependency for the touched RustFS crates.
- The backlog issue is broad; this PR addresses the `snafu` cleanup and the `heal` portion of the `anyhow` cleanup without closing the entire issue.
