### PR TITLE
chore: rename unparseable to unparsable for the typos gate

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -326,7 +326,7 @@ fn is_valid_xml_name(name: &str) -> bool {
 ///
 /// XML 1.0 permits tab/newline/carriage-return but forbids the other C0 control
 /// characters. The serializer escapes `< > & ' "` but does not strip these, so a
-/// metadata value carrying e.g. a `\u{1}` byte would still emit an unparseable
+/// metadata value carrying e.g. a `\u{1}` byte would still emit an unparsable
 /// document. Returns a borrowed slice when nothing needs stripping.
 fn sanitize_xml_text(value: &str) -> Cow<'_, str> {
     let is_illegal = |c: char| (c as u32) < 0x20 && c != '\t' && c != '\n' && c != '\r';


### PR DESCRIPTION
## Related Issues

N/A — unblocks the Typos CI check for all open PRs.

## Summary of Changes

The Typos workflow pins `crate-ci/typos@master`, whose dictionary now maps `unparseable` → `unparsable`. The word entered `rustfs/src/app/bucket_usecase.rs` via #4592 before the rule existed, so #4592's own CI passed, but every PR merge ref against current main now fails the Typos check (first observed on #4598). One-word comment fix; no behavior change.

## Verification

- `typos` (repo-wide, local run) — clean.
- Comment-only change; no code paths affected.

## Impact

N/A — documentation comment only.

## Additional Notes

N/A