### PR TITLE
fix(zip): validate CRC32 on small-entry extract fast path

### DIFF
--- a/crates/zip/src/lib.rs
+++ b/crates/zip/src/lib.rs
@@ -604,6 +604,14 @@ fn write_small_zip_entry<R: Read>(reader: &mut R, output_path: &Path, size: u64)
     let size = usize::try_from(size).map_err(|_| io::Error::other("small zip entry size overflow"))?;
     let mut buffer = [0_u8; SMALL_ZIP_EXTRACT_FAST_PATH_LIMIT as usize];
     reader.read_exact(&mut buffer[..size])?;
+    // `read_exact` stops as soon as the declared bytes are read and never performs the
+    // terminal zero-length read that the zip crate's `Crc32Reader` uses to validate the
+    // entry checksum. Force one extra read to EOF so a corrupted small entry is rejected
+    // here, matching the large-entry `io::copy` path which already reads through EOF.
+    let mut trailing = [0_u8; 1];
+    if reader.read(&mut trailing)? != 0 {
+        return Err(io::Error::other("small zip entry produced more data than its declared size").into());
+    }
     std::fs::write(output_path, &buffer[..size])?;
     Ok(())
 }
@@ -1554,6 +1562,39 @@ mod tests {
         assert!(
             fs::metadata(extract_path.join("escape.txt")).await.is_err(),
             "traversal entry must not be written inside the extraction target either"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_extract_zip_rejects_small_entry_with_corrupted_crc() {
+        let temp = tempdir().expect("tempdir should be created");
+        let zip_path = temp.path().join("corrupt-crc.zip");
+        let extract_path = temp.path().join("extract");
+
+        // A stored entry well under the small-entry fast-path limit so extraction takes
+        // the in-memory buffer path rather than the streaming `io::copy` path.
+        let content = b"small-entry-crc-payload";
+        assert!((content.len() as u64) <= SMALL_ZIP_EXTRACT_FAST_PATH_LIMIT);
+        build_zip_file_with_entries(&zip_path, &[("small.txt", content)])
+            .await
+            .expect("zip fixture should be created");
+
+        // Corrupt the stored entry data so its bytes no longer match the recorded CRC32.
+        let mut raw = fs::read(&zip_path).await.expect("zip fixture should be readable");
+        let offset = raw
+            .windows(content.len())
+            .position(|window| window == content)
+            .expect("stored entry data should be present in the zip");
+        raw[offset] ^= 0xFF;
+        fs::write(&zip_path, &raw).await.expect("corrupted zip should be writable");
+
+        let err = extract_zip_simple(&zip_path, &extract_path)
+            .await
+            .expect_err("small entry with a corrupted CRC should be rejected");
+
+        assert!(
+            matches!(err, ZipError::Io(ref e) if e.kind() == std::io::ErrorKind::InvalidData),
+            "expected an InvalidData checksum error, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1035

## Summary of Changes

Zip extraction has a small-entry fast path in `crates/zip/src/lib.rs` that is taken whenever a stored entry declares a size at or below 8 KiB. That path filled a fixed buffer with `read_exact` and wrote it straight to disk. Because `read_exact` stops the moment the declared number of bytes has been read, it never performed the terminal zero-length read that the zip library's checksum reader relies on to validate an entry's CRC32. As a result a corrupted small entry was extracted silently, while the large-entry path (which streams to end of input) already rejected the same corruption. This inconsistency meant tampered or damaged archives could yield wrong file contents without any error for entries under the fast-path threshold.

The fix forces the reader to end of input after the declared bytes are read, so the checksum reader runs its validation and returns an error on a CRC mismatch, exactly as the large-entry path does. A read that unexpectedly returns more data than the declared size is also rejected. Behavior for valid entries is unchanged.

## Verification

- `cargo fmt --all`
- `cargo test -p rustfs-zip`
- `cargo clippy -p rustfs-zip --tests -- -D warnings`

The new regression test builds a stored entry below the fast-path threshold, corrupts its bytes so they no longer match the recorded CRC32, and asserts that extraction fails. It was confirmed to fail before the fix and pass after it.

## Impact

Corrupted or tampered small entries now surface an error during extraction instead of producing incorrect contents. Extraction of valid archives is unaffected. No API, configuration, or deployment changes.

## Additional Notes

N/A
