### PR TITLE
ci: cancel superseded main release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Add concurrency to the `Build and Release` workflow.
- Cancel superseded `push` builds on the same ref, so repeated PR merges to `main` do not leave older release builds queued or running.
- Keep manual and scheduled builds isolated by grouping them by run id.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "ok .github/workflows/build.yml"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false -ignore 'label "sm-standard-[0-9]+" is unknown' .github/workflows/build.yml`
- `git diff --check`
- `scripts/security/check_workflow_pins.sh --enforce`
- `make pre-pr` not run because this is a workflow-only change and focused validation covered the changed surface.

## Impact
Only `Build and Release` runs triggered by `push` events are cancelled when a newer push for the same ref starts. Tag refs remain isolated by tag, and manual or scheduled runs are not cancelled by this concurrency rule.

## Additional Notes
This complements the PR-close cancellation workflow by covering the post-merge `push` workflow that runs on `main`.
