### PR TITLE
fix(admin): fail closed when DeleteServiceAccount can't load the target (backlog#806)

### DIFF
--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -108,6 +108,20 @@ fn is_service_account_owner_of(caller: &StoredCredentials, target_parent_user: &
     caller_parent == target_parent_user
 }
 
+/// Fail-closed ownership check used by DeleteServiceAccount for a caller that
+/// lacks the RemoveServiceAccount admin action.
+///
+/// Returns `true` only when the target service account was successfully loaded
+/// AND is owned by the caller. A `None` target — meaning `get_service_account`
+/// failed with a non-not-found error (e.g. a stored-credential decode error) so
+/// ownership could not be verified — denies, as does an owner mismatch. The
+/// previous `svc_account.is_some_and(|v| v.parent_user != user)` form returned
+/// `false` for a `None` target and thus fell through to the delete, an authz
+/// bypass (backlog#806).
+fn non_admin_may_delete_service_account(caller_user: &str, target_parent_user: Option<&str>) -> bool {
+    matches!(target_parent_user, Some(parent) if parent == caller_user)
+}
+
 fn map_service_account_lookup_error(err: rustfs_iam::error::Error, action: &str) -> S3Error {
     debug!(
         component = LOG_COMPONENT_ADMIN,
@@ -1288,12 +1302,20 @@ impl Operation for DeleteServiceAccount {
             .await
         {
             let user = if cred.parent_user.is_empty() {
-                &cred.access_key
+                cred.access_key.as_str()
             } else {
-                &cred.parent_user
+                cred.parent_user.as_str()
             };
 
-            if svc_account.is_some_and(|v| &v.parent_user != user) {
+            // Fail closed: a caller without the RemoveServiceAccount admin action
+            // may only delete a service account it OWNS. If the target could not be
+            // loaded (svc_account is None because get_service_account failed with a
+            // non-not-found error — e.g. a credential decode error), ownership cannot
+            // be verified, so deny rather than fall through to the delete. The
+            // previous `is_some_and(parent != user)` form skipped the guard on a
+            // None target, an authz bypass (backlog#806).
+            let target_parent = svc_account.as_ref().map(|v| v.parent_user.as_str());
+            if !non_admin_may_delete_service_account(user, target_parent) {
                 return Err(s3_error!(InvalidRequest, "service account not exist"));
             }
         }
@@ -1359,6 +1381,26 @@ mod tests {
     fn access_key_query_supports_external_alias() {
         let query: AccessKeyQuery = from_bytes(b"access-key=test-access-key").expect("parse query");
         assert_eq!(query.access_key, "test-access-key");
+    }
+
+    #[test]
+    fn non_admin_delete_is_fail_closed_on_unloadable_target() {
+        // Regression (backlog#806): a non-admin caller may delete ONLY a service
+        // account it owns; a None target (get_service_account failed to load /
+        // decode) must DENY, not fall through to the delete.
+        assert!(
+            non_admin_may_delete_service_account("alice", Some("alice")),
+            "owner may delete own service account"
+        );
+        assert!(!non_admin_may_delete_service_account("alice", Some("bob")), "non-owner must be denied");
+        assert!(
+            !non_admin_may_delete_service_account("alice", None),
+            "unloadable target (None) must be denied (fail-closed), not bypass the owner check"
+        );
+        assert!(
+            !non_admin_may_delete_service_account("", None),
+            "empty caller + unloadable target must still deny"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Part of the full-repo audit rustfs/backlog#806 (authz item).

## Summary of Changes

`DeleteServiceAccount` was **fail-open** on a target-lookup error. It called `get_service_account(target)` and, for any error other than not-found (e.g. a stored-credential **decode** error, or a transient IAM error), set `svc_account = None` and continued. The non-admin ownership guard then evaluated `svc_account.is_some_and(|v| &v.parent_user != user)` — which is `false` when `svc_account` is `None` — so the guard was **skipped** and execution fell through to the delete. A caller lacking the `RemoveServiceAccount` admin action could thus delete a service account they don't own if the target's stored credential failed to load.

Fix: extract a **fail-closed** helper `non_admin_may_delete_service_account(caller_user, target_parent_user: Option<&str>)` that returns `true` only when the target was successfully loaded **and** is owned by the caller. A `None` target (ownership unverifiable) or an owner mismatch now **denies**. Admins holding the `RemoveServiceAccount` action are unaffected (that branch is unchanged).

## Verification

- `cargo nextest run -p rustfs -E 'test(non_admin_delete_is_fail_closed)'` — passed (truth table: owner→allow, mismatch→deny, `None`→deny, empty-caller+`None`→deny).
- `cargo fmt --all`. (Full-feature `cargo clippy -p rustfs` is left to CI; local runs are being SIGTERM-killed under machine load — the change is a small helper + a condition inversion + a pure-function test.)

## Impact

Security fix (fail-open → fail-closed) on the admin DeleteServiceAccount path. No API/wire/config change. Legitimate owners and admins are unaffected; only the previously-bypassable "target failed to load" path now correctly denies.

## Additional Notes

N/A
