### PR TITLE
perf(ecstore): move FileInfo through GET shuffle instead of cloning

### DIFF
--- a/crates/ecstore/src/set_disk/metadata.rs
+++ b/crates/ecstore/src/set_disk/metadata.rs
@@ -839,6 +839,55 @@ impl SetDisks {
         Err(DiskError::ErasureReadQuorum)
     }
 
+    /// Ownership-taking variant of `shuffle_disks_and_parts_metadata_by_index`
+    /// (backlog#873): callers that already own the vectors avoid one deep
+    /// `FileInfo` clone per disk by moving entries into their shuffled slots.
+    ///
+    /// Semantics match the borrowing variant, including the fallback to the
+    /// mod-time based placement when `parity_blocks` or more sources are
+    /// inconsistent; the consistency check runs as a read-only first pass so
+    /// the fallback still sees the untouched inputs.
+    pub(super) fn shuffle_disks_and_parts_metadata_by_index_owned(
+        mut disks: Vec<Option<DiskStore>>,
+        mut parts_metadata: Vec<FileInfo>,
+        fi: &FileInfo,
+    ) -> (Vec<Option<DiskStore>>, Vec<FileInfo>) {
+        let distribution = &fi.erasure.distribution;
+
+        let mut inconsistent = 0;
+        for (k, v) in parts_metadata.iter().enumerate() {
+            if disks[k].is_none() || !v.is_valid() || distribution[k] != v.erasure.index {
+                inconsistent += 1;
+            }
+        }
+
+        let use_by_index = inconsistent < fi.erasure.parity_blocks;
+        let init = fi.mod_time.is_none();
+
+        let mut shuffled_disks = vec![None; disks.len()];
+        let mut shuffled_parts_metadata = vec![FileInfo::default(); parts_metadata.len()];
+
+        for k in 0..parts_metadata.len() {
+            if disks[k].is_none() {
+                continue;
+            }
+            let eligible = if use_by_index {
+                parts_metadata[k].is_valid() && distribution[k] == parts_metadata[k].erasure.index
+            } else {
+                init || parts_metadata[k].is_valid()
+            };
+            if !eligible {
+                continue;
+            }
+
+            let block_idx = distribution[k];
+            shuffled_parts_metadata[block_idx - 1] = std::mem::take(&mut parts_metadata[k]);
+            shuffled_disks[block_idx - 1] = disks[k].take();
+        }
+
+        (shuffled_disks, shuffled_parts_metadata)
+    }
+
     pub(super) fn shuffle_disks_and_parts_metadata_by_index(
         disks: &[Option<DiskStore>],
         parts_metadata: &[FileInfo],
@@ -947,5 +996,80 @@ impl SetDisks {
             shuffled_parts_errs[idx - 1] = *v;
         }
         shuffled_parts_errs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn shuffle_test_disks(tempdir: &tempfile::TempDir, count: usize) -> Vec<Option<DiskStore>> {
+        let endpoint =
+            Endpoint::try_from(tempdir.path().to_str().expect("tempdir path should be utf8")).expect("endpoint should parse");
+        let disk = new_disk(
+            &endpoint,
+            &DiskOption {
+                cleanup: false,
+                health_check: false,
+            },
+        )
+        .await
+        .expect("disk should be created");
+        // The shuffle only inspects Some/None and clones the Arc handle, so
+        // one shared disk handle per slot is sufficient.
+        (0..count).map(|_| Some(disk.clone())).collect()
+    }
+
+    fn shuffle_fixture(consistent: bool) -> (FileInfo, Vec<FileInfo>) {
+        let mut fi = FileInfo::new("bucket/object", 2, 1);
+        fi.mod_time = Some(time::OffsetDateTime::from_unix_timestamp(1_705_312_300).expect("valid timestamp"));
+        fi.size = 1;
+        fi.add_object_part(1, String::new(), 1, None, 1, None, None);
+
+        let slots = fi.erasure.distribution.len();
+        let parts = (0..slots)
+            .map(|k| {
+                let mut part_fi = fi.clone();
+                part_fi.erasure.index = if consistent {
+                    fi.erasure.distribution[k]
+                } else {
+                    // Misplace every source so the by-index pass is rejected
+                    // and the mod-time fallback placement runs instead.
+                    fi.erasure.distribution[(k + 1) % slots]
+                };
+                part_fi
+            })
+            .collect();
+        (fi, parts)
+    }
+
+    #[tokio::test]
+    async fn owned_shuffle_matches_borrowing_variant_when_consistent() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let (fi, parts) = shuffle_fixture(true);
+        let disks = shuffle_test_disks(&tempdir, parts.len()).await;
+
+        let (expected_disks, expected_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index(&disks, &parts, &fi);
+        let (owned_disks, owned_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index_owned(disks.clone(), parts, &fi);
+
+        assert_eq!(owned_parts, expected_parts, "owned shuffle must place identical metadata");
+        let expected_slots: Vec<bool> = expected_disks.iter().map(Option::is_some).collect();
+        let owned_slots: Vec<bool> = owned_disks.iter().map(Option::is_some).collect();
+        assert_eq!(owned_slots, expected_slots, "owned shuffle must fill identical disk slots");
+    }
+
+    #[tokio::test]
+    async fn owned_shuffle_matches_borrowing_variant_on_fallback() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let (fi, parts) = shuffle_fixture(false);
+        let disks = shuffle_test_disks(&tempdir, parts.len()).await;
+
+        let (expected_disks, expected_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index(&disks, &parts, &fi);
+        let (owned_disks, owned_parts) = SetDisks::shuffle_disks_and_parts_metadata_by_index_owned(disks.clone(), parts, &fi);
+
+        assert_eq!(owned_parts, expected_parts, "fallback placement must match the borrowing variant");
+        let expected_slots: Vec<bool> = expected_disks.iter().map(Option::is_some).collect();
+        let owned_slots: Vec<bool> = owned_disks.iter().map(Option::is_some).collect();
+        assert_eq!(owned_slots, expected_slots, "fallback disk slots must match the borrowing variant");
     }
 }

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -518,7 +518,10 @@ impl SetDisks {
     {
         let pipeline_started = Instant::now();
         debug!(bucket, object, requested_length = length, offset, "get_object_with_fileinfo start");
-        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index(disks, &files, &fi);
+        // Owned shuffle (backlog#873): `files` is consumed and its FileInfo
+        // entries move into their shuffled slots, avoiding one deep clone per
+        // disk; the disk handles are Arc clones and stay cheap.
+        let (disks, files) = Self::shuffle_disks_and_parts_metadata_by_index_owned(disks.to_vec(), files, &fi);
 
         let total_size = fi.size as usize;
 
@@ -671,19 +674,20 @@ impl SetDisks {
                 checksum_algo,
             };
             let mut setup_result = None;
-            if let Some((prefetched_part, handle)) = prefetched.take() {
-                if prefetched_part == current_part {
-                    setup_result = handle.join().await;
-                    if setup_result.is_none() {
-                        warn!(
-                            bucket,
-                            object,
-                            part_index = current_part,
-                            "Multipart reader-setup prefetch task did not complete; retrying synchronously"
-                        );
-                    }
+            // A stale prefetch (part mismatch) is dropped by the failed let
+            // chain, which aborts its task via the guard.
+            if let Some((prefetched_part, handle)) = prefetched.take()
+                && prefetched_part == current_part
+            {
+                setup_result = handle.join().await;
+                if setup_result.is_none() {
+                    warn!(
+                        bucket,
+                        object,
+                        part_index = current_part,
+                        "Multipart reader-setup prefetch task did not complete; retrying synchronously"
+                    );
                 }
-                // A stale prefetch guard is dropped here, aborting its task.
             }
             let (reader_setup, reader_setup_elapsed) = match setup_result {
                 Some(result) => result,


### PR DESCRIPTION
> **Stacked PR.** Base is `pr/backlog-870-multipart-prefetch`. Final PR in the stack.

## Related Issues

Fixes rustfs/backlog#873 (private backlog tracker).

## Summary of Changes

`shuffle_disks_and_parts_metadata_by_index` deep-cloned every valid `FileInfo`
(parts, erasure info, metadata map) once per disk on each GET. This adds an
ownership-taking variant that runs the same by-index consistency check as a
read-only first pass and then moves entries into their shuffled slots with
`mem::take`, and switches `get_object_with_fileinfo` to it — that call site
already owned the parts metadata vector. Disk handles are `Arc` clones and stay
cheap.

Scope notes from the audit:
- `get_object_fileinfo`'s `disks.clone()` stays: `DiskStore` is `Arc<Disk>`, so
  the clone is per-slot refcounting and correctly avoids holding the RwLock read
  guard across the metadata fanout awaits.
- `get_object_decode_reader_with_fileinfo` keeps the borrowing shuffle: its
  caller must retain files/disks for the legacy fallback path.
- The metadata-cache hit path still clones parts metadata; sharing via `Arc`
  changes read-path return types and is left as a follow-up.

## Verification

- `cargo test -p rustfs-ecstore --lib owned_shuffle` — 2/2 pass (by-index
  placement and mod-time fallback, both equivalent to the borrowing variant).
- `make pre-commit` — pass on this (stack tip).

## Impact

Removes one `FileInfo` deep clone per disk per GET. No behavior/API change:
equivalence tests confirm identical shuffle output.

## Additional Notes

Part of the backlog#869 GET/List optimization series.
