### PR TITLE
fix(rustfs): allow drop_non_drop on dial9 guard for non-Drop feature sets

### DIFF
--- a/rustfs/src/startup_entrypoint.rs
+++ b/rustfs/src/startup_entrypoint.rs
@@ -37,7 +37,9 @@ pub fn run_process() {
 
     // Flush and seal the trace segment before any exit path. `process::exit`
     // below does not run destructors, and neither does returning from `main`
-    // for a guard held in a `static`.
+    // for a guard held in a `static`. Under feature sets where the dial9 guard
+    // carries no Drop impl (e.g. `--features sftp`), this is an intentional no-op.
+    #[allow(clippy::drop_non_drop)]
     drop(dial9_guard);
 
     if let Err(ref e) = result {


### PR DESCRIPTION
## Summary

`drop(dial9_guard)` in `rustfs/src/startup_entrypoint.rs` trips
`clippy::drop_non_drop` under feature sets where the dial9 session guard has no
`Drop` impl (e.g. `--features sftp`, after #4663 made dial9 telemetry opt-in),
failing the **Test and Lint (sftp)** CI job on `main` and every branch based on
it. The drop is an intentional trace-flush point where the guard *does* implement
Drop; add `#[allow(clippy::drop_non_drop)]` so it is clean across all feature
combinations without changing behavior.

## Verification

- `cargo clippy -p rustfs --all-targets --features sftp -- -D warnings` (the exact
  invocation the failing job runs) — verified by CI.

## Impact

Clippy-only; no behavior change. Unblocks the sftp Test and Lint job.
