### PR TITLE
refactor(ecstore): source the namespace lock manager per-instance

### DIFF
--- a/crates/ecstore/src/runtime/instance.rs
+++ b/crates/ecstore/src/runtime/instance.rs
@@ -40,6 +40,7 @@
 //! single-instance behavior is byte-for-byte unchanged.
 
 use crate::layout::endpoints::SetupType;
+use rustfs_lock::{GlobalLockManager, get_global_lock_manager};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::RwLock;
 
@@ -58,15 +59,38 @@ pub struct InstanceContext {
     /// drift out of sync). Stored as one value so the three predicates can
     /// never observe a torn intermediate state.
     erasure_kind: RwLock<SetupType>,
+    /// This instance's namespace lock manager (Phase 5 Slice 3, backlog#939).
+    ///
+    /// Owned per-instance so two instances no longer share a lock namespace
+    /// (which would make same-named objects in different instances falsely
+    /// contend). Single-instance aliases the process singleton, so behavior is
+    /// unchanged; see [`bootstrap_ctx`].
+    lock_manager: Arc<GlobalLockManager>,
 }
 
 impl InstanceContext {
     /// Create a fresh instance context in the initial [`SetupType::Unknown`]
-    /// state — byte-for-byte equivalent to the old all-`false` erasure globals.
+    /// state with its own lock manager — byte-for-byte equivalent to the old
+    /// all-`false` erasure globals.
     pub fn new() -> Self {
+        Self::with_lock_manager(Arc::new(GlobalLockManager::new()))
+    }
+
+    /// Build a context bound to a specific lock manager.
+    ///
+    /// [`bootstrap_ctx`] uses this to alias the process-global lock manager so
+    /// single-instance deployments keep one shared namespace; `new` mints a
+    /// fresh manager for a genuinely independent instance.
+    fn with_lock_manager(lock_manager: Arc<GlobalLockManager>) -> Self {
         Self {
             erasure_kind: RwLock::new(SetupType::Unknown),
+            lock_manager,
         }
+    }
+
+    /// This instance's namespace lock manager.
+    pub fn lock_manager(&self) -> Arc<GlobalLockManager> {
+        self.lock_manager.clone()
     }
 
     /// Update this instance's erasure setup type.
@@ -116,7 +140,9 @@ static BOOTSTRAP_CTX: OnceLock<Arc<InstanceContext>> = OnceLock::new();
 /// falls back to before an `ECStore` is published, and the `Arc` that
 /// `ECStore::new` adopts as its own `ctx`.
 pub fn bootstrap_ctx() -> Arc<InstanceContext> {
-    BOOTSTRAP_CTX.get_or_init(|| Arc::new(InstanceContext::new())).clone()
+    BOOTSTRAP_CTX
+        .get_or_init(|| Arc::new(InstanceContext::with_lock_manager(get_global_lock_manager())))
+        .clone()
 }
 
 #[cfg(test)]
@@ -179,5 +205,28 @@ mod tests {
 
         assert!(ctx_b.is_erasure_sd().await);
         assert!(!ctx_b.is_erasure().await && !ctx_b.is_dist_erasure().await);
+    }
+
+    // Single-instance zero-change: the bootstrap context's lock manager is the
+    // very same Arc the process singleton hands out, so the lock namespace is
+    // unchanged from before Slice 3.
+    #[tokio::test]
+    async fn bootstrap_lock_manager_aliases_process_singleton() {
+        assert!(
+            Arc::ptr_eq(&bootstrap_ctx().lock_manager(), &get_global_lock_manager()),
+            "bootstrap context must alias the process lock-manager singleton"
+        );
+    }
+
+    // Two independent contexts own distinct lock managers — the property that
+    // stops two instances from falsely contending on same-named objects.
+    #[tokio::test]
+    async fn distinct_contexts_have_distinct_lock_managers() {
+        let ctx_a = InstanceContext::new();
+        let ctx_b = InstanceContext::new();
+        assert!(
+            !Arc::ptr_eq(&ctx_a.lock_manager(), &ctx_b.lock_manager()),
+            "fresh contexts must not share a lock manager"
+        );
     }
 }

--- a/crates/ecstore/src/runtime/sources.rs
+++ b/crates/ecstore/src/runtime/sources.rs
@@ -288,10 +288,6 @@ pub(crate) fn ensure_deployment_id(deployment_id: Uuid) {
     }
 }
 
-pub(crate) fn global_lock_manager() -> Arc<rustfs_lock::GlobalLockManager> {
-    rustfs_lock::get_global_lock_manager()
-}
-
 pub fn global_lock_client() -> Option<Arc<dyn LockClient>> {
     get_global_lock_client()
 }

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1716,6 +1716,10 @@ impl SetDisks {
         format: FormatV3,
         lockers: Vec<Arc<dyn LockClient>>,
     ) -> Arc<Self> {
+        // Single-instance sources the process bootstrap context (the one the
+        // owning ECStore adopts). Slice 8 threads a per-instance context in for
+        // true multi-instance.
+        let ctx = bootstrap_ctx();
         Arc::new(SetDisks {
             locker_owner,
             disks,
@@ -1731,18 +1735,24 @@ impl SetDisks {
                 .time_to_live(GET_OBJECT_METADATA_CACHE_TTL)
                 .build(),
             lockers,
-            local_lock_manager: runtime_sources::global_lock_manager(),
-            // Same injection pattern as local_lock_manager: single-instance
-            // sources the process bootstrap context (the one the owning ECStore
-            // adopts). Slice 8 threads a per-instance context for isolation.
-            ctx: bootstrap_ctx(),
+            // Sourced from the instance context so each instance owns its lock
+            // namespace (Phase 5 Slice 3). Single-instance: ctx aliases the
+            // process lock-manager singleton, so this is unchanged.
+            local_lock_manager: ctx.lock_manager(),
+            ctx,
         })
     }
 
     /// This set's per-instance runtime context (Phase 5, backlog#939).
-    #[allow(dead_code)] // Consumed starting Slice 3 (lock-namespace isolation).
+    #[allow(dead_code)] // Read by tests; consumed by later slices.
     pub(crate) fn instance_ctx(&self) -> &Arc<InstanceContext> {
         &self.ctx
+    }
+
+    /// The lock manager this set actually uses (test-only; Phase 5 Slice 3).
+    #[cfg(test)]
+    pub(crate) fn local_lock_manager_for_test(&self) -> &Arc<rustfs_lock::GlobalLockManager> {
+        &self.local_lock_manager
     }
 
     // async fn cached_disk_health(&self, index: usize) -> Option<bool> {

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1991,6 +1991,25 @@ mod tests {
         );
     }
 
+    // Phase 5 Slice 3 (backlog#939): a SetDisks sources its lock manager from
+    // its instance context (not an independent process lookup), and in a
+    // single-instance build that context aliases the process lock-manager
+    // singleton — so the lock namespace is unchanged.
+    #[tokio::test]
+    async fn set_disks_lock_manager_comes_from_instance_context() {
+        let store = new_read_lock_test_store().await;
+        let set_disks = store.pools[0].disk_set.first().expect("pool has one set");
+
+        assert!(
+            std::sync::Arc::ptr_eq(set_disks.local_lock_manager_for_test(), &set_disks.instance_ctx().lock_manager()),
+            "SetDisks lock manager must be sourced from its instance context"
+        );
+        assert!(
+            std::sync::Arc::ptr_eq(set_disks.local_lock_manager_for_test(), &rustfs_lock::get_global_lock_manager()),
+            "single-instance lock manager must alias the process singleton"
+        );
+    }
+
     #[tokio::test]
     async fn acquired_read_lock_marks_metadata_cache_safe_for_set_layer() {
         let store = new_read_lock_test_store().await;


### PR DESCRIPTION
## Summary

Phase 5 of the global-singleton consolidation (backlog#939) — **Slice 3**. Gives each instance its own **lock namespace** by sourcing `SetDisks`' lock manager from the instance context instead of the process singleton. This eliminates the false cross-instance mutual exclusion (and attendant ABBA deadlock risk) a shared `GlobalLockManager` would cause once instances coexist — the "🟠 fatal #2" raised in the adversarial design review.

> **Stacked on #4415** (Slice 2), which is stacked on #4413 (Slice 1). Base branch is the Slice 2 branch; this PR's diff is Slice 3 only. Retarget down the stack as each merges.

## Changes

- `InstanceContext` gains `lock_manager: Arc<GlobalLockManager>`.
  - `InstanceContext::new()` mints a **fresh** manager — a genuinely independent per-instance namespace.
  - `bootstrap_ctx()` **aliases** the process singleton via `get_global_lock_manager()`, so a single-instance deployment keeps exactly one shared namespace.
- `SetDisks::new` sources `local_lock_manager` from `ctx.lock_manager()` (the context it already adopts) rather than `runtime_sources::global_lock_manager()`. Single-instance: the same `Arc` as before — behavior unchanged.
- Removes the now-unused `runtime_sources::global_lock_manager()` wrapper (its only caller moved to the context).

## Why this is safe for single-instance

`bootstrap_ctx().lock_manager()` returns the very `Arc` `get_global_lock_manager()` hands out, and every `SetDisks` in a single-instance build adopts the bootstrap context. So the lock manager each set uses is byte-for-byte the same object as before this slice.

## Tests

- `bootstrap_lock_manager_aliases_process_singleton` — bootstrap ctx's manager `Arc::ptr_eq` the process singleton.
- `distinct_contexts_have_distinct_lock_managers` — two fresh contexts own different managers (the isolation property).
- `set_disks_lock_manager_comes_from_instance_context` — a real `SetDisks`' `local_lock_manager` is the one from its context **and** aliases the global singleton in a single-instance build.

## Verification

```bash
cargo test -p rustfs-ecstore        # 10 Phase 5 tests + set_disk::ops::locking regressions green
cargo clippy -p rustfs-ecstore --all-targets   # clean
make pre-commit                     # fmt + arch guards + quick-check pass
```

Refs: backlog#939 (Phase 5, Slice 3), stacked on #4415 (Slice 2).
