### PR TITLE
fix(checksums): reject md5 instead of silently returning crc32

### DIFF
--- a/crates/checksums/src/error.rs
+++ b/crates/checksums/src/error.rs
@@ -36,7 +36,7 @@ impl fmt::Display for UnknownChecksumAlgorithmError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            r#"unknown checksum algorithm "{}", please pass a known algorithm name ("crc32", "crc32c", "sha1", "sha256", "md5")"#,
+            r#"unknown checksum algorithm "{}", please pass a known algorithm name ("crc32", "crc32c", "crc64nvme", "sha1", "sha256")"#,
             self.checksum_algorithm
         )
     }

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -43,8 +43,6 @@ pub enum ChecksumAlgorithm {
     #[default]
     Crc32,
     Crc32c,
-    #[deprecated]
-    Md5,
     Sha1,
     Sha256,
     Crc64Nvme,
@@ -62,9 +60,6 @@ impl FromStr for ChecksumAlgorithm {
             Ok(Self::Sha1)
         } else if checksum_algorithm.eq_ignore_ascii_case(SHA_256_NAME) {
             Ok(Self::Sha256)
-        } else if checksum_algorithm.eq_ignore_ascii_case(MD5_NAME) {
-            // MD5 is now an alias for the default Crc32 since it is deprecated
-            Ok(Self::Crc32)
         } else if checksum_algorithm.eq_ignore_ascii_case(CRC_64_NVME_NAME) {
             Ok(Self::Crc64Nvme)
         } else {
@@ -79,8 +74,6 @@ impl ChecksumAlgorithm {
             Self::Crc32 => Box::<Crc32>::default(),
             Self::Crc32c => Box::<Crc32c>::default(),
             Self::Crc64Nvme => Box::<Crc64Nvme>::default(),
-            #[allow(deprecated)]
-            Self::Md5 => Box::<Crc32>::default(),
             Self::Sha1 => Box::<Sha1>::default(),
             Self::Sha256 => Box::<Sha256>::default(),
         }
@@ -91,8 +84,6 @@ impl ChecksumAlgorithm {
             Self::Crc32 => CRC_32_NAME,
             Self::Crc32c => CRC_32_C_NAME,
             Self::Crc64Nvme => CRC_64_NVME_NAME,
-            #[allow(deprecated)]
-            Self::Md5 => MD5_NAME,
             Self::Sha1 => SHA_1_NAME,
             Self::Sha256 => SHA_256_NAME,
         }
@@ -443,5 +434,24 @@ mod tests {
             .parse::<ChecksumAlgorithm>()
             .expect_err("it should error");
         assert_eq!("some invalid checksum algorithm", error.checksum_algorithm());
+    }
+
+    #[test]
+    fn test_unknown_algorithm_error_message_lists_supported_algorithms() {
+        let error = "nope".parse::<ChecksumAlgorithm>().expect_err("it should error");
+        let message = error.to_string();
+        assert!(message.contains("crc64nvme"), "message should advertise crc64nvme: {message}");
+        assert!(!message.contains("md5"), "message should not advertise the unsupported md5: {message}");
+    }
+
+    #[test]
+    fn test_md5_is_not_a_supported_checksum_algorithm() {
+        // MD5 is not an accepted S3 checksum algorithm here: parsing it must fail
+        // loudly rather than silently substituting a CRC32 hasher.
+        let error = "md5".parse::<ChecksumAlgorithm>().expect_err("md5 should not parse");
+        assert_eq!("md5", error.checksum_algorithm());
+
+        let error = "MD5".parse::<ChecksumAlgorithm>().expect_err("md5 should not parse");
+        assert_eq!("MD5", error.checksum_algorithm());
     }
 }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1035

## Summary of Changes

The `UnknownChecksumAlgorithmError` display message listed `crc32, crc32c, sha1, sha256, md5`, which omitted the genuinely accepted `crc64nvme` algorithm and advertised `md5`, which is not an accepted checksum algorithm in this crate. Callers who read the message were pointed at the wrong set of names.

More seriously, parsing the string `md5` returned the `Crc32` algorithm, and the corresponding enum variant produced a Crc32 hasher, so a caller asking for MD5 silently received a 4-byte CRC32 digest instead. This kind of silent substitution can corrupt integrity expectations without any error surfacing.

This change updates the error message to enumerate the actually accepted algorithms `crc32, crc32c, crc64nvme, sha1, sha256`, removes the unused `Md5` enum variant that caused the silent substitution, and makes parsing `md5` fail loudly with `UnknownChecksumAlgorithmError`. The standalone MD5 hasher type and its known-answer test are unchanged, since they were never reached through the parsing path. New tests assert the message advertises `crc64nvme` and not `md5`, and that parsing `md5` in any case is an error.

## Verification

- `cargo fmt --all`
- `cargo test -p rustfs-checksums`
- `cargo clippy -p rustfs-checksums --tests -- -D warnings`

## Impact

Parsing the string `md5` now returns an error where it previously returned a Crc32 algorithm. No in-repo caller constructed the removed variant or relied on the old behavior, and all accepted algorithm names are unchanged.

## Additional Notes

N/A
