### PR TITLE
fix(runtime): remove tokio io-uring feature and add regression guard

### DIFF
--- a/.config/make/lint-fmt.mak
+++ b/.config/make/lint-fmt.mak
@@ -45,6 +45,11 @@ logging-guardrails-check: ## Check logging guardrails for redaction and noise re
 	@echo "🪵 Checking logging guardrails..."
 	./scripts/check_logging_guardrails.sh
 
+.PHONY: tokio-io-uring-check
+tokio-io-uring-check: ## Check tokio io-uring runtime feature stays removed
+	@echo "🚫 Checking tokio io-uring feature guard..."
+	./scripts/check_no_tokio_io_uring.sh
+
 .PHONY: compilation-check
 compilation-check: core-deps ## Run compilation check
 	@echo "🔨 Running compilation check..."

--- a/.config/make/pre-commit.mak
+++ b/.config/make/pre-commit.mak
@@ -14,13 +14,13 @@ doc-paths-check: ## Check that instruction/architecture docs reference existing 
 	./scripts/check_doc_paths.sh
 
 .PHONY: pre-commit
-pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check doc-paths-check quick-check ## Run fast pre-commit checks without clippy/full tests
+pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check doc-paths-check quick-check ## Run fast pre-commit checks without clippy/full tests
 	@echo "✅ All pre-commit checks passed!"
 
 .PHONY: pre-pr
-pre-pr: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check doc-paths-check clippy-check test ## Run full pre-PR checks with clippy and tests
+pre-pr: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check doc-paths-check clippy-check test ## Run full pre-PR checks with clippy and tests
 	@echo "✅ All pre-PR checks passed!"
 
 .PHONY: dev-check
-dev-check: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check doc-paths-check quick-check ## Run fast local development checks
+dev-check: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check doc-paths-check quick-check ## Run fast local development checks
 	@echo "✅ Fast development checks passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Check architecture migration rules
         run: ./scripts/check_architecture_migration_rules.sh
 
+      - name: Check tokio io-uring feature guard
+        run: ./scripts/check_no_tokio_io_uring.sh
+
   test-and-lint:
     name: Test and Lint
     needs: skip-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,17 +5244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11467,13 +11456,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -171,7 +171,3 @@ harness = false
 
 [lib]
 doctest = false
-
-# io-uring is Linux-only. Scope the feature to Linux targets.
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio = { workspace = true, features = ["io-uring"] }

--- a/crates/io-core/Cargo.toml
+++ b/crates/io-core/Cargo.toml
@@ -34,13 +34,6 @@ tokio = { workspace = true, features = ["io-util", "fs", "rt", "sync"] }
 memmap2 = { workspace = true }
 rustfs-io-metrics = { workspace = true }
 
-# Enable tokio's io_uring-based runtime backend on Linux.
-# Note: this is a tokio runtime feature, not application-level io_uring usage.
-# See the Tokio 1.52.0 release notes and tokio-rs/tokio#7907 for the upstream
-# runtime feature context.
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio = { workspace = true, features = ["io-uring"] }
-
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -70,7 +70,3 @@ temp-env = { workspace = true }
 
 [features]
 default = []
-
-# io-uring is Linux-only. Scope the feature to Linux targets.
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio = { workspace = true, features = ["io-uring"] }

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -136,7 +136,3 @@ tokio = { workspace = true, features = ["test-util", "macros", "rt"] }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-
-# io-uring is Linux-only. Scope the feature to Linux targets.
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio = { workspace = true, features = ["io-uring"] }

--- a/crates/scanner/Cargo.toml
+++ b/crates/scanner/Cargo.toml
@@ -62,7 +62,3 @@ tokio = { workspace = true, features = ["test-util"] }
 
 [lib]
 doctest = false
-
-# io-uring is Linux-only. Scope the feature to Linux targets.
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio = { workspace = true, features = ["io-uring"] }

--- a/crates/zip/Cargo.toml
+++ b/crates/zip/Cargo.toml
@@ -54,7 +54,3 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
-
-# io-uring is Linux-only. Scope the feature to Linux targets.
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio = { workspace = true, features = ["io-uring"] }

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -191,8 +191,6 @@ mimalloc = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libsystemd.workspace = true
-# io-uring is Linux-only. Scope the feature to Linux targets.
-tokio = { workspace = true, features = ["io-uring"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 libmimalloc-sys = { version = "0.1.49", features = ["extended"] }

--- a/scripts/check_no_tokio_io_uring.sh
+++ b/scripts/check_no_tokio_io_uring.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard: tokio's io-uring runtime backend must stay disabled.
+#
+# Restricted Linux environments (Docker default seccomp, gVisor, proot,
+# old kernels) reject io_uring_setup with EACCES/ENOSYS. With the global
+# `--cfg tokio_unstable` in .cargo/config.toml, a tokio "io-uring" feature
+# anywhere in the workspace silently switches every Linux build's file I/O
+# onto that backend and turns the rejection into DiskAccessDenied at
+# startup (backlog#890). Any future io_uring integration must go through
+# an application-level, runtime-probed backend (backlog#894), never the
+# tokio runtime feature — so only the tokio dependency line is banned
+# here; an explicit `io-uring` crate dependency is allowed.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${CHECK_NO_TOKIO_IO_URING_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+cd "$ROOT_DIR"
+
+status=0
+
+while IFS=: read -r file line content; do
+    printf '%s:%s: tokio must not enable the "io-uring" runtime feature: %s\n' \
+        "$file" "$line" "$content" >&2
+    status=1
+done < <(rg -n '^[[:space:]]*tokio[[:space:]]*=.*"io-uring"' --glob '**/Cargo.toml' . || true)
+
+exit "$status"


### PR DESCRIPTION
## Related Issues

rustfs/backlog#890 (tracking: rustfs/backlog#897)

## Summary of Changes

- Remove the `[target.'cfg(target_os = "linux")'.dependencies] tokio = { features = ["io-uring"] }` declarations from 6 crates (`ecstore`, `io-core`, `kms`, `protocols`, `scanner`, `zip`) and the `rustfs` binary. Because `.cargo/config.toml` enables `--cfg tokio_unstable` globally, this feature silently switched every Linux build's file I/O onto tokio's unstable io_uring runtime backend.
- Restricted Linux environments (Docker default seccomp profile, gVisor, proot/Android, older kernels) reject `io_uring_setup` with `EACCES`/`ENOSYS`; tokio surfaced that as `PermissionDenied` on file reads and RustFS reported `DiskAccessDenied` at startup, so nodes failed to boot.
- Add `scripts/check_no_tokio_io_uring.sh` so the feature cannot silently return: it fails on any tokio dependency line enabling `"io-uring"`, while deliberately allowing a future application-level `io-uring` crate dependency (planned as a runtime-probed, feature-gated backend in rustfs/backlog#894). Wired into `make pre-commit`/`pre-pr`/`dev-check` and CI.
- `Cargo.lock` updated accordingly (drops the `io-uring` package and tokio's `io-uring`/`slab` edges).

Relationship to #4313: that PR identified this failure and removes the same dependency declarations, but has not been merged; the declarations are still live on `main`. This PR lands the dependency removal plus a regression guard. It intentionally does not include the startup endpoint logging change from #4313, which is orthogonal.

## Verification

- `make pre-commit` (passes; includes the new `tokio-io-uring-check` plus fmt, unsafe/architecture/logging/doc-path guards and `cargo check --workspace`)
- `./scripts/check_no_tokio_io_uring.sh` on a clean tree exits 0
- Negative self-test: injecting `tokio = { workspace = true, features = ["fs", "io-uring"] }` into a temporary `Cargo.toml` under a `CHECK_NO_TOKIO_IO_URING_ROOT` override makes the guard exit non-zero and print the offending file/line
- `rg 'name = "io-uring"' Cargo.lock` → no matches after the change

## Impact

- Linux builds no longer opt into tokio's unstable io_uring runtime backend; file I/O uses tokio's regular blocking-pool backend, matching macOS/Windows behavior. Nodes start normally under Docker default seccomp, gVisor, and proot.
- No API, configuration, or on-disk format changes. `--cfg tokio_unstable` is kept (required for tokio telemetry).
- New CI step and pre-commit target guard against reintroduction.

## Additional Notes

Observed failure chain on restricted Linux: `io_uring_setup(...) = -1 EACCES` → tokio file reads return `PermissionDenied` → `to_file_error` maps it to `FileAccessDenied` → surfaced as `DiskAccessDenied` and startup aborts. Any future io_uring adoption should go through an application-level backend with runtime capability probing and graceful fallback (design tracked in rustfs/backlog#897).
