### PR TITLE
fix(replication): log (not swallow) resync status persistence failure (backlog#799 B23)

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -2052,8 +2052,22 @@ pub async fn replicate_object<S: ReplicationStorage>(roi: ReplicateObjectInfo, s
             ..Default::default()
         };
 
-        if let Ok(u) = storage.put_object_metadata(&bucket, &object, &popts).await {
-            object_info = u;
+        match storage.put_object_metadata(&bucket, &object, &popts).await {
+            Ok(u) => object_info = u,
+            Err(e) => {
+                // Persisting the resynced replication status failed. Don't swallow
+                // it silently — the object's on-disk status now disagrees with the
+                // resync result and needs operator visibility (backlog#799 B23).
+                warn!(
+                    event = EVENT_RESYNC_TARGET_OPERATION_FAILED,
+                    component = LOG_COMPONENT_ECSTORE,
+                    subsystem = LOG_SUBSYSTEM_REPLICATION_RESYNC,
+                    bucket = %bucket,
+                    object = %object,
+                    error = %e,
+                    "Failed to persist resynced replication status metadata"
+                );
+            }
         }
 
         if let Some(stats) = runtime_sources::replication_stats() {


### PR DESCRIPTION
Fixes **B23** (rustfs/backlog#863; parent #799). Resync persisted its computed replication status via `put_object_metadata` but discarded the `Err` case (`if let Ok(u) = ...`), so a failure left the on-disk status disagreeing with the resync result silently. Now logged at warn. `cargo test -p rustfs-ecstore --lib replication_resyncer` — 24 passed.