### PR TITLE
refactor(ecstore): migrate the event notifier into InstanceContext (Phase 5 Slice 8)

### DIFF
--- a/crates/ecstore/src/runtime/global.rs
+++ b/crates/ecstore/src/runtime/global.rs
@@ -18,7 +18,6 @@ use crate::{
     bucket::lifecycle::bucket_lifecycle_ops::LifecycleSys,
     disk::DiskStore,
     layout::endpoints::{EndpointServerPools, PoolEndpoints, SetupType},
-    services::event_notification::EventNotifier,
     services::tier::tier::TierConfigMgr,
     store::ECStore,
 };
@@ -59,7 +58,6 @@ lazy_static! {
     pub static ref GLOBAL_LOCAL_DISK_SET_DRIVES: Arc<RwLock<TypeLocalDiskSetDrives>> = Arc::new(RwLock::new(Vec::new()));
     pub static ref GLOBAL_ROOT_DISK_THRESHOLD: RwLock<u64> = RwLock::new(0);
     pub static ref GLOBAL_LIFECYCLE_SYS: Arc<LifecycleSys> = LifecycleSys::new();
-    pub static ref GLOBAL_EVENT_NOTIFIER: Arc<RwLock<EventNotifier>> = EventNotifier::new();
     pub static ref GLOBAL_BOOT_TIME: OnceCell<SystemTime> = OnceCell::new();
     pub static ref GLOBAL_LOCAL_NODE_NAME_FALLBACK: String = "127.0.0.1:9000".to_string();
     pub static ref GLOBAL_LOCAL_NODE_NAME_HEX_FALLBACK: String =

--- a/crates/ecstore/src/runtime/instance.rs
+++ b/crates/ecstore/src/runtime/instance.rs
@@ -40,6 +40,7 @@
 //! single-instance behavior is byte-for-byte unchanged.
 
 use crate::layout::endpoints::{EndpointServerPools, SetupType};
+use crate::services::event_notification::EventNotifier;
 use crate::services::tier::tier::TierConfigMgr;
 use rustfs_lock::{GlobalLockManager, get_global_lock_manager};
 use s3s::region::Region;
@@ -90,6 +91,11 @@ pub struct InstanceContext {
     /// the "create-once, then share" semantics of the eager process static it
     /// replaces — while a genuinely independent instance gets its own.
     tier_config_mgr: OnceLock<Arc<RwLock<TierConfigMgr>>>,
+    /// This instance's event notifier (Phase 5 Slice 8, backlog#939).
+    ///
+    /// Lazily materialized like the tier config manager; holds the instance's
+    /// notification target list. Replaces the eager process static.
+    event_notifier: OnceLock<Arc<RwLock<EventNotifier>>>,
 }
 
 impl InstanceContext {
@@ -113,6 +119,7 @@ impl InstanceContext {
             deployment_id: OnceLock::new(),
             endpoints: OnceLock::new(),
             tier_config_mgr: OnceLock::new(),
+            event_notifier: OnceLock::new(),
         }
     }
 
@@ -172,6 +179,12 @@ impl InstanceContext {
         self.tier_config_mgr.get_or_init(TierConfigMgr::new).clone()
     }
 
+    /// This instance's event notifier, materializing it on first access.
+    /// Shared for the lifetime of the instance.
+    pub fn event_notifier(&self) -> Arc<RwLock<EventNotifier>> {
+        self.event_notifier.get_or_init(EventNotifier::new).clone()
+    }
+
     /// Update this instance's erasure setup type.
     pub async fn update_erasure_type(&self, setup_type: SetupType) {
         *self.erasure_kind.write().await = setup_type;
@@ -214,6 +227,7 @@ impl std::fmt::Debug for InstanceContext {
             .field("deployment_id", &self.deployment_id)
             .field("endpoints", &self.endpoints)
             .field("tier_config_mgr_set", &self.tier_config_mgr.get().is_some())
+            .field("event_notifier_set", &self.event_notifier.get().is_some())
             .finish_non_exhaustive()
     }
 }
@@ -452,6 +466,27 @@ mod tests {
         assert!(
             !Arc::ptr_eq(&ctx_a.tier_config_mgr(), &ctx_b.tier_config_mgr()),
             "fresh contexts must not share a tier config manager"
+        );
+    }
+
+    // The event notifier is materialized once and shared within an instance.
+    #[tokio::test]
+    async fn event_notifier_is_stable_within_an_instance() {
+        let ctx = InstanceContext::new();
+        assert!(
+            Arc::ptr_eq(&ctx.event_notifier(), &ctx.event_notifier()),
+            "repeated access must return the same notifier"
+        );
+    }
+
+    // Two contexts own distinct event notifiers.
+    #[tokio::test]
+    async fn distinct_contexts_have_distinct_event_notifier() {
+        let ctx_a = InstanceContext::new();
+        let ctx_b = InstanceContext::new();
+        assert!(
+            !Arc::ptr_eq(&ctx_a.event_notifier(), &ctx_b.event_notifier()),
+            "fresh contexts must not share an event notifier"
         );
     }
 }

--- a/crates/ecstore/src/runtime/sources.rs
+++ b/crates/ecstore/src/runtime/sources.rs
@@ -32,8 +32,8 @@ use crate::{
     error::Result,
     layout::endpoints::{EndpointServerPools, SetupType},
     runtime::global::{
-        GLOBAL_BOOT_TIME, GLOBAL_EVENT_NOTIFIER, GLOBAL_LIFECYCLE_SYS, GLOBAL_LOCAL_DISK_ID_MAP, GLOBAL_LOCAL_DISK_MAP,
-        GLOBAL_LOCAL_DISK_SET_DRIVES, GLOBAL_LOCAL_NODE_NAME_FALLBACK, GLOBAL_ROOT_DISK_THRESHOLD, TypeLocalDiskSetDrives,
+        GLOBAL_BOOT_TIME, GLOBAL_LIFECYCLE_SYS, GLOBAL_LOCAL_DISK_ID_MAP, GLOBAL_LOCAL_DISK_MAP, GLOBAL_LOCAL_DISK_SET_DRIVES,
+        GLOBAL_LOCAL_NODE_NAME_FALLBACK, GLOBAL_ROOT_DISK_THRESHOLD, TypeLocalDiskSetDrives,
         get_background_services_cancel_token, get_global_bucket_monitor, get_global_deployment_id, get_global_endpoints,
         get_global_endpoints_opt, get_global_lock_client, get_global_lock_clients, get_global_region, get_global_tier_config_mgr,
         global_rustfs_port, init_global_bucket_monitor, is_dist_erasure, is_erasure, is_erasure_sd, is_first_cluster_node_local,
@@ -399,7 +399,7 @@ pub fn transition_state_handle() -> Arc<TransitionState> {
 }
 
 pub(crate) fn event_notifier_handle() -> Arc<RwLock<EventNotifier>> {
-    GLOBAL_EVENT_NOTIFIER.clone()
+    crate::runtime::global::current_ctx().event_notifier()
 }
 
 pub(crate) async fn local_disk_by_path(path: &str) -> Option<DiskStore> {


### PR DESCRIPTION
## Summary

Phase 5 (backlog#939) — **Slice 8**. Moves the **event notifier** — the second stateful service handle — into the per-instance `InstanceContext`, following the tier-config-manager pattern (Slice 7).

> **Stacked on #4465** (Slices 5–7). Retarget to main once #4465 lands.

## Changes

- `InstanceContext` gains `event_notifier: OnceLock<Arc<RwLock<EventNotifier>>>`, materialized **lazily** on first access — keeps `new()` cheap and reproduces the eager static's create-once-then-share. The notifier owns the instance's notification target list.
- `sources.rs` `event_notifier_handle` keeps its signature and routes through the current instance's context; the static and its now-unused imports are removed.

## Backward compatibility

Single-instance: first access materializes one notifier shared for the process lifetime via the bootstrap context — byte-for-byte the same as the `lazy_static`.

## Tests

- `event_notifier_is_stable_within_an_instance` — repeated access returns the same `Arc`.
- `distinct_contexts_have_distinct_event_notifier` — two contexts own different notifiers.

## Verification

```bash
cargo test -p rustfs-ecstore        # 19 instance-context tests green
cargo clippy -p rustfs-ecstore --all-targets   # clean
make pre-commit                     # pass
```

Refs: backlog#939 (Phase 5, Slice 8), stacked on #4465.