### PR TITLE
perf(hotpath): add fine-grained PUT-path stage guards (HP-14)

### DIFF
--- a/crates/ecstore/src/erasure/coding/encode.rs
+++ b/crates/ecstore/src/erasure/coding/encode.rs
@@ -279,6 +279,7 @@ impl<'a> MultiWriter<'a> {
     }
 
     pub async fn shutdown(&mut self) -> std::io::Result<()> {
+        crate::hp_guard!("MultiWriter::shutdown");
         {
             let mut futures = FuturesUnordered::new();
             for (writer_opt, err) in self.writers.iter_mut().zip(self.errs.iter_mut()) {

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -2744,6 +2744,7 @@ impl SetDisks {
         committed_data_dir: &str,
         write_quorum: usize,
     ) -> OldDataDirCleanup {
+        crate::hp_guard!("SetDisks::commit_rename_data_dir");
         // Anti-misdelete guard (parity retained): MinIO sets `res.OldDataDir=""`
         // when old == new (`xl-storage.go:2796`) and `commitRenameDataDir` skips
         // the empty value (`:1837`). Rather miss a reclaim than delete the data

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -1629,6 +1629,7 @@ impl SetDisks {
     }
 
     async fn acquire_read_lock_diag(&self, op: &'static str, bucket: &str, object: &str) -> Result<ObjectLockDiagGuard> {
+        crate::hp_guard!("SetDisks::acquire_read_lock");
         let diag_enabled = is_object_lock_diag_enabled();
         let ns_lock = self.new_ns_lock(bucket, object).await?;
         let acquire_start = Instant::now();
@@ -1650,6 +1651,7 @@ impl SetDisks {
     }
 
     async fn acquire_write_lock_diag(&self, op: &'static str, bucket: &str, object: &str) -> Result<ObjectLockDiagGuard> {
+        crate::hp_guard!("SetDisks::acquire_write_lock");
         let diag_enabled = is_object_lock_diag_enabled();
         let ns_lock = self.new_ns_lock(bucket, object).await?;
         let acquire_start = Instant::now();

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -3515,7 +3515,11 @@ impl DefaultObjectUsecase {
                 .await
                 .map_err(ApiError::from)?,
         );
-        let previous_current_size = match store.get_object_info(&bucket, &key, &current_opts).await {
+        let previous_current_info = {
+            crate::hp_guard!("S3::put_object_prelookup");
+            store.get_object_info(&bucket, &key, &current_opts).await
+        };
+        let previous_current_size = match previous_current_info {
             Ok(existing_obj_info) => {
                 validate_existing_object_lock_for_write(&existing_obj_info, &opts)?;
                 Some(existing_obj_info.size.max(0) as u64)

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -1869,6 +1869,7 @@ impl S3Access for FS {
     ///
     /// This method returns `Ok(())` by default.
     async fn put_object(&self, req: &mut S3Request<PutObjectInput>) -> S3Result<()> {
+        crate::hp_guard!("S3Access::put_object");
         let req_info = ext_req_info_mut(&mut req.extensions)?;
         req_info.bucket = Some(req.input.bucket.clone());
         req_info.object = Some(req.input.key.clone());


### PR DESCRIPTION
## What

Adds `hp_guard!` measurement scopes to the PUT-path sub-stages called out in [backlog#935](https://github.com/rustfs/backlog/issues/935) item 2, closing the ~10ms instrumentation residual on the PUT success path that the existing coarse `writer_setup` / `encode` / `rename` stage metrics do not attribute.

Instrumented sub-stages:

- `SetDisks::acquire_read_lock` / `acquire_write_lock` — namespace lock acquisition
- `S3::put_object_prelookup` — pre-write `get_object_info` lookup
- `MultiWriter::shutdown` — bitrot writer flush/close
- `SetDisks::commit_rename_data_dir` — old data-dir reclaim
- `S3Access::put_object` — S3 authorization segment

## Why

The hotpath instrumentation scaffold (HP-14, already merged) has 40+ coarse whole-method spans but leaves several fine-grained PUT sub-stages unattributed, so ~10ms of the PUT success path does not roll up to any named stage. These guards let the warp A/B harness attribute that residual.

## Risk

Instrumentation only. `hp_guard!` expands to nothing without the `hotpath` feature, so this is a pure-observation change with zero behavior impact and zero cost in default builds. The pre-lookup site wraps only the lookup call in a scoped block so the guard measures that slice exactly while preserving the existing `match` and control flow.

## Verification

`cargo check -p rustfs-ecstore` and `cargo check -p rustfs`, both default and `--features hotpath`, all pass. `cargo fmt --all` clean.

Part of the HP-14 series ([backlog#935](https://github.com/rustfs/backlog/issues/935)); does not close the issue (item 3 alloc-mode fix remains, deferred on upstream hotpath).
