### PR TITLE
fix(ecstore): reject zero erasure block_size in codec streaming read

### DIFF
--- a/crates/ecstore/src/erasure/coding/erasure.rs
+++ b/crates/ecstore/src/erasure/coding/erasure.rs
@@ -787,6 +787,17 @@ impl Erasure {
     pub fn total_shard_count(&self) -> usize {
         self.data_shards + self.parity_shards
     }
+
+    /// Whether the erasure dimensions are safe for the shard/offset arithmetic.
+    ///
+    /// `block_size` and `data_shards` come straight from on-disk metadata; a
+    /// corrupted or crafted `xl.meta` can carry zero values that would panic the
+    /// `block_size`/`data_shards` divisions in [`Self::shard_size`],
+    /// [`Self::shard_file_size`] and [`Self::shard_file_offset`]. Read paths must
+    /// reject such metadata before performing those divisions.
+    pub fn has_valid_dimensions(&self) -> bool {
+        self.block_size > 0 && self.data_shards > 0
+    }
     // /// Calculate the shard size and total size for a given data size.
     // // Returns (shard_size, total_size) for the given data size
     // fn need_size(&self, data_size: usize) -> (usize, usize) {
@@ -960,6 +971,21 @@ mod tests {
         let owned = erasure.encode_data_owned(data).expect("owned encode should succeed");
 
         assert_eq!(owned, borrowed);
+    }
+
+    #[test]
+    fn has_valid_dimensions_rejects_zero_block_size_or_data_shards() {
+        // Well-formed erasure metadata is accepted.
+        assert!(Erasure::new(4, 2, 64).has_valid_dimensions());
+        assert!(Erasure::new_with_options(6, 4, 1, true).has_valid_dimensions());
+
+        // Corrupted on-disk metadata with a zero block_size or zero data_shards
+        // must be rejected before it reaches the shard/offset divisions.
+        // (parity_shards is kept 0 for the zero-data_shards cases so the
+        // Reed-Solomon encoder is not constructed with an invalid shard count.)
+        assert!(!Erasure::new(4, 2, 0).has_valid_dimensions());
+        assert!(!Erasure::new(0, 0, 64).has_valid_dimensions());
+        assert!(!Erasure::new(0, 0, 0).has_valid_dimensions());
     }
 
     #[test]

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -597,7 +597,7 @@ impl SetDisks {
 
         // Erasure params come from on-disk metadata; zero values must fail the read
         // instead of panicking on the block/shard divisions below.
-        if erasure.block_size == 0 || erasure.data_shards == 0 {
+        if !erasure.has_valid_dimensions() {
             return Err(Error::other(format!(
                 "invalid erasure metadata for {bucket}/{object}: block_size={}, data_blocks={}",
                 erasure.block_size, erasure.data_shards
@@ -959,14 +959,24 @@ impl SetDisks {
         metrics_size_bucket: &'static str,
         prefer_data_blocks_first_reader_setup: bool,
     ) -> Result<GetCodecStreamingReaderBuildOutcome> {
-        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index(disks, files, fi);
-
         let erasure = coding::Erasure::new_with_options(
             fi.erasure.data_blocks,
             fi.erasure.parity_blocks,
             fi.erasure.block_size,
             fi.uses_legacy_checksum,
         );
+
+        // Erasure params come from on-disk metadata; zero values must fail the read
+        // instead of panicking on the block/shard divisions inside the codec
+        // streaming reader below. Mirrors the legacy multipart guard.
+        if !erasure.has_valid_dimensions() {
+            return Err(Error::other(format!(
+                "invalid erasure metadata for {bucket}/{object}: block_size={}, data_blocks={}",
+                erasure.block_size, erasure.data_shards
+            )));
+        }
+
+        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index(disks, files, fi);
 
         if fi.parts.len() == 1 {
             let part = &fi.parts[0];
@@ -2294,6 +2304,34 @@ mod tests {
             fi,
             lock_optimization_enabled,
         )
+    }
+
+    #[tokio::test]
+    async fn codec_streaming_reader_rejects_zero_block_size_metadata() {
+        // Corrupted on-disk metadata: valid data/parity blocks but block_size == 0.
+        // The codec streaming entry must reject this and return an error instead of
+        // panicking on the block_size division inside the reader (mirrors the legacy
+        // multipart guard). The guard fires before any disk access, so empty disk /
+        // parts-metadata slices are sufficient.
+        let mut fi = codec_streaming_test_fileinfo(1024, 1);
+        fi.erasure.block_size = 0;
+
+        let result = SetDisks::get_object_decode_reader_with_fileinfo(
+            CODEC_STREAMING_TEST_BUCKET,
+            CODEC_STREAMING_TEST_OBJECT,
+            &fi,
+            &[],
+            &[],
+            0,
+            0,
+            false,
+            "test-object-class",
+            "test-size-bucket",
+            false,
+        )
+        .await;
+
+        assert!(result.is_err(), "zero block_size metadata must be rejected, not panic");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#868 (finding 868-1).

## Summary of Changes

The codec streaming GET reader (`SetDisks::get_object_decode_reader_with_fileinfo`
→ `build_codec_streaming_part_reader`) divides by `erasure.block_size` (via
`shard_file_offset` / `shard_file_size` and `part_offset / erasure.block_size`)
without validating the erasure dimensions first. The legacy multipart read path
already guards this (`read.rs`, rejecting `block_size == 0 || data_shards == 0`),
but `FileInfo::is_valid()` does not check `block_size`, so a corrupted or crafted
`xl.meta` with `block_size == 0` and `data_blocks > 0` passes validation and
reaches the division, panicking the read task with `attempt to divide by zero`
(reproduces even in release builds).

Changes:
- Add `Erasure::has_valid_dimensions()` (`block_size > 0 && data_shards > 0`).
- Reject invalid dimensions at the codec streaming entry, before any disk access,
  mirroring the legacy guard.
- Refactor the existing legacy guard to reuse the same predicate (behavior
  unchanged).

## Verification

- `make pre-pr`
- `cargo test -p rustfs-ecstore --lib erasure::coding::erasure::tests::has_valid_dimensions_rejects_zero_block_size_or_data_shards`
- `cargo test -p rustfs-ecstore --lib set_disk::read::tests::codec_streaming_reader_rejects_zero_block_size_metadata`
- Confirmed the new behavioral test fails (divide-by-zero panic at
  `erasure.rs` `shard_file_size`) without the guard and passes with it.

## Impact

Defensive guard only. On corrupted erasure metadata the codec streaming read now
returns an error instead of panicking the read task. No change for well-formed
objects. Codec streaming GET is opt-in and default-disabled, so this closes a
latent panic on an experimental path (severity P2 per adversarial review). No
API, config, or on-disk format change.

## Additional Notes

Found by a multi-agent core-storage reliability audit and independently
adversarially confirmed. The legacy read path was already guarded; this brings
the codec streaming path to parity.
