### PR TITLE
test(utils): unignore drive stats platform test

### DIFF
--- a/crates/utils/src/os/mod.rs
+++ b/crates/utils/src/os/mod.rs
@@ -125,12 +125,17 @@ mod tests {
         // Test passes if the function doesn't panic - the actual result depends on test environment
     }
 
-    #[ignore] // FIXME: failed in github actions
     #[test]
-    fn test_get_drive_stats_default() {
+    fn test_get_drive_stats_missing_device_or_default() {
+        #[cfg(target_os = "linux")]
+        {
+            let err = get_drive_stats(0, 0).expect_err("linux block device 0:0 should not exist");
+            assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        }
+
         #[cfg(not(target_os = "linux"))]
         {
-            let stats = get_drive_stats(0, 0).unwrap();
+            let stats = get_drive_stats(0, 0).expect("non-linux drive stats fallback should return defaults");
             assert_eq!(stats, IOStats::default());
         }
     }


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#917.

## Summary of Changes
- Remove the ignored `get_drive_stats` test and make it assert platform-specific behavior.
- On Linux, assert that reserved block device `0:0` returns `NotFound`.
- On non-Linux platforms, keep the existing default fallback assertion with contextual failure output.

## Verification
- `cargo test -p rustfs-utils --features os test_get_drive_stats_missing_device_or_default --lib`
- `cargo test -p rustfs-utils --features os os::tests --lib`
- `cargo test -p rustfs-utils --features os --lib`
- `cargo clippy -p rustfs-utils --features os --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
This only changes test coverage for `rustfs-utils`; runtime behavior is unchanged.

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
