### PR TITLE
fix(protocols): allow clippy::type_complexity in expiration worker tests

### DIFF
--- a/crates/protocols/src/swift/expiration_worker.rs
+++ b/crates/protocols/src/swift/expiration_worker.rs
@@ -657,6 +657,7 @@ mod tests {
     use std::sync::Mutex;
 
     #[derive(Default)]
+    #[allow(clippy::type_complexity)]
     struct MockExpirationObjectBackend {
         metadata_results: Mutex<VecDeque<SwiftResult<Option<HashMap<String, String>>>>>,
         delete_results: Mutex<VecDeque<SwiftResult<()>>>,


### PR DESCRIPTION
## Problem

`make pre-pr` fails on `main` at commit `7efacbdf9` due to a clippy error introduced in #4377.

Clippy `type_complexity` lint fires on:
```
crates/protocols/src/swift/expiration_worker.rs:661
metadata_results: Mutex<VecDeque<SwiftResult<Option<HashMap<String, String>>>>>
```

## Fix

Add `#[allow(clippy::type_complexity)]` to the `MockExpirationObjectBackend` test struct. This is test-only code where the nested generic type is inherent to the mock design and cannot be simplified without losing clarity.

## Verification

- `fmt-check`: ✅
- `unsafe-code-check`: ✅
- `architecture-migration-check`: ✅
- `logging-guardrails-check`: ✅
- `tokio-io-uring-check`: ✅
- `doc-paths-check`: ✅
- `clippy-check`: ✅ (after fix)
- `test` (nextest + doctests): ✅

## Baseline

`7efacbdf957bad4daaa7db153918c4b11744577f`
