### PR TITLE
fix(filemeta): satisfy clippy::field_reassign_with_default in replication_info_equals test

### DIFF
--- a/crates/filemeta/src/fileinfo.rs
+++ b/crates/filemeta/src/fileinfo.rs
@@ -896,22 +896,28 @@ mod tests {
         assert!(base.replication_info_equals(&FileInfo::default()));
 
         // Differing mark_deleted breaks equality.
-        let mut marked = FileInfo::default();
-        marked.mark_deleted = true;
+        let marked = FileInfo {
+            mark_deleted: true,
+            ..Default::default()
+        };
         assert!(!base.replication_info_equals(&marked));
 
         // Differing replication_state_internal breaks equality (regression guard:
         // this field used to be ignored by replication_info_equals).
-        let mut with_state = FileInfo::default();
-        with_state.replication_state_internal = Some(ReplicationState {
-            replicate_decision_str: "arn:aws:s3:::dest".to_string(),
+        let with_state = FileInfo {
+            replication_state_internal: Some(ReplicationState {
+                replicate_decision_str: "arn:aws:s3:::dest".to_string(),
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
         assert!(!base.replication_info_equals(&with_state));
 
         // Equal replication states remain equal.
-        let mut with_state_clone = FileInfo::default();
-        with_state_clone.replication_state_internal = with_state.replication_state_internal.clone();
+        let with_state_clone = FileInfo {
+            replication_state_internal: with_state.replication_state_internal.clone(),
+            ..Default::default()
+        };
         assert!(with_state.replication_info_equals(&with_state_clone));
     }
 }


### PR DESCRIPTION
## Problem

`Test and Lint` CI (`cargo clippy --all-targets` under `-D warnings`) fails on `main` for every PR:

```
error: field assignment outside of initializer for an instance created with Default::default()
  --> crates/filemeta/src/fileinfo.rs:900
```

The `replication_info_equals` test (added in #4322) builds `FileInfo` via `let mut x = FileInfo::default()` + field reassignment, which `clippy::field_reassign_with_default` rejects on the lib-test target. This blocks all open PRs.

## Fix

Rewrite the three constructions with struct-init syntax + `..Default::default()`, as clippy suggests. Test-only change, behavior unchanged.

## Verification

- `cargo fmt --all`
- `cargo clippy -p rustfs-filemeta --all-targets` — clean