### PR TITLE
fix(ecstore): add missing ctx field to multipart lock test store

### DIFF
--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -417,6 +417,7 @@ mod tests {
             decommission_cancelers: RwLock::new(Vec::new()),
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         }
     }
 


### PR DESCRIPTION
## What

Add the missing `ctx` field to the `ECStore` value constructed by `new_multipart_lock_test_store` in `crates/ecstore/src/store/multipart.rs`, adopting the process bootstrap context via `crate::runtime::instance::bootstrap_ctx()` (the same pattern already used by the `bootstrap_ctx` test in `store/mod.rs`).

## Why

`main` currently fails to build the `rustfs-ecstore` lib tests:

```
error[E0063]: missing field `ctx` in initializer of `store::ECStore`
   --> crates/ecstore/src/store/multipart.rs:410:9
```

This is a semantic merge conflict between two independently-landed PRs:

- #4437 added `new_multipart_lock_test_store`, which constructs `ECStore` field-by-field.
- The Phase 5 `InstanceContext` work (backlog#939) added a new `ctx` field to the `ECStore` struct.

Each was correct against its own base, but merged into `main` the test no longer names every field, breaking the lib-test build and, transitively, every `Test and Lint` / clippy job on all open PRs.

## Verification

- `cargo test -p rustfs-ecstore --no-run` — compiles cleanly
