### PR TITLE
fix(targets): disable HTTP redirects on webhook delivery client

### DIFF
--- a/crates/targets/src/target/webhook.rs
+++ b/crates/targets/src/target/webhook.rs
@@ -223,6 +223,12 @@ where
     fn build_http_client(args: &WebhookArgs) -> Result<Client, TargetError> {
         let mut client_builder = Client::builder()
             .timeout(Duration::from_secs(30))
+            // SSRF hardening (backlog#974): never follow HTTP redirects on webhook delivery.
+            // reqwest follows up to 10 redirects by default, which lets a malicious or
+            // compromised endpoint use a 3xx response to bounce the outbound request to an
+            // internal address (e.g. the cloud metadata service at 169.254.169.254),
+            // bypassing the outbound-endpoint validation performed on the configured URL.
+            .redirect(reqwest::redirect::Policy::none())
             .user_agent(crate::get_user_agent(crate::ServiceType::Basis));
         #[cfg(test)]
         {
@@ -458,6 +464,14 @@ where
             );
             self.delivery_counters.record_success();
             Ok(())
+        } else if status.is_redirection() {
+            // SSRF hardening (backlog#974): redirects are intentionally not followed
+            // (see build_http_client). Treat a 3xx response as a delivery failure rather
+            // than silently chasing the redirect to a potentially internal target.
+            Err(TargetError::Request(format!(
+                "{} returned redirect '{}'; redirects are not followed for webhook delivery",
+                self.args.endpoint, status
+            )))
         } else if status == StatusCode::FORBIDDEN {
             Err(TargetError::Authentication(format!(
                 "{} returned '{}', please check if your auth token is correctly set",
@@ -832,5 +846,47 @@ mod tests {
             Err(err) => err,
         };
         assert!(err.to_string().contains("not allowed"));
+    }
+
+    // SSRF hardening regression (backlog#974): the delivery client must not follow HTTP
+    // redirects, otherwise a 3xx from the endpoint could bounce the outbound request to an
+    // internal address (e.g. the cloud metadata service) and bypass endpoint validation.
+    #[tokio::test]
+    async fn test_webhook_client_does_not_follow_redirects() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        // Minimal HTTP server on an ephemeral loopback port.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let addr = listener.local_addr().expect("local addr");
+
+        // Serve exactly one request with a 302 pointing at an internal metadata address.
+        // If the client followed the redirect it would issue a second request to that
+        // (unreachable) target instead of returning the 3xx status.
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let response =
+                    "HTTP/1.1 302 Found\r\nLocation: http://169.254.169.254/latest/meta-data/\r\nContent-Length: 0\r\n\r\n";
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+
+        let client = WebhookTarget::<serde_json::Value>::build_http_client(&base_args()).expect("build client");
+
+        let resp = client
+            .post(format!("http://{addr}/hook"))
+            .body("{}")
+            .send()
+            .await
+            .expect("request should complete without following the redirect");
+
+        // Redirects are disabled, so the 3xx is surfaced as-is rather than chased to the
+        // internal Location target.
+        assert_eq!(resp.status().as_u16(), 302, "webhook client must not follow redirects");
+
+        handle.join().expect("mock server thread");
     }
 }


### PR DESCRIPTION
## Root cause

The webhook delivery client (`crates/targets/src/target/webhook.rs`, `build_http_client`) was built with `Client::builder()` using reqwest's **default redirect policy**, which follows up to 10 redirects. Although the configured `endpoint` is validated against outbound-egress rules, that validation only covers the initial URL. A malicious or compromised endpoint could respond with a `3xx` and a `Location` header pointing at an internal address (e.g. the cloud metadata service `169.254.169.254`), and reqwest would silently follow it — bypassing the outbound-target restriction. This is an SSRF hardening gap (P1).

## Fix (SSRF hardening)

- Set `.redirect(reqwest::redirect::Policy::none())` on the delivery client so redirects are never followed.
- Treat a `3xx` response as a delivery failure (`TargetError::Request`, error message includes the status code) instead of silently chasing the redirect.
- Change is confined to `webhook.rs`; no plugin manifest / contract changes. The webhook target is the only outbound HTTP (reqwest) target in the crate — MQTT/AMQP/Kafka use their own protocol clients and are unaffected.

## Verification

Only the target crate was checked (per scope):

- `cargo fmt --all` — clean
- `cargo check -p rustfs-targets` — passed
- `cargo clippy -p rustfs-targets --all-targets -- -D warnings` — clean
- `cargo test -p rustfs-targets webhook` — 15 passed, including the new `test_webhook_client_does_not_follow_redirects`, which stands up a loopback server returning `302 -> http://169.254.169.254/...` and asserts the client surfaces the `3xx` rather than following it.

Refs: https://github.com/rustfs/backlog/issues/974