### PR TITLE
ci(s3tests): fix weekly sweep runner infra (pin ubuntu-latest + setup-python)

### DIFF
--- a/.github/workflows/e2e-s3tests.yml
+++ b/.github/workflows/e2e-s3tests.yml
@@ -28,6 +28,22 @@
 # truth, also used locally and by the PR gate). This workflow only provisions
 # the server topology: a single node, or a real 4-node distributed cluster
 # (erasure-coded across nodes) behind an HAProxy round-robin load balancer.
+#
+# Runner infrastructure (ci-1, backlog#1149): this sweep needs BOTH a working
+# Docker daemon (to build the source image and run the single/multi topologies)
+# AND a Python toolchain with pip (for awscurl/tox and the pytest harness).
+# It previously ran on the self-hosted `sm-standard-4` label, which is served
+# by heterogeneous runners: some scheduled runs landed on minimal pods that
+# had neither `pip` (bare python3, `No module named pip`) nor `docker.sock`,
+# so "Install Python tools" died before any test executed (all 15 recorded
+# runs failed). Two changes make the infra assumptions explicit instead of
+# trusting drifting runner state:
+#   1. Pin to GitHub-hosted `ubuntu-latest`, which reliably ships Docker,
+#      docker compose, python3 and pip (no self-hosted fleet drift).
+#   2. Set up Python explicitly (actions/setup-python) before any pip usage,
+#      so the workflow stays correct even if the runner image changes.
+# The PR gate (ci.yml s3-implemented-tests) is unaffected: it avoids Docker
+# via DEPLOY_MODE=binary and defers all pip setup to run.sh's self-bootstrap.
 
 name: e2e-s3tests
 
@@ -99,7 +115,11 @@ defaults:
 
 jobs:
   s3tests:
-    runs-on: sm-standard-4
+    # GitHub-hosted: reliably provides Docker + docker compose + python3/pip.
+    # See the header note (ci-1) for why the self-hosted sm-standard-4 label
+    # was abandoned. TODO(ci-8): scheduled-failure alerting (auto-open issue)
+    # is added by the ci-8 composite action; do not implement it here.
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -110,6 +130,14 @@ jobs:
       TEST_MODE: ${{ matrix.test-mode }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      # Provision Python explicitly rather than trusting the runner image to
+      # ship a working pip (ci-1: a bare python3 without pip is what broke the
+      # scheduled sweep). Keeps the workflow correct across runner drift.
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
 
       - name: Cache pip downloads
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -130,9 +158,9 @@ jobs:
       - name: Build RustFS image (source, cached)
         run: |
           DOCKER_BUILDKIT=1 docker buildx build --load \
-            --platform ${PLATFORM} \
-            --cache-from type=gha,scope=${BUILDX_CACHE_SCOPE} \
-            --cache-to type=gha,mode=max,scope=${BUILDX_CACHE_SCOPE} \
+            --platform "${PLATFORM}" \
+            --cache-from "type=gha,scope=${BUILDX_CACHE_SCOPE}" \
+            --cache-to "type=gha,mode=max,scope=${BUILDX_CACHE_SCOPE}" \
             -t rustfs-ci \
             -f Dockerfile.source .
 
@@ -143,10 +171,10 @@ jobs:
           docker rm -f rustfs-single >/dev/null 2>&1 || true
           docker run -d --name rustfs-single \
             --network rustfs-net \
-            -p ${S3_PORT}:9000 \
+            -p "${S3_PORT}:9000" \
             -e RUSTFS_ADDRESS=0.0.0.0:9000 \
-            -e RUSTFS_ACCESS_KEY=${S3_ACCESS_KEY} \
-            -e RUSTFS_SECRET_KEY=${S3_SECRET_KEY} \
+            -e RUSTFS_ACCESS_KEY="${S3_ACCESS_KEY}" \
+            -e RUSTFS_SECRET_KEY="${S3_SECRET_KEY}" \
             -e RUSTFS_VOLUMES="/data/rustfs{0...3}" \
             -v /tmp/rustfs-single:/data \
             rustfs-ci
@@ -226,7 +254,7 @@ jobs:
 
       - name: Wait for RustFS ready
         run: |
-          for i in {1..120}; do
+          for _ in {1..120}; do
             if curl -sf "http://${S3_HOST}:${S3_PORT}/health" >/dev/null 2>&1; then
               echo "RustFS is ready"
               exit 0


### PR DESCRIPTION
## What & why

Task **ci-1** of the RustFS test-strategy plan (rustfs/backlog#1149, master rustfs/backlog#1155). **P0.**

The weekly full ceph/s3-tests sweep (`.github/workflows/e2e-s3tests.yml`, `schedule` path) has failed **every recorded run** — external S3-compatibility signal is currently zero.

## Root cause (from run evidence)

The job used `runs-on: sm-standard-4`, but that self-hosted label is served by **heterogeneous runners**:

| Run | Trigger | Runner it landed on | Result |
|-----|---------|---------------------|--------|
| [#28727691591](https://github.com/rustfs/rustfs/actions/runs/28727691591) (2026-07-05) | `schedule` | minimal pod `sm-standard-4-kkffg-runner-*` | **`Install Python tools` failed** — `No module named pip`; every later step skipped. Same pod also lacks `docker.sock`. |
| [#28603522001](https://github.com/rustfs/rustfs/actions/runs/28603522001) (2026-07-02) | `workflow_dispatch` | Ubicloud VM (`ubicloud-standard-4` image, full toolchain) | Passed pip/docker setup; only failed later at `Wait for RustFS ready` (a separate app/cluster concern, not infra). |

So the sweep depends on **two** things the runner must provide — a working **Docker daemon** (source image build + single/multi topologies) and a **Python+pip** toolchain (awscurl/tox + pytest) — and the drifting `sm-standard-4` fleet does not reliably provide either. The `Install Python tools` step ran a bare `python3 -m pip install ...` that assumes pip already exists, so it died immediately on the minimal pod.

Why the PR gate (`ci.yml` `s3-implemented-tests`) survives the same label: it avoids Docker entirely via `DEPLOY_MODE=binary` (pre-built debug binary artifact) and defers **all** pip setup to `scripts/s3-tests/run.sh`, which self-bootstraps pip (uv / `ensurepip`). It never runs a workflow-level `python3 -m pip`.

## Fix

Make the infra assumptions **explicit** rather than trusting drifting self-hosted state (per plan guidance "prefer explicit tool setup over assuming runner state"):

1. **Pin to GitHub-hosted `ubuntu-latest`** — reliably ships Docker, docker compose, python3 and pip; removes self-hosted fleet drift.
2. **Add `actions/setup-python`** before any pip usage — guarantees a working pip even if the runner image later changes.
3. **Document** the fix + rationale in the workflow header comment (acceptance requirement).
4. Quote shellcheck-flagged variables (SC2086) and drop an unused loop var (SC2034) in the untouched Docker steps so `actionlint` passes with **zero findings** on the file (repo `.github/AGENTS.md` gate).

PR-triggered path behavior is unchanged — the sweep has no PR trigger; `ci.yml` is untouched.

## Validation

- `actionlint .github/workflows/e2e-s3tests.yml` → **zero findings**.
- `workflow_dispatch` run of this branch: see comment below (confirming it clears the previously-failing pip/docker infra steps).

## Scope / deferred

- **Alerting on scheduled failure is ci-8's task** (a composite action built in parallel) — intentionally NOT implemented here; a `# TODO(ci-8)` hook is left in the job.
- The `multi`-topology `Wait for RustFS ready` failure seen on the Ubicloud dispatch run is an application/cluster-bringup concern outside ci-1's infra scope; ci-1's bar is that the sweep gets **past** pip/docker setup and reaches the test/report stage on both topologies.

Refs: rustfs/backlog#1149 (ci-1), rustfs/backlog#1155