### PR TITLE
fix(ecstore): fsync ancestor dirs for first object writes

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -5164,6 +5164,8 @@ impl DiskAPI for LocalDisk {
             // Inline: merge read + parse + write + rename into single spawn_blocking
             let src = src_file_path.clone();
             let dst = dst_file_path.clone();
+            // Captured by the closure to fsync the new object's ancestor dir chain.
+            let bucket_dir = dst_volume_dir.clone();
             let cleanup_path = if src_volume == super::RUSTFS_META_MULTIPART_BUCKET {
                 src_file_path.parent().map(|p| p.to_path_buf())
             } else {
@@ -5259,6 +5261,27 @@ impl DiskAPI for LocalDisk {
                 // Persist the commit rename's directory entry across power loss.
                 if sync && let Some(dst_parent) = dst.parent() {
                     os::fsync_dir_std(dst_parent)?;
+                }
+
+                // Same power-loss gap as the non-inline path (rustfs/backlog#922
+                // step 4): a first PUT creates the object dir (and any missing
+                // prefix dirs) whose entry in the bucket/prefix dir reliable_mkdir_all
+                // never fsynced. The fsync above persists the object dir's contents,
+                // not its own entry, so for a new inline object fsync the ancestor
+                // chain up to and including the bucket. Overwrites already have a
+                // durable object dir; the starts_with guard bounds the walk.
+                if sync && has_dst_buf.is_none() {
+                    let mut ancestor = dst.parent().and_then(|object_dir| object_dir.parent());
+                    while let Some(ancestor_dir) = ancestor {
+                        if !ancestor_dir.starts_with(&bucket_dir) {
+                            break;
+                        }
+                        os::fsync_dir_std(ancestor_dir)?;
+                        if ancestor_dir == bucket_dir.as_path() {
+                            break;
+                        }
+                        ancestor = ancestor_dir.parent();
+                    }
                 }
 
                 Ok::<(Option<uuid::Uuid>, Option<Vec<u8>>), std::io::Error>((old_data_dir, version_signature))
@@ -6411,6 +6434,42 @@ mod test {
         assert!(
             !os::fsync_dir_recorder::was_fsynced(&bucket_dir),
             "relaxed durability must not fsync the bucket dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rename_data_new_inline_object_fsyncs_new_ancestor_dirs() {
+        // The inline commit path (fi.data present) has the same mkdir gap as the
+        // non-inline path: a first PUT under a new prefix must fsync the newly
+        // created prefix and bucket dirs.
+        use tempfile::tempdir;
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+
+        let bucket = "new-inline-bucket";
+        let object = "prefix/new-inline-object";
+        let tmp_object = "tmp-new-inline";
+        ensure_test_volume(&disk, bucket).await;
+        ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
+
+        let _mode = durability_mode_override::set(DurabilityMode::Strict);
+        let version_id = Uuid::parse_str("99999999-9999-9999-9999-999999999999").expect("version id should parse");
+        // fi.data present -> no_inline is false -> the inline commit branch runs.
+        let new_fi = test_file_info(object, version_id, None, Some(Bytes::from_static(b"inline-payload")));
+        disk.rename_data(RUSTFS_META_TMP_BUCKET, tmp_object, new_fi, bucket, object)
+            .await
+            .expect("inline rename_data should commit the new object");
+
+        let bucket_dir = disk.get_bucket_path(bucket).expect("bucket path should resolve");
+        let prefix_dir = disk.get_object_path(bucket, "prefix").expect("prefix path should resolve");
+        assert!(
+            os::fsync_dir_recorder::was_fsynced(&prefix_dir),
+            "the newly created prefix dir must be fsynced on an inline first PUT"
+        );
+        assert!(
+            os::fsync_dir_recorder::was_fsynced(&bucket_dir),
+            "the bucket dir must be fsynced on an inline first PUT"
         );
     }
 

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -5122,6 +5122,30 @@ impl DiskAPI for LocalDisk {
                 return Err(to_file_error(err).into());
             }
 
+            // First PUT of an object creates its directory (and any missing prefix
+            // dirs) via reliable_mkdir_all, which never fsyncs the parent chain. The
+            // commit fsync above persists the object dir's *contents*, not its own
+            // entry in the bucket/prefix dir, so on power loss after ack the whole
+            // object dir could vanish (rustfs/backlog#922 step 4). For a new object
+            // (no prior xl.meta) fsync the ancestor chain from the object dir's
+            // parent up to and including the bucket so those new directory entries
+            // are durable. Overwrites already have a durable object dir. The
+            // starts_with guard bounds the walk to the bucket subtree. Relaxed/none
+            // accept the wider window, like the commit fsync above.
+            if has_dst_buf.is_none() && durability.syncs_commit_metadata() {
+                let mut ancestor = dst_file_path.parent().and_then(|object_dir| object_dir.parent());
+                while let Some(dir) = ancestor {
+                    if !dir.starts_with(&dst_volume_dir) {
+                        break;
+                    }
+                    os::fsync_dir(dir).await.map_err(to_file_error)?;
+                    if dir == dst_volume_dir.as_path() {
+                        break;
+                    }
+                    ancestor = dir.parent();
+                }
+            }
+
             if let Some(src_file_path_parent) = src_file_path.parent() {
                 if src_volume != super::RUSTFS_META_MULTIPART_BUCKET {
                     let _ = remove_std(src_file_path_parent);
@@ -6319,6 +6343,74 @@ mod test {
         assert!(
             os::fsync_dir_recorder::was_fsynced(&backup_parent),
             "old-metadata rollback backup must keep fsyncing its parent dir"
+        );
+    }
+
+    // Seed a first PUT of `object` (no prior version) through the non-inline
+    // rename_data path and return (disk, tempdir). The object dir and any prefix
+    // dirs are created during the commit.
+    async fn commit_new_object(mode: DurabilityMode, bucket: &str, object: &str) -> (LocalDisk, tempfile::TempDir) {
+        use tempfile::tempdir;
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        ensure_test_volume(&disk, bucket).await;
+        ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
+
+        let tmp_object = "tmp-new-object";
+        let version_id = Uuid::parse_str("77777777-7777-7777-7777-777777777777").expect("version id should parse");
+        let new_data_dir = Uuid::parse_str("88888888-8888-8888-8888-888888888888").expect("new data dir should parse");
+        let tmp_data_dir = dir
+            .path()
+            .join(RUSTFS_META_TMP_BUCKET)
+            .join(tmp_object)
+            .join(new_data_dir.to_string());
+        fs::create_dir_all(&tmp_data_dir)
+            .await
+            .expect("new tmp data dir should be created");
+        fs::write(tmp_data_dir.join("part.1"), b"new-data")
+            .await
+            .expect("new tmp data should be written");
+
+        let _mode = durability_mode_override::set(mode);
+        let new_fi = test_file_info(object, version_id, Some(new_data_dir), None);
+        disk.rename_data(RUSTFS_META_TMP_BUCKET, tmp_object, new_fi, bucket, object)
+            .await
+            .expect("rename_data should commit the new object");
+        (disk, dir)
+    }
+
+    #[tokio::test]
+    async fn test_rename_data_new_object_fsyncs_new_ancestor_dirs() {
+        // A first PUT under a new prefix must fsync every newly created ancestor
+        // directory (prefix dir and bucket dir) so the object dir's own entry
+        // survives power loss after ack (rustfs/backlog#922 step 4).
+        let bucket = "new-object-bucket";
+        let (disk, _dir) = commit_new_object(DurabilityMode::Strict, bucket, "prefix/new-object").await;
+
+        let bucket_dir = disk.get_bucket_path(bucket).expect("bucket path should resolve");
+        let prefix_dir = disk.get_object_path(bucket, "prefix").expect("prefix path should resolve");
+        assert!(
+            os::fsync_dir_recorder::was_fsynced(&prefix_dir),
+            "the newly created prefix dir must be fsynced"
+        );
+        assert!(
+            os::fsync_dir_recorder::was_fsynced(&bucket_dir),
+            "the bucket dir must be fsynced so the new prefix entry survives power loss"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rename_data_relaxed_new_object_skips_ancestor_fsync() {
+        // Relaxed persists shard payload but leaves metadata/directory commits to
+        // the page cache, so a new object must not fsync the ancestor chain.
+        let bucket = "new-object-bucket-relaxed";
+        let (disk, _dir) = commit_new_object(DurabilityMode::Relaxed, bucket, "prefix/new-object").await;
+
+        let bucket_dir = disk.get_bucket_path(bucket).expect("bucket path should resolve");
+        assert!(
+            !os::fsync_dir_recorder::was_fsynced(&bucket_dir),
+            "relaxed durability must not fsync the bucket dir"
         );
     }
 


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#922 (HP-1 step 4), rustfs/backlog#936 (HP series tracking).

## Summary of Changes

`reliable_mkdir_all` creates an object's directory (and any missing prefix dirs) with plain `mkdir` and never fsyncs the parent chain. The commit-point fsync in `rename_data` persists the object dir's **contents** (its `xl.meta` and data dir), but not the object dir's own entry in the bucket / prefix directory. So on the **first PUT** of an object, a power loss after the write is acknowledged could drop the whole object directory even though its contents were durable — an acknowledged write silently lost (backlog#922 step 4).

For a new object (no prior `xl.meta`) under a durability tier that syncs commit metadata, this fsyncs the ancestor chain from the object dir's parent up to and including the bucket after the commit rename, so the newly created directory entries survive power loss. A `starts_with` guard bounds the walk to the bucket subtree. This is applied on **both** commit paths:

- **Non-inline (erasure)**: async `os::fsync_dir` walk after the commit renames.
- **Inline**: synchronous `os::fsync_dir_std` walk inside the inline `spawn_blocking` closure.

Unaffected: overwrites (`has_dst_buf.is_some()`) already have a durable object dir; relaxed / none tiers accept the wider window like the existing commit fsync. Low frequency: only fires on the first PUT of an object.

## Verification

- `cargo test -p rustfs-ecstore --lib disk::local::test::test_rename_data` — pass (9 tests, incl. 3 new).
- `test_rename_data_new_object_fsyncs_new_ancestor_dirs` (non-inline) and `test_rename_data_new_inline_object_fsyncs_new_ancestor_dirs` (inline): a first PUT under a new prefix fsyncs both the prefix dir and the bucket dir (asserted via the `fsync_dir` recorder, since durability regressions are invisible to ordinary behavior tests).
- `test_rename_data_relaxed_new_object_skips_ancestor_fsync`: relaxed does not fsync the ancestor chain.
- `cargo test -p rustfs-ecstore --lib disk::local::test::crash_consistency` — pass (5 tests; the new-object commit path stays old-or-new).
- `make pre-commit` — pass.

## Impact

No on-disk format, config, or public API change. Strengthens durability: closes a power-loss window where a freshly-created object directory entry could be lost after ack, on both the erasure and inline commit paths. The added fsyncs are bounded to the first PUT of an object and to commit-metadata-syncing tiers. On-disk data is unchanged; only additional directory fsyncs are issued. The power-loss benefit itself is only observable under real fault injection (Linux dm-flakey / the crash-consistency destructive profile), which the merged harness (backlog#935) covers structurally.

## Additional Notes

Part of HP-1 (backlog#922): step 1 (`SyncMode::FileOnly`) and step 2 (parallelizing the tmp-meta write with the shard fdatasync, #4487) already landed. Step 3 (moving the shard fdatasync onto `BitrotWriter::shutdown` with a remote-disk sync contract) remains the higher-risk item for a separate change.

Note: CI `Test and Lint` may intermittently fail on the unrelated pre-existing flake `shard_read_costs_for_empty_disk_set_are_empty` (order-dependent, fixed separately in #4496); this PR's diff does not touch that module.
