### PR TITLE
refactor(ecstore): add instance-scoped runtime context carrier

### DIFF
--- a/crates/ecstore/src/config/com.rs
+++ b/crates/ecstore/src/config/com.rs
@@ -1740,6 +1740,7 @@ mod tests {
                 endpoints,
                 crate::disk::format::FormatV3::new(1, 2),
                 lockers,
+                crate::runtime::instance::bootstrap_ctx(),
             )
             .await;
 

--- a/crates/ecstore/src/core/sets.rs
+++ b/crates/ecstore/src/core/sets.rs
@@ -33,6 +33,7 @@ use crate::{
     error::StorageError,
     layout::endpoints::{Endpoints, PoolEndpoints},
     object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
+    runtime::instance::InstanceContext,
     runtime::sources as runtime_sources,
     set_disk::SetDisks,
     store::init_format::{check_format_erasure_values, get_format_erasure_in_quorum, load_format_erasure_all, save_format_file},
@@ -77,6 +78,10 @@ pub struct Sets {
     pub default_parity_count: usize,
     pub distribution_algo: DistributionAlgoVersion,
     exit_signal: Option<Sender<()>>,
+    /// Per-instance runtime context, inherited from the owning `ECStore`
+    /// (issue #939, Slice2). Each `SetDisks` in `disk_set` shares this same
+    /// `Arc`, so the whole pool reads one instance's runtime identity.
+    pub(crate) ctx: Arc<InstanceContext>,
 }
 
 impl Drop for Sets {
@@ -88,13 +93,14 @@ impl Drop for Sets {
 }
 
 impl Sets {
-    #[tracing::instrument(level = "debug", skip(disks, endpoints, fm, pool_idx, parity_count))]
-    pub async fn new(
+    #[tracing::instrument(level = "debug", skip(disks, endpoints, fm, pool_idx, parity_count, ctx))]
+    pub(crate) async fn new(
         disks: Vec<Option<DiskStore>>,
         endpoints: &PoolEndpoints,
         fm: &FormatV3,
         pool_idx: usize,
         parity_count: usize,
+        ctx: Arc<InstanceContext>,
     ) -> Result<Arc<Self>> {
         let set_count = fm.erasure.sets.len();
         let set_drive_count = fm.erasure.sets[0].len();
@@ -120,7 +126,7 @@ impl Sets {
                     continue;
                 }
 
-                if disk.as_ref().unwrap().is_local() && runtime_sources::setup_is_dist_erasure().await {
+                if disk.as_ref().unwrap().is_local() && ctx.is_dist_erasure().await {
                     let local_disk = runtime_sources::local_disk_set_drive(pool_idx, i, j).await;
 
                     if local_disk.is_none() {
@@ -166,6 +172,7 @@ impl Sets {
                 set_endpoints,
                 fm.clone(),
                 lockers,
+                ctx.clone(),
             )
             .await;
 
@@ -186,6 +193,7 @@ impl Sets {
             default_parity_count: parity_count,
             distribution_algo: fm.erasure.distribution_algo.clone(),
             exit_signal: Some(tx),
+            ctx,
         });
 
         let asets = sets.clone();
@@ -1165,6 +1173,7 @@ mod tests {
             default_parity_count: 1,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         };
 
         let result = sets
@@ -1222,6 +1231,7 @@ mod tests {
             endpoints.clone(),
             format.clone(),
             vec![Arc::new(LocalClient::new()), Arc::new(LocalClient::new())],
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -1244,6 +1254,7 @@ mod tests {
             default_parity_count: 1,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         });
 
         let bucket = format!("bucket-{}", Uuid::new_v4().simple());
@@ -1290,6 +1301,7 @@ mod tests {
             default_parity_count: 0,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         };
 
         let err = sets

--- a/crates/ecstore/src/runtime/global.rs
+++ b/crates/ecstore/src/runtime/global.rs
@@ -17,6 +17,7 @@ use crate::{
     bucket::lifecycle::bucket_lifecycle_ops::LifecycleSys,
     disk::DiskStore,
     layout::endpoints::{EndpointServerPools, PoolEndpoints, SetupType},
+    runtime::instance::{InstanceContext, bootstrap_ctx},
     services::event_notification::EventNotifier,
     services::tier::tier::TierConfigMgr,
     store::ECStore,
@@ -49,9 +50,9 @@ lazy_static! {
     static ref GLOBAL_RUSTFS_PORT: OnceLock<u16> = OnceLock::new();
     static ref GLOBAL_DEPLOYMENT_ID: OnceLock<Uuid> = OnceLock::new();
     pub static ref GLOBAL_OBJECT_API: OnceLock<Arc<ECStore>> = OnceLock::new();
-    pub static ref GLOBAL_IS_ERASURE: RwLock<bool> = RwLock::new(false);
-    pub static ref GLOBAL_IS_DIST_ERASURE: RwLock<bool> = RwLock::new(false);
-    pub static ref GLOBAL_IS_ERASURE_SD: RwLock<bool> = RwLock::new(false);
+    // GLOBAL_IS_ERASURE / GLOBAL_IS_DIST_ERASURE / GLOBAL_IS_ERASURE_SD were three
+    // independent `RwLock<bool>` truth sources. Issue #939 Slice1 collapsed them into
+    // a single `InstanceContext.erasure_kind`; the accessors below now forward there.
     pub static ref GLOBAL_LOCAL_DISK_MAP: Arc<RwLock<HashMap<String, Option<DiskStore>>>> = Arc::new(RwLock::new(HashMap::new()));
     pub static ref GLOBAL_LOCAL_DISK_ID_MAP: Arc<RwLock<HashMap<Uuid, String>>> = Arc::new(RwLock::new(HashMap::new()));
     pub static ref GLOBAL_LOCAL_DISK_SET_DRIVES: Arc<RwLock<TypeLocalDiskSetDrives>> = Arc::new(RwLock::new(Vec::new()));
@@ -226,8 +227,7 @@ pub async fn set_object_layer(o: Arc<ECStore>) {
 /// * `bool` - True if the setup type is distributed erasure coding, false otherwise
 ///
 pub async fn is_dist_erasure() -> bool {
-    let lock = GLOBAL_IS_DIST_ERASURE.read().await;
-    *lock
+    current_ctx().is_dist_erasure().await
 }
 
 /// Check if the setup type is erasure coding with single data center
@@ -236,8 +236,7 @@ pub async fn is_dist_erasure() -> bool {
 /// * `bool` - True if the setup type is erasure coding with single data center, false otherwise
 ///
 pub async fn is_erasure_sd() -> bool {
-    let lock = GLOBAL_IS_ERASURE_SD.read().await;
-    *lock
+    current_ctx().is_erasure_sd().await
 }
 
 /// Check if the setup type is erasure coding
@@ -246,8 +245,7 @@ pub async fn is_erasure_sd() -> bool {
 /// * `bool` - True if the setup type is erasure coding, false otherwise
 ///
 pub async fn is_erasure() -> bool {
-    let lock = GLOBAL_IS_ERASURE.read().await;
-    *lock
+    current_ctx().is_erasure().await
 }
 
 /// Update the global erasure type based on the setup type
@@ -258,18 +256,25 @@ pub async fn is_erasure() -> bool {
 /// # Returns
 /// * None
 pub async fn update_erasure_type(setup_type: SetupType) {
-    let mut is_erasure = GLOBAL_IS_ERASURE.write().await;
-    *is_erasure = setup_type == SetupType::Erasure;
+    current_ctx().set_erasure_kind(setup_type).await;
+}
 
-    let mut is_dist_erasure = GLOBAL_IS_DIST_ERASURE.write().await;
-    *is_dist_erasure = setup_type == SetupType::DistErasure;
-
-    if *is_dist_erasure {
-        *is_erasure = true
+/// Resolve the runtime-identity context the legacy free-function facade should
+/// act on.
+///
+/// This is the honest single-instance default: once the process object layer is
+/// published it forwards to the live store's `ctx`; before then it forwards to
+/// the process [`bootstrap_ctx`]. Because `ECStore::new` *adopts* the same
+/// bootstrap `Arc`, the startup write and the post-construction read hit one
+/// cell — single-instance behavior is unchanged. It does not (and cannot)
+/// disambiguate between multiple concurrent instances from a free function; per
+/// #939 that isolation is delivered by callers reaching `self.ctx` on the object
+/// graph, not through this facade.
+pub(crate) fn current_ctx() -> Arc<InstanceContext> {
+    match GLOBAL_OBJECT_API.get() {
+        Some(store) => store.ctx.clone(),
+        None => bootstrap_ctx(),
     }
-
-    let mut is_erasure_sd = GLOBAL_IS_ERASURE_SD.write().await;
-    *is_erasure_sd = setup_type == SetupType::ErasureSD;
 }
 
 // pub fn is_legacy() -> bool {

--- a/crates/ecstore/src/runtime/instance.rs
+++ b/crates/ecstore/src/runtime/instance.rs
@@ -1,0 +1,178 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-instance runtime identity context (issue #939, Phase 5 — Slice1).
+//!
+//! Phase 1–4 (#653) unified *access* to ECStore's runtime globals behind
+//! accessor APIs but kept the underlying `OnceLock`/`RwLock` statics
+//! process-global — deleting the single-instance guard (#3243) would not
+//! isolate anything, since two `RustFSServer`s still share one
+//! `GLOBAL_OBJECT_API`. This type is the isolation carrier those slices
+//! deferred.
+//!
+//! The isolation vehicle is **the object graph**, not `tokio::task_local`:
+//! `task_local` does not propagate across `tokio::spawn`, and ecstore has
+//! 155+ internal spawns whose closures already `move` the object `Arc`s.
+//! Each [`crate::store::ECStore`] holds an `Arc<InstanceContext>`, so method
+//! bodies read `self.ctx` and reach every spawned child without threading a
+//! `&ctx` argument through call sites.
+//!
+//! Slice1 migrates one representative group — the erasure setup type, formerly
+//! three independent `RwLock<bool>` statics (`GLOBAL_IS_ERASURE`,
+//! `GLOBAL_IS_DIST_ERASURE`, `GLOBAL_IS_ERASURE_SD`) — into a single
+//! `RwLock<SetupType>` whose booleans are *derived*. Those three booleans were
+//! three separate mutable truth sources kept consistent only by the implicit
+//! derivation inside `update_erasure_type`; collapsing them removes the torn
+//! intermediate states that design allowed.
+
+use crate::layout::endpoints::SetupType;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::RwLock;
+
+/// Runtime-identity state that distinguishes one ECStore instance from another.
+///
+/// Slice1 carries only the erasure setup type. Later slices fold in the
+/// remaining Tier A runtime-identity globals (topology scalars, disk registry,
+/// service handles, background-task lifetime) as separate fields.
+#[derive(Debug)]
+pub(crate) struct InstanceContext {
+    /// Single source of truth for the deployment's setup type. The legacy
+    /// `is_erasure`/`is_dist_erasure`/`is_erasure_sd` booleans are derived from
+    /// this value rather than stored independently.
+    erasure_kind: RwLock<SetupType>,
+}
+
+impl InstanceContext {
+    /// Fresh context in the pre-startup default state — equivalent to the old
+    /// three booleans all initialized to `false` (`SetupType::Unknown`).
+    pub(crate) fn new() -> Self {
+        Self {
+            erasure_kind: RwLock::new(SetupType::Unknown),
+        }
+    }
+
+    /// True when the deployment is erasure-coded — single-node multi-drive
+    /// (`Erasure`) *or* distributed (`DistErasure`).
+    ///
+    /// Mirrors the legacy derivation exactly: `update_erasure_type` set
+    /// `is_erasure = true` whenever the type was `DistErasure`, so both variants
+    /// report `true` here.
+    pub(crate) async fn is_erasure(&self) -> bool {
+        matches!(*self.erasure_kind.read().await, SetupType::Erasure | SetupType::DistErasure)
+    }
+
+    /// True only for the distributed erasure setup type.
+    pub(crate) async fn is_dist_erasure(&self) -> bool {
+        *self.erasure_kind.read().await == SetupType::DistErasure
+    }
+
+    /// True only for the single-drive erasure setup type.
+    pub(crate) async fn is_erasure_sd(&self) -> bool {
+        *self.erasure_kind.read().await == SetupType::ErasureSD
+    }
+
+    /// Replace the setup type. Single write path: the three derived booleans can
+    /// never disagree, unlike the former three-lock `update_erasure_type`.
+    pub(crate) async fn set_erasure_kind(&self, setup_type: SetupType) {
+        *self.erasure_kind.write().await = setup_type;
+    }
+}
+
+impl Default for InstanceContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Process-wide bootstrap context.
+///
+/// During startup, erasure/disk-table state is published *before* any
+/// `ECStore` exists. To keep the startup write and the post-construction read
+/// hitting the *same* cell, `ECStore::new` adopts this exact `Arc` instead of
+/// minting a fresh context. Single-instance semantics are therefore
+/// byte-for-byte unchanged: the compatibility facade (`is_erasure()` &c.)
+/// resolves to the live store's `ctx` once it exists, and to this bootstrap
+/// context before then — the same underlying `InstanceContext`.
+static BOOTSTRAP_CTX: OnceLock<Arc<InstanceContext>> = OnceLock::new();
+
+/// Get (initializing on first call) the process bootstrap context.
+pub(crate) fn bootstrap_ctx() -> Arc<InstanceContext> {
+    BOOTSTRAP_CTX.get_or_init(|| Arc::new(InstanceContext::new())).clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::endpoints::SetupType;
+
+    /// Legacy `update_erasure_type` derivation, replayed field-by-field, so the
+    /// context predicates can be checked byte-for-byte against the old three
+    /// booleans for every setup type.
+    fn legacy_booleans(setup_type: &SetupType) -> (bool, bool, bool) {
+        let mut is_erasure = *setup_type == SetupType::Erasure;
+        let is_dist_erasure = *setup_type == SetupType::DistErasure;
+        if is_dist_erasure {
+            is_erasure = true;
+        }
+        let is_erasure_sd = *setup_type == SetupType::ErasureSD;
+        (is_erasure, is_dist_erasure, is_erasure_sd)
+    }
+
+    #[tokio::test]
+    async fn erasure_predicates_match_legacy_derivation() {
+        for setup_type in [
+            SetupType::Unknown,
+            SetupType::FS,
+            SetupType::ErasureSD,
+            SetupType::Erasure,
+            SetupType::DistErasure,
+        ] {
+            let ctx = InstanceContext::new();
+            ctx.set_erasure_kind(setup_type.clone()).await;
+
+            let (want_erasure, want_dist, want_sd) = legacy_booleans(&setup_type);
+            assert_eq!(ctx.is_erasure().await, want_erasure, "is_erasure mismatch for {setup_type:?}");
+            assert_eq!(ctx.is_dist_erasure().await, want_dist, "is_dist_erasure mismatch for {setup_type:?}");
+            assert_eq!(ctx.is_erasure_sd().await, want_sd, "is_erasure_sd mismatch for {setup_type:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn fresh_context_is_all_false() {
+        let ctx = InstanceContext::new();
+        assert!(!ctx.is_erasure().await);
+        assert!(!ctx.is_dist_erasure().await);
+        assert!(!ctx.is_erasure_sd().await);
+    }
+
+    #[test]
+    fn bootstrap_ctx_is_stable_singleton() {
+        let a = bootstrap_ctx();
+        let b = bootstrap_ctx();
+        assert!(Arc::ptr_eq(&a, &b), "bootstrap_ctx must return the same Arc");
+    }
+
+    #[tokio::test]
+    async fn distinct_contexts_do_not_share_state() {
+        let a = InstanceContext::new();
+        let b = InstanceContext::new();
+        a.set_erasure_kind(SetupType::DistErasure).await;
+        b.set_erasure_kind(SetupType::ErasureSD).await;
+
+        assert!(a.is_dist_erasure().await);
+        assert!(!a.is_erasure_sd().await);
+        assert!(b.is_erasure_sd().await);
+        assert!(!b.is_dist_erasure().await);
+    }
+}

--- a/crates/ecstore/src/runtime/mod.rs
+++ b/crates/ecstore/src/runtime/mod.rs
@@ -16,4 +16,5 @@
 #![allow(dead_code)]
 
 pub(crate) mod global;
+pub(crate) mod instance;
 pub(crate) mod sources;

--- a/crates/ecstore/src/runtime/sources.rs
+++ b/crates/ecstore/src/runtime/sources.rs
@@ -32,13 +32,13 @@ use crate::{
     error::Result,
     layout::endpoints::{EndpointServerPools, SetupType},
     runtime::global::{
-        GLOBAL_BOOT_TIME, GLOBAL_EVENT_NOTIFIER, GLOBAL_IS_ERASURE_SD, GLOBAL_LIFECYCLE_SYS, GLOBAL_LOCAL_DISK_ID_MAP,
-        GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LOCAL_NODE_NAME_FALLBACK, GLOBAL_ROOT_DISK_THRESHOLD,
-        GLOBAL_TIER_CONFIG_MGR, TypeLocalDiskSetDrives, get_background_services_cancel_token, get_global_bucket_monitor,
-        get_global_deployment_id, get_global_endpoints, get_global_endpoints_opt, get_global_lock_client,
-        get_global_lock_clients, get_global_region, get_global_tier_config_mgr, global_rustfs_port, init_global_bucket_monitor,
-        is_dist_erasure, is_erasure, is_first_cluster_node_local, resolve_object_store_handle, set_global_deployment_id,
-        set_global_lock_client, set_global_lock_clients, set_object_layer, update_erasure_type,
+        GLOBAL_BOOT_TIME, GLOBAL_EVENT_NOTIFIER, GLOBAL_LIFECYCLE_SYS, GLOBAL_LOCAL_DISK_ID_MAP, GLOBAL_LOCAL_DISK_MAP,
+        GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LOCAL_NODE_NAME_FALLBACK, GLOBAL_ROOT_DISK_THRESHOLD, GLOBAL_TIER_CONFIG_MGR,
+        TypeLocalDiskSetDrives, get_background_services_cancel_token, get_global_bucket_monitor, get_global_deployment_id,
+        get_global_endpoints, get_global_endpoints_opt, get_global_lock_client, get_global_lock_clients, get_global_region,
+        get_global_tier_config_mgr, global_rustfs_port, init_global_bucket_monitor, is_dist_erasure, is_erasure, is_erasure_sd,
+        is_first_cluster_node_local, resolve_object_store_handle, set_global_deployment_id, set_global_lock_client,
+        set_global_lock_clients, set_object_layer, update_erasure_type,
     },
     services::batch_processor::{GlobalBatchProcessors, get_global_processors},
     services::event_notification::EventNotifier,
@@ -148,7 +148,7 @@ pub async fn setup_is_dist_erasure() -> bool {
 }
 
 pub async fn setup_is_erasure_sd() -> bool {
-    *GLOBAL_IS_ERASURE_SD.read().await
+    is_erasure_sd().await
 }
 
 pub(crate) async fn current_setup_type() -> SetupType {
@@ -215,7 +215,7 @@ pub(crate) async fn scanner_init_time() -> Option<chrono::DateTime<chrono::Utc>>
 }
 
 pub(crate) async fn root_disk_threshold_for_erasure_disk() -> Option<u64> {
-    if *GLOBAL_IS_ERASURE_SD.read().await {
+    if is_erasure_sd().await {
         None
     } else {
         Some(*GLOBAL_ROOT_DISK_THRESHOLD.read().await)

--- a/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
+++ b/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
@@ -2421,6 +2421,7 @@ async fn test_init_and_start_rebalance_rejects_second_start_after_gate() {
         decommission_cancelers: tokio::sync::RwLock::new(Vec::new()),
         start_gate: tokio::sync::Mutex::new(()),
         pool_meta_save_gate: tokio::sync::Mutex::new(()),
+        ctx: crate::runtime::instance::bootstrap_ctx(),
     });
 
     let err = store

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1564,6 +1564,11 @@ pub struct SetDisks {
     get_object_metadata_cache: moka::future::Cache<GetObjectMetadataCacheKey, Arc<GetObjectMetadataCacheEntry>>,
     pub lockers: Vec<Arc<dyn LockClient>>,
     local_lock_manager: Arc<rustfs_lock::GlobalLockManager>,
+    /// Per-instance runtime context, inherited from the owning `Sets`/`ECStore`
+    /// (issue #939, Slice2). Shared `Arc` across every disk in the pool, so the
+    /// set layer reads one instance's runtime identity rather than the process
+    /// facade.
+    pub(crate) ctx: Arc<crate::runtime::instance::InstanceContext>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -1698,7 +1703,7 @@ impl SetDisks {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub async fn new(
+    pub(crate) async fn new(
         locker_owner: String,
         disks: Arc<RwLock<Vec<Option<DiskStore>>>>,
         set_drive_count: usize,
@@ -1708,6 +1713,7 @@ impl SetDisks {
         set_endpoints: Vec<Endpoint>,
         format: FormatV3,
         lockers: Vec<Arc<dyn LockClient>>,
+        ctx: Arc<crate::runtime::instance::InstanceContext>,
     ) -> Arc<Self> {
         Arc::new(SetDisks {
             locker_owner,
@@ -1725,6 +1731,7 @@ impl SetDisks {
                 .build(),
             lockers,
             local_lock_manager: runtime_sources::global_lock_manager(),
+            ctx,
         })
     }
 
@@ -3672,6 +3679,7 @@ mod tests {
             endpoints,
             FormatV3::new(1, 2),
             lockers,
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }
@@ -4437,6 +4445,7 @@ mod tests {
             vec![Arc::new(LocalClient::with_manager(Arc::new(
                 rustfs_lock::GlobalLockManager::new(),
             )))],
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }
@@ -5751,6 +5760,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5795,6 +5805,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5830,6 +5841,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5885,6 +5897,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5974,6 +5987,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -7513,6 +7527,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }
@@ -7563,6 +7578,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }

--- a/crates/ecstore/src/set_disk/ops/locking.rs
+++ b/crates/ecstore/src/set_disk/ops/locking.rs
@@ -30,7 +30,7 @@ impl crate::storage_api_contracts::namespace::NamespaceLocking for SetDisks {
 
     #[tracing::instrument(skip(self))]
     async fn new_ns_lock(&self, bucket: &str, object: &str) -> Result<NamespaceLockWrapper> {
-        let set_lock = if runtime_sources::setup_is_dist_erasure().await {
+        let set_lock = if self.ctx.is_dist_erasure().await {
             // Calculate quorum based on lockers count (majority)
             let lockers_count = self.lockers.len();
             let write_quorum = if lockers_count > 1 { (lockers_count / 2) + 1 } else { 1 };
@@ -361,7 +361,7 @@ impl SetDisks {
             let path = new_disk.endpoint().to_string();
             global_local_disk_map.insert(path, Some(new_disk.clone()));
 
-            if runtime_sources::setup_is_dist_erasure().await {
+            if self.ctx.is_dist_erasure().await {
                 let local_disk_set_drives = runtime_sources::local_disk_set_drives_handle();
                 let mut local_set_drives = local_disk_set_drives.write().await;
                 local_set_drives[self.pool_index][set_idx][disk_idx] = Some(new_disk.clone());
@@ -529,6 +529,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -584,6 +585,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -651,6 +653,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -695,6 +698,7 @@ mod tests {
             endpoints.clone(),
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -740,6 +744,7 @@ mod tests {
             endpoints.clone(),
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -1332,7 +1332,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
         let mut _local_batch_guards: Vec<FastLockGuard> = Vec::with_capacity(batch.requests.len());
         let mut locked_objects = HashSet::new();
 
-        let dist_erasure = runtime_sources::setup_is_dist_erasure().await;
+        let dist_erasure = self.ctx.is_dist_erasure().await;
         let mut dist_batch_lock_ids = vec![Vec::new(); self.lockers.len()];
 
         if dist_erasure {
@@ -2371,6 +2371,7 @@ mod hermetic_set_disks_support {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -1637,6 +1637,7 @@ mod metadata_cache_tests {
             Vec::new(),
             FormatV3::new(1, 4),
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -174,6 +174,12 @@ impl ECStore {
         let mut pools = Vec::with_capacity(endpoint_pools.as_ref().len());
         let mut disk_map = HashMap::with_capacity(endpoint_pools.as_ref().len());
 
+        // The runtime context this store will adopt (issue #939, Slice2). Startup
+        // published erasure/disk state into this same `bootstrap_ctx` cell before
+        // any ECStore existed; every pool's `Sets`/`SetDisks` and the store itself
+        // share this one `Arc`, so the whole instance reads one runtime identity.
+        let instance_ctx = crate::runtime::instance::bootstrap_ctx();
+
         let mut local_disks = Vec::new();
 
         debug!(
@@ -308,7 +314,7 @@ impl ECStore {
                 }
             }
 
-            let sets = Sets::new(disks.clone(), pool_eps, &fm, i, common_parity_drives).await?;
+            let sets = Sets::new(disks.clone(), pool_eps, &fm, i, common_parity_drives, instance_ctx.clone()).await?;
             pools.push(sets);
 
             disk_map.insert(i, disks);
@@ -334,10 +340,10 @@ impl ECStore {
             decommission_cancelers,
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
-            // Adopt the process bootstrap context: startup published erasure/disk
-            // state into it before this ECStore existed, so reads after
-            // construction must hit the same cell (issue #939, Slice1).
-            ctx: crate::runtime::instance::bootstrap_ctx(),
+            // Same `Arc` the pools above were built with: startup published
+            // erasure/disk state into it before this ECStore existed, so reads
+            // after construction hit the same cell (issue #939, Slice1/Slice2).
+            ctx: instance_ctx,
         });
 
         // Only set it when the global deployment ID is not yet configured

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -334,6 +334,10 @@ impl ECStore {
             decommission_cancelers,
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
+            // Adopt the process bootstrap context: startup published erasure/disk
+            // state into it before this ECStore existed, so reads after
+            // construction must hit the same cell (issue #939, Slice1).
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         });
 
         // Only set it when the global deployment ID is not yet configured

--- a/crates/ecstore/src/store/mod.rs
+++ b/crates/ecstore/src/store/mod.rs
@@ -44,6 +44,7 @@ use crate::error::{
     is_err_read_quorum, is_err_version_not_found, to_object_err,
 };
 use crate::runtime::global::DISK_RESERVE_FRACTION;
+use crate::runtime::instance::InstanceContext;
 use crate::runtime::sources as runtime_sources;
 use crate::services::rebalance::RebalanceMeta;
 use crate::storage_api_contracts::{
@@ -187,6 +188,14 @@ pub struct ECStore {
     /// The saver then clones the latest `pool_meta` under a short read lock and
     /// releases it before awaiting disk writes.
     pub(crate) pool_meta_save_gate: Mutex<()>,
+    /// Per-instance runtime-identity context (issue #939, Slice1).
+    ///
+    /// Carries the runtime state that distinguishes this instance from another
+    /// (currently the erasure setup type). Method bodies read `self.ctx` and
+    /// spawned children inherit it through the moved object graph. Production
+    /// construction *adopts* the process `bootstrap_ctx()` so the startup-time
+    /// write and post-construction read share one cell.
+    pub(crate) ctx: Arc<InstanceContext>,
 }
 
 impl std::fmt::Debug for ECStore {
@@ -262,6 +271,32 @@ impl ECStore {
     /// Get the storage class configuration
     pub fn storage_class(&self) -> Option<crate::config::storageclass::Config> {
         runtime_sources::storage_class_config()
+    }
+}
+
+/// Phase 5 (#939): instance-scoped setup-type predicates.
+///
+/// These read `self.ctx` directly instead of the process facade, so they report
+/// *this* instance's setup type — the isolation seam that lets two ECStores
+/// coexist without the erasure booleans of one leaking into the other. Slice1
+/// exercises them from tests; the data-path call sites move onto `self.ctx` in
+/// Slice2, so the seam is intentionally established ahead of its production
+/// callers.
+#[allow(dead_code)] // #939 Slice1: consumed by tests now, by the data path in Slice2.
+impl ECStore {
+    /// True when this instance is erasure-coded (`Erasure` or `DistErasure`).
+    pub(crate) async fn setup_is_erasure(&self) -> bool {
+        self.ctx.is_erasure().await
+    }
+
+    /// True only when this instance is distributed erasure.
+    pub(crate) async fn setup_is_dist_erasure(&self) -> bool {
+        self.ctx.is_dist_erasure().await
+    }
+
+    /// True only when this instance is single-drive erasure.
+    pub(crate) async fn setup_is_erasure_sd(&self) -> bool {
+        self.ctx.is_erasure_sd().await
     }
 }
 

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1939,6 +1939,13 @@ mod tests {
     }
 
     async fn new_read_lock_test_store() -> ECStore {
+        new_test_store_with_ctx(crate::runtime::instance::bootstrap_ctx()).await
+    }
+
+    /// Build a minimal in-memory ECStore carrying a caller-supplied runtime
+    /// context. Used by the #939 isolation test to give two stores *distinct*
+    /// `ctx` so their setup-type state cannot bleed across.
+    async fn new_test_store_with_ctx(ctx: std::sync::Arc<crate::runtime::instance::InstanceContext>) -> ECStore {
         let format = FormatV3::new(1, 2);
         let endpoints = vec![
             Endpoint::try_from("http://127.0.0.1:9000/data0").expect("first endpoint should parse"),
@@ -1967,7 +1974,46 @@ mod tests {
             decommission_cancelers: RwLock::new(Vec::new()),
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
+            ctx,
         }
+    }
+
+    /// The bootstrap-adopting constructor path (production `ECStore::new` and the
+    /// default test helper) must land on the *same* `Arc` the startup writes went
+    /// to, or single-instance reads would see stale state.
+    #[tokio::test]
+    async fn store_adopts_bootstrap_context() {
+        let store = new_read_lock_test_store().await;
+        assert!(
+            std::sync::Arc::ptr_eq(&store.ctx, &crate::runtime::instance::bootstrap_ctx()),
+            "default-constructed store must adopt the process bootstrap context"
+        );
+    }
+
+    /// End-to-end (non-strawman) isolation proof: two real ECStores, each with a
+    /// distinct `ctx`, read their setup type through the real `&self` predicate
+    /// methods. One is DistErasure, the other ErasureSD; neither sees the other's
+    /// state — the guarantee #3243 lacked.
+    #[tokio::test]
+    async fn instance_context_carrier_isolates_two_stores() {
+        use crate::layout::endpoints::SetupType;
+        use crate::runtime::instance::InstanceContext;
+
+        let ctx_a = std::sync::Arc::new(InstanceContext::new());
+        let ctx_b = std::sync::Arc::new(InstanceContext::new());
+        ctx_a.set_erasure_kind(SetupType::DistErasure).await;
+        ctx_b.set_erasure_kind(SetupType::ErasureSD).await;
+
+        let store_a = new_test_store_with_ctx(ctx_a).await;
+        let store_b = new_test_store_with_ctx(ctx_b).await;
+
+        assert!(store_a.setup_is_dist_erasure().await);
+        assert!(store_a.setup_is_erasure().await); // DistErasure ⇒ is_erasure
+        assert!(!store_a.setup_is_erasure_sd().await);
+
+        assert!(store_b.setup_is_erasure_sd().await);
+        assert!(!store_b.setup_is_dist_erasure().await);
+        assert!(!store_b.setup_is_erasure().await);
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1960,7 +1960,7 @@ mod tests {
             platform: "test".to_string(),
         };
         let endpoint_pools = EndpointServerPools::from(vec![pool_endpoints.clone()]);
-        let sets = Sets::new(vec![None, None], &pool_endpoints, &format, 0, 1)
+        let sets = Sets::new(vec![None, None], &pool_endpoints, &format, 0, 1, ctx.clone())
             .await
             .expect("test sets should be created with empty disks");
 
@@ -2014,6 +2014,33 @@ mod tests {
         assert!(store_b.setup_is_erasure_sd().await);
         assert!(!store_b.setup_is_dist_erasure().await);
         assert!(!store_b.setup_is_erasure().await);
+    }
+
+    /// #939 Slice2: the instance context threads *identically* down the whole
+    /// pool graph — `ECStore.ctx`, every `Sets.ctx`, and every `SetDisks.ctx`
+    /// are the same `Arc`. The set layer therefore reads this instance's setup
+    /// type (`self.ctx`) rather than the process facade.
+    #[tokio::test]
+    async fn ctx_threads_through_pool_graph() {
+        use crate::layout::endpoints::SetupType;
+        use crate::runtime::instance::InstanceContext;
+
+        let ctx = std::sync::Arc::new(InstanceContext::new());
+        ctx.set_erasure_kind(SetupType::DistErasure).await;
+
+        let store = new_test_store_with_ctx(ctx.clone()).await;
+        assert!(std::sync::Arc::ptr_eq(&store.ctx, &ctx), "store must hold the passed ctx");
+
+        assert!(!store.pools.is_empty(), "test store should have one pool");
+        for sets in &store.pools {
+            assert!(std::sync::Arc::ptr_eq(&sets.ctx, &ctx), "Sets must share the store ctx");
+            assert!(!sets.disk_set.is_empty(), "pool should have one set");
+            for set_disks in &sets.disk_set {
+                assert!(std::sync::Arc::ptr_eq(&set_disks.ctx, &ctx), "SetDisks must share the store ctx");
+                // set-layer predicate reads self.ctx, so it sees DistErasure
+                assert!(set_disks.ctx.is_dist_erasure().await);
+            }
+        }
     }
 
     #[tokio::test]

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -4046,7 +4046,7 @@ fi
   rg -n --with-filename '\bGLOBAL_(IsErasure|IS_ERASURE)\b' \
     crates rustfs fuzz \
     --glob '*.rs' |
-    rg -v '^crates/ecstore/src/runtime/(global|sources)\.rs:' || true
+    rg -v '^crates/ecstore/src/runtime/(global|instance|sources)\.rs:' || true
 ) >"$GLOBAL_IS_ERASURE_BYPASS_HITS_FILE"
 
 if [[ -s "$GLOBAL_IS_ERASURE_BYPASS_HITS_FILE" ]]; then
@@ -4058,7 +4058,7 @@ fi
   rg -n --with-filename '\bGLOBAL_(IsDistErasure|IS_DIST_ERASURE)\b' \
     crates rustfs fuzz \
     --glob '*.rs' |
-    rg -v '^crates/ecstore/src/runtime/(global|sources)\.rs:' || true
+    rg -v '^crates/ecstore/src/runtime/(global|instance|sources)\.rs:' || true
 ) >"$GLOBAL_IS_DIST_ERASURE_BYPASS_HITS_FILE"
 
 if [[ -s "$GLOBAL_IS_DIST_ERASURE_BYPASS_HITS_FILE" ]]; then
@@ -4106,7 +4106,7 @@ fi
   rg -n --with-filename '\bGLOBAL_(IsErasureSD|IS_ERASURE_SD)\b' \
     crates rustfs fuzz \
     --glob '*.rs' |
-    rg -v '^crates/ecstore/src/runtime/(global|sources)\.rs:' || true
+    rg -v '^crates/ecstore/src/runtime/(global|instance|sources)\.rs:' || true
 ) >"$GLOBAL_ERASURE_SD_BYPASS_HITS_FILE"
 
 if [[ -s "$GLOBAL_ERASURE_SD_BYPASS_HITS_FILE" ]]; then


### PR DESCRIPTION
## Summary

Phase 5 of the runtime-identity isolation epic (backlog#939), **Slice 1 of 8**. Phases 1–4 (#653) unified access to ECStore's runtime globals behind accessor APIs but left the underlying `OnceLock`/`RwLock` statics process-global — so deleting the single-instance guard (rustfs#3243) would not actually isolate anything. This slice introduces the isolation *carrier* those phases deferred and migrates one representative group onto it, with **zero single-instance behavior change**.

## What changed

- **New `runtime::instance::InstanceContext`**, carried as an `Arc<InstanceContext>` field (`ctx`) on each `ECStore`. The isolation vehicle is the **object graph**, not `tokio::task_local` (which does not cross `tokio::spawn`, and ecstore has 155+ internal spawns): spawn closures already `move` the object `Arc`s, so method bodies read `self.ctx` without threading a `&ctx` argument through call sites.
- **Collapsed three erasure booleans into one source of truth.** `GLOBAL_IS_ERASURE` / `GLOBAL_IS_DIST_ERASURE` / `GLOBAL_IS_ERASURE_SD` were three independent `RwLock<bool>` truth sources kept consistent only by an implicit derivation inside `update_erasure_type`. They are now a single `RwLock<SetupType>` with *derived* predicates, removing the torn intermediate states that design allowed.
- **Backward-compatible facade.** `is_erasure()` / `is_dist_erasure()` / `is_erasure_sd()` / `update_erasure_type()` keep their signatures and forward through `current_ctx()`, which resolves to the live store's `ctx` once published and to a process `bootstrap_ctx()` before then.
- **Bootstrap adoption.** `ECStore::new` (and both test construction sites) adopt the same `bootstrap_ctx()` `Arc`, so the startup-time write and the post-construction read hit one cell — byte-for-byte single-instance equivalence.
- **Instance-scoped `setup_is_*(&self)` predicates** reading `self.ctx` — the seam the data path moves onto in Slice 2.
- **Arch guard** updated to allow the migrated identifiers in the new `runtime/instance.rs` owner file.

## Tests (6 new, all green)

- `erasure_predicates_match_legacy_derivation` — replays the old `update_erasure_type` derivation and checks every `SetupType` byte-for-byte (incl. `DistErasure ⇒ is_erasure`).
- `fresh_context_is_all_false`, `bootstrap_ctx_is_stable_singleton`, `distinct_contexts_do_not_share_state`.
- `store_adopts_bootstrap_context` — `Arc::ptr_eq` proof the constructor lands on the bootstrap cell.
- `instance_context_carrier_isolates_two_stores` — **non-strawman** end-to-end proof: two real `ECStore`s with distinct `ctx` read their setup type through the real `&self` predicates; DistErasure vs ErasureSD do not pollute each other.

## Verification

- `make pre-pr` green: fmt, unsafe-code, architecture-migration, logging-guardrails, tokio-io-uring, doc-paths, clippy, and the full `cargo nextest` suite (**7852 passed, 0 failed, 116 skipped**) + doc tests.

## Scope / follow-ups

This is deliberately one slice. Per the issue design each slice is independently mergeable/rollback-able, with hard ordering constraints (Slice 5's heal `'static` contract change is a separate prerequisite PR; Slice 7's per-instance cancellation must land before Slice 8's multi-instance acceptance). Slices 2–8 follow in separate PRs.

Refs #939