### PR TITLE
fix(ecstore): pass the new allow_inplace_legacy_fallback arg in codec streaming arity tests

### DIFF
--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -3463,6 +3463,7 @@ mod tests {
             "test-object-class",
             "test-size-bucket",
             false,
+            false,
         )
         .await;
         assert!(oversized.is_err(), "part_length > part_size must be rejected");
@@ -3481,6 +3482,7 @@ mod tests {
             false,
             "test-object-class",
             "test-size-bucket",
+            false,
             false,
         )
         .await;


### PR DESCRIPTION
## Problem

Main's workspace test build is currently broken (E0061), failing the Test and Lint jobs of every open PR: #4560 added a 15th parameter `allow_inplace_legacy_fallback` to `build_codec_streaming_part_reader`, while `codec_streaming_part_reader_rejects_oversized_part_and_missing_quorum` (merged from a branch cut before #4560) still calls it with 14 arguments. The merges were textually clean but semantically conflicting.

## Fix

Pass `false` at both call sites — these are negative tests asserting `Err` for an oversized part and missing quorum, outcomes independent of the fallback mode, and `false` preserves the historical whole-request fallback semantics (same value eager first-part reads use).

## Verification

- `cargo check -p rustfs-ecstore --all-targets` — the E0061 pair is gone
- `cargo test -p rustfs-ecstore --lib set_disk::read` — 114 passed, including the fixed test
- `cargo fmt --all` — clean