### PR TITLE
ci: run e2e smoke subset via nextest e2e-smoke profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -77,3 +77,19 @@ retries = 2
 filter = 'package(rustfs-ecstore) & test(/^store::bucket::tests::bucket_delete_(mark_delete_marks|purge_removes|default_s3_delete)/)'
 test-group = 'ecstore-serial-flaky'
 retries = 2
+
+# ---------------------------------------------------------------------------
+# e2e-smoke profile — PR smoke subset of the e2e_test crate (backlog#1149 ci-4)
+# ---------------------------------------------------------------------------
+# PR smoke subset of the e2e_test crate (backlog#1149 ci-4). This profile is
+# the single wiring mechanism for e2e tests in CI: other suites join by
+# extending this filter (or a sibling profile), never by adding ad-hoc e2e
+# jobs to ci.yml. Admission criteria (see crates/e2e_test/README.md): fast,
+# single-node topology, no external dependencies (no awscurl / Vault / fixed
+# ports / pre-started server), no #[ignore].
+#
+# Each e2e test spawns its own rustfs server on a random port with an isolated
+# temp dir (crates/e2e_test/src/common.rs), so the subset is parallel-safe.
+[profile.e2e-smoke]
+default-filter = 'package(e2e_test) & test(/^(delete_marker_migration_semantics|version_id_regression|list_objects_v2_pagination|list_object_versions_regression|list_objects_duplicates|list_buckets_double_slash|leading_slash_key|special_chars|create_bucket_region|delete_objects_versioning|head_object_consistency|head_object_range|copy_object_metadata|copy_source_invalid_date|content_encoding|anonymous_access|bucket_policy_check)_test::/)'
+fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      # Full setup with dependency caching: the migration-proof step below
+      # Full setup with dependency caching: the smoke-suite step below
       # compiles the e2e_test crate, which pulls in most of the workspace.
       # Without a restored cache this was a cold multi-GB build on every run.
       - name: Setup Rust environment
@@ -336,8 +336,13 @@ jobs:
       - name: Make binary executable
         run: chmod +x ./target/debug/rustfs
 
-      - name: Run delete-marker migration proof
-        run: cargo test -p e2e_test delete_marker_migration_semantics -- --nocapture --test-threads=1
+      # PR smoke subset of the in-repo e2e suite (backlog#1149 ci-4). The
+      # profile.e2e-smoke default-filter in .config/nextest.toml is the single
+      # wiring mechanism for e2e tests in CI — extend that filter instead of
+      # adding new e2e jobs here. Each test spawns its own rustfs server on a
+      # random port and reuses the downloaded debug binary above.
+      - name: Run e2e smoke suite
+        run: cargo nextest run --profile e2e-smoke -p e2e_test
 
       - name: Install s3s-e2e test tool
         uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # v2

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ docs/*
 !docs/testing/**
 !docs/superpowers/
 !docs/superpowers/**
+!docs/testing/
+!docs/testing/**
 docs/heal-scanner-logging-governance.md
 docs/benchmark/rustfs-target-bench/
 docs/benchmark/*.md

--- a/crates/e2e_test/README.md
+++ b/crates/e2e_test/README.md
@@ -1,0 +1,51 @@
+# e2e_test
+
+End-to-end test suite for RustFS. Tests spawn a real `rustfs` binary (see
+`src/common.rs`) and drive it with the AWS SDK.
+
+> This README currently only documents the CI smoke subset (backlog#1149
+> ci-4). The full contributor guide — how to add a case, fixture helpers,
+> `#[ignore]` semantics, harness topologies — is tracked as backlog#1153
+> infra-10 and will extend this file.
+
+## CI smoke subset (`--profile e2e-smoke`)
+
+A subset of this crate runs on every PR via the `e2e-tests` job:
+
+```bash
+cargo nextest run --profile e2e-smoke -p e2e_test
+```
+
+The selection lives in `.config/nextest.toml` under `[profile.e2e-smoke]`
+(`default-filter`). That filter is the **single wiring mechanism** for e2e
+tests in CI — extend it (or add a sibling profile) instead of adding new e2e
+jobs to `ci.yml`.
+
+### Admission criteria for the smoke subset
+
+A test module may join the smoke filter only if every test in it is:
+
+1. **Fast** — single-digit seconds per test; the whole subset must keep the
+   `e2e-tests` job ≤ 20 minutes.
+2. **Single-node** — spawns its own server via
+   `RustFSTestEnvironment`/`start_rustfs_server` on a random port with an
+   isolated temp dir. No `RustFSTestClusterEnvironment`, no fixed ports.
+3. **Dependency-free** — no pre-started server at `localhost:9000`, no Vault,
+   no fixed protocol ports. Tools that may be absent on the runner (e.g.
+   `awscurl`) are acceptable only when the test skips gracefully with a
+   visible log line (see `bucket_policy_check_test.rs`).
+4. **Not `#[ignore]`** — ignored tests are activation work (backlog#1149
+   ci-13 / backlog#1148 ilm-3), not smoke candidates.
+
+Note on `#[serial]`: nextest runs each test in its own process, so
+`serial_test`'s in-process mutex does **not** serialize across tests there
+(see the header of `.config/nextest.toml`). Smoke tests must therefore be
+parallel-safe by construction (random port + isolated temp dir), which the
+current subset is.
+
+### Authoritative test inventory
+
+`docs/testing/e2e-suite-inventory.md` records the per-module test counts as
+listed by `cargo nextest list -p e2e_test`. Regenerate it when adding or
+moving e2e tests so acceptance numbers in the test-strategy issues
+(backlog#1147–#1155) stay auditable.

--- a/docs/testing/e2e-suite-inventory.md
+++ b/docs/testing/e2e-suite-inventory.md
@@ -1,0 +1,62 @@
+# e2e_test suite inventory
+
+> Authoritative per-module test counts for the `e2e_test` crate (backlog#1149
+> ci-4), generated from `cargo nextest list -p e2e_test`. Regenerate with:
+> ```bash
+> cargo nextest list -p e2e_test | grep "^ " | sed "s/^ *//;s/::.*//" | sort | uniq -c
+> ```
+> Modules marked ✅ are in the PR smoke profile `e2e-smoke`
+> (`.config/nextest.toml`); admission criteria: `crates/e2e_test/README.md`.
+> Note: counts exclude `#[ignore]`d tests (nextest lists them separately).
+
+| module | tests | PR smoke |
+|---|---|---|
+| admin_timeout_regression_test | 1 |  |
+| anonymous_access_test | 3 | ✅ |
+| archive_download_integrity_test | 13 |  |
+| bucket_logging_test | 3 |  |
+| bucket_policy_check_test | 1 | ✅ |
+| checksum_upload_test | 6 |  |
+| cluster_concurrency_test | 2 |  |
+| common | 3 |  |
+| compression_test | 1 |  |
+| content_encoding_test | 3 | ✅ |
+| copy_object_metadata_test | 1 | ✅ |
+| copy_object_version_restore_test | 1 |  |
+| copy_source_invalid_date_test | 1 | ✅ |
+| create_bucket_region_test | 2 | ✅ |
+| delete_marker_migration_semantics_test | 2 | ✅ |
+| delete_object_no_content_length_test | 1 |  |
+| delete_objects_versioning_test | 2 | ✅ |
+| existing_object_tag_policy_test | 4 |  |
+| head_object_consistency_test | 1 | ✅ |
+| head_object_range_test | 1 | ✅ |
+| heal_erasure_disk_rebuild_test | 3 |  |
+| kms | 40 |  |
+| leading_slash_key_test | 2 | ✅ |
+| list_buckets_double_slash_test | 3 | ✅ |
+| list_object_versions_metadata_extension_test | 1 |  |
+| list_object_versions_regression_test | 2 | ✅ |
+| list_objects_duplicates_test | 3 | ✅ |
+| list_objects_v2_metadata_extension_test | 1 |  |
+| list_objects_v2_pagination_test | 12 | ✅ |
+| mc_mirror_small_bucket_test | 1 |  |
+| multipart_auth_test | 109 |  |
+| namespace_lock_quorum_test | 2 |  |
+| object_lambda_test | 16 |  |
+| object_lock | 33 |  |
+| overwrite_cleanup_regression_test | 1 |  |
+| protocols | 16 |  |
+| quota_test | 13 |  |
+| reliability_disk_fault_test | 3 |  |
+| reliant | 6 |  |
+| replication_extension_test | 36 |  |
+| security_boundary_test | 4 |  |
+| server_startup_failfast_test | 1 |  |
+| snowball_auto_extract_test | 6 |  |
+| special_chars_test | 14 | ✅ |
+| stale_multipart_cleanup_cluster_test | 1 |  |
+| tls_gen | 3 |  |
+| version_id_regression_test | 10 | ✅ |
+
+**Total listed: 394 tests across 47 modules · PR smoke subset: 63 tests / 17 modules** · generated 2026-07-10.


### PR DESCRIPTION
## Summary

Implements **ci-4** from the test-strategy plan (rustfs/backlog#1149, master rustfs/backlog#1155). P0.

The `e2e-tests` job ran exactly **1** of the e2e_test crate's ~400 tests (`delete_marker_migration_semantics` via `cargo test`). This PR wires a PR smoke subset through a nextest profile — the **single wiring mechanism** for e2e tests in CI going forward (repl-1, sec-5 etc. are filterset changes on this profile, never new ad-hoc e2e jobs).

## Changes
- `.config/nextest.toml`: new `[profile.e2e-smoke]` whose `default-filter` selects 17 fast / single-node / dependency-free modules = **63 tests**.
- `.github/workflows/ci.yml`: e2e job step `cargo test -p e2e_test delete_marker…` → `cargo nextest run --profile e2e-smoke -p e2e_test` (setup action already installs nextest; reuses the downloaded debug binary via common.rs's `can_reuse_inside_e2e`).
- `crates/e2e_test/README.md` (was empty): smoke admission criteria (fast / single-node / dependency-free / not-ignored) + the #[serial]-under-nextest caveat. Full guide remains backlog#1153 infra-10 (sole README owner; this is the ci-4 section it will extend).
- `docs/testing/e2e-suite-inventory.md`: authoritative per-module counts from `cargo nextest list` (394 listed tests / 47 modules; regeneration command included) — unifies acceptance-count wording across the strategy issues (replication_extension = 36, dual-node = 9).
- `.gitignore`: `!docs/testing/` whitelist (docs/* was ignored; same entry as #4666 — trivial overlap on rebase).

## Acceptance evidence
- Selected set verified: `cargo nextest list --profile e2e-smoke -p e2e_test` → exactly **63**.
- Module audit: all 17 modules have no `#[ignore]`, no cluster harness, no fixed ports; sole external-tool use (`awscurl` in bucket_policy_check) **skips gracefully with a visible log line** when absent.
- Local full run on a heavily loaded machine: **63/63 passed in 111s** (368 skipped by filter) — well under the ≤20min job budget.
- actionlint clean; pre-commit gates green (fmt/unsafe/arch-migration/logging/tokio-io-uring/doc-paths). quick-check skipped locally (zero Rust changes; machine saturated by parallel sessions) — CI's Test and Lint covers it.
- "3 consecutive green PRs" acceptance item: observable on this and following PRs.

## Coexistence
Parallel PRs touch the same files in different sections: #4666 (ci-10, [profile.ci] + test step) and #4673 (infra-12, migration gate step). Trivial rebases expected; no semantic conflicts.

Refs rustfs/backlog#1149 (ci-4), rustfs/backlog#1155.