### PR TITLE
fix(keystone): accept Swift storage tokens

### DIFF
--- a/crates/keystone/src/middleware.rs
+++ b/crates/keystone/src/middleware.rs
@@ -15,14 +15,14 @@
 //! Keystone authentication middleware
 //!
 //! This middleware intercepts HTTP requests and checks for OpenStack Keystone
-//! authentication headers (X-Auth-Token). If found, it validates the token
+//! authentication headers (X-Auth-Token or Swift X-Storage-Token). If found, it validates the token
 //! with Keystone and stores the authenticated credentials in task-local storage
 //! for use by downstream authentication handlers.
 //!
 //! ## Authentication Flow
 //!
 //! 1. Check if Keystone is enabled (via global provider)
-//! 2. Extract X-Auth-Token header from request
+//! 2. Extract X-Auth-Token or X-Storage-Token header from request
 //! 3. If token present:
 //!    - Validate with Keystone service
 //!    - On success: Store credentials in task-local, continue processing
@@ -49,6 +49,9 @@ use tower::{Layer, Service};
 use tracing::{debug, info, warn};
 
 use crate::KeystoneAuthProvider;
+
+const HEADER_X_AUTH_TOKEN: &str = "X-Auth-Token";
+const HEADER_X_STORAGE_TOKEN: &str = "X-Storage-Token";
 
 // Task-local storage for Keystone credentials
 // This allows passing credentials from middleware to auth handlers
@@ -140,11 +143,10 @@ where
                 }
             };
 
-            // Extract X-Auth-Token header
             let token = extract_keystone_token(req.headers());
 
             if let Some(token) = token {
-                debug!("Keystone middleware: Found X-Auth-Token header, validating");
+                debug!("Keystone middleware: Found Keystone token header, validating");
 
                 // Validate token with Keystone
                 match keystone_auth.authenticate_with_token(token).await {
@@ -191,7 +193,7 @@ where
             }
 
             // No Keystone token header present, pass through to normal S3 authentication
-            debug!("Keystone middleware: No X-Auth-Token header, passing through to S3 auth");
+            debug!("Keystone middleware: No Keystone token header, passing through to S3 auth");
             let resp = inner.call(req).await?;
             let (parts, body) = resp.into_parts();
             let body: BoxBody = body.map_err(Into::into).boxed_unsync();
@@ -200,14 +202,11 @@ where
     }
 }
 
-/// Extract Keystone token from request headers
-///
-/// Checks for X-Auth-Token header (Keystone v3 standard).
-/// Note: X-Storage-Token (Swift) support deferred to future PR per Q4.C
 fn extract_keystone_token(headers: &HeaderMap) -> Option<&str> {
-    headers.get("X-Auth-Token").and_then(|v| v.to_str().ok())
-    // TODO: Add X-Storage-Token support in Phase 2 (Swift API)
-    // .or_else(|| headers.get("X-Storage-Token").and_then(|v| v.to_str().ok()))
+    headers
+        .get(HEADER_X_AUTH_TOKEN)
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| headers.get(HEADER_X_STORAGE_TOKEN).and_then(|v| v.to_str().ok()))
 }
 
 /// Escape XML special characters to prevent injection
@@ -254,8 +253,18 @@ mod tests {
         let mut headers = HeaderMap::new();
         assert!(extract_keystone_token(&headers).is_none());
 
-        headers.insert("X-Auth-Token", "test-token-123".parse().unwrap());
+        headers.insert(HEADER_X_AUTH_TOKEN, "test-token-123".parse().expect("auth token header should parse"));
         assert_eq!(extract_keystone_token(&headers), Some("test-token-123"));
+
+        headers.clear();
+        headers.insert(
+            HEADER_X_STORAGE_TOKEN,
+            "swift-token-456".parse().expect("storage token header should parse"),
+        );
+        assert_eq!(extract_keystone_token(&headers), Some("swift-token-456"));
+
+        headers.insert(HEADER_X_AUTH_TOKEN, "auth-token-789".parse().expect("auth token header should parse"));
+        assert_eq!(extract_keystone_token(&headers), Some("auth-token-789"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#917.

## Summary of Changes
- Accept Swift `X-Storage-Token` as a Keystone token header in the Keystone middleware.
- Keep `X-Auth-Token` precedence when both headers are present.
- Cover missing, Keystone, Swift, and precedence cases in the middleware token extraction test.

## Verification
- `CARGO_TARGET_DIR=/tmp/rustfs-646-keystone-token CARGO_BUILD_JOBS=1 cargo test -p rustfs-keystone test_extract_keystone_token --lib`
- `CARGO_TARGET_DIR=/tmp/rustfs-646-keystone-token CARGO_BUILD_JOBS=1 cargo test -p rustfs-keystone middleware --lib`
- `CARGO_TARGET_DIR=/tmp/rustfs-646-keystone-token CARGO_BUILD_JOBS=1 cargo clippy -p rustfs-keystone --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
Swift clients can authenticate through Keystone middleware with `X-Storage-Token`. Existing `X-Auth-Token` behavior is unchanged.

## Additional Notes
N/A
