### PR TITLE
feat(iam): notification-path cache refreshes read without namespace locks

### DIFF
--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -1847,7 +1847,7 @@ where
 
     pub async fn group_notification_handler(&self, group: &str) -> Result<()> {
         let mut m = HashMap::new();
-        if let Err(err) = self.api.load_group(group, &mut m).await {
+        if let Err(err) = self.api.load_group_no_lock(group, &mut m).await {
             if !is_err_no_such_group(&err) {
                 return Err(err);
             }
@@ -1876,7 +1876,7 @@ where
 
     pub async fn policy_notification_handler(&self, policy: &str) -> Result<()> {
         let mut m = HashMap::new();
-        if let Err(err) = self.api.load_policy_doc(policy, &mut m).await {
+        if let Err(err) = self.api.load_policy_doc_no_lock(policy, &mut m).await {
             if !is_err_no_such_policy(&err) {
                 return Err(err);
             }
@@ -1927,7 +1927,7 @@ where
 
     pub async fn policy_mapping_notification_handler(&self, name: &str, user_type: UserType, is_group: bool) -> Result<()> {
         let mut m = HashMap::new();
-        if let Err(err) = self.api.load_mapped_policy(name, user_type, is_group, &mut m).await {
+        if let Err(err) = self.api.load_mapped_policy_no_lock(name, user_type, is_group, &mut m).await {
             if !is_err_no_such_policy(&err) {
                 return Err(err);
             }
@@ -1963,7 +1963,7 @@ where
     }
     pub async fn user_notification_handler(&self, name: &str, user_type: UserType) -> Result<()> {
         let mut m = HashMap::new();
-        if let Err(err) = self.api.load_user(name, user_type, &mut m).await {
+        if let Err(err) = self.api.load_user_no_lock(name, user_type, &mut m).await {
             if !is_err_no_such_user(&err) {
                 return Err(err);
             }
@@ -2028,7 +2028,7 @@ where
                 let mut policies = HashMap::new();
                 if let Err(err) = self
                     .api
-                    .load_mapped_policy(&parent_user, user_type, false, &mut policies)
+                    .load_mapped_policy_no_lock(&parent_user, user_type, false, &mut policies)
                     .await
                 {
                     if !is_err_no_such_policy(&err) {
@@ -2040,7 +2040,11 @@ where
             }
             UserType::Reg => {
                 let mut policies = HashMap::new();
-                if let Err(err) = self.api.load_mapped_policy(name, user_type, false, &mut policies).await {
+                if let Err(err) = self
+                    .api
+                    .load_mapped_policy_no_lock(name, user_type, false, &mut policies)
+                    .await
+                {
                     if !is_err_no_such_policy(&err) {
                         return Err(err);
                     }
@@ -2063,7 +2067,7 @@ where
                     let mut policies = HashMap::new();
                     if let Err(err) = self
                         .api
-                        .load_mapped_policy(&parent_user, UserType::Reg, false, &mut policies)
+                        .load_mapped_policy_no_lock(&parent_user, UserType::Reg, false, &mut policies)
                         .await
                     {
                         if !is_err_no_such_policy(&err) {
@@ -2076,7 +2080,7 @@ where
                     let mut policies = HashMap::new();
                     if let Err(err) = self
                         .api
-                        .load_mapped_policy(&parent_user, UserType::Sts, false, &mut policies)
+                        .load_mapped_policy_no_lock(&parent_user, UserType::Sts, false, &mut policies)
                         .await
                     {
                         if !is_err_no_such_policy(&err) {

--- a/crates/iam/src/store.rs
+++ b/crates/iam/src/store.rs
@@ -71,6 +71,35 @@ pub trait Store: Clone + Send + Sync + 'static {
     ) -> Result<()>;
 
     async fn load_all(&self, cache: &Cache) -> Result<()>;
+
+    // Lock-free variants used by the cross-node notification handlers.
+    //
+    // Notification-path cache refreshes are asynchronous, best-effort, and
+    // already tolerate stale values (the periodic reload converges them), so
+    // they must not depend on the node-counted namespace-lock quorum — the
+    // same rationale as the lock-free bootstrap `load_all` (rustfs#4304;
+    // MinIO's readConfig takes no distributed lock either). The defaults
+    // forward to the locked variants so existing `Store` implementations
+    // (including test mocks) keep their behavior; `ObjectStore` overrides
+    // them with lock-free reads.
+    async fn load_user_no_lock(&self, name: &str, user_type: UserType, m: &mut HashMap<String, UserIdentity>) -> Result<()> {
+        self.load_user(name, user_type, m).await
+    }
+    async fn load_group_no_lock(&self, name: &str, m: &mut HashMap<String, GroupInfo>) -> Result<()> {
+        self.load_group(name, m).await
+    }
+    async fn load_policy_doc_no_lock(&self, name: &str, m: &mut HashMap<String, PolicyDoc>) -> Result<()> {
+        self.load_policy_doc(name, m).await
+    }
+    async fn load_mapped_policy_no_lock(
+        &self,
+        name: &str,
+        user_type: UserType,
+        is_group: bool,
+        m: &mut HashMap<String, MappedPolicy>,
+    ) -> Result<()> {
+        self.load_mapped_policy(name, user_type, is_group, m).await
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/crates/iam/src/store/object.rs
+++ b/crates/iam/src/store/object.rs
@@ -109,7 +109,8 @@ fn get_mapped_policy_path(name: &str, user_type: UserType, is_group: bool) -> St
 enum LoadMode {
     /// On-line load on behalf of a live request: takes namespace locks.
     Locked,
-    /// Bulk snapshot load during bootstrap/reload: bypasses namespace locks.
+    /// Cache-refresh load (bootstrap/reload `load_all`, or a notification-path
+    /// single-object refresh): bypasses namespace locks.
     BootstrapNoLock,
 }
 
@@ -1088,6 +1089,33 @@ impl Store for ObjectStore {
         }
         let _ = ctx.cancel(); // TODO: check if this is needed
         Ok(())
+    }
+
+    // Notification-path cache refreshes read lock-free (see the trait docs):
+    // they are best-effort and stale-tolerant, so they must not fail on the
+    // node-counted lock quorum. Deletions triggered by these refreshes keep
+    // their locked write semantics.
+    async fn load_user_no_lock(&self, name: &str, user_type: UserType, m: &mut HashMap<String, UserIdentity>) -> Result<()> {
+        self.load_user_with(name, user_type, m, LoadMode::BootstrapNoLock).await
+    }
+    async fn load_group_no_lock(&self, name: &str, m: &mut HashMap<String, GroupInfo>) -> Result<()> {
+        self.load_group_with(name, m, LoadMode::BootstrapNoLock).await
+    }
+    async fn load_policy_doc_no_lock(&self, name: &str, m: &mut HashMap<String, PolicyDoc>) -> Result<()> {
+        let info = self.load_policy_with(name, LoadMode::BootstrapNoLock).await?;
+        m.insert(name.to_owned(), info);
+
+        Ok(())
+    }
+    async fn load_mapped_policy_no_lock(
+        &self,
+        name: &str,
+        user_type: UserType,
+        is_group: bool,
+        m: &mut HashMap<String, MappedPolicy>,
+    ) -> Result<()> {
+        self.load_mapped_policy_with(name, user_type, is_group, m, LoadMode::BootstrapNoLock)
+            .await
     }
 
     async fn load_all(&self, cache: &Cache) -> Result<()> {

--- a/crates/iam/tests/iam_bootstrap_no_lock_test.rs
+++ b/crates/iam/tests/iam_bootstrap_no_lock_test.rs
@@ -135,6 +135,16 @@ async fn load_all_bypasses_namespace_lock_quorum() {
             .await
             .unwrap_or_else(|err| panic!("load_all must bypass namespace locks (locked path failed with: {locked_err}): {err}"));
 
+        // P3 step 1: notification-path cache refreshes use the same lock-free
+        // reads, so a cross-node notification must also be able to refresh
+        // this group while the lock quorum is unavailable.
+        let mut notification_read = HashMap::new();
+        store
+            .load_group_no_lock(TEST_GROUP, &mut notification_read)
+            .await
+            .expect("lock-free notification-path load_group must succeed while the lock quorum is unavailable");
+        assert_eq!(notification_read[TEST_GROUP].members, TEST_MEMBERS);
+
         // Back in single-node mode the locked path works again; verify the
         // data survived the whole exercise intact (fail-closed integrity).
         drop(_mode_guard);


### PR DESCRIPTION
## Related Issues

P3 step 1 of rustfs/backlog#884 (follow-up to #4363). **Stacked on #4363** — base is `fix/iam-bootstrap-no-lock`; only the last commit is new. Retarget to `main` after #4363 merges.

## Summary of Changes

Cross-node notification handlers (group / policy / policy-mapping / user) refresh the local IAM cache with single-object reads that previously took distributed namespace read locks. These refreshes are asynchronous, best-effort, and stale-tolerant (the periodic reload converges them), so a node-counted lock-quorum failure on a peer must not fail them — the same rationale as the lock-free bootstrap `load_all`, and consistent with MinIO's lock-free `readConfig`.

- `Store` trait gains `load_user_no_lock` / `load_group_no_lock` / `load_policy_doc_no_lock` / `load_mapped_policy_no_lock` with defaults forwarding to the locked variants (existing implementations and test mocks keep their behavior).
- `ObjectStore` overrides them through the existing `LoadMode::BootstrapNoLock` plumbing from #4363. Deletions triggered by the handlers keep locked write semantics.
- The four `*_notification_handler` paths in `manager.rs` (8 call sites) switch to the lock-free variants.
- Integration test extended: with the lock quorum unavailable, `load_group_no_lock` succeeds exactly where the locked `load_group` fails.

**Deliberately out of scope** (needs side-effect extraction first, tracked in rustfs/backlog#884): request-path loads (`check_key`, `verify_temp_user_persistence`) and admin write-then-reload paths stay locked, because `load_user_identity` embeds expiry deletions inside the read.

## Verification

- `cargo test -p rustfs-iam --lib` — 156 passed
- `cargo test -p rustfs-iam --test iam_bootstrap_no_lock_test` — includes the new lock-quorum-unavailable notification-refresh assertion
- `make pre-commit` — passed

## Impact

Notification-driven IAM cache refreshes no longer depend on the distributed lock quorum: peer lock RPC hiccups or partial-cluster states cannot fail them. No API or on-disk change; `Store` trait additions are backward-compatible defaults.

## Additional Notes

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
