### PR TITLE
test(ecstore): serialize list_objects mutation-sequence tests

### DIFF
--- a/crates/ecstore/src/store/list_objects.rs
+++ b/crates/ecstore/src/store/list_objects.rs
@@ -7667,6 +7667,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn persistent_key_only_index_load_recovers_mutation_sequence_from_journal() {
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         let index_path = tempdir.path().join("persistent-key-only.index");
@@ -7786,6 +7787,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn list_objects_mutation_sequence_advances_per_bucket() {
         reset_list_objects_mutation_sequences_for_test().await;
 


### PR DESCRIPTION
## Related Issues

rustfs/backlog#840 (analysis recorded in https://github.com/rustfs/backlog/issues/840#issuecomment-4896235835)

## Summary of Changes

Fixes a scheduling-dependent flake in the `rustfs-ecstore` list_objects unit tests. Three tests share the global list-objects mutation-sequence state (the `LIST_OBJECTS_MUTATION_SEQUENCE` atomic plus the per-bucket sequence map) and all call `reset_list_objects_mutation_sequences_for_test()`, but only `observed_mutation_persists_namespace_journal_high_water` carried `#[serial_test::serial]`. The serial lock only excludes tests that also carry the attribute, so the unmarked tests still ran concurrently with it: the journal test's persist of `"bucket" -> 11` could land after the recovery test's reset, making `persistent_key_only_index_load_recovers_mutation_sequence_from_journal` observe 11 instead of the expected 9 (`left: 11, right: 9`); everything passes with `--test-threads=1`.

This PR adds `#[serial_test::serial]` to the two unmarked tests:

- `persistent_key_only_index_load_recovers_mutation_sequence_from_journal`
- `list_objects_mutation_sequence_advances_per_bucket`

Unique bucket names alone would not fix the flake: `list_objects_mutation_sequence_advances_per_bucket` asserts exact values produced by the single global atomic counter (independent of bucket name), which any concurrent observe call perturbs, and every reset zeroes that global state for whichever peer test is mid-flight. Serialization is required either way, and the file already uses `#[serial_test::serial]` in ~20 other tests, so this follows the established convention.

Test-only change; no production code is touched.

## Verification

- `cargo test -p rustfs-ecstore --lib list_objects` — 109 tests pass, re-run 5 consecutive times to confirm the flake is gone under the default multi-threaded runner
- `cargo clippy -p rustfs-ecstore --lib --tests --all-features` — clean
- `make pre-commit` — passed
- `cargo fmt --all --check` — clean

## Impact

N/A (test-only; removes CI flakiness in `rustfs-ecstore` list_objects tests)

## Additional Notes

Root-cause writeup is mirrored in the backlog tracker comment linked above.
