### PR TITLE
fix(multipart): don't pre-delete the committed part before rename_part (backlog#853)

### DIFF
--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -2688,10 +2688,14 @@ impl SetDisks {
         let dst_bucket = Arc::new(dst_bucket.to_string());
         let dst_object = Arc::new(dst_object.to_string());
 
-        // Match MinIO's multipart overwrite semantics: clear any stale destination
-        // part payload and metadata before the new per-disk rename fan-out begins.
-        self.cleanup_multipart_path(&[dst_object.to_string(), format!("{dst_object}.meta")])
-            .await;
+        // Do NOT pre-delete the destination part before renaming: the per-disk
+        // `rename_part` replaces `part.N` atomically (std::fs::rename) and rewrites
+        // `part.N.meta`, so the pre-delete is redundant — and destructive. It
+        // opened a window where an already-committed (ACKed) part was removed on
+        // every disk before the new rename landed, so a re-upload that then failed
+        // quorum destroyed the committed part outright (backlog#853 / #799 B4).
+        // The atomic rename overwrites in place; on quorum failure below we roll
+        // the destination back.
 
         let mut errs = Vec::with_capacity(disks.len());
 


### PR DESCRIPTION
## Summary

Partially fixes **B4** from the core-storage reliability audit (rustfs/backlog#853; parent rustfs/backlog#799) — the destructive-cleanup half.

`rename_part` unconditionally ran `cleanup_multipart_path([part.N, part.N.meta])` on **every disk before** the per-disk rename fan-out. But the per-disk `rename_part` already replaces `part.N` atomically (`std::fs::rename`, which overwrites on Unix) and rewrites `part.N.meta` — so the pre-delete is redundant, and **destructive**: it removed an already-committed (ACKed) part on all disks before the new rename landed, so a re-upload of the same part that then failed write quorum destroyed the committed part outright.

## Fix

Remove the pre-rename cleanup; rely on the atomic rename to overwrite in place. The quorum-failure rollback below is unchanged.

- **Success paths unchanged**: first upload (no dst) and retry (dst overwritten) both end with `part.N` replaced — verified by the existing multipart suite.
- **Failure path improved**: on partial rename, disks that weren't renamed keep the old committed part instead of having had it pre-deleted.

## Verification

```
cargo check -p rustfs-ecstore                    # clean
cargo test -p rustfs-ecstore --lib multipart     # 42 passed
cargo test -p rustfs-ecstore --lib io_primitives # 2 passed
cargo fmt --all
```

## Follow-up (design)

The other half of B4 — **serializing concurrent same-part uploads with an uploadId-scoped namespace lock** so two shard generations can't be mixed across disks (each bitrot-valid → silent corruption on read) — is a larger concurrency change and is tracked as a design follow-up on rustfs/backlog#853. This PR is the contained, strictly-safe improvement.
