### PR TITLE
fix(ecstore): keep local path startup fail-fast under Kubernetes

### DIFF
--- a/crates/config/src/constants/app.rs
+++ b/crates/config/src/constants/app.rs
@@ -153,8 +153,8 @@ pub const DEFAULT_UNSAFE_BYPASS_DISK_CHECK: bool = false;
 /// - `bounded`: wait for a finite window (see
 ///   `ENV_STARTUP_TOPOLOGY_WAIT_TIMEOUT`) then fail with an actionable error.
 /// - `fail-fast`: fail on the first non-transient resolution error (CI/local).
-/// - `auto`: Kubernetes -> orchestrated, distributed URL endpoints -> bounded,
-///   local path endpoints -> fail-fast.
+/// - `auto`: distributed URL endpoints use orchestrated on Kubernetes and
+///   bounded otherwise; local path endpoints use fail-fast (no DNS to await).
 pub const ENV_STARTUP_TOPOLOGY_WAIT_MODE: &str = "RUSTFS_STARTUP_TOPOLOGY_WAIT_MODE";
 
 /// Environment variable bounding how long startup waits for topology/DNS

--- a/crates/ecstore/src/layout/endpoints.rs
+++ b/crates/ecstore/src/layout/endpoints.rs
@@ -768,13 +768,16 @@ impl StartupTopologyPolicy {
             Some("bounded") => StartupTopologyWaitMode::Bounded,
             Some("fail-fast") | Some("failfast") | Some("strict") => StartupTopologyWaitMode::FailFast,
             // "auto", unset, or unrecognized: derive from the environment.
+            // Only URL-style (distributed) endpoints resolve hostnames and need
+            // to wait for DNS/topology convergence; local path endpoints never
+            // do, so they fail fast regardless of the platform.
             _ => {
-                if kubernetes {
-                    StartupTopologyWaitMode::Orchestrated
-                } else if distributed {
-                    StartupTopologyWaitMode::Bounded
-                } else {
+                if !distributed {
                     StartupTopologyWaitMode::FailFast
+                } else if kubernetes {
+                    StartupTopologyWaitMode::Orchestrated
+                } else {
+                    StartupTopologyWaitMode::Bounded
                 }
             }
         };
@@ -1351,6 +1354,12 @@ mod test {
         let local = StartupTopologyPolicy::resolve_from(None, false, false, None, None);
         assert_eq!(local.mode, StartupTopologyWaitMode::FailFast);
         assert_eq!(local.wait_timeout, Duration::ZERO);
+
+        // Local path endpoints stay fail-fast even under Kubernetes: they have
+        // no hostnames to resolve, so there is nothing to wait for.
+        let k8s_local = StartupTopologyPolicy::resolve_from(None, true, false, None, None);
+        assert_eq!(k8s_local.mode, StartupTopologyWaitMode::FailFast);
+        assert_eq!(k8s_local.wait_timeout, Duration::ZERO);
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Follow-up to #4631. Tracked by rustfs/backlog#1105.

## Summary of Changes

The startup topology convergence auto-detection added in #4631 checked Kubernetes before endpoint style: `if kubernetes { Orchestrated } else if distributed { Bounded } else { FailFast }`. A local path deployment (single or multi-drive, non-distributed) running inside Kubernetes therefore resolved to `orchestrated` with an effectively unbounded wait window. Path-style endpoints have no hostnames to resolve, so the wait never actually triggers and runtime behavior is unchanged — but the startup log advertised `mode=orchestrated` / `wait_timeout=MAX` for a purely local deployment, which is misleading and contradicts the documented policy (`local path endpoints -> fail-fast`).

This reorders the auto-detection by endpoint style first: only distributed URL endpoints (which resolve hostnames) select orchestrated on Kubernetes or bounded otherwise; local path endpoints stay fail-fast regardless of platform. The doc comment on `ENV_STARTUP_TOPOLOGY_WAIT_MODE` is updated to match, and a policy test case locks `Kubernetes + local path -> fail-fast`.

This is a semantics/logging correction, not a runtime behavior change for path-style endpoints. Distributed URL endpoints are unaffected (the derived mode is identical to before).

## Verification

- `cargo test -p rustfs-ecstore --lib layout::endpoints` (all pass)
- `KUBERNETES_SERVICE_HOST=10.0.0.1 cargo test -p rustfs-ecstore --lib layout::endpoints` (all pass; exercises the CI-in-Kubernetes path and the new fail-fast case)
- `cargo clippy -p rustfs-ecstore -p rustfs-config --all-targets` (no warnings)
- `cargo fmt --all --check` (clean)

## Impact

- Configuration: no new options. `auto` mode now classifies local path endpoints as fail-fast even under Kubernetes (previously orchestrated). No behavior change for path-style startup (no DNS to await); only the reported mode and startup log change.
- Compatibility: distributed URL endpoints unchanged; no on-disk/on-wire/API change.

## Additional Notes

Surfaced during a post-merge self-review of #4631.

I have read and agree to the CLA.
