### PR TITLE
fix: auto-repair breaking changes from 1b3727e2

### DIFF
--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -488,7 +488,7 @@ impl SetDisks {
                                     // Don't leak the partially-written healed shards in
                                     // .rustfs/tmp when heal fails midway (backlog#799 B20).
                                     let _ = self.delete_all(RUSTFS_META_TMP_BUCKET, &tmp_id).await;
-                                    return Err(e.into());
+                                    return Err(e);
                                 }
                                 // close_bitrot_writers(&mut writers).await?;
 


### PR DESCRIPTION
## What

Fix a clippy `useless_conversion` lint error on `main` (baseline `1b3727e2`).

## Why

Commit `1b3727e2` (fix(heal): clean up .rustfs/tmp healed shards on all failure paths) introduced `return Err(e.into())` at `crates/ecstore/src/set_disk/ops/heal.rs:491`. Since `e` is already `DiskError`, the `.into()` is a no-op and clippy now rejects it with `-D warnings`.

## How

- Removed the redundant `.into()` call: `return Err(e.into())` → `return Err(e)`

## Verification

- `make pre-commit` — passed (clippy + fmt + tests)
- `make pre-pr` — passed (full gate: fmt-check, unsafe-code-check, architecture-migration-check, logging-guardrails-check, doc-paths-check, clippy-check, test)
- s3s-e2e S3 compatibility — all 28 test cases passed (Basic + Advanced suites)
