### PR TITLE
docs(tier-ilm): note local-first invariant for expire/GET race fix

### DIFF
--- a/docs/operations/tier-ilm-debugging.md
+++ b/docs/operations/tier-ilm-debugging.md
@@ -73,16 +73,17 @@ If both `x-rustfs-internal-transitioned-versionID` and
 `x-minio-internal-transitioned-versionID` are the **empty string**, the object
 was transitioned to a non-versioned tier bucket and no versionId must be sent.
 
-## Known open issue: expire/GET race
-
-`expire_transitioned_object` deletes the remote tier version **before**
-deleting local metadata. A concurrent GET between those two steps reads a
-valid stored version_id whose remote version is already gone →
-`NoSuchVersion`. The proper fix is to delete local metadata first (making the
-object unreachable), then the remote tier version.
-
 ## Historical fixes (for context, already merged)
 
+- Expire/GET race (`NoSuchVersion` during expiry of a tiered object):
+  `expire_transitioned_object` used to delete the remote tier version
+  **before** local metadata, so a concurrent GET between the two steps read a
+  stored version_id whose remote version was already gone. Fixed in `#3491`:
+  local metadata is deleted **first** (making the object unreachable), and
+  remote-tier cleanup is driven by persisted free-version recovery
+  (`crates/ecstore/src/bucket/lifecycle/tier_free_version_recovery.rs`).
+  **Invariant — keep local-first ordering**: never remove a remote tier
+  version while live local metadata still points at it.
 - Nil-UUID versionId sent to tier (`NoSuchVersion`): reading code used
   `Uuid::from_slice(..).unwrap_or_default()`, converting an empty metadata
   value into `Uuid::nil()`. Fixed by the `and_then`/`filter` pattern above.


### PR DESCRIPTION
## What

The tier/ILM debugging guide (`docs/operations/tier-ilm-debugging.md`) listed the **expire/GET race** as a *known open issue*, claiming `expire_transitioned_object` deletes the remote tier version before local metadata and that the proper fix (local-first delete) was still pending.

That is stale. The fix landed in #3491.

## Why it's stale

`crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs`, `fn expire_transitioned_object` (~line 2244) now deletes **local metadata first**, with an explicit comment:

> Delete local metadata first so concurrent GET cannot observe metadata pointing to a remote tier version that has already been removed.

Remote-tier cleanup is driven by persisted free-version recovery (`crates/ecstore/src/bucket/lifecycle/tier_free_version_recovery.rs`), introduced by the same PR.

## Change

- Remove the `## Known open issue: expire/GET race` section.
- Add it to `## Historical fixes` instead: describe the race, cite #3491, and point at `tier_free_version_recovery.rs`.
- Record the **local-first ordering invariant** (never remove a remote tier version while live local metadata still points at it) so future edits don't regress it.

Doc-only change.

## Verification

- `scripts/check_doc_paths.sh` → `doc path check passed`
- `make pre-commit` → `✅ All pre-commit checks passed!`