### PR TITLE
fix(protocols): use constant-time secret comparison in FTPS and WebDAV auth

### DIFF
--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["network-programming", "filesystem"]
 
 [features]
 default = []
-ftps = ["dep:libunftp", "dep:unftp-core", "dep:rustls", "dep:rustfs-tls-runtime"]
+ftps = ["dep:libunftp", "dep:unftp-core", "dep:rustls", "dep:rustfs-tls-runtime", "dep:subtle"]
 swift = [
     "dep:rustfs-keystone",
     "dep:rustfs-ecstore",
@@ -53,7 +53,7 @@ swift = [
     "dep:base64",
     "dep:async-compression",
 ]
-webdav = ["dep:dav-server", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tokio-rustls", "dep:base64", "dep:rustls", "dep:percent-encoding", "dep:rustfs-tls-runtime"]
+webdav = ["dep:dav-server", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tokio-rustls", "dep:base64", "dep:rustls", "dep:percent-encoding", "dep:rustfs-tls-runtime", "dep:subtle"]
 sftp = ["dep:russh", "dep:russh-sftp", "dep:uuid", "dep:subtle", "dep:tokio-util", "dep:socket2"]
 
 [dependencies]

--- a/crates/protocols/src/ftps/server.rs
+++ b/crates/protocols/src/ftps/server.rs
@@ -26,6 +26,7 @@ use std::net::IpAddr;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
+use subtle::ConstantTimeEq;
 use tokio::sync::broadcast;
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
@@ -464,7 +465,15 @@ impl Authenticator for FtpsAuthenticator {
             AuthenticationError::BadUser
         })?;
 
-        if !identity.credentials.secret_key.eq(&s3_creds.secret_key) {
+        // Constant-time secret comparison to prevent timing side-channel
+        // attacks. Same primitive used by the SFTP handler and rustfs/src/auth.rs.
+        let secret_matches: bool = identity
+            .credentials
+            .secret_key
+            .as_bytes()
+            .ct_eq(s3_creds.secret_key.as_bytes())
+            .into();
+        if !secret_matches {
             warn!(
                 event = EVENT_FTPS_AUTH_STATE,
                 component = LOG_COMPONENT_PROTOCOLS,

--- a/crates/protocols/src/webdav/server.rs
+++ b/crates/protocols/src/webdav/server.rs
@@ -32,6 +32,7 @@ use std::convert::Infallible;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use subtle::ConstantTimeEq;
 use tokio::net::TcpListener;
 use tokio::sync::{broadcast, watch};
 use tokio_rustls::TlsAcceptor;
@@ -441,7 +442,15 @@ where
             WebDavInitError::Server("User not found".to_string())
         })?;
 
-        if !identity.credentials.secret_key.eq(&s3_creds.secret_key) {
+        // Constant-time secret comparison to prevent timing side-channel
+        // attacks. Same primitive used by the SFTP handler and rustfs/src/auth.rs.
+        let secret_matches: bool = identity
+            .credentials
+            .secret_key
+            .as_bytes()
+            .ct_eq(s3_creds.secret_key.as_bytes())
+            .into();
+        if !secret_matches {
             warn!(
                 event = EVENT_WEBDAV_AUTH_STATE,
                 component = LOG_COMPONENT_PROTOCOLS,


### PR DESCRIPTION
## Summary

The FTPS ([`ftps/server.rs`](crates/protocols/src/ftps/server.rs)) and WebDAV ([`webdav/server.rs`](crates/protocols/src/webdav/server.rs)) authentication handlers compared the client-supplied secret key against the stored secret with `String::eq`, which delegates to a `memcmp`-style comparison that short-circuits on the first differing byte. A network attacker who knows or enumerates a valid access key can recover the secret key one byte at a time via authentication response-timing analysis. Neither path is rate limited.

The SFTP handler already does this correctly with `subtle::ConstantTimeEq`; this brings FTPS and WebDAV in line.

## Fix

- FTPS and WebDAV now compare secret keys with `subtle::ConstantTimeEq::ct_eq`, matching SFTP and `rustfs/src/auth.rs::constant_time_eq`.
- `subtle` is added to the `ftps` and `webdav` feature dependency sets (previously gated on `sftp` only).

## Verification
- `cargo test -p rustfs-protocols --features ftps,webdav` — pass
- `cargo clippy -p rustfs-protocols --features ftps,webdav --all-targets` — clean

## Advisory
Addresses **GHSA-3p3x-734c-h5vx** — "Timing Side-Channel in FTPS and WebDAV Secret Key Comparison".

## Note (not addressed here)
The advisory also mentions FTPS user enumeration via distinguishable `BadUser` vs `BadPassword` responses. That is a separate behavioral change (libunftp maps them to distinct 530 replies) and is left out of this timing-focused fix to keep scope tight; happy to follow up if wanted.