### PR TITLE
fix(ecstore): reduce rename data version signatures

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3059,6 +3059,18 @@ fn local_disk_scan_lock_key(bucket: &str, base_dir: &str, filter_prefix: Option<
     (bucket.to_owned(), prefix)
 }
 
+fn rename_data_versions_signature(meta: &FileMeta) -> Option<Vec<u8>> {
+    if meta.versions.len() > 10 {
+        return None;
+    }
+
+    let mut signature = Vec::with_capacity(meta.versions.len() * 16);
+    for version in meta.versions.iter() {
+        signature.extend_from_slice(version.header.version_id.unwrap_or_default().as_bytes());
+    }
+    Some(signature)
+}
+
 fn is_root_path(path: impl AsRef<Path>) -> bool {
     path.as_ref().components().count() == 1 && path.as_ref().has_root()
 }
@@ -4077,6 +4089,7 @@ impl DiskAPI for LocalDisk {
                 let _ = xlmeta.data.remove_two(version_id, *old_data_dir);
             }
             xlmeta.add_version(fi)?;
+            let version_signature = rename_data_versions_signature(&xlmeta);
             let new_dst_buf = xlmeta.marshal_msg()?;
 
             let src_file_parent = src_file_path.parent().unwrap_or(src_volume_dir.as_path());
@@ -4197,7 +4210,7 @@ impl DiskAPI for LocalDisk {
 
             Ok(RenameDataResp {
                 old_data_dir: has_old_data_dir,
-                sign: None,
+                sign: version_signature,
             })
         } else {
             // Inline: merge read + parse + write + rename into single spawn_blocking
@@ -4209,7 +4222,7 @@ impl DiskAPI for LocalDisk {
                 None
             };
 
-            let (old_data_dir, _dst_buf) = tokio::task::spawn_blocking(move || {
+            let (old_data_dir, version_signature) = tokio::task::spawn_blocking(move || {
                 // Read existing xl.meta
                 let has_dst_buf = match std::fs::read(&dst) {
                     Ok(buf) => Some(Bytes::from(buf)),
@@ -4231,6 +4244,7 @@ impl DiskAPI for LocalDisk {
                     let _ = xlmeta.data.remove_two(version_id, *d);
                 }
                 xlmeta.add_version(fi)?;
+                let version_signature = rename_data_versions_signature(&xlmeta);
                 let new_buf = xlmeta.marshal_msg()?;
 
                 // Write new xl.meta + rename
@@ -4295,7 +4309,7 @@ impl DiskAPI for LocalDisk {
                     os::fsync_dir_std(dst_parent)?;
                 }
 
-                Ok::<(Option<uuid::Uuid>, Option<Bytes>), std::io::Error>((old_data_dir, has_dst_buf))
+                Ok::<(Option<uuid::Uuid>, Option<Vec<u8>>), std::io::Error>((old_data_dir, version_signature))
             })
             .await
             .map_err(DiskError::from)??;
@@ -4309,7 +4323,7 @@ impl DiskAPI for LocalDisk {
 
             Ok(RenameDataResp {
                 old_data_dir,
-                sign: None,
+                sign: version_signature,
             })
         }
     }
@@ -5027,6 +5041,7 @@ mod test {
             .expect("rename_data should commit");
 
         assert_eq!(resp.old_data_dir, Some(old_data_dir));
+        assert_eq!(resp.sign, Some(version_id.as_bytes().to_vec()));
         assert!(
             dst_object_dir
                 .join(old_data_dir.to_string())
@@ -5080,6 +5095,7 @@ mod test {
             .expect("inline rename_data should commit");
 
         assert_eq!(resp.old_data_dir, Some(old_data_dir));
+        assert_eq!(resp.sign, Some(version_id.as_bytes().to_vec()));
         let backup_path = dst_object_dir.join(old_data_dir.to_string()).join(STORAGE_FORMAT_FILE_BACKUP);
         assert!(backup_path.exists());
         // The rollback backup must contain the previous metadata bytes verbatim so

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -2396,6 +2396,13 @@ enum OrphanDirScan {
     Missing,
 }
 
+fn rename_data_versions_key(versions: &[u8]) -> Option<[u8; 8]> {
+    let prefix = versions.get(..8)?;
+    let mut key = [0; 8];
+    key.copy_from_slice(prefix);
+    Some(key)
+}
+
 impl SetDisks {
     pub(in crate::set_disk) fn default_read_quorum(&self) -> usize {
         self.set_drive_count - self.default_parity_count
@@ -2567,10 +2574,8 @@ impl SetDisks {
             return Err(ret_err);
         }
 
-        let versions = None;
-        // TODO: reduceCommonVersions
-
         let data_dir = Self::reduce_common_data_dir(&data_dirs, write_quorum);
+        let versions = Self::select_rename_data_versions(&disk_versions, &errs, write_quorum);
         let online_disks = Self::eval_disks(disks, &errs);
         let cleanup_disks = if let Some(data_dir) = data_dir {
             disks
@@ -2590,6 +2595,63 @@ impl SetDisks {
         };
 
         Ok((online_disks, versions, data_dir, cleanup_disks))
+    }
+
+    pub(in crate::set_disk) fn reduce_common_versions(disk_versions: &[Option<Vec<u8>>], write_quorum: usize) -> Option<Vec<u8>> {
+        let mut versions_count = HashMap::new();
+
+        for versions in disk_versions.iter().flatten() {
+            if let Some(key) = rename_data_versions_key(versions) {
+                *versions_count.entry(key).or_insert(0usize) += 1;
+            }
+        }
+
+        let (common_versions, max_count) = versions_count
+            .into_iter()
+            .max_by_key(|(_, count)| *count)
+            .unwrap_or(([0; 8], 0));
+
+        if max_count < write_quorum {
+            return None;
+        }
+
+        disk_versions
+            .iter()
+            .flatten()
+            .find(|versions| rename_data_versions_key(versions).is_some_and(|key| key == common_versions))
+            .cloned()
+    }
+
+    pub(in crate::set_disk) fn select_rename_data_versions(
+        disk_versions: &[Option<Vec<u8>>],
+        errs: &[Option<DiskError>],
+        write_quorum: usize,
+    ) -> Option<Vec<u8>> {
+        let mut versions = Self::reduce_common_versions(disk_versions, write_quorum);
+        for (dversions, err) in disk_versions.iter().zip(errs.iter()) {
+            if err.is_some() {
+                continue;
+            }
+            let Some(dversions) = dversions.as_ref().filter(|versions| !versions.is_empty()) else {
+                continue;
+            };
+
+            match versions.as_ref() {
+                Some(current_versions) if dversions != current_versions => {
+                    if dversions.len() > current_versions.len() {
+                        versions = Some(dversions.clone());
+                    }
+                    break;
+                }
+                Some(_) => {}
+                None => {
+                    versions = Some(dversions.clone());
+                    break;
+                }
+            }
+        }
+
+        versions
     }
 
     #[allow(dead_code)]

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -5958,6 +5958,41 @@ mod tests {
         assert_eq!(result, Some(uuid1)); // Ignore None votes; uuid1 should still meet quorum
     }
 
+    fn rename_versions_signature(first_key: u8, version_count: usize) -> Vec<u8> {
+        let mut signature = vec![0; version_count * 16];
+        signature[7] = first_key;
+        signature
+    }
+
+    #[test]
+    fn test_reduce_common_versions_requires_write_quorum() {
+        let common = rename_versions_signature(1, 1);
+        let other = rename_versions_signature(2, 1);
+
+        let disk_versions = vec![Some(common.clone()), Some(common.clone()), Some(other)];
+        let result = SetDisks::reduce_common_versions(&disk_versions, 2);
+        assert_eq!(result, Some(common));
+
+        let split_versions = vec![
+            Some(rename_versions_signature(1, 1)),
+            Some(rename_versions_signature(2, 1)),
+            None,
+        ];
+        let result = SetDisks::reduce_common_versions(&split_versions, 2);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_select_rename_data_versions_keeps_longer_success_disparity() {
+        let common = rename_versions_signature(1, 1);
+        let longer = rename_versions_signature(2, 2);
+        let disk_versions = vec![Some(common.clone()), Some(common), Some(longer.clone())];
+        let errs = vec![None, None, None];
+
+        let result = SetDisks::select_rename_data_versions(&disk_versions, &errs, 2);
+        assert_eq!(result, Some(longer));
+    }
+
     #[test]
     fn test_object_quorum_from_meta_returns_not_found_when_all_metadata_is_missing() {
         let errs = vec![


### PR DESCRIPTION
## Related Issues

Related: rustfs/backlog#911

## Summary of Changes

- Return rename-data version signatures from `LocalDisk::rename_data` for both non-inline and inline commit paths.
- Reduce rename-data version signatures across successful disks using write quorum.
- Preserve MinIO-style disparity handling: if a successful disk carries a longer version signature than the common quorum result, return it to trigger follow-up healing.
- Add regression coverage for quorum reduction and rename signature propagation.

## Verification

- `cargo test -p rustfs-ecstore reduce_common_versions --lib`
- `cargo test -p rustfs-ecstore select_rename_data_versions --lib`
- `cargo test -p rustfs-ecstore test_rename_data_writes_old_metadata_backup --lib`
- `cargo test -p rustfs-ecstore io_primitives --lib`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

Multipart completion can now observe version-signature disparity after rename and queue healing instead of silently returning no version information.

## Additional Notes

Used an isolated cargo target directory for focused validation because another local cargo process was holding the shared build lock.
