### PR TITLE
fix(lock): fence write commit on lock loss

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -254,6 +254,13 @@ impl ObjectLockDiagGuard {
             acquired_at: Instant::now(),
         }
     }
+
+    /// Whether the underlying namespace lock's heartbeat has observed a
+    /// refresh-quorum loss (backlog#899 Phase 2). Callers fence their commit
+    /// point on this so a stale lock holder does not race a double-write.
+    fn is_lock_lost(&self) -> bool {
+        self.guard.is_lock_lost()
+    }
 }
 
 impl Drop for ObjectLockDiagGuard {

--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -1342,6 +1342,22 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
             );
         }
 
+        // Phase 2 (backlog#899): fence the commit on lock loss before any destructive
+        // step. If the refresh heartbeat has observed a refresh-quorum loss, another
+        // writer may have re-acquired this object's lock; proceeding would race a
+        // double-write. Abort with a retryable error *before* cleanup_multipart_path
+        // (which removes the source parts) and rename_data (which commits the object),
+        // so a lost lock leaves the upload intact and retryable.
+        if object_lock_guard.as_ref().is_some_and(|guard| guard.is_lock_lost()) {
+            return Err(StorageError::NamespaceLockQuorumUnavailable {
+                mode: "complete_multipart_upload_commit",
+                bucket: bucket.to_string(),
+                object: object.to_string(),
+                required: 1,
+                achieved: 0,
+            });
+        }
+
         let complete_tail_stage_start = rustfs_io_metrics::put_stage_metrics_enabled().then(Instant::now);
         self.cleanup_multipart_path(&parts).await;
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -864,6 +864,22 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                 object_lock_guard = Some(self.acquire_write_lock_diag("put_object_commit", bucket, object).await?);
             }
 
+            // Phase 2 (backlog#899): fence the commit on lock loss. If the refresh
+            // heartbeat has observed a refresh-quorum loss, another writer may have
+            // re-acquired this object's lock; committing now would race a double-write.
+            // Abort with a retryable error *before* rename_data makes the new version
+            // durable — once rename_data returns Ok the write is committed and must
+            // never be aborted (that would violate "a committed write is not lost").
+            if object_lock_guard.as_ref().is_some_and(|guard| guard.is_lock_lost()) {
+                return Err(StorageError::NamespaceLockQuorumUnavailable {
+                    mode: "put_object_commit",
+                    bucket: bucket.to_string(),
+                    object: object.to_string(),
+                    required: 1,
+                    achieved: 0,
+                });
+            }
+
             let rename_stage_start = Instant::now();
             let (online_disks, _, op_old_dir, cleanup_disks) = Self::rename_data(
                 &shuffle_disks,

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -1214,6 +1214,31 @@ mod tests {
         drop(guard);
     }
 
+    // Phase 2 passthrough: NamespaceLockGuard::Standard must forward the distributed
+    // guard's lock-loss signal so the write path can fence its commit on it.
+    #[tokio::test]
+    async fn namespace_guard_forwards_lock_lost() {
+        let (clients, _counters) = counting_clients(&[
+            RefreshOutcome::NotFound,
+            RefreshOutcome::NotFound,
+            RefreshOutcome::Alive,
+            RefreshOutcome::Alive,
+        ]);
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Exclusive, "owner")
+            .with_ttl(Duration::from_millis(120))
+            .with_refresh_interval(Duration::from_millis(20));
+
+        let guard = lock.acquire_guard(&request).await.unwrap().unwrap();
+        tokio::time::sleep(Duration::from_millis(60)).await; // at least one tick -> lost
+
+        let ns_guard = crate::namespace::NamespaceLockGuard::Standard(guard);
+        assert!(
+            ns_guard.is_lock_lost(),
+            "NamespaceLockGuard::Standard must forward the distributed guard's lock-loss signal"
+        );
+    }
+
     // A5 -- refresh RPC jitter (Err) is not counted as not_found; the lock is not declared lost.
     #[tokio::test]
     async fn heartbeat_rpc_error_not_counted_as_lock_lost() {

--- a/crates/lock/src/namespace/mod.rs
+++ b/crates/lock/src/namespace/mod.rs
@@ -118,6 +118,16 @@ impl NamespaceLockGuard {
             Self::Fast(guard) => guard.is_released(),
         }
     }
+
+    /// Whether the distributed guard's refresh heartbeat has observed a
+    /// refresh-quorum loss (backlog#899 Phase 2). Local (fast) locks are
+    /// single-node and never lose quorum, so they always report `false`.
+    pub fn is_lock_lost(&self) -> bool {
+        match self {
+            Self::Standard(guard) => guard.is_lock_lost(),
+            Self::Fast(_) => false,
+        }
+    }
 }
 
 /// Namespace lock for managing locks by resource namespaces


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#899 (lock-ttl-01) — Phase 2, follow-up to the merged Phase 0+1 (#4388).

## Summary of Changes

Phase 0+1 (#4388) made object write locks refreshable and observable: the heartbeat
marks the guard lost when it can no longer refresh a quorum, but does not act on it.
Phase 2 closes the partition double-write window by fencing the commit on lock loss.

Under a partition, a long write's lock can expire on an unreachable node and be
reclaimed, letting a third party re-form quorum and re-acquire the lock. Phase 1 only
warns; the original writer keeps going and both can commit — a torn/double write.

Changes:
- Expose the loss signal up the guard stack: `NamespaceLockGuard::is_lock_lost()`
  (forwards the distributed guard; local/fast locks are single-node and always
  `false`) and `ObjectLockDiagGuard::is_lock_lost()`.
- Fence the commit in `put_object` and `complete_multipart_upload`: immediately before
  `rename_data` (the atomic commit point), if the guard reports lock loss, abort with a
  retryable `NamespaceLockQuorumUnavailable` (S3 `ServiceUnavailable`, 503). In
  multipart, the check is placed before `cleanup_multipart_path` so a lost lock leaves
  the upload intact and retryable.

Deliberate design choices (please review):
- **Fence at the commit point, not a `select!` wrap.** The essential safety property is
  "never commit after losing the lock." A discrete `is_lock_lost()` check right before
  `rename_data` guarantees that deterministically, and — critically — a write that has
  already reached `rename_data` `Ok` (durable) is **never** aborted, preserving "a
  committed write is not lost." A `select!` wrap of the long pre-commit section (earlier
  abort, slightly tighter window) is left as an optional follow-up; it adds async
  restructuring risk for no additional commit-safety.
- **Loss criterion unchanged.** Phase 2 only reacts to the same `LockLostSignal` Phase 1
  already sets (`not_found > entries.len() - refresh_quorum`); it does not redefine when
  loss fires. The criterion-cardinality question (entries.len() vs total clients) remains
  a tuning follow-up.
- **Scope.** Covers the two client double-write paths (PUT, CompleteMultipartUpload).
  Heal (internal, lower double-write risk) and the long-GET read side
  (`SetDiskLockGuardedReader`, overlaps #864 and concerns torn reads rather than
  double-writes) are deferred as tracked follow-ups.

Residual window (unchanged, inherent): a loss detected in the gap between the fence and
`rename_data` completing is not caught — hard fencing needs storage-layer fence tokens,
out of scope here. Phase 2 narrows the window; it does not add a hard fence.

## Verification

- `make pre-pr`
- `cargo test -p rustfs-lock --lib namespace_guard_forwards_lock_lost` — the namespace
  guard forwards the distributed guard's lock-loss signal. Phase 1's heartbeat
  loss/keepalive tests continue to pass.

## Impact

A write that loses its lock quorum mid-flight now aborts with a retryable 503 before
committing, instead of racing a second writer. No change for single-node/fast locks or
for writes that keep their lock. No API or on-disk format change.

## Additional Notes

**P1 — pending maintainer review before merge**, especially the fence-vs-`select!`
choice and the deferred heal/read-side scope. Design detail: backlog#899.
