### PR TITLE
fix(ecstore): hide encrypted object checksums

### DIFF
--- a/crates/ecstore/src/object_api/types.rs
+++ b/crates/ecstore/src/object_api/types.rs
@@ -764,9 +764,13 @@ impl ObjectInfo {
             return Ok((checksums, true));
         }
 
-        // TODO: decrypt checksums
-
         if let Some(data) = &self.checksum {
+            if self.is_encrypted() {
+                // Object-level encrypted checksum bytes require SSE decrypt material,
+                // so do not expose them as plaintext checksum headers here.
+                return Ok((HashMap::new(), false));
+            }
+
             let (checksums, is_multipart) = rustfs_rio::read_checksums(data.as_ref(), 0);
             return Ok((checksums, is_multipart));
         }
@@ -1173,6 +1177,73 @@ mod tests {
         };
 
         assert!(info.is_encrypted());
+    }
+
+    #[test]
+    fn decrypt_checksums_reads_plain_object_checksum() {
+        let checksum = rustfs_rio::Checksum::new_from_data(rustfs_rio::ChecksumType::CRC32, b"plain-object")
+            .expect("test checksum should be valid");
+        let checksum_key = checksum.checksum_type.to_string();
+        let expected_checksum = checksum.encoded.clone();
+        let info = ObjectInfo {
+            checksum: Some(checksum.to_bytes(&[])),
+            ..Default::default()
+        };
+
+        let (checksums, is_multipart) = info
+            .decrypt_checksums(0, &HeaderMap::new())
+            .expect("plain checksum should decode");
+
+        assert!(!is_multipart);
+        assert_eq!(checksums.get(&checksum_key), Some(&expected_checksum));
+    }
+
+    #[test]
+    fn decrypt_checksums_hides_encrypted_object_checksum_without_decrypt_material() {
+        let checksum = rustfs_rio::Checksum::new_from_data(rustfs_rio::ChecksumType::CRC32, b"encrypted-object")
+            .expect("test checksum should be valid");
+        let info = ObjectInfo {
+            checksum: Some(checksum.to_bytes(&[])),
+            user_defined: Arc::new(HashMap::from([(
+                rustfs_utils::http::headers::AMZ_SERVER_SIDE_ENCRYPTION.to_string(),
+                "AES256".to_string(),
+            )])),
+            ..Default::default()
+        };
+
+        let (checksums, is_multipart) = info
+            .decrypt_checksums(0, &HeaderMap::new())
+            .expect("encrypted checksum should fail closed");
+
+        assert!(!is_multipart);
+        assert!(checksums.is_empty());
+    }
+
+    #[test]
+    fn decrypt_checksums_keeps_encrypted_part_checksum_metadata() {
+        let checksum = rustfs_rio::Checksum::new_from_data(rustfs_rio::ChecksumType::CRC32, b"encrypted-object")
+            .expect("test checksum should be valid");
+        let part_checksums = HashMap::from([("x-amz-checksum-crc32".to_string(), "AAAAAA==".to_string())]);
+        let info = ObjectInfo {
+            checksum: Some(checksum.to_bytes(&[])),
+            user_defined: Arc::new(HashMap::from([(
+                rustfs_utils::http::headers::AMZ_SERVER_SIDE_ENCRYPTION.to_string(),
+                "AES256".to_string(),
+            )])),
+            parts: Arc::new(vec![ObjectPartInfo {
+                number: 2,
+                checksums: Some(part_checksums.clone()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        let (checksums, is_multipart) = info
+            .decrypt_checksums(2, &HeaderMap::new())
+            .expect("part checksum metadata should remain readable");
+
+        assert!(is_multipart);
+        assert_eq!(checksums, part_checksums);
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#916.

## Summary of Changes
- Fail closed for encrypted object-level checksum bytes in `ObjectInfo::decrypt_checksums` when the ecstore layer has no SSE decrypt material, preventing ciphertext from being emitted as checksum headers.
- Preserve existing plaintext object checksum decoding and multipart part checksum metadata behavior.
- Add regression coverage for plaintext, encrypted object-level, and encrypted part checksum paths.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore object_api::types::tests::decrypt_checksums --lib`
- `cargo test -p rustfs-ecstore checksum --lib`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `git diff --check`

## Impact
Encrypted object-level checksums without decrypt material are omitted instead of returned. Plaintext and part-level checksum paths remain unchanged.

## Additional Notes
Full encrypted checksum decryption still depends on a storage metadata contract carrying decryptable checksum material into ecstore.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
