### PR TITLE
refactor(ecstore): move region topology scalar into InstanceContext

### DIFF
--- a/crates/ecstore/src/runtime/global.rs
+++ b/crates/ecstore/src/runtime/global.rs
@@ -45,7 +45,7 @@ pub const DISK_RESERVE_FRACTION: f64 = 0.15;
 //
 // Tier A (needs migration): GLOBAL_OBJECT_API, GLOBAL_IS_ERASURE*, GLOBAL_LOCAL_DISK_*,
 //   GLOBAL_ROOT_DISK_THRESHOLD, GLOBAL_LIFECYCLE_SYS, GLOBAL_EVENT_NOTIFIER, etc.
-// Tier B (keep as static): GLOBAL_RUSTFS_PORT, GLOBAL_REGION, env var caches, etc.
+// Tier B (keep as static): GLOBAL_RUSTFS_PORT, env var caches, etc.
 lazy_static! {
     static ref GLOBAL_RUSTFS_PORT: OnceLock<u16> = OnceLock::new();
     static ref GLOBAL_DEPLOYMENT_ID: OnceLock<Uuid> = OnceLock::new();
@@ -65,7 +65,8 @@ lazy_static! {
     pub static ref GLOBAL_LOCAL_NODE_NAME_FALLBACK: String = "127.0.0.1:9000".to_string();
     pub static ref GLOBAL_LOCAL_NODE_NAME_HEX_FALLBACK: String =
         rustfs_utils::crypto::hex(GLOBAL_LOCAL_NODE_NAME_FALLBACK.as_bytes());
-    pub static ref GLOBAL_REGION: OnceLock<s3s::region::Region> = OnceLock::new();
+    // GLOBAL_REGION migrated to InstanceContext.region (issue #939 Slice4); the
+    // set_global_region/get_global_region accessors below forward through current_ctx().
     pub static ref GLOBAL_LOCAL_LOCK_CLIENT: OnceLock<Arc<dyn LockClient>> = OnceLock::new();
     pub static ref GLOBAL_LOCK_CLIENTS: OnceLock<HashMap<String, Arc<dyn LockClient>>> = OnceLock::new();
     pub static ref GLOBAL_BUCKET_MONITOR: OnceLock<Arc<Monitor>> = OnceLock::new();
@@ -295,9 +296,7 @@ pub(crate) type TypeLocalDiskSetDrives = Vec<Vec<Vec<Option<DiskStore>>>>;
 /// # Returns
 /// * None
 pub fn set_global_region(region: s3s::region::Region) {
-    GLOBAL_REGION
-        .set(region)
-        .expect("GLOBAL_REGION should be initialized once during startup");
+    current_ctx().set_region(region);
 }
 
 /// Get the global region
@@ -306,7 +305,7 @@ pub fn set_global_region(region: s3s::region::Region) {
 /// * `Option<s3s::region::Region>` - The global region, if set
 ///
 pub fn get_global_region() -> Option<s3s::region::Region> {
-    GLOBAL_REGION.get().cloned()
+    current_ctx().region()
 }
 
 /// Initialize the global background services cancellation token

--- a/crates/ecstore/src/runtime/instance.rs
+++ b/crates/ecstore/src/runtime/instance.rs
@@ -57,6 +57,10 @@ pub(crate) struct InstanceContext {
     /// bootstrap context deliberately holds the process-global manager (see
     /// [`bootstrap_ctx`]) so single-instance locking is byte-for-byte unchanged.
     local_lock_manager: Arc<rustfs_lock::GlobalLockManager>,
+    /// The instance's S3 region (issue #939, Slice4 — topology scalars). A
+    /// write-once cell that preserves the former `GLOBAL_REGION` fail-fast
+    /// contract *per instance*: a second write is a startup bug and panics.
+    region: OnceLock<s3s::region::Region>,
 }
 
 impl InstanceContext {
@@ -77,6 +81,7 @@ impl InstanceContext {
         Self {
             erasure_kind: RwLock::new(SetupType::Unknown),
             local_lock_manager,
+            region: OnceLock::new(),
         }
     }
 
@@ -84,6 +89,20 @@ impl InstanceContext {
     /// the set layer locks within this instance's namespace.
     pub(crate) fn local_lock_manager(&self) -> Arc<rustfs_lock::GlobalLockManager> {
         self.local_lock_manager.clone()
+    }
+
+    /// Publish this instance's region. Fail-fast, exactly as the old
+    /// `set_global_region`: a second write means startup published conflicting
+    /// region state, so it panics rather than silently keeping the first value.
+    pub(crate) fn set_region(&self, region: s3s::region::Region) {
+        self.region
+            .set(region)
+            .expect("instance region should be initialized once during startup");
+    }
+
+    /// This instance's region, if published.
+    pub(crate) fn region(&self) -> Option<s3s::region::Region> {
+        self.region.get().cloned()
     }
 
     /// True when the deployment is erasure-coded — single-node multi-drive
@@ -233,5 +252,40 @@ mod tests {
             !Arc::ptr_eq(&a.local_lock_manager(), &rustfs_lock::get_global_lock_manager()),
             "a fresh context must not share the process-global lock manager"
         );
+    }
+
+    fn test_region(name: &str) -> s3s::region::Region {
+        s3s::region::Region::new(name.into()).expect("valid test region")
+    }
+
+    /// Slice4: region round-trips through the context and starts empty.
+    #[tokio::test]
+    async fn region_round_trips_through_context() {
+        let ctx = InstanceContext::new();
+        assert!(ctx.region().is_none(), "region starts unset");
+        ctx.set_region(test_region("us-east-1"));
+        assert_eq!(ctx.region().map(|r| r.as_str().to_string()), Some("us-east-1".to_string()));
+    }
+
+    /// Slice4: two instances hold independent regions — the isolation this slice
+    /// delivers for the topology scalar.
+    #[tokio::test]
+    async fn distinct_contexts_have_independent_regions() {
+        let a = InstanceContext::new();
+        let b = InstanceContext::new();
+        a.set_region(test_region("us-east-1"));
+        b.set_region(test_region("eu-west-2"));
+        assert_eq!(a.region().unwrap().as_str(), "us-east-1");
+        assert_eq!(b.region().unwrap().as_str(), "eu-west-2");
+    }
+
+    /// Slice4: the former `GLOBAL_REGION` fail-fast contract is preserved
+    /// per-instance — a second write is a startup bug and panics.
+    #[tokio::test]
+    #[should_panic(expected = "initialized once")]
+    async fn set_region_twice_fails_fast() {
+        let ctx = InstanceContext::new();
+        ctx.set_region(test_region("us-east-1"));
+        ctx.set_region(test_region("eu-west-2"));
     }
 }

--- a/scripts/check_architecture_migration_rules.sh
+++ b/scripts/check_architecture_migration_rules.sh
@@ -4202,7 +4202,7 @@ fi
   rg -n --with-filename '\bGLOBAL_(DEPLOYMENT_ID|REGION|RUSTFS_PORT)\b|\bglobalDeploymentIDPtr\b|\bruntime::global::global_rustfs_port\b' \
     crates rustfs fuzz \
     --glob '*.rs' |
-    rg -v '^(crates/common/src/globals|crates/ecstore/src/runtime/(global|sources))\.rs:' || true
+    rg -v '^(crates/common/src/globals|crates/ecstore/src/runtime/(global|instance|sources))\.rs:' || true
 ) >"$GLOBAL_RUNTIME_SCALAR_BYPASS_HITS_FILE"
 
 if [[ -s "$GLOBAL_RUNTIME_SCALAR_BYPASS_HITS_FILE" ]]; then


### PR DESCRIPTION
## Summary

**Slice 4 of 8** of the runtime-identity isolation epic (backlog#939), on the convergence integration branch (which already carries Slices 1–3). This slice starts the **topology scalars → `InstanceContext`** work with its cleanest representative, `GLOBAL_REGION`, and — per the design's explicit constraint — **preserves the per-instance fail-fast contract** rather than downgrading the write-once guard to a warning.

## What changed

- **`InstanceContext` gains a write-once `region: OnceLock<Region>`** with:
  - `set_region` — panics on a second write, exactly as the old `set_global_region` did (fail-fast, now per instance);
  - `region()` — reader.
- **`set_global_region` / `get_global_region` become thin facades** forwarding through `current_ctx()`. Signatures are unchanged, so the app-layer readers in the `rustfs` crate are untouched. During startup the write lands on the bootstrap context (before any `ECStore`), and reads resolve to the same cell once the store adopts it — byte-for-byte single-instance behavior.
- **Removed the `GLOBAL_REGION` static** and corrected the stale `// Tier B (keep as static)` comment (the #939 plan lists region as a Tier A migration). Updated the architecture-migration guard to allow the migrated identifier in the new `runtime/instance.rs` owner file.

## Tests

- `region_round_trips_through_context` — starts empty, round-trips a set value.
- `distinct_contexts_have_independent_regions` — two instances hold independent regions (the isolation delivered here).
- `set_region_twice_fails_fast` — `#[should_panic]`, proving the write-once fail-fast survives per instance.

## Verification

- `make pre-pr` green: fmt, unsafe-code, architecture-migration, logging-guardrails, tokio-io-uring, doc-paths, clippy, and the full `cargo nextest` suite (**7859 passed, 0 failed, 116 skipped**) + doc tests. (One retry needed for a transient Xcode-SDK linker glitch unrelated to the change.)

## Scope

Region only. The other topology scalars get their own slices because they carry extra complications: `deployment_id` has a **dual truth source** with `ECStore.id` (elimination needs its own careful change), and `GLOBAL_ENDPOINTS` is used broadly across the cluster layer. Hard ordering unchanged: Slice 7 (per-instance cancellation) before Slice 8's multi-instance acceptance; Slice 5's heal `'static` contract change is a separate prerequisite PR.

Refs #939