### PR TITLE
docs: make CONTRIBUTING and Makefile help match real verification gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ This guide covers the local development environment and the checks expected befo
 
 **MANDATORY**: All code must be properly formatted before committing. This project enforces strict formatting standards to maintain code consistency and readability.
 
-#### Pre-commit Requirements
+#### Verification Requirements
 
-Before every commit, you **MUST**:
+Before submitting your changes for review, you **MUST**:
 
 1. **Format your code**:
 
@@ -47,33 +47,53 @@ make fmt
 # Check if code is properly formatted
 make fmt-check
 
-# Run clippy checks
-make clippy
+# Run clippy checks (all targets, all features, -D warnings)
+make clippy-check
 
-# Run compilation check
-make check
+# Fast workspace compilation check (excludes e2e_test)
+make quick-check
 
-# Run tests
+# Full compilation check (cargo check --all-targets)
+make compilation-check
+
+# Run tests (shell script tests + workspace tests + doc tests)
 make test
 
-# Run all pre-commit checks (format + clippy + check + test)
+# Fast pre-commit gate — see below for exactly what it runs
 make pre-commit
 
-# Setup git hooks (one-time setup)
-make setup-hooks
+# Full pre-PR gate (pre-commit gates + clippy + tests)
+make pre-pr
 ```
 
-### 🔒 Automated Pre-commit Hooks
+#### What `make pre-commit` and `make pre-pr` actually run
 
-This project includes a pre-commit hook that automatically runs before each commit to ensure:
+`make pre-commit` is the **fast** gate. It runs, in order
+(see `.config/make/pre-commit.mak`):
 
-- ✅ Code is properly formatted (`cargo fmt --all --check`)
-- ✅ No clippy warnings (`cargo clippy --all-targets --all-features -- -D warnings`)
-- ✅ Code compiles successfully (`cargo check --all-targets`)
+1. `fmt-check` — `cargo fmt --all --check`
+2. `unsafe-code-check` — `./scripts/check_unsafe_code_allowances.sh`
+3. `architecture-migration-check` — `./scripts/check_architecture_migration_rules.sh`
+4. `logging-guardrails-check` — `./scripts/check_logging_guardrails.sh`
+5. `tokio-io-uring-check` — `./scripts/check_no_tokio_io_uring.sh`
+6. `doc-paths-check` — `./scripts/check_doc_paths.sh`
+7. `quick-check` — `cargo check --workspace --exclude e2e_test`
 
-#### Setting Up Pre-commit Hooks
+**`make pre-commit` does NOT run clippy and does NOT run any tests.**
+A green `make pre-commit` is not enough to open a pull request.
 
-Run this command once after cloning the repository:
+`make pre-pr` is the **full** gate: it runs all of the guard checks above,
+then `clippy-check` (`cargo clippy --all-targets --all-features -- -D warnings`)
+and `test` (shell script tests, workspace tests excluding `e2e_test`, and doc
+tests). Run `make pre-pr` before opening or updating a pull request — this is
+what CI enforces.
+
+### 🔒 Git Pre-commit Hooks (optional)
+
+Git hooks are **not** versioned in this repository, so a fresh clone has no
+active pre-commit hook. If you add your own `.git/hooks/pre-commit` (a good
+choice is a one-liner that runs `make pre-commit`), you can mark it executable
+with:
 
 ```bash
 make setup-hooks
@@ -84,6 +104,9 @@ Or manually:
 ```bash
 chmod +x .git/hooks/pre-commit
 ```
+
+With or without a hook, the expectation is the same: run `make pre-commit`
+before committing and `make pre-pr` before opening a pull request.
 
 ### 📝 Formatting Configuration
 
@@ -97,7 +120,7 @@ single_line_let_else_max_width = 100
 
 ### 🚫 Commit Prevention
 
-If your code doesn't meet the formatting requirements, the pre-commit hook will:
+If you set up a pre-commit hook and your code doesn't meet the formatting requirements, the hook will:
 
 1. **Block the commit** and show clear error messages
 2. **Provide exact commands** to fix the issues
@@ -119,9 +142,10 @@ Example output when formatting fails:
 
 1. **Make your changes**
 2. **Format your code**: `make fmt` or `cargo fmt --all`
-3. **Run pre-commit checks**: `make pre-commit`
+3. **Run the fast gate**: `make pre-commit` (no clippy, no tests)
 4. **Commit your changes**: `git commit -m "your message"`
-5. **Push to your branch**: `git push`
+5. **Run the full gate before opening/updating a PR**: `make pre-pr` (clippy + tests)
+6. **Push to your branch**: `git push`
 
 ### 🛠️ IDE Integration
 

--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,11 @@ How to use me:
 
 	🔧 Code Quality:
 		make fmt                                 # Format code
-		make clippy                              # Run clippy checks
-		make test                                # Run tests
-		make pre-commit                          # Run fast pre-commit checks
-		make pre-pr                              # Run full pre-PR checks
+		make clippy-check                        # Run clippy (all targets, all features, -D warnings)
+		make quick-check                         # Fast workspace compile check (excludes e2e_test)
+		make test                                # Script tests + workspace tests + doc tests
+		make pre-commit                          # Fast gate: fmt-check + guard scripts + quick-check (NO clippy, NO tests)
+		make pre-pr                              # Full pre-PR gate: pre-commit gates + clippy-check + test
 
 	🚀 Quick Start:
 		make build                               # Build RustFS binary


### PR DESCRIPTION
## What

Formalizes the existing `ecstore-serial-flaky` nextest mechanism into a strict CI gate. Implements **ci-10** (absorbed **infra-15**; strict semantics adjudicated) from the RustFS test-strategy issue rustfs/backlog#1149 (master plan rustfs/backlog#1155). Flake source of truth is rustfs/backlog#937.

This is a formalization, not a rebuild — the `[test-groups]` serialization and the two backlog#937 groups already existed; this adds the profile, quarantine retry semantics, JUnit output, CI wiring, and the written policy.

## Profile semantics

`.config/nextest.toml`:

- **`[profile.ci]`**: `retries = 0` (strict — a new race must fail on its first occurrence, never retried away), `fail-fast = false`, JUnit at `target/nextest/ci/junit.xml`.
- **Quarantine**: two `[[profile.ci.overrides]]` entries granting `retries = 2` **only under the ci profile**, each with a comment linking the OPEN issue backlog#937. Members:
  - `concurrent_resend_same_part_commits_one_generation`
  - `store::bucket::tests::bucket_delete_(mark_delete_marks|purge_removes|default_s3_delete)`
  - Each entry re-declares the `ecstore-serial-flaky` test-group so serialization holds under the ci profile (nextest evaluates a named profile's own overrides list, not `default`'s).
- **Local `default` profile**: unchanged — serializes the flaky groups, **never retries**.
- Every quarantine entry MUST link one OPEN issue (policy enforced by review). No reference to rustfs#4496 (a merged PR, not a flake tracker).

## CI wiring (`.github/workflows/ci.yml`)

- Main test step (`cargo nextest run --all --exclude e2e_test`) now runs `--profile ci`.
- New "Upload test junit report" step: `if: always()`, `retention-days: 3`, name `junit-test-and-lint-${{ github.run_number }}`.
- **Migration-proof step decision** (one-line justified in the file): kept on the **default** profile. A second `--profile ci` run would clobber `target/nextest/ci/junit.xml`, and none of its tests are quarantined so it gains nothing from the ci retry overrides.

## Flake policy

New `docs/testing/README.md` (skeleton **owned by backlog#1153 / infra-11**) with the flake policy section: discover → open issue within 24h → quarantine with issue link → fix or delete within 30 days. Local default never retries; JUnit `flaky` markers are the observable. AGENTS.md verification section gains a one-line pointer to it. (CONTRIBUTING.md intentionally untouched — owned by a parallel task.)

`.gitignore` gains `!docs/testing/` / `!docs/testing/**` whitelist entries so the testing docs dir is trackable (previously `docs/*` ignored it).

## Verification evidence

- `cargo nextest run --profile ci -p rustfs-utils` → `24 tests run: 24 passed`; `target/nextest/ci/junit.xml` emitted (4590 bytes, valid `<testsuites>`). Profile + all quarantine filtersets parse (nextest validates every override at startup).
- `actionlint .github/workflows/ci.yml` → CLEAN (v1.7.12).
- `scripts/check_doc_paths.sh` → passed.
- **Flaky-marker drill** (throwaway crate, to prove the quarantine retry + JUnit marker mechanism without running the full suite): a test that fails on first attempt and passes on retry, under `retries=2` override + global `retries=0`, produced:
  ```
  RETRY 2/3   flakedemo tests::quarantined_flaky
  TRY 2 PASS  flakedemo tests::quarantined_flaky
  Summary  1 test run: 1 passed (1 flaky), 0 skipped
  ```
  and JUnit contained a `<flakyFailure ... type="test failure with exit code 101">` element — i.e. a quarantined test that passes only after a retry is visibly marked `flaky`.

Per repo note, the full workspace suite was **not** run (machine busy); required verification is profile-parses + junit-emits, both confirmed.

## Coexistence note

A parallel PR (**ci-4**) adds `[profile.e2e-smoke]` to the same `.config/nextest.toml` and edits the e2e job in `ci.yml`. Changes are in different sections (distinct profile tables; different ci.yml steps) — expect a trivial rebase, no semantic conflict.

## Refs

- rustfs/backlog#1149 (ci-10, absorbed infra-15)
- rustfs/backlog#937 (flake source of truth / first quarantine members)
- rustfs/backlog#1155 (master plan)
