### PR TITLE
fix(ecstore): bound listing walks by drive stall, not total duration

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -14,7 +14,7 @@
 
 use crate::config::storageclass::DEFAULT_INLINE_BLOCK;
 use crate::data_usage::local_snapshot::ensure_data_usage_layout;
-use crate::disk::disk_store::get_object_disk_read_timeout;
+use crate::disk::disk_store::{get_drive_walkdir_stall_timeout, get_object_disk_read_timeout};
 use crate::disk::{
     BUCKET_META_PREFIX, CHECK_PART_FILE_CORRUPT, CHECK_PART_FILE_NOT_FOUND, CHECK_PART_SUCCESS, CHECK_PART_UNKNOWN,
     CHECK_PART_VOLUME_NOT_FOUND, CheckPartsResp, DeleteOptions, DiskAPI, DiskInfo, DiskInfoOptions, DiskLocation, DiskMetrics,
@@ -1413,6 +1413,29 @@ where
     W: AsyncWrite + Unpin,
 {
     out.write_obj(obj).await.map_err(metacache_write_error)
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+/// Bound one drive read issued by a walk with the stall timeout.
+///
+/// A walk is not failed for taking a long time — a large directory tree is not a
+/// fault. It is failed only when the drive stops answering, so the timeout wraps
+/// each individual read rather than the walk as a whole. Time spent blocked
+/// writing to a slow consumer is deliberately outside this budget.
+async fn with_walk_stall_timeout<T, F>(stall: Option<Duration>, fut: F) -> Result<T>
+where
+    F: std::future::Future<Output = Result<T>>,
+{
+    match stall {
+        Some(stall) if !stall.is_zero() => match timeout(stall, fut).await {
+            Ok(res) => res,
+            Err(_) => Err(DiskError::Timeout),
+        },
+        _ => fut.await,
+    }
 }
 
 impl FileCacheReclaimReader {
@@ -3808,7 +3831,9 @@ impl LocalDisk {
 
         // TODO: add lock
 
-        let mut entries = match self.list_dir("", &opts.bucket, &current, -1).await {
+        let stall = opts.stall_timeout_duration();
+
+        let mut entries = match with_walk_stall_timeout(stall, self.list_dir("", &opts.bucket, &current, -1)).await {
             Ok(res) => res,
             Err(e) => {
                 if e != DiskError::VolumeNotFound && e != Error::FileNotFound {
@@ -3889,9 +3914,9 @@ impl LocalDisk {
                     continue;
                 }
 
-                let metadata = self
-                    .read_metadata(bucket, format!("{}/{}", &current, &entry).as_str())
-                    .await?;
+                let metadata =
+                    with_walk_stall_timeout(stall, self.read_metadata(bucket, format!("{}/{}", &current, &entry).as_str()))
+                        .await?;
 
                 let entry = entry.strip_suffix(STORAGE_FORMAT_FILE).unwrap_or_default().to_owned();
                 let name = entry.trim_end_matches(SLASH_SEPARATOR);
@@ -4009,7 +4034,7 @@ impl LocalDisk {
 
             let fname = format!("{}/{}", &meta.name, STORAGE_FORMAT_FILE);
 
-            match self.read_metadata(&opts.bucket, fname.as_str()).await {
+            match with_walk_stall_timeout(stall, self.read_metadata(&opts.bucket, fname.as_str())).await {
                 Ok(res) => {
                     if is_dir_obj {
                         meta.name = meta.name.trim_end_matches(GLOBAL_DIR_SUFFIX_WITH_SLASH).to_owned();
@@ -4052,7 +4077,7 @@ impl LocalDisk {
                         );
                     } else if !is_dir_obj
                         && self
-                            .object_dir_has_listable_child(&opts.bucket, &meta.name, &dir_to_skip, opts.incl_deleted)
+                            .object_dir_has_listable_child(&opts.bucket, &meta.name, &dir_to_skip, opts.incl_deleted, stall)
                             .await?
                     {
                         // A plain object `a` shares its backing directory with any
@@ -4075,7 +4100,7 @@ impl LocalDisk {
                             if opts.recursive
                                 || opts.incl_deleted
                                 || self
-                                    .directory_has_listing_entry(&opts.bucket, &meta.name, opts.incl_deleted)
+                                    .directory_has_listing_entry(&opts.bucket, &meta.name, opts.incl_deleted, stall)
                                     .await?
                             {
                                 schedule_dir(&mut dir_stack, meta.name, false, None);
@@ -4149,6 +4174,7 @@ impl LocalDisk {
         object_name: &str,
         data_dirs: &HashSet<String>,
         incl_deleted: bool,
+        stall: Option<Duration>,
     ) -> Result<bool> {
         // The backing dir usually holds only the xl.meta plus the version data
         // dirs, so a read bounded just past that count decides the common case
@@ -4159,7 +4185,7 @@ impl LocalDisk {
         let mut probed = HashSet::new();
 
         for count in [bounded, -1] {
-            let entries = match self.list_dir("", bucket, object_name, count).await {
+            let entries = match with_walk_stall_timeout(stall, self.list_dir("", bucket, object_name, count)).await {
                 Ok(entries) => entries,
                 Err(err) => {
                     if err == DiskError::VolumeNotFound || err == Error::FileNotFound {
@@ -4183,7 +4209,10 @@ impl LocalDisk {
                 }
 
                 let child_path = path_join_buf(&[object_name, child]);
-                if self.directory_has_listing_entry(bucket, &child_path, incl_deleted).await? {
+                if self
+                    .directory_has_listing_entry(bucket, &child_path, incl_deleted, stall)
+                    .await?
+                {
                     return Ok(true);
                 }
             }
@@ -4200,7 +4229,13 @@ impl LocalDisk {
     /// `incl_deleted`, any `xl.meta` counts (versioned listings surface
     /// delete-marker-only objects too); otherwise the metadata must hold a
     /// visible version.
-    async fn directory_has_listing_entry(&self, bucket: &str, dir_name: &str, incl_deleted: bool) -> Result<bool> {
+    async fn directory_has_listing_entry(
+        &self,
+        bucket: &str,
+        dir_name: &str,
+        incl_deleted: bool,
+        stall: Option<Duration>,
+    ) -> Result<bool> {
         let mut stack = vec![dir_name.trim_matches('/').to_owned()];
 
         while let Some(current) = stack.pop() {
@@ -4208,7 +4243,7 @@ impl LocalDisk {
                 continue;
             }
 
-            let entries = match self.list_dir("", bucket, &current, -1).await {
+            let entries = match with_walk_stall_timeout(stall, self.list_dir("", bucket, &current, -1)).await {
                 Ok(entries) => entries,
                 Err(err) => {
                     if err == DiskError::VolumeNotFound || err == Error::FileNotFound {
@@ -4229,7 +4264,7 @@ impl LocalDisk {
                     }
 
                     let metadata_path = path_join_buf(&[current.as_str(), STORAGE_FORMAT_FILE]);
-                    match self.read_metadata(bucket, metadata_path.as_str()).await {
+                    match with_walk_stall_timeout(stall, self.read_metadata(bucket, metadata_path.as_str())).await {
                         Ok(metadata) => {
                             let file_meta = match FileMeta::load(&metadata) {
                                 Ok(file_meta) => file_meta,
@@ -5219,6 +5254,15 @@ impl DiskAPI for LocalDisk {
     async fn walk_dir<W: AsyncWrite + Unpin + Send>(&self, opts: WalkDirOptions, wr: &mut W) -> Result<()> {
         self.wait_for_startup_cleanup().await;
 
+        // Callers that do not pin a stall budget inherit the configured default, so
+        // every local walk keeps a liveness bound even when the wrapper-level total
+        // timeout is skipped.
+        let mut opts = opts;
+        if opts.stall_timeout_ms.is_none() {
+            opts.stall_timeout_ms = Some(duration_millis(get_drive_walkdir_stall_timeout()));
+        }
+        let stall = opts.stall_timeout_duration();
+
         let volume_dir = self.get_bucket_path(&opts.bucket)?;
 
         if !skip_access_checks(&opts.bucket)
@@ -5238,16 +5282,18 @@ impl DiskAPI for LocalDisk {
         let mut skip_current_dir_object = false;
         let mut multipart_dir_to_skip: HashSet<String> = HashSet::new();
         if opts.base_dir.ends_with(SLASH_SEPARATOR) {
-            if let Ok(data) = self
-                .read_metadata(
+            if let Ok(data) = with_walk_stall_timeout(
+                stall,
+                self.read_metadata(
                     &opts.bucket,
                     path_join_buf(&[
                         format!("{}{}", opts.base_dir.trim_end_matches(SLASH_SEPARATOR), GLOBAL_DIR_SUFFIX).as_str(),
                         STORAGE_FORMAT_FILE,
                     ])
                     .as_str(),
-                )
-                .await
+                ),
+            )
+            .await
             {
                 let meta = MetaCacheEntry {
                     name: opts.base_dir.clone(),
@@ -7109,6 +7155,128 @@ mod test {
                 .is_err(),
             "blocking scan writer shutdown should stay pending"
         );
+    }
+
+    /// A writer that stalls on every write, standing in for a slow listing
+    /// consumer (quorum merge, a lagging peer drive).
+    struct SlowWriter {
+        delay: Duration,
+        sleep: Option<std::pin::Pin<Box<Sleep>>>,
+    }
+
+    impl AsyncWrite for SlowWriter {
+        fn poll_write(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            if self.sleep.is_none() {
+                let delay = self.delay;
+                self.sleep = Some(Box::pin(tokio::time::sleep(delay)));
+            }
+
+            let sleep = self.sleep.as_mut().expect("sleep was just installed");
+            match sleep.as_mut().poll(cx) {
+                std::task::Poll::Ready(()) => {
+                    self.sleep = None;
+                    std::task::Poll::Ready(Ok(buf.len()))
+                }
+                std::task::Poll::Pending => std::task::Poll::Pending,
+            }
+        }
+
+        fn poll_flush(self: std::pin::Pin<&mut Self>, _cx: &mut std::task::Context<'_>) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    // #4644: the stall budget bounds a single drive read, never the walk as a
+    // whole. A walk that keeps making progress must survive even when the total
+    // time spent blocked on a slow consumer dwarfs the stall timeout.
+    #[tokio::test]
+    async fn walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let bucket = "test-bucket";
+        for idx in 0..4 {
+            let object_dir = dir.path().join(bucket).join(format!("prefix/object-{idx}"));
+            fs::create_dir_all(&object_dir).await.expect("object dir should be created");
+            fs::write(object_dir.join(STORAGE_FORMAT_FILE), b"meta")
+                .await
+                .expect("object metadata should be written");
+        }
+
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+
+        let stall = Duration::from_millis(300);
+        let write_delay = Duration::from_millis(150);
+        let opts = WalkDirOptions {
+            bucket: bucket.to_string(),
+            base_dir: "prefix/".to_string(),
+            recursive: true,
+            stall_timeout_ms: Some(duration_millis(stall)),
+            ..Default::default()
+        };
+
+        let mut writer = SlowWriter {
+            delay: write_delay,
+            sleep: None,
+        };
+
+        let started = std::time::Instant::now();
+        let result = disk.walk_dir(opts, &mut writer).await;
+        let elapsed = started.elapsed();
+
+        assert!(result.is_ok(), "a walk making steady progress must not time out, got {result:?}");
+        assert!(
+            elapsed > stall,
+            "test is only meaningful if the walk outlives the stall budget, elapsed {elapsed:?} vs stall {stall:?}"
+        );
+    }
+
+    // #4644: the stall timeout is what catches a drive that stops answering.
+    #[tokio::test(start_paused = true)]
+    async fn with_walk_stall_timeout_fails_only_when_a_read_stops_answering() {
+        let stall = Duration::from_millis(100);
+
+        let hung = with_walk_stall_timeout(Some(stall), async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(())
+        })
+        .await;
+        assert!(
+            matches!(hung, Err(DiskError::Timeout)),
+            "a read that stops answering must trip the stall budget, got {hung:?}"
+        );
+
+        let prompt = with_walk_stall_timeout(Some(stall), async { Ok(7_u32) })
+            .await
+            .expect("a prompt read must pass through");
+        assert_eq!(prompt, 7);
+
+        // No budget configured: the read is unbounded on purpose.
+        let unbounded = with_walk_stall_timeout(None, async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(())
+        })
+        .await;
+        assert!(unbounded.is_ok(), "an unset stall budget must not bound the read");
+
+        let disabled = with_walk_stall_timeout(Some(Duration::ZERO), async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(())
+        })
+        .await;
+        assert!(disabled.is_ok(), "a zero stall budget must disable the bound");
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/services/rebalance/worker.rs
+++ b/crates/ecstore/src/services/rebalance/worker.rs
@@ -19,6 +19,11 @@ use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
+/// Background walks skip the total timeout, so the per-read stall budget is what
+/// catches a drive that stops answering. Keep it generous: rebalance is not
+/// latency-sensitive, and one slow read is not a dead drive.
+const BACKGROUND_WALKDIR_STALL_TIMEOUT: Duration = Duration::from_secs(60);
+
 pub(super) fn resolve_rebalance_worker_result<T>(
     set_idx: usize,
     worker_result: std::result::Result<Result<T>, tokio::task::JoinError>,
@@ -490,6 +495,7 @@ impl SetDisks {
                 recursive: true,
                 min_disks: listing_quorum,
                 skip_walkdir_total_timeout: true,
+                walkdir_stall_timeout: Some(BACKGROUND_WALKDIR_STALL_TIMEOUT),
                 agreed: Some(Box::new(move |entry: MetaCacheEntry| {
                     debug!(
                         event = EVENT_REBALANCE_LISTING,

--- a/crates/ecstore/src/set_disk/ops/heal_walk.rs
+++ b/crates/ecstore/src/set_disk/ops/heal_walk.rs
@@ -25,6 +25,12 @@
 use super::super::*;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+/// Background walks skip the total timeout, so the per-read stall budget is what
+/// catches a drive that stops answering. Keep it generous: a heal walk is not
+/// latency-sensitive, and one slow read is not a dead drive.
+const BACKGROUND_WALKDIR_STALL_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// A single `(object, version)` unit surfaced by the disk-walk union enumerator.
 ///
@@ -199,6 +205,7 @@ impl SetDisks {
             report_not_found: false,
             per_disk_limit: 0,
             skip_walkdir_total_timeout: true,
+            walkdir_stall_timeout: Some(BACKGROUND_WALKDIR_STALL_TIMEOUT),
             agreed: Some(Box::new(move |entry: MetaCacheEntry| {
                 let collector = agreed_collector.clone();
                 Box::pin(async move {

--- a/crates/ecstore/src/store/list_objects.rs
+++ b/crates/ecstore/src/store/list_objects.rs
@@ -6372,7 +6372,7 @@ impl SetDisks {
                 filter_prefix: opts.filter_prefix.clone(),
                 forward_to: opts.marker.clone(),
                 per_disk_limit: limit,
-                skip_total_timeout: false,
+                skip_total_timeout: true,
                 walkdir_timeout: opts.walkdir_timeout,
                 walkdir_stall_timeout: opts.walkdir_stall_timeout,
             },
@@ -6395,6 +6395,10 @@ impl SetDisks {
                 forward_to: opts.marker,
                 min_disks: raw_min_disks,
                 per_disk_limit: limit,
+                // A foreground listing is bounded by lack of drive progress (the walk
+                // stall timeout) and by the page limit, never by how long a healthy
+                // walk takes — a large prefix on slow media is not a fault (#4644).
+                skip_walkdir_total_timeout: true,
                 walkdir_timeout: opts.walkdir_timeout,
                 walkdir_stall_timeout: opts.walkdir_stall_timeout,
                 agreed: Some(Box::new(move |entry: MetaCacheEntry| {


### PR DESCRIPTION
## What

Foreground S3 listings wrapped the entire `walk_dir` stream in a single wall-clock timeout (`RUSTFS_DRIVE_WALKDIR_TIMEOUT_SECS`, default `5`). That budget measures *how much data the walk has to produce*, not *whether the drive is still answering*, so a healthy but large prefix on slow media returns `500 InternalError / Io error: timeout` to the client. The timer also kept running while the walk was blocked writing into the metacache merge consumer, charging merge-side backpressure to the producer.

`WalkDirOptions::stall_timeout_ms` already carried exactly the right semantics, but it was only honored by the remote-disk RPC walk (`remote_disk.rs`). `LocalDisk::walk_dir` ignored it entirely, so a single-drive deployment — the configuration in #2999 — had no way to distinguish a hung drive from a big directory. The producer-side total timeout was largely redundant for fault detection (the consumer's `peek_with_timeout` is what actually catches a dead drive) while remaining actively harmful for large listings.

## How

- `LocalDisk::walk_dir` now bounds **each individual drive read** with the stall budget — `list_dir` and `read_metadata`, including the recursive reads inside `object_dir_has_listable_child` and `directory_has_listing_entry`. It defaults the budget from `RUSTFS_DRIVE_WALKDIR_STALL_TIMEOUT_SECS` when the caller does not pin one, so no walk loses its liveness bound.
- Writes into the metacache stream are deliberately left outside the budget: blocking on a slow consumer is not a drive fault.
- `SetDisks::list_path` sets `skip_walkdir_total_timeout: true` and relies on the stall budget plus the existing page-limit early cancel from #3001.

A walk that keeps making progress now runs to completion; a drive that stops answering still fails with `DiskError::Timeout`.

### Heal and rebalance

Both already set `skip_walkdir_total_timeout: true`, which meant their local walks previously ran with **no** liveness bound at all. Defaulting the stall budget would have silently tightened them from "unbounded" to the 5 s default — a new failure mode this PR has no business introducing. They now pass an explicit, generous 60 s stall budget, which also brings local walks in line with the remote-disk path (which has applied a stall timeout to these walks all along).

## Testing

- `walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget` — a walk whose total duration far exceeds the stall budget, purely because the consumer is slow, must succeed. Mutation-checked: temporarily wrapping the whole `scan_dir` in the stall timeout (i.e. reverting to total-duration semantics) turns this test red with `Err(Timeout)`, so it genuinely pins the per-read semantics rather than just passing.
- `with_walk_stall_timeout_fails_only_when_a_read_stops_answering` — a read that hangs trips the budget; a prompt read passes through; an unset or zero budget leaves the read unbounded.
- Existing coverage that constrains this change stays green: `list_path_still_uses_disk_after_prior_walk_timeout`, `list_path_system_prefix_survives_prior_walk_timeout`, `walk_dir_skip_total_timeout_keeps_stream_pending`, `walk_dir_writer_backpressure_timeout_does_not_mark_drive_failure`, and the `metacache_set` stall/quorum suite.
- `cargo nextest run -p rustfs-ecstore --lib` → 2389 passed, 1 skipped. `cargo clippy -p rustfs-ecstore --all-targets` clean. `make pre-commit` passed.

> Note for reviewers: `cargo test -p rustfs-ecstore --lib` (without nextest) fails ~5 bucket/multipart/lock tests with `InsufficientWriteQuorum`. That reproduces on a clean tree at the same base commit (6 failures there) and is the known process-global-singleton flakiness, unrelated to this change. It does not occur under nextest's process isolation, which is what CI uses.

## Compatibility

No config or API change. `RUSTFS_DRIVE_WALKDIR_TIMEOUT_SECS` still applies to every walk that does not skip the total timeout (background scanner walks, direct `walk_dir` callers). Deployments currently working around #2999 by raising it — or by setting `RUSTFS_DRIVE_TIMEOUT_PROFILE=high_latency` — keep working, and should no longer need to.

Fixes #4644
Refs #2999, #3001
