### PR TITLE
perf(ecstore): right-size BytesMut encode ingest capacity to the EC-expanded block

### DIFF
--- a/crates/ecstore/src/erasure/coding/encode.rs
+++ b/crates/ecstore/src/erasure/coding/encode.rs
@@ -87,6 +87,48 @@ fn use_bytesmut_ingest() -> bool {
         rustfs_utils::get_env_bool(ENV_RUSTFS_ERASURE_ENCODE_BYTESMUT_INGEST, DEFAULT_RUSTFS_ERASURE_ENCODE_BYTESMUT_INGEST)
     })
 }
+/// Read up to `limit` bytes into `buf`'s uninitialized spare capacity, appending after its
+/// current length, and distinguish a clean EOF from a short read.
+///
+/// Mirrors `rustfs_utils::read_full_or_eof` semantics: returns `Ok(None)` when EOF is reached
+/// before any byte is read, `Ok(Some(n))` once at least one byte is read, preserves
+/// `InvalidData` errors (e.g. checksum mismatches) raised after a partial fill, and wraps other
+/// partial-fill errors as `UnexpectedEof`. Unlike `resize` followed by a slice read, the spare
+/// capacity is never zero-filled first, so full-block ingest skips a per-block memset.
+async fn read_full_buf_or_eof<R>(reader: &mut R, buf: &mut BytesMut, limit: usize) -> std::io::Result<Option<usize>>
+where
+    R: AsyncRead + Unpin,
+{
+    use bytes::BufMut as _;
+    use tokio::io::AsyncReadExt as _;
+
+    debug_assert!(buf.is_empty(), "block ingest buffer must start empty");
+    debug_assert!(limit > 0, "limit must be non-zero (block_size is validated upstream)");
+    let mut total = 0;
+    while total < limit {
+        let mut limited = (&mut *buf).limit(limit - total);
+        let n = match reader.read_buf(&mut limited).await {
+            Ok(n) => n,
+            Err(e) => {
+                if total == 0 {
+                    return Err(e);
+                }
+                // Preserve InvalidData (e.g. checksum mismatch) instead of wrapping it as
+                // UnexpectedEof, so proper error handling can occur upstream.
+                if e.kind() == std::io::ErrorKind::InvalidData {
+                    return Err(e);
+                }
+                return Err(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e));
+            }
+        };
+        if n == 0 {
+            break;
+        }
+        total += n;
+    }
+    if total == 0 { Ok(None) } else { Ok(Some(total)) }
+}
+
 fn queued_block_bytes(block: &[Bytes]) -> usize {
     block.iter().map(Bytes::len).sum()
 }
@@ -371,9 +413,27 @@ impl Erasure {
     #[cfg_attr(feature = "hotpath", hotpath::measure)]
     pub async fn encode<R>(
         self: Arc<Self>,
+        reader: R,
+        writers: &mut [Option<BitrotWriterWrapper>],
+        quorum: usize,
+    ) -> std::io::Result<(R, usize)>
+    where
+        R: AsyncRead + Send + Sync + Unpin + 'static,
+    {
+        let use_bytesmut_ingest = use_bytesmut_ingest();
+        self.encode_with_ingest_mode(reader, writers, quorum, use_bytesmut_ingest)
+            .await
+    }
+
+    /// Streaming encode with an explicit ingest-buffer strategy. `encode` resolves the
+    /// strategy from `RUSTFS_ERASURE_ENCODE_BYTESMUT_INGEST`; tests call this directly to
+    /// exercise both paths regardless of the cached environment value.
+    async fn encode_with_ingest_mode<R>(
+        self: Arc<Self>,
         mut reader: R,
         writers: &mut [Option<BitrotWriterWrapper>],
         quorum: usize,
+        use_bytesmut_ingest: bool,
     ) -> std::io::Result<(R, usize)>
     where
         R: AsyncRead + Send + Sync + Unpin + 'static,
@@ -393,20 +453,24 @@ impl Erasure {
 
         let task = tokio::spawn(async move {
             let block_size = self.block_size;
-            let use_bytesmut_ingest = use_bytesmut_ingest();
             let mut total = 0;
             if use_bytesmut_ingest {
-                let mut buf = BytesMut::with_capacity(block_size);
-                buf.resize(block_size, 0);
+                // HP-10 (rustfs/backlog#931): reserve the EC-expanded block size up front.
+                // Both shard-size formulas are monotone in data_len, so the resize to
+                // `need_total_size` inside `encode_data_bytes_mut` always stays within this
+                // capacity and never reallocates. Reading into uninitialized spare capacity
+                // (instead of resize + slice read) also skips zero-filling each fresh buffer.
+                let ingest_capacity = expanded_block_bytes.max(block_size);
+                let mut buf = BytesMut::with_capacity(ingest_capacity);
                 loop {
-                    match rustfs_utils::read_full_or_eof(&mut reader, &mut buf[..]).await {
+                    match read_full_buf_or_eof(&mut reader, &mut buf, block_size).await {
                         Ok(Some(n)) => {
                             debug_assert!(n > 0, "non-zero block_size prevents zero-length reads");
+                            debug_assert_eq!(buf.len(), n, "ingest buffer length must equal bytes read");
                             total += n;
                             let encode_buf = buf;
                             let res = self.clone().encode_block_bytes_mut(encode_buf, n).await?;
-                            buf = BytesMut::with_capacity(block_size);
-                            buf.resize(block_size, 0);
+                            buf = BytesMut::with_capacity(ingest_capacity);
                             let queued_bytes = queued_block_bytes(&res);
                             rustfs_io_metrics::add_ec_encode_inflight_bytes(queued_bytes);
                             let send_wait_stage_start = stage_timer_if_enabled();
@@ -1154,6 +1218,103 @@ mod tests {
         assert!(err.to_string().contains("single-block non-inline fast path"));
         for c in committed {
             assert!(c.lock().unwrap().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn read_full_buf_or_eof_returns_none_on_empty_reader() {
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        let mut buf = BytesMut::with_capacity(16);
+
+        let res = read_full_buf_or_eof(&mut reader, &mut buf, 8).await.unwrap();
+
+        assert_eq!(res, None);
+        assert!(buf.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_full_buf_or_eof_reads_partial_tail() {
+        let data = b"tail".to_vec();
+        let mut reader = Cursor::new(data.clone());
+        let mut buf = BytesMut::with_capacity(64);
+
+        let res = read_full_buf_or_eof(&mut reader, &mut buf, 16).await.unwrap();
+
+        assert_eq!(res, Some(data.len()));
+        assert_eq!(&buf[..], &data[..]);
+        assert!(buf.capacity() >= 64, "pre-reserved spare capacity must be kept");
+    }
+
+    #[tokio::test]
+    async fn read_full_buf_or_eof_stops_at_limit() {
+        let data = vec![7u8; 32];
+        let mut reader = Cursor::new(data.clone());
+        let mut buf = BytesMut::with_capacity(64);
+
+        let res = read_full_buf_or_eof(&mut reader, &mut buf, 16).await.unwrap();
+
+        assert_eq!(res, Some(16));
+        assert_eq!(&buf[..], &data[..16]);
+
+        // The remaining bytes are still readable as the next block.
+        let mut next = BytesMut::with_capacity(64);
+        let res = read_full_buf_or_eof(&mut reader, &mut next, 16).await.unwrap();
+        assert_eq!(res, Some(16));
+        assert_eq!(&next[..], &data[16..]);
+    }
+
+    async fn committed_shards_for_ingest_mode(use_bytesmut_ingest: bool, uses_legacy: bool, payload: &[u8]) -> Vec<Vec<u8>> {
+        const DATA_SHARDS: usize = 2;
+        const PARITY_SHARDS: usize = 2;
+        const TOTAL_SHARDS: usize = DATA_SHARDS + PARITY_SHARDS;
+        const BLOCK_SIZE: usize = 64;
+
+        let committed: Vec<Arc<Mutex<Vec<u8>>>> = (0..TOTAL_SHARDS).map(|_| Arc::new(Mutex::new(Vec::new()))).collect();
+        let mut writers: Vec<Option<BitrotWriterWrapper>> = committed
+            .iter()
+            .map(|c| Some(bitrot_writer(DeferredCommitWriter::new(c.clone()), BLOCK_SIZE / DATA_SHARDS)))
+            .collect();
+
+        let erasure = Arc::new(Erasure::new_with_options(DATA_SHARDS, PARITY_SHARDS, BLOCK_SIZE, uses_legacy));
+        let reader = tokio::io::BufReader::new(Cursor::new(payload.to_vec()));
+        let (_reader, total) = erasure
+            .encode_with_ingest_mode(reader, &mut writers, DATA_SHARDS, use_bytesmut_ingest)
+            .await
+            .expect("encode should succeed");
+        assert_eq!(total, payload.len());
+
+        committed
+            .iter()
+            .map(|c| c.lock().expect("committed buffer should be lockable").clone())
+            .collect()
+    }
+
+    /// HP-10 (rustfs/backlog#931) merge gate: the BytesMut ingest path must produce
+    /// byte-for-byte identical shard streams to the default Vec ingest path, for both
+    /// legacy-aware shard-size formulas, across empty, sub-block, exactly-full-block,
+    /// and multi-block-with-partial-tail payloads.
+    #[tokio::test]
+    async fn bytesmut_ingest_matches_vec_ingest_byte_for_byte() {
+        const BLOCK_SIZE: usize = 64;
+        let payloads: Vec<Vec<u8>> = vec![
+            Vec::new(),
+            b"tiny".to_vec(),
+            (0..BLOCK_SIZE as u32).map(|i| i as u8).collect(), // exactly one full block
+            vec![3u8; BLOCK_SIZE * 4],                         // whole number of blocks
+            (0..(BLOCK_SIZE * 3 + 7) as u32).map(|i| (i % 251) as u8).collect(), // partial tail
+        ];
+
+        for uses_legacy in [false, true] {
+            for payload in &payloads {
+                let vec_path = committed_shards_for_ingest_mode(false, uses_legacy, payload).await;
+                let bytesmut_path = committed_shards_for_ingest_mode(true, uses_legacy, payload).await;
+                assert_eq!(
+                    vec_path,
+                    bytesmut_path,
+                    "ingest paths must be byte-identical (legacy={uses_legacy}, payload_len={})",
+                    payload.len()
+                );
+            }
         }
     }
 

--- a/crates/ecstore/src/erasure/coding/erasure.rs
+++ b/crates/ecstore/src/erasure/coding/erasure.rs
@@ -610,6 +610,12 @@ impl Erasure {
 
     /// Encode data from an owned `BytesMut` buffer, avoiding the initial copy
     /// from a borrowed slice into a fresh `BytesMut`.
+    ///
+    /// Capacity contract: when the caller pre-reserves
+    /// `shard_size() * total_shard_count()` bytes (the EC-expanded size of a full
+    /// block), the `resize(need_total_size)` below stays within capacity for every
+    /// `data_len <= block_size` — both shard-size formulas are monotone in
+    /// `data_len` — so this function never reallocates the buffer.
     #[cfg_attr(feature = "hotpath", hotpath::measure)]
     pub fn encode_data_bytes_mut(&self, mut data_buffer: BytesMut, data_len: usize) -> io::Result<Vec<Bytes>> {
         let shard_size_fn = if self.uses_legacy {
@@ -1008,13 +1014,68 @@ mod tests {
     fn encode_data_bytes_mut_matches_borrowed_path() {
         for uses_legacy in [false, true] {
             let erasure = Erasure::new_with_options(4, 2, 64, uses_legacy);
-            for data in [Vec::new(), b"small payload".to_vec(), (0_u8..37).collect::<Vec<_>>()] {
+            let block_size = erasure.block_size;
+            let expanded_block_bytes = erasure.shard_size() * erasure.total_shard_count();
+            let cases: Vec<Vec<u8>> = vec![
+                Vec::new(),
+                b"small payload".to_vec(),
+                (0_u8..37).collect(),
+                vec![0xA5; block_size - 1], // last block one byte short of full
+                vec![0x5A; block_size],     // exactly one full block
+            ];
+            for data in cases {
                 let borrowed = erasure.encode_data(&data).expect("borrowed encode should succeed");
-                let bytes_mut = BytesMut::from(&data[..]);
+
                 let owned = erasure
-                    .encode_data_bytes_mut(bytes_mut, data.len())
+                    .encode_data_bytes_mut(BytesMut::from(&data[..]), data.len())
                     .expect("bytesmut encode should succeed");
                 assert_eq!(owned, borrowed);
+
+                // Ingest-shaped buffer: spare capacity pre-reserved for the EC-expanded
+                // block, exactly what the HP-10 streaming ingest path hands over.
+                let mut ingest = BytesMut::with_capacity(expanded_block_bytes.max(block_size));
+                ingest.extend_from_slice(&data);
+                let preallocated = erasure
+                    .encode_data_bytes_mut(ingest, data.len())
+                    .expect("preallocated bytesmut encode should succeed");
+                assert_eq!(preallocated, borrowed);
+
+                // Buffer longer than data_len (stale bytes past the logical block)
+                // must be truncated before padding.
+                let mut oversized = BytesMut::from(&data[..]);
+                oversized.extend_from_slice(&[0xFF; 8]);
+                let truncated = erasure
+                    .encode_data_bytes_mut(oversized, data.len())
+                    .expect("oversized bytesmut encode should succeed");
+                assert_eq!(truncated, borrowed);
+            }
+        }
+    }
+
+    /// HP-10 capacity invariant: both shard-size formulas are monotone in `data_len`,
+    /// so pre-reserving `shard_size(block_size) * total_shard_count` covers the
+    /// `need_total_size` of every block-or-smaller payload and the ingest buffer
+    /// never reallocates inside `encode_data_bytes_mut`.
+    #[test]
+    fn shard_size_monotonicity_bounds_expanded_block_capacity() {
+        for shard_fn in [calc_shard_size, calc_shard_size_legacy] {
+            for data_shards in 1usize..=16 {
+                for block_size in [1usize, 2, 63, 64, 65, 1024, 4096] {
+                    let full = shard_fn(block_size, data_shards);
+                    let mut prev = shard_fn(0, data_shards);
+                    for data_len in 1..=block_size {
+                        let cur = shard_fn(data_len, data_shards);
+                        assert!(cur >= prev, "shard size must be monotone (len {data_len}, shards {data_shards})");
+                        assert!(cur <= full, "per-block shard size must not exceed the full-block bound");
+                        prev = cur;
+                    }
+                }
+                // Spot-check the production-scale block size at its boundaries.
+                let block_size = 1usize << 20;
+                let full = shard_fn(block_size, data_shards);
+                for data_len in [0usize, 1, block_size / 2, block_size - 1, block_size] {
+                    assert!(shard_fn(data_len, data_shards) <= full);
+                }
             }
         }
     }


### PR DESCRIPTION
## Related Issues

https://github.com/rustfs/backlog/issues/931 (HP-10), parent https://github.com/rustfs/backlog/issues/936.

## Summary of Changes

The env-gated `RUSTFS_ERASURE_ENCODE_BYTESMUT_INGEST` experimental encode-ingest path allocated its per-block `BytesMut` with only `block_size` capacity, so the `resize(need_total_size)` (~2x for typical EC layouts) inside `Erasure::encode_data_bytes_mut` always reallocated and memcpy'd the whole block — the experimental path saved nothing over the default `Vec` path. This PR fixes the capacity math on that path:

- `crates/ecstore/src/erasure/coding/encode.rs`: the ingest buffer is now allocated with `expanded_block_bytes` (`shard_size() * total_shard_count()`) capacity. Both legacy-aware shard-size formulas are monotone in `data_len`, so `need_total_size` never exceeds this capacity for any block-or-smaller payload and the resize inside `encode_data_bytes_mut` never reallocates.
- Per the adversarial-verification correction recorded on the issue, the block is read into uninitialized spare capacity via a new `read_full_buf_or_eof` helper (`bytes::BufMut::limit` + `AsyncReadExt::read_buf`) instead of `resize(block_size, 0)` followed by a slice read, so the eliminated full-block memcpy is not traded for a full-block memset on each fresh buffer. The helper mirrors `rustfs_utils::read_full_or_eof` EOF and checksum-mismatch (`InvalidData`) error semantics exactly.
- `encode` is split into a thin public wrapper plus a private `encode_with_ingest_mode(..., use_bytesmut_ingest)` so tests can drive both ingest paths deterministically regardless of the `OnceLock`-cached environment value. The default `Vec` ingest path is byte-for-byte untouched at runtime.

What this deliberately does not do: the default is NOT flipped — `DEFAULT_RUSTFS_ERASURE_ENCODE_BYTESMUT_INGEST` stays `false`. The issue's adversarial verification makes flipping conditional on statistically significant criterion + warp put-4mib/multipart/mixed A/B wins re-measured on Linux (production fsync semantics and allocator); those benchmarks are not available here, so this PR only fixes the capacity math and keeps the experimental path env-gated.

Benefit is stated per the corrected analysis, not the original proposal: allocation count is unchanged (one expanded-block allocation per block either way, since `freeze()` consumes the buffer), and the real saving on the experimental path is eliminating the per-block full-block memcpy (and, thanks to the spare-capacity read, avoiding the would-be replacement memset). Per the issue's own profiling, `encode_data` including the copy is ~4.8% of nosync PUT wall time, so the expected end-to-end effect is roughly ~1% nosync and <0.1% under default sync — a micro-optimization that makes the experimental path meaningful, not a headline win.

### Compatibility

Encoded output is byte-for-byte equivalent: `encode_data`, `encode_data_owned`, and `encode_data_bytes_mut` produce identical shards for both the legacy and current shard-size formulas, and the two streaming ingest modes commit identical shard streams through the bitrot writers. This is backed by unit tests, not just reasoning:

- `erasure::tests::encode_data_bytes_mut_matches_borrowed_path` (extended): plain, ingest-shaped (pre-reserved expanded capacity), and oversized-buffer inputs, for `uses_legacy` in `[false, true]`, covering empty, sub-block, `block_size - 1`, and exactly-full-block payloads.
- `erasure::tests::shard_size_monotonicity_bounds_expanded_block_capacity` (new): exhaustively verifies for both shard formulas that shard size is monotone in `data_len` and never exceeds the full-block bound — the invariant that makes the pre-reserved capacity always sufficient.
- `encode::tests::bytesmut_ingest_matches_vec_ingest_byte_for_byte` (new, merge gate): end-to-end streaming encode, asserting the BytesMut ingest path commits byte-identical shard streams to the default Vec path for both shard formulas across empty, sub-block, exactly-full-block, whole-blocks, and multi-block-with-partial-tail payloads.
- `encode::tests::read_full_buf_or_eof_*` (new): EOF-before-any-byte, partial-tail, and block-boundary semantics of the new read helper.

No persistence format, wire format, or metadata change.

## Verification

- `cargo fmt --all` clean; `cargo check -p rustfs-ecstore` clean; `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` clean; `make pre-commit` passes.
- `cargo test -p rustfs-ecstore --lib erasure::coding`: 121 passed, 0 failed (includes all new/extended equivalence tests).
- `cargo test -p rustfs-ecstore` full suite: 2003 passed, 4 failed — the 4 failures (`store::bucket::tests::bucket_delete_*` x3, `bucket::migration::tests::migrates_real_minio_bucket_metadata_end_to_end`) are the known parallel-load flakes tracked in https://github.com/rustfs/backlog/issues/937 and all pass when rerun in isolation; none touch erasure.
- `cargo bench -p rustfs-ecstore --bench erasure_benchmark -- "encode_simd/simd_impl/.*1024KB_1024KB-block"` A/B against a criterion baseline (`--save-baseline hp10-before`) captured from the pre-change code on the same machine. The deltas are not probative on this box: successive runs swung between "no change" and +38% on the same config (8+4: 79.6 µs baseline → 110.3 µs → 85.7 µs across runs), and a control run of the *unchanged* pre-change code against its own baseline also reported +20-23% "regression" — the local macOS noise floor (background load, P/E-core scheduling, thermal) exceeds any plausible effect. Structurally this is expected: the benchmark exercises `Erasure::encode_data`, whose code is untouched by this PR, while the changed ingest path is env-gated and not covered by criterion. Raw numbers from all runs are in the collapsible section below.

<details>
<summary>criterion raw numbers (macOS dev machine, high noise — see control run)</summary>

Baseline (pre-change code, `--save-baseline hp10-before`): 4+2 46.9 µs, 6+3 59.9 µs, 8+4 79.6 µs (center estimates).

Run 1 with this change: 4+2 48.2 µs (+0.2%, p=0.84, "no change"), 6+3 63.2 µs (+3.7%), 8+4 110.3 µs (+38.1%).

Run 2 with this change (immediately after): 4+2 59.6 µs (+33.7%), 6+3 68.4 µs (+13.1%), 8+4 85.7 µs (+8.0%).

Control run of the unchanged pre-change code vs its own `hp10-before` baseline: 4+2 49.6 µs (+19.8%), 6+3 60.4 µs (+0.9%), 8+4 96.6 µs (+22.7%) — identical code "regressing" 20%+ against itself demonstrates the noise floor.

</details>

## Impact

No behavior change for default deployments: the `Vec` ingest path remains the default and its runtime code is unchanged. Operators who enable `RUSTFS_ERASURE_ENCODE_BYTESMUT_INGEST=true` get the intended zero-extra-copy ingest instead of a hidden realloc+memcpy. Peak per-block memory is unchanged (the expanded block was already allocated at encode time); the buffer's full capacity now exists from read time instead of encode time, which matches the default path's lifetime once shards are split.

## Additional Notes

Follow-up work per the issue remains open: Linux criterion + warp A/B (put-4mib/multipart/mixed) to decide whether to flip the default, and an `encode_batched` BytesMut variant before the legacy `Vec` path could ever be removed. Priority was re-rated P2/P3 by the adversarial verification; this PR intentionally ships only the low-risk capacity/copy fix.
