### PR TITLE
test(ecstore): run shard_read_costs empty test under a Tokio runtime

### DIFF
--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -4008,8 +4008,15 @@ mod tests {
         assert!(part.etag.is_empty());
     }
 
-    #[test]
-    fn shard_read_costs_for_empty_disk_set_are_empty() {
+    // Runs under a Tokio runtime like the sibling reservation tests:
+    // shard_read_costs_for_disks consults process-global topology state
+    // (local_endpoint_hosts_for_shard_costs), whose fast-lock manager lazily
+    // spawns a background cleanup task on first access. As a plain sync #[test]
+    // this panicked with a TryCurrentError whenever it was the first test in a
+    // process to touch that global (e.g. under nextest's per-test isolation),
+    // making it order-dependent flaky in CI.
+    #[tokio::test]
+    async fn shard_read_costs_for_empty_disk_set_are_empty() {
         assert!(shard_read_costs_for_disks(&[]).is_empty());
     }
 


### PR DESCRIPTION
## Related Issues

N/A (CI flake fix). Unblocks #4493 and stabilizes Test and Lint for other PRs.

## Summary of Changes

`shard_read_costs_for_empty_disk_set_are_empty` was a plain sync `#[test]`, but `shard_read_costs_for_disks` consults process-global topology state (`local_endpoint_hosts_for_shard_costs`) whose fast-lock manager lazily spawns a background cleanup task (`tokio::spawn`) on first access. When this test was the first in a process to touch that global — as it is under nextest's per-test isolation — the spawn panicked with `TryCurrentError` (no runtime), making the test order-dependent flaky in CI: it passes only when a sibling `#[tokio::test]` initializes the manager under a runtime first.

Run it under a Tokio runtime (`#[tokio::test]`), matching the sibling reservation tests in the same module. Test-only change; no production behavior change.

## Verification

- Reproduced the failure on `origin/main` (with no other changes): the test panics at `crates/lock/src/fast_lock/manager.rs:380` under both `cargo test` (shared process) and `cargo nextest run` (isolated).
- After the change: `cargo test` and `cargo nextest run` both pass the test in isolation.
- `make pre-commit` — pass.

## Impact

Test-only. Removes an order-dependent CI flake in `Test and Lint` that intermittently fails unrelated PRs (it surfaced on #4493, whose diff does not touch this module — proven by reverting that PR's change and reproducing the same failure).

## Additional Notes

The deeper cause is that a synchronous helper transitively triggers a lazy global that assumes a Tokio runtime; aligning the test with its `#[tokio::test]` siblings is the minimal, low-risk fix. Making the global's cleanup-task spawn tolerant of a missing runtime would be a broader, separate change.
