### PR TITLE
fix: replace while-let loop with for-loop to fix clippy lint on main

### DIFF
--- a/crates/ecstore/src/erasure/coding/decode.rs
+++ b/crates/ecstore/src/erasure/coding/decode.rs
@@ -1031,8 +1031,8 @@ where
         // before the retirement pass mutates `self.readers` below.
         {
             let mut sets = FuturesUnordered::new();
-            let mut reader_iter = ReaderLaunchIter::new(&mut self.readers, &read_costs, locality_preference_enabled);
-            while let Some((i, reader)) = reader_iter.next() {
+            let reader_iter = ReaderLaunchIter::new(&mut self.readers, &read_costs, locality_preference_enabled);
+            for (i, reader) in reader_iter {
                 if reader.is_none() {
                     continue;
                 }


### PR DESCRIPTION
## Problem

Commit `3e4a7c1f` (fix(ecstore): lockstep EC stripe read) introduced a `while let Some(...)` iteration pattern at `crates/ecstore/src/erasure/coding/decode.rs:1035` that triggers `clippy::while_let_on_iterator` (denied by `-D warnings`), causing `make pre-pr` to fail.

## Fix

Replace `while let Some((i, reader)) = reader_iter.next()` with the idiomatic `for (i, reader) in reader_iter` and remove the now-unnecessary `mut` qualifier on `reader_iter`.

## Verification

- ✅ `cargo clippy -p rustfs-ecstore -- -D warnings` — passes clean
- ✅ `cargo test -p rustfs-ecstore` — all tests pass
- ✅ `cargo fmt --all --check` — no formatting changes
- ✅ s3s-e2e (S3 compatibility) — all 19 tests PASSED
