### PR TITLE
fix(ecstore): read the persisted SSE-C nonce in the GET decrypt resolver (unbreaks S3 CI)

### DIFF
--- a/crates/ecstore/src/object_api/readers.rs
+++ b/crates/ecstore/src/object_api/readers.rs
@@ -48,7 +48,6 @@ const DEFAULT_SSE_ALGORITHM: &str = "AES256";
 const DARE_PAYLOAD_SIZE: i64 = 64 * 1024;
 #[cfg(feature = "rio-v2")]
 const DARE_PACKAGE_SIZE: i64 = DARE_PAYLOAD_SIZE + 32;
-#[cfg(feature = "rio-v2")]
 const MINIO_INTERNAL_ENCRYPTION_IV_HEADER: &str = "X-Minio-Internal-Server-Side-Encryption-Iv";
 #[cfg(feature = "rio-v2")]
 const MINIO_INTERNAL_ENCRYPTION_ALGORITHM_HEADER: &str = "X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm";
@@ -1293,10 +1292,28 @@ fn resolve_ssec_material(oi: &ObjectInfo, headers: &HeaderMap<HeaderValue>) -> R
 
     Ok(EncryptionMaterial {
         key_bytes,
-        base_nonce: generate_ssec_nonce(&oi.bucket, &oi.name),
+        base_nonce: read_stored_ssec_nonce(&oi.user_defined, &oi.bucket, &oi.name),
         key_kind: EncryptionKeyKind::Direct,
         reader_backend: crate::io_support::rio::ReadEncryptionBackend::Legacy,
     })
+}
+
+/// Resolve the SSE-C Direct base nonce for decryption.
+///
+/// Since #4576 the encrypt side uses a fresh random nonce per encryption and
+/// persists it under `x-rustfs-encryption-iv` (plus the MinIO interop key);
+/// this reader-side resolver must read that stored value back or every SSE-C
+/// GET fails its first AEAD block. Legacy objects written before random
+/// nonces were persisted carry no stored IV and were encrypted with the
+/// deterministic `(bucket, key)` nonce, so fall back to recomputing it. Must
+/// stay in lockstep with `read_stored_ssec_nonce` in rustfs/src/storage/sse.rs
+/// (the API-layer twin of this resolver).
+fn read_stored_ssec_nonce(metadata: &HashMap<String, String>, bucket: &str, key: &str) -> [u8; 12] {
+    metadata_get(metadata, INTERNAL_ENCRYPTION_IV_HEADER)
+        .or_else(|| metadata_get(metadata, MINIO_INTERNAL_ENCRYPTION_IV_HEADER))
+        .and_then(|encoded| BASE64_STANDARD.decode(encoded).ok())
+        .and_then(|bytes| <[u8; 12]>::try_from(bytes.as_slice()).ok())
+        .unwrap_or_else(|| generate_ssec_nonce(bucket, key))
 }
 
 async fn resolve_managed_material(bucket: &str, object: &str, metadata: &HashMap<String, String>) -> Result<EncryptionMaterial> {
@@ -1611,6 +1628,38 @@ mod tests {
         let mut bytes = [0u8; 16];
         bytes.copy_from_slice(&digest);
         bytes
+    }
+
+    /// Regression for the #4576 fallout: the encrypt side persists a random
+    /// SSE-C nonce, and this reader-side resolver must read it back — falling
+    /// back to the deterministic legacy nonce only when no IV was stored.
+    /// Reverting the stored-nonce lookup breaks the first two cases.
+    #[test]
+    fn read_stored_ssec_nonce_prefers_persisted_iv_and_falls_back_for_legacy() {
+        let stored = [7u8; 12];
+        let deterministic = generate_ssec_nonce("bucket", "object");
+        assert_ne!(stored, deterministic, "test nonce must differ from the deterministic value");
+
+        let mut metadata = HashMap::new();
+        metadata.insert(INTERNAL_ENCRYPTION_IV_HEADER.to_string(), BASE64_STANDARD.encode(stored));
+        assert_eq!(read_stored_ssec_nonce(&metadata, "bucket", "object"), stored);
+
+        // MinIO interop key only, in non-canonical casing: the lookup is
+        // case-insensitive like every other internal-metadata read here.
+        let mut metadata = HashMap::new();
+        metadata.insert(MINIO_INTERNAL_ENCRYPTION_IV_HEADER.to_ascii_lowercase(), BASE64_STANDARD.encode(stored));
+        assert_eq!(read_stored_ssec_nonce(&metadata, "bucket", "object"), stored);
+
+        // Legacy object: no stored IV → deterministic fallback.
+        assert_eq!(read_stored_ssec_nonce(&HashMap::new(), "bucket", "object"), deterministic);
+
+        // Corrupt values (bad base64 / wrong length) also fall back instead of erroring.
+        let mut metadata = HashMap::new();
+        metadata.insert(INTERNAL_ENCRYPTION_IV_HEADER.to_string(), "not-base64!!".to_string());
+        assert_eq!(read_stored_ssec_nonce(&metadata, "bucket", "object"), deterministic);
+        let mut metadata = HashMap::new();
+        metadata.insert(INTERNAL_ENCRYPTION_IV_HEADER.to_string(), BASE64_STANDARD.encode([1u8; 8]));
+        assert_eq!(read_stored_ssec_nonce(&metadata, "bucket", "object"), deterministic);
     }
 
     fn ssec_headers_from_key(key_bytes: [u8; 32]) -> HeaderMap<HeaderValue> {


### PR DESCRIPTION
## Related Issues

Fixes the SSE-C read regression introduced by #4576 (refs rustfs/backlog#1039). Root cause of the "S3 Implemented Tests" CI job blowing past its 60-minute timeout (and getting reported as `cancelled`) on every PR and main push since 2026-07-09 ~01:50Z.

## Root cause

#4576 switched SSE-C encryption to a random per-encryption nonce, persisted under `x-rustfs-encryption-iv` (+ MinIO interop key), and updated the decrypt-material resolver **in `rustfs/src/storage/sse.rs`** to read the stored nonce back. But the byte-level GET decryption does not use that resolver: it lives in **`crates/ecstore/src/object_api/readers.rs`**, whose `resolve_ssec_material` is a duplicated twin that still recomputed the deterministic legacy nonce `generate_ssec_nonce(bucket, key)`.

Result: encrypt with random nonce N₁, decrypt with deterministic N₀ → the first AEAD block fails (`decrypt error: aead::Error`), the body stream aborts after the 200 response headers, and every SSE-C GET dies with `IncompleteRead(0 bytes read, N more expected)` on the client. All 8 SSE-C tests in the implemented s3-tests whitelist fail this way (single-part, multipart, POST-object, and `get_part` variants), reproduced locally against the main-tip debug binary:

```
FAILED test_encrypted_transfer_13b  - ... IncompleteRead(0 bytes read, 13 more expected)
FAILED test_encrypted_transfer_1b   - ... IncompleteRead(0 bytes read, 1 more expected)
FAILED test_encrypted_transfer_1MB  - ... IncompleteRead(0 bytes read, 1048576 more expected)
FAILED test_encrypted_transfer_1kb  - ...
FAILED test_encryption_sse_c_post_object_authenticated_request - ...
FAILED test_encryption_sse_c_multipart_upload - ... (31457280 more expected)
FAILED test_encryption_sse_c_unaligned_multipart_upload - ...
FAILED test_non_multipart_sse_c_get_part - ...
============ 8 failed, 443 passed in 458.59s ============
```

Server-side signature: `rustfs::app::object_usecase` logs `GetObject streaming body read failed ... error="decrypt error: aead::Error"` and ecstore logs `Set disk object read pipeline failed ... reason="downstream_closed"`.

The verbose failure dumps (`-vv --showlocals --tb=long`, `MAXFAIL=0`) are what shows up as walls of debug-like output in the Actions console.

## Fix

`resolve_ssec_material` now resolves the base nonce exactly like the #4576 encrypt side: prefer the persisted IV (`x-rustfs-encryption-iv`, falling back to the case-insensitive MinIO interop key), and only recompute the deterministic legacy nonce when no IV is stored (objects written before #4576) or the stored value is undecodable. The `MINIO_INTERNAL_ENCRYPTION_IV_HEADER` constant loses its `rio-v2` cfg-gate since the default build now needs it too. One file, +54/−1.

The doc comment pins the invariant: this resolver must stay in lockstep with `read_stored_ssec_nonce` in `rustfs/src/storage/sse.rs` — the duplication between the two SSE material resolvers is exactly what let #4576 fix one side and miss the other.

## Verification

- New unit test `read_stored_ssec_nonce_prefers_persisted_iv_and_falls_back_for_legacy` — stored IV (both header keys, non-canonical casing), legacy fallback, and corrupt-value fallback; the stored-IV cases fail on revert.
- Single-request repro: SSE-C PUT+GET roundtrip against a local 4-disk server — broken on main tip (`0 read, but total bytes expected is 14`), byte-identical after the fix.
- Full implemented s3-tests whitelist against the fixed debug binary (same env as CI: `DEPLOY_MODE=binary`, `XDIST=4`, `MAXFAIL=0`): **451 passed, 0 failed** — matching the last green CI run from 2026-07-08 (451 passed in 7:19).
- `cargo fmt` / guard scripts / `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` / `cargo nextest run -p rustfs-ecstore`: pass (single-crate change; full matrix on CI).

## Notes

- Objects written by #4576-era binaries carry the persisted IV and decrypt correctly with this fix; pre-#4576 objects keep decrypting via the deterministic fallback. Objects OVERWRITTEN under the same key while broken were never readable in that window (write side was fine, so their data is intact and readable once this fix deploys).
- Follow-up worth filing: consolidate the duplicated SSE-C material resolvers (`rustfs/src/storage/sse.rs` vs `crates/ecstore/src/object_api/readers.rs`) so the next encryption change cannot fix one and miss the other.
