### PR TITLE
test(ecstore): fit concurrent-resend guard inside lock acquire ceiling

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4710,7 +4710,7 @@ mod tests {
 
         // Distinct payloads with distinct sizes: a mixed-generation reassembly
         // would produce bytes matching none of them (or fail the read outright).
-        let candidates: Vec<Vec<u8>> = (0..6)
+        let candidates: Vec<Vec<u8>> = (0..3)
             .map(|g| {
                 let len = 4096 + g * 512;
                 vec![b'a' + g as u8; len]
@@ -4722,14 +4722,22 @@ mod tests {
         // 1. A lost/stolen fast-lock wakeup could strand a waiter until the
         //    deadline — fixed for real in fast_lock::shard by bounding each
         //    notification wait (NOTIFY_WAIT_CAP re-polling).
-        // 2. Under the full nextest suite on loaded CI disks, the six
-        //    *legitimately serialized* cross-disk commits can exceed the small
-        //    default acquire timeout (5s) all by themselves — observed on CI
-        //    even with fix 1 in place. Raise the timeout to the production
-        //    default (30s) for the concurrent section so the guard asserts the
-        //    correctness property (exactly one intact generation), not disk
-        //    latency. `#[serial]` keeps the process-wide env override isolated.
-        let results = temp_env::async_with_vars([(rustfs_config::ENV_OBJECT_LOCK_ACQUIRE_TIMEOUT, Some("30"))], async {
+        // 2. Under the full nextest suite on loaded CI disks, the
+        //    *legitimately serialized* cross-disk commits can exceed the
+        //    acquire deadline all by themselves — observed on CI at the 5s
+        //    default and the 30s production default with six resends, and
+        //    again at 60s, which is a hard ceiling: fast_lock clamps every
+        //    requested timeout to MAX_ACQUIRE_TIMEOUT (60s), so raising the
+        //    env override higher is a no-op (the Timeout error still reports
+        //    the requested value). Keep the guard about the correctness
+        //    property, not disk latency: request the full 60s ceiling and cap
+        //    the queue depth at three resends, so the last waiter sits behind
+        //    at most two serialized commits (~12s each on the slowest observed
+        //    CI runner, comfortably inside the deadline). Three concurrent
+        //    resends still race the streaming phase and contend on the commit
+        //    lock, which is all the generation-mixing regression needs.
+        //    `#[serial]` keeps the process-wide env override isolated.
+        let results = temp_env::async_with_vars([(rustfs_config::ENV_OBJECT_LOCK_ACQUIRE_TIMEOUT, Some("60"))], async {
             let mut tasks = tokio::task::JoinSet::new();
             for payload in candidates.iter().cloned() {
                 let store = ecstore.clone();


### PR DESCRIPTION
## Related Issues

Follow-up to #4370 (backlog#853). No standalone issue: N/A.

## Summary of Changes

`concurrent_resend_same_part_commits_one_generation` still fails under full-suite nextest runs on loaded machines, panicking with a spurious `Lock(Timeout)` even after #4370 raised the test-local acquire timeout to the 30s production default. The test passes in isolation in under a second, so this is pure disk/CPU-load sensitivity: the *legitimately serialized* cross-disk commits behind the uploadId commit lock can exceed the acquire deadline all by themselves.

A first attempt raised the test-local `RUSTFS_OBJECT_LOCK_ACQUIRE_TIMEOUT` to 120s, and CI falsified it: both `Test and Lint` and `Test and Lint (rio-v2)` failed with `Timeout { ..., timeout: 120s }` after exactly ~60s of wall time. The root cause is that `fast_lock` clamps every requested acquire timeout to `MAX_ACQUIRE_TIMEOUT` (60s) in `crates/lock/src/fast_lock/shard.rs`, while the `Timeout` error reports the caller-requested value, so any override above 60s is a silent no-op. On the slowest observed CI runners, five serialized commits exceed that 60s hard ceiling (~12s per commit), so no timeout value can make the six-resend guard robust.

This PR therefore requests the full 60s ceiling explicitly (documenting the clamp in the test comment) and caps the queue depth at three concurrent resends, bounding the last waiter to at most two serialized commits (~24s worst case observed, a 2.5x margin under the ceiling). Three concurrent resends still race the fully concurrent streaming phase and contend on the commit lock, which is all the generation-mixing regression needs. Every correctness assertion is unchanged: all resends must succeed without lock timeout, exactly one intact generation stays visible, and the reassembled object bytes must match the winning payload exactly.

The misleading `Timeout` error (requested vs. effective clamped deadline) is flagged as a separate follow-up task rather than fixed here, to keep this PR's scope narrow.

## Verification

- `cargo nextest run -p rustfs-ecstore -E 'test(concurrent_resend_same_part_commits_one_generation)'` — pass (0.29s)
- `cargo nextest run -p rustfs-ecstore` — 1973 passed, 1 skipped (an unrelated `#[ignore]` test), 0 failed
- `make pre-pr` — pass (fmt + arch checks + clippy + tests; run on the previous iteration of this diff, whose delta is limited to comments, the env-override literal, and the resend count inside the same test function)
- `cargo fmt --all --check` — clean

## Impact

Test-only change; no production behavior, API, or configuration impact.

## Additional Notes

The `Test and Lint (swift)` failure on earlier runs of this PR is unrelated: it is the `clippy::type_complexity` error in `crates/protocols/src/swift/expiration_worker.rs` introduced on main by #4380 and fixed by #4385. This branch is rebased onto latest main; the swift job will stay red until #4385 merges.
