### PR TITLE
fix(credentials): fail closed when deriving RPC secret from default credentials

### DIFF
--- a/crates/credentials/src/credentials.rs
+++ b/crates/credentials/src/credentials.rs
@@ -259,7 +259,18 @@ fn resolve_rpc_secret(env_secret: Option<&str>, global_access: Option<&str>, glo
     }
 
     match (global_access, global_secret) {
-        (Some(access_key), Some(secret_key)) => derive_rpc_secret(access_key, secret_key),
+        (Some(access_key), Some(secret_key)) => {
+            // Fail closed: never derive the RPC secret while the default secret
+            // key is in effect. The derivation uses `secret_key` as the HMAC key,
+            // so a public default secret yields a publicly computable RPC secret
+            // that any network peer can use to forge internode RPC signatures.
+            // Operators running with default credentials must configure
+            // RUSTFS_RPC_SECRET (or set a non-default RUSTFS_SECRET_KEY) instead.
+            if secret_key.trim() == DEFAULT_SECRET_KEY {
+                return None;
+            }
+            derive_rpc_secret(access_key, secret_key)
+        }
         _ => None,
     }
 }
@@ -575,12 +586,19 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_rpc_secret_allows_default_credentials_for_derivation() {
+    fn test_resolve_rpc_secret_rejects_default_credentials_for_derivation() {
         assert!(resolve_rpc_secret(None, None, None).is_none());
 
-        let expected = derive_rpc_secret(DEFAULT_ACCESS_KEY, DEFAULT_SECRET_KEY).expect("secret should derive");
+        // Fail closed: the default secret key must not yield a derivable RPC
+        // secret, otherwise the derived value is publicly computable and any
+        // network peer can forge internode RPC signatures.
+        assert!(resolve_rpc_secret(None, Some(DEFAULT_ACCESS_KEY), Some(DEFAULT_SECRET_KEY)).is_none());
+
+        // A default access key paired with a non-default secret key is still
+        // safe to derive: the HMAC key (the secret key) is not public.
+        let expected = derive_rpc_secret(DEFAULT_ACCESS_KEY, "custom-global-secret").expect("secret should derive");
         assert_eq!(
-            resolve_rpc_secret(None, Some(DEFAULT_ACCESS_KEY), Some(DEFAULT_SECRET_KEY)).as_deref(),
+            resolve_rpc_secret(None, Some(DEFAULT_ACCESS_KEY), Some("custom-global-secret")).as_deref(),
             Some(expected.as_str())
         );
 


### PR DESCRIPTION
## Summary

The internode RPC HMAC secret is derived from the S3 credential pair via `derive_rpc_secret` when `RUSTFS_RPC_SECRET` is unset (the default posture). The derivation uses the **secret key as the HMAC key**, so when the default secret key (`rustfsadmin`) is in effect the derived RPC secret is a fixed, publicly computable value (`-PqYGe2ayRLOjiy4Xxtah3D6kb-OhQZjMvF5j-b8H8I`). Any network peer can then forge valid `x-rustfs-signature` / `x-rustfs-timestamp` headers and invoke internode RPC routes (e.g. `read_file_stream`), bypassing S3 IAM/bucket policy entirely.

`normalize_rpc_secret` already rejected the literal default when supplied directly as `RUSTFS_RPC_SECRET`, but `resolve_rpc_secret` still **derived** a secret from the default credential pair — the incomplete-fix gap flagged in the advisory.

## Fix

Make the derivation path fail closed: `resolve_rpc_secret` refuses to derive while the default secret key is in effect, forcing operators to set `RUSTFS_RPC_SECRET` (or a non-default `RUSTFS_SECRET_KEY`). The guard is on the **secret key** (the HMAC key) only — a default *access* key paired with a non-default secret key stays unguessable and is still allowed to derive.

### Behavior change
- Single-node deployments are unaffected (no cross-node RPC is issued to self).
- Distributed clusters started with default credentials **and** no `RUSTFS_RPC_SECRET` will now fail internode RPC auth instead of running with a public secret. This is intentional (fail closed); operators must configure one of the two.

## Verification
- `cargo test -p rustfs-credentials` — pass (updated `test_resolve_rpc_secret_*` to assert the fail-closed behavior)
- `cargo clippy -p rustfs-credentials --all-targets` — clean

## Advisory
Addresses **GHSA-68cw-96m3-h2cf** — "Incomplete fix for CVE-2025-68926: internode-RPC HMAC signing key derived from the S3 access/secret pair". Follow-up hardening to CVE-2026-45039 (GHSA-r5qv-rc46-hv8q), which fixed the literal-default fallback but left the default-credential *derivation* path open.