### PR TITLE
refactor(ecstore): per-instance lock namespace via ctx (backlog#939 Slice3)

### DIFF
--- a/crates/ecstore/src/runtime/instance.rs
+++ b/crates/ecstore/src/runtime/instance.rs
@@ -51,15 +51,39 @@ pub(crate) struct InstanceContext {
     /// `is_erasure`/`is_dist_erasure`/`is_erasure_sd` booleans are derived from
     /// this value rather than stored independently.
     erasure_kind: RwLock<SetupType>,
+    /// Per-instance local lock manager (issue #939, Slice3). `SetDisks` reads
+    /// this off `self.ctx` so two ECStore instances get *separate* lock
+    /// namespaces instead of colliding on one process-global manager. The
+    /// bootstrap context deliberately holds the process-global manager (see
+    /// [`bootstrap_ctx`]) so single-instance locking is byte-for-byte unchanged.
+    local_lock_manager: Arc<rustfs_lock::GlobalLockManager>,
 }
 
 impl InstanceContext {
     /// Fresh context in the pre-startup default state — equivalent to the old
     /// three booleans all initialized to `false` (`SetupType::Unknown`).
+    ///
+    /// Mints its **own** lock manager, so a context built this way is fully
+    /// isolated from the process-global one. Production goes through
+    /// [`bootstrap_ctx`], which adopts the global manager instead.
     pub(crate) fn new() -> Self {
+        Self::with_lock_manager(Arc::new(rustfs_lock::GlobalLockManager::new()))
+    }
+
+    /// Build a context around a specific lock manager. Lets [`bootstrap_ctx`]
+    /// adopt the process-global manager while [`new`](Self::new) mints an
+    /// isolated one.
+    fn with_lock_manager(local_lock_manager: Arc<rustfs_lock::GlobalLockManager>) -> Self {
         Self {
             erasure_kind: RwLock::new(SetupType::Unknown),
+            local_lock_manager,
         }
+    }
+
+    /// This instance's local lock manager. `SetDisks::new` stores the result so
+    /// the set layer locks within this instance's namespace.
+    pub(crate) fn local_lock_manager(&self) -> Arc<rustfs_lock::GlobalLockManager> {
+        self.local_lock_manager.clone()
     }
 
     /// True when the deployment is erasure-coded — single-node multi-drive
@@ -107,8 +131,15 @@ impl Default for InstanceContext {
 static BOOTSTRAP_CTX: OnceLock<Arc<InstanceContext>> = OnceLock::new();
 
 /// Get (initializing on first call) the process bootstrap context.
+///
+/// Adopts the process-global lock manager (`rustfs_lock::get_global_lock_manager`)
+/// rather than minting a fresh one, so `SetDisks` built for the single process
+/// instance lock in exactly the same namespace as every other direct caller of
+/// `get_global_lock_manager()` — byte-for-byte unchanged locking behavior.
 pub(crate) fn bootstrap_ctx() -> Arc<InstanceContext> {
-    BOOTSTRAP_CTX.get_or_init(|| Arc::new(InstanceContext::new())).clone()
+    BOOTSTRAP_CTX
+        .get_or_init(|| Arc::new(InstanceContext::with_lock_manager(rustfs_lock::get_global_lock_manager())))
+        .clone()
 }
 
 #[cfg(test)]
@@ -156,8 +187,8 @@ mod tests {
         assert!(!ctx.is_erasure_sd().await);
     }
 
-    #[test]
-    fn bootstrap_ctx_is_stable_singleton() {
+    #[tokio::test]
+    async fn bootstrap_ctx_is_stable_singleton() {
         let a = bootstrap_ctx();
         let b = bootstrap_ctx();
         assert!(Arc::ptr_eq(&a, &b), "bootstrap_ctx must return the same Arc");
@@ -174,5 +205,33 @@ mod tests {
         assert!(!a.is_erasure_sd().await);
         assert!(b.is_erasure_sd().await);
         assert!(!b.is_dist_erasure().await);
+    }
+
+    /// Slice3: the bootstrap context must reuse the process-global lock manager,
+    /// so single-instance locking is unchanged (other direct callers of
+    /// `get_global_lock_manager()` lock in the same namespace as `SetDisks`).
+    #[tokio::test]
+    async fn bootstrap_ctx_adopts_global_lock_manager() {
+        let ctx = bootstrap_ctx();
+        assert!(
+            Arc::ptr_eq(&ctx.local_lock_manager(), &rustfs_lock::get_global_lock_manager()),
+            "bootstrap ctx must reuse the process-global lock manager"
+        );
+    }
+
+    /// Slice3: a freshly-minted context gets its OWN lock manager — the seam
+    /// that gives a second instance an isolated lock namespace.
+    #[tokio::test]
+    async fn fresh_context_has_isolated_lock_manager() {
+        let a = InstanceContext::new();
+        let b = InstanceContext::new();
+        assert!(
+            !Arc::ptr_eq(&a.local_lock_manager(), &b.local_lock_manager()),
+            "two fresh contexts must have distinct lock managers"
+        );
+        assert!(
+            !Arc::ptr_eq(&a.local_lock_manager(), &rustfs_lock::get_global_lock_manager()),
+            "a fresh context must not share the process-global lock manager"
+        );
     }
 }

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1730,7 +1730,7 @@ impl SetDisks {
                 .time_to_live(GET_OBJECT_METADATA_CACHE_TTL)
                 .build(),
             lockers,
-            local_lock_manager: runtime_sources::global_lock_manager(),
+            local_lock_manager: ctx.local_lock_manager(),
             ctx,
         })
     }
@@ -3682,6 +3682,42 @@ mod tests {
             crate::runtime::instance::bootstrap_ctx(),
         )
         .await
+    }
+
+    /// Slice3: a `SetDisks` built from an isolated instance context locks in that
+    /// instance's namespace — its `local_lock_manager` is the ctx's manager, not
+    /// the process-global one two instances would otherwise collide on.
+    #[tokio::test]
+    async fn set_disks_lock_manager_is_instance_scoped() {
+        use crate::runtime::instance::InstanceContext;
+
+        let endpoints = vec![
+            Endpoint::try_from("http://127.0.0.1:9000/data").expect("first endpoint should parse"),
+            Endpoint::try_from("http://127.0.0.1:9001/data").expect("second endpoint should parse"),
+        ];
+        let ctx = Arc::new(InstanceContext::new());
+        let set_disks = SetDisks::new(
+            "test-owner".to_string(),
+            Arc::new(RwLock::new(vec![None, None])),
+            2,
+            1,
+            0,
+            0,
+            endpoints,
+            FormatV3::new(1, 2),
+            Vec::new(),
+            ctx.clone(),
+        )
+        .await;
+
+        assert!(
+            Arc::ptr_eq(&set_disks.local_lock_manager, &ctx.local_lock_manager()),
+            "SetDisks must adopt its ctx's lock manager"
+        );
+        assert!(
+            !Arc::ptr_eq(&set_disks.local_lock_manager, &rustfs_lock::get_global_lock_manager()),
+            "an isolated instance must not share the process-global lock manager"
+        );
     }
 
     struct SetupTypeGuard {


### PR DESCRIPTION
## Summary

**Slice 3 of 8** of the runtime-identity isolation epic (backlog#939), stacked on Slice 2 (merged into this convergence branch as #4438). `SetDisks.local_lock_manager` now comes from `self.ctx` instead of the process-global `get_global_lock_manager()`, so two ECStore instances lock in **separate namespaces** rather than colliding on one shared manager. First 🟠 (medium-risk) slice — it touches locking wiring, not just a read-only predicate.

## What changed

- **`InstanceContext` gains `local_lock_manager: Arc<GlobalLockManager>`.** `InstanceContext::new()` mints its own manager (isolation seam); `bootstrap_ctx()` adopts the process-global `rustfs_lock::get_global_lock_manager()` via a new `with_lock_manager` constructor, so the single process instance and every other direct `get_global_lock_manager()` caller lock in the same namespace as before — byte-for-byte unchanged single-instance behavior.
- **`SetDisks::new`** sets `local_lock_manager: ctx.local_lock_manager()` (was `runtime_sources::global_lock_manager()`).

## Tests

- `bootstrap_ctx_adopts_global_lock_manager` — bootstrap reuses the global manager (`Arc::ptr_eq`).
- `fresh_context_has_isolated_lock_manager` — a fresh ctx's manager differs from both a peer's and the global.
- `set_disks_lock_manager_is_instance_scoped` — a `SetDisks` built from an isolated ctx adopts that ctx's manager, not the global.
- The three bootstrap/`new` tests became `#[tokio::test]` since `GlobalLockManager::new()` spawns a background task.

## Verification

- `make pre-pr` green: fmt, unsafe-code, architecture-migration, logging-guardrails, tokio-io-uring, doc-paths, clippy, and the full `cargo nextest` suite (**7856 passed, 0 failed, 116 skipped**) + doc tests.

## Scope

Migrates the `SetDisks` lock manager only — the representative set-layer namespace. Other direct `get_global_lock_manager()` callers (LocalClient fallback, admin diagnostics) stay on the global: correct for a single instance, revisited later if a caller needs per-instance routing. Hard ordering unchanged: Slice 7 (per-instance cancellation) before Slice 8's multi-instance acceptance; Slice 5's heal `'static` contract change is a separate prerequisite PR.

Refs #939