### PR TITLE
fix: auto-repair breaking changes from 0271d7aa

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -10360,7 +10360,15 @@ mod tests {
 
         let mut reader = PutObjReader::from_vec(b"hello".to_vec());
         set_disks
-            .put_object(bucket, "object", &mut reader, &ObjectOptions::default())
+            .put_object(
+                bucket,
+                "object",
+                &mut reader,
+                &ObjectOptions {
+                    no_lock: true,
+                    ..ObjectOptions::default()
+                },
+            )
             .await
             .expect("object should be written");
 


### PR DESCRIPTION
fix(test): set no_lock in ecstore listing test without lock clients

## Problem

The `set_level_listing_trait_methods_use_existing_listing_implementation` test in `rustfs-ecstore` was failing with:

```
object should be written: Lock(Internal { message: "No lock clients available" })
```

The test helper `make_local_bucket_test_set_disks()` creates a `SetDisks` with empty lock clients (no distributed lock backend), but `put_object` unconditionally acquires a write lock at the commit stage (line 2874) when `no_lock` is false (the default).

## Fix

Set `no_lock: true` in the `ObjectOptions` passed to `put_object` in the failing test, since the test exercises listing functionality, not locking behavior.

## Verification

- `cargo test -p rustfs-ecstore --lib` → **1835 passed, 0 failed** (previously 1834 passed, 1 failed)
- All other crates' lib tests pass
- `cargo clippy --workspace --all-targets` → clean

## Baseline

`0271d7aa2bef061d6c096e1a8ed03a100e757411`
