### PR TITLE
chore(security): exclude test/dev paths from secret scanning

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,14 @@
+# GitHub secret scanning path exclusions.
+# Secrets detected under these paths are auto-closed as "ignored by
+# configuration" and are not blocked by push protection.
+#
+# Deliberately NOT excluded: production source files (e.g. rustfs/src/**,
+# crates/*/src/**) even when a hit sits inside a #[cfg(test)] module or a
+# doc-comment example — excluding the file would also stop scanning the
+# production code in it. Close those alerts manually as "used in tests".
+paths-ignore:
+  - "crates/e2e_test/**" # dedicated e2e test crate, test credentials throughout
+  - "**/tests/**" # Rust integration-test dirs (crates/*/tests, rustfs/tests)
+  - "**/benches/**" # benchmark harnesses
+  - ".docker/**" # local docker-compose dev configs (e.g. mqtt vm.args cookie)
+  - ".vscode/**" # local editor launch configs


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

GitHub secret scanning (Copilot generic password detection, `results:generic`) currently flags every hard-coded test credential; all 14 open alerts are test fixtures, doc-comment examples, or local-dev configs. This adds `.github/secret_scanning.yml` with `paths-ignore` so detections under dedicated test/dev paths are auto-closed as "ignored by configuration" and skipped by push protection: `crates/e2e_test/**`, `**/tests/**`, `**/benches/**`, `.docker/**`, `.vscode/**`.

Production source files are deliberately not excluded even when the current hits sit inside `#[cfg(test)]` modules or doc comments (e.g. `rustfs/src/storage/sse.rs`) — excluding a src file would also blind scanning for real leaks in the same file. Those alerts (13, 17, 18, 19, 20, 21, 24; each verified to be a test fixture or doc example) are closed manually with resolution "used in tests" instead.

## Verification

- YAML parse and shape check (single `paths-ignore` key, string glob entries) via `python3` + `pyyaml` — pass
- Repo-config-only change (no Rust code or product behavior), so `make pre-commit` is not applicable; the focused check above validates the changed surface

## Impact

- Secrets committed under the excluded paths will no longer raise secret-scanning alerts or trigger push protection. This is the documented trade-off for test-only directories; a real credential must not be committed there either way.
- No runtime, API, or build impact.

## Additional Notes

GitHub limits: max 1,000 `paths-ignore` entries, 1 MB file size. Existing open alerts in excluded paths are not guaranteed to be retroactively closed; if the 7 alerts under `crates/e2e_test/**` and `.docker/**` remain open after merge, close them via the API with resolution `used_in_tests`.
