### PR TITLE
test(ecstore): pass allow_inplace_legacy_fallback in codec streaming tests

### DIFF
--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -3463,6 +3463,7 @@ mod tests {
             "test-object-class",
             "test-size-bucket",
             false,
+            false,
         )
         .await;
         assert!(oversized.is_err(), "part_length > part_size must be rejected");
@@ -3481,6 +3482,7 @@ mod tests {
             false,
             "test-object-class",
             "test-size-bucket",
+            false,
             false,
         )
         .await;


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Update two `build_codec_streaming_part_reader` test calls to pass the new `allow_inplace_legacy_fallback` argument. This keeps the regression test compiling after the helper signature changed.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore codec_streaming_part_reader_rejects_oversized_part_and_missing_quorum -- --nocapture`
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings`

## Impact
Test-only compile fix. No runtime behavior change.

## Additional Notes
Unblocks the current `Test and Lint` compile failure on branches based on the latest main.
