### PR TITLE
feat(app): per-server auth and application context for multiple embedded servers

### DIFF
--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -1084,6 +1084,14 @@ impl DefaultBucketUsecase {
         }
     }
 
+    /// Build the use-case bound to an explicit application context
+    /// (backlog#1052 S6): the per-server request path passes its own context
+    /// so the use-case resolves that server's store; `None` falls back to the
+    /// ambient default.
+    pub fn with_context(context: Option<std::sync::Arc<crate::runtime_sources::AppContext>>) -> Self {
+        Self { context }
+    }
+
     fn global_region(&self) -> Option<Region> {
         self.context.as_ref().and_then(|context| context.region().get())
     }

--- a/rustfs/src/app/context/global.rs
+++ b/rustfs/src/app/context/global.rs
@@ -230,6 +230,11 @@ impl AppContext {
         self.action_credentials.clone()
     }
 
+    /// Publish this context's own root credentials (backlog#1052 S6).
+    pub fn publish_action_credentials(&self, credentials: rustfs_credentials::Credentials) -> bool {
+        self.action_credentials.publish(credentials)
+    }
+
     pub fn region(&self) -> Arc<dyn RegionInterface> {
         self.region.clone()
     }
@@ -341,10 +346,23 @@ static APP_CONTEXT_SINGLETON: OnceLock<Arc<AppContext>> = OnceLock::new();
 
 /// Initialize global application context once and return the canonical instance.
 pub fn init_global_app_context(context: AppContext) -> Arc<AppContext> {
-    let context = APP_CONTEXT_SINGLETON.get_or_init(|| Arc::new(context)).clone();
-    let resolver_context = context.clone();
+    publish_global_app_context(Arc::new(context))
+}
+
+/// Publish an already-constructed application context as the process default,
+/// first-writer-wins (backlog#1052 S6).
+///
+/// A per-server startup constructs its own context and installs it into its
+/// own [`ServerContextSlot`](super::server_slot::ServerContextSlot); it also
+/// calls this so the *first* server's context becomes the ambient default that
+/// legacy free-function readers resolve. Later servers publish too, but the
+/// `OnceLock` keeps the first — their own slot already carries their context,
+/// so their request path stays isolated regardless.
+pub fn publish_global_app_context(context: Arc<AppContext>) -> Arc<AppContext> {
+    let canonical = APP_CONTEXT_SINGLETON.get_or_init(|| context).clone();
+    let resolver_context = canonical.clone();
     let _ = set_object_store_resolver(Arc::new(move || Some(resolver_context.object_store())));
-    context
+    canonical
 }
 
 /// Get global application context if it has been initialized.

--- a/rustfs/src/app/context/startup.rs
+++ b/rustfs/src/app/context/startup.rs
@@ -13,18 +13,12 @@
 // limitations under the License.
 
 use super::super::storage_api::context::ECStore;
-use super::global::{AppContext, get_global_app_context, init_global_app_context};
+use super::global::{AppContext, publish_global_app_context};
 use super::runtime_sources;
 use super::server_slot::ServerContextSlot;
 use rustfs_kms::KmsServiceManager;
 use std::io::Result;
 use std::sync::Arc;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum StartupAppContextBootstrap {
-    AlreadyAvailable,
-    Initialized,
-}
 
 impl AppContext {
     pub(crate) fn ensure_startup_kms_interface() -> Arc<KmsServiceManager> {
@@ -37,40 +31,16 @@ impl AppContext {
         server_ctx: &ServerContextSlot,
         iam: Arc<rustfs_iam::sys::IamSys<rustfs_iam::store::object::ObjectStore>>,
     ) -> Result<()> {
-        ensure_startup_app_context_after_iam_with(
-            || get_global_app_context().is_some(),
-            || {
-                // The caller hands over the IAM system it just built for this
-                // server (backlog#1052 S3) — no read-back through the process
-                // singleton, so a future second server's context owns its own.
-                init_global_app_context(AppContext::with_default_interfaces(store, iam, kms_interface));
-                Ok(())
-            },
-        )?;
-        // Install this server's context slot (backlog#1052 S2). Today the
-        // context is still the process singleton, so the slot mirrors it;
-        // once contexts become per-server (S3) this hands each server its own.
-        if let Some(context) = get_global_app_context() {
-            let _ = server_ctx.install(context);
-        }
+        // Each server constructs its OWN application context around its own
+        // store, IAM system, and KMS interface (backlog#1052 S6), then installs
+        // it into its own slot so its request path resolves its own state. It
+        // also publishes to the process default (first server wins) so legacy
+        // free-function readers keep resolving the first server's context.
+        let context = Arc::new(AppContext::with_default_interfaces(store, iam, kms_interface));
+        publish_global_app_context(context.clone());
+        let _ = server_ctx.install(context);
         Ok(())
     }
-}
-
-fn ensure_startup_app_context_after_iam_with<IsAvailable, InitContext>(
-    is_available: IsAvailable,
-    init_context: InitContext,
-) -> Result<StartupAppContextBootstrap>
-where
-    IsAvailable: FnOnce() -> bool,
-    InitContext: FnOnce() -> Result<()>,
-{
-    if is_available() {
-        return Ok(StartupAppContextBootstrap::AlreadyAvailable);
-    }
-
-    init_context()?;
-    Ok(StartupAppContextBootstrap::Initialized)
 }
 
 fn ensure_startup_kms_interface_with<T, GetManager, InitManager>(get_manager: GetManager, init_manager: InitManager) -> Arc<T>
@@ -83,56 +53,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{StartupAppContextBootstrap, ensure_startup_app_context_after_iam_with, ensure_startup_kms_interface_with};
-    use std::io::Error;
+    use super::ensure_startup_kms_interface_with;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
-
-    #[test]
-    fn startup_app_context_bootstrap_reuses_existing_context() {
-        let init_calls = Arc::new(AtomicUsize::new(0));
-        let init_calls_for_assert = init_calls.clone();
-
-        let disposition = ensure_startup_app_context_after_iam_with(
-            || true,
-            move || {
-                init_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            },
-        )
-        .expect("existing app context should be reused");
-
-        assert_eq!(disposition, StartupAppContextBootstrap::AlreadyAvailable);
-        assert_eq!(init_calls_for_assert.load(Ordering::SeqCst), 0);
-    }
-
-    #[test]
-    fn startup_app_context_bootstrap_initializes_missing_context() {
-        let init_calls = Arc::new(AtomicUsize::new(0));
-        let init_calls_for_assert = init_calls.clone();
-
-        let disposition = ensure_startup_app_context_after_iam_with(
-            || false,
-            move || {
-                init_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            },
-        )
-        .expect("missing app context should initialize");
-
-        assert_eq!(disposition, StartupAppContextBootstrap::Initialized);
-        assert_eq!(init_calls_for_assert.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn startup_app_context_bootstrap_returns_init_error() {
-        let err = ensure_startup_app_context_after_iam_with(|| false, || Err(Error::other("iam unavailable")))
-            .expect_err("init failure should be returned");
-
-        assert_eq!(err.to_string(), "iam unavailable");
-    }
 
     #[test]
     fn startup_kms_interface_reuses_existing_manager() {

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -295,6 +295,14 @@ impl DefaultMultipartUsecase {
         }
     }
 
+    /// Build the use-case bound to an explicit application context
+    /// (backlog#1052 S6): the per-server request path passes its own context
+    /// so the use-case resolves that server's store; `None` falls back to the
+    /// ambient default.
+    pub fn with_context(context: Option<std::sync::Arc<crate::runtime_sources::AppContext>>) -> Self {
+        Self { context }
+    }
+
     fn bucket_metadata_sys(&self) -> Option<Arc<RwLock<metadata_sys::BucketMetadataSys>>> {
         self.context.as_ref().and_then(|context| context.bucket_metadata().handle())
     }

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -2336,6 +2336,14 @@ impl DefaultObjectUsecase {
         }
     }
 
+    /// Build the use-case bound to an explicit application context
+    /// (backlog#1052 S6): the per-server request path passes its own context
+    /// so the use-case resolves that server's store; `None` falls back to the
+    /// ambient default.
+    pub fn with_context(context: Option<std::sync::Arc<crate::runtime_sources::AppContext>>) -> Self {
+        Self { context }
+    }
+
     fn bucket_metadata_sys(&self) -> Option<Arc<RwLock<metadata_sys::BucketMetadataSys>>> {
         self.context.as_ref().and_then(|context| context.bucket_metadata().handle())
     }

--- a/rustfs/src/auth.rs
+++ b/rustfs/src/auth.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::runtime_sources::{current_action_credentials, current_ready_iam_handle};
+use crate::runtime_sources::{AppContext, current_action_credentials, current_ready_iam_handle};
 use http::HeaderMap;
 use http::Uri;
 use rustfs_credentials::Credentials;
@@ -243,6 +243,21 @@ fn iam_lookup_error_to_s3_error(_err: &IamError) -> S3Error {
 
 // check_key_valid checks the key is valid or not. return the user's credentials and if the user is the owner.
 pub async fn check_key_valid(session_token: &str, access_key: &str) -> S3Result<(Credentials, bool)> {
+    check_key_valid_with_context(session_token, access_key, None).await
+}
+
+/// Validate an access key, resolving the root credentials and IAM system from
+/// an explicit application context when one is given (backlog#1052 S6).
+///
+/// A per-server request path passes its own context so a second embedded
+/// server authenticates against its own root identity and IAM domain instead
+/// of the process defaults; `None` falls back to the ambient globals — the
+/// single-instance legacy behavior that all existing callers keep.
+pub async fn check_key_valid_with_context(
+    session_token: &str,
+    access_key: &str,
+    ctx: Option<&AppContext>,
+) -> S3Result<(Credentials, bool)> {
     // KEYSTONE INTEGRATION: Check if Keystone credentials are present in task-local storage
     // This handles both:
     // 1. Pure X-Auth-Token requests (access_key may be empty)
@@ -331,7 +346,13 @@ pub async fn check_key_valid(session_token: &str, access_key: &str) -> S3Result<
         return Err(s3_error!(InvalidAccessKeyId, "Keystone authentication requires X-Auth-Token header"));
     }
 
-    let Some(mut cred) = current_action_credentials() else {
+    // Prefer this server's context (backlog#1052 S6); fall back to the ambient
+    // process credentials when no context was threaded in.
+    let root_cred = match ctx {
+        Some(context) => context.action_credentials().get(),
+        None => current_action_credentials(),
+    };
+    let Some(mut cred) = root_cred else {
         return Err(S3Error::with_message(
             S3ErrorCode::InternalError,
             format!("get_global_action_cred {:?}", IamError::IamSysNotInitialized),
@@ -341,7 +362,12 @@ pub async fn check_key_valid(session_token: &str, access_key: &str) -> S3Result<
     let sys_cred = cred.clone();
 
     if !constant_time_eq(&cred.access_key, access_key) {
-        let Ok(iam_store) = current_ready_iam_handle() else {
+        let iam_store = match ctx {
+            Some(context) if context.iam().is_ready() => Ok(context.iam().handle()),
+            Some(_) => Err(()),
+            None => current_ready_iam_handle().map_err(|_| ()),
+        };
+        let Ok(iam_store) = iam_store else {
             return Err(S3Error::with_message(
                 S3ErrorCode::InternalError,
                 format!("check_key_valid {:?}", IamError::IamSysNotInitialized),

--- a/rustfs/src/startup_embedded.rs
+++ b/rustfs/src/startup_embedded.rs
@@ -172,6 +172,7 @@ pub(crate) async fn run_embedded_startup(args: EmbeddedStartupArgs) -> Result<Em
         }
     };
 
+    let credentials_slot = server_ctx.clone();
     let service_runtime = init_embedded_startup_runtime_services(
         &config,
         endpoint_pools,
@@ -185,6 +186,12 @@ pub(crate) async fn run_embedded_startup(args: EmbeddedStartupArgs) -> Result<Em
         signal_embedded_startup_shutdown(&shutdown_handle, &cancel_token);
         init_error(err)
     })?;
+
+    // Publish this server's root credentials into its own application context
+    // (backlog#1052 S6) so its request path authenticates against its own
+    // identity — a second embedded server no longer falls back to the first
+    // server's process-global credentials.
+    publish_embedded_server_credentials(&credentials_slot, &identity.access_key, &identity.secret_key);
 
     publish_embedded_startup_ready(service_runtime.iam_bootstrap, listen_context.readiness.as_ref())
         .await
@@ -212,6 +219,18 @@ pub(crate) async fn run_embedded_startup(args: EmbeddedStartupArgs) -> Result<Em
 
 fn init_error(err: impl std::fmt::Display) -> EmbeddedStartupError {
     EmbeddedStartupError::Init(err.to_string())
+}
+
+/// Seed a server's own root credentials into its application context so its
+/// request path validates keys against its own identity (backlog#1052 S6).
+fn publish_embedded_server_credentials(server_ctx: &ServerContextSlot, access_key: &str, secret_key: &str) {
+    if let Some(app_context) = server_ctx.app_context() {
+        app_context.publish_action_credentials(rustfs_credentials::Credentials {
+            access_key: access_key.to_string(),
+            secret_key: secret_key.to_string(),
+            ..Default::default()
+        });
+    }
 }
 
 #[cfg(test)]

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -17,7 +17,7 @@ use super::ecfs::FS;
 use super::{
     PolicySys, StorageError, get_bucket_metadata, get_bucket_policy_raw, get_public_access_block_config, is_err_bucket_not_found,
 };
-use crate::auth::{check_key_valid, get_condition_values_with_query_and_client_info, get_session_token};
+use crate::auth::{check_key_valid_with_context, get_condition_values_with_query_and_client_info, get_session_token};
 use crate::error::ApiError;
 use crate::license::license_check;
 use crate::server::RemoteAddr;
@@ -919,9 +919,18 @@ impl S3Access for FS {
         //     // cx.extensions_mut(),
         // );
 
+        // Resolve auth against this server's context (backlog#1052 S6) so a
+        // second embedded server validates keys against its own root identity
+        // and IAM domain; the slot resolves the process default when it has
+        // not been installed, keeping single-instance behavior unchanged.
+        let app_context = self.server_ctx().app_context();
         let (cred, is_owner) = if let Some(input_cred) = cx.credentials() {
-            let (cred, is_owner) =
-                check_key_valid(get_session_token(cx.uri(), cx.headers()).unwrap_or_default(), &input_cred.access_key).await?;
+            let (cred, is_owner) = check_key_valid_with_context(
+                get_session_token(cx.uri(), cx.headers()).unwrap_or_default(),
+                &input_cred.access_key,
+                app_context.as_deref(),
+            )
+            .await?;
             (Some(cred), is_owner)
         } else {
             (None, false)
@@ -929,15 +938,23 @@ impl S3Access for FS {
 
         let request_context = cx.extensions_mut().get::<RequestContext>().cloned();
 
+        let region = app_context
+            .as_deref()
+            .and_then(|context| context.region().get())
+            .or_else(runtime_sources::current_region);
+
         let req_info = ReqInfo {
             cred,
             is_owner,
-            region: runtime_sources::current_region(),
+            region,
             request_context,
             ..Default::default()
         };
 
+        // Publish this server's context slot so downstream data-plane handlers
+        // resolve the same store (backlog#1052 S6).
         let ext = cx.extensions_mut();
+        ext.insert(self.server_ctx().clone());
         ext.insert(req_info);
         license_check().map_err(|er| match er.kind() {
             std::io::ErrorKind::PermissionDenied => s3_error!(AccessDenied, "{er}"),

--- a/rustfs/src/storage/ecfs.rs
+++ b/rustfs/src/storage/ecfs.rs
@@ -95,6 +95,11 @@ impl FS {
         Self { server_ctx }
     }
 
+    /// This server's request-path context slot (backlog#1052 S2/S6).
+    pub(crate) fn server_ctx(&self) -> &std::sync::Arc<runtime_sources::ServerContextSlot> {
+        &self.server_ctx
+    }
+
     async fn replication_tagging_enabled(bucket: &str, object: &str) -> bool {
         get_bucket_replication_config(bucket)
             .await
@@ -261,7 +266,7 @@ impl S3 for FS {
         &self,
         req: S3Request<AbortMultipartUploadInput>,
     ) -> S3Result<S3Response<AbortMultipartUploadOutput>> {
-        let usecase = s3_api::default_multipart_usecase();
+        let usecase = s3_api::multipart_usecase_for(self);
         usecase.execute_abort_multipart_upload(req).await
     }
 
@@ -271,14 +276,14 @@ impl S3 for FS {
         req: S3Request<CompleteMultipartUploadInput>,
     ) -> S3Result<S3Response<CompleteMultipartUploadOutput>> {
         crate::hp_guard!("S3::complete_multipart_upload");
-        let usecase = s3_api::default_multipart_usecase();
+        let usecase = s3_api::multipart_usecase_for(self);
         Box::pin(usecase.execute_complete_multipart_upload(req)).await
     }
 
     /// Copy an object from one location to another
     #[instrument(level = "debug", skip(self, req))]
     async fn copy_object(&self, req: S3Request<CopyObjectInput>) -> S3Result<S3Response<CopyObjectOutput>> {
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         Box::pin(usecase.execute_copy_object(req)).await
     }
 
@@ -288,7 +293,7 @@ impl S3 for FS {
         fields(start_time=?time::OffsetDateTime::now_utc())
     )]
     async fn create_bucket(&self, req: S3Request<CreateBucketInput>) -> S3Result<S3Response<CreateBucketOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_create_bucket(req).await
     }
 
@@ -298,20 +303,20 @@ impl S3 for FS {
         req: S3Request<CreateMultipartUploadInput>,
     ) -> S3Result<S3Response<CreateMultipartUploadOutput>> {
         crate::hp_guard!("S3::create_multipart_upload");
-        let usecase = s3_api::default_multipart_usecase();
+        let usecase = s3_api::multipart_usecase_for(self);
         usecase.execute_create_multipart_upload(req).await
     }
 
     /// Delete a bucket
     #[instrument(level = "debug", skip(self, req))]
     async fn delete_bucket(&self, req: S3Request<DeleteBucketInput>) -> S3Result<S3Response<DeleteBucketOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_bucket(req).await
     }
 
     #[instrument(level = "debug", skip(self))]
     async fn delete_bucket_cors(&self, req: S3Request<DeleteBucketCorsInput>) -> S3Result<S3Response<DeleteBucketCorsOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_bucket_cors(req).await
     }
 
@@ -319,7 +324,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketEncryptionInput>,
     ) -> S3Result<S3Response<DeleteBucketEncryptionOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_bucket_encryption(req).await
     }
 
@@ -328,7 +333,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketLifecycleInput>,
     ) -> S3Result<S3Response<DeleteBucketLifecycleOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_bucket_lifecycle(req).await
     }
 
@@ -336,7 +341,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketPolicyInput>,
     ) -> S3Result<S3Response<DeleteBucketPolicyOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_bucket_policy(req).await
     }
 
@@ -344,7 +349,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketReplicationInput>,
     ) -> S3Result<S3Response<DeleteBucketReplicationOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_bucket_replication(req).await
     }
 
@@ -353,7 +358,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeleteBucketTaggingInput>,
     ) -> S3Result<S3Response<DeleteBucketTaggingOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_bucket_tagging(req).await
     }
 
@@ -382,7 +387,7 @@ impl S3 for FS {
         &self,
         req: S3Request<DeletePublicAccessBlockInput>,
     ) -> S3Result<S3Response<DeletePublicAccessBlockOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_delete_public_access_block(req).await
     }
 
@@ -390,7 +395,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self, req))]
     async fn delete_object(&self, req: S3Request<DeleteObjectInput>) -> S3Result<S3Response<DeleteObjectOutput>> {
         crate::hp_guard!("S3::delete_object");
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         Box::pin(usecase.execute_delete_object(req)).await
     }
 
@@ -485,7 +490,7 @@ impl S3 for FS {
     /// Delete multiple objects
     #[instrument(level = "debug", skip(self, req))]
     async fn delete_objects(&self, req: S3Request<DeleteObjectsInput>) -> S3Result<S3Response<DeleteObjectsOutput>> {
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         usecase.execute_delete_objects(req).await
     }
 
@@ -531,7 +536,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self))]
     async fn get_bucket_cors(&self, req: S3Request<GetBucketCorsInput>) -> S3Result<S3Response<GetBucketCorsOutput>> {
         record_s3_op(S3Operation::GetBucketCors);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_cors(req).await
     }
 
@@ -540,7 +545,7 @@ impl S3 for FS {
         req: S3Request<GetBucketEncryptionInput>,
     ) -> S3Result<S3Response<GetBucketEncryptionOutput>> {
         record_s3_op(S3Operation::GetBucketEncryption);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_encryption(req).await
     }
 
@@ -550,7 +555,7 @@ impl S3 for FS {
         req: S3Request<GetBucketLifecycleConfigurationInput>,
     ) -> S3Result<S3Response<GetBucketLifecycleConfigurationOutput>> {
         record_s3_op(S3Operation::GetBucketLifecycleConfiguration);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_lifecycle_configuration(req).await
     }
 
@@ -558,7 +563,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self, req))]
     async fn get_bucket_location(&self, req: S3Request<GetBucketLocationInput>) -> S3Result<S3Response<GetBucketLocationOutput>> {
         record_s3_op(S3Operation::GetBucketLocation);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_location(req).await
     }
 
@@ -567,13 +572,13 @@ impl S3 for FS {
         req: S3Request<GetBucketNotificationConfigurationInput>,
     ) -> S3Result<S3Response<GetBucketNotificationConfigurationOutput>> {
         record_s3_op(S3Operation::GetBucketNotificationConfiguration);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_notification_configuration(req).await
     }
 
     async fn get_bucket_policy(&self, req: S3Request<GetBucketPolicyInput>) -> S3Result<S3Response<GetBucketPolicyOutput>> {
         record_s3_op(S3Operation::GetBucketPolicy);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_policy(req).await
     }
 
@@ -582,7 +587,7 @@ impl S3 for FS {
         req: S3Request<GetBucketPolicyStatusInput>,
     ) -> S3Result<S3Response<GetBucketPolicyStatusOutput>> {
         record_s3_op(S3Operation::GetBucketPolicyStatus);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_policy_status(req).await
     }
 
@@ -591,7 +596,7 @@ impl S3 for FS {
         req: S3Request<GetBucketReplicationInput>,
     ) -> S3Result<S3Response<GetBucketReplicationOutput>> {
         record_s3_op(S3Operation::GetBucketReplication);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_replication(req).await
     }
 
@@ -622,7 +627,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self))]
     async fn get_bucket_tagging(&self, req: S3Request<GetBucketTaggingInput>) -> S3Result<S3Response<GetBucketTaggingOutput>> {
         record_s3_op(S3Operation::GetBucketTagging);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_tagging(req).await
     }
 
@@ -632,7 +637,7 @@ impl S3 for FS {
         req: S3Request<GetPublicAccessBlockInput>,
     ) -> S3Result<S3Response<GetPublicAccessBlockOutput>> {
         record_s3_op(S3Operation::GetPublicAccessBlock);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_public_access_block(req).await
     }
 
@@ -642,7 +647,7 @@ impl S3 for FS {
         req: S3Request<GetBucketVersioningInput>,
     ) -> S3Result<S3Response<GetBucketVersioningOutput>> {
         record_s3_op(S3Operation::GetBucketVersioning);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_get_bucket_versioning(req).await
     }
 
@@ -676,7 +681,7 @@ impl S3 for FS {
     )]
     async fn get_object(&self, req: S3Request<GetObjectInput>) -> S3Result<S3Response<GetObjectOutput>> {
         crate::hp_guard!("S3::get_object");
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         Box::pin(usecase.execute_get_object(req)).await
     }
 
@@ -702,7 +707,7 @@ impl S3 for FS {
         &self,
         req: S3Request<GetObjectAttributesInput>,
     ) -> S3Result<S3Response<GetObjectAttributesOutput>> {
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         usecase.execute_get_object_attributes(req).await
     }
 
@@ -954,14 +959,14 @@ impl S3 for FS {
 
     #[instrument(level = "debug", skip(self, req))]
     async fn head_bucket(&self, req: S3Request<HeadBucketInput>) -> S3Result<S3Response<HeadBucketOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_head_bucket(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn head_object(&self, req: S3Request<HeadObjectInput>) -> S3Result<S3Response<HeadObjectOutput>> {
         crate::hp_guard!("S3::head_object");
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         usecase.execute_head_object(req).await
     }
 
@@ -969,7 +974,7 @@ impl S3 for FS {
     async fn list_buckets(&self, req: S3Request<ListBucketsInput>) -> S3Result<S3Response<ListBucketsOutput>> {
         // List buckets not associated with a bucket, give it bucket label "*" to denote "all".
         record_s3_op(S3Operation::ListBuckets);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_list_buckets(req).await
     }
 
@@ -978,7 +983,7 @@ impl S3 for FS {
         req: S3Request<ListMultipartUploadsInput>,
     ) -> S3Result<S3Response<ListMultipartUploadsOutput>> {
         record_s3_op(S3Operation::ListMultipartUploads);
-        let usecase = s3_api::default_multipart_usecase();
+        let usecase = s3_api::multipart_usecase_for(self);
         usecase.execute_list_multipart_uploads(req).await
     }
 
@@ -987,14 +992,14 @@ impl S3 for FS {
         req: S3Request<ListObjectVersionsInput>,
     ) -> S3Result<S3Response<ListObjectVersionsOutput>> {
         record_s3_op(S3Operation::ListObjectVersions);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_list_object_versions(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn list_objects(&self, req: S3Request<ListObjectsInput>) -> S3Result<S3Response<ListObjectsOutput>> {
         record_s3_op(S3Operation::ListObjects);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_list_objects(req).await
     }
 
@@ -1002,14 +1007,14 @@ impl S3 for FS {
     async fn list_objects_v2(&self, req: S3Request<ListObjectsV2Input>) -> S3Result<S3Response<ListObjectsV2Output>> {
         crate::hp_guard!("S3::list_objects_v2");
         record_s3_op(S3Operation::ListObjectsV2);
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_list_objects_v2(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn list_parts(&self, req: S3Request<ListPartsInput>) -> S3Result<S3Response<ListPartsOutput>> {
         record_s3_op(S3Operation::ListParts);
-        let usecase = s3_api::default_multipart_usecase();
+        let usecase = s3_api::multipart_usecase_for(self);
         usecase.execute_list_parts(req).await
     }
 
@@ -1063,7 +1068,7 @@ impl S3 for FS {
 
     #[instrument(level = "debug", skip(self))]
     async fn put_bucket_cors(&self, req: S3Request<PutBucketCorsInput>) -> S3Result<S3Response<PutBucketCorsOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_cors(req).await
     }
 
@@ -1109,7 +1114,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketEncryptionInput>,
     ) -> S3Result<S3Response<PutBucketEncryptionOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_encryption(req).await
     }
 
@@ -1118,7 +1123,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketLifecycleConfigurationInput>,
     ) -> S3Result<S3Response<PutBucketLifecycleConfigurationOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_lifecycle_configuration(req).await
     }
 
@@ -1126,12 +1131,12 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketNotificationConfigurationInput>,
     ) -> S3Result<S3Response<PutBucketNotificationConfigurationOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_notification_configuration(req).await
     }
 
     async fn put_bucket_policy(&self, req: S3Request<PutBucketPolicyInput>) -> S3Result<S3Response<PutBucketPolicyOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_policy(req).await
     }
 
@@ -1139,7 +1144,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketReplicationInput>,
     ) -> S3Result<S3Response<PutBucketReplicationOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_replication(req).await
     }
 
@@ -1169,13 +1174,13 @@ impl S3 for FS {
         &self,
         req: S3Request<PutPublicAccessBlockInput>,
     ) -> S3Result<S3Response<PutPublicAccessBlockOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_public_access_block(req).await
     }
 
     #[instrument(level = "debug", skip(self))]
     async fn put_bucket_tagging(&self, req: S3Request<PutBucketTaggingInput>) -> S3Result<S3Response<PutBucketTaggingOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_tagging(req).await
     }
 
@@ -1184,7 +1189,7 @@ impl S3 for FS {
         &self,
         req: S3Request<PutBucketVersioningInput>,
     ) -> S3Result<S3Response<PutBucketVersioningOutput>> {
-        let usecase = s3_api::default_bucket_usecase();
+        let usecase = s3_api::bucket_usecase_for(self);
         usecase.execute_put_bucket_versioning(req).await
     }
 
@@ -1209,7 +1214,7 @@ impl S3 for FS {
     #[instrument(level = "debug", skip(self, req))]
     async fn put_object(&self, req: S3Request<PutObjectInput>) -> S3Result<S3Response<PutObjectOutput>> {
         crate::hp_guard!("S3::put_object");
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         Box::pin(usecase.execute_put_object(self, req)).await
     }
 
@@ -1555,7 +1560,7 @@ impl S3 for FS {
     }
 
     async fn restore_object(&self, req: S3Request<RestoreObjectInput>) -> S3Result<S3Response<RestoreObjectOutput>> {
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         usecase.execute_restore_object(req).await
     }
 
@@ -1563,7 +1568,7 @@ impl S3 for FS {
         &self,
         req: S3Request<SelectObjectContentInput>,
     ) -> S3Result<S3Response<SelectObjectContentOutput>> {
-        let usecase = s3_api::default_object_usecase();
+        let usecase = s3_api::object_usecase_for(self);
         usecase.execute_select_object_content(req).await
     }
 
@@ -1571,14 +1576,14 @@ impl S3 for FS {
     async fn upload_part(&self, req: S3Request<UploadPartInput>) -> S3Result<S3Response<UploadPartOutput>> {
         crate::hp_guard!("S3::upload_part");
         record_s3_op(S3Operation::UploadPart);
-        let usecase = s3_api::default_multipart_usecase();
+        let usecase = s3_api::multipart_usecase_for(self);
         usecase.execute_upload_part(req).await
     }
 
     #[instrument(level = "debug", skip(self, req))]
     async fn upload_part_copy(&self, req: S3Request<UploadPartCopyInput>) -> S3Result<S3Response<UploadPartCopyOutput>> {
         record_s3_op(S3Operation::UploadPartCopy);
-        let usecase = s3_api::default_multipart_usecase();
+        let usecase = s3_api::multipart_usecase_for(self);
         Box::pin(usecase.execute_upload_part_copy(req)).await
     }
 }

--- a/rustfs/src/storage/s3_api/mod.rs
+++ b/rustfs/src/storage/s3_api/mod.rs
@@ -40,3 +40,18 @@ pub(crate) fn default_multipart_usecase() -> DefaultMultipartUsecase {
 pub(crate) fn default_object_usecase() -> DefaultObjectUsecase {
     DefaultObjectUsecase::from_global()
 }
+
+/// Resolve the object use-case for a server's request path (backlog#1052 S6):
+/// bind it to the server's own application context so it resolves that
+/// server's store instead of the ambient process default.
+pub(crate) fn object_usecase_for(fs: &crate::storage::ecfs::FS) -> DefaultObjectUsecase {
+    DefaultObjectUsecase::with_context(fs.server_ctx().app_context())
+}
+
+pub(crate) fn bucket_usecase_for(fs: &crate::storage::ecfs::FS) -> DefaultBucketUsecase {
+    DefaultBucketUsecase::with_context(fs.server_ctx().app_context())
+}
+
+pub(crate) fn multipart_usecase_for(fs: &crate::storage::ecfs::FS) -> DefaultMultipartUsecase {
+    DefaultMultipartUsecase::with_context(fs.server_ctx().app_context())
+}

--- a/rustfs/tests/embedded_multi_instance_test.rs
+++ b/rustfs/tests/embedded_multi_instance_test.rs
@@ -104,3 +104,78 @@ async fn two_embedded_servers_start_and_shutdown_independently() {
 
     server_a.shutdown().await;
 }
+
+// backlog#1052 auth acceptance: two embedded servers with *different*
+// credentials each authenticate against their own root identity. Server B
+// accepts its own access key and rejects server A's. This exercises the
+// per-server auth path (each request resolves its own AppContext for
+// credential validation).
+//
+// NOTE: full bucket-namespace isolation is a separate, deeper follow-up: the
+// ecstore data plane still resolves some lower-level reads (peer/disk/bucket
+// metadata) through the process-global object handle, so the two servers do
+// not yet present independent bucket listings even though each holds its own
+// store object. That isolation is the remaining work on #1052.
+#[tokio::test]
+async fn two_embedded_servers_authenticate_with_their_own_credentials() {
+    let port_a = match find_available_port() {
+        Ok(port) => port,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(err) => panic!("find free port for server A: {err}"),
+    };
+    let server_a = RustFSServerBuilder::new()
+        .address(format!("127.0.0.1:{port_a}"))
+        .access_key("access-key-a")
+        .secret_key("secret-key-a")
+        .build()
+        .await
+        .expect("start embedded server A");
+
+    let port_b = match find_available_port() {
+        Ok(port) => port,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            server_a.shutdown().await;
+            return;
+        }
+        Err(err) => {
+            server_a.shutdown().await;
+            panic!("find free port for server B: {err}");
+        }
+    };
+    let server_b = RustFSServerBuilder::new()
+        .address(format!("127.0.0.1:{port_b}"))
+        .access_key("access-key-b")
+        .secret_key("secret-key-b")
+        .build()
+        .await
+        .expect("start embedded server B");
+
+    // Server B authenticates with its OWN key — before per-server auth this
+    // failed with InvalidAccessKeyId because validation used the process
+    // (server A's) credentials.
+    let client_b = s3_client(&server_b.endpoint(), "access-key-b", "secret-key-b");
+    client_b
+        .list_buckets()
+        .send()
+        .await
+        .expect("server B must authenticate with its own credentials");
+
+    // Server B rejects server A's key — the two servers have distinct root
+    // identities.
+    let cross = s3_client(&server_b.endpoint(), "access-key-a", "secret-key-a")
+        .list_buckets()
+        .send()
+        .await;
+    assert!(cross.is_err(), "server B must reject server A's access key; got {cross:?}");
+
+    // Server A still authenticates with its own key.
+    let client_a = s3_client(&server_a.endpoint(), "access-key-a", "secret-key-a");
+    client_a
+        .list_buckets()
+        .send()
+        .await
+        .expect("server A must authenticate with its own credentials");
+
+    server_a.shutdown().await;
+    server_b.shutdown().await;
+}


### PR DESCRIPTION
## What

The auth + application-context stage of [backlog#1052](https://github.com/rustfs/backlog/issues/1052) (S6). Each embedded server now authenticates against — and its request path resolves — its **own** application context, so two servers with different root credentials each accept their own access key and reject the other's.

- **AppContext is per-server**: `ensure_startup_after_iam` constructs a fresh context around this server's store + IAM + KMS and installs it into the server's own `ServerContextSlot`, then publishes it as the process default first-writer-wins (`publish_global_app_context`) for legacy ambient readers. The old "reuse the global if present" branch is gone.
- **Auth is per-server**: `FS::check` (the S3 data-plane access gate) resolves auth against `self.server_ctx`'s context. `check_key_valid` gains a `_with_context` variant that takes the root credentials and IAM system from an explicit context (`None` = ambient, unchanged for all 140+ existing callers). The region and the server context slot are published into the request extensions.
- **Credential seeding**: each embedded server seeds its own root credentials into its context (`ActionCredentialHandle::publish`) at startup, so validation no longer falls back to the first server's process-global identity.
- **Use-cases resolve per-server**: the bucket/object/multipart use-cases take `&FS` (`*_usecase_for`) and resolve their store from the server's context.

## Acceptance

`two_embedded_servers_authenticate_with_their_own_credentials`: two servers with distinct credentials each authenticate with their own key and reject the other's. A diagnostic during development confirmed server B's use-case resolves its **own** store object (distinct store id, slot install succeeds).

## Known follow-up

Full bucket-namespace isolation still requires threading the instance context through the **lower ecstore data plane** — `handle_list_bucket` → `peer_sys.list_bucket()`, the disk registry, and bucket-metadata reads still resolve via the process `GLOBAL_OBJECT_API`/`current_ctx()` (the first published store). So the two servers don't yet present independent bucket listings even though each holds its own store object. That deeper pass — a continuation of the #939 object-graph ctx threading, ~155 internal paths — is the remaining work on #1052 and is tracked separately.

## Verification

`make pre-pr` green (fmt, arch guards, clippy, workspace nextest, doc tests); embedded basic + deferred-IAM + both multi-instance e2e pass.

**Stacked on #4628** (S5 guard change). Refs: rustfs/backlog#1052 (S6).