### PR TITLE
fix(protocols): simplify swift expiration test types

### DIFF
--- a/crates/protocols/src/swift/expiration_worker.rs
+++ b/crates/protocols/src/swift/expiration_worker.rs
@@ -656,15 +656,17 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
+    type MetadataResult = SwiftResult<Option<HashMap<String, String>>>;
+
     #[derive(Default)]
     struct MockExpirationObjectBackend {
-        metadata_results: Mutex<VecDeque<SwiftResult<Option<HashMap<String, String>>>>>,
+        metadata_results: Mutex<VecDeque<MetadataResult>>,
         delete_results: Mutex<VecDeque<SwiftResult<()>>>,
         deleted_objects: Mutex<Vec<(String, String, String)>>,
     }
 
     impl MockExpirationObjectBackend {
-        fn with_metadata_result(result: SwiftResult<Option<HashMap<String, String>>>) -> Self {
+        fn with_metadata_result(result: MetadataResult) -> Self {
             Self {
                 metadata_results: Mutex::new(VecDeque::from([result])),
                 ..Default::default()


### PR DESCRIPTION
## Related Issues

Related: rustfs/backlog#915

## Summary of Changes

- Introduce a test-only type alias for Swift expiration metadata results.
- Fix the `clippy::type_complexity` failure reported by the Swift test/lint CI job after PR #4380.

## Verification

- `cargo test -p rustfs-protocols --features swift delete_expired_object --lib`
- `cargo clippy -p rustfs-protocols --features swift --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

No runtime behavior change. This only simplifies test scaffolding.

## Additional Notes

N/A
