### PR TITLE
ci: cancel PR workflows on close

### DIFF
--- a/.github/workflows/architecture-migration-rules.yml
+++ b/.github/workflows/architecture-migration-rules.yml
@@ -16,6 +16,7 @@ name: Architecture Migration Rules
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: [ main ]
     paths:
       - "ARCHITECTURE.md"
@@ -27,9 +28,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  cancel-closed-pr-runs:
+    name: Cancel Closed PR Runs
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain cancellation run
+        run: echo "PR closed; this run only cancels older runs in the same concurrency group."
+
   architecture-migration-rules:
     name: Architecture Migration Rules
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,6 +25,7 @@ on:
       - '.github/workflows/**'
       - 'scripts/security/check_workflow_pins.sh'
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: [ main ]
     paths:
       - '**/Cargo.toml'
@@ -40,12 +41,25 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cancel-closed-pr-runs:
+    name: Cancel Closed PR Runs
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain cancellation run
+        run: echo "PR closed; this run only cancels older runs in the same concurrency group."
+
   security-audit:
     name: Security Audit
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -71,6 +85,7 @@ jobs:
 
   cargo-deny:
     name: Cargo Deny
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -92,6 +107,7 @@ jobs:
 
   workflow-pin-report:
     name: Workflow Pin Report
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -104,7 +120,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ on:
       - ".github/workflows/audit.yml"
       - ".github/workflows/performance.yml"
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: [ main ]
     paths-ignore:
       - "**.md"
@@ -63,7 +64,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -72,8 +73,17 @@ env:
 
 jobs:
 
+  cancel-closed-pr-runs:
+    name: Cancel Closed PR Runs
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain cancellation run
+        run: echo "PR closed; this run only cancels older runs in the same concurrency group."
+
   skip-check:
     name: Skip Duplicate Actions
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ name: CLA Check
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
   merge_group:
     types: [checks_requested]
   issue_comment:
@@ -28,9 +28,21 @@ permissions:
   issues: write
   checks: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  cancel-closed-pr-runs:
+    name: Cancel Closed PR Runs
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain cancellation run
+        run: echo "PR closed; this run only cancels older runs in the same concurrency group."
+
   cla:
-    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
+    if: ${{ (github.event_name != 'issue_comment' || github.event.issue.pull_request) && (github.event_name != 'pull_request_target' || github.event.action != 'closed') }}
     runs-on: ubuntu-latest
     steps:
       - name: Report CLA result for merge queue

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,6 +16,7 @@ name: Fuzz
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     paths:
       - "fuzz/**"
       - "scripts/fuzz/**"
@@ -41,7 +42,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -50,13 +51,21 @@ env:
   RUSTFLAGS: "--cfg tokio_unstable -C target-feature=-crt-static"
 
 jobs:
+  cancel-closed-pr-runs:
+    name: Cancel Closed PR Runs
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain cancellation run
+        run: echo "PR closed; this run only cancels older runs in the same concurrency group."
+
   # ──────────────────────────────────────────────────────────────
   # Phase 1: Build all fuzz harness binaries once.
   # ──────────────────────────────────────────────────────────────
   fuzz-build:
     name: Build Fuzz Harness
     if: >
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' && github.event.action != 'closed') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: sm-standard-4
@@ -110,7 +119,7 @@ jobs:
     name: "Smoke / ${{ matrix.target }}"
     needs: fuzz-build
     if: >
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' && github.event.action != 'closed') ||
       (github.event_name == 'workflow_dispatch' &&
         (github.event.inputs.profile == 'smoke' || github.event.inputs.profile == 'both'))
     runs-on: sm-standard-4

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,6 +24,7 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/nix.yml'
   pull_request:
+    types: [ opened, synchronize, reopened, closed ]
     branches: [ "main" ]
     paths:
       - 'flake.nix'
@@ -34,15 +35,24 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 permissions:
   contents: read
   id-token: write
 
 jobs:
+  cancel-closed-pr-runs:
+    name: Cancel Closed PR Runs
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain cancellation run
+        run: echo "PR closed; this run only cancels older runs in the same concurrency group."
+
   nix-validation:
     name: Nix Build & Check
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add `closed` PR triggers to PR-related workflows so a merge or close creates a lightweight cancellation run.
- Key PR workflow concurrency groups by PR number instead of `github.ref`, so merged PR close events still match earlier PR runs.
- Add `Cancel Closed PR Runs` no-op jobs that explain the cancellation-only run while skipping heavy jobs on PR close.

## Verification
- `ruby -e 'ARGV.each { |f| require "yaml"; YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/audit.yml .github/workflows/fuzz.yml .github/workflows/nix.yml .github/workflows/architecture-migration-rules.yml .github/workflows/cla.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false -ignore 'label "sm-standard-[0-9]+" is unknown' .github/workflows/ci.yml .github/workflows/audit.yml .github/workflows/fuzz.yml .github/workflows/nix.yml .github/workflows/architecture-migration-rules.yml .github/workflows/cla.yml`
- `git diff --check`
- `scripts/security/check_workflow_pins.sh --enforce`
- `make pre-pr` not run per maintainer request.

## Impact
Closed or merged PRs will trigger a small workflow run whose purpose is to cancel older runs in the same workflow and PR concurrency group. Normal PR, push, schedule, and manual workflow behavior remains unchanged.

## Additional Notes
The `actionlint` ignore only suppresses existing custom runner label warnings.
