### PR TITLE
fix(ecstore): stop rejecting recoverable degraded reads in codec parity verification

### DIFF
--- a/crates/ecstore/src/erasure/codec/bridge.rs
+++ b/crates/ecstore/src/erasure/codec/bridge.rs
@@ -206,6 +206,9 @@ impl RustfsCodecDecodeEngine {
             return Ok(());
         }
 
+        // All slots must be present here: the verification path reconstructs
+        // missing parity alongside data (see `reconstruct_into`), so a `None`
+        // slot is an internal invariant violation, not a degraded-read state.
         let mut shard_refs = Vec::with_capacity(self.data_shards + self.parity_shards);
         for (index, shard) in shards.iter().enumerate() {
             let shard = shard.as_ref().ok_or_else(|| {
@@ -274,9 +277,25 @@ impl ErasureDecodeEngine for RustfsCodecDecodeEngine {
 
         if let Some(codec) = self.codec()? {
             let needs_source_parity_verification = self.needs_source_parity_verification(shards);
-            codec
-                .reconstruct_data_opt(shards)
-                .map_err(|err| io::Error::other(format!("RustFS codec reconstruct failed: {err:?}")))?;
+            if needs_source_parity_verification {
+                // Rebuild missing parity together with missing data so the
+                // shard set is complete for `verify`. Rebuilt parity is
+                // consistent with the reconstructed data by construction, so
+                // the verification below is equivalent to checking only the
+                // originally-present source parity — the same semantics as the
+                // legacy `decode_data_with_reconstruction_verification` path.
+                // Rebuilding only data here would leave missing parity slots
+                // as `None` and misreport a recoverable degraded read (for
+                // example one missing data shard plus one missing parity
+                // shard) as an inconsistent-source failure.
+                codec
+                    .reconstruct_opt(shards)
+                    .map_err(|err| io::Error::other(format!("RustFS codec reconstruct failed: {err:?}")))?;
+            } else {
+                codec
+                    .reconstruct_data_opt(shards)
+                    .map_err(|err| io::Error::other(format!("RustFS codec reconstruct failed: {err:?}")))?;
+            }
             self.verify_source_parity(&codec, shards, needs_source_parity_verification)?;
         }
 
@@ -518,6 +537,86 @@ mod tests {
 
         assert!(reconstruct_with(&legacy, &mut legacy_shards).is_err());
         assert!(reconstruct_with(&rustfs, &mut rustfs_shards).is_err());
+    }
+
+    #[test]
+    fn rustfs_codec_decode_engine_recovers_missing_data_and_parity() {
+        // backlog#868 item 2: one missing data shard plus one missing parity
+        // shard is recoverable, but the parity verification path used to
+        // require every shard slot to be present after data-only
+        // reconstruction and misreported this degraded read as a failure.
+        let erasure = Erasure::new(6, 4, 96);
+        let mut shards = encoded_shards(&erasure, &(0u8..=191u8).collect::<Vec<_>>());
+        let expected_data = shards.iter().take(erasure.data_shards).cloned().collect::<Vec<_>>();
+        shards[1] = None;
+        shards[erasure.data_shards + 1] = None;
+
+        let engine = RustfsCodecDecodeEngine::new(&erasure).expect("engine should be created");
+        reconstruct_with(&engine, &mut shards).expect("one missing data shard plus one missing parity shard is recoverable");
+
+        assert_eq!(shards.iter().take(erasure.data_shards).cloned().collect::<Vec<_>>(), expected_data);
+        assert!(shards[erasure.data_shards + 1].is_some(), "missing parity is rebuilt for verification");
+    }
+
+    #[test]
+    fn rustfs_codec_decode_engine_matches_legacy_on_missing_data_and_parity() {
+        let erasure = Erasure::new(6, 4, 96);
+        let mut legacy_shards = encoded_shards(&erasure, &(0u8..=191u8).rev().collect::<Vec<_>>());
+        let mut rustfs_shards = legacy_shards.clone();
+        for shards in [&mut legacy_shards, &mut rustfs_shards] {
+            shards[2] = None;
+            shards[erasure.data_shards] = None;
+        }
+
+        let legacy = LegacyEcDecodeEngine::new(erasure.clone());
+        let rustfs = RustfsCodecDecodeEngine::new(&erasure).expect("engine should be created");
+
+        reconstruct_with(&legacy, &mut legacy_shards).expect("legacy should recover missing data plus parity");
+        reconstruct_with(&rustfs, &mut rustfs_shards).expect("rustfs codec should recover missing data plus parity");
+
+        assert_eq!(
+            rustfs_shards.iter().take(erasure.data_shards).cloned().collect::<Vec<_>>(),
+            legacy_shards.iter().take(erasure.data_shards).cloned().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rustfs_codec_decode_engine_rejects_corrupt_parity_with_missing_data_and_parity() {
+        // The degraded-read allowance must not weaken inconsistent-source
+        // rejection: with one data and one parity shard missing, a corrupted
+        // surviving parity shard still fails verification.
+        let erasure = Erasure::new(6, 4, 96);
+        let mut shards = encoded_shards(&erasure, &(0u8..=191u8).collect::<Vec<_>>());
+        shards[0] = None;
+        shards[erasure.data_shards] = None;
+        let Some(corrupt_parity) = shards[erasure.data_shards + 1].as_mut() else {
+            panic!("test parity shard should be present");
+        };
+        corrupt_parity[0] ^= 0x80;
+
+        let engine = RustfsCodecDecodeEngine::new(&erasure).expect("engine should be created");
+        let err = reconstruct_with(&engine, &mut shards).expect_err("corrupt surviving parity must still be rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("inconsistent read source shards"));
+    }
+
+    #[test]
+    fn rustfs_codec_decode_engine_rejects_stale_data_with_missing_data_and_parity() {
+        let erasure = Erasure::new(6, 4, 96);
+        let mut shards = encoded_shards(&erasure, &(0u8..=191u8).collect::<Vec<_>>());
+        shards[0] = None;
+        shards[erasure.data_shards] = None;
+        let Some(stale_data) = shards[1].as_mut() else {
+            panic!("test data shard should be present");
+        };
+        stale_data[0] ^= 0x40;
+
+        let engine = RustfsCodecDecodeEngine::new(&erasure).expect("engine should be created");
+        let err = reconstruct_with(&engine, &mut shards).expect_err("stale surviving data must still be rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("inconsistent read source shards"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes rustfs/backlog#868 item 2, the prerequisite fix for rustfs/backlog#930 (HP-9, parent tracking issue rustfs/backlog#936): the RustFS codec streaming decode engine's source parity verification rejected recoverable degraded reads.

In `crates/ecstore/src/erasure/codec/bridge.rs`, `RustfsCodecDecodeEngine::reconstruct_into` called `reconstruct_data_opt`, which rebuilds only missing data shards, but `verify_source_parity` then required every shard slot (data and parity) to be present. A degraded read with one missing data shard plus one missing parity shard (for example 6 data + 4 parity with 8 shards available) is fully recoverable, yet it failed with `missing shard N after RustFS codec reconstruction` instead of returning the object.

The fix: when source parity verification is needed (a data shard is missing and more than `data_shards` shards are available), reconstruct missing parity together with missing data via `reconstruct_opt` so `verify` runs over a complete shard set. Rebuilt parity is consistent with the reconstructed data by construction, so the check remains equivalent to verifying only the originally-present source parity, which is exactly the legacy `Erasure::decode_data_with_reconstruction_verification` semantics (`erasure.rs`: `decode_data_and_parity` followed by comparison against a snapshot of the parity that was actually read). The non-verification path is unchanged and still uses `reconstruct_data_opt`.

This fix only unblocks the misrejected recoverable scenario; it does not flip any default. The HP-9 codec streaming default-switch evaluation (redoing the backlog#727 A/B with its original hard gates) remains separate follow-up work on rustfs/backlog#930.

## Inconsistent-source rejection is not weakened

Truly inconsistent sources are still rejected with `inconsistent read source shards`: `verify` recomputes parity from the (reconstructed) data shards and compares it against the originally-present parity, so any surviving corrupt parity or stale data shard still fails verification. New regression tests pin both directions:

- `rustfs_codec_decode_engine_recovers_missing_data_and_parity`: 6+4 with 1 data + 1 parity missing now succeeds and returns byte-identical data (previously misreported as `missing shard N`).
- `rustfs_codec_decode_engine_matches_legacy_on_missing_data_and_parity`: the recovered data is byte-identical to the legacy engine's output for the same loss pattern.
- `rustfs_codec_decode_engine_rejects_corrupt_parity_with_missing_data_and_parity`: same mixed-missing scenario with a corrupted surviving parity shard is still rejected as inconsistent.
- `rustfs_codec_decode_engine_rejects_stale_data_with_missing_data_and_parity`: same scenario with a stale surviving data shard is still rejected as inconsistent.

All four new tests were verified to fail on the pre-fix code (the recovery tests hit the spurious `missing shard` error; the rejection tests pin the correct `inconsistent read source shards` reason). The pre-existing rejection tests (`rejects_inconsistent_reconstruction_sources`, `rejects_stale_data_source`) and the missing-parity-only no-op test (`leaves_missing_parity_unreconstructed`) are unchanged and still pass.

## Compatibility

- Default GET behavior is unchanged: codec streaming stays opt-in (`RUSTFS_GET_CODEC_STREAMING_ENABLE` default false), and this PR flips no gates. The fixed code path only runs when the RustFS codec engine is selected.
- Shard-slot output changes only inside the verification path (missing parity slots are now rebuilt, matching what the legacy engine's `decode_data_and_parity` already does); all consumers (`decode_reader.rs::decode_stripe_into`) read only the data shards.
- No on-disk format, metadata, wire, or API changes.

## Coordination with #4392 (HP-2 lockstep / deferred parity)

This change is based on main including #4392 and, per the coordination requirement from its verification, the #4392 degraded-read regressions were re-run on top of this fix in both gate modes (`RUSTFS_GET_LOCKSTEP_DATA_SHARDS_ONLY_ENABLE=false` and `=true`): the decode.rs lockstep suite (`test_erasure_decode_recovers_when_data_shard_dies_midway`, `test_lockstep_healthy_get_reads_only_data_shards`, `test_lockstep_default_reads_all_shards_per_stripe`, `test_erasure_decode_rejects_inconsistent_parity_engaged_midstream`), the `io_support::bitrot` deferred stripe handle tests, and the e2e disk-fault suite (`test_degraded_read_write_with_one_disk_offline`, `test_bitrot_corrupted_shard_read_returns_correct_data`, `test_fresh_disk_replacement_heals_after_sigkill_restart`). All green in both modes.

## Verification

- `cargo fmt` clean; `cargo clippy -p rustfs-ecstore --all-targets --all-features` clean.
- `cargo test -p rustfs-ecstore --lib`: 2009 passed; the only 4 failures (`bucket_delete_*` x3, `bucket::migration::migrates_real_minio_bucket_metadata_end_to_end`) are the known parallel-load flakes tracked in rustfs/backlog#937 (InsufficientWriteQuorum from shared global state) and all 4 pass when run in isolation.
- `cargo test -p rustfs-ecstore --lib erasure::` / `io_support::bitrot` / `set_disk::read` (251 tests) pass with the lockstep gate off and on, and with `RUSTFS_GET_CODEC_STREAMING_ENABLE=true`.
- e2e `reliability_disk_fault_test` suite passes with the lockstep gate off and on (env is inherited by the spawned server binary).
- `make pre-commit` passes.
