### PR TITLE
fix: harden io-core and concurrency boundaries against panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9331,6 +9331,7 @@ dependencies = [
  "rustfs-io-metrics",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/concurrency/src/config.rs
+++ b/crates/concurrency/src/config.rs
@@ -117,27 +117,19 @@ impl ConcurrencyConfig {
         let mut config = Self::default();
 
         // Read from environment if available
-        if let Ok(val) = std::env::var("RUSTFS_TIMEOUT_DEFAULT")
-            && let Ok(secs) = val.parse::<u64>()
-        {
+        if let Some(secs) = parse_env::<u64>("RUSTFS_TIMEOUT_DEFAULT") {
             config.timeout_policy.default_timeout = Duration::from_secs(secs);
         }
 
-        if let Ok(val) = std::env::var("RUSTFS_TIMEOUT_MAX")
-            && let Ok(secs) = val.parse::<u64>()
-        {
+        if let Some(secs) = parse_env::<u64>("RUSTFS_TIMEOUT_MAX") {
             config.timeout_policy.max_timeout = Duration::from_secs(secs);
         }
 
-        if let Ok(val) = std::env::var("RUSTFS_BACKPRESSURE_BUFFER_SIZE")
-            && let Ok(size) = val.parse::<usize>()
-        {
+        if let Some(size) = parse_env::<usize>("RUSTFS_BACKPRESSURE_BUFFER_SIZE") {
             config.backpressure_policy.buffer_size = size;
         }
 
-        if let Ok(val) = std::env::var("RUSTFS_IO_BUFFER_SIZE")
-            && let Ok(size) = val.parse::<usize>()
-        {
+        if let Some(size) = parse_env::<usize>("RUSTFS_IO_BUFFER_SIZE") {
             config.scheduler_policy.base_buffer_size = size;
         }
 
@@ -146,6 +138,9 @@ impl ConcurrencyConfig {
 
     /// Validate configuration
     pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.timeout_policy.default_timeout.is_zero() || self.timeout_policy.max_timeout.is_zero() {
+            return Err(ConfigError::InvalidTimeout("timeouts must be > 0".to_string()));
+        }
         if self.timeout_policy.default_timeout > self.timeout_policy.max_timeout {
             return Err(ConfigError::InvalidTimeout("default_timeout cannot exceed max_timeout".to_string()));
         }
@@ -153,6 +148,10 @@ impl ConcurrencyConfig {
             return Err(ConfigError::InvalidTimeout("min_timeout cannot exceed max_timeout".to_string()));
         }
 
+        // A zero-capacity pipe (duplex(0)) never accepts writes, hanging producers forever.
+        if self.backpressure_policy.buffer_size == 0 {
+            return Err(ConfigError::InvalidBackpressure("buffer_size must be > 0".to_string()));
+        }
         if self.backpressure_policy.high_watermark <= self.backpressure_policy.low_watermark
             || self.backpressure_policy.high_watermark > 100
         {
@@ -161,13 +160,34 @@ impl ConcurrencyConfig {
             ));
         }
 
+        if self.scheduler_policy.base_buffer_size == 0 {
+            return Err(ConfigError::InvalidScheduler("base_buffer_size must be > 0".to_string()));
+        }
         if self.scheduler_policy.base_buffer_size > self.scheduler_policy.max_buffer_size {
             return Err(ConfigError::InvalidScheduler(
                 "base_buffer_size cannot exceed max_buffer_size".to_string(),
             ));
         }
+        // Ensure the derived io-core config also holds its invariants.
+        self.scheduler_policy
+            .to_core_config()
+            .validate()
+            .map_err(|e| ConfigError::InvalidScheduler(e.to_string()))?;
 
         Ok(())
+    }
+}
+
+/// Parse an environment variable, logging a warning instead of silently
+/// falling back to the default when the value is set but unparsable.
+fn parse_env<T: std::str::FromStr>(name: &str) -> Option<T> {
+    let val = std::env::var(name).ok()?;
+    match val.parse() {
+        Ok(parsed) => Some(parsed),
+        Err(_) => {
+            tracing::warn!(env_var = name, value = %val, "ignoring unparsable environment variable");
+            None
+        }
     }
 }
 
@@ -229,6 +249,69 @@ mod tests {
             config.validate().is_err(),
             "validate() should return an error when min_timeout > max_timeout"
         );
+    }
+
+    #[test]
+    fn test_zero_backpressure_buffer_size_rejected() {
+        let config = ConcurrencyConfig {
+            backpressure_policy: PipeBackpressurePolicy {
+                buffer_size: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(
+            matches!(config.validate(), Err(ConfigError::InvalidBackpressure(_))),
+            "validate() must reject buffer_size=0 (duplex(0) hangs all writes)"
+        );
+    }
+
+    #[test]
+    fn test_zero_timeouts_rejected() {
+        let config = ConcurrencyConfig {
+            timeout_policy: TimeoutManagerPolicy {
+                default_timeout: Duration::ZERO,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(matches!(config.validate(), Err(ConfigError::InvalidTimeout(_))));
+
+        let config = ConcurrencyConfig {
+            timeout_policy: TimeoutManagerPolicy {
+                max_timeout: Duration::ZERO,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(matches!(config.validate(), Err(ConfigError::InvalidTimeout(_))));
+    }
+
+    #[test]
+    fn test_zero_scheduler_base_buffer_size_rejected() {
+        let config = ConcurrencyConfig {
+            scheduler_policy: SchedulerPolicy {
+                base_buffer_size: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(matches!(config.validate(), Err(ConfigError::InvalidScheduler(_))));
+    }
+
+    #[test]
+    fn test_small_max_buffer_size_passes_core_validation() {
+        // max_buffer_size below the io-core default min_buffer_size (4KB) must
+        // still yield a valid core config (min lowered by to_core_config).
+        let config = ConcurrencyConfig {
+            scheduler_policy: SchedulerPolicy {
+                base_buffer_size: 1024,
+                max_buffer_size: 2048,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/crates/concurrency/src/scheduler.rs
+++ b/crates/concurrency/src/scheduler.rs
@@ -49,12 +49,16 @@ impl Default for SchedulerPolicy {
 impl SchedulerPolicy {
     /// Convert facade policy to io-core scheduler config.
     pub fn to_core_config(&self) -> rustfs_io_core::IoSchedulerConfig {
+        let default = rustfs_io_core::IoSchedulerConfig::default();
         rustfs_io_core::IoSchedulerConfig {
             base_buffer_size: self.base_buffer_size,
             max_buffer_size: self.max_buffer_size,
+            // Keep min <= base <= max: the io-core default min (4KB) would make
+            // `clamp(min, max)` panic for policies with a smaller max_buffer_size.
+            min_buffer_size: default.min_buffer_size.min(self.base_buffer_size).min(self.max_buffer_size),
             high_priority_size_threshold: self.high_priority_threshold,
             low_priority_size_threshold: self.low_priority_threshold,
-            ..rustfs_io_core::IoSchedulerConfig::default()
+            ..default
         }
     }
 }
@@ -264,6 +268,16 @@ mod tests {
         let manager = SchedulerManager::new(1024, 4096, 512, 2048);
         let priority = manager.get_priority(100);
         assert!(priority.is_high());
+    }
+
+    #[test]
+    fn test_small_max_buffer_size_does_not_panic() {
+        // Regression: max_buffer_size below the io-core default min (4KB) used to
+        // panic in the core clamp (min > max) on the first buffer-size calculation.
+        let manager = SchedulerManager::new(1024, 2048, 512, 2048);
+        let size = manager.calculate_buffer_size(1024, StorageMedia::Ssd, AccessPattern::Sequential, IoLoadLevel::Medium, 1);
+        assert!(size > 0 && size <= 2048);
+        assert!(manager.core_config().validate().is_ok());
     }
 
     #[test]

--- a/crates/io-core/Cargo.toml
+++ b/crates/io-core/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "fs", "rt", "sync"] }
 memmap2 = { workspace = true }
 rustfs-io-metrics = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/io-core/src/backpressure.rs
+++ b/crates/io-core/src/backpressure.rs
@@ -223,7 +223,18 @@ impl BackpressureMonitor {
 
     /// Release a slot after operation completes.
     pub fn release(&self) {
-        let prev = self.current.fetch_sub(1, Ordering::Relaxed);
+        // Guard against underflow: an unpaired release at 0 must not wrap to
+        // usize::MAX, which would permanently reject all future acquisitions.
+        let prev = match self
+            .current
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| current.checked_sub(1))
+        {
+            Ok(prev) => prev,
+            Err(_) => {
+                tracing::warn!("BackpressureMonitor::release called with no outstanding acquisition; ignoring");
+                0
+            }
+        };
         let low_threshold = self.config.low_threshold();
 
         // Update state if needed
@@ -360,6 +371,22 @@ mod tests {
         monitor.release();
         // State should be Normal (1 < low_threshold=2)
         assert_eq!(monitor.state(), BackpressureState::Normal);
+    }
+
+    #[test]
+    fn test_release_underflow_stays_at_zero() {
+        // An unpaired release at current==0 must not wrap to usize::MAX,
+        // which would make try_acquire reject everything forever.
+        let monitor = BackpressureMonitor::with_defaults();
+
+        monitor.release();
+        assert_eq!(monitor.current(), 0);
+
+        // The monitor must still be usable.
+        assert!(monitor.try_acquire());
+        assert_eq!(monitor.current(), 1);
+        monitor.release();
+        assert_eq!(monitor.current(), 0);
     }
 
     #[test]

--- a/crates/io-core/src/scheduler.rs
+++ b/crates/io-core/src/scheduler.rs
@@ -36,7 +36,14 @@ pub enum IoPriority {
 
 impl IoPriority {
     /// Determine priority based on request size.
+    ///
+    /// A negative `size` means the size is unknown (-1 by convention) and maps
+    /// to `Normal`; casting it to `usize` would wrap to a huge value and
+    /// misclassify the request as `Low`.
     pub fn from_size(size: i64, high_threshold: usize, low_threshold: usize) -> Self {
+        if size < 0 {
+            return IoPriority::Normal;
+        }
         let size = size as usize;
         if size < high_threshold {
             IoPriority::High
@@ -729,6 +736,13 @@ mod tests {
         assert_eq!(IoPriority::from_size(1024, 64 * 1024, 4 * 1024 * 1024), IoPriority::High);
         assert_eq!(IoPriority::from_size(1024 * 1024, 64 * 1024, 4 * 1024 * 1024), IoPriority::Normal);
         assert_eq!(IoPriority::from_size(10 * 1024 * 1024, 64 * 1024, 4 * 1024 * 1024), IoPriority::Low);
+    }
+
+    #[test]
+    fn test_io_priority_unknown_size_is_normal() {
+        // -1 means "size unknown" and must not wrap to usize::MAX (=> Low).
+        assert_eq!(IoPriority::from_size(-1, 64 * 1024, 4 * 1024 * 1024), IoPriority::Normal);
+        assert_eq!(IoPriority::from_size(i64::MIN, 64 * 1024, 4 * 1024 * 1024), IoPriority::Normal);
     }
 
     #[test]

--- a/crates/io-core/src/timeout_wrapper.rs
+++ b/crates/io-core/src/timeout_wrapper.rs
@@ -375,23 +375,19 @@ pub fn calculate_adaptive_timeout(
         1.0 // No adjustment
     };
 
+    // Adaptive timeout bounds: 5 seconds minimum, 10 minutes maximum.
+    const MIN_SECS: f64 = 5.0;
+    const MAX_SECS: f64 = 600.0;
+
     // If we have historical rate data, use it for estimation
-    let estimated_duration = if let Some(rate) = historical_rate_bps {
-        if rate > 0 {
-            let estimated_secs = (object_size as f64 / rate as f64) * 1.2; // 20% buffer
-            Duration::from_secs_f64(estimated_secs)
-        } else {
-            base_timeout
-        }
-    } else {
-        base_timeout
+    let estimated_secs = match historical_rate_bps {
+        Some(rate) if rate > 0 => (object_size as f64 / rate as f64) * 1.2, // 20% buffer
+        _ => base_timeout.as_secs_f64(),
     };
 
-    // Apply timeout multiplier but clamp to reasonable bounds
-    let adaptive_duration = Duration::from_secs_f64(estimated_duration.as_secs_f64() * timeout_multiplier);
-
-    // Clamp to 5 seconds minimum and 10 minutes maximum
-    adaptive_duration.clamp(Duration::from_secs(5), Duration::from_secs(600))
+    // Clamp BEFORE constructing the Duration: `from_secs_f64` panics when the
+    // estimate overflows Duration (huge object_size with a tiny historical rate).
+    Duration::from_secs_f64((estimated_secs * timeout_multiplier).clamp(MIN_SECS, MAX_SECS))
 }
 
 /// Estimate bytes per second transfer rate.
@@ -433,6 +429,18 @@ mod tests {
             ..Default::default()
         };
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_adaptive_timeout_extreme_estimate_does_not_panic() {
+        // A huge object with a tiny historical rate used to overflow
+        // Duration::from_secs_f64 and panic; it must clamp to the upper bound.
+        let timeout = calculate_adaptive_timeout(Duration::from_secs(30), Some(1), 0, u64::MAX);
+        assert_eq!(timeout, Duration::from_secs(600));
+
+        // Tiny estimates clamp to the lower bound.
+        let timeout = calculate_adaptive_timeout(Duration::from_secs(30), Some(u64::MAX), 0, 1);
+        assert_eq!(timeout, Duration::from_secs(5));
     }
 
     #[test]


### PR DESCRIPTION
Fixes five confirmed latent panic/boundary defects in `crates/io-core` and `crates/concurrency` (S15/S24/S28/S29/S34 from the parent audit).

Ref: rustfs/backlog#1024

## Defects and fixes

### S15 — `SchedulerPolicy` with `max_buffer_size < 4096` panicked on first buffer-size calculation
`SchedulerPolicy::to_core_config` passed base/max/thresholds through but left io-core's `min_buffer_size` at its default 4KB, so a policy like `{base: 1024, max: 2048}` made the first `calculate_strategy` call execute `buffer_size.clamp(4096, 2048)` and panic (`min > max`).
**Fix**: `to_core_config` now lowers `min_buffer_size` to `min(default_min, base_buffer_size, max_buffer_size)` so the core invariant `min <= base <= max` always holds, and `ConcurrencyConfig::validate` now runs `IoSchedulerConfig::validate` on the derived core config.

### S24 — `ConcurrencyConfig::validate` allowed `buffer_size = 0` and zero timeouts; `from_env` swallowed parse errors
`RUSTFS_BACKPRESSURE_BUFFER_SIZE=0` passed validation but `duplex(0)` never accepts writes, hanging producers forever; `RUSTFS_TIMEOUT_DEFAULT=0` made every wrapped operation time out immediately; an unparsable env value (e.g. `=4MB`) silently fell back to the default with no diagnostic.
**Fix**: `validate` now rejects zero backpressure `buffer_size`, zero `default_timeout`/`max_timeout`, and zero scheduler `base_buffer_size`; `from_env` logs a structured `warn!` when a set env var fails to parse.

### S28 — `IoPriority::from_size` cast negative sizes to `usize`
`file_size = -1` (documented as "unknown") wrapped to `usize::MAX` and classified the request as `Low` priority.
**Fix**: negative sizes now return `IoPriority::Normal`, aligned with the sibling implementation `from_size_with_thresholds` in `rustfs/src/storage/concurrency/io_schedule.rs`.

### S29 — `BackpressureMonitor::release` underflowed with no recovery path
An unpaired `release()` at `current == 0` did an unguarded `fetch_sub(1)`, wrapping `current` to `usize::MAX`; from then on `try_acquire` rejected every request and `reset_stats` offered no recovery.
**Fix**: `release` uses `fetch_update` with `checked_sub(1)`, stays at 0 on underflow, and emits a `warn!`.

### S34 — `calculate_adaptive_timeout` panicked in `Duration::from_secs_f64` on unbounded estimates
`object_size` near `u64::MAX` with `historical_rate_bps = Some(1)` produced an estimate beyond `Duration`'s range; the panic happened before the existing `clamp(5s, 600s)` could apply.
**Fix**: clamp the estimated seconds to `[5.0, 600.0]` before constructing the `Duration`.

## Tests
One regression test per defect (each would have triggered the old panic/hang/misbehavior):
- `test_small_max_buffer_size_does_not_panic` + `test_small_max_buffer_size_passes_core_validation` (S15)
- `test_zero_backpressure_buffer_size_rejected`, `test_zero_timeouts_rejected`, `test_zero_scheduler_base_buffer_size_rejected` (S24)
- `test_io_priority_unknown_size_is_normal` (S28)
- `test_release_underflow_stays_at_zero` (S29)
- `test_adaptive_timeout_extreme_estimate_does_not_panic` (S34)

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p rustfs-io-core -p rustfs-concurrency --all-targets -- -D warnings`
- `cargo test -p rustfs-io-core -p rustfs-concurrency` (152 tests, all pass)
- `scripts/check_layer_dependencies.sh`, `check_architecture_migration_rules.sh`, `check_unsafe_code_allowances.sh`, `check_logging_guardrails.sh`, `check_doc_paths.sh` — all pass