### PR TITLE
fix(notify): report cursor gap when history is evicted instead of silently dropping events

### DIFF
--- a/crates/notify/src/integration.rs
+++ b/crates/notify/src/integration.rs
@@ -47,6 +47,12 @@ pub struct LiveEventBatch {
     pub events: Vec<Arc<Event>>,
     pub next_sequence: u64,
     pub truncated: bool,
+    /// Set when the consumer's cursor is older than the oldest event still
+    /// retained in the ring buffer: events between the cursor and the oldest
+    /// retained sequence were evicted and can never be delivered. Consumers
+    /// must treat a `gap` as lost events (e.g. trigger a full re-sync/alert)
+    /// instead of assuming the returned batch is contiguous with their cursor.
+    pub gap: bool,
 }
 
 /// Notify the system of monitoring indicators
@@ -438,6 +444,7 @@ mod tests {
 
         assert_eq!(batch.next_sequence, 2);
         assert!(!batch.truncated);
+        assert!(!batch.gap);
         assert_eq!(batch.events.len(), 1);
         assert_eq!(batch.events[0].s3.object.key, "two");
     }
@@ -452,6 +459,7 @@ mod tests {
 
         assert_eq!(batch.next_sequence, 1);
         assert!(batch.truncated);
+        assert!(!batch.gap);
         assert_eq!(batch.events.len(), 1);
         assert_eq!(batch.events[0].s3.object.key, "one");
     }
@@ -473,5 +481,6 @@ mod tests {
         assert_eq!(batch.events[0].s3.object.key, "object");
         assert_eq!(batch.next_sequence, 1);
         assert!(!batch.truncated);
+        assert!(!batch.gap);
     }
 }

--- a/crates/notify/src/pipeline.rs
+++ b/crates/notify/src/pipeline.rs
@@ -39,6 +39,15 @@ impl LiveEventHistory {
         let mut next_sequence = after_sequence;
         let mut truncated = false;
 
+        // A gap means the consumer's cursor points before the oldest event we
+        // still retain: the events in between were evicted from the ring buffer
+        // and can never be delivered. Report it so the consumer knows it lost
+        // events instead of silently resuming from the oldest available one.
+        let gap = match self.events.front() {
+            Some((oldest, _)) => after_sequence.saturating_add(1) < *oldest,
+            None => false,
+        };
+
         for (sequence, event) in self.events.iter() {
             if *sequence <= after_sequence {
                 continue;
@@ -55,6 +64,7 @@ impl LiveEventHistory {
             events,
             next_sequence,
             truncated,
+            gap,
         }
     }
 }
@@ -103,7 +113,7 @@ pub type NotifyEventBridge = NotifyPipeline;
 
 #[cfg(test)]
 mod tests {
-    use super::{LiveEventHistory, NotifyPipeline};
+    use super::{LiveEventHistory, MAX_RECENT_LIVE_EVENTS, NotifyPipeline};
     use crate::{Event, integration::NotificationMetrics, notifier::EventNotifier, rule_engine::NotifyRuleEngine};
     use rustfs_s3_types::EventName;
     use std::sync::Arc;
@@ -135,7 +145,35 @@ mod tests {
         let batch = pipeline.recent_live_events_since(0, 16).await;
         assert_eq!(batch.next_sequence, 1);
         assert!(!batch.truncated);
+        assert!(!batch.gap);
         assert_eq!(batch.events.len(), 1);
         assert_eq!(batch.events[0].s3.object.key, "one");
+    }
+
+    #[test]
+    fn snapshot_reports_gap_when_cursor_predates_evicted_history() {
+        let mut history = LiveEventHistory::default();
+        // Fill past the ring-buffer capacity so the oldest events are evicted.
+        let total = MAX_RECENT_LIVE_EVENTS + 128;
+        for i in 1..=total {
+            history.record(Arc::new(Event::new_test_event("bucket", &i.to_string(), EventName::ObjectCreatedPut)));
+        }
+
+        let oldest_retained = (total - MAX_RECENT_LIVE_EVENTS + 1) as u64;
+
+        // A consumer whose cursor sits inside the evicted range must be told a
+        // gap exists instead of silently resuming from the oldest available.
+        let batch = history.snapshot_since(10, 4096);
+        assert!(batch.gap, "cursor predating evicted history must report a gap");
+        assert_eq!(batch.events.first().unwrap().s3.object.key, oldest_retained.to_string());
+
+        // A cursor contiguous with the oldest retained event must not report a gap.
+        let contiguous = history.snapshot_since(oldest_retained - 1, 4096);
+        assert!(!contiguous.gap, "cursor contiguous with retained history must not report a gap");
+
+        // A caught-up cursor must not report a gap either.
+        let caught_up = history.snapshot_since(total as u64, 4096);
+        assert!(!caught_up.gap);
+        assert!(caught_up.events.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

`LiveEventHistory::snapshot_since` (`crates/notify/src/pipeline.rs`) is the cursor/history API behind the live-event feed. When a consumer's cursor points before the oldest event still retained in the 1024-entry ring buffer, the events in between have been evicted and can never be delivered. The old implementation simply resumed from the oldest available event without any signal, so cursor-based consumers (long-poll / SSE style) assumed the returned batch was contiguous with their cursor and silently lost events without knowing it. This is the notification-completeness defect reported in rustfs/backlog#969.

## Fix

Add a `gap: bool` field to `LiveEventBatch` (`crates/notify/src/integration.rs`) and set it in `snapshot_since` whenever the consumer's cursor is older than the oldest retained sequence (`after_sequence + 1 < oldest_retained`). Consumers can now detect the loss and react (full re-sync / alert) instead of assuming continuity. This is the smallest change that fits the existing return type and keeps the crate's cursor/buffer API style; the flag is `false` for contiguous and caught-up cursors, so existing behavior is unchanged when no eviction gap exists.

Scope note: the change is contained to `crates/notify`. Propagating the flag across the peer RPC boundary (`GetLiveEventsResponse` proto + admin fan-in) is a natural follow-up but was intentionally left out to keep this fix minimal and within the crate that owns the root cause.

## Verification

Only the target crate was checked, per the constrained build environment:

- `cargo fmt --all`
- `cargo check -p rustfs-notify`
- `cargo clippy -p rustfs-notify --all-targets -- -D warnings`
- `cargo test -p rustfs-notify` — 86 passed, including the new `snapshot_reports_gap_when_cursor_predates_evicted_history` regression test that fills and evicts past the ring-buffer capacity, pulls with a lagging cursor, and asserts `gap = true` (plus contiguous/caught-up cursors report `gap = false`).

Closes: https://github.com/rustfs/backlog/issues/969