### PR TITLE
fix(rustfs): fail GetObject stream on short body instead of truncating

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -888,6 +888,17 @@ impl<R: AsyncRead + Unpin> AsyncRead for GetObjectStreamingReader<R> {
                         "GetObject streaming body ended before expected length"
                     );
                     self.finish_err();
+                    // The inner reader signalled a clean EOF before delivering the full
+                    // Content-Length. Returning Ok here would hand the client a truncated body
+                    // under a full Content-Length: the peer treats the short body as complete
+                    // (e.g. `mc mirror` writes a short file and considers it done — the
+                    // "incomplete data mirroring" in issue #2955). Surface an error instead so
+                    // the transfer fails loudly and the client retries rather than persisting
+                    // truncated data.
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "get object streaming body ended before the expected content length",
+                    )));
                 } else {
                     self.completed = true;
                     self.finish_ok();
@@ -7131,6 +7142,39 @@ mod tests {
             .expect("complete streaming body should read successfully");
 
         assert_eq!(out, b"hello");
+        assert_eq!(GetObjectGuard::concurrent_count(), initial);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn get_object_streaming_reader_errors_on_short_eof() {
+        use tokio::io::AsyncReadExt;
+
+        // The inner reader delivers 5 bytes then a clean EOF, but the advertised
+        // Content-Length is 10. The reader must surface an error rather than a clean EOF, so
+        // the client sees a failed transfer instead of silently persisting a truncated body
+        // (the "incomplete data mirroring" of #2955).
+        let initial = GetObjectGuard::concurrent_count();
+        let guard = GetObjectGuard::new();
+        assert_eq!(GetObjectGuard::concurrent_count(), initial + 1);
+
+        let mut reader = GetObjectStreamingReader::new(
+            std::io::Cursor::new(b"short".to_vec()),
+            "test-bucket",
+            "truncated-object",
+            10,
+            Duration::ZERO,
+            GetObjectBodyLifecycle::tracked(guard),
+        );
+        let mut out = Vec::new();
+        let err = reader
+            .read_to_end(&mut out)
+            .await
+            .expect_err("short body under a larger Content-Length must fail the stream");
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert_eq!(out, b"short", "bytes read before the short EOF are still delivered");
+
+        drop(reader);
         assert_eq!(GetObjectGuard::concurrent_count(), initial);
     }
 


### PR DESCRIPTION
## Summary

Addresses the "incomplete data mirroring" reported in #2955: with one writer and two concurrent `mc mirror --watch` readers over a 10G dataset, the mirrored (read) side ended up *short* — final size close to but below expected — and the run only completed cleanly with `--max-workers 1`.

## Root cause (read-side silent truncation)

`GetObjectStreamingReader::poll_read` wraps the GET response body and tracks `emitted` vs `expected` (`expected` = the advertised Content-Length, derived from `ObjectInfo::get_actual_size()`). When the inner reader returned a **clean EOF before delivering the full Content-Length** (`emitted < expected`), the code logged a `short_eof` warning and flipped the lifecycle to error for metrics — but then still returned `Poll::Ready(Ok(()))`, i.e. a normal end of body. The client received a truncated body under a full Content-Length and treated it as complete (e.g. `mc mirror` persists the short file and moves on).

The legacy duplex read path produces exactly this shape under contention: when a part-by-part `get_object_with_fileinfo` stream fails mid-transfer (disk-read timeout, quorum loss, bitrot on a later block, or a client/peer disconnect), the spawned streaming task logs the error and **drops the duplex writer**, so the response reader observes a clean 0-byte EOF with fewer bytes emitted than promised. The two slow mirror readers competing with the writer for disk-read permits made this window easy to hit; `--max-workers 1` avoids the contention and the truncation with it.

## Change

Return `UnexpectedEof` from the short-EOF branch instead of a clean `Ok(())`. The error surfaces through `GetObjectReaderStream` as a mid-body stream error, so hyper aborts the framed response and the client sees a **failed** transfer (and retries) rather than persisting truncated data.

This is a strict correctness improvement:
- `expected` is derived from the same `ObjectInfo` as the reader's byte budget, and the reader wrappers (`LimitReader`, `RangedDecompressReader`) are upper bounds that never pad — so a short clean EOF only happens on genuine truncation or a metadata-accounting inconsistency, both of which must fail loudly rather than silently truncate.
- Zero-length objects (`expected == 0`) never reach this branch (short-circuited at construction and in `GetObjectReaderStream::poll_next`).
- HEAD and all fully-buffered body paths (`MemoryTrackedBytesStream`) do not use this reader and are unaffected.

## Testing

- `cargo test -p rustfs --lib app::object_usecase::tests::get_object_streaming_reader` → 4 passed.
  - New `get_object_streaming_reader_errors_on_short_eof`: inner reader delivers 5 bytes then EOF under `expected = 10`; asserts `read_to_end` fails with `UnexpectedEof`, the 5 already-read bytes are still delivered, and the lifecycle guard is released.
  - Existing streaming-reader tests (full-body success, stall timeout, guard release on drop) still pass.

## Adversarial validation

Ran correctness and compatibility/concurrency reviewer passes over the diff:
- **Correctness**: traced every construction path and every source of `expected` (ranged GET, SSE-C/SSE-KMS, compression, multipart, inline, zero-length). `expected` always equals the reader's contracted output for a healthy object; no legitimate path delivers fewer bytes than a correctly-advertised Content-Length at a clean EOF. No false positive.
- **Compatibility/concurrency**: mid-stream error translation surfaces a broken transfer (not a silent 200); the lifecycle guard, disk-read permit, and foreground-read guard are all released on Drop with no double-finish; no upstream layer depended on the old clean-EOF behavior; no existing test asserted it.

## Notes / follow-ups (not in this PR)

The investigation also surfaced two related, higher-risk items left for separate changes: the disk-read admission permit is held for the entire slow-client body transfer (writes bypass it), which is the throughput/`--max-workers 1` behavior; and client-disconnect `BrokenPipe` on the write/emit side is classified as a server read/decode failure (log/heal noise, overlaps #2761).