### PR TITLE
fix(heal): gate finalize on transient skips and fix progress failed count

### DIFF
--- a/crates/heal/src/heal/erasure_healer.rs
+++ b/crates/heal/src/heal/erasure_healer.rs
@@ -441,17 +441,24 @@ impl ErasureSetHealer {
             current_object_index = 0;
         }
 
-        // 5. finalize. Only declare the set healed when nothing failed —
-        // otherwise the resume/checkpoint state must survive so the failures are
-        // retried instead of being silently marked "completed" and discarded
-        // (backlog#855 / #799 B6).
-        if failed_objects > 0 {
+        // 5. finalize. Only declare the set healed when nothing failed AND
+        // nothing was transiently skipped — otherwise the resume/checkpoint
+        // state must survive so the failed/skipped versions are retried instead
+        // of being silently marked "completed" and discarded
+        // (backlog#855 / #799 B6 / #1033). Transient skips (unmet quorum,
+        // DiskNotFound, SlowDown, cancellation) are recorded in the checkpoint's
+        // skipped set, which suppresses them on resume; treating a skip pass as
+        // complete would discard that set and never re-heal the versions. The
+        // skip may be because the disk is still down, so these are deferred to a
+        // later heal cycle via the same bounded-retry mechanism as failures —
+        // never hot-retried in place here.
+        if failed_objects > 0 || skipped_objects > 0 {
             if resume_manager.schedule_retry().await? {
                 // Both persistence layers must be reset together: schedule_retry
                 // rewinds the resume state (cursor + counters), and the
-                // checkpoint's per-version dedup sets + position must be cleared
-                // in lockstep, or the retry would skip the very versions it is
-                // meant to re-heal.
+                // checkpoint's per-version dedup + skipped sets and position must
+                // be cleared in lockstep, or the retry would skip the very
+                // versions it is meant to re-heal.
                 checkpoint_manager.reset_for_retry().await?;
                 // Retry budget remains: state has been reset for a full re-scan.
                 // Return Err so `heal_erasure_set` preserves (does not clean up)
@@ -464,11 +471,12 @@ impl ErasureSetHealer {
                     subsystem = LOG_SUBSYSTEM_ERASURE_HEALER,
                     set_disk_id,
                     failed_objects,
+                    skipped_objects,
                     state = "retry_scheduled",
-                    "Erasure set heal pass finished with failures; scheduled full re-heal retry"
+                    "Erasure set heal pass finished with unhealed versions; scheduled full re-heal retry"
                 );
                 return Err(Error::other(format!(
-                    "Erasure set heal incomplete: {failed_objects} object(s) failed; retry scheduled"
+                    "Erasure set heal incomplete: {failed_objects} failed, {skipped_objects} skipped object(s); retry scheduled"
                 )));
             }
 
@@ -483,13 +491,14 @@ impl ErasureSetHealer {
                 subsystem = LOG_SUBSYSTEM_ERASURE_HEALER,
                 set_disk_id,
                 failed_objects,
+                skipped_objects,
                 state = "failed_after_retries",
-                "Erasure set heal exhausted retries with unrecovered failures"
+                "Erasure set heal exhausted retries with unrecovered versions"
             );
             let _ = resume_manager.cleanup().await;
             let _ = checkpoint_manager.cleanup().await;
             return Err(Error::other(format!(
-                "Erasure set heal exhausted retries with {failed_objects} unrecovered object(s)"
+                "Erasure set heal exhausted retries with {failed_objects} failed, {skipped_objects} skipped object(s)"
             )));
         }
 
@@ -981,6 +990,9 @@ mod resume_loop_tests {
         Ok,
         /// The version vanished before heal ran (deleted mid-heal).
         VersionNotFound,
+        /// A transient infrastructure condition (offline disk / unmet quorum):
+        /// the version must be recorded as skipped and retried on a later pass.
+        Transient,
     }
 
     #[derive(Default)]
@@ -1071,6 +1083,7 @@ mod resume_loop_tests {
                 HealOutcome::VersionNotFound => {
                     Ok((HealResultItem::default(), Some(Error::Storage(EcstoreError::FileVersionNotFound))))
                 }
+                HealOutcome::Transient => Ok((HealResultItem::default(), Some(Error::Storage(EcstoreError::DiskNotFound)))),
             }
         }
         async fn heal_bucket(&self, _b: &str, _o: &HealOpts) -> Result<HealResultItem> {
@@ -1377,5 +1390,79 @@ mod resume_loop_tests {
         let checkpoint = env.checkpoint.get_checkpoint().await;
         assert!(checkpoint.processed_objects.is_empty());
         assert_eq!(checkpoint.current_object_index, 0);
+    }
+
+    #[tokio::test]
+    async fn test_transient_error_recorded_as_skipped_not_failed() {
+        // A version whose heal hits a transient infrastructure error (offline
+        // disk) must be counted as skipped, never failed, and never recorded as a
+        // success. Regression guard for backlog#1033. (The per-page checkpoint
+        // skipped set is pruned by complete_page once the page advances; the
+        // durable skip signal is the counter, which the finalize block gates on.)
+        let env = make_env().await;
+        env.storage.set_page(
+            None,
+            Page {
+                items: vec![item("ok", None, false), item("down", Some("v1"), false)],
+                next: None,
+                truncated: false,
+            },
+        );
+        env.storage.set_outcome("down", Some("v1"), HealOutcome::Transient);
+
+        let (_processed, successful, failed, skipped, result) = run(&env).await;
+        result.expect("a transient skip must not fail the bucket pass");
+        assert_eq!(successful, 1, "the healthy version still heals");
+        assert_eq!(failed, 0, "a transient error is not a failure");
+        assert_eq!(skipped, 1, "the transient version is skipped");
+
+        // The transient version must actually have been attempted, not silently
+        // dropped, so the skip reflects a real unmet heal.
+        assert!(
+            env.storage.calls().contains(&("down".to_string(), Some("v1".to_string()))),
+            "the transient version must be attempted before being skipped"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transient_skip_pass_not_marked_completed_state_survives() {
+        // The finalize block must NOT declare a clean completion when a pass had
+        // transient skips (even with zero hard failures): it must not
+        // mark_completed and must preserve the resume/checkpoint state (via the
+        // bounded-retry mechanism) so a later heal cycle re-heals the skipped
+        // versions. Regression guard for backlog#1033 (Transient invariant).
+        let env = make_env().await;
+        env.storage.set_page(
+            None,
+            Page {
+                items: vec![item("down", Some("v1"), false)],
+                next: None,
+                truncated: false,
+            },
+        );
+        env.storage.set_outcome("down", Some("v1"), HealOutcome::Transient);
+
+        let result = env
+            .healer
+            .execute_heal_with_resume(&["b".to_string()], "pool_0_set_0", &env.resume, &env.checkpoint)
+            .await;
+
+        result.expect_err("a pass with transient skips must not report clean completion");
+
+        // State must survive for a later pass: not marked completed, and the
+        // bounded retry was armed rather than the state being cleaned up.
+        let state = env.resume.get_state().await;
+        assert!(!state.completed, "a transient-skip pass must not be marked completed");
+        assert_eq!(
+            state.retry_count, 1,
+            "the bounded retry must be armed, preserving state for the next cycle"
+        );
+        // reset_for_retry clears the skipped set so the next pass re-heals the
+        // version instead of suppressing it as already-skipped.
+        let checkpoint = env.checkpoint.get_checkpoint().await;
+        assert!(
+            checkpoint.skipped_objects.is_empty(),
+            "the skipped set must be cleared so the retry re-heals the version"
+        );
     }
 }

--- a/crates/heal/src/heal/progress.rs
+++ b/crates/heal/src/heal/progress.rs
@@ -200,6 +200,22 @@ mod tests {
     }
 
     #[test]
+    fn test_heal_progress_successful_heal_reports_zero_failed() {
+        // A successful single-object heal must record the object's size as bytes
+        // processed WITHOUT inflating the failure count: the `failed` positional
+        // arg is distinct from `bytes`. Regression guard for backlog#1033 where
+        // the success paths passed object_size for both, corrupting
+        // objects_failed / the admin-visible success rate.
+        let object_size = 4096u64;
+        let mut progress = HealProgress::new();
+        progress.update_progress(3, 3, 0, object_size);
+
+        assert_eq!(progress.objects_healed, 3);
+        assert_eq!(progress.objects_failed, 0, "a successful heal must report zero failures");
+        assert_eq!(progress.bytes_processed, object_size);
+    }
+
+    #[test]
     fn test_heal_progress_set_current_object() {
         let mut progress = HealProgress::new();
         let initial_time = progress.last_update_time;

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -920,7 +920,7 @@ impl HealTask {
 
                 {
                     let mut progress = self.progress.write().await;
-                    progress.update_progress(3, 3, object_size, object_size);
+                    progress.update_progress(3, 3, 0, object_size);
                 }
                 self.record_result_item(result).await;
                 Ok(())
@@ -1085,7 +1085,7 @@ impl HealTask {
 
                 {
                     let mut progress = self.progress.write().await;
-                    progress.update_progress(4, 4, object_size, object_size);
+                    progress.update_progress(4, 4, 0, object_size);
                 }
                 self.record_result_item(result).await;
                 Ok(())
@@ -1882,7 +1882,7 @@ impl HealTask {
 
                 {
                     let mut progress = self.progress.write().await;
-                    progress.update_progress(3, 3, object_size, object_size);
+                    progress.update_progress(3, 3, 0, object_size);
                 }
                 self.record_result_item(result).await;
                 Ok(())


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1033

## Summary of Changes

This fixes two confirmed findings in the erasure-set healer.

The finalize block in `execute_heal_with_resume` only gated completion on `failed_objects`. A pass that healed everything except versions hit by transient infrastructure conditions (unmet quorum, `DiskNotFound`, `SlowDown`, `OperationCanceled`) had `failed_objects == 0` and `skipped_objects > 0`, yet was marked completed: it called `mark_completed()`, `heal_erasure_set` then cleaned up the resume and checkpoint state, and the task cleared the per-disk healing marker. That violated the documented `Transient` invariant that a skipped version is retried on a later pass — the skip set was discarded and the versions were never re-healed.

The fix broadens the finalize gate from `failed_objects > 0` to `failed_objects > 0 || skipped_objects > 0` and reuses the exact state-preservation mechanism the failure path already uses, rather than adding new control flow: `resume_manager.schedule_retry()` (bounded by the existing retry budget) plus `checkpoint_manager.reset_for_retry()`, then returns `Err`. Returning `Err` is what makes `heal_erasure_set` preserve (not clean up) the resume/checkpoint state and makes the task keep the healing markers. Because `schedule_retry` rewinds the cursor and `reset_for_retry` clears the per-version dedup and skipped sets, the skipped versions are re-scanned and re-healed on the next heal cycle. No hot re-scan loop is introduced: the `Err` simply propagates up and the retry is deferred to a later heal cycle, since the disk may still be down. When the retry budget is exhausted, the state is dropped but the markers are still kept (via `Err`) so a later cycle starts fresh, exactly as the failure path already behaves.

Separately, the object heal and EC-decode heal success paths called `update_progress(3, 3, object_size, object_size)` / `update_progress(4, 4, object_size, object_size)`, passing `object_size` as the `failed` positional argument. A successful heal therefore set `objects_failed = object_size`, corrupting the admin-visible failure count and success rate. These now pass `0` for the `failed` argument while still recording `object_size` as bytes processed.

## Verification

Toolchain note: the repo-pinned `1.96` channel could not be (re)installed in this environment because the `rustc` component download was quarantined externally; the already-present `stable` toolchain is rustc 1.96.0 (the exact required version) and was used via `RUSTUP_TOOLCHAIN=stable`. The integration-test binaries share process-global singletons and must be run with per-test isolation.

- `cargo fmt --all`
- `cargo test -p rustfs-heal --lib` — 201 passed, 0 failed
- `cargo nextest run -p rustfs-heal` — 224 passed, 0 failed

## Impact

No API, configuration, or on-disk format changes. Behavioral change only in the heal control path: a heal pass with transient skips is no longer reported as fully healed; its resume and checkpoint state and the per-disk healing markers survive so a later heal cycle retries the skipped versions. The admin-visible heal failure count and success rate are now accurate for successful heals.

## Additional Notes

The transient-skip retry deliberately defers to the next heal cycle rather than re-scanning in place, because the transient condition (for example an offline disk) may still be present.
