### PR TITLE
fix(rio-v2): detect DARE stream truncation at package boundary

### DIFF
--- a/crates/rio-v2/src/encrypt_reader.rs
+++ b/crates/rio-v2/src/encrypt_reader.rs
@@ -462,6 +462,19 @@ where
                         let n = read_buf.filled().len();
                         if n == 0 {
                             if *this.header_read == 0 {
+                                // Clean EOF at a package boundary. Execution only reaches here
+                                // with `finalized == false` (the finalized case is consumed at the
+                                // loop top). If at least one package of the current part has been
+                                // decrypted (`ref_nonce.is_some()`) but we never saw a final-flagged
+                                // package, the final package is missing => DARE truncation. Zero
+                                // decrypted packages (`ref_nonce.is_none()`) is a legitimately empty
+                                // object (encrypt emits no packages for empty plaintext), so accept.
+                                if this.ref_nonce.is_some() {
+                                    return Poll::Ready(Err(io::Error::new(
+                                        io::ErrorKind::UnexpectedEof,
+                                        "DARE stream truncated before a finalized package",
+                                    )));
+                                }
                                 *this.finished = true;
                                 return Poll::Ready(Ok(()));
                             }
@@ -850,5 +863,122 @@ mod tests {
 
         assert_eq!(decrypted, expected);
         assert_ne!(encrypted_one, encrypted_two[..encrypted_one.len()]);
+    }
+
+    #[tokio::test]
+    async fn decrypt_reader_rejects_stream_truncated_at_package_boundary() {
+        // Plaintext spans three packages: two full non-final 64KiB packages plus a
+        // short final-flagged package. Dropping the final package at the boundary
+        // between complete packages must be detected as DARE truncation.
+        let plaintext = vec![0xCD; DARE_PAYLOAD_SIZE * 2 + 19];
+        let key_bytes = [0x21u8; 32];
+        let base_nonce = [0x37u8; 12];
+
+        let mut encrypted = Vec::new();
+        EncryptReader::new(Cursor::new(plaintext.clone()), key_bytes, base_nonce)
+            .read_to_end(&mut encrypted)
+            .await
+            .expect("encrypt multi-package plaintext");
+
+        // Two full non-final packages precede the final package; truncate at their boundary.
+        let truncated = encrypted[..DARE_PACKAGE_SIZE * 2].to_vec();
+        assert!(truncated.len() < encrypted.len(), "truncation must drop the final package");
+
+        let mut decrypted = Vec::new();
+        let err = DecryptReader::new(Cursor::new(truncated), key_bytes, base_nonce)
+            .read_to_end(&mut decrypted)
+            .await
+            .expect_err("truncated DARE stream must fail to decrypt");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn empty_plaintext_roundtrips_without_truncation_error() {
+        // Empty plaintext emits zero DARE packages; decrypt must accept it as an
+        // empty object rather than a truncated stream (no false positive).
+        let key_bytes = [0x5Au8; 32];
+        let base_nonce = [0x11u8; 12];
+
+        let mut encrypted = Vec::new();
+        EncryptReader::new(Cursor::new(Vec::new()), key_bytes, base_nonce)
+            .read_to_end(&mut encrypted)
+            .await
+            .expect("encrypt empty plaintext");
+        assert!(encrypted.is_empty(), "empty plaintext must emit no DARE packages");
+
+        let mut decrypted = Vec::new();
+        DecryptReader::new(Cursor::new(encrypted), key_bytes, base_nonce)
+            .read_to_end(&mut decrypted)
+            .await
+            .expect("decrypt empty DARE stream");
+        assert!(decrypted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn multi_package_stream_full_roundtrip_succeeds() {
+        // Regression: a complete multi-package stream (ending with a final-flagged
+        // package) still decrypts to the original plaintext.
+        let plaintext = vec![0x7Eu8; DARE_PAYLOAD_SIZE * 2 + 123];
+        let key_bytes = [0x93u8; 32];
+        let base_nonce = [0x4Cu8; 12];
+
+        let mut encrypted = Vec::new();
+        EncryptReader::new(Cursor::new(plaintext.clone()), key_bytes, base_nonce)
+            .read_to_end(&mut encrypted)
+            .await
+            .expect("encrypt multi-package plaintext");
+
+        let mut decrypted = Vec::new();
+        DecryptReader::new(Cursor::new(encrypted), key_bytes, base_nonce)
+            .read_to_end(&mut decrypted)
+            .await
+            .expect("decrypt complete multi-package stream");
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[tokio::test]
+    async fn multipart_stream_full_roundtrip_and_truncation() {
+        let object_key = [0x64u8; 32];
+        let part_one_plaintext = vec![0xA1; DARE_PAYLOAD_SIZE + 31];
+        // Part two spans multiple packages so it can be truncated within the part.
+        let part_two_plaintext = vec![0xB2; DARE_PAYLOAD_SIZE * 2 + 7];
+
+        let mut encrypted_one = Vec::new();
+        EncryptReader::new_multipart_with_object_key(Cursor::new(part_one_plaintext.clone()), object_key, 1)
+            .read_to_end(&mut encrypted_one)
+            .await
+            .expect("encrypt multipart part one");
+
+        let mut encrypted_two = Vec::new();
+        EncryptReader::new_multipart_with_object_key(Cursor::new(part_two_plaintext.clone()), object_key, 2)
+            .read_to_end(&mut encrypted_two)
+            .await
+            .expect("encrypt multipart part two");
+
+        let mut encrypted = encrypted_one.clone();
+        encrypted.extend_from_slice(&encrypted_two);
+
+        // Full multipart stream decrypts back to the concatenated plaintext.
+        let mut decrypted = Vec::new();
+        DecryptReader::new_multipart_with_object_key(Cursor::new(encrypted.clone()), object_key, vec![1, 2])
+            .read_to_end(&mut decrypted)
+            .await
+            .expect("decrypt complete multipart stream");
+        let mut expected = part_one_plaintext.clone();
+        expected.extend_from_slice(&part_two_plaintext);
+        assert_eq!(decrypted, expected);
+
+        // Truncate within part two at its first internal package boundary, dropping its
+        // final package. Part one still ends via `finalized`; the failure surfaces only
+        // once part two hits EOF with at least one decrypted package and no final flag.
+        let truncated = encrypted[..encrypted_one.len() + DARE_PACKAGE_SIZE].to_vec();
+        assert!(truncated.len() < encrypted.len(), "truncation must drop part two's final package");
+
+        let mut sink = Vec::new();
+        let err = DecryptReader::new_multipart_with_object_key(Cursor::new(truncated), object_key, vec![1, 2])
+            .read_to_end(&mut sink)
+            .await
+            .expect_err("multipart stream truncated within a part must fail");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1045

## Summary of Changes

`DecryptReader::poll_read` treated a clean end of stream at a DARE package boundary as a successful completion without ever requiring that a final-flagged package had been observed. As a result, ciphertext truncated exactly at a 64 KiB package boundary (dropping the final-flagged package) decrypted successfully, defeating DARE 2.0 truncation detection that the reference implementation surfaces as an unexpected end of file.

This change adds a truncation guard in the boundary end-of-stream branch. Execution only reaches that branch after the finalized case has already been consumed at the top of the read loop, so at this point no final-flagged package is in effect. If at least one package of the current part has already been decrypted but the stream ends before a final-flagged package, the reader now returns an unexpected-end-of-file error instead of silently succeeding.

Two legitimate cases are deliberately preserved and cannot trigger a false positive. The reference nonce field is None in every constructor, is set from the first decrypted package of the current part, and is reset to None when a multipart reader advances to the next part, so its presence is an exact witness for at least one package having been decrypted in the current part. Because encryption emits zero packages for empty plaintext, an empty object reaches this branch with that field still unset and is accepted as a valid empty stream. Intermediate multipart parts never reach this branch at all: they end through the finalized path at the top of the loop, which advances to the next part and resets state. Only a stream, or an individual part, that ends after at least one decrypted package without a final-flagged package now errors. The existing mid-header end-of-stream branch, which already errors correctly, is left unchanged.

## Verification

- `cargo test -p rustfs-rio-v2`
- `cargo clippy -p rustfs-rio-v2 --tests -- -D warnings`
- `cargo fmt --all`

Four tests were added in the crate. A truncation test encrypts a multi-package stream, truncates the ciphertext at a package boundary dropping the final package, and asserts the decrypt fails with an unexpected-end-of-file error; this test was confirmed to fail before the guard was added and to pass with it. An empty-plaintext round trip confirms an empty object still decrypts to empty output without error. A full multi-package round trip confirms complete streams still decrypt to the original plaintext. A multipart test confirms a complete multipart stream decrypts successfully and that a multipart stream truncated within a part errors.

## Impact

Corrupted or maliciously truncated encrypted objects that happen to end on a package boundary are now rejected on read instead of returning incomplete plaintext as if it were complete. There is no impact on valid empty objects, complete single-part streams, or complete multipart streams. No public interface changes.

## Additional Notes

N/A
