### PR TITLE
refactor(ecstore): thread InstanceContext down the object graph (Phase 5 Slice 2)

### DIFF
--- a/crates/ecstore/src/core/sets.rs
+++ b/crates/ecstore/src/core/sets.rs
@@ -33,6 +33,7 @@ use crate::{
     error::StorageError,
     layout::endpoints::{Endpoints, PoolEndpoints},
     object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
+    runtime::instance::{InstanceContext, bootstrap_ctx},
     runtime::sources as runtime_sources,
     set_disk::SetDisks,
     store::init_format::{check_format_erasure_values, get_format_erasure_in_quorum, load_format_erasure_all, save_format_file},
@@ -77,6 +78,12 @@ pub struct Sets {
     pub default_parity_count: usize,
     pub distribution_algo: DistributionAlgoVersion,
     exit_signal: Option<Sender<()>>,
+    /// Per-instance runtime context (Phase 5, backlog#939).
+    ///
+    /// Carried down the object graph (ECStore → Sets → SetDisks) so that
+    /// instance-scoped state resolves through the owning instance rather than a
+    /// process global. Consumed starting Slice 3 (lock-namespace isolation).
+    ctx: Arc<InstanceContext>,
 }
 
 impl Drop for Sets {
@@ -186,6 +193,10 @@ impl Sets {
             default_parity_count: parity_count,
             distribution_algo: fm.erasure.distribution_algo.clone(),
             exit_signal: Some(tx),
+            // Single-instance: same bootstrap context the owning ECStore adopts
+            // (constructed before the store, so sourced here directly). Slice 8
+            // threads a per-instance context in for true multi-instance.
+            ctx: bootstrap_ctx(),
         });
 
         let asets = sets.clone();
@@ -198,6 +209,12 @@ impl Sets {
 
     pub fn set_drive_count(&self) -> usize {
         self.set_drive_count
+    }
+
+    /// This pool's per-instance runtime context (Phase 5, backlog#939).
+    #[allow(dead_code)] // Consumed starting Slice 3 (lock-namespace isolation).
+    pub(crate) fn instance_ctx(&self) -> &Arc<InstanceContext> {
+        &self.ctx
     }
 
     pub async fn monitor_and_connect_endpoints(&self, mut rx: Receiver<()>) {
@@ -1165,6 +1182,7 @@ mod tests {
             default_parity_count: 1,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: bootstrap_ctx(),
         };
 
         let result = sets
@@ -1244,6 +1262,7 @@ mod tests {
             default_parity_count: 1,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: bootstrap_ctx(),
         });
 
         let bucket = format!("bucket-{}", Uuid::new_v4().simple());
@@ -1290,6 +1309,7 @@ mod tests {
             default_parity_count: 0,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: bootstrap_ctx(),
         };
 
         let err = sets

--- a/crates/ecstore/src/runtime/instance.rs
+++ b/crates/ecstore/src/runtime/instance.rs
@@ -48,6 +48,7 @@ use tokio::sync::RwLock;
 /// This is intentionally minimal in the first migration slice; subsequent
 /// slices move additional identity/runtime state (topology, disk registry,
 /// service handles, cancellation token) into this struct.
+#[derive(Debug)]
 pub struct InstanceContext {
     /// The deployment's erasure setup type.
     ///

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -81,6 +81,7 @@ use crate::error::{GenericError, ObjectApiError, is_err_object_not_found};
 use crate::io_support::bitrot::{create_bitrot_reader, create_bitrot_reader_from_bytes, create_bitrot_writer};
 use crate::object_api::ObjectOptions;
 use crate::object_api::get_object_body_cache_hook;
+use crate::runtime::instance::{InstanceContext, bootstrap_ctx};
 use crate::runtime::sources as runtime_sources;
 use crate::services::batch_processor::AsyncBatchProcessor;
 use crate::storage_api_contracts::{
@@ -1564,6 +1565,12 @@ pub struct SetDisks {
     get_object_metadata_cache: moka::future::Cache<GetObjectMetadataCacheKey, Arc<GetObjectMetadataCacheEntry>>,
     pub lockers: Vec<Arc<dyn LockClient>>,
     local_lock_manager: Arc<rustfs_lock::GlobalLockManager>,
+    /// Per-instance runtime context (Phase 5, backlog#939).
+    ///
+    /// The leaf of the object-graph ctx plumbing (ECStore → Sets → SetDisks).
+    /// Slice 3 sources `local_lock_manager` from this context to give each
+    /// instance its own lock namespace.
+    ctx: Arc<InstanceContext>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -1725,7 +1732,17 @@ impl SetDisks {
                 .build(),
             lockers,
             local_lock_manager: runtime_sources::global_lock_manager(),
+            // Same injection pattern as local_lock_manager: single-instance
+            // sources the process bootstrap context (the one the owning ECStore
+            // adopts). Slice 8 threads a per-instance context for isolation.
+            ctx: bootstrap_ctx(),
         })
+    }
+
+    /// This set's per-instance runtime context (Phase 5, backlog#939).
+    #[allow(dead_code)] // Consumed starting Slice 3 (lock-namespace isolation).
+    pub(crate) fn instance_ctx(&self) -> &Arc<InstanceContext> {
+        &self.ctx
     }
 
     // async fn cached_disk_health(&self, index: usize) -> Option<bool> {

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1971,6 +1971,26 @@ mod tests {
         }
     }
 
+    // Phase 5 Slice 2 (backlog#939): the instance context flows down the whole
+    // object graph — ECStore, its Sets, and their SetDisks must all carry the
+    // same `Arc<InstanceContext>` in a single-instance deployment.
+    #[tokio::test]
+    async fn instance_context_flows_through_object_graph() {
+        let store = new_read_lock_test_store().await;
+
+        let sets = store.pools.first().expect("test store has one pool");
+        assert!(
+            std::sync::Arc::ptr_eq(&store.ctx, sets.instance_ctx()),
+            "Sets must carry the store's instance context"
+        );
+
+        let set_disks = sets.disk_set.first().expect("pool has one set");
+        assert!(
+            std::sync::Arc::ptr_eq(sets.instance_ctx(), set_disks.instance_ctx()),
+            "SetDisks must carry the Sets' instance context"
+        );
+    }
+
     #[tokio::test]
     async fn acquired_read_lock_marks_metadata_cache_safe_for_set_layer() {
         let store = new_read_lock_test_store().await;


### PR DESCRIPTION
## Summary

Phase 5 of the global-singleton consolidation (backlog#939) — **Slice 2**. Extends the per-instance `InstanceContext` plumbing introduced in Slice 1 (#4413) from `ECStore` down through the object graph to `Sets` and `SetDisks`.

> **Stacked on #4413** (Slice 1). Base branch is the Slice 1 branch; this PR's diff is Slice 2 only. Retarget to `main` once #4413 merges.

## Why

The chosen design carries multi-instance isolation on the **object graph** (`ECStore → Vec<Arc<Sets>> → SetDisks`), because these objects are what actually flow through the ~155 internal `tokio::spawn` boundaries where a `task_local` would be lost. This slice lays that structural plumbing so later slices can source instance-scoped state (locks in Slice 3, disk registry in Slice 5, service handles in Slice 6) from `self.ctx` instead of a process global.

## Changes

- `Sets` and `SetDisks` each gain a `ctx: Arc<InstanceContext>` field.
- Sourced exactly like `SetDisks`' existing `local_lock_manager` (internal, not a new constructor parameter): single-instance takes the process **bootstrap context** — the same `Arc` `ECStore::new` adopts — so **no constructor signatures change** and single-instance behavior is unchanged. Slice 8 threads a real per-instance context in for true multi-instance.
- `instance_ctx()` accessors on both types — named to avoid the existing `SetDisks::ctx()`, which returns the unrelated operation-family `SetDisksCtx`. Marked `#[allow(dead_code)]` until Slice 3 consumes them for lock-namespace isolation.
- `InstanceContext` now derives `Debug` (both `Sets` and `SetDisks` derive `Debug`).

## Test

`instance_context_flows_through_object_graph` builds a real store-with-pools and asserts `ECStore`, its `Sets`, and their `SetDisks` all share **one** `Arc<InstanceContext>` (`Arc::ptr_eq`) in a single-instance build. (Cross-instance isolation is asserted once threading lands in Slice 8; this slice guarantees single-context consistency.)

## Verification

```bash
cargo test -p rustfs-ecstore        # 7 Phase 5 tests green (4 instance + 2 store + 1 graph)
cargo clippy -p rustfs-ecstore --all-targets   # clean
make pre-commit                     # fmt + arch guards + quick-check pass
```

Refs: backlog#939 (Phase 5, Slice 2), stacked on #4413 (Slice 1).
