### PR TITLE
refactor(ecstore): sink instance context into Sets/SetDisks (backlog#939 Slice2)

### DIFF
--- a/crates/ecstore/src/config/com.rs
+++ b/crates/ecstore/src/config/com.rs
@@ -1740,6 +1740,7 @@ mod tests {
                 endpoints,
                 crate::disk::format::FormatV3::new(1, 2),
                 lockers,
+                crate::runtime::instance::bootstrap_ctx(),
             )
             .await;
 

--- a/crates/ecstore/src/core/sets.rs
+++ b/crates/ecstore/src/core/sets.rs
@@ -33,6 +33,7 @@ use crate::{
     error::StorageError,
     layout::endpoints::{Endpoints, PoolEndpoints},
     object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
+    runtime::instance::InstanceContext,
     runtime::sources as runtime_sources,
     set_disk::SetDisks,
     store::init_format::{check_format_erasure_values, get_format_erasure_in_quorum, load_format_erasure_all, save_format_file},
@@ -77,6 +78,10 @@ pub struct Sets {
     pub default_parity_count: usize,
     pub distribution_algo: DistributionAlgoVersion,
     exit_signal: Option<Sender<()>>,
+    /// Per-instance runtime context, inherited from the owning `ECStore`
+    /// (issue #939, Slice2). Each `SetDisks` in `disk_set` shares this same
+    /// `Arc`, so the whole pool reads one instance's runtime identity.
+    pub(crate) ctx: Arc<InstanceContext>,
 }
 
 impl Drop for Sets {
@@ -88,13 +93,14 @@ impl Drop for Sets {
 }
 
 impl Sets {
-    #[tracing::instrument(level = "debug", skip(disks, endpoints, fm, pool_idx, parity_count))]
-    pub async fn new(
+    #[tracing::instrument(level = "debug", skip(disks, endpoints, fm, pool_idx, parity_count, ctx))]
+    pub(crate) async fn new(
         disks: Vec<Option<DiskStore>>,
         endpoints: &PoolEndpoints,
         fm: &FormatV3,
         pool_idx: usize,
         parity_count: usize,
+        ctx: Arc<InstanceContext>,
     ) -> Result<Arc<Self>> {
         let set_count = fm.erasure.sets.len();
         let set_drive_count = fm.erasure.sets[0].len();
@@ -120,7 +126,7 @@ impl Sets {
                     continue;
                 }
 
-                if disk.as_ref().unwrap().is_local() && runtime_sources::setup_is_dist_erasure().await {
+                if disk.as_ref().unwrap().is_local() && ctx.is_dist_erasure().await {
                     let local_disk = runtime_sources::local_disk_set_drive(pool_idx, i, j).await;
 
                     if local_disk.is_none() {
@@ -166,6 +172,7 @@ impl Sets {
                 set_endpoints,
                 fm.clone(),
                 lockers,
+                ctx.clone(),
             )
             .await;
 
@@ -186,6 +193,7 @@ impl Sets {
             default_parity_count: parity_count,
             distribution_algo: fm.erasure.distribution_algo.clone(),
             exit_signal: Some(tx),
+            ctx,
         });
 
         let asets = sets.clone();
@@ -1165,6 +1173,7 @@ mod tests {
             default_parity_count: 1,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         };
 
         let result = sets
@@ -1222,6 +1231,7 @@ mod tests {
             endpoints.clone(),
             format.clone(),
             vec![Arc::new(LocalClient::new()), Arc::new(LocalClient::new())],
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -1244,6 +1254,7 @@ mod tests {
             default_parity_count: 1,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         });
 
         let bucket = format!("bucket-{}", Uuid::new_v4().simple());
@@ -1290,6 +1301,7 @@ mod tests {
             default_parity_count: 0,
             distribution_algo: DistributionAlgoVersion::V1,
             exit_signal: None,
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         };
 
         let err = sets

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1564,6 +1564,11 @@ pub struct SetDisks {
     get_object_metadata_cache: moka::future::Cache<GetObjectMetadataCacheKey, Arc<GetObjectMetadataCacheEntry>>,
     pub lockers: Vec<Arc<dyn LockClient>>,
     local_lock_manager: Arc<rustfs_lock::GlobalLockManager>,
+    /// Per-instance runtime context, inherited from the owning `Sets`/`ECStore`
+    /// (issue #939, Slice2). Shared `Arc` across every disk in the pool, so the
+    /// set layer reads one instance's runtime identity rather than the process
+    /// facade.
+    pub(crate) ctx: Arc<crate::runtime::instance::InstanceContext>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -1698,7 +1703,7 @@ impl SetDisks {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub async fn new(
+    pub(crate) async fn new(
         locker_owner: String,
         disks: Arc<RwLock<Vec<Option<DiskStore>>>>,
         set_drive_count: usize,
@@ -1708,6 +1713,7 @@ impl SetDisks {
         set_endpoints: Vec<Endpoint>,
         format: FormatV3,
         lockers: Vec<Arc<dyn LockClient>>,
+        ctx: Arc<crate::runtime::instance::InstanceContext>,
     ) -> Arc<Self> {
         Arc::new(SetDisks {
             locker_owner,
@@ -1725,6 +1731,7 @@ impl SetDisks {
                 .build(),
             lockers,
             local_lock_manager: runtime_sources::global_lock_manager(),
+            ctx,
         })
     }
 
@@ -3672,6 +3679,7 @@ mod tests {
             endpoints,
             FormatV3::new(1, 2),
             lockers,
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }
@@ -4437,6 +4445,7 @@ mod tests {
             vec![Arc::new(LocalClient::with_manager(Arc::new(
                 rustfs_lock::GlobalLockManager::new(),
             )))],
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }
@@ -5751,6 +5760,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5795,6 +5805,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5830,6 +5841,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5885,6 +5897,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -5974,6 +5987,7 @@ mod tests {
             vec![endpoint],
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -7513,6 +7527,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }
@@ -7563,6 +7578,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }

--- a/crates/ecstore/src/set_disk/ops/locking.rs
+++ b/crates/ecstore/src/set_disk/ops/locking.rs
@@ -30,7 +30,7 @@ impl crate::storage_api_contracts::namespace::NamespaceLocking for SetDisks {
 
     #[tracing::instrument(skip(self))]
     async fn new_ns_lock(&self, bucket: &str, object: &str) -> Result<NamespaceLockWrapper> {
-        let set_lock = if runtime_sources::setup_is_dist_erasure().await {
+        let set_lock = if self.ctx.is_dist_erasure().await {
             // Calculate quorum based on lockers count (majority)
             let lockers_count = self.lockers.len();
             let write_quorum = if lockers_count > 1 { (lockers_count / 2) + 1 } else { 1 };
@@ -361,7 +361,7 @@ impl SetDisks {
             let path = new_disk.endpoint().to_string();
             global_local_disk_map.insert(path, Some(new_disk.clone()));
 
-            if runtime_sources::setup_is_dist_erasure().await {
+            if self.ctx.is_dist_erasure().await {
                 let local_disk_set_drives = runtime_sources::local_disk_set_drives_handle();
                 let mut local_set_drives = local_disk_set_drives.write().await;
                 local_set_drives[self.pool_index][set_idx][disk_idx] = Some(new_disk.clone());
@@ -529,6 +529,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -584,6 +585,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -651,6 +653,7 @@ mod tests {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -695,6 +698,7 @@ mod tests {
             endpoints.clone(),
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 
@@ -740,6 +744,7 @@ mod tests {
             endpoints.clone(),
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -1332,7 +1332,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
         let mut _local_batch_guards: Vec<FastLockGuard> = Vec::with_capacity(batch.requests.len());
         let mut locked_objects = HashSet::new();
 
-        let dist_erasure = runtime_sources::setup_is_dist_erasure().await;
+        let dist_erasure = self.ctx.is_dist_erasure().await;
         let mut dist_batch_lock_ids = vec![Vec::new(); self.lockers.len()];
 
         if dist_erasure {
@@ -2371,6 +2371,7 @@ mod hermetic_set_disks_support {
             endpoints,
             format,
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await;
 

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -1637,6 +1637,7 @@ mod metadata_cache_tests {
             Vec::new(),
             FormatV3::new(1, 4),
             Vec::new(),
+            crate::runtime::instance::bootstrap_ctx(),
         )
         .await
     }

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -174,6 +174,12 @@ impl ECStore {
         let mut pools = Vec::with_capacity(endpoint_pools.as_ref().len());
         let mut disk_map = HashMap::with_capacity(endpoint_pools.as_ref().len());
 
+        // The runtime context this store will adopt (issue #939, Slice2). Startup
+        // published erasure/disk state into this same `bootstrap_ctx` cell before
+        // any ECStore existed; every pool's `Sets`/`SetDisks` and the store itself
+        // share this one `Arc`, so the whole instance reads one runtime identity.
+        let instance_ctx = crate::runtime::instance::bootstrap_ctx();
+
         let mut local_disks = Vec::new();
 
         debug!(
@@ -308,7 +314,7 @@ impl ECStore {
                 }
             }
 
-            let sets = Sets::new(disks.clone(), pool_eps, &fm, i, common_parity_drives).await?;
+            let sets = Sets::new(disks.clone(), pool_eps, &fm, i, common_parity_drives, instance_ctx.clone()).await?;
             pools.push(sets);
 
             disk_map.insert(i, disks);
@@ -334,10 +340,10 @@ impl ECStore {
             decommission_cancelers,
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
-            // Adopt the process bootstrap context: startup published erasure/disk
-            // state into it before this ECStore existed, so reads after
-            // construction must hit the same cell (issue #939, Slice1).
-            ctx: crate::runtime::instance::bootstrap_ctx(),
+            // Same `Arc` the pools above were built with: startup published
+            // erasure/disk state into it before this ECStore existed, so reads
+            // after construction hit the same cell (issue #939, Slice1/Slice2).
+            ctx: instance_ctx,
         });
 
         // Only set it when the global deployment ID is not yet configured

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1960,7 +1960,7 @@ mod tests {
             platform: "test".to_string(),
         };
         let endpoint_pools = EndpointServerPools::from(vec![pool_endpoints.clone()]);
-        let sets = Sets::new(vec![None, None], &pool_endpoints, &format, 0, 1)
+        let sets = Sets::new(vec![None, None], &pool_endpoints, &format, 0, 1, ctx.clone())
             .await
             .expect("test sets should be created with empty disks");
 
@@ -2014,6 +2014,33 @@ mod tests {
         assert!(store_b.setup_is_erasure_sd().await);
         assert!(!store_b.setup_is_dist_erasure().await);
         assert!(!store_b.setup_is_erasure().await);
+    }
+
+    /// #939 Slice2: the instance context threads *identically* down the whole
+    /// pool graph — `ECStore.ctx`, every `Sets.ctx`, and every `SetDisks.ctx`
+    /// are the same `Arc`. The set layer therefore reads this instance's setup
+    /// type (`self.ctx`) rather than the process facade.
+    #[tokio::test]
+    async fn ctx_threads_through_pool_graph() {
+        use crate::layout::endpoints::SetupType;
+        use crate::runtime::instance::InstanceContext;
+
+        let ctx = std::sync::Arc::new(InstanceContext::new());
+        ctx.set_erasure_kind(SetupType::DistErasure).await;
+
+        let store = new_test_store_with_ctx(ctx.clone()).await;
+        assert!(std::sync::Arc::ptr_eq(&store.ctx, &ctx), "store must hold the passed ctx");
+
+        assert!(!store.pools.is_empty(), "test store should have one pool");
+        for sets in &store.pools {
+            assert!(std::sync::Arc::ptr_eq(&sets.ctx, &ctx), "Sets must share the store ctx");
+            assert!(!sets.disk_set.is_empty(), "pool should have one set");
+            for set_disks in &sets.disk_set {
+                assert!(std::sync::Arc::ptr_eq(&set_disks.ctx, &ctx), "SetDisks must share the store ctx");
+                // set-layer predicate reads self.ctx, so it sees DistErasure
+                assert!(set_disks.ctx.is_dist_erasure().await);
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

**Slice 2 of 8** of the runtime-identity isolation epic (backlog#939), **stacked on Slice 1 (#4426)**. Slice 1 introduced the `InstanceContext` carrier on `ECStore`; this slice sinks it into the set layer so data-path methods read `self.ctx` instead of the process facade.

> Base branch is the Slice 1 PR branch — review after / together with #4426. The diff shown here is Slice 2 only.

## What changed

- **`Sets` and `SetDisks` each hold an `Arc<InstanceContext>` field**, inherited from the owning `ECStore`.
- **`Sets::new` / `SetDisks::new` take a `ctx` parameter** and store it; both became `pub(crate)` (all call sites are ecstore-internal) so the crate-private `InstanceContext` stays out of a public signature.
- **Production threading is one `Arc`:** `ECStore::new` builds a single `bootstrap_ctx()`, passes `ctx.clone()` to every `Sets::new` → every `SetDisks::new`, and adopts the same `Arc` on the store. The whole pool graph shares one cell — byte-for-byte single-instance equivalence.
- **Representative data-path reads migrated off the facade onto `self.ctx`:** `Sets::new` local-disk selection, and `SetDisks::{delete_objects, new_ns_lock, renew_disk}` dist-erasure gating. The one non-`&self` helper (`get_object_metadata_cache_bypass_reason`) stays on the facade.
- All 18 test construction sites pass `bootstrap_ctx()`.

## Tests

- New `ctx_threads_through_pool_graph`: `Arc::ptr_eq` proof down `ECStore` → `Sets` → `SetDisks`, plus the set layer reading `DistErasure` from `self.ctx`.
- Slice 1's isolation proof still green.

## Verification

- `make pre-pr` green: fmt, unsafe-code, architecture-migration, logging-guardrails, tokio-io-uring, doc-paths, clippy, and the full `cargo nextest` suite (**7853 passed, 0 failed, 116 skipped**) + doc tests.

> Note: the local `cargo test` single-process fallback flakes a few `rustfs`/`ecstore` tests on pre-existing global-singleton pollution (e.g. `SetupTypeGuard`-mutating tests racing readers); these pass in isolation and under CI's nextest process isolation. Unrelated to this change.

## Follow-ups

Slice 3 (per-instance lock namespace: `SetDisks.local_lock_manager` from `self.ctx`) is next, then topology scalars (Slice 4), etc. Hard ordering unchanged: Slice 5's heal `'static` contract change is a separate prerequisite PR; Slice 7 before Slice 8.

Refs #939