### PR TITLE
chore: drop unused wildmatch workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,6 @@ urlencoding = "2.1.3"
 uuid = { version = "1.23.4", features = ["v4", "fast-rng", "macro-diagnostics"] }
 vaultrs = { version = "0.8.0" }
 walkdir = "2.5.0"
-wildmatch = { version = "2.6.1", features = ["serde"] }
 windows = { version = "0.62.2" }
 xxhash-rust = { version = "0.8.16", features = ["xxh64", "xxh3"] }
 zip = "8.6.0"

--- a/crates/notify/src/rules/pattern.rs
+++ b/crates/notify/src/rules/pattern.rs
@@ -61,10 +61,10 @@ pub fn match_simple(pattern_str: &str, object_name: &str) -> bool {
         // AWS S3 docs: A single asterisk (*) in the rule matches all objects.
         return true;
     }
-    // WildMatch considers an empty pattern to not match anything, which is usually desired.
-    // If pattern_str is empty, it means no specific filter, so it depends on interpretation.
-    // Go's wildcard.MatchSimple might treat empty pattern differently.
-    // For now, assume empty pattern means no match unless it's explicitly "*".
+    // An empty pattern matches nothing, which is usually desired: an empty
+    // pattern_str means no specific filter was supplied. Go's NewRulesMap
+    // defaults to "*", so an empty pattern reaching here is unlikely to mean
+    // "match all" — treat it as no match unless it is explicitly "*".
     if pattern_str.is_empty() {
         return false; // Or true if an empty pattern means "match all" in some contexts.
         // Given Go's NewRulesMap defaults to "*", an empty pattern from Filter is unlikely to mean "match all".
@@ -77,10 +77,10 @@ pub fn match_simple(pattern_str: &str, object_name: &str) -> bool {
 /// every other character — crucially including `?` — is matched literally.
 ///
 /// S3 event notification prefix/suffix filters treat `*` as the only wildcard;
-/// AWS does not assign any special meaning to `?`. Earlier this matcher delegated
-/// to `wildmatch`, which interprets `?` as a single-character wildcard, so a
-/// literal `?` in a prefix/suffix filter (or object key) would over-match and
-/// misroute events (backlog#979). This hand-rolled matcher keeps `?` literal.
+/// AWS does not assign any special meaning to `?`. A generic glob matcher that
+/// interprets `?` as a single-character wildcard would let a literal `?` in a
+/// prefix/suffix filter (or object key) over-match and misroute events
+/// (backlog#979), so this matcher is hand-rolled to keep `?` literal.
 fn glob_match_star_only(pattern: &str, text: &str) -> bool {
     let pattern: Vec<char> = pattern.chars().collect();
     let text: Vec<char> = text.chars().collect();
@@ -156,7 +156,7 @@ mod tests {
 
     /// Regression test for backlog#979 (c): S3 filter semantics treat `*` as the
     /// only wildcard. `?` must be matched literally, not as a single-character
-    /// wildcard (which is how the previous `wildmatch`-based matcher behaved).
+    /// wildcard (the way a generic glob matcher would treat it).
     #[test]
     fn question_mark_is_literal_not_single_char_wildcard() {
         // `?` is a literal: it only matches a literal `?`, never an arbitrary char.


### PR DESCRIPTION
## What

PR #4468 removed the last use of the `wildmatch` crate — `crates/notify` swapped it for a hand-rolled star-only glob matcher (`glob_match_star_only`) to keep S3 filter semantics correct (literal `?`, backlog#979). That PR dropped the dependency from `crates/notify/Cargo.toml` but left the declaration in the root `Cargo.toml` `[workspace.dependencies]` behind as an orphan.

`cargo shear` flags it as not used by any workspace member. This removes the stray line.

## Changes

- Drop `wildmatch = { version = "2.6.1", features = ["serde"] }` from the root `Cargo.toml` workspace dependencies.
- Refresh the comments in `crates/notify/src/rules/pattern.rs` that still referenced the removed `wildmatch` crate, so they describe the current hand-rolled matcher instead of a dependency that no longer exists.

## Notes

Metadata/comment-only cleanup — no behavior change. `match_simple` still resolves to the same `glob_match_star_only` implementation and all existing tests are unchanged.

## Verification

- `cargo shear --fix` (found and removed the one unused workspace dep)
- `cargo check -p rustfs-notify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)