### PR TITLE
fix(ecstore): reach orphan-dir purge on nil-version delete miss (#4189)

### DIFF
--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -220,6 +220,18 @@ fn should_create_delete_marker_for_missing_object(opts: &ObjectOptions) -> bool 
     opts.versioned && opts.version_id.is_none() && !opts.delete_marker && !opts.data_movement
 }
 
+/// Whether a delete-time lookup miss on a directory key should trigger an orphan
+/// empty-directory tree purge (issue #4189).
+///
+/// The lookup surfaces *version*-not-found here, not object-not-found: `del_opts`
+/// pins `version_id = Uuid::nil()` for directory keys, so a missing dir object fails
+/// the specific-version lookup. Both misses must be accepted, otherwise the real
+/// HTTP delete path (which always sets the nil version) never reaches the purge and
+/// the ghost folder survives with a fake 204 — the exact #4189 symptom.
+fn should_purge_orphan_dir_on_missing(err: &Error, object: &str) -> bool {
+    (is_err_object_not_found(err) || is_err_version_not_found(err)) && rustfs_utils::path::is_dir_object(object)
+}
+
 fn version_aware_lookup_opts(opts: &ObjectOptions, no_lock: bool) -> ObjectOptions {
     let mut lookup_opts = opts.clone();
     lookup_opts.no_lock = no_lock;
@@ -957,10 +969,7 @@ impl ECStore {
                 // disk as an orphan empty-directory tree (issue #4189): listings show
                 // it as a common prefix, but no regular delete path can remove it.
                 // Purge the orphan tree so folder deletes actually take effect.
-                if is_err_object_not_found(&err)
-                    && rustfs_utils::path::is_dir_object(object)
-                    && self.purge_orphan_dir_object(bucket, object).await
-                {
+                if should_purge_orphan_dir_on_missing(&err, object) && self.purge_orphan_dir_object(bucket, object).await {
                     return Ok(ObjectInfo {
                         bucket: bucket.to_owned(),
                         name: decode_dir_object(object),
@@ -1773,6 +1782,43 @@ mod tests {
         assert!(!should_create_delete_marker_for_missing_object(&version_delete));
         assert!(!should_create_delete_marker_for_missing_object(&delete_marker_replication));
         assert!(!should_create_delete_marker_for_missing_object(&data_movement));
+    }
+
+    // issue #4189 regression: `del_opts` pins `version_id = Uuid::nil()` on directory
+    // keys, so deleting a ghost folder over HTTP fails the lookup with *version*-not-found
+    // (not object-not-found). The orphan-purge guard must accept both misses, or the
+    // ghost tree survives behind a fake 204 — the exact reported symptom.
+    #[test]
+    fn should_purge_orphan_dir_on_version_not_found_for_dir_key() {
+        assert!(
+            should_purge_orphan_dir_on_missing(&StorageError::FileVersionNotFound, "ghost/"),
+            "the real HTTP delete path yields version-not-found on dir keys and must reach the purge"
+        );
+        assert!(
+            should_purge_orphan_dir_on_missing(
+                &StorageError::VersionNotFound("bucket".into(), "ghost/".into(), Uuid::nil().to_string()),
+                "ghost/"
+            ),
+            "typed VersionNotFound on a dir key must also reach the purge"
+        );
+    }
+
+    #[test]
+    fn should_purge_orphan_dir_on_object_not_found_for_dir_key() {
+        assert!(should_purge_orphan_dir_on_missing(&StorageError::FileNotFound, "ghost/"));
+        assert!(should_purge_orphan_dir_on_missing(
+            &StorageError::ObjectNotFound("bucket".into(), "ghost/".into()),
+            "ghost/"
+        ));
+    }
+
+    #[test]
+    fn should_not_purge_orphan_dir_for_regular_key_or_other_errors() {
+        // A regular (non-directory) key must never trigger a prefix purge, even on a miss.
+        assert!(!should_purge_orphan_dir_on_missing(&StorageError::FileVersionNotFound, "regular.txt"));
+        assert!(!should_purge_orphan_dir_on_missing(&StorageError::FileNotFound, "regular.txt"));
+        // Non-miss errors (e.g. quorum failures) must not be masked by a purge attempt.
+        assert!(!should_purge_orphan_dir_on_missing(&StorageError::ErasureReadQuorum, "ghost/"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PR #4220 added a purge for **orphan empty-directory trees** — folder keys (`prefix/`) whose on-disk tree contains no `xl.meta` anywhere (typically left behind by an interrupted delete). Listings surface them as phantom common prefixes, but no regular delete path could remove them (#4189).

That fix **does not take effect on the real HTTP `DeleteObject` path.** The purge guard only accepted object-not-found:

```rust
if is_err_object_not_found(&err) && is_dir_object(object) && self.purge_orphan_dir_object(...).await { ... }
```

But `del_opts()` (`rustfs/src/storage/options.rs`) pins `version_id = Uuid::nil()` for directory keys:

```rust
opts.version_id = if is_dir_object(object) && vid.is_none() {
    Some(Uuid::nil().to_string())   // dir keys always carry the nil version
} else { vid };
```

So a missing dir object fails the **specific-version** lookup with `FileVersionNotFound`, not object-not-found. The guard short-circuits → the store returns the error → the API layer (`execute_delete_object`) converts version-not-found into a **fake 204**. The ghost folder survives — the exact #4189 symptom.

The existing unit tests passed only because they call `purge_orphan_dir_object` directly, bypassing the nil-version lookup that the real path always takes.

## Fix

Accept both misses in the guard, extracted as `should_purge_orphan_dir_on_missing`:

```rust
fn should_purge_orphan_dir_on_missing(err: &Error, object: &str) -> bool {
    (is_err_object_not_found(err) || is_err_version_not_found(err)) && rustfs_utils::path::is_dir_object(object)
}
```

Non-directory keys and non-miss errors (e.g. quorum failures) are unaffected. The cross-disk data-safety refusal inside `purge_orphan_dir_object` (any drive holding real data under the prefix → refuse on every drive) is unchanged.

## Verification

**Real environment** — a running 4-disk erasure server (`rustfs server disk1..4`), orphan `ghost/sub/leaf` tree planted directly on all drives (no `xl.meta`):

| Step | Before this PR | After |
|---|---|---|
| `LIST` shows `ghost/` common prefix | yes | yes |
| `DELETE ghost/` → 204 | yes | yes |
| `ghost/` removed from all 4 drives | **no (survives)** | **yes ✓** |
| `ghost/` gone from listing | no | yes ✓ |
| real object under same prefix untouched | — | yes ✓ |
| prefix with real data on any drive → refused, all drives preserved | — | yes ✓ |

**Unit tests** — adds `should_purge_orphan_dir_on_missing` predicate regression tests (version-not-found / object-not-found on directory keys → purge; regular keys and non-miss errors → no purge). Existing 4 `purge_orphan_dir_object` tests still pass.

## Related

- Fixes the real-path gap left by #4220
- rustfs/rustfs#4189 (user report)
- rustfs/backlog#798 (design record)