### PR TITLE
fix(ecstore): bound every walk filesystem call by the stall budget

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1425,17 +1425,26 @@ fn duration_millis(duration: Duration) -> u64 {
 /// fault. It is failed only when the drive stops answering, so the timeout wraps
 /// each individual read rather than the walk as a whole. Time spent blocked
 /// writing to a slow consumer is deliberately outside this budget.
+///
+/// Every filesystem call a walk makes must go through this, because the listing
+/// path skips the wrapper-level total timeout: an unbounded read would leave the
+/// walk with no liveness bound of its own.
+async fn with_walk_stall_deadline<T, F>(stall: Option<Duration>, fut: F) -> Result<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    match stall {
+        Some(stall) if !stall.is_zero() => timeout(stall, fut).await.map_err(|_| DiskError::Timeout),
+        _ => Ok(fut.await),
+    }
+}
+
+/// [`with_walk_stall_deadline`] for reads that already yield a [`Result`].
 async fn with_walk_stall_timeout<T, F>(stall: Option<Duration>, fut: F) -> Result<T>
 where
     F: std::future::Future<Output = Result<T>>,
 {
-    match stall {
-        Some(stall) if !stall.is_zero() => match timeout(stall, fut).await {
-            Ok(res) => res,
-            Err(_) => Err(DiskError::Timeout),
-        },
-        _ => fut.await,
-    }
+    with_walk_stall_deadline(stall, fut).await?
 }
 
 impl FileCacheReclaimReader {
@@ -4105,7 +4114,10 @@ impl LocalDisk {
                     if err == Error::FileNotFound || err == Error::IsNotRegular {
                         // NOT an object, append to stack (with slash)
                         // If dirObject, but no metadata (which is unexpected) we skip it.
-                        if !is_dir_obj && !is_empty_dir(self.get_object_path(&opts.bucket, &meta.name)?).await {
+                        if !is_dir_obj
+                            && !with_walk_stall_deadline(stall, is_empty_dir(self.get_object_path(&opts.bucket, &meta.name)?))
+                                .await?
+                        {
                             meta.name.push_str(SLASH_SEPARATOR);
                             if opts.recursive
                                 || opts.incl_deleted
@@ -5276,7 +5288,7 @@ impl DiskAPI for LocalDisk {
         let volume_dir = self.get_bucket_path(&opts.bucket)?;
 
         if !skip_access_checks(&opts.bucket)
-            && let Err(e) = access(&volume_dir).await
+            && let Err(e) = with_walk_stall_deadline(stall, access(&volume_dir)).await?
         {
             return Err(to_access_error(e, DiskError::VolumeAccessDenied).into());
         }
@@ -5316,16 +5328,18 @@ impl DiskAPI for LocalDisk {
                 let fpath =
                     self.get_object_path(&opts.bucket, path_join_buf(&[opts.base_dir.as_str(), STORAGE_FORMAT_FILE]).as_str())?;
 
-                if let Ok(meta) = tokio::fs::metadata(&fpath).await
+                if let Ok(meta) = with_walk_stall_deadline(stall, tokio::fs::metadata(&fpath)).await?
                     && meta.is_file()
                 {
                     skip_current_dir_object = true;
-                    if let Ok(meta_bytes) = self
-                        .read_metadata(
+                    if let Ok(meta_bytes) = with_walk_stall_deadline(
+                        stall,
+                        self.read_metadata(
                             opts.bucket.as_str(),
                             path_join_buf(&[opts.base_dir.as_str(), STORAGE_FORMAT_FILE]).as_str(),
-                        )
-                        .await
+                        ),
+                    )
+                    .await?
                         && let Ok(file_meta) = FileMeta::load(&meta_bytes)
                         && let Ok(data_dirs) = file_meta.get_data_dirs()
                     {
@@ -7254,6 +7268,13 @@ mod test {
     }
 
     // #4644: the stall timeout is what catches a drive that stops answering.
+    //
+    // This exercises the bound directly rather than through `walk_dir`. A drive
+    // read only outlives the budget when the drive itself hangs, and a local disk
+    // offers no seam to make a real read hang: `access`/`read_dir`/`read_metadata`
+    // dispatch to tokio's blocking pool, so on a healthy filesystem they always
+    // complete first. Racing them against a paused clock would only buy a flaky
+    // test.
     #[tokio::test(start_paused = true)]
     async fn with_walk_stall_timeout_fails_only_when_a_read_stops_answering() {
         let stall = Duration::from_millis(100);
@@ -7287,6 +7308,29 @@ mod test {
         })
         .await;
         assert!(disabled.is_ok(), "a zero stall budget must disable the bound");
+    }
+
+    // #4644: reads that do not yield a Result (`access`, `is_empty_dir`,
+    // `fs::metadata`) are bounded by the same budget — the listing path has no
+    // total timeout left to fall back on.
+    #[tokio::test(start_paused = true)]
+    async fn with_walk_stall_deadline_bounds_reads_that_do_not_yield_a_result() {
+        let stall = Duration::from_millis(100);
+
+        let hung = with_walk_stall_deadline(Some(stall), async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            true
+        })
+        .await;
+        assert!(
+            matches!(hung, Err(DiskError::Timeout)),
+            "a hung infallible read must trip the stall budget, got {hung:?}"
+        );
+
+        let prompt = with_walk_stall_deadline(Some(stall), async { true })
+            .await
+            .expect("a prompt read must pass through");
+        assert!(prompt);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #4647 (merged), which switched foreground listing walks off the wrapper-level total timeout and onto a per-read stall budget.

## The gap

#4647 removed the total timeout from the listing path, so the stall budget is now the walk's *only* liveness bound. It routed `list_dir` and `read_metadata` through that budget — but four filesystem calls were left unbounded:

| Location | Call |
| --- | --- |
| `walk_dir`, volume probe | `access(&volume_dir)` |
| `walk_dir`, dir-object branch | `tokio::fs::metadata(&fpath)` |
| `walk_dir`, dir-object branch | `read_metadata(..)` for the `xl.meta` |
| `scan_dir` | `is_empty_dir(..)` |

On a drive that stops answering, any one of these parks the walk with nothing to bound it. The request is not lost — the metacache merge consumer's own `peek_with_timeout` eventually gives up and aborts the producer — but the failure is attributed to a stalled *reader* rather than to the drive that actually hung, and the walk holds its scan lock until then. Under the total timeout this could not happen, so the gap was introduced by #4647 itself.

## The fix

Split the helper so reads that do not yield a `Result` go through the same budget:

- `with_walk_stall_deadline(stall, fut)` — bounds any future, maps expiry to `DiskError::Timeout`
- `with_walk_stall_timeout(stall, fut)` — the existing `Result`-yielding wrapper, now a thin flatten over the above

and route the four remaining calls through it. Behavior when the budget is unset or zero is unchanged (unbounded), as is every error mapping on the success path.

I audited the four functions that make up the walk (`walk_dir`, `scan_dir`, `object_dir_has_listable_child`, `directory_has_listing_entry`) and there are now no unbounded filesystem calls left in any of them. `wait_for_startup_cleanup` is deliberately excluded: it is a startup barrier, not a drive read, and it already carries its own `STARTUP_CLEANUP_WAIT_TIMEOUT`.

## Testing

- `with_walk_stall_deadline_bounds_reads_that_do_not_yield_a_result` — new; a hung infallible read trips the budget, a prompt one passes through.
- `walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget` — from #4647, still mutation-checked: wrapping the whole `scan_dir` in the stall timeout (i.e. reverting to total-duration semantics) turns it red with `Err(Timeout)`.
- `cargo nextest run -p rustfs-ecstore --lib` → 2390 passed, 1 skipped, on top of merged `main`. `cargo clippy -p rustfs-ecstore --all-targets` clean, `cargo fmt --all --check` clean.

### On testing the stall trip through `walk_dir` itself

I tried to add one and deliberately dropped it. A real read only outlives the budget when the drive hangs, and `LocalDisk` offers no seam to make one hang: `access` / `read_dir` / `read_metadata` all dispatch to tokio's blocking pool, so on a healthy filesystem they complete long before any budget worth setting. The only way to force expiry is to race the blocking pool against a paused clock, which buys a flaky test rather than a real guarantee. The bound is therefore tested directly, and the wiring of each call site is a structural property (the helpers take `stall` as a parameter, so a new call site cannot silently skip it without being written to). I left a comment in the test saying so.

Refs #4644, #4647
