### PR TITLE
fix(protocols): resolve clippy type_complexity in swift expiration worker tests

### DIFF
--- a/crates/protocols/src/swift/expiration_worker.rs
+++ b/crates/protocols/src/swift/expiration_worker.rs
@@ -656,9 +656,11 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
 
+    type MetadataResult = SwiftResult<Option<HashMap<String, String>>>;
+
     #[derive(Default)]
     struct MockExpirationObjectBackend {
-        metadata_results: Mutex<VecDeque<SwiftResult<Option<HashMap<String, String>>>>>,
+        metadata_results: Mutex<VecDeque<MetadataResult>>,
         delete_results: Mutex<VecDeque<SwiftResult<()>>>,
         deleted_objects: Mutex<Vec<(String, String, String)>>,
     }


### PR DESCRIPTION
The `Test and Lint (swift)` CI job fails on main (run 28881271231 @ 62a31e4ec) with `clippy::type_complexity` on `MockExpirationObjectBackend.metadata_results` in `crates/protocols/src/swift/expiration_worker.rs`, which blocks the swift matrix for every open PR. This factors the offending type into a `MetadataResult` alias inside the test module. Test-only change, no behavior change, no public API change.

Verification: `cargo clippy -p rustfs-protocols --all-targets --features swift -- -D warnings` clean; `cargo test -p rustfs-protocols --features swift --lib` 352 passed.