### PR TITLE
fix: ci failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,6 +286,7 @@ jobs:
 
             read -r console_url console_sha256 < <("$python_bin" - "$console_json" <<'PY'
           import json
+          import re
           import sys
 
           with open(sys.argv[1], encoding="utf-8") as handle:
@@ -296,7 +297,10 @@ jobs:
               digest = asset.get("digest", "")
               url = asset.get("browser_download_url", "")
               if name.startswith("rustfs-console-") and name.endswith(".zip") and digest.startswith("sha256:") and url:
-                  print(url, digest.split(":", 1)[1])
+                  sha256 = digest.split(":", 1)[1]
+                  if not re.fullmatch(r"[0-9a-fA-F]{64}", sha256):
+                      raise SystemExit(f"console zip asset has invalid sha256 digest: {sha256}")
+                  sys.stdout.buffer.write(f"{url} {sha256}\n".encode("utf-8"))
                   break
           else:
               raise SystemExit("no console zip asset with sha256 digest found")


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.


ci failed quite a time like: https://github.com/rustfs/rustfs/actions/runs/28821583231/job/85474339185

this patch fix it.

cause in windows there is `\r` so checksum failed