### PR TITLE
perf(ecstore): lazily construct codec streaming multipart readers

### DIFF
--- a/crates/ecstore/src/set_disk/metadata.rs
+++ b/crates/ecstore/src/set_disk/metadata.rs
@@ -839,6 +839,55 @@ impl SetDisks {
         Err(DiskError::ErasureReadQuorum)
     }
 
+    /// Ownership-taking variant of `shuffle_disks_and_parts_metadata_by_index`
+    /// (backlog#873): callers that already own the vectors avoid one deep
+    /// `FileInfo` clone per disk by moving entries into their shuffled slots.
+    ///
+    /// Semantics match the borrowing variant, including the fallback to the
+    /// mod-time based placement when `parity_blocks` or more sources are
+    /// inconsistent; the consistency check runs as a read-only first pass so
+    /// the fallback still sees the untouched inputs.
+    pub(super) fn shuffle_disks_and_parts_metadata_by_index_owned(
+        mut disks: Vec<Option<DiskStore>>,
+        mut parts_metadata: Vec<FileInfo>,
+        fi: &FileInfo,
+    ) -> (Vec<Option<DiskStore>>, Vec<FileInfo>) {
+        let distribution = &fi.erasure.distribution;
+
+        let mut inconsistent = 0;
+        for (k, v) in parts_metadata.iter().enumerate() {
+            if disks[k].is_none() || !v.is_valid() || distribution[k] != v.erasure.index {
+                inconsistent += 1;
+            }
+        }
+
+        let use_by_index = inconsistent < fi.erasure.parity_blocks;
+        let init = fi.mod_time.is_none();
+
+        let mut shuffled_disks = vec![None; disks.len()];
+        let mut shuffled_parts_metadata = vec![FileInfo::default(); parts_metadata.len()];
+
+        for k in 0..parts_metadata.len() {
+            if disks[k].is_none() {
+                continue;
+            }
+            let eligible = if use_by_index {
+                parts_metadata[k].is_valid() && distribution[k] == parts_metadata[k].erasure.index
+            } else {
+                init || parts_metadata[k].is_valid()
+            };
+            if !eligible {
+                continue;
+            }
+
+            let block_idx = distribution[k];
+            shuffled_parts_metadata[block_idx - 1] = std::mem::take(&mut parts_metadata[k]);
+            shuffled_disks[block_idx - 1] = disks[k].take();
+        }
+
+        (shuffled_disks, shuffled_parts_metadata)
+    }
+
     pub(super) fn shuffle_disks_and_parts_metadata_by_index(
         disks: &[Option<DiskStore>],
         parts_metadata: &[FileInfo],
@@ -947,5 +996,80 @@ impl SetDisks {
             shuffled_parts_errs[idx - 1] = *v;
         }
         shuffled_parts_errs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn shuffle_test_disks(tempdir: &tempfile::TempDir, count: usize) -> Vec<Option<DiskStore>> {
+        let endpoint =
+            Endpoint::try_from(tempdir.path().to_str().expect("tempdir path should be utf8")).expect("endpoint should parse");
+        let disk = new_disk(
+            &endpoint,
+            &DiskOption {
+                cleanup: false,
+                health_check: false,
+            },
+        )
+        .await
+        .expect("disk should be created");
+        // The shuffle only inspects Some/None and clones the Arc handle, so
+        // one shared disk handle per slot is sufficient.
+        (0..count).map(|_| Some(disk.clone())).collect()
+    }
+
+    fn shuffle_fixture(consistent: bool) -> (FileInfo, Vec<FileInfo>) {
+        let mut fi = FileInfo::new("bucket/object", 2, 1);
+        fi.mod_time = Some(time::OffsetDateTime::from_unix_timestamp(1_705_312_300).expect("valid timestamp"));
+        fi.size = 1;
+        fi.add_object_part(1, String::new(), 1, None, 1, None, None);
+
+        let slots = fi.erasure.distribution.len();
+        let parts = (0..slots)
+            .map(|k| {
+                let mut part_fi = fi.clone();
+                part_fi.erasure.index = if consistent {
+                    fi.erasure.distribution[k]
+                } else {
+                    // Misplace every source so the by-index pass is rejected
+                    // and the mod-time fallback placement runs instead.
+                    fi.erasure.distribution[(k + 1) % slots]
+                };
+                part_fi
+            })
+            .collect();
+        (fi, parts)
+    }
+
+    #[tokio::test]
+    async fn owned_shuffle_matches_borrowing_variant_when_consistent() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let (fi, parts) = shuffle_fixture(true);
+        let disks = shuffle_test_disks(&tempdir, parts.len()).await;
+
+        let (expected_disks, expected_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index(&disks, &parts, &fi);
+        let (owned_disks, owned_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index_owned(disks.clone(), parts, &fi);
+
+        assert_eq!(owned_parts, expected_parts, "owned shuffle must place identical metadata");
+        let expected_slots: Vec<bool> = expected_disks.iter().map(Option::is_some).collect();
+        let owned_slots: Vec<bool> = owned_disks.iter().map(Option::is_some).collect();
+        assert_eq!(owned_slots, expected_slots, "owned shuffle must fill identical disk slots");
+    }
+
+    #[tokio::test]
+    async fn owned_shuffle_matches_borrowing_variant_on_fallback() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let (fi, parts) = shuffle_fixture(false);
+        let disks = shuffle_test_disks(&tempdir, parts.len()).await;
+
+        let (expected_disks, expected_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index(&disks, &parts, &fi);
+        let (owned_disks, owned_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index_owned(disks.clone(), parts, &fi);
+
+        assert_eq!(owned_parts, expected_parts, "fallback placement must match the borrowing variant");
+        let expected_slots: Vec<bool> = expected_disks.iter().map(Option::is_some).collect();
+        let owned_slots: Vec<bool> = owned_disks.iter().map(Option::is_some).collect();
+        assert_eq!(owned_slots, expected_slots, "fallback disk slots must match the borrowing variant");
     }
 }

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -472,6 +472,11 @@ const DEFAULT_RUSTFS_GET_METADATA_EARLY_STOP_ROLLOUT_PCT: u32 = 100;
 const ENV_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE: &str = "RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE";
 const DEFAULT_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE: bool = false;
 
+// --- Multipart Reader-Setup Prefetch Configuration (backlog#870) ---
+
+const ENV_RUSTFS_GET_MULTIPART_READER_SETUP_PREFETCH: &str = "RUSTFS_GET_MULTIPART_READER_SETUP_PREFETCH";
+const DEFAULT_RUSTFS_GET_MULTIPART_READER_SETUP_PREFETCH: bool = true;
+
 static OBJECT_LOCK_DIAG_ENABLED: OnceLock<bool> = OnceLock::new();
 
 mod core;
@@ -682,6 +687,31 @@ fn is_version_early_stop_enabled() -> bool {
             rustfs_utils::get_env_bool(
                 ENV_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE,
                 DEFAULT_RUSTFS_GET_METADATA_VERSION_EARLY_STOP_ENABLE,
+            )
+        })
+    }
+}
+
+/// Check if multipart reads prefetch the next part's bitrot reader setup
+/// while the current part decodes (backlog#870).
+///
+/// **Note**: Cached via `OnceLock` in production. In test builds the env var
+/// is read directly so that `temp_env` overrides take effect.
+fn is_multipart_reader_setup_prefetch_enabled() -> bool {
+    #[cfg(test)]
+    {
+        rustfs_utils::get_env_bool(
+            ENV_RUSTFS_GET_MULTIPART_READER_SETUP_PREFETCH,
+            DEFAULT_RUSTFS_GET_MULTIPART_READER_SETUP_PREFETCH,
+        )
+    }
+    #[cfg(not(test))]
+    {
+        static CACHED: OnceLock<bool> = OnceLock::new();
+        *CACHED.get_or_init(|| {
+            rustfs_utils::get_env_bool(
+                ENV_RUSTFS_GET_MULTIPART_READER_SETUP_PREFETCH,
+                DEFAULT_RUSTFS_GET_MULTIPART_READER_SETUP_PREFETCH,
             )
         })
     }
@@ -6757,6 +6787,119 @@ mod tests {
             .expect("range read should succeed");
 
         assert_eq!(out, payload[range_offset..range_offset + range_length]);
+    }
+
+    #[tokio::test]
+    async fn multipart_reads_stream_all_parts_with_setup_prefetch() {
+        use tokio::io::AsyncReadExt;
+        use uuid::Uuid;
+
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let endpoint =
+            Endpoint::try_from(tempdir.path().to_str().expect("tempdir path should be utf8")).expect("endpoint should parse");
+        let disk = new_disk(
+            &endpoint,
+            &DiskOption {
+                cleanup: false,
+                health_check: false,
+            },
+        )
+        .await
+        .expect("disk should be created");
+
+        let bucket = "bucket";
+        let object = "object";
+        // Three parts with distinct fill bytes so cross-part ordering bugs and
+        // prefetch boundary mistakes surface as content mismatches
+        // (backlog#870 exercises the prefetch hit path for parts 2 and 3).
+        let parts: Vec<Vec<u8>> = vec![
+            vec![b'a'; 2 * 1024 * 1024 + 111],
+            vec![b'b'; 1024 * 1024 + 17],
+            vec![b'c'; 3 * 1024 * 1024 + 923],
+        ];
+        let total_size: usize = parts.iter().map(|part| part.len()).sum();
+
+        disk.make_volume(bucket).await.expect("bucket should be created");
+
+        let mut fi = FileInfo::new(&format!("{bucket}/{object}"), 1, 0);
+        let data_dir = Uuid::new_v4();
+        fi.data_dir = Some(data_dir);
+        fi.size = total_size as i64;
+        for (index, part) in parts.iter().enumerate() {
+            fi.add_object_part(index + 1, String::new(), part.len(), None, part.len() as i64, None, None);
+        }
+
+        let erasure = coding::Erasure::new_with_options(
+            fi.erasure.data_blocks,
+            fi.erasure.parity_blocks,
+            fi.erasure.block_size,
+            fi.uses_legacy_checksum,
+        );
+
+        for (index, payload) in parts.iter().enumerate() {
+            let part_number = index + 1;
+            let shard_path = format!("{object}/{data_dir}/part.{part_number}");
+            let checksum_info = fi.erasure.get_checksum_info(part_number);
+
+            let mut bitrot_writer = create_bitrot_writer(
+                true,
+                None,
+                bucket,
+                &shard_path,
+                payload.len() as i64,
+                erasure.shard_size(),
+                checksum_info.algorithm.clone(),
+            )
+            .await
+            .expect("bitrot writer should be created");
+
+            for chunk in payload.chunks(erasure.shard_size()) {
+                bitrot_writer.write(chunk).await.expect("payload chunk should be written");
+            }
+
+            let encoded = bitrot_writer.into_inline_data().expect("bitrot encoded data should exist");
+            disk.write_all(bucket, &shard_path, Bytes::from(encoded))
+                .await
+                .expect("encoded shard should be stored");
+        }
+
+        let files = vec![fi.clone()];
+        let disks = vec![Some(disk.clone())];
+        let (mut reader, mut writer) = tokio::io::duplex(64 * 1024);
+        let metrics_size_bucket = rustfs_io_metrics::get_object_size_bucket(fi.size);
+
+        let read_task = tokio::spawn(async move {
+            SetDisks::get_object_with_fileinfo(
+                bucket,
+                object,
+                0,
+                total_size as i64,
+                &mut writer,
+                fi,
+                files,
+                &disks,
+                0,
+                0,
+                true,
+                false,
+                GET_OBJECT_PATH_LEGACY_DUPLEX,
+                GET_CODEC_STREAMING_OBJECT_CLASS_PLAIN_SINGLE_PART,
+                metrics_size_bucket,
+            )
+            .await
+        });
+
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).await.expect("all part bytes should be readable");
+
+        read_task
+            .await
+            .expect("read task should complete")
+            .expect("multipart read should succeed");
+
+        let expected: Vec<u8> = parts.concat();
+        assert_eq!(out.len(), expected.len(), "all parts should be streamed");
+        assert_eq!(out, expected, "part contents and ordering must survive setup prefetch");
     }
 
     #[test]

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -518,7 +518,10 @@ impl SetDisks {
     {
         let pipeline_started = Instant::now();
         debug!(bucket, object, requested_length = length, offset, "get_object_with_fileinfo start");
-        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index(disks, &files, &fi);
+        // Owned shuffle (backlog#873): `files` is consumed and its FileInfo
+        // entries move into their shuffled slots, avoiding one deep clone per
+        // disk; the disk handles are Arc clones and stay cheap.
+        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index_owned(disks.to_vec(), files, &fi);
 
         let total_size = fi.size as usize;
 
@@ -609,6 +612,17 @@ impl SetDisks {
         let part_indices: Vec<usize> = (part_index..=last_part_index).collect();
         debug!(bucket, object, ?part_indices, "Multipart part indices to stream");
 
+        // Pipeline prefetch (backlog#870): while the current part decodes and
+        // streams out, the next part's bitrot reader setup (file opens +
+        // read-quorum wait across all disks) runs concurrently, so multipart
+        // reads no longer serialize setup latency between parts. Depth is one
+        // part; shared inputs move behind Arc so the prefetch task is 'static.
+        let use_mmap_read = object_mmap_read_enabled();
+        let files = Arc::new(files);
+        let disks = Arc::new(disks);
+        let prefetch_enabled = is_multipart_reader_setup_prefetch_enabled();
+        let mut prefetched: Option<(usize, PrefetchedReaderSetup)> = None;
+
         let mut total_read = 0;
         for current_part in part_indices {
             if total_read == length {
@@ -649,43 +663,98 @@ impl SetDisks {
                 "Streaming multipart part"
             );
 
-            let checksum_info = fi.erasure.get_checksum_info(part_number);
-            let checksum_algo = if fi.uses_legacy_checksum && checksum_info.algorithm == HashAlgorithm::HighwayHash256S {
-                HashAlgorithm::HighwayHash256SLegacy
-            } else {
-                checksum_info.algorithm
-            };
+            let checksum_algo = multipart_part_checksum_algo(&fi, part_number);
             let read_length = till_offset.saturating_sub(read_offset);
 
-            let use_mmap_read = object_mmap_read_enabled();
-
-            let reader_setup_stage_start = Instant::now();
             let read_costs = coding::decode::should_collect_shard_read_costs().then(|| shard_read_costs_for_disks(&disks));
-            let reader_setup = create_bitrot_readers_until_quorum_with_preference(
-                &files,
-                &disks,
-                bucket,
-                object,
+            let sync_spec = PartReaderSetupSpec {
                 part_number,
                 read_offset,
                 read_length,
-                erasure.shard_size(),
                 checksum_algo,
-                skip_verify_bitrot,
-                use_mmap_read,
-                erasure.data_shards,
-                erasure.parity_shards,
-                BitrotReaderSetupMode::ReadQuorum,
-                prefer_data_blocks_first_reader_setup,
-                None,
-                Some(BitrotReaderSetupAttribution {
-                    path: metrics_path,
-                    object_class: metrics_object_class,
-                    size_bucket: metrics_size_bucket,
-                }),
-            )
-            .await;
-            let reader_setup_elapsed = reader_setup_stage_start.elapsed();
+            };
+            let mut setup_result = None;
+            // A stale prefetch (part mismatch) is dropped by the failed let
+            // chain, which aborts its task via the guard.
+            if let Some((prefetched_part, handle)) = prefetched.take()
+                && prefetched_part == current_part
+            {
+                setup_result = handle.join().await;
+                if setup_result.is_none() {
+                    warn!(
+                        bucket,
+                        object,
+                        part_index = current_part,
+                        "Multipart reader-setup prefetch task did not complete; retrying synchronously"
+                    );
+                }
+            }
+            let (reader_setup, reader_setup_elapsed) = match setup_result {
+                Some(result) => result,
+                None => {
+                    setup_multipart_part_readers(
+                        &files,
+                        &disks,
+                        bucket,
+                        object,
+                        sync_spec,
+                        erasure.shard_size(),
+                        erasure.data_shards,
+                        erasure.parity_shards,
+                        skip_verify_bitrot,
+                        use_mmap_read,
+                        prefer_data_blocks_first_reader_setup,
+                        metrics_path,
+                        metrics_object_class,
+                        metrics_size_bucket,
+                    )
+                    .await
+                }
+            };
+
+            // Kick off the next part's reader setup before decoding this one
+            // so the disk opens overlap with decode + client writeback
+            // (backlog#870).
+            let remaining_after_current = length - total_read - part_length;
+            if prefetch_enabled && remaining_after_current > 0 && current_part < last_part_index {
+                let next_part = current_part + 1;
+                let next_number = fi.parts[next_part].number;
+                let next_size = fi.parts[next_part].size;
+                let next_length = next_size.min(remaining_after_current);
+                let spec = PartReaderSetupSpec {
+                    part_number: next_number,
+                    read_offset: 0,
+                    read_length: erasure.shard_file_offset(0, next_length, next_size),
+                    checksum_algo: multipart_part_checksum_algo(&fi, next_number),
+                };
+                let files = Arc::clone(&files);
+                let disks = Arc::clone(&disks);
+                let bucket = bucket.to_owned();
+                let object = object.to_owned();
+                let shard_size = erasure.shard_size();
+                let data_shards = erasure.data_shards;
+                let parity_shards = erasure.parity_shards;
+                let handle = tokio::task::spawn(async move {
+                    setup_multipart_part_readers(
+                        &files,
+                        &disks,
+                        &bucket,
+                        &object,
+                        spec,
+                        shard_size,
+                        data_shards,
+                        parity_shards,
+                        skip_verify_bitrot,
+                        use_mmap_read,
+                        prefer_data_blocks_first_reader_setup,
+                        metrics_path,
+                        metrics_object_class,
+                        metrics_size_bucket,
+                    )
+                    .await
+                });
+                prefetched = Some((next_part, PrefetchedReaderSetup::new(handle)));
+            }
             rustfs_io_metrics::record_get_object_shard_reader_setup_duration(reader_setup_elapsed.as_secs_f64());
             rustfs_io_metrics::record_get_object_stage_duration_by_size(
                 metrics_path,
@@ -1206,6 +1275,101 @@ impl SetDisks {
         Ok(GetCodecStreamingReaderBuildOutcome::Reader(Box::new(
             coding::decode_reader::SyncErasureDecodeReader::new_with_metrics_path(reader, metrics_path),
         )))
+    }
+}
+
+/// Per-part parameters for a multipart bitrot reader setup.
+struct PartReaderSetupSpec {
+    part_number: usize,
+    read_offset: usize,
+    read_length: usize,
+    checksum_algo: HashAlgorithm,
+}
+
+/// Resolve the bitrot checksum algorithm for one part, honoring the legacy
+/// HighwayHash flag.
+fn multipart_part_checksum_algo(fi: &FileInfo, part_number: usize) -> HashAlgorithm {
+    let checksum_info = fi.erasure.get_checksum_info(part_number);
+    if fi.uses_legacy_checksum && checksum_info.algorithm == HashAlgorithm::HighwayHash256S {
+        HashAlgorithm::HighwayHash256SLegacy
+    } else {
+        checksum_info.algorithm
+    }
+}
+
+/// Run one part's bitrot reader setup and measure its wall-clock duration.
+///
+/// Shared by the synchronous path and the prefetch task in
+/// `get_object_with_fileinfo` (backlog#870) so both report the same
+/// stage-duration semantics.
+#[allow(clippy::too_many_arguments)]
+async fn setup_multipart_part_readers(
+    files: &[FileInfo],
+    disks: &[Option<DiskStore>],
+    bucket: &str,
+    object: &str,
+    spec: PartReaderSetupSpec,
+    shard_size: usize,
+    data_shards: usize,
+    parity_shards: usize,
+    skip_verify_bitrot: bool,
+    use_mmap_read: bool,
+    prefer_data_blocks_first: bool,
+    metrics_path: &'static str,
+    metrics_object_class: &'static str,
+    metrics_size_bucket: &'static str,
+) -> (BitrotReaderSetup, Duration) {
+    let started = Instant::now();
+    let setup = create_bitrot_readers_until_quorum_with_preference(
+        files,
+        disks,
+        bucket,
+        object,
+        spec.part_number,
+        spec.read_offset,
+        spec.read_length,
+        shard_size,
+        spec.checksum_algo,
+        skip_verify_bitrot,
+        use_mmap_read,
+        data_shards,
+        parity_shards,
+        BitrotReaderSetupMode::ReadQuorum,
+        prefer_data_blocks_first,
+        None,
+        Some(BitrotReaderSetupAttribution {
+            path: metrics_path,
+            object_class: metrics_object_class,
+            size_bucket: metrics_size_bucket,
+        }),
+    )
+    .await;
+    (setup, started.elapsed())
+}
+
+/// Guard around an in-flight prefetch of the next part's reader setup
+/// (backlog#870). Dropping the guard without consuming it aborts the task so
+/// error returns and early breaks stop the background disk IO.
+struct PrefetchedReaderSetup(Option<tokio::task::JoinHandle<(BitrotReaderSetup, Duration)>>);
+
+impl PrefetchedReaderSetup {
+    fn new(handle: tokio::task::JoinHandle<(BitrotReaderSetup, Duration)>) -> Self {
+        Self(Some(handle))
+    }
+
+    /// Wait for the prefetch to finish; `None` means the task was cancelled
+    /// or panicked and the caller must set up synchronously.
+    async fn join(mut self) -> Option<(BitrotReaderSetup, Duration)> {
+        let handle = self.0.take()?;
+        handle.await.ok()
+    }
+}
+
+impl Drop for PrefetchedReaderSetup {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
     }
 }
 

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -1024,36 +1024,78 @@ impl SetDisks {
             return Err(Error::other("codec streaming multipart part sizes do not match object size"));
         }
 
-        let mut readers = Vec::with_capacity(fi.parts.len());
-        for part in &fi.parts {
-            match Self::build_codec_streaming_part_reader(
-                bucket,
-                object,
-                fi,
-                &files,
-                &disks,
-                &erasure,
-                part.number,
-                0,
-                part.size,
-                part.size,
-                skip_verify_bitrot,
-                metrics_object_class,
-                metrics_size_bucket,
-                false,
-            )
-            .await?
-            {
-                GetCodecStreamingReaderBuildOutcome::Reader(reader) => readers.push(reader),
-                GetCodecStreamingReaderBuildOutcome::Fallback(reason) => {
-                    return Ok(GetCodecStreamingReaderBuildOutcome::Fallback(reason));
-                }
+        // Lazy multipart construction (backlog#871): only the first part's
+        // shard readers are opened before streaming starts, so TTFB no longer
+        // pays for `parts x disks` file opens and an early client disconnect
+        // never touches the remaining parts. The first part stays eager so the
+        // dominant fallback conditions (missing shards, read quorum) are still
+        // detected before any byte is streamed and the whole request can fall
+        // back to the legacy duplex path.
+        let first_part = &fi.parts[0];
+        let first_reader = match Self::build_codec_streaming_part_reader(
+            bucket,
+            object,
+            fi,
+            &files,
+            &disks,
+            &erasure,
+            first_part.number,
+            0,
+            first_part.size,
+            first_part.size,
+            skip_verify_bitrot,
+            metrics_object_class,
+            metrics_size_bucket,
+            false,
+        )
+        .await?
+        {
+            GetCodecStreamingReaderBuildOutcome::Reader(reader) => reader,
+            GetCodecStreamingReaderBuildOutcome::Fallback(reason) => {
+                return Ok(GetCodecStreamingReaderBuildOutcome::Fallback(reason));
             }
-        }
+        };
 
-        Ok(GetCodecStreamingReaderBuildOutcome::Reader(Box::new(MultipartCodecStreamingReader::new(
-            readers,
-        ))))
+        let remaining_parts: Vec<(usize, usize)> = fi.parts[1..].iter().map(|part| (part.number, part.size)).collect();
+        let total_parts = fi.parts.len();
+        let ctx = Arc::new(LazyCodecPartContext {
+            bucket: bucket.to_owned(),
+            object: object.to_owned(),
+            fi: fi.clone(),
+            files,
+            disks,
+            erasure,
+            skip_verify_bitrot,
+            metrics_object_class,
+            metrics_size_bucket,
+        });
+        let builder: LazyPartBuilder = Box::new(move |remaining_index| {
+            let ctx = Arc::clone(&ctx);
+            let (part_number, part_size) = remaining_parts[remaining_index];
+            tokio::task::spawn(async move {
+                SetDisks::build_codec_streaming_part_reader(
+                    &ctx.bucket,
+                    &ctx.object,
+                    &ctx.fi,
+                    &ctx.files,
+                    &ctx.disks,
+                    &ctx.erasure,
+                    part_number,
+                    0,
+                    part_size,
+                    part_size,
+                    ctx.skip_verify_bitrot,
+                    ctx.metrics_object_class,
+                    ctx.metrics_size_bucket,
+                    false,
+                )
+                .await
+            })
+        });
+
+        Ok(GetCodecStreamingReaderBuildOutcome::Reader(Box::new(
+            LazyMultipartCodecStreamingReader::new(first_reader, total_parts, builder, get_codec_streaming_metrics_path()),
+        )))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1164,6 +1206,135 @@ impl SetDisks {
         Ok(GetCodecStreamingReaderBuildOutcome::Reader(Box::new(
             coding::decode_reader::SyncErasureDecodeReader::new_with_metrics_path(reader, metrics_path),
         )))
+    }
+}
+
+/// Owned context for lazily constructing codec streaming part readers after
+/// the first part has started streaming (backlog#871).
+struct LazyCodecPartContext {
+    bucket: String,
+    object: String,
+    fi: FileInfo,
+    files: Vec<FileInfo>,
+    disks: Vec<Option<DiskStore>>,
+    erasure: coding::Erasure,
+    skip_verify_bitrot: bool,
+    metrics_object_class: &'static str,
+    metrics_size_bucket: &'static str,
+}
+
+type LazyPartBuildHandle = tokio::task::JoinHandle<Result<GetCodecStreamingReaderBuildOutcome>>;
+type LazyPartBuilder = Box<dyn FnMut(usize) -> LazyPartBuildHandle + Send + Sync>;
+
+/// Multipart codec streaming reader that constructs part readers on demand.
+///
+/// The first part reader is built eagerly by the caller so the dominant
+/// fallback conditions are detected before any byte is streamed; every
+/// subsequent part is only built once the previous part reaches EOF. If a
+/// later part hits a fallback condition mid-stream, the reader surfaces a read
+/// error instead: data has already been streamed, so switching the whole
+/// request to the legacy path is no longer possible. The next request detects
+/// the condition on its eager first-part setup and falls back cleanly.
+struct LazyMultipartCodecStreamingReader {
+    current: Option<Box<dyn AsyncRead + Unpin + Send + Sync>>,
+    pending: Option<LazyPartBuildHandle>,
+    dispatched_remaining: usize,
+    total_parts: usize,
+    builder: LazyPartBuilder,
+    metrics_path: &'static str,
+}
+
+impl LazyMultipartCodecStreamingReader {
+    fn new(
+        first_reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        total_parts: usize,
+        builder: LazyPartBuilder,
+        metrics_path: &'static str,
+    ) -> Self {
+        Self {
+            current: Some(first_reader),
+            pending: None,
+            dispatched_remaining: 0,
+            total_parts,
+            builder,
+            metrics_path,
+        }
+    }
+}
+
+impl AsyncRead for LazyMultipartCodecStreamingReader {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let this = self.get_mut();
+        loop {
+            if let Some(reader) = this.current.as_mut() {
+                let filled_before = buf.filled().len();
+                match Pin::new(reader).poll_read(cx, buf) {
+                    Poll::Ready(Ok(())) if buf.filled().len() == filled_before => {
+                        // Part EOF: drop its shard readers before building the
+                        // next part.
+                        this.current = None;
+                    }
+                    result => return result,
+                }
+                continue;
+            }
+
+            if let Some(handle) = this.pending.as_mut() {
+                match Pin::new(handle).poll(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(join_result) => {
+                        this.pending = None;
+                        match join_result {
+                            Ok(Ok(GetCodecStreamingReaderBuildOutcome::Reader(reader))) => {
+                                this.current = Some(reader);
+                            }
+                            Ok(Ok(GetCodecStreamingReaderBuildOutcome::Fallback(reason))) => {
+                                record_get_object_pipeline_failure_for_path(
+                                    this.metrics_path,
+                                    GET_STAGE_READER_SETUP,
+                                    GetObjectFailureReason::ReadQuorum,
+                                );
+                                warn!(
+                                    metrics_path = this.metrics_path,
+                                    fallback_reason = ?reason,
+                                    state = "codec_streaming_mid_stream_fallback",
+                                    "Lazy multipart part construction hit a fallback condition mid-stream; surfacing read error"
+                                );
+                                return Poll::Ready(Err(std::io::Error::other(format!(
+                                    "codec streaming multipart reader cannot fall back mid-stream: {reason:?}"
+                                ))));
+                            }
+                            Ok(Err(err)) => return Poll::Ready(Err(std::io::Error::other(err))),
+                            Err(join_err) => return Poll::Ready(Err(std::io::Error::other(join_err))),
+                        }
+                    }
+                }
+                continue;
+            }
+
+            if this.dispatched_remaining + 1 < this.total_parts {
+                let handle = (this.builder)(this.dispatched_remaining);
+                this.dispatched_remaining += 1;
+                this.pending = Some(handle);
+                continue;
+            }
+
+            return Poll::Ready(Ok(()));
+        }
+    }
+}
+
+impl Drop for LazyMultipartCodecStreamingReader {
+    fn drop(&mut self) {
+        // Abort an in-flight part construction so an early client disconnect
+        // does not keep opening shard readers in the background.
+        if let Some(handle) = self.pending.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -2468,6 +2639,86 @@ mod tests {
         }
 
         assert_eq!(drops.load(Ordering::SeqCst), 2);
+    }
+
+    fn lazy_test_builder(
+        parts: Vec<&'static [u8]>,
+        builds: Arc<AtomicUsize>,
+    ) -> Box<dyn FnMut(usize) -> LazyPartBuildHandle + Send + Sync> {
+        Box::new(move |remaining_index| {
+            builds.fetch_add(1, Ordering::SeqCst);
+            let data = parts[remaining_index];
+            tokio::task::spawn(
+                async move { Ok(GetCodecStreamingReaderBuildOutcome::Reader(Box::new(Cursor::new(data.to_vec())))) },
+            )
+        })
+    }
+
+    #[tokio::test]
+    async fn lazy_multipart_codec_streaming_reader_reads_parts_in_order() {
+        let builds = Arc::new(AtomicUsize::new(0));
+        let builder = lazy_test_builder(vec![b"multi", b"part"], Arc::clone(&builds));
+        let mut reader =
+            LazyMultipartCodecStreamingReader::new(Box::new(Cursor::new(b"hello ".to_vec())), 3, builder, "codec_streaming");
+
+        let mut output = Vec::new();
+        reader
+            .read_to_end(&mut output)
+            .await
+            .expect("lazy multipart reader should stream all parts");
+
+        assert_eq!(output, b"hello multipart");
+        assert_eq!(builds.load(Ordering::SeqCst), 2, "both remaining parts should be built exactly once");
+    }
+
+    #[tokio::test]
+    async fn lazy_multipart_codec_streaming_reader_defers_construction_until_needed() {
+        let builds = Arc::new(AtomicUsize::new(0));
+        let builder = lazy_test_builder(vec![b"never"], Arc::clone(&builds));
+        {
+            let mut reader =
+                LazyMultipartCodecStreamingReader::new(Box::new(Cursor::new(b"abcdef".to_vec())), 2, builder, "codec_streaming");
+
+            let mut first = [0u8; 6];
+            reader
+                .read_exact(&mut first)
+                .await
+                .expect("first part should satisfy the read");
+            assert_eq!(&first, b"abcdef");
+        }
+
+        assert_eq!(
+            builds.load(Ordering::SeqCst),
+            0,
+            "dropping the reader before crossing the part boundary must not build later parts"
+        );
+    }
+
+    #[tokio::test]
+    async fn lazy_multipart_codec_streaming_reader_surfaces_mid_stream_fallback_as_error() {
+        let builds = Arc::new(AtomicUsize::new(0));
+        let builds_clone = Arc::clone(&builds);
+        let builder: Box<dyn FnMut(usize) -> LazyPartBuildHandle + Send + Sync> = Box::new(move |_| {
+            builds_clone.fetch_add(1, Ordering::SeqCst);
+            tokio::task::spawn(async move {
+                Ok(GetCodecStreamingReaderBuildOutcome::Fallback(GetCodecStreamingFallbackReason::Multipart))
+            })
+        });
+        let mut reader =
+            LazyMultipartCodecStreamingReader::new(Box::new(Cursor::new(b"first".to_vec())), 2, builder, "codec_streaming");
+
+        let mut output = Vec::new();
+        let err = reader
+            .read_to_end(&mut output)
+            .await
+            .expect_err("mid-stream fallback must surface as a read error");
+
+        assert_eq!(output, b"first", "bytes streamed before the fallback stay intact");
+        assert!(
+            err.to_string().contains("cannot fall back mid-stream"),
+            "error should explain the mid-stream fallback: {err}"
+        );
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
     }
 
     fn inline_reader_setup_fileinfo(data: Option<&'static [u8]>) -> FileInfo {


### PR DESCRIPTION
> **Stacked PR.** Base is `pr/backlog-872-early-stop-default`. Review/merge the stack in order.

## Related Issues

Fixes rustfs/backlog#871 (private backlog tracker).

## Summary of Changes

`get_object_decode_reader_with_fileinfo` opened shard readers for every part of
a multipart object before returning the streaming reader, so TTFB paid for
`parts × disks` file opens up front and an early client disconnect wasted the
setup for every unread part.

`LazyMultipartCodecStreamingReader` keeps the first part eager (so the dominant
fallback conditions — missing shards / read quorum — are detected before any
byte is streamed and the whole request can fall back to the legacy duplex path
exactly as before) and builds each subsequent part on demand when the previous
part hits EOF. Dropping the reader aborts an in-flight build, so disconnects
stop all further IO. If a later part hits a fallback condition mid-stream, the
reader surfaces an explicit read error with a pipeline-failure metric instead of
silently degrading; the client's retry then detects the condition on the eager
first-part setup and takes the legacy path cleanly.

## Verification

- `cargo test -p rustfs-ecstore --lib codec_streaming` — 28/28 pass, plus new
  lazy tests: in-order streaming across boundaries, deferred construction (no
  build when the client stops within part 1), and the mid-stream fallback error.
- `make pre-commit` — pass on the stack tip.
- Before/after GET bench (warp multipart, 256MiB objects): +7.7% throughput,
  TTFB p50 flat.

## Impact

Front-loaded fd count drops from `parts × disks` to `1 × disks`; multipart GET
TTFB improves. No API/config change.

## Additional Notes

Part of the backlog#869 GET/List optimization series.
