### PR TITLE
fix(admin): make server_info retry re-dial and match peer disks by resolved host

### DIFF
--- a/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
@@ -147,6 +147,20 @@ impl PeerRestClient {
         evict_failed_connection(&self.grid_host).await;
     }
 
+    /// Prepare this client for an immediate fresh-connection retry.
+    ///
+    /// On a network-like failure `finalize_result` both evicts the channel and
+    /// sets the offline gate, after which `get_client` fast-fails with
+    /// "temporarily offline" and only the async background recovery monitor
+    /// would clear the gate (not within this call). So a plain `evict_connection`
+    /// is not enough to make an in-call retry actually re-dial: the gate still
+    /// short-circuits it. This drops the cached channel AND clears the gate so
+    /// the very next `get_client` re-dials. See rustfs/backlog#1049 (P1-B).
+    pub async fn prepare_retry(&self) {
+        self.evict_connection().await;
+        self.offline.store(false, Ordering::Release);
+    }
+
     fn is_network_like_error(err: &Error) -> bool {
         let message = err.to_string().to_ascii_lowercase();
         [
@@ -1161,6 +1175,22 @@ mod tests {
             .expect_err("offline peer should fast-fail before dialing");
 
         assert!(err.to_string().contains("temporarily offline"));
+    }
+
+    #[tokio::test]
+    async fn peer_rest_client_prepare_retry_clears_offline_gate() {
+        // finalize_result sets the offline gate on a network error; without
+        // clearing it, an in-call retry would fast-fail on the gate instead of
+        // re-dialing (rustfs/backlog#1049 P1-B). prepare_retry must clear it.
+        let client = test_peer_client();
+        client.offline.store(true, Ordering::Release);
+
+        client.prepare_retry().await;
+
+        assert!(
+            !client.offline.load(Ordering::Acquire),
+            "prepare_retry must clear the offline gate so the next get_client re-dials"
+        );
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/services/notification_sys.rs
+++ b/crates/ecstore/src/services/notification_sys.rs
@@ -27,6 +27,7 @@ use rustfs_madmin::health::{Cpus, MemInfo, OsInfo, Partitions, ProcInfo, SysConf
 use rustfs_madmin::metrics::RealtimeMetrics;
 use rustfs_madmin::net::NetInfo;
 use rustfs_madmin::{ItemState, ServerProperties, StorageInfo};
+use rustfs_utils::XHost;
 use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
@@ -385,9 +386,13 @@ impl NotificationSys {
                     Err(_) => debug!("peer {host} server_info timed out (attempt 1/2) after {peer_timeout:?}"),
                 }
 
-                // Drop the suspect channel so the retry re-dials on a fresh
-                // connection instead of reusing the bad one.
-                client.evict_connection().await;
+                // Drop the suspect channel AND clear the offline gate so the
+                // retry actually re-dials. A network-like first failure runs
+                // through `finalize_result`, which sets the offline gate; a bare
+                // `evict_connection` would leave that gate up and the retry would
+                // fast-fail with "temporarily offline" instead of reconnecting
+                // (rustfs/backlog#1049 P1-B).
+                client.prepare_retry().await;
 
                 // Second and final attempt on the fresh channel.
                 match timeout(peer_timeout, client.server_info()).await {
@@ -1150,7 +1155,7 @@ async fn peer_disk_health(host: &str) -> Option<PeerDiskHealth> {
                 let Some(ep) = set.set_endpoints.get(idx) else {
                     continue;
                 };
-                if host != ep.host_port() {
+                if !endpoint_host_matches(host, &ep.host_port()) {
                     continue;
                 }
                 let online = match slot {
@@ -1376,7 +1381,7 @@ fn synthesized_disks(host: &str, endpoints: &EndpointServerPools, state: ItemSta
 
     for pool in endpoints.as_ref() {
         for ep in pool.endpoints.as_ref() {
-            if (host.is_empty() && ep.is_local) || host == ep.host_port() {
+            if (host.is_empty() && ep.is_local) || endpoint_host_matches(host, &ep.host_port()) {
                 disks.push(rustfs_madmin::Disk {
                     endpoint: ep.to_string(),
                     state: state.to_string().to_owned(),
@@ -1390,6 +1395,27 @@ fn synthesized_disks(host: &str, endpoints: &EndpointServerPools, state: ItemSta
     }
 
     disks
+}
+
+/// Whether `peer_host` refers to the same node as an endpoint whose
+/// `host_port()` is `ep_host_port`.
+///
+/// `PeerRestClient::host` is an `XHost`, which resolves names to an address on
+/// construction (`hosts_sorted` -> `XHost::try_from` -> `to_socket_addrs`), so
+/// `peer_host` is the resolved `IP:port`. An endpoint's `host_port()`, however,
+/// is `url.host():port` — still the raw `hostname:port` on hostname-based
+/// deployments. A plain string compare therefore misses on hostname clusters,
+/// leaving the synthesized/degraded drive list empty and `unknownDisks` at 0
+/// (rustfs/rustfs#4607 follow-up). Compare directly first (fast path / IP
+/// deployments), then canonicalize the endpoint side through the same `XHost`
+/// resolution and compare again.
+fn endpoint_host_matches(peer_host: &str, ep_host_port: &str) -> bool {
+    if peer_host == ep_host_port {
+        return true;
+    }
+    XHost::try_from(ep_host_port.to_string())
+        .map(|resolved| resolved.to_string() == peer_host)
+        .unwrap_or(false)
 }
 
 fn aggregate_notification_failures(operation: &str, failures: Vec<String>) -> Result<()> {
@@ -1699,6 +1725,29 @@ mod tests {
             .checked_sub(SERVER_INFO_CACHE_MAX_AGE + Duration::from_secs(1))
             .expect("test clock underflow");
         assert!(!cached_snapshot_is_fresh(Some(stale)), "an old success is stale");
+    }
+
+    #[test]
+    fn endpoint_host_matches_direct_and_canonicalized() {
+        // Direct match (IP deployment): peer host already equals host_port.
+        assert!(endpoint_host_matches("10.0.0.12:9000", "10.0.0.12:9000"));
+        // Different IPs must not match.
+        assert!(!endpoint_host_matches("10.0.0.12:9000", "10.0.0.99:9000"));
+
+        // Hostname deployment: `PeerRestClient::host` is the resolved `IP:port`,
+        // the endpoint keeps the raw `hostname:port`. Resolve "localhost" the
+        // same way `XHost` does (avoids depending on external DNS) and confirm
+        // the canonical compare matches — the regression this fixes is the
+        // synthesized/degraded drive list going empty on hostname clusters.
+        let resolved = XHost::try_from("localhost:9000".to_string())
+            .expect("localhost should resolve")
+            .to_string();
+        assert!(
+            endpoint_host_matches(&resolved, "localhost:9000"),
+            "resolved localhost ({resolved}) must match the hostname endpoint"
+        );
+        // A resolved address that is not localhost must not match.
+        assert!(!endpoint_host_matches("203.0.113.1:9000", "localhost:9000"));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #4607 addressing two [P1] review findings. Both are verified real bugs (not just theoretical), each with a regression test.

## Finding 1 — the retry did not actually re-dial on network errors

`server_info()` runs through `finalize_result`, which on a network-like error sets the client's `offline` gate (and evicts the channel). The P1-B in-call retry then called `evict_connection` and immediately re-invoked `server_info()`, but `get_client()` short-circuits on the `offline` gate and returns `"temporarily offline"` without dialing. Only the async background recovery monitor would clear the gate — not within this call. So the retry re-dialed only in the timeout branch (which never runs `finalize_result`), and was a no-op in the transport/half-open error branch the retry was meant to cover.

Fix: add `PeerRestClient::prepare_retry()` = `evict_connection()` + clear the `offline` gate, and call it before the retry instead of `evict_connection()`. Now the retry genuinely re-dials in both branches.

Test: `peer_rest_client_prepare_retry_clears_offline_gate`.

## Finding 2 — synthesized/degraded drives went empty on hostname deployments

`PeerRestClient::host` is an `XHost`, and `hosts_sorted()` builds it via `XHost::try_from` → `to_socket_addrs()`, which resolves the name to an address — so `client.host.to_string()` is the resolved `IP:port` (e.g. `10.0.0.12:9000`). But `synthesized_disks()` and `peer_disk_health()` matched it against `Endpoint::host_port()`, which is `url.host():port` — still the raw `hostname:port` (e.g. `node1:9000`) on hostname-based clusters. The compare missed, the drive list came back empty, and `unknownDisks` stayed `0` — i.e. the exact "drives vanish from the summary" regression #4607 set out to fix would still reproduce on hostname deployments (this also affected the pre-existing `offline` path). IP-based deployments happened to match, which is why it slipped through.

Fix: compare through a shared `endpoint_host_matches(peer_host, ep_host_port)` helper — direct compare first (fast path / IP deployments), then canonicalize the endpoint side through the same `XHost` resolution and compare again. Used by both `synthesized_disks` and `peer_disk_health`.

Test: `endpoint_host_matches_direct_and_canonicalized` (uses `localhost` so it does not depend on external DNS).

## Testing

- `cargo test -p rustfs-ecstore` — 32 notification_sys + peer_rest_client tests pass, including the two new regression tests above.
- `cargo fmt --all`, `cargo clippy -p rustfs-ecstore`, and the repo architecture guard scripts all pass.

Follow-up to rustfs/rustfs#4607 · tracked in rustfs/backlog#1049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
