### PR TITLE
perf(ecstore): backfill previous current size from rename_data and skip the pre-PUT lookup

### DIFF
--- a/crates/e2e_test/src/data_usage_test.rs
+++ b/crates/e2e_test/src/data_usage_test.rs
@@ -99,6 +99,57 @@ async fn data_usage_reports_all_objects() -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
+/// Regression test for rustfs/backlog#1009: on a non-locked, non-versioned
+/// bucket the PUT usecase skips its pre-PUT lookup and accounts overwrites
+/// with the size backfilled by rename_data. From the moment the bucket shows
+/// up in data usage, an overwrite must report exactly the new size (never
+/// old+new double-counted) and a single object.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+#[ignore = "Starts a rustfs server and requires awscurl; enable when running full E2E"]
+async fn data_usage_reports_overwrite_size_delta_exactly() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    init_logging();
+
+    let mut env = RustFSTestEnvironment::new().await?;
+    env.start_rustfs_server(vec![]).await?;
+
+    let client = env.create_s3_client();
+    let bucket = "data-usage-overwrite";
+    let first_size = 1024_u64;
+    let overwrite_size = 4096_u64;
+
+    client.create_bucket().bucket(bucket).send().await?;
+    client
+        .put_object()
+        .bucket(bucket)
+        .key("resized")
+        .body(ByteStream::from(vec![1u8; first_size as usize]))
+        .send()
+        .await?;
+    client
+        .put_object()
+        .bucket(bucket)
+        .key("resized")
+        .body(ByteStream::from(vec![2u8; overwrite_size as usize]))
+        .send()
+        .await?;
+
+    // The in-memory record is synchronous with the PUT responses, so the
+    // first poll that knows the bucket must already be exact; a transient
+    // first_size + overwrite_size reading would mean the overwrite was
+    // double-counted and only later repaired by the scanner.
+    let usage = wait_for_bucket_usage(&env, bucket, |usage| usage.buckets_usage.contains_key(bucket)).await?;
+    let bucket_usage = usage.buckets_usage.get(bucket).expect("bucket usage should exist");
+    assert_eq!(
+        bucket_usage.size, overwrite_size,
+        "overwrite must account exactly the new size, not double-count the previous one"
+    );
+    assert_eq!(bucket_usage.objects_count, 1, "overwrite must not create a second object");
+
+    env.stop_server();
+    Ok(())
+}
+
 /// Regression test for issue #3898.
 /// Versioned buckets should expose versions and delete markers through admin data usage.
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -274,8 +274,8 @@ pub mod disk {
         BATCH_READ_VERSION_MAX_ITEMS, BUCKET_META_PREFIX, BatchReadVersionItem, BatchReadVersionReq, BatchReadVersionResp,
         CheckPartsResp, DeleteOptions, Disk, DiskAPI, DiskInfo, DiskInfoOptions, DiskLocation, DiskOption, DiskStore,
         FileInfoVersions, FileReader, FileWriter, HEALING_MARKER_PATH, RUSTFS_META_BUCKET, ReadMultipleReq, ReadMultipleResp,
-        ReadOptions, RenameDataResp, STORAGE_FORMAT_FILE, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, new_disk,
-        validate_batch_read_version_item_count,
+        ReadOptions, RenameDataResp, RenameOldCurrentSize, STORAGE_FORMAT_FILE, UpdateMetadataOpts, VolumeInfo, WalkDirOptions,
+        new_disk, validate_batch_read_version_item_count,
     };
     pub use bytes::Bytes;
     pub use endpoint::Endpoint;
@@ -351,7 +351,7 @@ pub mod notification {
 pub mod object {
     pub use crate::object_api::{
         BLOCK_SIZE_V2, ERASURE_ALGORITHM, GetObjectBodyCacheHook, GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader,
-        RangedDecompressReader, StreamConsumer, register_get_object_body_cache_hook,
+        RangedDecompressReader, RenameOldCurrentVote, StreamConsumer, register_get_object_body_cache_hook,
     };
 }
 

--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -2632,6 +2632,7 @@ impl DiskAPI for RemoteDisk {
 mod tests {
     use super::*;
     use crate::cluster::rpc::internode_data_transport::{InternodeDataTransportCapabilities, TcpHttpInternodeDataTransport};
+    use crate::disk::RenameOldCurrentSize;
     use crate::runtime::sources as runtime_sources;
     use serde_json::Value;
     use std::io::{self as std_io, Write};
@@ -3055,11 +3056,74 @@ mod tests {
         );
     }
 
+    /// Wire compatibility for the `old_current_size` backfill field
+    /// (rustfs/backlog#1009) across a mixed-version cluster, in both
+    /// directions and on both wire formats (named msgpack + JSON fallback).
+    #[test]
+    fn rename_data_resp_old_current_size_wire_compat_with_pre_upgrade_peers() {
+        /// The struct shape a pre-upgrade binary serializes and deserializes.
+        #[derive(Debug, Serialize, serde::Deserialize)]
+        struct LegacyRenameDataResp {
+            old_data_dir: Option<Uuid>,
+            sign: Option<Vec<u8>>,
+        }
+
+        // Pre-upgrade peer -> upgraded node: the absent field must decode as
+        // "not reported" (None), never as "no previous version".
+        let legacy = LegacyRenameDataResp {
+            old_data_dir: Some(Uuid::new_v4()),
+            sign: Some(vec![3_u8; 16]),
+        };
+        let legacy_msgpack = encode_msgpack_named(&legacy).expect("legacy payload should encode");
+        let decoded = decode_msgpack_or_json::<RenameDataResp>(&legacy_msgpack, "", "RenameDataResp")
+            .expect("upgraded decoder must accept a legacy msgpack payload");
+        assert_eq!(decoded.old_data_dir, legacy.old_data_dir);
+        assert_eq!(decoded.old_current_size, None);
+
+        let legacy_json = serde_json::to_string(&legacy).expect("legacy payload should encode as json");
+        let decoded = decode_msgpack_or_json::<RenameDataResp>(&[], &legacy_json, "RenameDataResp")
+            .expect("upgraded decoder must accept a legacy json payload");
+        assert_eq!(decoded.old_current_size, None);
+
+        // Upgraded node -> pre-upgrade peer: the unknown field must be ignored.
+        let upgraded = RenameDataResp {
+            old_data_dir: Some(Uuid::new_v4()),
+            sign: None,
+            old_current_size: Some(RenameOldCurrentSize { live_size: Some(123) }),
+        };
+        let upgraded_msgpack = encode_msgpack_named(&upgraded).expect("upgraded payload should encode");
+        let legacy_view: LegacyRenameDataResp = rmp_serde::from_slice(upgraded_msgpack.as_slice())
+            .expect("pre-upgrade decoder must ignore the unknown msgpack field");
+        assert_eq!(legacy_view.old_data_dir, upgraded.old_data_dir);
+
+        let upgraded_json = serde_json::to_string(&upgraded).expect("upgraded payload should encode as json");
+        let _: LegacyRenameDataResp =
+            serde_json::from_str(&upgraded_json).expect("pre-upgrade decoder must ignore the unknown json field");
+
+        // The third state — reported "no live current version" — must survive
+        // the wire as Some(live_size: None) and never collapse into the outer
+        // "not reported" None on either format.
+        let fresh_key = RenameDataResp {
+            old_data_dir: None,
+            sign: None,
+            old_current_size: Some(RenameOldCurrentSize { live_size: None }),
+        };
+        let fresh_msgpack = encode_msgpack_named(&fresh_key).expect("fresh-key payload should encode");
+        let decoded = decode_msgpack_or_json::<RenameDataResp>(&fresh_msgpack, "", "RenameDataResp")
+            .expect("fresh-key msgpack payload should decode");
+        assert_eq!(decoded.old_current_size, Some(RenameOldCurrentSize { live_size: None }));
+        let fresh_json = serde_json::to_string(&fresh_key).expect("fresh-key payload should encode as json");
+        let decoded = decode_msgpack_or_json::<RenameDataResp>(&[], &fresh_json, "RenameDataResp")
+            .expect("fresh-key json payload should decode");
+        assert_eq!(decoded.old_current_size, Some(RenameOldCurrentSize { live_size: None }));
+    }
+
     #[test]
     fn rename_data_resp_named_msgpack_is_smaller_than_json() {
         let response = RenameDataResp {
             old_data_dir: Some(Uuid::new_v4()),
             sign: Some(vec![1_u8; 32]),
+            old_current_size: Some(RenameOldCurrentSize { live_size: Some(4096) }),
         };
         let json = serde_json::to_vec(&response).expect("rename data response json should encode");
         let named_msgpack = encode_msgpack_named(&response).expect("rename data response named msgpack should encode");

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -3984,7 +3984,7 @@ fn local_disk_scan_lock_key(bucket: &str, base_dir: &str, filter_prefix: Option<
 /// accounting can reuse it instead of a separate pre-PUT metadata fanout
 /// (rustfs/backlog#1009). Must mirror what `get_object_info` without a
 /// version id reports: latest live version → its size; missing key,
-/// unparseable version meta, or delete-marker latest → `None`.
+/// unparsable version meta, or delete-marker latest → `None`.
 /// `into_fileinfo` with an empty version id is the same latest-version
 /// selection the read path uses (free versions excluded).
 fn rename_data_old_current_size(dst_meta: &FileMeta, dst_volume: &str, dst_path: &str) -> RenameOldCurrentSize {

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -19,8 +19,8 @@ use crate::disk::{
     BUCKET_META_PREFIX, CHECK_PART_FILE_CORRUPT, CHECK_PART_FILE_NOT_FOUND, CHECK_PART_SUCCESS, CHECK_PART_UNKNOWN,
     CHECK_PART_VOLUME_NOT_FOUND, CheckPartsResp, DeleteOptions, DiskAPI, DiskInfo, DiskInfoOptions, DiskLocation, DiskMetrics,
     FileInfoVersions, FileReader, FileWriter, MmapCopyStageMetrics, RUSTFS_META_BUCKET, RUSTFS_META_TMP_BUCKET,
-    RUSTFS_META_TMP_DELETED_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions, RenameDataResp, STORAGE_FORMAT_FILE,
-    STORAGE_FORMAT_FILE_BACKUP, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, conv_part_err_to_int,
+    RUSTFS_META_TMP_DELETED_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions, RenameDataResp, RenameOldCurrentSize,
+    STORAGE_FORMAT_FILE, STORAGE_FORMAT_FILE_BACKUP, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, conv_part_err_to_int,
     endpoint::Endpoint,
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
@@ -3979,6 +3979,23 @@ fn local_disk_scan_lock_key(bucket: &str, base_dir: &str, filter_prefix: Option<
     (bucket.to_owned(), prefix)
 }
 
+/// Observe the destination's "current object" size from the already-parsed
+/// dst xl.meta before `add_version` commits the incoming write, so PUT
+/// accounting can reuse it instead of a separate pre-PUT metadata fanout
+/// (rustfs/backlog#1009). Must mirror what `get_object_info` without a
+/// version id reports: latest live version → its size; missing key,
+/// unparseable version meta, or delete-marker latest → `None`.
+/// `into_fileinfo` with an empty version id is the same latest-version
+/// selection the read path uses (free versions excluded).
+fn rename_data_old_current_size(dst_meta: &FileMeta, dst_volume: &str, dst_path: &str) -> RenameOldCurrentSize {
+    RenameOldCurrentSize {
+        live_size: match dst_meta.into_fileinfo(dst_volume, dst_path, "", false, false, false) {
+            Ok(prev) if !prev.deleted => Some(prev.size),
+            _ => None,
+        },
+    }
+}
+
 fn rename_data_versions_signature(meta: &FileMeta) -> Option<Vec<u8>> {
     if meta.versions.len() > 10 {
         return None;
@@ -5037,6 +5054,8 @@ impl DiskAPI for LocalDisk {
                 skip_parent = parent.to_path_buf();
             }
 
+            let old_current_size = rename_data_old_current_size(&xlmeta, dst_volume, dst_path);
+
             let version_id = fi.version_id.unwrap_or_default();
             let has_old_data_dir = xlmeta.find_unshared_data_dir_for_version(Some(version_id));
             if let Some(old_data_dir) = has_old_data_dir.as_ref() {
@@ -5240,6 +5259,7 @@ impl DiskAPI for LocalDisk {
             Ok(RenameDataResp {
                 old_data_dir: has_old_data_dir,
                 sign: version_signature,
+                old_current_size: Some(old_current_size),
             })
         } else {
             // Inline: merge read + parse + write + rename into single spawn_blocking
@@ -5252,8 +5272,10 @@ impl DiskAPI for LocalDisk {
             } else {
                 None
             };
+            let dst_volume_owned = dst_volume.to_string();
+            let dst_path_owned = dst_path.to_string();
 
-            let (old_data_dir, version_signature) = tokio::task::spawn_blocking(move || {
+            let (old_data_dir, version_signature, old_current_size) = tokio::task::spawn_blocking(move || {
                 // Read existing xl.meta
                 let has_dst_buf = match std::fs::read(&dst) {
                     Ok(buf) => Some(Bytes::from(buf)),
@@ -5268,6 +5290,8 @@ impl DiskAPI for LocalDisk {
                 {
                     xlmeta = nmeta
                 }
+
+                let old_current_size = rename_data_old_current_size(&xlmeta, &dst_volume_owned, &dst_path_owned);
 
                 let version_id = fi.version_id.unwrap_or_default();
                 let old_data_dir = xlmeta.find_unshared_data_dir_for_version(Some(version_id));
@@ -5365,7 +5389,11 @@ impl DiskAPI for LocalDisk {
                     }
                 }
 
-                Ok::<(Option<uuid::Uuid>, Option<Vec<u8>>), std::io::Error>((old_data_dir, version_signature))
+                Ok::<(Option<uuid::Uuid>, Option<Vec<u8>>, RenameOldCurrentSize), std::io::Error>((
+                    old_data_dir,
+                    version_signature,
+                    old_current_size,
+                ))
             })
             .await
             .map_err(DiskError::from)??;
@@ -5380,6 +5408,7 @@ impl DiskAPI for LocalDisk {
             Ok(RenameDataResp {
                 old_data_dir,
                 sign: version_signature,
+                old_current_size: Some(old_current_size),
             })
         }
     }
@@ -5977,6 +6006,65 @@ mod test {
         match disk.make_volume(volume).await {
             Ok(()) | Err(DiskError::VolumeExists) => {}
             Err(err) => panic!("test volume should be available: {err:?}"),
+        }
+    }
+
+    /// Semantics of the rename_data old-current-size observation
+    /// (rustfs/backlog#1009): it must mirror what `get_object_info` without a
+    /// version id would have reported just before the commit.
+    mod rename_data_old_current_size_semantics {
+        use super::*;
+
+        fn live_version(size: i64, mod_time: OffsetDateTime) -> FileInfo {
+            FileInfo {
+                name: "bucket/object".to_string(),
+                version_id: Some(Uuid::new_v4()),
+                size,
+                mod_time: Some(mod_time),
+                ..Default::default()
+            }
+        }
+
+        #[test]
+        fn missing_destination_meta_reports_no_live_version() {
+            let meta = FileMeta::new();
+            assert_eq!(rename_data_old_current_size(&meta, "bucket", "object").live_size, None);
+        }
+
+        #[test]
+        fn live_latest_reports_its_size() {
+            let mut meta = FileMeta::new();
+            meta.add_version(live_version(111, OffsetDateTime::now_utc()))
+                .expect("live version should be added");
+            assert_eq!(rename_data_old_current_size(&meta, "bucket", "object").live_size, Some(111));
+        }
+
+        #[test]
+        fn newest_live_version_wins_over_older_ones() {
+            let now = OffsetDateTime::now_utc();
+            let mut meta = FileMeta::new();
+            meta.add_version(live_version(111, now - time::Duration::seconds(10)))
+                .expect("older live version should be added");
+            meta.add_version(live_version(222, now))
+                .expect("newer live version should be added");
+            assert_eq!(rename_data_old_current_size(&meta, "bucket", "object").live_size, Some(222));
+        }
+
+        #[test]
+        fn delete_marker_latest_hides_older_live_versions() {
+            let now = OffsetDateTime::now_utc();
+            let mut meta = FileMeta::new();
+            meta.add_version(live_version(111, now - time::Duration::seconds(10)))
+                .expect("live version should be added");
+            let marker = FileInfo {
+                name: "bucket/object".to_string(),
+                version_id: Some(Uuid::new_v4()),
+                deleted: true,
+                mod_time: Some(now),
+                ..Default::default()
+            };
+            meta.add_version(marker).expect("delete marker should be added");
+            assert_eq!(rename_data_old_current_size(&meta, "bucket", "object").live_size, None);
         }
     }
 

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -839,10 +839,30 @@ pub struct DiskOption {
     pub health_check: bool,
 }
 
+/// Size of the destination's "current object" observed by `rename_data` while
+/// it re-reads the destination xl.meta anyway, so PUT accounting can reuse it
+/// instead of issuing its own pre-PUT metadata fanout (rustfs/backlog#1009).
+///
+/// `live_size` mirrors what `get_object_info` without a version id would have
+/// reported just before the commit: `Some(size)` when the latest version was a
+/// live object, `None` when the key did not exist or its latest version was a
+/// delete marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RenameOldCurrentSize {
+    pub live_size: Option<i64>,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct RenameDataResp {
     pub old_data_dir: Option<Uuid>,
     pub sign: Option<Vec<u8>>,
+    /// `None` means the disk did not report the observation (a pre-upgrade
+    /// peer whose wire payload lacks the field), which is why this is not
+    /// flattened into `Option<i64>`: "not reported" must stay distinguishable
+    /// from "no live current version". `#[serde(default)]` keeps both msgpack
+    /// and JSON wire formats compatible in mixed-version clusters.
+    #[serde(default)]
+    pub old_current_size: Option<RenameOldCurrentSize>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1229,10 +1249,12 @@ mod tests {
         let resp = RenameDataResp {
             old_data_dir: Some(uuid),
             sign: Some(signature.clone()),
+            old_current_size: Some(RenameOldCurrentSize { live_size: Some(9) }),
         };
 
         assert_eq!(resp.old_data_dir, Some(uuid));
         assert_eq!(resp.sign, Some(signature));
+        assert_eq!(resp.old_current_size, Some(RenameOldCurrentSize { live_size: Some(9) }));
     }
 
     /// Test constants

--- a/crates/ecstore/src/object_api/types.rs
+++ b/crates/ecstore/src/object_api/types.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 use super::*;
+use crate::disk::RenameOldCurrentSize;
+use std::sync::OnceLock;
+
 use crate::storage_api_contracts::{
     list::VersionMarker,
     object::{
@@ -66,6 +69,30 @@ pub struct ObjectOptions {
     pub want_checksum: Option<Checksum>,
     pub skip_verify_bitrot: bool,
     pub capacity_scope_token: Option<Uuid>,
+
+    /// When set, `SetDisks::put_object` deposits the erasure-set vote over the
+    /// per-disk rename_data old-current-size observations here after the
+    /// commit, so the PUT usecase can account for the overwritten size without
+    /// its own pre-PUT metadata fanout (rustfs/backlog#1009). A pure
+    /// in-process out-parameter: never serialized and never fed into
+    /// `ObjectInfo`, events, replication, or ILM.
+    pub put_old_current_vote: Option<Arc<OnceLock<RenameOldCurrentVote>>>,
+}
+
+/// Outcome of voting the per-disk [`RenameOldCurrentSize`] observations
+/// returned by `rename_data` across an erasure set (rustfs/backlog#1009).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenameOldCurrentVote {
+    /// At least write-quorum successful disks agreed on the same observation.
+    Quorum(RenameOldCurrentSize),
+    /// Every successful disk reported an observation but no single value
+    /// reached write quorum (e.g. heal-lagged replicas disagree). Transient;
+    /// callers fall back for this write only.
+    NoQuorum,
+    /// At least one successful disk did not report the observation at all — a
+    /// pre-upgrade peer. Callers should stop relying on the backfill until the
+    /// cluster finishes its rolling upgrade.
+    Unsupported,
 }
 
 impl ObjectOptions {

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -46,11 +46,13 @@ use crate::diagnostics::get::{
     GetObjectFailureReason, classify_disk_error, get_stage_timer_if_enabled, record_get_object_pipeline_failure,
     record_get_object_pipeline_failure_for_path, record_get_stage_duration_if_enabled,
 };
+use crate::disk::RenameOldCurrentSize;
 use crate::erasure::coding::BitrotReader;
 use crate::io_support::bitrot::{
     BitrotReaderStageMetrics, DeferredReaderStripeHandle, create_bitrot_reader_with_stage_metrics,
     create_deferred_bitrot_reader_with_stripe_handle, object_mmap_read_enabled,
 };
+use crate::object_api::RenameOldCurrentVote;
 use crate::set_disk::shard_source::ShardReadCost;
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::counter;
@@ -2480,6 +2482,34 @@ impl SetDisks {
         data_count
     }
 
+    /// Vote the per-disk `rename_data` old-current-size observations
+    /// (rustfs/backlog#1009). Entries are `None` for disks whose rename
+    /// failed (excluded from the vote); `Some(None)` marks a disk that
+    /// succeeded but did not report the observation — a pre-upgrade peer —
+    /// which poisons the whole vote to `Unsupported` so callers stop relying
+    /// on the backfill instead of misreading "not reported" as "no previous
+    /// version".
+    pub(in crate::set_disk) fn reduce_rename_old_current_vote(
+        observations: &[Option<Option<RenameOldCurrentSize>>],
+        write_quorum: usize,
+    ) -> RenameOldCurrentVote {
+        let mut counts: HashMap<Option<i64>, usize> = HashMap::new();
+        for observation in observations.iter().flatten() {
+            match observation {
+                None => return RenameOldCurrentVote::Unsupported,
+                Some(observed) => *counts.entry(observed.live_size).or_insert(0) += 1,
+            }
+        }
+
+        // Two distinct values can never both reach write quorum (2 * write
+        // quorum > disk count), so ties only occur below quorum and resolve
+        // to NoQuorum regardless of HashMap iteration order.
+        match counts.into_iter().max_by_key(|(_, count)| *count) {
+            Some((live_size, count)) if count >= write_quorum => RenameOldCurrentVote::Quorum(RenameOldCurrentSize { live_size }),
+            _ => RenameOldCurrentVote::NoQuorum,
+        }
+    }
+
     #[tracing::instrument(level = "debug", skip(disks, file_infos))]
     #[allow(clippy::type_complexity)]
     pub(in crate::set_disk) async fn rename_data(
@@ -2490,7 +2520,13 @@ impl SetDisks {
         dst_bucket: &str,
         dst_object: &str,
         write_quorum: usize,
-    ) -> disk::error::Result<(Vec<Option<DiskStore>>, Option<Vec<u8>>, Option<Uuid>, Vec<Option<DiskStore>>)> {
+    ) -> disk::error::Result<(
+        Vec<Option<DiskStore>>,
+        Option<Vec<u8>>,
+        Option<Uuid>,
+        Vec<Option<DiskStore>>,
+        RenameOldCurrentVote,
+    )> {
         let mut futures = Vec::with_capacity(disks.len());
 
         let mut errs = Vec::with_capacity(disks.len());
@@ -2528,6 +2564,7 @@ impl SetDisks {
 
         let mut disk_versions = vec![None; disks.len()];
         let mut data_dirs = vec![None; disks.len()];
+        let mut old_current_observations = vec![None; disks.len()];
 
         let results = join_all(futures).await;
 
@@ -2536,6 +2573,7 @@ impl SetDisks {
                 Ok(res) => {
                     data_dirs[idx] = res.old_data_dir;
                     disk_versions[idx].clone_from(&res.sign);
+                    old_current_observations[idx] = Some(res.old_current_size);
                     errs.push(None);
                 }
                 Err(e) => {
@@ -2639,6 +2677,7 @@ impl SetDisks {
 
         let data_dir = Self::reduce_common_data_dir(&data_dirs, write_quorum);
         let versions = Self::select_rename_data_versions(&disk_versions, &errs, write_quorum);
+        let old_current_vote = Self::reduce_rename_old_current_vote(&old_current_observations, write_quorum);
         let online_disks = Self::eval_disks(disks, &errs);
         let cleanup_disks = if let Some(data_dir) = data_dir {
             disks
@@ -2657,7 +2696,7 @@ impl SetDisks {
             vec![None; disks.len()]
         };
 
-        Ok((online_disks, versions, data_dir, cleanup_disks))
+        Ok((online_disks, versions, data_dir, cleanup_disks, old_current_vote))
     }
 
     pub(in crate::set_disk) fn reduce_common_versions(disk_versions: &[Option<Vec<u8>>], write_quorum: usize) -> Option<Vec<u8>> {

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -6152,6 +6152,47 @@ mod tests {
         assert_eq!(result, Some(uuid1)); // Ignore None votes; uuid1 should still meet quorum
     }
 
+    #[test]
+    fn test_reduce_rename_old_current_vote() {
+        use crate::disk::RenameOldCurrentSize;
+        use crate::object_api::RenameOldCurrentVote;
+
+        fn reported(live_size: Option<i64>) -> Option<Option<RenameOldCurrentSize>> {
+            Some(Some(RenameOldCurrentSize { live_size }))
+        }
+
+        // Quorum agreement on an overwrite; the failed disk (outer None) is
+        // excluded from the vote.
+        let observations = vec![reported(Some(42)), reported(Some(42)), reported(Some(42)), None];
+        assert_eq!(
+            SetDisks::reduce_rename_old_current_vote(&observations, 3),
+            RenameOldCurrentVote::Quorum(RenameOldCurrentSize { live_size: Some(42) })
+        );
+
+        // Quorum agreement on a fresh key (no live current version).
+        let observations = vec![reported(None), reported(None), reported(None), reported(None)];
+        assert_eq!(
+            SetDisks::reduce_rename_old_current_vote(&observations, 3),
+            RenameOldCurrentVote::Quorum(RenameOldCurrentSize { live_size: None })
+        );
+
+        // Heal-lagged replicas disagree below write quorum.
+        let observations = vec![reported(Some(42)), reported(Some(42)), reported(Some(7)), reported(None)];
+        assert_eq!(SetDisks::reduce_rename_old_current_vote(&observations, 3), RenameOldCurrentVote::NoQuorum);
+
+        // A successful disk that did not report the observation (pre-upgrade
+        // peer) poisons the vote even though the reporters agree at quorum.
+        let observations = vec![reported(Some(42)), reported(Some(42)), reported(Some(42)), Some(None)];
+        assert_eq!(
+            SetDisks::reduce_rename_old_current_vote(&observations, 3),
+            RenameOldCurrentVote::Unsupported
+        );
+
+        // Nothing to vote on at all.
+        let observations = vec![None, None, None, None];
+        assert_eq!(SetDisks::reduce_rename_old_current_vote(&observations, 3), RenameOldCurrentVote::NoQuorum);
+    }
+
     fn rename_versions_signature(first_key: u8, version_count: usize) -> Vec<u8> {
         let mut signature = vec![0; version_count * 16];
         signature[7] = first_key;

--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -1420,7 +1420,7 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
 
         let complete_tail_stage_start = rustfs_io_metrics::put_stage_metrics_enabled().then(Instant::now);
 
-        let (online_disks, versions, op_old_dir, cleanup_disks) = Self::rename_data(
+        let (online_disks, versions, op_old_dir, cleanup_disks, _old_current_vote) = Self::rename_data(
             &shuffle_disks,
             RUSTFS_META_MULTIPART_BUCKET,
             &upload_id_path,

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -888,7 +888,7 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
             }
 
             let rename_stage_start = Instant::now();
-            let (online_disks, _, op_old_dir, cleanup_disks) = Self::rename_data(
+            let (online_disks, _, op_old_dir, cleanup_disks, old_current_vote) = Self::rename_data(
                 &shuffle_disks,
                 RUSTFS_META_TMP_BUCKET,
                 tmp_dir.as_str(),
@@ -898,6 +898,13 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                 write_quorum,
             )
             .await?;
+            // Surface the old-current-size vote to the PUT usecase so it can
+            // account for the overwritten object without a pre-PUT lookup
+            // (rustfs/backlog#1009). The commit above is already durable, so a
+            // consumer-side fallback never affects the write itself.
+            if let Some(slot) = &opts.put_old_current_vote {
+                let _ = slot.set(old_current_vote);
+            }
             let rename_stage_ms = rename_stage_start.elapsed().as_millis() as u64;
             rustfs_io_metrics::record_put_object_stage_duration("set_disk_rename", rename_stage_ms as f64);
             if (rename_stage_ms as u128) >= SET_DISK_COMMIT_TAIL_WARN_THRESHOLD_MS {
@@ -2500,6 +2507,168 @@ mod put_object_tmp_cleanup_tests {
         );
 
         drop(temp_dirs);
+    }
+}
+
+#[cfg(test)]
+mod put_object_old_current_backfill_tests {
+    //! End-to-end coverage for rustfs/backlog#1009: `put_object` must deposit
+    //! the quorum-voted old-current-size of the destination into
+    //! `opts.put_old_current_vote`, matching exactly what `get_object_info`
+    //! reported before the write, so the PUT usecase can skip its pre-PUT
+    //! lookup without changing usage accounting.
+
+    use super::hermetic_set_disks_support::hermetic_set_disks;
+    use super::*;
+    use crate::disk::{DiskAPI as _, RenameOldCurrentSize};
+    use crate::object_api::RenameOldCurrentVote;
+    use std::sync::OnceLock;
+
+    fn opts_with_slot(versioned: bool) -> (ObjectOptions, Arc<OnceLock<RenameOldCurrentVote>>) {
+        let slot = Arc::new(OnceLock::new());
+        let opts = ObjectOptions {
+            versioned,
+            put_old_current_vote: Some(slot.clone()),
+            ..Default::default()
+        };
+        (opts, slot)
+    }
+
+    fn quorum_live_size(slot: &OnceLock<RenameOldCurrentVote>) -> Option<i64> {
+        match slot.get().copied() {
+            Some(RenameOldCurrentVote::Quorum(observed)) => observed.live_size,
+            other => panic!("expected a quorum old-current-size vote, got {other:?}"),
+        }
+    }
+
+    /// Non-versioned PUTs: a fresh key votes "no live current version"; an
+    /// overwrite votes exactly the size `get_object_info` reported before the
+    /// write, for both the inline and the non-inline commit branch.
+    #[tokio::test]
+    async fn put_object_backfills_old_current_size_inline_and_non_inline() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "backlog1009-bucket";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+
+        // (object, first write size, overwrite size); 1 MiB payloads take the
+        // non-inline branch, small payloads the inline branch.
+        let cases = [
+            ("inline-object", 1024_usize, 2048_usize),
+            ("non-inline-object", 1 << 20, (1 << 20) + 512),
+        ];
+        for (object, first_size, overwrite_size) in cases {
+            let (opts, slot) = opts_with_slot(false);
+            let mut reader = PutObjReader::from_vec(vec![1u8; first_size]);
+            set_disks
+                .put_object(bucket, object, &mut reader, &opts)
+                .await
+                .expect("fresh put_object should succeed");
+            assert_eq!(quorum_live_size(&slot), None, "{object}: fresh key must vote no live current version");
+
+            let previous = set_disks
+                .get_object_info(bucket, object, &ObjectOptions::default())
+                .await
+                .expect("get_object_info should see the first write");
+
+            let (opts, slot) = opts_with_slot(false);
+            let mut reader = PutObjReader::from_vec(vec![2u8; overwrite_size]);
+            set_disks
+                .put_object(bucket, object, &mut reader, &opts)
+                .await
+                .expect("overwrite put_object should succeed");
+            assert_eq!(
+                quorum_live_size(&slot),
+                Some(previous.size),
+                "{object}: overwrite must vote exactly the pre-lookup size"
+            );
+        }
+    }
+
+    /// Versioned PUTs: the second write creates a new version, and the vote
+    /// must report the previous latest live version's size (what decides
+    /// objects_count in the versioned accounting path).
+    #[tokio::test]
+    async fn put_object_backfills_old_current_size_for_versioned_writes() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "backlog1009-versioned-bucket";
+        let object = "versioned-object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+
+        let (opts, slot) = opts_with_slot(true);
+        let mut reader = PutObjReader::from_vec(vec![1u8; 1024]);
+        let first = set_disks
+            .put_object(bucket, object, &mut reader, &opts)
+            .await
+            .expect("first versioned put_object should succeed");
+        assert_eq!(quorum_live_size(&slot), None, "fresh versioned key must vote no live current version");
+
+        let (opts, slot) = opts_with_slot(true);
+        let mut reader = PutObjReader::from_vec(vec![2u8; 4096]);
+        let second = set_disks
+            .put_object(bucket, object, &mut reader, &opts)
+            .await
+            .expect("second versioned put_object should succeed");
+        assert_ne!(first.version_id, second.version_id, "versioned writes must create distinct versions");
+        assert_eq!(
+            quorum_live_size(&slot),
+            Some(first.size),
+            "a new version must vote the previous latest live version's size"
+        );
+
+        // A default-opts PUT must not panic or deposit anywhere: the slot is
+        // simply absent.
+        let mut reader = PutObjReader::from_vec(vec![3u8; 64]);
+        set_disks
+            .put_object(bucket, object, &mut reader, &ObjectOptions::default())
+            .await
+            .expect("slot-less put_object should succeed");
+    }
+
+    /// A delete-marker-latest destination must vote "no live current version"
+    /// through the real commit path — the pre-lookup this replaces reported
+    /// the resurrecting PUT as a fresh key (objects_count +1), and the
+    /// backfill has to preserve that.
+    #[tokio::test]
+    async fn put_object_over_delete_marker_votes_no_live_current() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "backlog1009-marker-bucket";
+        let object = "resurrected-object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+
+        let versioned_opts = ObjectOptions {
+            versioned: true,
+            ..Default::default()
+        };
+
+        let mut reader = PutObjReader::from_vec(vec![1u8; 1024]);
+        set_disks
+            .put_object(bucket, object, &mut reader, &versioned_opts)
+            .await
+            .expect("versioned put_object should succeed");
+
+        let marker = set_disks
+            .delete_object(bucket, object, versioned_opts.clone())
+            .await
+            .expect("versioned delete should create a delete marker");
+        assert!(marker.delete_marker, "versioned delete without a version id must create a marker");
+
+        let (opts, slot) = opts_with_slot(true);
+        let mut reader = PutObjReader::from_vec(vec![2u8; 2048]);
+        set_disks
+            .put_object(bucket, object, &mut reader, &opts)
+            .await
+            .expect("put_object over the delete marker should succeed");
+        assert_eq!(
+            quorum_live_size(&slot),
+            None,
+            "a delete-marker latest must vote no live current version, like the pre-lookup's ObjectNotFound"
+        );
     }
 }
 

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -191,8 +191,8 @@ use tracing::{debug, error, instrument, warn};
 use uuid::Uuid;
 
 use super::storage_api::object_usecase::{
-    StorageDeletedObject, StorageObjectInfo as ObjectInfo, StorageObjectLockDeleteOptions, StorageObjectOptions as ObjectOptions,
-    StorageObjectToDelete as ObjectToDelete, StoragePutObjReader as PutObjReader,
+    RenameOldCurrentVote, StorageDeletedObject, StorageObjectInfo as ObjectInfo, StorageObjectLockDeleteOptions,
+    StorageObjectOptions as ObjectOptions, StorageObjectToDelete as ObjectToDelete, StoragePutObjReader as PutObjReader,
 };
 use crate::app::object_data_cache::{
     GetObjectBodyCacheLookup, GetObjectBodyCachePlan, GetObjectBodyCacheRequest, ObjectDataCacheAdapter,
@@ -3510,25 +3510,46 @@ impl DefaultObjectUsecase {
         )
         .await?;
 
-        let current_opts: ObjectOptions = internal_object_info_lookup_opts(
-            get_opts(&bucket, &key, version_id.clone(), None, &req.headers)
-                .await
-                .map_err(ApiError::from)?,
-        );
-        let previous_current_info = {
-            crate::hp_guard!("S3::put_object_prelookup");
-            store.get_object_info(&bucket, &key, &current_opts).await
+        // rustfs/backlog#1009: on buckets without object-lock the pre-PUT
+        // lookup exists only to learn the previous current size for usage
+        // accounting, and rename_data re-reads the destination xl.meta on
+        // every disk anyway. Skip the full-set fanout here and let the commit
+        // backfill that size through `opts.put_old_current_vote`. Fail-closed:
+        // an explicit versionId PUT (different lookup semantics), unreadable
+        // bucket metadata, object-lock enabled, or a cluster peer too old to
+        // report the observation all keep (or permanently restore) the
+        // original pre-lookup path.
+        let put_prelookup_backfill = if version_id.is_none() && put_prelookup_backfill_usable(&bucket).await {
+            let slot = Arc::new(std::sync::OnceLock::new());
+            opts.put_old_current_vote = Some(slot.clone());
+            Some(slot)
+        } else {
+            None
         };
-        let previous_current_size = match previous_current_info {
-            Ok(existing_obj_info) => {
-                validate_existing_object_lock_for_write(&existing_obj_info, &opts)?;
-                Some(existing_obj_info.size.max(0) as u64)
-            }
-            Err(err) => {
-                if !is_err_object_not_found(&err) && !is_err_version_not_found(&err) {
-                    return Err(ApiError::from(err).into());
+        let previous_current_size = if put_prelookup_backfill.is_some() {
+            // Resolved from the rename_data backfill after the store write.
+            None
+        } else {
+            let current_opts: ObjectOptions = internal_object_info_lookup_opts(
+                get_opts(&bucket, &key, version_id.clone(), None, &req.headers)
+                    .await
+                    .map_err(ApiError::from)?,
+            );
+            let previous_current_info = {
+                crate::hp_guard!("S3::put_object_prelookup");
+                store.get_object_info(&bucket, &key, &current_opts).await
+            };
+            match previous_current_info {
+                Ok(existing_obj_info) => {
+                    validate_existing_object_lock_for_write(&existing_obj_info, &opts)?;
+                    Some(existing_obj_info.size.max(0) as u64)
                 }
-                None
+                Err(err) => {
+                    if !is_err_object_not_found(&err) && !is_err_version_not_found(&err) {
+                        return Err(ApiError::from(err).into());
+                    }
+                    None
+                }
             }
         };
 
@@ -3762,6 +3783,11 @@ impl DefaultObjectUsecase {
 
         maybe_enqueue_transition_immediate(&obj_info, LcEventSrc::S3PutObject).await;
         let _ = invalidate_object_data_cache_after_put_success(&cache_adapter, &bucket, &key).await;
+
+        let previous_current_size = match &put_prelookup_backfill {
+            None => previous_current_size,
+            Some(slot) => resolve_backfilled_previous_current_size(&bucket, &key, slot.get().copied()),
+        };
 
         let put_versioned = BucketVersioningSys::prefix_enabled(&bucket, &key).await;
         // Fast in-memory update for immediate quota and admin usage consistency
@@ -6567,6 +6593,81 @@ async fn bucket_object_locking_enabled(bucket: &str) -> bool {
         .is_ok_and(|metadata| metadata.object_locking())
 }
 
+/// Set once a PUT observes that the erasure set cannot report the rename_data
+/// old-current-size (a pre-upgrade peer in a mixed-version cluster). From then
+/// on every PUT in this process keeps the exact pre-lookup accounting path;
+/// the flag clears only on restart, which a rolling upgrade performs anyway
+/// (rustfs/backlog#1009).
+static PUT_PRELOOKUP_BACKFILL_UNAVAILABLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Latch so the per-PUT NoQuorum fallback warns once per process and stays at
+/// debug afterwards — a heal-lagged erasure set could otherwise emit one warn
+/// per overwrite PUT on the hot path.
+static PUT_BACKFILL_NO_QUORUM_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the PUT usecase may skip its pre-PUT `get_object_info` fanout and
+/// account with the old-current-size backfilled by `rename_data`
+/// (rustfs/backlog#1009). Fail-closed on every uncertainty: object-lock
+/// enabled keeps the WORM validation pre-lookup (note the deliberate contrast
+/// with `bucket_object_locking_enabled`: unreadable bucket metadata counts as
+/// locked here), and a previously observed pre-upgrade peer disables the skip
+/// for the whole process.
+async fn put_prelookup_backfill_usable(bucket: &str) -> bool {
+    if PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.load(std::sync::atomic::Ordering::Relaxed) {
+        return false;
+    }
+    put_prelookup_backfill_allowed_by_lock_config(get_bucket_metadata(bucket).await.map(|metadata| metadata.object_locking()))
+}
+
+/// The WORM half of the gate, kept pure so the fail-closed matrix is
+/// unit-testable: only a readable lock config that says "not locked" may skip
+/// the pre-lookup (and with it `validate_existing_object_lock_for_write`).
+fn put_prelookup_backfill_allowed_by_lock_config<E>(object_locking: Result<bool, E>) -> bool {
+    matches!(object_locking, Ok(false))
+}
+
+/// Turn the rename_data old-current-size vote into the
+/// `previous_current_size` the usage accounting expects. Only a quorum vote is
+/// trusted; both degraded outcomes account the write as if the key were fresh,
+/// which over-counts (never under-counts) usage until the next authoritative
+/// scanner refresh reconciles it — fail-closed for quota enforcement.
+fn resolve_backfilled_previous_current_size(bucket: &str, key: &str, vote: Option<RenameOldCurrentVote>) -> Option<u64> {
+    match vote {
+        Some(RenameOldCurrentVote::Quorum(observed)) => observed.live_size.map(|size| size.max(0) as u64),
+        Some(RenameOldCurrentVote::NoQuorum) => {
+            // A heal-lagged set can hit this on every overwrite, so only the
+            // first occurrence per process warns; the rest stay at debug to
+            // keep the PUT hot path off the log (logging governance).
+            if !PUT_BACKFILL_NO_QUORUM_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                warn!(
+                    target: "rustfs::app::object_usecase",
+                    bucket = %bucket,
+                    key = %key,
+                    "rename_data old-current-size observations disagreed below write quorum; accounting such PUTs as fresh keys until the scanner reconciles (further occurrences logged at debug)"
+                );
+            } else {
+                debug!(
+                    target: "rustfs::app::object_usecase",
+                    bucket = %bucket,
+                    key = %key,
+                    "rename_data old-current-size vote below write quorum; accounting this PUT as a fresh key"
+                );
+            }
+            None
+        }
+        Some(RenameOldCurrentVote::Unsupported) | None => {
+            PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.store(true, std::sync::atomic::Ordering::Relaxed);
+            warn!(
+                target: "rustfs::app::object_usecase",
+                bucket = %bucket,
+                key = %key,
+                "erasure set did not report the rename_data old-current-size (pre-upgrade peer?); restoring the pre-PUT lookup path for this process"
+            );
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -6593,6 +6694,65 @@ mod tests {
             service: None,
             trailing_headers: None,
         }
+    }
+
+    /// rustfs/backlog#1009: the WORM half of the pre-lookup skip gate must be
+    /// fail-closed — only a readable lock config that says "not locked" may
+    /// skip the pre-lookup (which is where
+    /// `validate_existing_object_lock_for_write` runs). An inverted branch or
+    /// a weakened error arm here would silently drop WORM validation.
+    #[test]
+    fn put_prelookup_backfill_lock_gate_is_fail_closed() {
+        assert!(put_prelookup_backfill_allowed_by_lock_config::<StorageError>(Ok(false)));
+        assert!(!put_prelookup_backfill_allowed_by_lock_config::<StorageError>(Ok(true)));
+        assert!(!put_prelookup_backfill_allowed_by_lock_config(Err(StorageError::ConfigNotFound)));
+    }
+
+    /// rustfs/backlog#1009: the backfilled vote must translate into the exact
+    /// `previous_current_size` semantics the accounting expects, and only the
+    /// pre-upgrade-peer outcome may flip the process-wide sticky fallback.
+    /// A single test keeps the assertions on the global flag ordered.
+    #[test]
+    fn resolve_backfilled_previous_current_size_matrix_and_sticky_fallback() {
+        use crate::storage::storage_api::ecstore_disk::RenameOldCurrentSize;
+        use std::sync::atomic::Ordering;
+
+        let quorum = |live_size| Some(RenameOldCurrentVote::Quorum(RenameOldCurrentSize { live_size }));
+
+        assert_eq!(resolve_backfilled_previous_current_size("b", "k", quorum(Some(5))), Some(5));
+        assert_eq!(
+            resolve_backfilled_previous_current_size("b", "k", quorum(Some(-1))),
+            Some(0),
+            "negative sizes clamp to zero like the pre-lookup path"
+        );
+        assert_eq!(resolve_backfilled_previous_current_size("b", "k", quorum(None)), None);
+
+        assert!(!PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.load(Ordering::Relaxed));
+        assert_eq!(
+            resolve_backfilled_previous_current_size("b", "k", Some(RenameOldCurrentVote::NoQuorum)),
+            None
+        );
+        assert!(
+            !PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.load(Ordering::Relaxed),
+            "a transient quorum miss must not disable the backfill process-wide"
+        );
+
+        assert_eq!(
+            resolve_backfilled_previous_current_size("b", "k", Some(RenameOldCurrentVote::Unsupported)),
+            None
+        );
+        assert!(
+            PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.load(Ordering::Relaxed),
+            "a pre-upgrade peer must restore the pre-lookup path for the whole process"
+        );
+        PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.store(false, Ordering::Relaxed);
+
+        assert_eq!(resolve_backfilled_previous_current_size("b", "k", None), None);
+        assert!(
+            PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.load(Ordering::Relaxed),
+            "an unset slot after a successful PUT counts as unsupported"
+        );
+        PUT_PRELOOKUP_BACKFILL_UNAVAILABLE.store(false, Ordering::Relaxed);
     }
 
     #[test]

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -982,9 +982,9 @@ pub(crate) mod object_usecase {
         object_utils, options, request_context, s3_api, set_disk, sse, storage_class, timeout_wrapper,
     };
     pub(crate) use crate::storage::storage_api::{
-        ECStore, RFC1123, StorageDeletedObject, StorageObjectInfo, StorageObjectLockDeleteOptions, StorageObjectOptions,
-        StorageObjectToDelete, StoragePutObjReader, check_preconditions, get_validated_store, has_replication_rules,
-        parse_object_lock_legal_hold, parse_object_lock_retention, parse_part_number_i32_to_usize,
+        ECStore, RFC1123, RenameOldCurrentVote, StorageDeletedObject, StorageObjectInfo, StorageObjectLockDeleteOptions,
+        StorageObjectOptions, StorageObjectToDelete, StoragePutObjReader, check_preconditions, get_validated_store,
+        has_replication_rules, parse_object_lock_legal_hold, parse_object_lock_retention, parse_part_number_i32_to_usize,
         remove_object_lock_metadata_for_copy, strip_managed_encryption_metadata, validate_bucket_object_lock_enabled,
         validate_object_key, validate_sse_headers_for_read, validate_sse_headers_for_write, validate_ssec_for_read,
         wrap_response_with_cors,

--- a/rustfs/src/storage/mod.rs
+++ b/rustfs/src/storage/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use storage_api::{
     FileReader, FileWriter, GetObjectReader, HashReader, LocalPeerS3Client, MetricType, NotificationSys, OBJECT_LOCK_CONFIG,
     ObjectInfo, ObjectLockBlockReason, ObjectOptions, ObjectPartInfo, PEER_RESTSIGNAL, PEER_RESTSUB_SYS, PolicySys,
     PoolEndpoints, PutObjReader, QuotaError, RUSTFS_META_BUCKET, RawFileInfo, ReadMultipleReq, ReadMultipleResp, ReadOptions,
-    RenameDataResp, ReplicationStats, ReplicationStatusType, Result, SERVICE_SIGNAL_REFRESH_CONFIG,
+    RenameDataResp, RenameOldCurrentVote, ReplicationStats, ReplicationStatusType, Result, SERVICE_SIGNAL_REFRESH_CONFIG,
     SERVICE_SIGNAL_RELOAD_DYNAMIC, SetupType, StorageDeletedObject, StorageDiskRpcExt, StorageError, StorageGetObjectReader,
     StorageObjectInfo, StorageObjectOptions, StorageObjectToDelete, StoragePeerS3ClientExt, StoragePutObjReader,
     StorageReplicationConfigExt, StorageVersioningConfigExt, TONIC_RPC_PREFIX, TierConfigMgr, UpdateMetadataOpts, VolumeInfo,

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -371,7 +371,7 @@ pub(crate) mod ecstore_disk {
     pub(crate) use rustfs_ecstore::api::disk::{
         BatchReadVersionReq, BatchReadVersionResp, CheckPartsResp, DeleteOptions, DiskAPI, DiskInfo, DiskInfoOptions, DiskStore,
         FileInfoVersions, FileReader, FileWriter, RUSTFS_META_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions,
-        RenameDataResp, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, get_object_disk_read_timeout,
+        RenameDataResp, RenameOldCurrentSize, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, get_object_disk_read_timeout,
         validate_batch_read_version_item_count,
     };
     pub(crate) use rustfs_ecstore::api::disk::{endpoint, error, error_reduce};
@@ -442,7 +442,9 @@ pub(crate) mod ecstore_rpc {
 }
 
 pub(crate) mod ecstore_object {
-    pub(crate) use rustfs_ecstore::api::object::{GetObjectBodyCacheHook, register_get_object_body_cache_hook};
+    pub(crate) use rustfs_ecstore::api::object::{
+        GetObjectBodyCacheHook, RenameOldCurrentVote, register_get_object_body_cache_hook,
+    };
 }
 
 pub(crate) mod ecstore_set_disk {
@@ -532,6 +534,7 @@ pub(crate) type ReadMultipleReq = ecstore_disk::ReadMultipleReq;
 pub(crate) type ReadMultipleResp = ecstore_disk::ReadMultipleResp;
 pub(crate) type ReadOptions = ecstore_disk::ReadOptions;
 pub(crate) type RenameDataResp = ecstore_disk::RenameDataResp;
+pub(crate) type RenameOldCurrentVote = ecstore_object::RenameOldCurrentVote;
 pub(crate) type ReplicationStatusType = ecstore_bucket::replication::ReplicationStatusType;
 pub(crate) type ReplicationStats = StorageReplicationStatsHandle;
 pub(crate) type SetupType = ecstore_layout::SetupType;


### PR DESCRIPTION
Implements rustfs/backlog#1009 (HP-7 rescoped): every PUT used to issue an unconditional `get_object_info` before reading the body, whose only surviving consumers are usage accounting (`previous_current_size`) and WORM validation. `rename_data` already parses the destination xl.meta on every disk during the commit, so the old size was read twice per PUT — the pre-lookup costs one namespace read-lock plus a full-set `read_version` fanout (~4-5% of PUT latency on mixed-256k objects, per the HP-7 profiling in backlog#928).

## What changed

- **Wire (`RenameDataResp`)**: new `#[serde(default)] old_current_size: Option<RenameOldCurrentSize>` where `RenameOldCurrentSize { live_size: Option<i64> }`. Outer `None` means "disk did not report" (pre-upgrade peer); inner `None` means "no live current version" (fresh key or delete-marker latest). Keeping the two `None`s separate is what makes mixed-version clusters safe: an absent field can never be misread as "the object did not exist". Both msgpack-named and JSON legs stay compatible in either direction, and the third state (reported-but-no-live-version) survives both formats (all test-pinned).
- **Disk (`LocalDisk::rename_data`)**: both commit branches (non-inline and inline) observe the destination's latest version from the already-parsed dst `FileMeta` before `add_version`, via `FileMeta::into_fileinfo` with an empty version id — the same latest-version selection the read path uses, so delete-marker/missing/free-version semantics match `get_object_info` exactly. No new syscall, no new failure mode in the commit sequence (all observation errors collapse to `None`).
- **Set (`SetDisks::rename_data`)**: the per-disk observations are voted like `reduce_common_data_dir`: a value must reach write quorum to be trusted (`Quorum`); disagreement below quorum is `NoQuorum`; any successful disk that did not report poisons the vote to `Unsupported`. Two distinct values can never both reach write quorum (parity is capped at N/2 on every config path, so 2·wq > N).
- **Surface**: `ObjectOptions` gains an in-process out-parameter `put_old_current_vote: Option<Arc<OnceLock<RenameOldCurrentVote>>>` that `SetDisks::put_object` fills after the commit. `ObjectInfo` is untouched — nothing new flows into events, replication, or ILM payloads (the hard red line from the issue). `ObjectOptions` has no serde derive, so the field can never cross a wire.
- **App (`put_object` usecase)**: when the bucket has no object-lock configuration and the PUT carries no explicit `?versionId=`, the pre-PUT `get_object_info` fanout is skipped and accounting uses the backfilled size. Fail-closed gates:
  - unreadable bucket metadata counts as locked (keeps the pre-lookup + WORM validation path); the WORM half of the gate is a pure function with a fail-closed unit-test matrix;
  - `NoQuorum` falls back to fresh-key accounting for that write only (over-counts, never under-counts, until the authoritative scanner reconciles — conservative for quota); warns once per process, then debug, so a heal-lagged set cannot flood the hot-path log;
  - `Unsupported` (pre-upgrade peer) additionally flips a process-wide sticky flag that restores the original pre-lookup path until restart, so a rolling upgrade degrades to at most one imprecise record per upgraded node.

`copy_object`'s pre-lookup and CompleteMultipartUpload are out of scope per the issue (multipart discards the vote explicitly).

## Accounting equivalence

For every PUT shape the backfilled `previous_current_size` is bit-identical to what the pre-lookup produced: fresh key → `None`; non-versioned overwrite → `Some(old stored size)` (exact size delta); versioned write → previous latest live size (drives `objects_count` ±1); zero-byte, compressed (both paths use the stored `fi.size`), inline and non-inline branches all covered. One deliberate divergence: on **single-pool** deployments a delete-marker-latest used to yield `Some(0)` because `SetDisks::get_object_info` returns `Ok` with `delete_marker: true` (multi-pool translates it to `ObjectNotFound` → `None`). The backfill always reports `None`, matching the multi-pool and semantically correct side: a PUT that resurrects a deleted key now counts the object again on single-pool too.

The observation is taken under the per-object write lock at commit time, so concurrent overwrites of the same key now account against the immediately-prior committed version — strictly more accurate than the old unlocked pre-lookup, which could double-read the same stale size.

## Compatibility

- Old peer → new node: absent field decodes as `None` ("not reported") → vote is `Unsupported` → sticky fallback to the original path.
- New node → old peer: the unknown msgpack/JSON field is ignored (test-pinned against a legacy-shaped decoder). The proto schema is unchanged — evolution happens inside the opaque serde blob.
- WORM: buckets with object-lock enabled keep the exact original pre-lookup + `validate_existing_object_lock_for_write` path. Non-lock buckets cannot hold retention/legal-hold metadata (invariant already relied on by `can_skip_delete_objects_pre_stat`), so skipping the validation there is a no-op. Enabling object-lock on an existing bucket is monotonic and takes effect for the next PUT — the same window the old path had. Conditional writes (If-Match/If-None-Match) were never served by this pre-lookup — they run inside `SetDisks::put_object::check_write_precondition`.

## Tests

- `disk::local::test::rename_data_old_current_size_semantics::*` — latest/newest-wins/delete-marker/missing semantics against hand-built `FileMeta`s.
- `set_disk::tests::test_reduce_rename_old_current_vote` — quorum/no-quorum/unsupported/failed-disk vote matrix.
- `set_disk::ops::object::put_object_old_current_backfill_tests::*` — end-to-end on a 4-disk hermetic set: the backfilled vote equals the pre-write `get_object_info` size for inline, non-inline, and versioned writes; a PUT over a real committed delete marker votes "no live current"; slot-less PUTs unaffected.
- `cluster::rpc::remote_disk::tests::rename_data_resp_old_current_size_wire_compat_with_pre_upgrade_peers` — both wire directions, both formats, plus the reported-fresh-key third state.
- `app::object_usecase::tests::put_prelookup_backfill_lock_gate_is_fail_closed` — the WORM gate matrix (locked / unlocked / unreadable metadata).
- `app::object_usecase::tests::resolve_backfilled_previous_current_size_matrix_and_sticky_fallback` — vote→accounting translation, negative-size clamp, and sticky-flag behavior.
- `e2e_test::data_usage_test::data_usage_reports_overwrite_size_delta_exactly` (ignore-gated like its siblings) — a real-server overwrite must report exactly the new size from the first usage poll, never old+new.

## Adversarial validation

Six independent reviewer passes over the final diff (correctness, security, concurrency/durability, compatibility, performance, test-coverage). Correctness, security, concurrency/durability, and compatibility returned null reports (attacks included quorum boundaries at wq−1, two-values-at-quorum reachability, delete-marker topology divergence, commit-sequence purity/panic-safety on hostile xl.meta, lock-loss fencing, rolling-upgrade decode in both directions, WORM TOCTOU via late lock enablement, i64::MIN size payloads). Performance flagged the per-PUT NoQuorum warn (fixed: once-per-process latch, then debug) and noted the observation runs on all rename_data callers (accepted: single-version parse on already-read bytes; per-disk gating would need another wire field). Test-coverage findings all addressed (gate matrix unit test, hermetic delete-marker case, wire third-state round-trip, e2e overwrite accounting).

One pre-existing inconsistency surfaced during review, untouched by this PR and filed separately: `test_put_object_overwrite_blocked_by_legal_hold` in `crates/e2e_test` still asserts overwrite rejection, contradicting the versioned-new-write early-return introduced by #3179; the e2e crate is excluded from regular CI so it never surfaced.

## Verification

- `make fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check doc-paths-check`: PASS
- `cargo clippy --all-targets --all-features -- -D warnings`: PASS
- `cargo nextest run --all --exclude e2e_test` + doc tests: PASS

Closes rustfs/backlog#1009.
