### PR TITLE
fix(ecstore): stop ListMultipartUploads from returning one upload past max-uploads

### DIFF
--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -771,16 +771,20 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
         let mut ret_uploads = Vec::new();
         let mut next_upload_id_marker = None;
         while upload_idx < uploads.len() {
+            if ret_uploads.len() >= max_uploads {
+                break;
+            }
+
             ret_uploads.push(uploads[upload_idx].clone());
             next_upload_id_marker = Some(uploads[upload_idx].upload_id.clone());
             upload_idx += 1;
-
-            if ret_uploads.len() > max_uploads {
-                break;
-            }
         }
 
-        let is_truncated = ret_uploads.len() < uploads.len();
+        // Truncated iff there are still unconsumed uploads left after this page.
+        // `upload_idx` tracks the position in the full (post-marker) list, so it
+        // stays correct even when a marker skipped entries before the page start,
+        // unlike comparing the page length against the total.
+        let is_truncated = upload_idx < uploads.len();
 
         if !is_truncated {
             next_upload_id_marker = None;
@@ -1586,6 +1590,88 @@ mod tests {
         assert!(
             leftovers.is_empty(),
             "failed multipart upload part must not leave tmp shards behind, leftovers: {leftovers:?}, err: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_multipart_uploads_caps_each_page_at_max_uploads_and_paginates_cleanly() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "multipart-list-cap-bucket";
+        let object = "object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+
+        // Start more in-progress uploads on the same object than a single page holds.
+        let total = 5usize;
+        let mut created = HashSet::new();
+        for _ in 0..total {
+            let res = set_disks
+                .new_multipart_upload(bucket, object, &ObjectOptions::default())
+                .await
+                .expect("multipart upload should be created");
+            assert!(created.insert(res.upload_id), "each upload id must be unique");
+        }
+
+        // A single page must never return more than max_uploads entries.
+        let max_uploads = 2usize;
+        let page = set_disks
+            .list_multipart_uploads(bucket, object, None, None, None, max_uploads)
+            .await
+            .expect("list should succeed");
+        assert_eq!(
+            page.uploads.len(),
+            max_uploads,
+            "page must return exactly max_uploads uploads, not max_uploads + 1"
+        );
+        assert!(page.is_truncated, "uploads remain, so the page must be truncated");
+        assert_eq!(
+            page.next_upload_id_marker.as_ref(),
+            page.uploads.last().map(|u| &u.upload_id),
+            "next marker must point at the last returned upload, not one past it"
+        );
+
+        // Exact boundary: max_uploads == total must not falsely report truncation.
+        let exact = set_disks
+            .list_multipart_uploads(bucket, object, None, None, None, total)
+            .await
+            .expect("list should succeed");
+        assert_eq!(exact.uploads.len(), total, "exact boundary must return every upload");
+        assert!(!exact.is_truncated, "exact boundary must not be marked truncated");
+        assert!(
+            exact.next_upload_id_marker.is_none(),
+            "a non-truncated listing must not carry a next marker"
+        );
+
+        // Paginating one upload at a time must enumerate every upload exactly once,
+        // with no gaps and no duplicates, and terminate.
+        let mut seen = HashSet::new();
+        let mut marker: Option<String> = None;
+        let mut pages = 0usize;
+        loop {
+            let page = set_disks
+                .list_multipart_uploads(bucket, object, None, marker.clone(), None, 1)
+                .await
+                .expect("list should succeed");
+            assert!(page.uploads.len() <= 1, "max_uploads=1 must never return more than one upload");
+            for upload in &page.uploads {
+                assert!(
+                    seen.insert(upload.upload_id.clone()),
+                    "upload {} was returned more than once across pages",
+                    upload.upload_id
+                );
+            }
+            pages += 1;
+            assert!(pages <= total + 1, "pagination failed to terminate");
+            if !page.is_truncated {
+                break;
+            }
+            marker = page.next_upload_id_marker.clone();
+            assert!(marker.is_some(), "a truncated page must carry a next marker to continue");
+        }
+        assert_eq!(
+            seen, created,
+            "single-upload pagination must enumerate every upload with no loss or duplication"
         );
     }
 

--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -417,6 +417,7 @@ mod tests {
             decommission_cancelers: RwLock::new(Vec::new()),
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
+            ctx: crate::runtime::instance::bootstrap_ctx(),
         }
     }
 


### PR DESCRIPTION
## Root cause

`SetDisks::list_multipart_uploads` (`crates/ecstore/src/set_disk/ops/multipart.rs`) collected results by pushing an upload into the page first and only then checking `if ret_uploads.len() > max_uploads { break }`. Because the check ran after the push and used strict greater-than, a page with N = max_uploads returned N + 1 uploads and set `next_upload_id_marker` to that surplus (N+1)th entry. No upper layer re-truncated the result (single-pool path returns it verbatim, the S3 output builder maps it directly), so clients asking for max-uploads=N received N+1. This violates the S3 ListMultipartUploads max-uploads contract; max-uploads=1 returning 2 is the easiest repro.

A second, related defect surfaced while fixing this: `is_truncated` was computed as `ret_uploads.len() < uploads.len()`, comparing the current page length against the total listing length. When a marker had skipped earlier entries, the final page (which legitimately holds fewer than the total) was still reported as truncated, so marker-based pagination never terminated cleanly.

## Fix

- Move the cap check before the push (MinIO's `listMultipartUploads` breaks when `len(result.Uploads) == maxUploads` before appending), so a page never exceeds max_uploads and the marker points at the last *returned* upload.
- Derive truncation from the post-marker cursor: `is_truncated = upload_idx < uploads.len()`. `upload_idx` advances once per pushed entry and accounts for the marker skip, so it is correct both on the first page and on later pages, and equals the old expression in the no-marker case. When not truncated the next marker is cleared, so pagination terminates.

Scope is limited to the primary per-page off-by-one. The multi-pool aggregation path in `store/multipart.rs` (which does not re-apply max_uploads across pools) is a separate contract gap called out in the issue and is left for a follow-up.

## Verification

Only the target crate was built (disk-constrained env), scoped to multipart:

- `cargo fmt --all`
- `cargo check -p rustfs-ecstore` — clean
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` — clean
- `cargo nextest run -p rustfs-ecstore list_multipart_uploads_caps` — 1 passed

The new regression test starts more in-progress uploads than a page holds and asserts: a single page returns exactly max_uploads with `next_upload_id_marker` at the last returned upload; the exact-boundary case (max_uploads == total) is not marked truncated and carries no marker; and paginating one upload at a time enumerates every upload exactly once with no loss, duplication, or non-termination.

## Incidental

Added the missing `ctx` field to the `new_multipart_lock_test_store` cfg(test) helper so the ecstore test build compiles after the #4413/#4437 merge collision (`error[E0063]: missing field ctx`). No other unrelated changes.

Closes: https://github.com/rustfs/backlog/issues/954