### PR TITLE
fix(crypto): reject plaintext fallback without crypto

### DIFF
--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -35,7 +35,7 @@ chacha20poly1305 = { workspace = true, optional = true }
 jsonwebtoken = { workspace = true }
 base64-simd = { workspace = true }
 pbkdf2 = { workspace = true, optional = true }
-rand = { workspace = true, optional = true }
+rand = { workspace = true }
 rsa = { workspace = true, features = ["sha2"] }
 serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true, optional = true }
@@ -55,7 +55,6 @@ crypto = [
     "dep:argon2",
     "dep:chacha20poly1305",
     "dep:pbkdf2",
-    "dep:rand",
     "dep:sha2",
 ]
 

--- a/crates/crypto/src/encdec.rs
+++ b/crates/crypto/src/encdec.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(feature = "fips"))]
+#[cfg(all(any(test, feature = "crypto"), not(feature = "fips")))]
 mod aes;
 
 #[cfg(any(test, feature = "crypto"))]

--- a/crates/crypto/src/encdec/decrypt.rs
+++ b/crates/crypto/src/encdec/decrypt.rs
@@ -53,6 +53,6 @@ fn decrypt<T: aes_gcm::aead::Aead>(stream: T, nonce: &[u8], data: &[u8]) -> Resu
 }
 
 #[cfg(not(any(test, feature = "crypto")))]
-pub fn decrypt_data(_password: &[u8], data: &[u8]) -> Result<Vec<u8>, crate::Error> {
-    Ok(data.to_vec())
+pub fn decrypt_data(_password: &[u8], _data: &[u8]) -> Result<Vec<u8>, crate::Error> {
+    Err(crate::Error::ErrCryptoDisabled)
 }

--- a/crates/crypto/src/encdec/encrypt.rs
+++ b/crates/crypto/src/encdec/encrypt.rs
@@ -75,6 +75,6 @@ fn encrypt<T: aes_gcm::aead::Aead>(
 }
 
 #[cfg(not(any(test, feature = "crypto")))]
-pub fn encrypt_data(_password: &[u8], data: &[u8]) -> Result<Vec<u8>, crate::Error> {
-    Ok(data.to_vec())
+pub fn encrypt_data(_password: &[u8], _data: &[u8]) -> Result<Vec<u8>, crate::Error> {
+    Err(crate::Error::ErrCryptoDisabled)
 }

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     #[error("invalid key length")]
     ErrInvalidKeyLength,
 
+    #[error("crypto feature is disabled")]
+    ErrCryptoDisabled,
+
     #[cfg(any(test, feature = "crypto"))]
     #[error("{0}")]
     ErrInvalidLength(#[from] sha2::digest::InvalidLength),

--- a/crates/crypto/tests/no_crypto_feature.rs
+++ b/crates/crypto/tests/no_crypto_feature.rs
@@ -1,0 +1,19 @@
+use rustfs_crypto::{Error, decrypt_data, encrypt_data};
+
+#[test]
+fn encrypt_data_returns_error_without_crypto_feature() {
+    let plain = b"must not be returned as ciphertext";
+
+    let result = encrypt_data(b"password", plain);
+
+    assert!(matches!(result, Err(Error::ErrCryptoDisabled)));
+}
+
+#[test]
+fn decrypt_data_returns_error_without_crypto_feature() {
+    let ciphertext = b"must not be returned as plaintext";
+
+    let result = decrypt_data(b"password", ciphertext);
+
+    assert!(matches!(result, Err(Error::ErrCryptoDisabled)));
+}

--- a/crates/crypto/tests/no_crypto_feature.rs
+++ b/crates/crypto/tests/no_crypto_feature.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "crypto"))]
+
 use rustfs_crypto::{Error, decrypt_data, encrypt_data};
 
 #[test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#646.

## Summary of Changes
- Stop `encrypt_data` and `decrypt_data` from returning plaintext when the `crypto` feature is disabled.
- Return a typed `ErrCryptoDisabled` error for no-crypto builds instead.
- Keep `rand` available as a normal dependency because license token signing already uses it outside the encryption feature gate.
- Add a no-default-features integration test for the disabled crypto path.

## Verification
- `CARGO_TARGET_DIR=/tmp/rustfs-646-crypto-no-plaintext CARGO_BUILD_JOBS=1 cargo test -p rustfs-crypto --no-default-features --test no_crypto_feature`
- `CARGO_TARGET_DIR=/tmp/rustfs-646-crypto-default CARGO_BUILD_JOBS=1 cargo test -p rustfs-crypto --lib`
- `CARGO_TARGET_DIR=/tmp/rustfs-646-crypto-default CARGO_BUILD_JOBS=1 cargo clippy -p rustfs-crypto --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/rustfs-646-crypto-no-plaintext CARGO_BUILD_JOBS=1 cargo clippy -p rustfs-crypto --no-default-features --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
No change for default builds with the `crypto` feature enabled. No-crypto builds now fail closed instead of treating plaintext as encrypted data.

## Additional Notes
The original pending note referenced a Swift encryption file that is not present in the current tree. The live plaintext fallback is in the shared crypto crate, so this PR fixes that reachable behavior directly.
