### PR TITLE
fix: repair main build (swift clippy assert + ecstore multipart test ctx)

### DIFF
--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -417,6 +417,7 @@ mod tests {
             decommission_cancelers: RwLock::new(Vec::new()),
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         }
     }
 

--- a/crates/protocols/src/swift/expiration_worker.rs
+++ b/crates/protocols/src/swift/expiration_worker.rs
@@ -984,10 +984,7 @@ mod tests {
 
         let tracked = match worker.scan_all_objects_with_backend(&backend).await {
             Ok(tracked) => tracked,
-            Err(err) => {
-                assert!(false, "scan candidates should be tracked: {err}");
-                0
-            }
+            Err(err) => panic!("scan candidates should be tracked: {err}"),
         };
 
         assert_eq!(tracked, 2);


### PR DESCRIPTION
Repairs two independent breakages currently on `main` that together red-line every `Test and Lint` / clippy job on all open PRs. Each is a one-liner; both are needed for CI to pass, so they ride together.

## 1. swift clippy — `assertions_on_constants`

`cargo clippy -p rustfs-protocols --all-targets --features swift -- -D warnings` fails:

```
error: this assertion is always `false`
   --> crates/protocols/src/swift/expiration_worker.rs:988:17
    |
988 |                 assert!(false, "scan candidates should be tracked: {err}");
    = help: replace this with `panic!()` or `unreachable!()`
```

Replace `assert!(false, ...)` with `panic!(...)` (the clippy-recommended form) and drop the now-dead `0` fallthrough.

## 2. ecstore E0063 — missing `ctx` field

`cargo test -p rustfs-ecstore` fails to compile:

```
error[E0063]: missing field `ctx` in initializer of `store::ECStore`
   --> crates/ecstore/src/store/multipart.rs:410:9
```

A semantic merge conflict between two independently-landed PRs:

- #4437 added `new_multipart_lock_test_store`, which constructs `ECStore` field-by-field.
- The Phase 5 `InstanceContext` work (backlog#939) added a new `ctx` field to the `ECStore` struct.

Each was correct on its own base; merged into `main` the test no longer names every field. Adopt the process bootstrap context via `crate::runtime::instance::bootstrap_ctx()`, matching the existing `bootstrap_ctx` test in `store/mod.rs`.

## Verification

- `cargo clippy -p rustfs-protocols --all-targets --features swift -- -D warnings` — passes
- `cargo test -p rustfs-ecstore --no-run` — compiles cleanly
