### PR TITLE
fix(ecstore): roll back delete on set-level quorum failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "rustfs-uring"
 version = "0.1.0"
-source = "git+https://github.com/rustfs/uring?rev=39018c09cde98b380658f1a1511349a3574daddf#39018c09cde98b380658f1a1511349a3574daddf"
+source = "git+https://github.com/rustfs/uring?rev=f577ba0bfd6c3d74f9bdc54b573b8fcb45d6bc22#f577ba0bfd6c3d74f9bdc54b573b8fcb45d6bc22"
 dependencies = [
  "io-uring",
  "libc",

--- a/crates/ecstore/src/disk/disk_store.rs
+++ b/crates/ecstore/src/disk/disk_store.rs
@@ -813,6 +813,7 @@ impl LocalDiskWrapper {
                     immediate: false,
                     undo_write: false,
                     old_data_dir: None,
+                    ..Default::default()
                 },
             )
             .await?;

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -19,8 +19,9 @@ use crate::disk::{
     BUCKET_META_PREFIX, CHECK_PART_FILE_CORRUPT, CHECK_PART_FILE_NOT_FOUND, CHECK_PART_SUCCESS, CHECK_PART_UNKNOWN,
     CHECK_PART_VOLUME_NOT_FOUND, CheckPartsResp, DeleteOptions, DiskAPI, DiskInfo, DiskInfoOptions, DiskLocation, DiskMetrics,
     FileInfoVersions, FileReader, FileWriter, MmapCopyStageMetrics, OldCurrentSize, RUSTFS_META_BUCKET, RUSTFS_META_TMP_BUCKET,
-    RUSTFS_META_TMP_DELETED_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions, RenameDataResp, STORAGE_FORMAT_FILE,
-    STORAGE_FORMAT_FILE_BACKUP, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, conv_part_err_to_int,
+    RUSTFS_META_TMP_DELETED_BUCKET, RUSTFS_META_TMP_ROLLBACK_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions,
+    RenameDataResp, STORAGE_FORMAT_FILE, STORAGE_FORMAT_FILE_BACKUP, UpdateMetadataOpts, VolumeInfo, WalkDirOptions,
+    conv_part_err_to_int,
     endpoint::Endpoint,
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
@@ -3371,6 +3372,95 @@ impl LocalDisk {
     //     })
     // }
 
+    // --- delete quorum-rollback staging helpers (backlog#864) ---
+
+    /// Absolute path of a rollback staging token directory on this disk.
+    fn rollback_token_dir_path(&self, token: Uuid) -> Result<PathBuf> {
+        self.get_object_path(RUSTFS_META_TMP_ROLLBACK_BUCKET, token.to_string().as_str())
+    }
+
+    /// prepare: record the create-from-absent sentinel (no xl.meta backup).
+    async fn stage_created_from_absent(&self, token: Uuid) -> Result<()> {
+        let tdir = self.rollback_token_dir_path(token)?;
+        fs::create_dir_all(&tdir).await.map_err(to_volume_error)?;
+        fs::write(tdir.join(".created_from_absent"), b"")
+            .await
+            .map_err(to_file_error)?;
+        Ok(())
+    }
+
+    /// prepare: back up the pre-delete `xl.meta` into the token dir and return it.
+    async fn stage_backup_meta(&self, token: Uuid, buf: &[u8]) -> Result<PathBuf> {
+        let tdir = self.rollback_token_dir_path(token)?;
+        fs::create_dir_all(&tdir).await.map_err(to_volume_error)?;
+        fs::write(tdir.join(STORAGE_FORMAT_FILE), buf).await.map_err(to_file_error)?;
+        Ok(tdir)
+    }
+
+    /// undo: self-describing rollback keyed by the staged token dir. A missing
+    /// token dir is a benign idempotent no-op (this disk never staged anything).
+    async fn undo_staged_delete(&self, volume: &str, path: &str, token: Uuid) -> Result<()> {
+        let tdir = self.rollback_token_dir_path(token)?;
+        if !os::file_exists(&tdir) {
+            warn!(disk = %self.endpoint, %token, "undo_delete: no staged token dir, treating as no-op");
+            return Ok(());
+        }
+
+        let volume_dir = self.get_bucket_path(volume)?;
+        let file_path = self.get_object_path(volume, path)?;
+        let xl_path = path_join(&[file_path.as_path(), Path::new(STORAGE_FORMAT_FILE)]);
+
+        if os::file_exists(tdir.join(".created_from_absent")) {
+            // absent leg: remove the phantom marker created from nothing.
+            if let Err(err) = self.delete_file(&volume_dir, &xl_path, false, false).await
+                && err != DiskError::FileNotFound
+                && err != DiskError::VolumeNotFound
+            {
+                warn!(disk = %self.endpoint, %token, ?err, "undo_delete: failed to remove phantom marker");
+            }
+        } else if os::file_exists(tdir.join(STORAGE_FORMAT_FILE)) {
+            // restore leg: rename the backup xl.meta back, then each staged data-dir.
+            // base_dir is the bucket dir (not the object dir): a branch-B delete may
+            // have removed the object dir, and the rename must recreate it.
+            let backup_meta = tdir.join(STORAGE_FORMAT_FILE);
+            rename_all(&backup_meta, &xl_path, &volume_dir).await?;
+
+            let mut rd = fs::read_dir(&tdir).await.map_err(to_volume_error)?;
+            while let Some(entry) = rd.next_entry().await.map_err(to_volume_error)? {
+                let name = entry.file_name();
+                if name == ".created_from_absent" {
+                    continue;
+                }
+                let dst = path_join(&[file_path.as_path(), Path::new(&name)]);
+                if let Err(err) = rename_all(entry.path(), &dst, &volume_dir).await {
+                    warn!(disk = %self.endpoint, %token, ?err, "undo_delete: failed to restore staged data-dir");
+                }
+            }
+        }
+
+        // best-effort cleanup: leftover staging is reclaimed by the orphan sweeper.
+        if let Err(err) = fs::remove_dir_all(&tdir).await
+            && err.kind() != ErrorKind::NotFound
+        {
+            warn!(disk = %self.endpoint, %token, ?err, "undo_delete: failed to clean token dir");
+        }
+        Ok(())
+    }
+
+    /// commit: drain the staged token dir to trash once quorum is reached. A
+    /// missing token dir is a benign no-op.
+    async fn commit_staged_delete(&self, token: Uuid) -> Result<()> {
+        let tdir = self.rollback_token_dir_path(token)?;
+        if os::file_exists(&tdir)
+            && let Err(err) = self.move_to_trash(&tdir, true, false).await
+            && err != DiskError::FileNotFound
+            && err != DiskError::VolumeNotFound
+        {
+            warn!(disk = %self.endpoint, %token, ?err, "commit_delete: failed to drain staged token dir to trash");
+        }
+        Ok(())
+    }
+
     async fn move_to_trash(&self, delete_path: &PathBuf, recursive: bool, immediate_purge: bool) -> Result<()> {
         // if recursive {
         //     remove_all_std(delete_path).map_err(to_volume_error)?;
@@ -3699,7 +3789,21 @@ impl LocalDisk {
         Ok((bytes, modtime))
     }
 
-    async fn delete_versions_internal(&self, volume: &str, path: &str, fis: &[FileInfo]) -> Result<()> {
+    async fn delete_versions_internal(
+        &self,
+        volume: &str,
+        path: &str,
+        fis: &[FileInfo],
+        stage_rollback: bool,
+        token: Option<Uuid>,
+    ) -> Result<()> {
+        // test-only fault injection (design §7.1): fail before staging so the
+        // object on this disk is provably untouched. Compiled out in production.
+        #[cfg(test)]
+        if stage_rollback && delete_fault::should_fail_early(volume, self.endpoint.disk_idx as usize) {
+            return Err(DiskError::FaultyDisk);
+        }
+
         let volume_dir = self.get_bucket_path(volume)?;
         let xlpath = self.get_object_path(volume, format!("{path}/{STORAGE_FORMAT_FILE}").as_str())?;
 
@@ -3712,6 +3816,20 @@ impl LocalDisk {
         let mut fm = FileMeta::default();
 
         fm.unmarshal_msg(&data)?;
+
+        // #864 prepare: an object exists on this disk, so back up its pre-delete
+        // xl.meta once before any destructive change. Absent disks returned above
+        // (FileNotFound / empty data) never create a token dir, so their undo is a
+        // benign no-op (design §2.3). All this object's data-dirs share one token.
+        let staged_dir = if stage_rollback {
+            if let Some(token) = token {
+                Some(self.stage_backup_meta(token, &data).await?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
         for fi in fis.iter() {
             let data_dir = match fm.delete_version(fi) {
@@ -3731,7 +3849,10 @@ impl LocalDisk {
                 let _ = fm.data.remove(vec![vid, dir]);
 
                 let dir_path = self.get_object_path(volume, format!("{path}/{dir}").as_str())?;
-                if let Err(err) = self.move_to_trash(&dir_path, true, false).await
+                if let Some(tdir) = staged_dir.as_ref() {
+                    let staged_data = path_join(&[tdir.as_path(), Path::new(dir.to_string().as_str())]);
+                    rename_all_ignore_missing_source(&dir_path, &staged_data, tdir.as_path()).await?;
+                } else if let Err(err) = self.move_to_trash(&dir_path, true, false).await
                     && !(err == DiskError::FileNotFound || err == DiskError::VolumeNotFound)
                 {
                     return Err(err);
@@ -3742,15 +3863,22 @@ impl LocalDisk {
         // Remove xl.meta when no versions remain
         if fm.versions.is_empty() {
             self.delete_file(&volume_dir, &xlpath, true, false).await?;
-            return Ok(());
+        } else {
+            // Update xl.meta atomically: a concurrent reader or crash mid-write must
+            // never observe a truncated xl.meta for versions that were not deleted.
+            let buf = fm.marshal_msg()?;
+
+            self.write_all_meta(volume, format!("{path}/{STORAGE_FORMAT_FILE}").as_str(), &buf, true)
+                .await?;
         }
 
-        // Update xl.meta atomically: a concurrent reader or crash mid-write must
-        // never observe a truncated xl.meta for versions that were not deleted.
-        let buf = fm.marshal_msg()?;
-
-        self.write_all_meta(volume, format!("{path}/{STORAGE_FORMAT_FILE}").as_str(), &buf, true)
-            .await?;
+        // test-only fault injection (design §7.1): model an errored-but-staged disk
+        // that applied the delete then reports failure; the set-layer undo fan-out
+        // must still restore it. Compiled out in production.
+        #[cfg(test)]
+        if stage_rollback && delete_fault::should_fail_after_stage(volume, self.endpoint.disk_idx as usize) {
+            return Err(DiskError::FaultyDisk);
+        }
 
         Ok(())
     }
@@ -6310,6 +6438,31 @@ impl DiskAPI for LocalDisk {
                 .await;
         }
 
+        // #864 rollback-token interception, placed AFTER the slash delegation so a
+        // token can never target a directory/slash path (delete_prefix is excluded,
+        // see design §5). Directory objects reach delete_version already encoded (no
+        // leading slash), so the assert pins the invariant for tests.
+        if opts.undo_delete.is_some() || opts.commit_delete.is_some() {
+            debug_assert!(
+                !path.starts_with(SLASH_SEPARATOR),
+                "rollback token must never target a slash/directory path"
+            );
+        }
+        if let Some(token) = opts.undo_delete {
+            return self.undo_staged_delete(volume, path, token).await;
+        }
+        if let Some(token) = opts.commit_delete {
+            return self.commit_staged_delete(token).await;
+        }
+
+        // test-only fault injection (design §7.1): force a delete failure on
+        // selected disks BEFORE any staging so the object is provably untouched.
+        // Compiled out of production builds (`#[cfg(test)]`), so zero prod impact.
+        #[cfg(test)]
+        if opts.stage_rollback && delete_fault::should_fail_early(volume, self.endpoint.disk_idx as usize) {
+            return Err(DiskError::FaultyDisk);
+        }
+
         let volume_dir = self.get_bucket_path(volume)?;
 
         let file_path = self.get_object_path(volume, path)?;
@@ -6325,6 +6478,15 @@ impl DiskAPI for LocalDisk {
                 }
 
                 if fi.deleted && force_del_marker {
+                    // create-from-absent leg: a fresh delete-marker is written where
+                    // no object existed. Record an absent sentinel (no xl.meta backup)
+                    // so an undo removes the phantom marker instead of restoring a
+                    // non-existent backup (design §2.2 / §3).
+                    if opts.stage_rollback
+                        && let Some(token) = opts.rollback_token
+                    {
+                        self.stage_created_from_absent(token).await?;
+                    }
                     return self.write_metadata("", volume, path, fi).await;
                 }
 
@@ -6337,6 +6499,20 @@ impl DiskAPI for LocalDisk {
         };
 
         let mut meta = FileMeta::load(&buf)?;
+
+        // #864 prepare: back up the pre-delete xl.meta verbatim before any
+        // destructive change. Not fsynced (design §4): in-process undo relies on
+        // same-disk rename, and crash recovery is delegated to heal.
+        let staged_dir = if opts.stage_rollback {
+            if let Some(token) = opts.rollback_token {
+                Some(self.stage_backup_meta(token, &buf).await?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let old_dir = meta.delete_version(&fi)?;
 
         if let Some(uuid) = old_dir {
@@ -6346,7 +6522,12 @@ impl DiskAPI for LocalDisk {
             let old_path = path_join(&[file_path.as_path(), Path::new(uuid.to_string().as_str())]);
             check_path_length(old_path.to_string_lossy().as_ref())?;
 
-            if let Err(err) = self.move_to_trash(&old_path, true, false).await
+            if let Some(tdir) = staged_dir.as_ref() {
+                // stage (same-disk rename) the data-dir into the token dir rather
+                // than trashing it, so an undo can rename it back.
+                let staged_data = path_join(&[tdir.as_path(), Path::new(uuid.to_string().as_str())]);
+                rename_all_ignore_missing_source(&old_path, &staged_data, tdir.as_path()).await?;
+            } else if let Err(err) = self.move_to_trash(&old_path, true, false).await
                 && err != DiskError::FileNotFound
                 && err != DiskError::VolumeNotFound
             {
@@ -6367,22 +6548,42 @@ impl DiskAPI for LocalDisk {
 
         if !meta.versions.is_empty() {
             let buf = meta.marshal_msg()?;
-            return self
-                .write_all_meta(volume, format!("{path}{SLASH_SEPARATOR}{STORAGE_FORMAT_FILE}").as_str(), &buf, true)
-                .await;
+            self.write_all_meta(volume, format!("{path}{SLASH_SEPARATOR}{STORAGE_FORMAT_FILE}").as_str(), &buf, true)
+                .await?;
+        } else {
+            self.delete_file(&volume_dir, &xl_path, true, false).await?;
         }
 
-        self.delete_file(&volume_dir, &xl_path, true, false).await
+        // test-only fault injection (design §7.1): the delete has been applied and
+        // the rollback content is staged; model an "errored-but-staged" disk that
+        // reports failure so the set-layer undo fan-out must still restore it.
+        #[cfg(test)]
+        if opts.stage_rollback && delete_fault::should_fail_after_stage(volume, self.endpoint.disk_idx as usize) {
+            return Err(DiskError::FaultyDisk);
+        }
+
+        Ok(())
     }
+
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn delete_versions(&self, volume: &str, versions: Vec<FileInfoVersions>, _opts: DeleteOptions) -> Vec<Option<Error>> {
+    async fn delete_versions(&self, volume: &str, versions: Vec<FileInfoVersions>, opts: DeleteOptions) -> Vec<Option<Error>> {
         let mut errs = Vec::with_capacity(versions.len());
         for _ in 0..versions.len() {
             errs.push(None);
         }
 
         for (i, ver) in versions.iter().enumerate() {
-            if let Err(e) = self.delete_versions_internal(volume, ver.name.as_str(), &ver.versions).await {
+            // #864 batch prepare: each (op, object) carries a unique token, aligned
+            // by position with the `versions` array (never derived from name).
+            let token = if opts.stage_rollback {
+                opts.rollback_tokens.get(i).copied()
+            } else {
+                None
+            };
+            if let Err(e) = self
+                .delete_versions_internal(volume, ver.name.as_str(), &ver.versions, opts.stage_rollback, token)
+                .await
+            {
                 errs[i] = Some(e);
             } else {
                 errs[i] = None;
@@ -6560,6 +6761,65 @@ async fn get_disk_info(drive_path: PathBuf) -> Result<(rustfs_utils::os::DiskInf
     };
 
     Ok((disk_info, root_drive))
+}
+
+/// Test-only fault-injection knob for the delete rollback path (backlog#864,
+/// design §7.1). The delete path has no natural injection point, so set-layer
+/// tests use this to force selected disks (by `disk_idx`) to fail either before
+/// staging (`FAIL_EARLY`) or after apply+stage (`FAIL_AFTER_STAGE`). Gated on
+/// `#[cfg(test)]`, so it is compiled out of production entirely — the seam never
+/// leaks into a release build and does not alter the `Disk` enum's behavior.
+#[cfg(test)]
+pub(crate) mod delete_fault {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+
+    type BucketDiskSet = HashMap<String, HashSet<usize>>;
+
+    fn fail_early() -> &'static Mutex<BucketDiskSet> {
+        static M: OnceLock<Mutex<BucketDiskSet>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+    fn fail_after_stage() -> &'static Mutex<BucketDiskSet> {
+        static M: OnceLock<Mutex<BucketDiskSet>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Arm/disarm are keyed by bucket so an armed fault can only ever hit the
+    /// erasure set under test — unrelated buckets (including other tests running
+    /// in parallel, since delete rollback is on by default) never match. This
+    /// keeps the seam hermetic without serializing the whole delete test surface.
+    pub(crate) fn arm_fail_early(bucket: &str, disk_idxs: &[usize]) {
+        fail_early()
+            .lock()
+            .unwrap()
+            .insert(bucket.to_string(), disk_idxs.iter().copied().collect());
+    }
+    pub(crate) fn arm_fail_after_stage(bucket: &str, disk_idxs: &[usize]) {
+        fail_after_stage()
+            .lock()
+            .unwrap()
+            .insert(bucket.to_string(), disk_idxs.iter().copied().collect());
+    }
+    pub(crate) fn disarm(bucket: &str) {
+        fail_early().lock().unwrap().remove(bucket);
+        fail_after_stage().lock().unwrap().remove(bucket);
+    }
+    pub(crate) fn should_fail_early(bucket: &str, disk_idx: usize) -> bool {
+        fail_early()
+            .lock()
+            .unwrap()
+            .get(bucket)
+            .is_some_and(|s| s.contains(&disk_idx))
+    }
+    pub(crate) fn should_fail_after_stage(bucket: &str, disk_idx: usize) -> bool {
+        fail_after_stage()
+            .lock()
+            .unwrap()
+            .get(bucket)
+            .is_some_and(|s| s.contains(&disk_idx))
+    }
 }
 
 #[cfg(test)]
@@ -8783,7 +9043,7 @@ mod test {
             .await
             .expect("existing metadata should be written");
 
-        disk.delete_versions_internal(bucket, object, &[missing_fi, existing_fi])
+        disk.delete_versions_internal(bucket, object, &[missing_fi, existing_fi], false, None)
             .await
             .expect("missing non-deleted version should not abort deletion");
 
@@ -10578,6 +10838,7 @@ mod test {
             immediate: true,
             undo_write: false,
             old_data_dir: None,
+            ..Default::default()
         };
         disk.delete("test-volume", "test-file.txt", delete_opts)
             .await
@@ -12109,5 +12370,450 @@ mod test {
             mean,
             (reads * shard_mib) as f64 / wall,
         );
+    }
+
+    // backlog#864: disk-layer contract for the delete quorum-rollback.
+    mod delete_rollback_864 {
+        use super::*;
+        use tempfile::tempdir;
+
+        fn rollback_token_dir(root: &std::path::Path, token: Uuid) -> std::path::PathBuf {
+            root.join(RUSTFS_META_TMP_ROLLBACK_BUCKET).join(token.to_string())
+        }
+
+        /// Single-disk scaffold: one single-version object with a real data-dir.
+        async fn seed_single_version(
+            root: &std::path::Path,
+            disk: &LocalDisk,
+            bucket: &str,
+            object: &str,
+        ) -> (Uuid, Uuid, Vec<u8>) {
+            ensure_test_volume(disk, bucket).await;
+            let vid = Uuid::new_v4();
+            let data_dir = Uuid::new_v4();
+            let object_dir = root.join(bucket).join(object);
+            fs::create_dir_all(object_dir.join(data_dir.to_string()))
+                .await
+                .expect("data dir should be created");
+            fs::write(object_dir.join(data_dir.to_string()).join("part.1"), b"payload-864")
+                .await
+                .expect("part should be written");
+            let fi = test_file_info(object, vid, Some(data_dir), None);
+            let original = test_meta(fi);
+            fs::write(object_dir.join(STORAGE_FORMAT_FILE), &original)
+                .await
+                .expect("xl.meta should be written");
+            (vid, data_dir, original)
+        }
+
+        // #1 prepare backs up the original xl.meta + stages the data-dir; the
+        // object enters its deleted state (branch B: last version -> xl.meta gone).
+        #[tokio::test]
+        async fn stage_rollback_backs_up_original_then_applies_delete_branch_b() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/obj");
+            let (vid, data_dir, original) = seed_single_version(dir.path(), &disk, bucket, object).await;
+
+            let token = Uuid::new_v4();
+            disk.delete_version(
+                bucket,
+                object,
+                test_file_info(object, vid, Some(data_dir), None),
+                false,
+                DeleteOptions {
+                    stage_rollback: true,
+                    rollback_token: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("staged delete should succeed");
+
+            let object_dir = dir.path().join(bucket).join(object);
+            assert!(
+                !object_dir.join(STORAGE_FORMAT_FILE).exists(),
+                "xl.meta must be removed after last-version delete"
+            );
+            assert!(
+                !object_dir.join(data_dir.to_string()).exists(),
+                "data-dir must be moved out of object dir"
+            );
+            let tdir = rollback_token_dir(dir.path(), token);
+            assert_eq!(
+                fs::read(tdir.join(STORAGE_FORMAT_FILE))
+                    .await
+                    .expect("backup xl.meta must exist"),
+                original,
+                "rollback backup must be the pre-delete xl.meta verbatim"
+            );
+            assert_eq!(
+                fs::read(tdir.join(data_dir.to_string()).join("part.1"))
+                    .await
+                    .expect("staged data-dir must exist"),
+                b"payload-864",
+                "data-dir must be staged (renamed) into the token dir, not sent to trash"
+            );
+        }
+
+        // #2 undo restores the object byte-for-byte (branch B); token dir cleaned.
+        #[tokio::test]
+        async fn undo_delete_restores_object_byte_for_byte_branch_b() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/obj");
+            let (vid, data_dir, original) = seed_single_version(dir.path(), &disk, bucket, object).await;
+
+            let token = Uuid::new_v4();
+            let fi = test_file_info(object, vid, Some(data_dir), None);
+            disk.delete_version(
+                bucket,
+                object,
+                fi.clone(),
+                false,
+                DeleteOptions {
+                    stage_rollback: true,
+                    rollback_token: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+            disk.delete_version(
+                bucket,
+                object,
+                fi,
+                false,
+                DeleteOptions {
+                    undo_delete: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("undo should succeed");
+
+            let object_dir = dir.path().join(bucket).join(object);
+            assert_eq!(
+                fs::read(object_dir.join(STORAGE_FORMAT_FILE))
+                    .await
+                    .expect("xl.meta restored"),
+                original,
+                "undo must restore the original xl.meta byte-for-byte"
+            );
+            assert_eq!(
+                fs::read(object_dir.join(data_dir.to_string()).join("part.1"))
+                    .await
+                    .expect("data-dir restored"),
+                b"payload-864",
+                "undo must restore the data-dir"
+            );
+            assert!(!rollback_token_dir(dir.path(), token).exists(), "token dir must be cleaned after undo");
+        }
+
+        // #3 undo branch A: other versions remain -> restore the full original xl.meta.
+        #[tokio::test]
+        async fn undo_delete_restores_when_other_versions_remain_branch_a() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/obj");
+            ensure_test_volume(&disk, bucket).await;
+
+            let vid_del = Uuid::new_v4();
+            let vid_keep = Uuid::new_v4();
+            let dd_del = Uuid::new_v4();
+            let dd_keep = Uuid::new_v4();
+            let object_dir = dir.path().join(bucket).join(object);
+            fs::create_dir_all(object_dir.join(dd_del.to_string())).await.unwrap();
+            fs::create_dir_all(object_dir.join(dd_keep.to_string())).await.unwrap();
+
+            let mut meta = FileMeta::default();
+            meta.add_version(test_file_info(object, vid_del, Some(dd_del), None)).unwrap();
+            meta.add_version(test_file_info(object, vid_keep, Some(dd_keep), None))
+                .unwrap();
+            let original = meta.marshal_msg().unwrap();
+            fs::write(object_dir.join(STORAGE_FORMAT_FILE), &original).await.unwrap();
+
+            let token = Uuid::new_v4();
+            let fi_del = test_file_info(object, vid_del, Some(dd_del), None);
+            disk.delete_version(
+                bucket,
+                object,
+                fi_del.clone(),
+                false,
+                DeleteOptions {
+                    stage_rollback: true,
+                    rollback_token: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+            assert!(object_dir.join(STORAGE_FORMAT_FILE).exists());
+
+            disk.delete_version(
+                bucket,
+                object,
+                fi_del,
+                false,
+                DeleteOptions {
+                    undo_delete: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                fs::read(object_dir.join(STORAGE_FORMAT_FILE)).await.unwrap(),
+                original,
+                "undo must restore the full original xl.meta (both versions), not the rewritten subset"
+            );
+        }
+
+        // #4 commit moves the staged content to trash; object stays deleted.
+        #[tokio::test]
+        async fn commit_delete_moves_staged_to_trash() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/obj");
+            let (vid, data_dir, _original) = seed_single_version(dir.path(), &disk, bucket, object).await;
+
+            let token = Uuid::new_v4();
+            let fi = test_file_info(object, vid, Some(data_dir), None);
+            disk.delete_version(
+                bucket,
+                object,
+                fi.clone(),
+                false,
+                DeleteOptions {
+                    stage_rollback: true,
+                    rollback_token: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+            disk.delete_version(
+                bucket,
+                object,
+                fi,
+                false,
+                DeleteOptions {
+                    commit_delete: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+            assert!(
+                !rollback_token_dir(dir.path(), token).exists(),
+                "committed token dir must be drained to trash"
+            );
+            assert!(
+                !dir.path().join(bucket).join(object).join(STORAGE_FORMAT_FILE).exists(),
+                "object stays deleted after commit"
+            );
+            let trash = dir.path().join(RUSTFS_META_TMP_DELETED_BUCKET);
+            let mut rd = fs::read_dir(&trash).await.expect("trash dir should exist");
+            assert!(rd.next_entry().await.unwrap().is_some(), "staged content must land in trash on commit");
+        }
+
+        // #5 create-from-absent leg: staging records a sentinel; undo removes the
+        // phantom marker instead of restoring a non-existent backup.
+        #[tokio::test]
+        async fn stage_rollback_create_from_absent_undo_removes_phantom_marker() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/ghost");
+            ensure_test_volume(&disk, bucket).await;
+
+            let vid = Uuid::new_v4();
+            let fi = FileInfo {
+                name: object.to_string(),
+                version_id: Some(vid),
+                deleted: true,
+                mark_deleted: true,
+                mod_time: Some(OffsetDateTime::now_utc()),
+                ..Default::default()
+            };
+            let token = Uuid::new_v4();
+            disk.delete_version(
+                bucket,
+                object,
+                fi.clone(),
+                true,
+                DeleteOptions {
+                    stage_rollback: true,
+                    rollback_token: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+            let object_dir = dir.path().join(bucket).join(object);
+            assert!(
+                object_dir.join(STORAGE_FORMAT_FILE).exists(),
+                "a fresh delete-marker xl.meta must have been created"
+            );
+            let tdir = rollback_token_dir(dir.path(), token);
+            assert!(
+                tdir.join(".created_from_absent").exists(),
+                "absent sentinel must be recorded (no backup to restore)"
+            );
+            assert!(!tdir.join(STORAGE_FORMAT_FILE).exists(), "create-from-absent leg has no xl.meta backup");
+
+            disk.delete_version(
+                bucket,
+                object,
+                fi,
+                true,
+                DeleteOptions {
+                    undo_delete: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+            assert!(
+                !object_dir.join(STORAGE_FORMAT_FILE).exists(),
+                "undo of a create-from-absent delete must remove the phantom marker, not no-op"
+            );
+            assert!(!tdir.exists(), "token dir cleaned");
+        }
+
+        // #6 undo is idempotent: unknown token dir -> Ok, object untouched.
+        #[tokio::test]
+        async fn undo_delete_is_noop_when_token_dir_absent() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/obj");
+            let (vid, data_dir, original) = seed_single_version(dir.path(), &disk, bucket, object).await;
+
+            disk.delete_version(
+                bucket,
+                object,
+                test_file_info(object, vid, Some(data_dir), None),
+                false,
+                DeleteOptions {
+                    undo_delete: Some(Uuid::new_v4()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("undo with unknown token must be a benign no-op, not an error");
+
+            assert_eq!(
+                fs::read(dir.path().join(bucket).join(object).join(STORAGE_FORMAT_FILE))
+                    .await
+                    .unwrap(),
+                original,
+                "no-op undo must leave the object untouched"
+            );
+        }
+
+        // #7 batch: multiple versions, single token -> all restored on undo.
+        #[tokio::test]
+        async fn delete_versions_internal_multi_version_single_token_undo_restores_all() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/multi");
+            ensure_test_volume(&disk, bucket).await;
+
+            let v1 = Uuid::new_v4();
+            let v2 = Uuid::new_v4();
+            let d1 = Uuid::new_v4();
+            let d2 = Uuid::new_v4();
+            let object_dir = dir.path().join(bucket).join(object);
+            fs::create_dir_all(object_dir.join(d1.to_string())).await.unwrap();
+            fs::create_dir_all(object_dir.join(d2.to_string())).await.unwrap();
+            let mut meta = FileMeta::default();
+            meta.add_version(test_file_info(object, v1, Some(d1), None)).unwrap();
+            meta.add_version(test_file_info(object, v2, Some(d2), None)).unwrap();
+            let original = meta.marshal_msg().unwrap();
+            fs::write(object_dir.join(STORAGE_FORMAT_FILE), &original).await.unwrap();
+
+            let token = Uuid::new_v4();
+            let vers = vec![FileInfoVersions {
+                name: object.to_string(),
+                versions: vec![
+                    test_file_info(object, v1, Some(d1), None),
+                    test_file_info(object, v2, Some(d2), None),
+                ],
+                ..Default::default()
+            }];
+            let errs = disk
+                .delete_versions(
+                    bucket,
+                    vers,
+                    DeleteOptions {
+                        stage_rollback: true,
+                        rollback_tokens: vec![token],
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(errs.iter().all(Option::is_none), "staged batch delete should succeed: {errs:?}");
+            let tdir = rollback_token_dir(dir.path(), token);
+            assert!(tdir.join(d1.to_string()).exists() && tdir.join(d2.to_string()).exists());
+
+            disk.delete_version(
+                bucket,
+                object,
+                test_file_info(object, v1, Some(d1), None),
+                false,
+                DeleteOptions {
+                    undo_delete: Some(token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                fs::read(object_dir.join(STORAGE_FORMAT_FILE)).await.unwrap(),
+                original,
+                "undo must restore the full two-version xl.meta"
+            );
+            assert!(
+                object_dir.join(d1.to_string()).exists() && object_dir.join(d2.to_string()).exists(),
+                "both data-dirs must be restored"
+            );
+        }
+
+        // #8 gate: stage_rollback=false takes the legacy path (no staging dir).
+        #[tokio::test]
+        async fn stage_rollback_false_matches_legacy_delete_and_creates_no_rollback_dir() {
+            let dir = tempdir().unwrap();
+            let endpoint = Endpoint::try_from(dir.path().to_str().unwrap()).unwrap();
+            let disk = LocalDisk::new(&endpoint, false).await.unwrap();
+            let (bucket, object) = ("bucket", "dir/obj");
+            let (vid, data_dir, _original) = seed_single_version(dir.path(), &disk, bucket, object).await;
+
+            disk.delete_version(
+                bucket,
+                object,
+                test_file_info(object, vid, Some(data_dir), None),
+                false,
+                DeleteOptions::default(),
+            )
+            .await
+            .unwrap();
+
+            assert!(!dir.path().join(bucket).join(object).join(STORAGE_FORMAT_FILE).exists());
+            assert!(
+                !dir.path().join(RUSTFS_META_TMP_ROLLBACK_BUCKET).exists(),
+                "legacy path must never create the rollback staging area"
+            );
+        }
     }
 }

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -31,6 +31,14 @@ pub const MIGRATING_META_BUCKET: &str = ".minio.sys";
 pub const RUSTFS_META_MULTIPART_BUCKET: &str = ".rustfs.sys/multipart";
 pub const RUSTFS_META_TMP_BUCKET: &str = ".rustfs.sys/tmp";
 pub const RUSTFS_META_TMP_DELETED_BUCKET: &str = ".rustfs.sys/tmp/.trash";
+/// Staging area for the delete quorum-rollback (backlog#864). Sibling of
+/// `.trash` under `tmp`, deliberately kept separate from the overwrite backup
+/// (`xl.meta.bkp`) so the two rollback mechanisms never share paths. A failed
+/// delete stages the pre-delete `xl.meta` (and its data-dirs) here so an
+/// `undo_delete` fan-out can restore the object; a committed delete drains the
+/// staged content to `.trash`. Like `.trash`, this prefix must be excluded from
+/// data-usage/list/heal traversal.
+pub const RUSTFS_META_TMP_ROLLBACK_BUCKET: &str = ".rustfs.sys/tmp/.rollback";
 pub const BUCKET_META_PREFIX: &str = "buckets";
 pub const FORMAT_CONFIG_FILE: &str = "format.json";
 /// Per-disk marker present while an erasure-set heal is rebuilding this disk.
@@ -882,8 +890,30 @@ pub struct RenameDataResp {
 pub struct DeleteOptions {
     pub recursive: bool,
     pub immediate: bool,
+    /// Overwrite-rollback flag (issue #4107). Reserved for `rename_data` undo;
+    /// never reuse it for the delete rollback below — use `undo_delete` instead.
     pub undo_write: bool,
     pub old_data_dir: Option<Uuid>,
+    // --- delete quorum-rollback (backlog#864) ---
+    // All new fields default to the legacy behavior and carry `#[serde(default)]`
+    // so a peer that predates them (rolling upgrade) still decodes the option.
+    /// prepare: back up the pre-delete `xl.meta` (and stage its data-dirs) into
+    /// the rollback token dir before applying the destructive delete.
+    #[serde(default)]
+    pub stage_rollback: bool,
+    /// prepare token for the single-object delete path.
+    #[serde(default)]
+    pub rollback_token: Option<Uuid>,
+    /// prepare tokens for the batch delete path, aligned by position with the
+    /// `versions` array (one unique token per (op, object)).
+    #[serde(default)]
+    pub rollback_tokens: Vec<Uuid>,
+    /// undo: self-describing restore/removal keyed by the staged token dir.
+    #[serde(default)]
+    pub undo_delete: Option<Uuid>,
+    /// commit: drain the staged token dir to trash once quorum is reached.
+    #[serde(default)]
+    pub commit_delete: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1123,12 +1153,19 @@ mod tests {
             immediate: false,
             undo_write: true,
             old_data_dir: Some(Uuid::new_v4()),
+            ..Default::default()
         };
 
         assert!(opts.recursive);
         assert!(!opts.immediate);
         assert!(opts.undo_write);
         assert!(opts.old_data_dir.is_some());
+        // #864 additions default to the legacy (no-op) behavior.
+        assert!(!opts.stage_rollback);
+        assert!(opts.rollback_token.is_none());
+        assert!(opts.rollback_tokens.is_empty());
+        assert!(opts.undo_delete.is_none());
+        assert!(opts.commit_delete.is_none());
     }
 
     /// Test ReadOptions structure

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -222,6 +222,17 @@ pub const MAX_PARTS_COUNT: usize = 10000;
 pub(crate) const RUSTFS_MULTIPART_BUCKET_KEY: &str = "x-rustfs-internal-multipart-bucket";
 pub(crate) const RUSTFS_MULTIPART_OBJECT_KEY: &str = "x-rustfs-internal-multipart-object";
 const ENV_ISSUE3031_DIAG_ENABLE: &str = "RUSTFS_ISSUE3031_DIAG_ENABLE";
+/// Gate for the delete quorum-rollback (backlog#864). Default on: a delete that
+/// fails to reach write quorum stages then undoes its local changes so the
+/// object survives. Set `RUSTFS_DELETE_ROLLBACK_ENABLE=false` to fall back to
+/// the legacy fail-forward behavior (matches MinIO: leave the partial delete for
+/// heal to converge).
+pub(crate) const ENV_DELETE_ROLLBACK_ENABLE: &str = "RUSTFS_DELETE_ROLLBACK_ENABLE";
+pub(crate) const DEFAULT_DELETE_ROLLBACK_ENABLE: bool = true;
+
+pub(crate) fn delete_rollback_enabled() -> bool {
+    rustfs_utils::get_env_bool(ENV_DELETE_ROLLBACK_ENABLE, DEFAULT_DELETE_ROLLBACK_ENABLE)
+}
 
 struct ObjectLockDiagGuard {
     guard: NamespaceLockGuard,

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -1313,38 +1313,123 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
         let disks = self.disk_inventory().await;
         let write_quorum = disks.len() / 2 + 1;
 
-        let mut futures = Vec::with_capacity(disks.len());
-        let mut errs = Vec::with_capacity(disks.len());
+        // Legacy fail-forward path (RUSTFS_DELETE_ROLLBACK_ENABLE=off): no staging,
+        // no undo — a quorum-failed delete leaves the partial state for heal.
+        if !delete_rollback_enabled() {
+            let mut futures = Vec::with_capacity(disks.len());
+            for disk in disks.iter() {
+                futures.push(async move {
+                    if let Some(disk) = disk {
+                        disk.delete_version(bucket, object, fi.clone(), force_del_marker, DeleteOptions::default())
+                            .await
+                    } else {
+                        Err(DiskError::DiskNotFound)
+                    }
+                });
+            }
+            let errs: Vec<Option<DiskError>> = join_all(futures).await.into_iter().map(|r| r.err()).collect();
+            return resolve_tiered_decommission_write_quorum_result(&errs, write_quorum, bucket, object);
+        }
 
+        // Phase 1 (prepare + apply): each disk stages its pre-delete state under a
+        // shared token before applying the destructive change. force_del_marker is
+        // threaded so the create-from-absent leg also records its sentinel.
+        let token = Uuid::new_v4();
+        let mut futures = Vec::with_capacity(disks.len());
         for disk in disks.iter() {
+            let opts = DeleteOptions {
+                stage_rollback: true,
+                rollback_token: Some(token),
+                ..Default::default()
+            };
             futures.push(async move {
                 if let Some(disk) = disk {
-                    match disk
-                        .delete_version(bucket, object, fi.clone(), force_del_marker, DeleteOptions::default())
-                        .await
-                    {
-                        Ok(r) => Ok(r),
-                        Err(e) => Err(e),
-                    }
+                    disk.delete_version(bucket, object, fi.clone(), force_del_marker, opts).await
                 } else {
                     Err(DiskError::DiskNotFound)
                 }
             });
         }
+        let errs: Vec<Option<DiskError>> = join_all(futures).await.into_iter().map(|r| r.err()).collect();
 
-        let results = join_all(futures).await;
-        for result in results {
-            match result {
-                Ok(_) => {
-                    errs.push(None);
+        let result = resolve_tiered_decommission_write_quorum_result(&errs, write_quorum, bucket, object);
+
+        // Phase 2 (undo | commit). Both fan out unconditionally to every Some disk
+        // (never filtered by `err.is_none()`): each disk self-describes via its
+        // token dir, so unstaged disks no-op and errored-but-staged disks are still
+        // restored. This is the core correctness fix (design §2.4).
+        match &result {
+            Err(_) => {
+                // Undo synchronously, before returning (and, for the locked single
+                // delete, before the write lock is released): the object must not
+                // vanish on a quorum-failed delete.
+                let mut undo_futs = Vec::with_capacity(disks.len());
+                for disk in disks.iter() {
+                    if let Some(disk) = disk.as_ref() {
+                        let disk = disk.clone();
+                        let bucket = bucket.to_string();
+                        let object = object.to_string();
+                        let fi = fi.clone();
+                        undo_futs.push(async move {
+                            disk.delete_version(
+                                &bucket,
+                                &object,
+                                fi,
+                                false,
+                                DeleteOptions {
+                                    undo_delete: Some(token),
+                                    ..Default::default()
+                                },
+                            )
+                            .await
+                        });
+                    }
                 }
-                Err(e) => {
-                    errs.push(Some(e));
+                let undo_error_count = join_all(undo_futs).await.iter().filter(|r| r.is_err()).count();
+                if undo_error_count > 0 {
+                    warn!(
+                        target: "rustfs_ecstore::set_disk",
+                        bucket = %bucket,
+                        object = %object,
+                        undo_error_count,
+                        "delete quorum rollback reported errors (residue left for heal)"
+                    );
                 }
+            }
+            Ok(()) => {
+                // Commit synchronously: drain each disk's staging to trash before
+                // returning. The design left detached-vs-synchronous open; we take
+                // synchronous so no `.rollback` residue outlives a successful delete
+                // (deterministic for callers and avoids capacity/GC races). A failed
+                // commit only leaks staging to the orphan sweeper — it can never
+                // resurrect a deleted object (design §6, #898).
+                let mut commit_futs = Vec::with_capacity(disks.len());
+                for disk in disks.iter() {
+                    if let Some(disk) = disk.as_ref() {
+                        let disk = disk.clone();
+                        let bucket = bucket.to_string();
+                        let object = object.to_string();
+                        let fi = fi.clone();
+                        commit_futs.push(async move {
+                            disk.delete_version(
+                                &bucket,
+                                &object,
+                                fi,
+                                false,
+                                DeleteOptions {
+                                    commit_delete: Some(token),
+                                    ..Default::default()
+                                },
+                            )
+                            .await
+                        });
+                    }
+                }
+                let _ = join_all(commit_futs).await;
             }
         }
 
-        resolve_tiered_decommission_write_quorum_result(&errs, write_quorum, bucket, object)
+        result
     }
 
     #[tracing::instrument(skip(self))]
@@ -1542,6 +1627,16 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
             vers.push(fi_vers);
         }
 
+        // #864 rollback: one unique token per (op, object), aligned by position
+        // with `vers`. All versions of an object share a single token (its whole
+        // xl.meta is backed up once). Empty when rollback is disabled.
+        let rollback_enabled = delete_rollback_enabled();
+        let rollback_tokens: Vec<Uuid> = if rollback_enabled {
+            (0..vers.len()).map(|_| Uuid::new_v4()).collect()
+        } else {
+            Vec::new()
+        };
+
         let disks = self.disks.read().await;
 
         let disks = disks.clone();
@@ -1552,9 +1647,14 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
 
         for disk in disks.iter() {
             let vers = vers.clone();
+            let opts = DeleteOptions {
+                stage_rollback: rollback_enabled,
+                rollback_tokens: rollback_tokens.clone(),
+                ..Default::default()
+            };
             futures.push(async move {
                 if let Some(disk) = disk {
-                    disk.delete_versions(bucket, vers, DeleteOptions::default()).await
+                    disk.delete_versions(bucket, vers, opts).await
                 } else {
                     let mut errs = Vec::with_capacity(vers.len());
                     for _ in 0..vers.len() {
@@ -1612,6 +1712,92 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
                     ));
                 } else {
                     del_errs[obj_idx] = Some(to_object_err(err.into(), vec![bucket, &objects[obj_idx].object_name.clone()]));
+                }
+            }
+        }
+
+        // #864 Phase 2 (undo | commit), per object. Reuse the single-object token
+        // primitives, fanning out unconditionally to every Some disk: each disk
+        // self-describes via its token dir, so unstaged disks (FileNotFound
+        // `continue`, DiskNotFound) no-op while errored-but-staged disks restore.
+        // The per-object quorum verdict mirrors the reporting loop above but skips
+        // the S3 object-not-found suppression, keying strictly on the disk outcome.
+        if rollback_enabled {
+            let write_quorum = disks.len() / 2 + 1;
+            for (j, ver) in vers.iter().enumerate() {
+                let Some(token) = rollback_tokens.get(j).copied() else {
+                    continue;
+                };
+                let Some(rep_idx) = ver.versions.first().map(|fi| fi.idx) else {
+                    continue;
+                };
+
+                let mut disk_err = vec![None; disks.len()];
+                for (disk_idx, entry) in disk_err.iter_mut().enumerate() {
+                    *entry = del_obj_errs[disk_idx][rep_idx].clone();
+                }
+                let quorum_failed = reduce_write_quorum_errs(&disk_err, OBJECT_OP_IGNORED_ERRS, write_quorum).is_some();
+
+                if quorum_failed {
+                    // Undo synchronously so a quorum-failed key survives on all disks.
+                    let mut undo_futs = Vec::with_capacity(disks.len());
+                    for disk in disks.iter() {
+                        if let Some(disk) = disk.as_ref() {
+                            let disk = disk.clone();
+                            let bucket = bucket.to_string();
+                            let object = ver.name.clone();
+                            let fi = ver.versions[0].clone();
+                            undo_futs.push(async move {
+                                disk.delete_version(
+                                    &bucket,
+                                    &object,
+                                    fi,
+                                    false,
+                                    DeleteOptions {
+                                        undo_delete: Some(token),
+                                        ..Default::default()
+                                    },
+                                )
+                                .await
+                            });
+                        }
+                    }
+                    let undo_error_count = join_all(undo_futs).await.iter().filter(|r| r.is_err()).count();
+                    if undo_error_count > 0 {
+                        warn!(
+                            target: "rustfs_ecstore::set_disk",
+                            bucket = %bucket,
+                            object = %ver.name,
+                            undo_error_count,
+                            "batch delete quorum rollback reported errors (residue left for heal)"
+                        );
+                    }
+                } else {
+                    // Commit synchronously (see delete_object_version rationale):
+                    // drain staging to trash before returning so no residue leaks.
+                    let mut commit_futs = Vec::with_capacity(disks.len());
+                    for disk in disks.iter() {
+                        if let Some(disk) = disk.as_ref() {
+                            let disk = disk.clone();
+                            let bucket = bucket.to_string();
+                            let object = ver.name.clone();
+                            let fi = ver.versions[0].clone();
+                            commit_futs.push(async move {
+                                disk.delete_version(
+                                    &bucket,
+                                    &object,
+                                    fi,
+                                    false,
+                                    DeleteOptions {
+                                        commit_delete: Some(token),
+                                        ..Default::default()
+                                    },
+                                )
+                                .await
+                            });
+                        }
+                    }
+                    let _ = join_all(commit_futs).await;
                 }
             }
         }
@@ -2773,5 +2959,181 @@ mod delete_objects_lock_gating_tests {
 
         assert!(errs[0].is_none(), "no_lock batch delete should not fail with a lock error: {:?}", errs[0]);
         assert!(deleted[0].found, "existing object must still be deleted");
+    }
+}
+
+#[cfg(test)]
+mod delete_rollback_864_set_layer {
+    //! backlog#864: set-layer invariants for the delete quorum-rollback. These
+    //! directly cover the blind spot the audit named: existing delete_objects_*
+    //! tests never inject partial-disk failure and never assert that a committed
+    //! object survives a quorum-failed delete. The fault knob is armed per bucket
+    //! (unique per test) so parallel deletes in other tests are never affected.
+
+    use super::hermetic_set_disks_support::hermetic_set_disks;
+    use super::*;
+    use crate::disk::DiskAPI as _;
+    use crate::disk::RUSTFS_META_TMP_ROLLBACK_BUCKET;
+    use crate::disk::local::delete_fault;
+
+    async fn put_plain_object(set_disks: &Arc<SetDisks>, bucket: &str, object: &str) {
+        let mut reader = PutObjReader::from_vec(vec![9u8; 4096]);
+        set_disks
+            .put_object(bucket, object, &mut reader, &ObjectOptions::default())
+            .await
+            .expect("object should be written");
+    }
+
+    fn object_meta_exists(temp: &std::path::Path, bucket: &str, object: &str) -> bool {
+        temp.join(bucket).join(object).join("xl.meta").exists()
+    }
+
+    async fn rollback_residue(temp: &std::path::Path) -> bool {
+        let p = temp.join(RUSTFS_META_TMP_ROLLBACK_BUCKET);
+        match tokio::fs::read_dir(&p).await {
+            Ok(mut rd) => rd.next_entry().await.unwrap().is_some(),
+            Err(_) => false,
+        }
+    }
+
+    // #8 core invariant: a quorum-failed single delete leaves the object on every
+    // disk (no half-delete).
+    #[tokio::test]
+    async fn single_delete_quorum_failure_leaves_object_on_all_disks() {
+        let (temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "rb864-survive";
+        for d in &disk_stores {
+            d.make_volume(bucket).await.unwrap();
+        }
+        put_plain_object(&set_disks, bucket, "obj").await;
+
+        // 2 of 4 disks fail before staging -> only 2 succeed < write_quorum(3).
+        delete_fault::arm_fail_early(bucket, &[2, 3]);
+        let res = set_disks.delete_object(bucket, "obj", ObjectOptions::default()).await;
+        delete_fault::disarm(bucket);
+
+        assert!(res.is_err(), "delete below write quorum must return an error, not silently succeed");
+
+        set_disks
+            .get_object_info(bucket, "obj", &ObjectOptions::default())
+            .await
+            .expect("object must survive a quorum-failed delete");
+        for (i, t) in temp_dirs.iter().enumerate() {
+            assert!(
+                object_meta_exists(t.path(), bucket, "obj"),
+                "disk {i}: xl.meta must be intact after rollback (no half-delete)"
+            );
+        }
+        assert!(
+            !rollback_residue(temp_dirs[0].path()).await,
+            "quorum-fail undo must drain rollback staging"
+        );
+    }
+
+    // #9 no phantom marker: a quorum-failed force-delete-marker create leaves no
+    // delete marker on any disk.
+    #[tokio::test]
+    async fn force_delete_marker_quorum_failure_leaves_no_phantom_marker() {
+        let (temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "rb864-ghost";
+        for d in &disk_stores {
+            d.make_volume(bucket).await.unwrap();
+        }
+        // object absent on every disk -> create-from-absent leg.
+
+        let opts = ObjectOptions {
+            versioned: true,
+            delete_marker: true,
+            ..Default::default()
+        };
+
+        delete_fault::arm_fail_early(bucket, &[2, 3]);
+        let res = set_disks.delete_object(bucket, "ghost", opts).await;
+        delete_fault::disarm(bucket);
+
+        assert!(res.is_err(), "force-marker create below quorum must fail");
+        for (i, t) in temp_dirs.iter().enumerate() {
+            assert!(
+                !object_meta_exists(t.path(), bucket, "ghost"),
+                "disk {i}: a quorum-failed delete-marker create must not leave a phantom marker"
+            );
+        }
+    }
+
+    // #10 batch: every key below quorum is undone and survives on all disks.
+    #[tokio::test]
+    async fn batch_delete_quorum_failure_restores_every_key() {
+        let (temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "rb864-batch";
+        for d in &disk_stores {
+            d.make_volume(bucket).await.unwrap();
+        }
+        put_plain_object(&set_disks, bucket, "keep").await;
+        put_plain_object(&set_disks, bucket, "gone").await;
+
+        // 3 of 4 disks apply then report failure -> quorum(3) not reached for
+        // either key; both must be restored on all disks by the per-key undo.
+        delete_fault::arm_fail_after_stage(bucket, &[1, 2, 3]);
+        let objects = vec![
+            ObjectToDelete {
+                object_name: "keep".into(),
+                ..Default::default()
+            },
+            ObjectToDelete {
+                object_name: "gone".into(),
+                ..Default::default()
+            },
+        ];
+        let (_deleted, errs) = set_disks.delete_objects(bucket, objects, ObjectOptions::default()).await;
+        delete_fault::disarm(bucket);
+
+        assert!(
+            errs[0].is_some() && errs[1].is_some(),
+            "both keys below quorum must report errors: {errs:?}"
+        );
+        for key in ["keep", "gone"] {
+            set_disks
+                .get_object_info(bucket, key, &ObjectOptions::default())
+                .await
+                .unwrap_or_else(|e| panic!("{key} must survive quorum-failed batch delete: {e:?}"));
+            for (i, t) in temp_dirs.iter().enumerate() {
+                assert!(
+                    object_meta_exists(t.path(), bucket, key),
+                    "disk {i} key {key}: xl.meta must be intact after per-key undo"
+                );
+            }
+        }
+        assert!(
+            !rollback_residue(temp_dirs[0].path()).await,
+            "batch undo must drain rollback staging on all keys"
+        );
+    }
+
+    // #11 healthy delete: object gone, no .rollback residue on any disk.
+    #[tokio::test]
+    async fn quorum_success_delete_leaves_no_rollback_residue() {
+        let (temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "rb864-ok";
+        for d in &disk_stores {
+            d.make_volume(bucket).await.unwrap();
+        }
+        put_plain_object(&set_disks, bucket, "obj").await;
+
+        set_disks
+            .delete_object(bucket, "obj", ObjectOptions::default())
+            .await
+            .expect("healthy delete should succeed");
+
+        set_disks
+            .get_object_info(bucket, "obj", &ObjectOptions::default())
+            .await
+            .expect_err("object must be gone after a quorum-success delete");
+        for (i, t) in temp_dirs.iter().enumerate() {
+            assert!(!object_meta_exists(t.path(), bucket, "obj"), "disk {i}: object deleted");
+            assert!(
+                !rollback_residue(t.path()).await,
+                "disk {i}: commit must drain rollback staging (no leak)"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#864 — the **delete half**. The overwrite half was already fixed by #4107; this adds the symmetric rollback for the delete path.

## Summary of Changes

On a set-level delete quorum failure, the disks that already applied the delete were not
rolled back, so a DELETE that returns 5xx could still make the object disappear (a failed
delete becoming a real delete). This mirrors the #4107 overwrite `undo_write` model onto
the delete path.

Three-phase `prepare → quorum → undo | commit`:
- **prepare** (`stage_rollback`): before the destructive local change, back up the full
  `xl.meta` and **same-disk rename** (metadata-level, not copy) the deleted data dir into a
  per-token rollback dir (`.rustfs.sys/tmp/.rollback/{token}/`). The create-from-absent leg
  (force-del-marker on a missing object) records a `.created_from_absent` sentinel instead.
- **quorum**: unchanged (`reduce_write_quorum_errs`).
- **undo | commit**: undo/commit fan out to **all** disks (not `err.is_none()`-filtered);
  each disk **self-decides from its token manifest** — has `xl.meta` → restore it and the
  staged data dirs; has the absent sentinel → delete the just-created marker; no token dir →
  idempotent no-op. This eliminates ghost markers, batch-delete `None` ambiguity, and
  half-applied errored disks.

Scope: single-object (`delete_object_version`) and batch (`delete_objects`, per-(op,object)
unique token aligned to the versions array), disk layer (`delete_version`,
`delete_versions_internal`) and set layer. Gated by `RUSTFS_DELETE_ROLLBACK_ENABLE`
(default on; `off` restores the previous MinIO-style fail-forward). `DeleteOptions` gains 4
`Default`-compatible, RPC-serialized fields; the `undo_write` overwrite path is untouched.

Deliberate design choices (please review): RustFS already chose "roll back successful disks
on quorum failure" for overwrite (#4107); this extends the same house philosophy to delete
(MinIO is fail-forward here). Staging via same-disk rename keeps undo fsync-free and
metadata-level; undo is best-effort (warn on failure, residue left to heal), introducing no
worse failure class than today.

## Verification

- `make pre-pr` (green — full workspace incl. RPC consumers of `DeleteOptions`)
- Disk-layer + set-layer TDD tests for: undo restores object on quorum failure, commit
  cleans rollback on success, self-describing idempotent no-op on unstaged disks,
  create-from-absent marker removal, batch per-object token alignment.

## Impact

A delete that fails set quorum no longer leaves the object deleted on the successful disks;
it is restored. Successful deletes are unchanged (byte-identical when `stage_rollback` is
off). Behind `RUSTFS_DELETE_ROLLBACK_ENABLE` (default on). No on-disk format change; the
rollback dir lives under `.rustfs.sys/tmp/.rollback`, distinct from the overwrite `.bkp`.

## Additional Notes

**P1 — pending maintainer review before merge** (delete critical path). Design produced by a
multi-agent research + adversarial design round (3 NEEDS_CHANGES rounds); full design and
open questions (fault-injection granularity, orphan-cleaner age bound, detached-commit
tradeoff — defaults adopted, noted in code) are in backlog#864.
