### PR TITLE
test(ecstore): serialize load-sensitive flaky tests via nextest test-group

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,25 @@
+# nextest configuration for RustFS.
+#
+# Serialize two known load-sensitive / global-state-sharing ecstore test groups
+# so the full parallel nextest suite stops producing spurious failures
+# (backlog #937). These tests pass in isolation but flake under the loaded
+# parallel run for two distinct reasons:
+#
+#   * store::bucket::tests::bucket_delete_* share process/global state (disk
+#     registry, lock client) and race make_bucket into InsufficientWriteQuorum
+#     when run concurrently with other ecstore tests.
+#   * bucket_lifecycle_ops::tests::concurrent_resend_same_part_commits_one_generation
+#     asserts a lock-acquire correctness property whose serialized cross-disk
+#     commits exceed the (already max'd, 60s) acquire deadline only when the
+#     suite saturates disk I/O.
+#
+# serial_test's #[serial] attribute does NOT serialize these across runs:
+# nextest executes each test in its own process, where the in-process
+# serial_test mutex has no effect. A nextest test-group with max-threads = 1 is
+# the mechanism that actually serializes across nextest's process boundary.
+[test-groups]
+ecstore-serial-flaky = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(rustfs-ecstore) & (test(concurrent_resend_same_part_commits_one_generation) | test(/^store::bucket::tests::bucket_delete_(mark_delete_marks|purge_removes|default_s3_delete)/))'
+test-group = 'ecstore-serial-flaky'


### PR DESCRIPTION
## Related Issues

Short-term mitigation for rustfs/backlog#937 (two ecstore test groups flake under the parallel nextest suite). Long-term global-singleton isolation is tracked as a separate follow-up in the same issue.

## Summary of Changes

Adds `.config/nextest.toml` with a `ecstore-serial-flaky` test-group (`max-threads = 1`) that matches the two known load-sensitive groups and runs them serialized across nextest's process boundary. `serial_test`'s `#[serial]` attribute does not serialize these tests, because nextest runs each test in its own process where the in-process mutex has no effect — a nextest test-group is the mechanism that actually serializes across that boundary.

The two flaking groups and why they flake:
- `store::bucket::tests::bucket_delete_*` share global disk-registry / lock-client state and race `make_bucket` into `InsufficientWriteQuorum` when run concurrently with other ecstore tests.
- `bucket::lifecycle::bucket_lifecycle_ops::tests::concurrent_resend_same_part_commits_one_generation` asserts a lock-acquire correctness property whose serialized cross-disk commits exceed the already-maxed 60s acquire deadline only when the suite saturates disk I/O.

No test logic or production code is changed. This deterministically fixes the global-state contention (bucket_delete) and removes same-suite load stacking for the lock-timeout test; the residual disk-saturation sensitivity of `concurrent_resend` is addressed by the long-term isolation follow-up.

## Verification

- `cargo nextest show-config test-groups -p rustfs-ecstore --lib` — confirms all four tests are assigned to `ecstore-serial-flaky`.
- `cargo nextest run -p rustfs-ecstore --lib -E '<the four tests>'` — 4 passed under the serial group.

## Impact

CI-only. Removes flaky-failure noise from the `Test and Lint*` matrix on in-flight PRs. Slightly serializes four ecstore tests (sub-second each), negligible wall-clock impact. No runtime/API/config/deployment impact.

## Additional Notes

Follow-up (separate PR, tracked in rustfs/backlog#937): rewrite `bucket_delete_*` to the fully-isolated pattern (construct `SetDisks` directly, no global disk registry / lock client), per the approach used in #4389, and desensitize `concurrent_resend` to disk latency.