### PR TITLE
fix(ecstore): restore Windows async read trait import

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -62,7 +62,7 @@ use std::{
 };
 use time::OffsetDateTime;
 use tokio::fs::{self, File};
-use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind, ReadBuf};
 use tokio::sync::{Notify, RwLock};
 use tokio::time::{Instant, Sleep, interval_at, timeout};
 use tracing::{debug, error, info, warn};

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -62,7 +62,9 @@ use std::{
 };
 use time::OffsetDateTime;
 use tokio::fs::{self, File};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind, ReadBuf};
+#[cfg(not(unix))]
+use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind, ReadBuf};
 use tokio::sync::{Notify, RwLock};
 use tokio::time::{Instant, Sleep, interval_at, timeout};
 use tracing::{debug, error, info, warn};


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Restore the `tokio::io::AsyncReadExt` import required by the non-Unix disk read fallback.

Without this trait in scope, Windows builds fail with `E0599` when compiling the existing `read_exact()` call on `tokio::fs::File`. This change only restores compilation and does not alter runtime behavior.

## Verification

- `cargo fmt --all --check`
- `cargo build --release -p rustfs`
- `make pre-commit`

The release build was verified on `windows-x86_64`.

## Impact

Restores Windows compilation. No API, configuration, storage format, or runtime behavior changes are expected.

## Additional Notes
