### PR TITLE
fix(admin): keep datausage live refresh stable

### DIFF
--- a/crates/ecstore/src/data_usage/mod.rs
+++ b/crates/ecstore/src/data_usage/mod.rs
@@ -1727,6 +1727,102 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn scanner_snapshot_can_reduce_object_layer_refreshed_memory_usage() {
+        clear_usage_memory_cache_for_test().await;
+
+        let now = SystemTime::now();
+        replace_bucket_usage_memory_from_authoritative(
+            "bucket-a",
+            BucketUsageInfo {
+                objects_count: 100,
+                versions_count: 100,
+                size: 1_000,
+                ..Default::default()
+            },
+            now,
+        )
+        .await;
+
+        let scanner_decrease = data_usage_info_for_test("bucket-a", 60, 600, now + Duration::from_secs(10));
+        replace_bucket_usage_memory_from_info(&scanner_decrease).await;
+
+        let mut response = scanner_decrease.clone();
+        apply_bucket_usage_memory_overlay(&mut response).await;
+
+        assert_eq!(response.objects_total_count, 60);
+        assert_eq!(response.objects_total_size, 600);
+        assert_eq!(
+            response
+                .buckets_usage
+                .get("bucket-a")
+                .map(|usage| (usage.objects_count, usage.size)),
+            Some((60, 600))
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scanner_backend_snapshot_can_reduce_backend_memory_usage() {
+        clear_usage_memory_cache_for_test().await;
+
+        let now = SystemTime::now();
+        let complete_snapshot = data_usage_info_for_test("bucket-a", 100, 1_000, now);
+        replace_bucket_usage_memory_from_info(&complete_snapshot).await;
+
+        let scanner_decrease = data_usage_info_for_test("bucket-a", 60, 600, now + Duration::from_secs(10));
+        replace_bucket_usage_memory_from_info(&scanner_decrease).await;
+
+        let mut response = scanner_decrease.clone();
+        apply_bucket_usage_memory_overlay(&mut response).await;
+
+        assert_eq!(response.objects_total_count, 60);
+        assert_eq!(response.objects_total_size, 600);
+        assert_eq!(
+            response
+                .buckets_usage
+                .get("bucket-a")
+                .map(|usage| (usage.objects_count, usage.size)),
+            Some((60, 600))
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn authoritative_refresh_can_reduce_memory_usage() {
+        clear_usage_memory_cache_for_test().await;
+
+        let now = SystemTime::now();
+        let complete_snapshot = data_usage_info_for_test("bucket-a", 100, 1_000, now);
+        replace_bucket_usage_memory_from_info(&complete_snapshot).await;
+
+        replace_bucket_usage_memory_from_authoritative(
+            "bucket-a",
+            BucketUsageInfo {
+                objects_count: 60,
+                versions_count: 60,
+                size: 600,
+                ..Default::default()
+            },
+            now + Duration::from_secs(10),
+        )
+        .await;
+
+        let mut response = data_usage_info_for_test("bucket-a", 60, 600, now + Duration::from_secs(10));
+        apply_bucket_usage_memory_overlay(&mut response).await;
+
+        assert_eq!(response.objects_total_count, 60);
+        assert_eq!(response.objects_total_size, 600);
+        assert_eq!(
+            response
+                .buckets_usage
+                .get("bucket-a")
+                .map(|usage| (usage.objects_count, usage.size)),
+            Some((60, 600))
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn scanner_sync_preserves_newer_memory_update() {
         clear_usage_memory_cache_for_test().await;
 

--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -253,7 +253,6 @@ impl DefaultAdminUsecase {
         replace_bucket_usage_memory_from_info(&info).await;
         apply_bucket_usage_memory_overlay(&mut info).await;
         Self::refresh_live_bucket_usage_for_data_usage_info(store.clone(), &mut info).await;
-        apply_bucket_usage_memory_overlay(&mut info).await;
 
         let storage_info = StorageAdminApi::storage_info(store.as_ref()).await;
 


### PR DESCRIPTION
## Related Issues
Related to #3775.

## Summary of Changes
Keep `/rustfs/admin/v3/datausageinfo` stable after its live object-layer bucket refresh by avoiding a second in-memory overlay pass that could reapply an older cached snapshot over the freshly computed usage.

Remove the global `authoritative` memory-cache guard. Scanner-persisted decreases, including lifecycle scanner expiries, can now lower memory usage after an object-layer refresh instead of keeping quota and overlays over-counted until another object-layer refresh happens.

Update regression coverage so scanner snapshots are explicitly allowed to reduce object-layer-refreshed memory usage, while the existing dirty-memory tests continue to protect request-path writes and deletes from stale scanner snapshots.

Adversarial validation: correctness attacked partial scanner snapshots, scanner-owned ILM decreases, object-layer refresh decreases, and dirty request-path overlays; concurrency/durability found no new lock or IO ordering changes; compatibility found no API, wire, or on-disk format change; performance found one fewer overlay pass and no new per-object IO, spawn, or heavy clone path; test coverage is pinned by the updated scanner decrease regression and the existing data usage module tests.

## Verification
- `cargo fmt --all --check`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs-ecstore data_usage::tests::scanner_snapshot_can_reduce_object_layer_refreshed_memory_usage -- --exact`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs-ecstore data_usage::tests::scanner_backend_snapshot_can_reduce_backend_memory_usage -- --exact`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs-ecstore data_usage::tests::authoritative_refresh_can_reduce_memory_usage -- --exact`
- `CARGO_INCREMENTAL=0 cargo test -p rustfs-ecstore data_usage::tests`
- `CARGO_INCREMENTAL=0 cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings`
- `CARGO_INCREMENTAL=0 cargo check -p rustfs --lib`
- `git diff --check`

## Impact
Prevents admin data usage and Console bucket stats from being pushed back down by an older memory overlay after a fuller live bucket usage view has already been computed. Scanner-sourced usage can still decrease on later scanner/backend refreshes, so real deletes and lifecycle expiries observed by scanner are not pinned high. No configuration, API, or storage format change.

## Additional Notes
N/A
