### PR TITLE
perf(ecstore): parallelize tmp xl.meta write and shard fdatasync on commit

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -4977,28 +4977,40 @@ impl DiskAPI for LocalDisk {
             } else {
                 SyncMode::None
             };
-            self.write_all_private(
-                src_volume,
-                &format!("{}/{}", &src_path, STORAGE_FORMAT_FILE),
-                new_dst_buf.into(),
-                tmp_meta_sync,
-                src_file_parent,
-            )
-            .await?;
-
-            // Make shard files durable before the commit rename: once rename_data
-            // succeeds the write is acknowledged, so data must not live only in the
-            // page cache. Multipart parts were already synced during rename_part, so
-            // their fdatasync here is a cheap no-op. A missing source dir is left for
-            // the rename below to report through the existing rollback path.
-            // Payload durability: kept by both strict and relaxed.
-            if durability.syncs_data_shards()
-                && let Some((src_data_path, _)) = has_data_dir_path.as_ref()
-                && let Err(err) = os::sync_dir_files(src_data_path).await
-                && err.kind() != ErrorKind::NotFound
-            {
-                return Err(to_file_error(err).into());
-            }
+            // The tmp xl.meta write and the shard-file fdatasync are independent
+            // (disjoint paths) and both only need to be durable before the commit
+            // renames below, so run them concurrently to drop a blocking
+            // round-trip from the PUT commit critical path (rustfs/backlog#922
+            // step 2). The "contents durable -> rename -> dst dir fsync" ordering
+            // is unchanged — both futures complete before any rename — which the
+            // rename_data crash-consistency harness (backlog#935) exercises.
+            //
+            // Shard durability: once rename_data succeeds the write is
+            // acknowledged, so data must not live only in the page cache.
+            // Multipart parts were already synced during rename_part, so their
+            // fdatasync here is a cheap no-op. A missing source dir is left for the
+            // rename below to report through the existing rollback path. Payload
+            // durability is kept by both strict and relaxed.
+            // Bound to a local so the borrow lives across the join! below.
+            let tmp_meta_rel_path = format!("{}/{}", &src_path, STORAGE_FORMAT_FILE);
+            let tmp_meta_write =
+                self.write_all_private(src_volume, &tmp_meta_rel_path, new_dst_buf.into(), tmp_meta_sync, src_file_parent);
+            let shard_sync = async {
+                if durability.syncs_data_shards()
+                    && let Some((src_data_path, _)) = has_data_dir_path.as_ref()
+                    && let Err(err) = os::sync_dir_files(src_data_path).await
+                    && err.kind() != ErrorKind::NotFound
+                {
+                    return Err::<(), DiskError>(to_file_error(err).into());
+                }
+                Ok(())
+            };
+            let (tmp_meta_res, shard_sync_res) = tokio::join!(tmp_meta_write, shard_sync);
+            // Surface a tmp-meta failure first (its prior serial position), then a
+            // shard-sync failure; either aborts before any rename, exactly as the
+            // sequential version did.
+            tmp_meta_res?;
+            shard_sync_res?;
 
             if let Some((src_data_path, dst_data_path)) = has_data_dir_path.as_ref()
                 && let Err(err) = rename_all(src_data_path, dst_data_path, &skip_parent).await


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#922 (HP-1 step 2), rustfs/backlog#936 (HP series tracking).

## Summary of Changes

The non-inline `rename_data` commit path made the tmp `xl.meta` durable and then fdatasynced the shard files in two sequential `await`s, each its own blocking round-trip. The two operations touch disjoint paths (the tmp `xl.meta` under the tmp bucket vs the shard data dir) and have no ordering constraint between them — both only need to be durable before the commit renames that follow.

This runs them concurrently with `tokio::join!`, dropping a blocking round-trip from the PUT commit critical path (backlog#922 step 2).

Invariants preserved:
- The "contents durable → rename → dst dir fsync" ordering is unchanged: both futures complete before any rename.
- A failure in either aborts before the rename, exactly as the sequential version did; the tmp-meta error is still surfaced first (its prior serial position).
- Payload and metadata durability semantics are identical under the strict and relaxed tiers (`syncs_data_shards` / `syncs_commit_metadata` gating is untouched).

This is the moderate-risk, ordering-preserving step of HP-1, unblocked now that the crash-consistency harness (backlog#935, merged in #4478) is in `main` to validate it. The higher-risk step 3 (moving the shard fdatasync onto `BitrotWriter::shutdown`, which also needs a remote-disk sync contract) stays separate.

## Verification

- `cargo test -p rustfs-ecstore --lib disk::local::test::crash_consistency` — pass (5 tests; a pre-commit crash at each injection point still reopens as old-or-new across strict/relaxed).
- `cargo test -p rustfs-ecstore --lib disk::local::test::test_rename_data` — pass (6 tests, incl. `test_rename_data_relaxed_keeps_shard_sync_skips_commit_fsyncs`, which confirms the shard fdatasync still runs after parallelization, and the graceful pre-commit rollback failpoint).
- `cargo test -p rustfs-ecstore --lib disk::os` — pass (8 tests).
- `cargo check -p rustfs-ecstore` — no new warnings.
- `make pre-commit` — pass.

## Impact

No on-disk format, config, or public API change. The set of fsync/fdatasync calls and their happens-before-rename ordering are identical; only the scheduling of the two independent pre-rename durability operations changes (sequential → concurrent). The throughput effect is platform-dependent (fewer serial blocking round-trips on the commit path) and left to the warp A/B gate (backlog#935, merged in #4480), which includes the drive-sync on/off matrix.

## Additional Notes

Part of HP-1 (backlog#922). Step 1 (`SyncMode::FileOnly` for the tmp write) already landed; step 3 (shard fdatasync moved to writer shutdown + remote sync contract) and step 4 (mkdir bucket-dir fsync gap) remain separate follow-ups.
