### PR TITLE
test(ecstore): serialize bucket_delete tests to fix cargo-test global race

### DIFF
--- a/crates/ecstore/src/store/bucket.rs
+++ b/crates/ecstore/src/store/bucket.rs
@@ -328,6 +328,7 @@ mod tests {
         disk::endpoint::Endpoint,
         layout::endpoints::{EndpointServerPools, Endpoints, PoolEndpoints},
     };
+    use serial_test::serial;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use time::OffsetDateTime;
@@ -479,7 +480,19 @@ mod tests {
         );
     }
 
+    // #[serial] with the crate-wide default key: these tests drive make_bucket /
+    // delete_bucket through the process-global local-disk registry and lock
+    // client (see crates/ecstore/src/runtime/global.rs), and through Sets::new
+    // which reads the process-global erasure mode. Running them concurrently with
+    // other tests that touch those globals races make_bucket into
+    // InsufficientWriteQuorum under `cargo test` (single process). serial_test
+    // serializes them across the
+    // in-process suite; nextest's per-test processes are covered separately by the
+    // ecstore-serial-flaky test-group in .config/nextest.toml (backlog #937).
+    // Full instance-level isolation is blocked on the InstanceContext migration
+    // (backlog #939) and is not attempted here.
     #[tokio::test]
+    #[serial]
     async fn bucket_delete_mark_delete_marks_metadata_deleted_without_physical_object_delete() {
         let (disk_paths, ecstore) = setup_bucket_delete_test_env().await;
         let bucket = format!("bucket-mark-delete-{}", Uuid::new_v4().simple());
@@ -514,6 +527,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn bucket_delete_purge_removes_bucket_data_and_internal_metadata() {
         let (disk_paths, ecstore) = setup_bucket_delete_test_env().await;
         let bucket = format!("bucket-purge-{}", Uuid::new_v4().simple());
@@ -548,6 +562,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn bucket_delete_default_s3_delete_still_rejects_non_empty_bucket() {
         let (disk_paths, ecstore) = setup_bucket_delete_test_env().await;
         let bucket = format!("bucket-s3-delete-{}", Uuid::new_v4().simple());


### PR DESCRIPTION
## Related Issues

Middle-tier fix for rustfs/backlog#937 (`cargo test` side of the two flaky groups). Follows the short-term nextest test-group mitigation (#4558). Full instance-level isolation remains tracked in rustfs/backlog#939.

## Summary of Changes

Adds `#[serial]` (serial_test, crate default key) to the three `store::bucket::tests::bucket_delete_*` tests. These drive `make_bucket` / `delete_bucket` through the process-global local-disk registry (`GLOBAL_LOCAL_DISK_MAP`) and lock client, and through `Sets::new` which reads the process-global erasure mode. Under `cargo test` (single process, many threads) they race other global-touching tests and fail deterministically with `InsufficientWriteQuorum`. `#[serial]` serializes them across the in-process suite; nextest's per-test processes are already covered by the `ecstore-serial-flaky` test-group in `.config/nextest.toml` (#4558), so the two runners are now both covered.

Why this and not full isolation: an isolation attempt (inject a hermetic peer + build a throwaway ECStore) proved the primary root cause is fixable, but `Sets::new` reads a competing process-global erasure mode and a single-instance disk topology, and `Sets` has private fields that block constructing it around `Sets::new`. Complete instance-level isolation therefore depends on the backlog#939 `InstanceContext` migration and is intentionally not attempted here.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo check -p rustfs-ecstore --tests` — Finished.
- Discriminating repro at `--test-threads=16`, 3 rounds each: baseline (no `#[serial]`) fails all three `bucket_delete_*` every round; with `#[serial]` all three pass every round.

## Impact

Test-only. Removes the deterministic `cargo test` failure of the three `bucket_delete_*` tests; slightly serializes them against the existing serial suite (sub-second each). No runtime / API / config / deployment impact.

## Additional Notes

The same `--test-threads=16` repro surfaced a *different, deeper* same-family flake: `bucket::migration::tests::migrates_real_minio_bucket_metadata_end_to_end` fails with an empty `BucketMetadataSys`. Its root cause is the `GLOBAL_BUCKET_METADATA_SYS` `OnceLock` (set-once): whichever test sets it first wins, so `#[serial]` does not help (confirmed: adding `#[serial]` to it does not fix it). That belongs to the backlog#939 instance-isolation work and is intentionally left out of this PR; it is not a regression from this change (it fails on `main` too under the same repro).
