### PR TITLE
refactor(ecstore): migrate tier config manager into InstanceContext

### DIFF
--- a/crates/ecstore/src/runtime/global.rs
+++ b/crates/ecstore/src/runtime/global.rs
@@ -47,10 +47,10 @@ pub const DISK_RESERVE_FRACTION: f64 = 0.15;
 //   GLOBAL_ROOT_DISK_THRESHOLD, GLOBAL_LIFECYCLE_SYS, GLOBAL_EVENT_NOTIFIER, etc.
 // Tier B (keep as static): GLOBAL_RUSTFS_PORT, env var caches, etc.
 //
-// Phase 5 (backlog#939): the erasure setup type, the S3 region, the deployment
-// id, and the endpoint topology moved into the per-instance `InstanceContext`
-// (see `super::instance`); their facades below now forward to the current
-// instance's context.
+// Phase 5 (backlog#939): identity/runtime state (erasure setup, S3 region,
+// deployment id, endpoint topology, tier config manager, ...) is moving into
+// the per-instance `InstanceContext` (see `super::instance`); the facades below
+// forward to the current instance's context.
 lazy_static! {
     static ref GLOBAL_RUSTFS_PORT: OnceLock<u16> = OnceLock::new();
     pub static ref GLOBAL_OBJECT_API: OnceLock<Arc<ECStore>> = OnceLock::new();
@@ -58,7 +58,6 @@ lazy_static! {
     pub static ref GLOBAL_LOCAL_DISK_ID_MAP: Arc<RwLock<HashMap<Uuid, String>>> = Arc::new(RwLock::new(HashMap::new()));
     pub static ref GLOBAL_LOCAL_DISK_SET_DRIVES: Arc<RwLock<TypeLocalDiskSetDrives>> = Arc::new(RwLock::new(Vec::new()));
     pub static ref GLOBAL_ROOT_DISK_THRESHOLD: RwLock<u64> = RwLock::new(0);
-    pub static ref GLOBAL_TIER_CONFIG_MGR: Arc<RwLock<TierConfigMgr>> = TierConfigMgr::new();
     pub static ref GLOBAL_LIFECYCLE_SYS: Arc<LifecycleSys> = LifecycleSys::new();
     pub static ref GLOBAL_EVENT_NOTIFIER: Arc<RwLock<EventNotifier>> = EventNotifier::new();
     pub static ref GLOBAL_BOOT_TIME: OnceCell<SystemTime> = OnceCell::new();
@@ -172,7 +171,7 @@ pub async fn is_first_cluster_node_local() -> bool {
 }
 
 pub fn get_global_tier_config_mgr() -> Arc<RwLock<TierConfigMgr>> {
-    GLOBAL_TIER_CONFIG_MGR.clone()
+    current_ctx().tier_config_mgr()
 }
 
 /// Create a new object layer instance

--- a/crates/ecstore/src/runtime/instance.rs
+++ b/crates/ecstore/src/runtime/instance.rs
@@ -40,6 +40,7 @@
 //! single-instance behavior is byte-for-byte unchanged.
 
 use crate::layout::endpoints::{EndpointServerPools, SetupType};
+use crate::services::tier::tier::TierConfigMgr;
 use rustfs_lock::{GlobalLockManager, get_global_lock_manager};
 use s3s::region::Region;
 use std::sync::{Arc, OnceLock};
@@ -51,7 +52,6 @@ use uuid::Uuid;
 /// This is intentionally minimal in the first migration slice; subsequent
 /// slices move additional identity/runtime state (topology, disk registry,
 /// service handles, cancellation token) into this struct.
-#[derive(Debug)]
 pub struct InstanceContext {
     /// The deployment's erasure setup type.
     ///
@@ -83,6 +83,13 @@ pub struct InstanceContext {
     /// Write-once: storage startup publishes the server pools exactly once.
     /// Replaces the process-global endpoints static.
     endpoints: OnceLock<EndpointServerPools>,
+    /// This instance's tier configuration manager (Phase 5 Slice 7, backlog#939).
+    ///
+    /// Lazily materialized on first access so `InstanceContext::new()` stays
+    /// cheap: single-instance creates one shared manager on first use — exactly
+    /// the "create-once, then share" semantics of the eager process static it
+    /// replaces — while a genuinely independent instance gets its own.
+    tier_config_mgr: OnceLock<Arc<RwLock<TierConfigMgr>>>,
 }
 
 impl InstanceContext {
@@ -105,6 +112,7 @@ impl InstanceContext {
             region: OnceLock::new(),
             deployment_id: OnceLock::new(),
             endpoints: OnceLock::new(),
+            tier_config_mgr: OnceLock::new(),
         }
     }
 
@@ -158,6 +166,12 @@ impl InstanceContext {
         self.endpoints.get().cloned()
     }
 
+    /// This instance's tier configuration manager, materializing it on first
+    /// access. Shared for the lifetime of the instance.
+    pub fn tier_config_mgr(&self) -> Arc<RwLock<TierConfigMgr>> {
+        self.tier_config_mgr.get_or_init(TierConfigMgr::new).clone()
+    }
+
     /// Update this instance's erasure setup type.
     pub async fn update_erasure_type(&self, setup_type: SetupType) {
         *self.erasure_kind.write().await = setup_type;
@@ -187,6 +201,20 @@ impl InstanceContext {
 impl Default for InstanceContext {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// Manual Debug: service handles (e.g. the tier config manager) are not Debug,
+// so summarize their materialization state rather than their contents.
+impl std::fmt::Debug for InstanceContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstanceContext")
+            .field("erasure_kind", &self.erasure_kind)
+            .field("region", &self.region)
+            .field("deployment_id", &self.deployment_id)
+            .field("endpoints", &self.endpoints)
+            .field("tier_config_mgr_set", &self.tier_config_mgr.get().is_some())
+            .finish_non_exhaustive()
     }
 }
 
@@ -402,5 +430,28 @@ mod tests {
         let ctx = InstanceContext::new();
         ctx.set_endpoints(endpoints_with_pools(1));
         ctx.set_endpoints(endpoints_with_pools(2));
+    }
+
+    // The tier config manager is materialized once and shared for the
+    // instance's lifetime — the "create-once, then share" contract of the
+    // eager process static it replaced.
+    #[tokio::test]
+    async fn tier_config_mgr_is_stable_within_an_instance() {
+        let ctx = InstanceContext::new();
+        assert!(
+            Arc::ptr_eq(&ctx.tier_config_mgr(), &ctx.tier_config_mgr()),
+            "repeated access must return the same manager"
+        );
+    }
+
+    // Two contexts own distinct tier config managers.
+    #[tokio::test]
+    async fn distinct_contexts_have_distinct_tier_config_mgr() {
+        let ctx_a = InstanceContext::new();
+        let ctx_b = InstanceContext::new();
+        assert!(
+            !Arc::ptr_eq(&ctx_a.tier_config_mgr(), &ctx_b.tier_config_mgr()),
+            "fresh contexts must not share a tier config manager"
+        );
     }
 }

--- a/crates/ecstore/src/runtime/sources.rs
+++ b/crates/ecstore/src/runtime/sources.rs
@@ -33,12 +33,12 @@ use crate::{
     layout::endpoints::{EndpointServerPools, SetupType},
     runtime::global::{
         GLOBAL_BOOT_TIME, GLOBAL_EVENT_NOTIFIER, GLOBAL_LIFECYCLE_SYS, GLOBAL_LOCAL_DISK_ID_MAP, GLOBAL_LOCAL_DISK_MAP,
-        GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LOCAL_NODE_NAME_FALLBACK, GLOBAL_ROOT_DISK_THRESHOLD, GLOBAL_TIER_CONFIG_MGR,
-        TypeLocalDiskSetDrives, get_background_services_cancel_token, get_global_bucket_monitor, get_global_deployment_id,
-        get_global_endpoints, get_global_endpoints_opt, get_global_lock_client, get_global_lock_clients, get_global_region,
-        get_global_tier_config_mgr, global_rustfs_port, init_global_bucket_monitor, is_dist_erasure, is_erasure, is_erasure_sd,
-        is_first_cluster_node_local, resolve_object_store_handle, set_global_deployment_id, set_global_lock_client,
-        set_global_lock_clients, set_object_layer, update_erasure_type,
+        GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LOCAL_NODE_NAME_FALLBACK, GLOBAL_ROOT_DISK_THRESHOLD, TypeLocalDiskSetDrives,
+        get_background_services_cancel_token, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints,
+        get_global_endpoints_opt, get_global_lock_client, get_global_lock_clients, get_global_region, get_global_tier_config_mgr,
+        global_rustfs_port, init_global_bucket_monitor, is_dist_erasure, is_erasure, is_erasure_sd, is_first_cluster_node_local,
+        resolve_object_store_handle, set_global_deployment_id, set_global_lock_client, set_global_lock_clients, set_object_layer,
+        update_erasure_type,
     },
     services::batch_processor::{GlobalBatchProcessors, get_global_processors},
     services::event_notification::EventNotifier,
@@ -387,7 +387,7 @@ pub(crate) fn local_disk_set_drives_handle() -> Arc<RwLock<TypeLocalDiskSetDrive
 }
 
 pub(crate) fn tier_config_mgr_handle() -> Arc<RwLock<TierConfigMgr>> {
-    GLOBAL_TIER_CONFIG_MGR.clone()
+    get_global_tier_config_mgr()
 }
 
 pub fn expiry_state_handle() -> Arc<RwLock<ExpiryState>> {
@@ -521,7 +521,7 @@ pub(crate) async fn initialize_local_disk_maps(endpoint_pools: EndpointServerPoo
 }
 
 pub(crate) async fn init_tier_config_mgr(store: Arc<ECStore>) -> Result<()> {
-    GLOBAL_TIER_CONFIG_MGR.write().await.init(store).await
+    get_global_tier_config_mgr().write().await.init(store).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Phase 5 (backlog#939) — **Slice 7**. Moves the **tier config manager** — the first *service handle* — out of the eager process static into the per-instance `InstanceContext`, establishing the pattern for the remaining service Arcs (lifecycle, event notifier, expiry/transition state, …).

> **Stacked on Slice 6 (#4469)** → 5 (#4465) → 4 (#4462). Retarget down the stack as each merges.

## The pattern (why it's safe and keeps `new()` cheap)

`InstanceContext` gains `tier_config_mgr: OnceLock<Arc<RwLock<TierConfigMgr>>>`, materialized **lazily on first access**. This reproduces the eager static's real semantics — "create once on first use, then share" — without making context construction heavyweight:

- **Single-instance**: the bootstrap context creates one manager on first access and shares it for every later `get_global_tier_config_mgr()` call — byte-for-byte the same as the `lazy_static` did.
- **Multi-instance**: each context materializes its own.

## Changes

- `global.rs` `get_global_tier_config_mgr` and `sources.rs` `tier_config_mgr_handle` / `init_tier_config_mgr` keep their signatures and route through the current instance's context; the static is removed. All access already funnels through these helpers.
- `InstanceContext` gets a manual `Debug` impl (`TierConfigMgr` isn't `Debug`; the handle is summarized as set/unset).

## Tests

- `tier_config_mgr_is_stable_within_an_instance` — repeated access returns the same `Arc`.
- `distinct_contexts_have_distinct_tier_config_mgr` — two contexts own different managers.

## Verification

```bash
cargo test -p rustfs-ecstore        # 17 instance-context tests green
cargo clippy -p rustfs-ecstore --all-targets   # clean
make pre-commit                     # pass
```

Refs: backlog#939 (Phase 5, Slice 7), stacked on #4469 (Slice 6).