### PR TITLE
fix(ecstore): clear lifecycle metadata cache

### DIFF
--- a/crates/ecstore/src/bucket/metadata.rs
+++ b/crates/ecstore/src/bucket/metadata.rs
@@ -689,6 +689,7 @@ impl BucketMetadata {
             }
             BUCKET_LIFECYCLE_CONFIG => {
                 self.lifecycle_config_xml = data;
+                self.lifecycle_config = None;
                 self.lifecycle_config_updated_at = updated;
             }
             BUCKET_SSECONFIG => {
@@ -1238,6 +1239,23 @@ mod test {
         assert_eq!(bucket_targets.targets.len(), 1);
         assert_eq!(bucket_targets.targets[0].endpoint, "s3.amazonaws.com");
         assert_eq!(bucket_targets.targets[0].target_bucket, "target-bucket");
+    }
+
+    #[test]
+    fn lifecycle_update_config_clears_parsed_config_on_delete() {
+        let mut bm = BucketMetadata::new("test-bucket");
+        let lifecycle_xml = br#"<LifecycleConfiguration><Rule><ID>rule1</ID><Status>Enabled</Status><Expiration><Days>30</Days></Expiration></Rule></LifecycleConfiguration>"#;
+
+        bm.update_config(BUCKET_LIFECYCLE_CONFIG, lifecycle_xml.to_vec())
+            .expect("lifecycle config should update");
+        bm.parse_all_configs().expect("lifecycle config should parse");
+        assert!(bm.lifecycle_config.is_some());
+
+        bm.update_config(BUCKET_LIFECYCLE_CONFIG, Vec::new())
+            .expect("lifecycle config delete should update metadata");
+
+        assert!(bm.lifecycle_config_xml.is_empty());
+        assert!(bm.lifecycle_config.is_none());
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/bucket/metadata_sys.rs
+++ b/crates/ecstore/src/bucket/metadata_sys.rs
@@ -16,8 +16,8 @@ use super::metadata::{BucketMetadata, load_bucket_metadata};
 use super::quota::BucketQuota;
 use super::target::BucketTargets;
 use crate::bucket::bucket_target_sys::BucketTargetSys;
-use crate::bucket::metadata::{BUCKET_LIFECYCLE_CONFIG, load_bucket_metadata_parse};
-use crate::bucket::utils::{deserialize, is_meta_bucketname};
+use crate::bucket::metadata::load_bucket_metadata_parse;
+use crate::bucket::utils::is_meta_bucketname;
 use crate::error::{Error, Result, is_err_bucket_not_found};
 use crate::runtime::sources as runtime_sources;
 use crate::storage_api_contracts::heal::HealOperations as _;
@@ -454,32 +454,6 @@ impl BucketMetadataSys {
     }
 
     pub async fn delete(&mut self, bucket: &str, config_file: &str) -> Result<OffsetDateTime> {
-        if config_file == BUCKET_LIFECYCLE_CONFIG {
-            let meta = match self.get_config_from_disk(bucket).await {
-                Ok(res) => res,
-                Err(err) => {
-                    if err != Error::ConfigNotFound {
-                        return Err(err);
-                    } else {
-                        BucketMetadata::new(bucket)
-                    }
-                }
-            };
-
-            if !meta.lifecycle_config_xml.is_empty() {
-                if let Ok(cfg) = deserialize::<BucketLifecycleConfiguration>(&meta.lifecycle_config_xml) {
-                    if let Some(_v) = cfg.rules.first() {}
-                } else {
-                    tracing::warn!(
-                        bucket = %bucket,
-                        "delete: failed to parse lifecycle config XML"
-                    );
-                }
-            }
-
-            // TODO: other lifecycle handle
-        }
-
         self.update_and_parse(bucket, config_file, Vec::new(), false).await
     }
 


### PR DESCRIPTION
## Related Issues
Fixes rustfs/backlog#906

## Summary of Changes
- Clear the parsed lifecycle metadata cache when lifecycle config is overwritten or deleted.
- Remove the lifecycle delete placeholder branch that parsed XML but did not apply any behavior, so deletion follows the same metadata update path as other configs.
- Add a regression test for lifecycle delete clearing the parsed config cache.

## Verification
- `cargo test -p rustfs-ecstore lifecycle_update_config_clears_parsed_config_on_delete --lib`
- `cargo test -p rustfs-ecstore metadata_sys --lib`
- `cargo test -p rustfs-ecstore bucket_target --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`

## Impact
No API or configuration changes. Deleted lifecycle metadata no longer leaves a stale parsed lifecycle config in memory.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
