### PR TITLE
docs(runbook): internode gRPC A/B acceptance gates, artifact layout, bench-host prereqs

### DIFF
--- a/docs/operations/internode-grpc-benchmark-runbook.md
+++ b/docs/operations/internode-grpc-benchmark-runbook.md
@@ -36,8 +36,10 @@ already-running server. Use `--dry-run` to preview the env and command.
   compose cluster, kills `FAILOVER_NODE`, benchmarks; writes
   `target/bench/four-node-failover-<ts>/`).
 
-Store the paired artifacts as `target/bench/internode-transport/{baseline,after-P0,after-P1,after-P3}/`
-(the paths the design docs reference). `target/` is gitignored — attach the artifacts to the PR.
+The one-click driver writes each run to `target/bench/internode-transport/<stage>-<phase>/`
+(e.g. `p0-before/`, `p0-after/`, `p1-before/`, `p1-after/`, `p3-before/`, `p3-after/`), each
+containing the emitted `server-env.sh` plus the underlying bench artifacts. `target/` is
+gitignored — attach the paired directories to the PR / issue.
 
 ## Metrics to capture (Prometheus)
 
@@ -90,6 +92,50 @@ column, everything else at defaults. Roll a restart between runs.
   Failover: `run_four_node_cluster_failover_bench.sh`, kill a node with
   `RUSTFS_INTERNODE_OFFLINE_BYPASS=true`; expect faster failover and a correct
   `rustfs_cluster_servers_offline_total` (1 while the node is down, back to 0 after recovery).
+
+## Acceptance gates & artifact layout
+
+Each stage's paired run must satisfy an explicit gate before its numbers are accepted. Record
+the gate verdict (pass/fail + measured delta) in the paired directory's `summary` and attach it.
+
+| Stage | Bench | Acceptance gate | Primary metric(s) |
+|---|---|---|---|
+| **P0** | `run_internode_transport_baseline.sh` | small-RPC `duration_ms` (DiskInfo/Ping) **down**; large-metadata (ReadMultiple/BatchReadVersion) throughput **up**; a `>4 MiB` multi-version `xl.meta` no longer fails `out_of_range` (functional). | `..._operation_duration_ms{operation}`, `..._operation_payload_bytes`, object-bench throughput |
+| **P1** | `run_internode_transport_baseline.sh` (mixed: large `ReadAll` + high-frequency `Refresh`) | **lock p99 down ≥ 20%** with `RUSTFS_INTERNODE_CHANNEL_ISOLATION=true` vs baseline. | lock p99 (lock metrics), `..._operation_large_payloads_total` |
+| **P3 cold-start** | `run_internode_transport_baseline.sh` (fresh cluster, first cross-node op) | first cross-node op latency **drops ~one connect RTT** with `RUSTFS_INTERNODE_PREWARM=true`. | `..._dial_avg_time_nanos`, first-op `..._operation_duration_ms` |
+| **P3 offline** | dedicated *sustained-offline + survivor cross-node access* experiment (the standard four-node failover bench is **not** sensitive to the bypass — quorum holds, `recovery_seconds=0`) | with `RUSTFS_INTERNODE_OFFLINE_BYPASS=true`, survivor cross-node op latency to the downed peer **fast-fails** instead of hanging the dial timeout; `rustfs_cluster_servers_offline_total` = **1** while down, back to **0** after recovery. | `rustfs_cluster_servers_offline_total`, survivor cross-node `..._operation_duration_ms`, `..._dial_errors_total` |
+
+> **P2 is not a throughput gate.** Its acceptance is operational: `msgpack_json_fallback_total`
+> must read **0** across a full release window before `RUSTFS_INTERNODE_RPC_MSGPACK_ONLY=true`
+> is enabled (see the msgpack convergence runbook). Do not benchmark P2 as before/after throughput.
+
+Artifact layout per stage (attach both halves + the diff):
+
+```
+target/bench/internode-transport/
+  p0-before/  p0-after/     # server-env.sh + object-bench summaries + metric deltas
+  p1-before/  p1-after/     # + lock p99 delta (the ≥20% gate)
+  p3-before/  p3-after/     # cold-start + sustained-offline experiment + offline gauge trace
+```
+
+## Bench-host prerequisites (ansible bare-metal)
+
+Captured while running the first real A/B on a 4-node ansible cluster; needed before any live run:
+
+- **RPC secret is mandatory on current `main`.** Internode RPC fails closed: default creds
+  (`RUSTFS_SECRET_KEY=rustfsadmin`) with no `RUSTFS_RPC_SECRET` → `No valid auth token` → the cluster
+  never reaches `storage_quorum`. Set a **non-default** `RUSTFS_RPC_SECRET`, identical on every node.
+- **systemd start timeout.** The install unit is `Type=notify`; READY only fires after quorum, which on
+  freshly-purged disks exceeds a 30 s `TimeoutStartSec` → crash loop. Use a drop-in `TimeoutStartSec=infinity`.
+- **Server-side metrics need OTLP.** RustFS has no Prometheus pull endpoint (`/admin/v3/metrics` is NDJSON,
+  not exposition); it only pushes via OTLP. To capture lock/offline/internode metrics, run an
+  otel-collector (OTLP receiver → Prometheus exporter) and set `RUSTFS_OBS_ENDPOINT`,
+  `RUSTFS_OBS_METRICS_EXPORT_ENABLED=true`, `RUSTFS_OBS_METER_INTERVAL=5`. For lock p99 also set
+  `RUSTFS_OBJECT_LOCK_DIAG_ENABLE=true` (default off).
+- **P3 offline method.** Standard failover is quorum-insensitive to the bypass. Use a *sustained-offline +
+  survivor cross-node access* run instead: all nodes up → stop one node (sustained) → warm up to trip
+  offline detection → drive warp on the survivors only (`--host` excludes the dead node) → compare
+  survivor op p99 and `rustfs_cluster_servers_offline_total` for `RUSTFS_INTERNODE_OFFLINE_BYPASS` off/on.
 
 ## Rollback
 


### PR DESCRIPTION
## What

Documentation-only update to the internode gRPC A/B benchmark runbook, based on the first real before/after run on a 4-node cluster (rustfs/backlog#1041).

- Adds an explicit **acceptance-gate table** per stage (P0 transport signals; P1 lock p99 ↓≥20%; P3 cold-start prewarm + sustained-offline bypass) and clarifies that P2 is an operational gate, not a throughput A/B.
- Fixes the **artifact-path** description to match what the driver actually writes (`internode-transport/<stage>-<phase>/`), replacing the stale `{baseline,after-P0,...}` layout.
- Adds a **bench-host prerequisites** section capturing gotchas found while running it: mandatory non-default `RUSTFS_RPC_SECRET` (internode RPC fails closed on default creds → no quorum), the `Type=notify` systemd start-timeout drop-in, the OTLP→Prometheus path required for server-side lock/offline metrics (`RUSTFS_OBJECT_LOCK_DIAG_ENABLE`, `RUSTFS_OBS_*`), and the sustained-offline survivor method for P3.

## Why

The runbook previously described acceptance gates only prose-loosely and referenced artifact paths the one-click driver does not produce. The bench-host prerequisites are upgrade-blocking in practice (a default-cred cluster cannot form quorum on a build carrying the RPC-secret hardening) and were undocumented.

## Verification

Docs only — no code changes. Content reflects a real run whose results are recorded in rustfs/backlog#1041.
