### PR TITLE
fix: auto-repair clippy warnings from 93ffbdb9b

### DIFF
--- a/crates/ecstore/src/store/multipart.rs
+++ b/crates/ecstore/src/store/multipart.rs
@@ -417,6 +417,7 @@ mod tests {
             decommission_cancelers: RwLock::new(Vec::new()),
             start_gate: Mutex::new(()),
             pool_meta_save_gate: Mutex::new(()),
+            ctx: Arc::new(crate::runtime::instance::InstanceContext::new()),
         }
     }
 

--- a/crates/protocols/src/swift/expiration_worker.rs
+++ b/crates/protocols/src/swift/expiration_worker.rs
@@ -985,8 +985,7 @@ mod tests {
         let tracked = match worker.scan_all_objects_with_backend(&backend).await {
             Ok(tracked) => tracked,
             Err(err) => {
-                assert!(false, "scan candidates should be tracked: {err}");
-                0
+                panic!("scan candidates should be tracked: {err}");
             }
         };
 


### PR DESCRIPTION
## Auto-repair: clippy warnings from upstream changes

**Baseline:** `93ffbdb9bd4c91285d5d51f3ec46cd149c135d53` (17 commits pulled)

### Issues found

`make pre-pr` (specifically `clippy-check`) failed with 2 errors:

1. **`crates/ecstore/src/store/multipart.rs:410`** — missing field `ctx` in initializer of `ECStore`. The `ctx: Arc<InstanceContext>` field was added in the Phase 5 instance context work but the test helper `new_multipart_lock_test_store()` was not updated.

2. **`crates/protocols/src/swift/expiration_worker.rs:988`** — `assert!(false, ...)` triggers `clippy::assertions-on-constants` lint. Replaced with `panic!(...)` and removed the dead `0` value.

### Fixes (minimal)

- Added `ctx: Arc::new(crate::runtime::instance::InstanceContext::new())` to the ECStore struct literal in the multipart test helper.
- Replaced `assert!(false, "scan candidates should be tracked: {err}"); 0` with `panic!("scan candidates should be tracked: {err}")`.

### Verification

- `make pre-pr` passes (fmt, unsafe-code, architecture-migration, logging-guardrails, tokio-io-uring, doc-paths, clippy, tests).
- 3 flaky tests in `delete_objects_stat_gating_test` fail intermittently under full parallel runs but pass when run in isolation — pre-existing race condition, not related to these changes.
