### PR TITLE
fix(ecstore): reject renewing a mis-mounted drive into the wrong set (backlog#799 B19)

### DIFF
--- a/crates/ecstore/src/set_disk/ops/locking.rs
+++ b/crates/ecstore/src/set_disk/ops/locking.rs
@@ -338,6 +338,18 @@ impl SetDisks {
             }
         };
 
+        // The drive's format may place it in a different erasure set than this
+        // one. Claiming a misplaced drive into `self.disks` would let two sets
+        // manage the same drive and degrade together, so reject it here
+        // (backlog#799 B19).
+        if set_idx != self.set_index {
+            warn!(
+                "renew_disk: drive {:?} belongs to set {} but is being renewed on set {}; skipping",
+                ep, set_idx, self.set_index
+            );
+            return;
+        }
+
         // Check that the endpoint matches
 
         let _ = new_disk.set_disk_id(Some(fm.erasure.this)).await;


### PR DESCRIPTION
Fixes **B19** (rustfs/backlog#863; parent #799). `renew_disk` resolved the drive's (set, disk) index from its format via `find_disk_index` but never verified the resolved `set_idx` matched this SetDisks' own `set_index` before inserting into `self.disks`. A mis-mounted drive placed by its format in another set could be claimed by this set too, so two sets could manage the same drive and degrade together. Now skipped with a warning when `set_idx != self.set_index`. `cargo test -p rustfs-ecstore --lib locking` — 5 passed.