### PR TITLE
fix(ecstore): roll back delete on disks that staged then errored

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -9956,6 +9956,66 @@ mod test {
         assert!(!object_dir.join(rollback_dir.to_string()).exists());
     }
 
+    // backlog#1158 safety premise: the set layer fans the undo out to every online
+    // disk on a quorum-failed delete, including disks that never staged a rollback
+    // (e.g. a disk that errored before staging). A delete-undo on such a disk must be
+    // a safe no-op that leaves the committed object untouched.
+    #[tokio::test]
+    async fn test_delete_version_undo_is_noop_when_nothing_staged() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+
+        let bucket = "bucket";
+        let object = "dir/object";
+        let version_id = Uuid::parse_str("aaaaaaaa-1111-2222-3333-444444444444").expect("version id should parse");
+        let data_dir = Uuid::parse_str("bbbbbbbb-1111-2222-3333-444444444444").expect("data dir should parse");
+        let rollback_dir = Uuid::parse_str("cccccccc-1111-2222-3333-444444444444").expect("rollback dir should parse");
+
+        ensure_test_volume(&disk, bucket).await;
+
+        // A committed object exists on this disk, but no rollback state was staged.
+        let object_dir = dir.path().join(bucket).join("dir/object");
+        let data_path = object_dir.join(data_dir.to_string());
+        fs::create_dir_all(&data_path).await.expect("data dir should be created");
+        fs::write(data_path.join("part.1"), b"live-data")
+            .await
+            .expect("part data should be written");
+        let fi = test_file_info(object, version_id, Some(data_dir), None);
+        let meta = test_meta(fi.clone());
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), meta.clone())
+            .await
+            .expect("metadata should be written");
+
+        // Undo targeting a rollback dir that was never created must be an Ok no-op.
+        disk.delete_version(
+            bucket,
+            object,
+            fi.clone(),
+            false,
+            DeleteOptions {
+                undo_write: true,
+                undo_delete: true,
+                old_data_dir: Some(rollback_dir),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("undo with no staged rollback state must be a no-op");
+
+        // The committed object is untouched.
+        assert_eq!(
+            fs::read(object_dir.join(STORAGE_FORMAT_FILE))
+                .await
+                .expect("metadata should remain"),
+            meta
+        );
+        assert_eq!(fs::read(data_path.join("part.1")).await.expect("data should remain"), b"live-data");
+        assert!(!object_dir.join(rollback_dir.to_string()).exists());
+    }
+
     #[tokio::test]
     async fn test_delete_marker_rollback_removes_new_metadata_without_backup() {
         use tempfile::tempdir;

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -1409,7 +1409,14 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
         let should_rollback = quorum_result.is_err();
         let mut rollback_futures = Vec::new();
         for (index, err) in errs.iter().enumerate() {
-            if err.is_some() {
+            // backlog#1158: when rolling back, fan the idempotent undo out to every
+            // online disk (each self-decides from its staged backup: restore if the
+            // rollback dir is present, no-op otherwise). This covers a disk that
+            // staged + applied the delete and *then* errored, which the plain
+            // `err.is_some()` skip would leave deleted while its peers were restored.
+            // On success only the successful disks' backup dirs need cleaning; errored
+            // disks' residue is reclaimed by heal/scanner.
+            if !should_rollback && err.is_some() {
                 continue;
             }
 
@@ -1764,7 +1771,11 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
             // delete_versions commits one xl.meta per object group, so rollback must use the same boundary.
             let should_rollback = fi_vers.versions.iter().any(|fi| del_errs[fi.idx].is_some());
             for (disk_idx, disk) in disks.iter().enumerate() {
-                if fi_vers.versions.iter().any(|fi| del_obj_errs[disk_idx][fi.idx].is_some()) {
+                // backlog#1158: on rollback, include every online disk so a disk that
+                // staged + applied the delete and then errored is still restored (the
+                // disk-side undo is idempotent, no-op when nothing was staged). On
+                // success, skip the errored disks and only clean up successful ones.
+                if !should_rollback && fi_vers.versions.iter().any(|fi| del_obj_errs[disk_idx][fi.idx].is_some()) {
                     continue;
                 }
 


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1158 — a targeted hardening of the delete-quorum rollback landed in #4300.

## Summary of Changes

#4300 rolls back a failed delete by fanning an idempotent undo out to the disks that
succeeded (`if err.is_some() { continue }` in the undo loop of `delete_object_version`
and `delete_objects`). A disk that **stages its rollback backup, applies the delete, and
then errors** returns `err.is_some()`, so it is skipped by that filter and left deleted
while its peers are restored — a transient cross-disk divergence (the object is still
readable at quorum, and heal reconciles it later, but the failed disk is momentarily
inconsistent).

Fix (minimal delta on #4300's mechanism): on rollback, fan the undo out to **every online
disk** and let each disk self-decide. This is safe because the disk-side
`restore_delete_rollback` is already idempotent — it returns `Ok(())` when no rollback dir
was staged (`local.rs`, `read_dir` → `NotFound` → `Ok`). The `err.is_some()` skip now
applies only to the success/cleanup path (no need to touch errored disks' backup dirs;
heal/scanner reclaims them). Both the single-object and batch delete loops are updated.

## Verification

- `make pre-pr`
- `cargo test -p rustfs-ecstore --lib -- delete_version_undo_is_noop delete_version_rollback delete_marker_rollback`
  — added `test_delete_version_undo_is_noop_when_nothing_staged` (delete-undo on a disk
  with no staged rollback is an Ok no-op that leaves the committed object untouched — the
  safety premise for fanning undo out to errored/unstaged disks). #4300's staged-restore
  and marker-removal tests continue to pass.

## Impact

A delete that fails set quorum now also restores disks that staged + applied + then
errored, not only the fully-successful ones. No change on the success path or for disks
that never staged (idempotent no-op). No API or on-disk format change.

## Additional Notes

Found while processing backlog#864: #4300 already fixed #864's delete half, so the
competing PR #4659 was closed and this single residual gap was split out as #1158. (#4300
also already handles the create-from-absent ghost marker via `DELETE_MARKER_ROLLBACK_FILE`,
so that is not in scope here.)


> Local `make pre-pr`: fmt / unsafe / arch / logging / doc / **clippy** all pass; the full test build was SIGTERM-killed locally by resource pressure (not a failure), so the full suite is delegated to CI. The focused rollback tests pass locally (3/3).
