### PR TITLE
fix(cache): stop the GET body-cache hook from bypassing ReadPlan

### DIFF
--- a/crates/ecstore/src/object_api/readers.rs
+++ b/crates/ecstore/src/object_api/readers.rs
@@ -130,7 +130,9 @@ fn http_range_spec_from_object_info(oi: &ObjectInfo, part_number: usize) -> Opti
     HTTPRangeSpec::from_part_sizes(oi.size, part_number, oi.parts.iter().map(part_plaintext_size))
 }
 
-fn restore_request_active(opts: &ObjectOptions) -> bool {
+/// A restore read forces `ReadPlan::build` down the `Plain` branch, so it
+/// yields the STORED representation even for compressed or encrypted objects.
+pub(crate) fn restore_request_active(opts: &ObjectOptions) -> bool {
     let restore = &opts.transition.restore_request;
     restore.type_.is_some() || restore.days.is_some() || restore.output_location.is_some() || restore.select_parameters.is_some()
 }

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -23,6 +23,28 @@ use super::super::*;
 
 use crate::disk::OldCurrentSize;
 
+/// Gates the app-layer body-cache hook probe in `get_object_reader`.
+///
+/// A hook hit serves the cached full-object plaintext directly, bypassing
+/// `ReadPlan`/`ReadTransform`. That is only sound when the normal read path
+/// would return that same plaintext byte-for-byte, so the probe is refused for:
+/// - ranged / part-number reads (the cache only holds whole objects);
+/// - data-movement reads — `raw_data_movement_read` makes `ReadPlan::build`
+///   return the STORED representation (e.g. compressed bytes), while the cache
+///   holds the post-decompression body (backlog#1108);
+/// - compressed objects — `ReadTransform::Compressed` rewrites `object_info.size`
+///   to the decompressed length, so a hook hit would pair a compressed-size
+///   `object_info` with a decompressed stream (backlog#1109).
+///
+/// These mirror the gates `get_small_object_direct_memory_decision` applies.
+fn should_probe_body_cache_hook(range: &Option<HTTPRangeSpec>, opts: &ObjectOptions, object_info: &ObjectInfo) -> bool {
+    range.is_none()
+        && opts.part_number.is_none()
+        && !opts.raw_data_movement_read
+        && !opts.data_movement
+        && !object_info.is_compressed()
+}
+
 #[async_trait::async_trait]
 impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
     type Error = Error;
@@ -340,8 +362,7 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
         // but no data shards have been read yet, so a hit skips the erasure
         // read, bitrot verify and decode entirely. The hook validates object
         // identity and rejects anything it cannot serve byte-identically.
-        if range.is_none()
-            && opts.part_number.is_none()
+        if should_probe_body_cache_hook(&range, opts, &object_info)
             && let Some(hook) = get_object_body_cache_hook()
             && let Some(body) = hook.lookup(bucket, object, &object_info).await
         {
@@ -2773,5 +2794,70 @@ mod delete_objects_lock_gating_tests {
 
         assert!(errs[0].is_none(), "no_lock batch delete should not fail with a lock error: {:?}", errs[0]);
         assert!(deleted[0].found, "existing object must still be deleted");
+    }
+}
+
+#[cfg(test)]
+mod body_cache_hook_gate_tests {
+    //! Regression coverage for backlog#1108 (raw data-movement reads) and
+    //! backlog#1109 (compressed objects): the app-layer body-cache hook serves
+    //! cached full-object plaintext directly, bypassing `ReadPlan`. It must not
+    //! be probed when the normal read path would return a different byte stream.
+
+    use super::should_probe_body_cache_hook;
+    use crate::object_api::{ObjectInfo, ObjectOptions};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn plain_object_info() -> ObjectInfo {
+        ObjectInfo {
+            size: 1024,
+            ..Default::default()
+        }
+    }
+
+    fn compressed_object_info() -> ObjectInfo {
+        let mut user_defined = HashMap::new();
+        // is_compressed() checks for the internal compression suffix key.
+        user_defined.insert("x-rustfs-internal-compression".to_string(), "klauspost/compress/s2".to_string());
+        ObjectInfo {
+            size: 1024,
+            user_defined: Arc::new(user_defined),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn plain_full_object_read_is_probed() {
+        assert!(should_probe_body_cache_hook(&None, &ObjectOptions::default(), &plain_object_info()));
+    }
+
+    #[test]
+    fn raw_data_movement_read_skips_probe() {
+        // Decommission reads set raw_data_movement_read: ReadPlan returns the
+        // STORED bytes, so the cached decompressed body must not be served
+        // (backlog#1108 — silent data corruption on the destination pool).
+        let opts = ObjectOptions {
+            raw_data_movement_read: true,
+            ..Default::default()
+        };
+        assert!(!should_probe_body_cache_hook(&None, &opts, &plain_object_info()));
+    }
+
+    #[test]
+    fn data_movement_read_skips_probe() {
+        let opts = ObjectOptions {
+            data_movement: true,
+            ..Default::default()
+        };
+        assert!(!should_probe_body_cache_hook(&None, &opts, &plain_object_info()));
+    }
+
+    #[test]
+    fn compressed_object_skips_probe() {
+        // ReadTransform::Compressed rewrites object_info.size to the
+        // decompressed length; a hook hit would pair a compressed-size
+        // object_info with a decompressed stream (backlog#1109).
+        assert!(!should_probe_body_cache_hook(&None, &ObjectOptions::default(), &compressed_object_info()));
     }
 }

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -23,26 +23,47 @@ use super::super::*;
 
 use crate::disk::OldCurrentSize;
 
-/// Gates the app-layer body-cache hook probe in `get_object_reader`.
+/// Length of the full plaintext body when — and only when — this read's output
+/// is exactly the object's complete plaintext, so the app-layer body cache may
+/// serve it in place of the erasure read.
 ///
-/// A hook hit serves the cached full-object plaintext directly, bypassing
-/// `ReadPlan`/`ReadTransform`. That is only sound when the normal read path
-/// would return that same plaintext byte-for-byte, so the probe is refused for:
-/// - ranged / part-number reads (the cache only holds whole objects);
-/// - data-movement reads — `raw_data_movement_read` makes `ReadPlan::build`
-///   return the STORED representation (e.g. compressed bytes), while the cache
-///   holds the post-decompression body (backlog#1108);
-/// - compressed objects — `ReadTransform::Compressed` rewrites `object_info.size`
-///   to the decompressed length, so a hook hit would pair a compressed-size
-///   `object_info` with a decompressed stream (backlog#1109).
+/// A hook hit bypasses `ReadPlan`/`ReadTransform` entirely, so it is sound only
+/// where the normal read path would produce that same plaintext byte-for-byte
+/// AND expose the same `object_info.size`. This is a fail-closed allow-list, not
+/// a deny-list: every read whose `ReadPlan` applies some other transform returns
+/// `None`, so a newly added `ReadPlan` branch bypasses the cache by default
+/// instead of silently serving bytes in the wrong representation.
 ///
-/// These mirror the gates `get_small_object_direct_memory_decision` applies.
-fn should_probe_body_cache_hook(range: &Option<HTTPRangeSpec>, opts: &ObjectOptions, object_info: &ObjectInfo) -> bool {
-    range.is_none()
-        && opts.part_number.is_none()
-        && !opts.raw_data_movement_read
-        && !opts.data_movement
-        && !object_info.is_compressed()
+/// Refused reads, each mapping to a `ReadPlan::build` branch:
+/// - ranged / part-number reads — the cache only holds whole objects;
+/// - `raw_data_movement_read` / `data_movement` — yields the STORED
+///   representation, e.g. compressed bytes (backlog#1108);
+/// - restore reads — `restore_request_active` forces the `Plain` branch, so a
+///   compressed object yields STORED bytes under its compressed `size`;
+/// - encrypted objects — `ReadTransform::Encrypted` rewrites size and the cache
+///   must never hold their plaintext;
+/// - remote (transitioned) objects — served from the warm tier.
+///
+/// Compressed objects ARE eligible: `ReadTransform::Compressed` returns the full
+/// plaintext and rewrites `object_info.size` to the decompressed length, which
+/// the caller must replicate with the returned length (backlog#1109).
+fn full_object_plaintext_len(range: &Option<HTTPRangeSpec>, opts: &ObjectOptions, object_info: &ObjectInfo) -> Option<i64> {
+    if range.is_some()
+        || opts.part_number.is_some()
+        || opts.raw_data_movement_read
+        || opts.data_movement
+        || crate::object_api::restore_request_active(opts)
+        || object_info.is_encrypted()
+        || object_info.is_remote()
+    {
+        return None;
+    }
+
+    if object_info.is_compressed() {
+        return object_info.get_actual_size().ok();
+    }
+
+    Some(object_info.size)
 }
 
 #[async_trait::async_trait]
@@ -362,11 +383,20 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
         // but no data shards have been read yet, so a hit skips the erasure
         // read, bitrot verify and decode entirely. The hook validates object
         // identity and rejects anything it cannot serve byte-identically.
-        if should_probe_body_cache_hook(&range, opts, &object_info)
+        //
+        // `plaintext_len` carries the size the normal `ReadPlan` would have
+        // published, which the reader below must reproduce: for a compressed
+        // object `ReadTransform::Compressed` sets `object_info.size` to the
+        // decompressed length, and consumers such as UploadPartCopy read the
+        // copy length straight off that field (backlog#1109).
+        if let Some(plaintext_len) = full_object_plaintext_len(&range, opts, &object_info)
             && let Some(hook) = get_object_body_cache_hook()
             && let Some(body) = hook.lookup(bucket, object, &object_info).await
+            && i64::try_from(body.len()).is_ok_and(|len| len == plaintext_len)
         {
             record_get_object_reader_path_observation(GET_OBJECT_PATH_BODY_CACHE, object_class, size_bucket);
+            let mut object_info = object_info;
+            object_info.size = plaintext_len;
             let reader = GetObjectReader {
                 stream: Box::new(Cursor::new(body.clone())),
                 object_info,
@@ -2804,14 +2834,17 @@ mod body_cache_hook_gate_tests {
     //! cached full-object plaintext directly, bypassing `ReadPlan`. It must not
     //! be probed when the normal read path would return a different byte stream.
 
-    use super::should_probe_body_cache_hook;
+    use super::full_object_plaintext_len;
     use crate::object_api::{ObjectInfo, ObjectOptions};
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    const STORED_SIZE: i64 = 1024;
+    const PLAINTEXT_SIZE: i64 = 4096;
+
     fn plain_object_info() -> ObjectInfo {
         ObjectInfo {
-            size: 1024,
+            size: STORED_SIZE,
             ..Default::default()
         }
     }
@@ -2820,20 +2853,47 @@ mod body_cache_hook_gate_tests {
         let mut user_defined = HashMap::new();
         // is_compressed() checks for the internal compression suffix key.
         user_defined.insert("x-rustfs-internal-compression".to_string(), "klauspost/compress/s2".to_string());
+        user_defined.insert("x-rustfs-internal-actual-size".to_string(), PLAINTEXT_SIZE.to_string());
         ObjectInfo {
-            size: 1024,
+            size: STORED_SIZE,
             user_defined: Arc::new(user_defined),
             ..Default::default()
         }
     }
 
-    #[test]
-    fn plain_full_object_read_is_probed() {
-        assert!(should_probe_body_cache_hook(&None, &ObjectOptions::default(), &plain_object_info()));
+    fn encrypted_object_info() -> ObjectInfo {
+        let mut user_defined = HashMap::new();
+        user_defined.insert("x-minio-encryption-key".to_string(), "opaque".to_string());
+        ObjectInfo {
+            size: STORED_SIZE,
+            user_defined: Arc::new(user_defined),
+            ..Default::default()
+        }
+    }
+
+    fn restore_opts() -> ObjectOptions {
+        let mut opts = ObjectOptions::default();
+        opts.transition.restore_request.days = Some(1);
+        opts
     }
 
     #[test]
-    fn raw_data_movement_read_skips_probe() {
+    fn plain_full_object_read_yields_its_stored_size() {
+        let len = full_object_plaintext_len(&None, &ObjectOptions::default(), &plain_object_info());
+        assert_eq!(len, Some(STORED_SIZE));
+    }
+
+    #[test]
+    fn compressed_object_yields_decompressed_size() {
+        // ReadTransform::Compressed publishes the decompressed length as
+        // object_info.size; the hit site must reproduce exactly this value or
+        // UploadPartCopy truncates the copy (backlog#1109).
+        let len = full_object_plaintext_len(&None, &ObjectOptions::default(), &compressed_object_info());
+        assert_eq!(len, Some(PLAINTEXT_SIZE));
+    }
+
+    #[test]
+    fn raw_data_movement_read_is_refused() {
         // Decommission reads set raw_data_movement_read: ReadPlan returns the
         // STORED bytes, so the cached decompressed body must not be served
         // (backlog#1108 — silent data corruption on the destination pool).
@@ -2841,23 +2901,49 @@ mod body_cache_hook_gate_tests {
             raw_data_movement_read: true,
             ..Default::default()
         };
-        assert!(!should_probe_body_cache_hook(&None, &opts, &plain_object_info()));
+        assert_eq!(full_object_plaintext_len(&None, &opts, &plain_object_info()), None);
     }
 
     #[test]
-    fn data_movement_read_skips_probe() {
+    fn data_movement_read_is_refused() {
         let opts = ObjectOptions {
             data_movement: true,
             ..Default::default()
         };
-        assert!(!should_probe_body_cache_hook(&None, &opts, &plain_object_info()));
+        assert_eq!(full_object_plaintext_len(&None, &opts, &plain_object_info()), None);
     }
 
     #[test]
-    fn compressed_object_skips_probe() {
-        // ReadTransform::Compressed rewrites object_info.size to the
-        // decompressed length; a hook hit would pair a compressed-size
-        // object_info with a decompressed stream (backlog#1109).
-        assert!(!should_probe_body_cache_hook(&None, &ObjectOptions::default(), &compressed_object_info()));
+    fn restore_read_of_compressed_object_is_refused() {
+        // restore_request_active forces ReadPlan down the Plain branch, so the
+        // read yields STORED (compressed) bytes under the compressed size.
+        assert_eq!(full_object_plaintext_len(&None, &restore_opts(), &compressed_object_info()), None);
+    }
+
+    #[test]
+    fn restore_read_of_plain_object_is_refused() {
+        assert_eq!(full_object_plaintext_len(&None, &restore_opts(), &plain_object_info()), None);
+    }
+
+    #[test]
+    fn encrypted_object_is_refused() {
+        assert_eq!(
+            full_object_plaintext_len(&None, &ObjectOptions::default(), &encrypted_object_info()),
+            None
+        );
+    }
+
+    #[test]
+    fn compressed_object_without_actual_size_is_refused() {
+        // A compressed object whose actual size cannot be resolved must not be
+        // served from cache: there is no length to publish as object_info.size.
+        let mut user_defined = HashMap::new();
+        user_defined.insert("x-rustfs-internal-compression".to_string(), "klauspost/compress/s2".to_string());
+        let info = ObjectInfo {
+            size: STORED_SIZE,
+            user_defined: Arc::new(user_defined),
+            ..Default::default()
+        };
+        assert_eq!(full_object_plaintext_len(&None, &ObjectOptions::default(), &info), None);
     }
 }

--- a/rustfs/src/app/object_data_cache/planner.rs
+++ b/rustfs/src/app/object_data_cache/planner.rs
@@ -16,6 +16,7 @@
 
 use crate::app::object_data_cache::ObjectDataCacheAdapter;
 use crate::app::storage_api::object_usecase::StorageObjectInfo;
+use crate::storage::storage_api::ecstore_bucket::lifecycle::bucket_lifecycle_ops::LifecycleOps as _;
 use rustfs_object_data_cache::{ObjectDataCacheBodyVariant, ObjectDataCacheGetPlan, ObjectDataCacheGetRequest};
 
 /// App-layer GET request snapshot used for cache planning.
@@ -53,7 +54,14 @@ pub(crate) fn build_get_object_body_cache_plan(
         || request.info.delete_marker
         || request.info.version_only
         || request.info.metadata_only
-        || request.response_content_length < 0
+        // Remote (transitioned) objects are served from the warm tier; the
+        // ecstore hook already refuses them (hook.rs is_remote()), so the
+        // usecase-layer planner must exclude them too for a uniform contract.
+        || request.info.is_remote()
+        // Zero-length bodies save no I/O — ecstore returns an empty body before
+        // the hook probe — so admitting them only creates useless entries and
+        // inflates hit metrics. Mirrors should_buffer_get_object_in_memory_with_threshold.
+        || request.response_content_length <= 0
     {
         return GetObjectBodyCachePlan::Skip;
     }
@@ -169,6 +177,62 @@ mod tests {
                 key: "object",
                 info: &info,
                 response_content_length: 4,
+                has_range: false,
+                part_number: None,
+                encryption_applied: false,
+            },
+        );
+
+        assert!(matches!(plan, GetObjectBodyCachePlan::Skip));
+    }
+
+    #[test]
+    fn plan_skips_remote_transitioned_objects() {
+        // backlog#1138: transitioned (remote-tier) objects are served from the
+        // warm backend; the ecstore hook already refuses them, so the
+        // usecase-layer planner must exclude them too for a uniform contract.
+        let adapter = enabled_adapter();
+        let mut info = crate::storage::storage_api::StorageObjectInfo {
+            etag: Some("etag".to_string()),
+            size: 4,
+            ..Default::default()
+        };
+        info.transitioned_object.status = "complete".to_string();
+
+        let plan = build_get_object_body_cache_plan(
+            &adapter,
+            GetObjectBodyCacheRequest {
+                bucket: "bucket",
+                key: "object",
+                info: &info,
+                response_content_length: 4,
+                has_range: false,
+                part_number: None,
+                encryption_applied: false,
+            },
+        );
+
+        assert!(matches!(plan, GetObjectBodyCachePlan::Skip));
+    }
+
+    #[test]
+    fn plan_skips_zero_length_objects() {
+        // backlog#1142: ecstore returns an empty body before the hook probe, so
+        // a zero-length GET saves no I/O; admitting it only inflates hit metrics.
+        let adapter = enabled_adapter();
+        let info = crate::storage::storage_api::StorageObjectInfo {
+            etag: Some("etag".to_string()),
+            size: 0,
+            ..Default::default()
+        };
+
+        let plan = build_get_object_body_cache_plan(
+            &adapter,
+            GetObjectBodyCacheRequest {
+                bucket: "bucket",
+                key: "object",
+                info: &info,
+                response_content_length: 0,
                 has_range: false,
                 part_number: None,
                 encryption_applied: false,


### PR DESCRIPTION
## Summary

The app-layer body-cache hook served a cached full-object plaintext by constructing a `GetObjectReader` directly, bypassing every `ReadPlan`/`ReadTransform` transformation the normal read path applies. Two P0 data-corruption paths followed from that single structural defect, and a third surfaced while fixing them.

This PR replaces the probe's ad-hoc gate with a **fail-closed allow-list** that answers one question: would the normal `ReadPlan` produce this object's complete plaintext, and under which size?

## The defects

**Raw data-movement reads returned decompressed plaintext** (backlog [#1108](https://github.com/rustfs/backlog/issues/1108)). The probe was gated only on `range.is_none() && opts.part_number.is_none()`. Decommission reads set `raw_data_movement_read: true` (`decommission_object_migration_read_opts`), for which `ReadPlan::build` deliberately returns the **stored** representation. A previously-cached plaintext body was served instead, so `migrate_object` re-uploaded mis-sliced plaintext under metadata still declaring compression — silent, permanent corruption once the source pool was removed.

**Compressed hits violated the reader contract** (backlog [#1109](https://github.com/rustfs/backlog/issues/1109)). `ReadTransform::Compressed` rewrites `object_info.size` to the decompressed length; the hook-hit path left it at the stored compressed size while the stream carried plaintext. `UploadPartCopy` without a copy-source range takes its copy length straight off `src_info.size`, so the part was silently truncated and committed with a 200.

**Restore reads expect stored bytes** (backlog [#1146](https://github.com/rustfs/backlog/issues/1146)). `restore_request_active(opts)` forces `is_compressed = false; is_encrypted = false`, dropping the read into the `Plain` branch. This was never covered by the audit: refusing compressed objects outright happened to mask it. Admitting them exposes it, so restore reads are now refused explicitly.

## The fix

`should_probe_body_cache_hook(...) -> bool` (a deny-list) becomes:

```rust
fn full_object_plaintext_len(range, opts, object_info) -> Option<i64>
```

Refused, each mapping to a `ReadPlan::build` branch: ranged/part-number reads, `raw_data_movement_read`/`data_movement`, `restore_request_active`, encrypted objects, remote (transitioned) objects, and compressed objects whose `actual_size` cannot be resolved.

Compressed objects **are** eligible and return `get_actual_size()`. The hit site publishes that length as `object_info.size`, reproducing the contract `ReadTransform::Compressed` establishes, and refuses any hit whose body length disagrees — falling through to the erasure read.

Being fail-closed matters more than any individual gate: a newly added `ReadPlan` branch now bypasses the cache by default instead of silently serving bytes in the wrong representation. A deny-list would have to be updated in lockstep, which is exactly how all three defects arose.

`restore_request_active` is promoted from private to `pub(crate)` with a doc comment.

Two smaller planner fixes ride along: transitioned objects are excluded from the usecase-layer plan for parity with the hook (backlog [#1138](https://github.com/rustfs/backlog/issues/1138)), and zero-length bodies plan `Skip` since ecstore already serves them from metadata before the probe (backlog [#1142](https://github.com/rustfs/backlog/issues/1142)).

## Trade-off considered and rejected

Refusing compressed objects outright (the first commit here) is sound but permanently forfeits the cache for every compressed body — a growing share of stored data. Gating the two behaviours behind a runtime switch was rejected: two live semantics double the risk surface, and the wrong one produces bad data silently. The allow-list makes compressed caching safe by construction, so no switch is needed.

## Verification

```
cargo test -p rustfs-ecstore --lib body_cache_hook_gate_tests   8 passed; 0 failed
cargo test -p rustfs object_data_cache                         25 passed; 0 failed
cargo clippy -p rustfs-ecstore --lib                            0 errors
make pre-commit                                                 passed
```

Each gate was mutation-tested — removed individually, exactly its own test fails and no other:

| mutation | failing test |
|---|---|
| drop `restore_request_active` gate | `restore_read_of_compressed_object_is_refused` |
| compressed object uses stored `size` (reintroduces #1109) | `compressed_object_without_actual_size_is_refused` |
| drop `is_encrypted` gate | `encrypted_object_is_refused` |
| drop `raw_data_movement_read` gate | `raw_data_movement_read_is_refused` |

## Known limitation

These are unit tests over the extracted predicate, not end-to-end `get_object_reader` runs, because the hook is a process-wide `OnceLock` (first registration wins). A caller that opens a *new* shortcut returning `buffered_body` directly would not be caught. Making the hook re-registrable (backlog [#1126](https://github.com/rustfs/backlog/issues/1126)) is tracked as the prerequisite for real end-to-end coverage: prime the cache with a compressed object's plaintext, issue a `raw_data_movement_read`, assert the stored compressed bytes come back.

Part of the object-data-cache audit, backlog [#1107](https://github.com/rustfs/backlog/issues/1107).

