### PR TITLE
fix(ecstore): fsync inline rename_data rollback backup

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3869,10 +3869,28 @@ impl DiskAPI for LocalDisk {
                     && let Some(dst_parent) = dst.parent()
                 {
                     let old_path = dst_parent.join(old_dir.to_string()).join(STORAGE_FORMAT_FILE_BACKUP);
-                    if let Some(old_parent) = old_path.parent() {
+                    let old_parent = old_path.parent().map(|p| p.to_path_buf());
+                    if let Some(ref old_parent) = old_parent {
                         std::fs::create_dir_all(old_parent)?;
                     }
-                    std::fs::write(&old_path, buf).map_err(to_file_error)?;
+                    // This rollback backup is the sole restore source for a later
+                    // undo_write when the set-level write quorum fails. Persist it as
+                    // durably as the new xl.meta written above (and as the non-inline
+                    // branch does): a bare std::fs::write leaves both the bytes and the
+                    // new directory entry in the page cache, so a crash before a
+                    // rollback could restore a lost or truncated backup.
+                    let mut backup = std::fs::OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .truncate(true)
+                        .open(&old_path)?;
+                    std::io::Write::write_all(&mut backup, buf)?;
+                    if sync {
+                        backup.sync_data()?;
+                        if let Some(ref old_parent) = old_parent {
+                            os::fsync_dir_std(old_parent)?;
+                        }
+                    }
                 }
 
                 match std::fs::rename(&src, &dst) {
@@ -4581,11 +4599,12 @@ mod test {
         ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
 
         let old_fi = test_file_info(object, version_id, Some(old_data_dir), None);
+        let old_meta = test_meta(old_fi);
         let dst_object_dir = dir.path().join(bucket).join(object);
         fs::create_dir_all(dst_object_dir.join(old_data_dir.to_string()))
             .await
             .expect("old data dir should be created");
-        fs::write(dst_object_dir.join(STORAGE_FORMAT_FILE), test_meta(old_fi))
+        fs::write(dst_object_dir.join(STORAGE_FORMAT_FILE), &old_meta)
             .await
             .expect("old metadata should be written");
 
@@ -4601,11 +4620,15 @@ mod test {
             .expect("inline rename_data should commit");
 
         assert_eq!(resp.old_data_dir, Some(old_data_dir));
-        assert!(
-            dst_object_dir
-                .join(old_data_dir.to_string())
-                .join(STORAGE_FORMAT_FILE_BACKUP)
-                .exists()
+        let backup_path = dst_object_dir.join(old_data_dir.to_string()).join(STORAGE_FORMAT_FILE_BACKUP);
+        assert!(backup_path.exists());
+        // The rollback backup must contain the previous metadata bytes verbatim so
+        // that undo_write can restore the prior committed object; guards the inline
+        // backup write against truncation/corruption regressions.
+        assert_eq!(
+            fs::read(&backup_path).await.expect("backup should be readable"),
+            old_meta,
+            "inline rollback backup must contain the previous metadata bytes verbatim"
         );
         assert!(
             !dst_object_dir

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3883,12 +3883,13 @@ impl DiskAPI for LocalDisk {
                         .create(true)
                         .write(true)
                         .truncate(true)
-                        .open(&old_path)?;
-                    std::io::Write::write_all(&mut backup, buf)?;
+                        .open(&old_path)
+                        .map_err(to_file_error)?;
+                    std::io::Write::write_all(&mut backup, buf).map_err(to_file_error)?;
                     if sync {
-                        backup.sync_data()?;
+                        backup.sync_data().map_err(to_file_error)?;
                         if let Some(ref old_parent) = old_parent {
-                            os::fsync_dir_std(old_parent)?;
+                            os::fsync_dir_std(old_parent).map_err(to_file_error)?;
                         }
                     }
                 }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#868 (core-storage audit finding disk-durability-01).

## Summary of Changes

In `LocalDisk::rename_data`, the inline branch writes the previous version's
`xl.meta` as a rollback backup (`<old_data_dir>/xl.meta.bkp`) using a bare
`std::fs::write`, which fsyncs neither the file nor the new directory entry —
even when `drive_sync_enabled()` is true. The same closure already fsyncs the
new `xl.meta` (`sync_data`) and the commit rename's destination directory
(`fsync_dir_std`), and the non-inline branch persists its backup durably too.

That `.bkp` is the sole restore source for `delete_version(undo_write=true)`
when a set-level write quorum fails. With sync enabled, an inline overwrite of
an object that has a prior data dir, followed by a power loss and a quorum
failure that triggers `undo_write`, could restore a lost or truncated backup
and fail to roll back to the previous committed object.

Change: write the inline backup via `OpenOptions` + `write_all`, and when sync
is enabled, `sync_data()` the backup file and `fsync_dir_std` its parent
directory — mirroring the new-`xl.meta` write and the non-inline branch.

## Verification

- `make pre-pr`
- `cargo test -p rustfs-ecstore --lib rename_data_writes_old_metadata_backup`
- Extended `test_rename_data_writes_old_metadata_backup_for_inline_overwrite`
  to assert the `.bkp` contents equal the previous metadata bytes verbatim
  (regression guard for the rewritten backup write). The non-inline and
  undo-restore tests continue to pass.

## Impact

Durability hardening only, behind `drive_sync_enabled()` (`RUSTFS_DRIVE_SYNC_ENABLE`).
No change to the backup's contents or to normal read/write behavior; brings the
inline rollback backup to durability parity with the non-inline path. No API,
config, or on-disk format change.

## Additional Notes

fsync durability is not observable from an in-process test, so this relies on
the symmetry with the already-synced writes in the same closure plus the
content regression guard above. Found by a multi-agent core-storage reliability
audit and independently adversarially confirmed (P2).
