### PR TITLE
refactor(ecstore,heal): return the local disk map as an owned read guard (Phase 5 disk-registry prep)

### DIFF
--- a/crates/ecstore/src/runtime/sources.rs
+++ b/crates/ecstore/src/runtime/sources.rs
@@ -50,7 +50,7 @@ use rustfs_kms::{ObjectEncryptionService, get_global_encryption_service};
 use rustfs_lock::client::LockClient;
 use s3s::dto::BucketLifecycleConfiguration;
 use s3s::region::Region;
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::{OwnedRwLockReadGuard, RwLock};
 use tokio_util::sync::CancellationToken;
 use tonic::transport::Channel;
 use uuid::Uuid;
@@ -362,8 +362,16 @@ pub fn bucket_monitor() -> Option<Arc<Monitor>> {
     get_global_bucket_monitor()
 }
 
-pub async fn local_disk_map_read() -> RwLockReadGuard<'static, HashMap<String, Option<DiskStore>>> {
-    GLOBAL_LOCAL_DISK_MAP.read().await
+/// Acquire a read guard over the local disk map as an **owned** guard.
+///
+/// Returns an [`OwnedRwLockReadGuard`] (holding an `Arc` clone of the lock)
+/// rather than a `'static` borrow of the process global. This decouples callers
+/// (notably the heal crate, which holds the guard across `.await`) from the
+/// global's `'static` lifetime, so the map can later move into the per-instance
+/// `InstanceContext` (Phase 5 disk-registry migration, backlog#939) without a
+/// cross-crate signature change. Single-instance behavior is unchanged.
+pub async fn local_disk_map_read() -> OwnedRwLockReadGuard<HashMap<String, Option<DiskStore>>> {
+    GLOBAL_LOCAL_DISK_MAP.clone().read_owned().await
 }
 
 pub(crate) fn init_bucket_monitor_for_current_endpoints() {

--- a/crates/heal/src/heal/mod.rs
+++ b/crates/heal/src/heal/mod.rs
@@ -137,7 +137,13 @@ pub(crate) type Endpoint = EcstoreEndpoint;
 pub(crate) type StorageError = EcstoreStorageError;
 pub(crate) type LocalDiskMap = std::collections::HashMap<String, Option<DiskStore>>;
 
-pub(crate) async fn local_disk_map_read() -> tokio::sync::RwLockReadGuard<'static, LocalDiskMap> {
+/// Read the local disk map as an owned guard.
+///
+/// Returns an owned guard (see the ecstore boundary), so the heal manager can
+/// hold it across `.await` without depending on a `'static` process global —
+/// the prerequisite for moving the disk map into the per-instance
+/// `InstanceContext` (backlog#939). Usage is otherwise unchanged.
+pub(crate) async fn local_disk_map_read() -> tokio::sync::OwnedRwLockReadGuard<LocalDiskMap> {
     ecstore_local_disk_map_read().await
 }
 


### PR DESCRIPTION
## Summary

**Prerequisite** for the Phase 5 disk-registry migration (backlog#939). The local disk map can't move from the process global into the per-instance `InstanceContext` while callers depend on a `'static` read guard borrowed from that global. This PR changes the contract to an **owned** guard first.

## Change

`local_disk_map_read` now returns `OwnedRwLockReadGuard<..>` (via `Arc::read_owned`) instead of `RwLockReadGuard<'static, _>`:

- **ecstore** `runtime::sources::local_disk_map_read` holds an `Arc` clone of the lock rather than a `'static` borrow of `GLOBAL_LOCAL_DISK_MAP`.
- **heal**'s forwarding accessor and its callers — which hold the guard across `.await` while clearing/writing per-disk markers (`heal/mod.rs`, `heal/manager.rs`) — keep **identical behavior**: the owned guard derefs to the same map, so iteration is unchanged.

## Why it's safe

Single-instance behavior is byte-for-byte unchanged — the same read lock is held across the same awaits; only the guard's *ownership* changes (owned Arc vs `'static` borrow). This is purely a contract change that unblocks sourcing the map from the current instance's context in a follow-up.

## Verification

```bash
cargo test -p rustfs-heal                              # 201 tests green
cargo clippy -p rustfs-ecstore -p rustfs-heal --all-targets   # clean
make pre-commit                                       # fmt + arch guards + quick-check pass
```

Refs: backlog#939 (Phase 5, disk-registry prerequisite).