### PR TITLE
docs: update security advisory lessons

### DIFF
--- a/.agents/skills/security-advisory-lessons/SKILL.md
+++ b/.agents/skills/security-advisory-lessons/SKILL.md
@@ -73,6 +73,7 @@ For the full pattern map, read [advisory-patterns.md](references/advisory-patter
 - Match protocol commands to the same S3 actions as HTTP, such as `RETR` to `GetObject`, `SIZE`/`MDTM` to `HeadObject`, `MKD` to `CreateBucket`, and bucket probes to `ListBucket` or `HeadBucket`.
 - Review every handler in a protocol driver, not only the changed handler, because RustFS advisories show mixed guarded and unguarded siblings in the same driver.
 - Regression tests for protocol frontends should deny the shared authorization hook and prove the backend is not reached for the denied command.
+- Compare protocol secrets in constant time, normalize invalid-user and invalid-secret failures where practical, and add rate limiting before exposing password-style protocol endpoints.
 
 ### Paths, object keys, and filesystem access
 - Never join untrusted bucket/object/RPC path strings onto filesystem roots without normalization and boundary checks.
@@ -82,7 +83,8 @@ For the full pattern map, read [advisory-patterns.md](references/advisory-patter
 
 ### Secrets, default credentials, and crypto
 - Do not ship hard-coded shared tokens, HMAC secrets, private keys, or production test keys.
-- Defaults for internode/RPC auth must fail closed for network-reachable deployments or require explicit opt-in with loud warnings.
+- Defaults for root credentials and internode/RPC auth must fail closed for network-reachable deployments or generate per-install random secrets; warnings alone are not a security boundary.
+- Keep cryptographic roles separated: root S3 credentials, RPC HMAC keys, and STS/JWT signing keys must not be reused or deterministically derived from each other.
 - License or token validation must use signatures with embedded public/verifying keys only; do not use private-key decryption as authenticity.
 - Plan key rotation and key IDs when removing exposed keys.
 

--- a/.agents/skills/security-advisory-lessons/references/advisory-patterns.md
+++ b/.agents/skills/security-advisory-lessons/references/advisory-patterns.md
@@ -40,6 +40,7 @@ Update this file only when an advisory adds or changes a reusable lesson, affect
 
 - `GHSA-3g29-xff2-92vp`: FTP `RETR` and `SIZE`/`MDTM` read paths authenticated the user but skipped IAM before calling storage. Lesson: non-HTTP protocol frontends must enforce the same per-operation authorization as the S3 API before backend access.
 - `GHSA-g3vq-vv42-f647`: FTPS `MKD` called `create_bucket` without checking `s3:CreateBucket`. Lesson: protocol command handlers need action-specific checks even when sibling handlers already authorize correctly.
+- `GHSA-3p3x-734c-h5vx`: FTPS and WebDAV compared secret keys with early-return string equality, while FTPS also returned distinguishable invalid-user and invalid-password failures. Lesson: password-style protocol auth needs constant-time secret comparison, indistinguishable failures where practical, and rate limiting.
 
 ### Filesystem paths and object key traversal
 
@@ -49,8 +50,11 @@ Update this file only when an advisory adds or changes a reusable lesson, affect
 
 ### Secrets, defaults, and cryptographic misuse
 
+- `GHSA-j59h-h7q5-q348`: RustFS shipped known default root credentials that could authenticate to S3, admin APIs, IAM, KMS, and console surfaces. Lesson: root credentials must be operator-provided or generated per install; known defaults and warnings are not acceptable for network-reachable deployments.
 - `GHSA-h956-rh7x-ppgj`: gRPC used the hard-coded token `rustfs rpc` on both client and server. Lesson: source-visible shared tokens are authentication bypasses.
 - `GHSA-r5qv-rc46-hv8q`: internode RPC HMAC secret fell back to the public default `rustfsadmin`. Lesson: RPC/internode auth must fail closed instead of silently using public defaults.
+- `GHSA-75fx-qg6f-8rm7` and `GHSA-68cw-96m3-h2cf`: internode RPC secrets were derivable from known root credentials, making raw storage RPC signatures forgeable when explicit RPC secrets were unset. Lesson: RPC auth keys must be independent random secrets, never derived from S3 root credentials, and raw storage RPC should not share the public S3 listener without an internode-only boundary.
+- `GHSA-m77q-r63m-pj89`: STS JWTs used the root secret key as the shared token signing key, allowing token forgery when the root secret was known. Lesson: STS signing keys need key separation, rotation, and key IDs; do not reuse root credentials for JWT/HMAC signing.
 - `GHSA-923g-jp7v-f97f`: license verification embedded a production RSA private key and used private-key decryption as authenticity. Lesson: ship verifying/public keys only and use real signature verification.
 
 ### Sensitive logging and debug output


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Updated the local security-advisory-lessons skill with new GitHub Security Advisory lessons.
- Added guidance for default credentials, RPC/STS key separation, and timing-safe protocol auth.

## Verification
- `git diff --check` on touched skill Markdown files
- Ruby check for frontmatter, TODO, TBD, and placeholder markers

## Impact
Documentation/agent-skill only. No product code changes.

## Additional Notes
Advisories reviewed: GHSA-j59h-h7q5-q348, GHSA-75fx-qg6f-8rm7, GHSA-m77q-r63m-pj89, GHSA-68cw-96m3-h2cf, GHSA-3p3x-734c-h5vx.
