### PR TITLE
fix(heal): treat no-heal-required format results as noop

### DIFF
--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -450,6 +450,7 @@ impl HealTask {
 
     fn is_no_heal_required_error(err: &Error) -> bool {
         match err {
+            Error::Storage(EcstoreError::NoHealRequired) | Error::Disk(DiskError::NoHealRequired) => true,
             Error::Other(message) => matches!(message.as_str(), "No heal required" | "No healing is required"),
             _ => matches!(err.to_string().as_str(), "No heal required" | "No healing is required"),
         }
@@ -2400,7 +2401,7 @@ mod tests {
         async fn heal_format(&self, _dry_run: bool) -> Result<(HealResultItem, Option<Error>)> {
             let no_heal_required = *self.format_no_heal_required.lock().unwrap();
             if no_heal_required {
-                Ok((HealResultItem::default(), Some(Error::other("No heal required"))))
+                Ok((HealResultItem::default(), Some(Error::Storage(EcstoreError::NoHealRequired))))
             } else {
                 Ok((HealResultItem::default(), None))
             }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Treat typed `NoHealRequired` heal format results as a no-op instead of a failed erasure set heal.
- Update the heal task test mock to return the production `EcstoreError::NoHealRequired` wrapper so the regression path matches runtime behavior.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `sed -n '1,2240p' crates/heal/src/heal/task.rs | rg -n '\.unwrap\(\)|\.expect\(| as (u8|u16|u32|u64|usize|i8|i16|i32|i64|isize)\b|Result<.*String>|Box<dyn.*Error|println!|eprintln!|Ordering::Relaxed' || true`

Full `make pre-commit` and `make pre-pr` were not run before opening this draft PR.

## Impact
- Prevents "No heal required" format results from being reported as failed heal tasks.
- No API, configuration, deployment, or migration impact expected.

## Additional Notes
Opened as draft because full local pre-commit/pre-PR gates have not been run yet.
