### PR TITLE
test(utils): extend Linux fs type mappings

### DIFF
--- a/crates/utils/src/os/fs_type.rs
+++ b/crates/utils/src/os/fs_type.rs
@@ -28,6 +28,10 @@
 pub(crate) fn get_fs_type(fs_type: u64) -> &'static str {
     // Magic numbers for various filesystems.
     match fs_type {
+        0xadf5 => "ADFS",
+        0xadff => "AFFS",
+        0x5346414F | 0x6B414653 => "AFS",
+        0x0187 => "AUTOFS",
         0x01021994 => "TMPFS",
         0x4d44 => "MSDOS",
         0x6969 => "NFS",
@@ -35,17 +39,44 @@ pub(crate) fn get_fs_type(fs_type: u64) -> &'static str {
         0xf15f => "ecryptfs",
         0x794c7630 => "overlayfs",
         0x52654973 => "REISERFS",
+        0x73757245 => "CODA",
+        0x28cd3d45 | 0x453dcd28 => "CRAMFS",
+        0x64626720 => "DEBUGFS",
+        0x73636673 => "SECURITYFS",
+        0xf97cff8c => "SELINUXFS",
+        0x43415d53 => "SMACKFS",
+        0x858458f6 => "RAMFS",
+        0x958458f6 => "HUGETLBFS",
         0x58465342 => "XFS",
         0x9123683E => "BTRFS",
         0x00c36400 => "CEPH",
         0x2011BAB0 => "EXFAT",
+        0x414A53 => "EFS",
         0xE0F5E1E2 => "EROFS",
         0xF2F52010 => "F2FS",
+        0x3434 => "NILFS2",
+        0xf995e849 => "HPFS",
         0x9660 => "ISOFS",
+        0x72b6 => "JFFS2",
         0x65735546 => "FUSE",
         0x73717368 => "SQUASHFS",
+        0x6165676C => "PSTOREFS",
+        0xde5e81e4 => "EFIVARFS",
+        0x00c0ffee => "HOSTFS",
+        0x137F | 0x138F => "MINIX",
+        0x2468 | 0x2478 => "MINIX2",
+        0x4d5a => "MINIX3",
+        0x564c => "NCPFS",
+        0x7461636f => "OCFS2",
+        0x9fa1 => "OPENPROMFS",
+        0x002f => "QNX4",
+        0x68191122 => "QNX6",
+        0x517B => "SMB",
         0xFF534D42 => "CIFS",
         0xFE534D42 => "SMB2",
+        0x27e0eb => "CGROUP",
+        0x63677270 => "CGROUP2",
+        0x74726163 => "TRACEFS",
         0x01021997 => "V9FS",
         0xca451a4e => "BCACHEFS",
         _ => "UNKNOWN",
@@ -64,15 +95,50 @@ mod tests {
 
     #[test]
     fn map_verified_linux_uapi_filesystem_magic_numbers() {
+        assert_eq!(get_fs_type(0xadf5), "ADFS");
+        assert_eq!(get_fs_type(0xadff), "AFFS");
+        assert_eq!(get_fs_type(0x5346414F), "AFS");
+        assert_eq!(get_fs_type(0x0187), "AUTOFS");
         assert_eq!(get_fs_type(0x00c36400), "CEPH");
+        assert_eq!(get_fs_type(0x73757245), "CODA");
+        assert_eq!(get_fs_type(0x28cd3d45), "CRAMFS");
+        assert_eq!(get_fs_type(0x453dcd28), "CRAMFS");
+        assert_eq!(get_fs_type(0x64626720), "DEBUGFS");
+        assert_eq!(get_fs_type(0x73636673), "SECURITYFS");
+        assert_eq!(get_fs_type(0xf97cff8c), "SELINUXFS");
+        assert_eq!(get_fs_type(0x43415d53), "SMACKFS");
+        assert_eq!(get_fs_type(0x858458f6), "RAMFS");
+        assert_eq!(get_fs_type(0x958458f6), "HUGETLBFS");
         assert_eq!(get_fs_type(0x2011BAB0), "EXFAT");
+        assert_eq!(get_fs_type(0x414A53), "EFS");
         assert_eq!(get_fs_type(0xE0F5E1E2), "EROFS");
         assert_eq!(get_fs_type(0xF2F52010), "F2FS");
+        assert_eq!(get_fs_type(0x3434), "NILFS2");
+        assert_eq!(get_fs_type(0xf995e849), "HPFS");
         assert_eq!(get_fs_type(0x9660), "ISOFS");
+        assert_eq!(get_fs_type(0x72b6), "JFFS2");
         assert_eq!(get_fs_type(0x65735546), "FUSE");
         assert_eq!(get_fs_type(0x73717368), "SQUASHFS");
+        assert_eq!(get_fs_type(0x6165676C), "PSTOREFS");
+        assert_eq!(get_fs_type(0xde5e81e4), "EFIVARFS");
+        assert_eq!(get_fs_type(0x00c0ffee), "HOSTFS");
+        assert_eq!(get_fs_type(0x137F), "MINIX");
+        assert_eq!(get_fs_type(0x138F), "MINIX");
+        assert_eq!(get_fs_type(0x2468), "MINIX2");
+        assert_eq!(get_fs_type(0x2478), "MINIX2");
+        assert_eq!(get_fs_type(0x4d5a), "MINIX3");
+        assert_eq!(get_fs_type(0x564c), "NCPFS");
+        assert_eq!(get_fs_type(0x7461636f), "OCFS2");
+        assert_eq!(get_fs_type(0x9fa1), "OPENPROMFS");
+        assert_eq!(get_fs_type(0x002f), "QNX4");
+        assert_eq!(get_fs_type(0x68191122), "QNX6");
+        assert_eq!(get_fs_type(0x6B414653), "AFS");
+        assert_eq!(get_fs_type(0x517B), "SMB");
         assert_eq!(get_fs_type(0xFF534D42), "CIFS");
         assert_eq!(get_fs_type(0xFE534D42), "SMB2");
+        assert_eq!(get_fs_type(0x27e0eb), "CGROUP");
+        assert_eq!(get_fs_type(0x63677270), "CGROUP2");
+        assert_eq!(get_fs_type(0x74726163), "TRACEFS");
         assert_eq!(get_fs_type(0x01021997), "V9FS");
         assert_eq!(get_fs_type(0xca451a4e), "BCACHEFS");
     }


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#917

## Summary of Changes
- Extend Linux filesystem magic mapping in `rustfs-utils` for values verified against Linux `include/uapi/linux/magic.h`.
- Cover the added less-common filesystems with deterministic unit assertions.
- Keep unverified non-uapi values as `UNKNOWN`.

## Verification
- `cargo test -p rustfs-utils --features os map_verified_linux_uapi_filesystem_magic_numbers --lib`
- `cargo test -p rustfs-utils --features os os::fs_type --lib`
- `cargo test -p rustfs-utils --features os --lib`
- `cargo clippy -p rustfs-utils --features os --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
Improves Linux filesystem type reporting only. No API, storage format, or runtime behavior changes outside filesystem-name mapping.

## Additional Notes
N/A
