### PR TITLE
feat(ecstore): make replication timing intervals env-overridable for tests

### DIFF
--- a/crates/e2e_test/src/common.rs
+++ b/crates/e2e_test/src/common.rs
@@ -514,6 +514,29 @@ impl Drop for RustFSTestEnvironment {
     }
 }
 
+/// Short-interval replication timing overrides for fast e2e runs
+/// (backlog#1147 repl-4).
+///
+/// Returns the full set of replication background-loop env vars with
+/// millisecond values so failure-recovery scenarios converge in seconds
+/// instead of the production defaults (health check 5s, MRF flush 10s,
+/// resync retry poll up to 60s). Pass to
+/// [`RustFSTestEnvironment::start_rustfs_server_with_env`] as
+/// `&replication_fast_env()`. The server reads each value once at background
+/// task startup, so the vars must be set before the process starts. Values
+/// below 10ms are clamped server-side to avoid busy-spin.
+pub fn replication_fast_env() -> Vec<(&'static str, &'static str)> {
+    // Env var names mirror `crates/ecstore/src/bucket/replication/replication_timing.rs`
+    // (this is a process-boundary contract: the vars are passed to the spawned
+    // server, not consumed in-process). The names are pinned by the
+    // `env_var_names_are_a_cross_process_contract` test in that module.
+    vec![
+        ("RUSTFS_REPL_HEALTH_CHECK_INTERVAL_MS", "200"),
+        ("RUSTFS_REPL_MRF_FLUSH_INTERVAL_MS", "100"),
+        ("RUSTFS_REPL_RESYNC_POLL_MAX_MS", "250"),
+    ]
+}
+
 async fn execute_awscurl_with_service(
     url: &str,
     method: &str,

--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -78,7 +78,6 @@ use tracing::warn;
 use url::Url;
 use uuid::Uuid;
 
-const DEFAULT_HEALTH_CHECK_DURATION: Duration = Duration::from_secs(5);
 const DEFAULT_HEALTH_CHECK_RELOAD_DURATION: Duration = Duration::from_secs(30 * 60);
 const REDACTED_CREDENTIAL: &str = "<redacted>";
 
@@ -335,7 +334,9 @@ impl BucketTargetSys {
     }
 
     pub async fn heartbeat(&self) {
-        let mut interval = tokio::time::interval(DEFAULT_HEALTH_CHECK_DURATION);
+        // Probe interval: `RUSTFS_REPL_HEALTH_CHECK_INTERVAL_MS` (default 5000ms,
+        // clamped to >=10ms), read once when the heartbeat task starts.
+        let mut interval = tokio::time::interval(crate::bucket::replication::replication_timing::health_check_interval());
         loop {
             interval.tick().await;
 

--- a/crates/ecstore/src/bucket/replication/mod.rs
+++ b/crates/ecstore/src/bucket/replication/mod.rs
@@ -39,6 +39,7 @@ mod replication_storage_boundary;
 mod replication_tagging_boundary;
 mod replication_target_boundary;
 mod replication_target_config_bridge;
+pub(crate) mod replication_timing;
 mod replication_versioning_boundary;
 mod runtime_boundary;
 

--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -738,7 +738,8 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
     /// Starts the MRF persister — ongoing background task.
     ///
     /// Drains `mrf_save_rx` (entries that overflowed the normal worker channels) and
-    /// writes them to the on-disk MRF file every 10 seconds or when 1 000 new
+    /// writes them to the on-disk MRF file every flush interval (default 10s,
+    /// overridable via `RUSTFS_REPL_MRF_FLUSH_INTERVAL_MS`) or when 1 000 new
     /// entries accumulate.  Each flush rewrites the whole cumulative backlog so no
     /// previously-persisted (and not-yet-replayed) entry is lost; the file is only
     /// consumed and cleared at startup.
@@ -762,7 +763,9 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
             let mut flushed_len = 0usize;
             let mut dirty = false;
             let mut capped = false;
-            let mut interval = tokio::time::interval(Duration::from_secs(10));
+            // Flush interval: `RUSTFS_REPL_MRF_FLUSH_INTERVAL_MS` (default 10000ms,
+            // clamped to >=10ms), read once when the persister task starts.
+            let mut interval = tokio::time::interval(super::replication_timing::mrf_flush_interval());
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             loop {
@@ -992,6 +995,14 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
 
     /// Start the resync routine that runs in a loop
     async fn start_resync_routine(self: Arc<Self>, buckets: Vec<String>, cancellation_token: CancellationToken) {
+        // Retry-poll sleep upper bound: `RUSTFS_REPL_RESYNC_POLL_MAX_MS`
+        // (default 60000ms, clamped to >=10ms), read once when this routine
+        // starts. The anti-busy-spin floor is min(1s, max) so the default
+        // keeps the historical "sleep at least one second" behavior while
+        // short test overrides stay short.
+        let max_sleep = super::replication_timing::resync_poll_max_sleep();
+        let max_sleep_ms = u64::try_from(max_sleep.as_millis()).unwrap_or(u64::MAX).max(1);
+        let floor_sleep = Duration::from_secs(1).min(max_sleep);
         // Run the replication resync in a loop
         loop {
             let self_clone = self.clone();
@@ -1007,14 +1018,14 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
                 }
             }
 
-            // Generate random duration between 0 and 1 minute
+            // Generate a random duration between 0 and `max_sleep` (default 1 minute)
             use rand::RngExt;
-            let duration_millis = rand::rng().random_range(0..60_000);
+            let duration_millis = rand::rng().random_range(0..max_sleep_ms);
             let mut duration = Duration::from_millis(duration_millis);
 
-            // Make sure to sleep at least a second to avoid high CPU ticks
-            if duration < Duration::from_secs(1) {
-                duration = Duration::from_secs(1);
+            // Make sure to sleep at least `floor_sleep` to avoid high CPU ticks
+            if duration < floor_sleep {
+                duration = floor_sleep;
             }
 
             tokio::time::sleep(duration).await;

--- a/crates/ecstore/src/bucket/replication/replication_timing.rs
+++ b/crates/ecstore/src/bucket/replication/replication_timing.rs
@@ -1,0 +1,223 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Env-overridable timing knobs for replication background loops
+//! (backlog#1147 repl-4).
+//!
+//! Defaults are identical to the previously hardcoded values; the env vars
+//! exist so tests and operators can shorten the loops (e.g. fast e2e runs).
+//! Every value is read **once, when the owning background task starts** —
+//! changing an env var mid-run does not affect already-running loops.
+//! Invalid values fall back to the default with a `warn!`; values below
+//! [`MIN_INTERVAL`] are clamped so an override of `0`/near-zero can never
+//! busy-spin a loop (`tokio::time::interval` also panics on a zero period).
+
+use std::time::Duration;
+use tracing::warn;
+
+use super::replication_logging::{LOG_COMPONENT_ECSTORE, LOG_SUBSYSTEM_REPLICATION};
+
+/// Overrides the remote-target health-check probe interval, in milliseconds.
+/// Default: `5000` (5s). Test/ops tuning only.
+pub(crate) const ENV_REPL_HEALTH_CHECK_INTERVAL_MS: &str = "RUSTFS_REPL_HEALTH_CHECK_INTERVAL_MS";
+
+/// Overrides the MRF persistence flush interval, in milliseconds.
+/// Default: `10000` (10s). Test/ops tuning only.
+pub(crate) const ENV_REPL_MRF_FLUSH_INTERVAL_MS: &str = "RUSTFS_REPL_MRF_FLUSH_INTERVAL_MS";
+
+/// Overrides the upper bound of the random resync retry-poll sleep, in
+/// milliseconds. Default: `60000` (60s). Test/ops tuning only.
+pub(crate) const ENV_REPL_RESYNC_POLL_MAX_MS: &str = "RUSTFS_REPL_RESYNC_POLL_MAX_MS";
+
+const DEFAULT_HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(5_000);
+const DEFAULT_MRF_FLUSH_INTERVAL: Duration = Duration::from_millis(10_000);
+const DEFAULT_RESYNC_POLL_MAX: Duration = Duration::from_millis(60_000);
+
+/// Hard floor for every replication timing override. Values below this are
+/// clamped (with a `warn!`) so a pathological override cannot busy-spin a
+/// background loop. The defaults are all far above this floor, so clamping
+/// never alters default behavior.
+pub(crate) const MIN_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Remote-target health-check probe interval
+/// ([`ENV_REPL_HEALTH_CHECK_INTERVAL_MS`], default 5s).
+pub(crate) fn health_check_interval() -> Duration {
+    env_interval(ENV_REPL_HEALTH_CHECK_INTERVAL_MS, DEFAULT_HEALTH_CHECK_INTERVAL)
+}
+
+/// MRF persistence flush interval
+/// ([`ENV_REPL_MRF_FLUSH_INTERVAL_MS`], default 10s).
+pub(crate) fn mrf_flush_interval() -> Duration {
+    env_interval(ENV_REPL_MRF_FLUSH_INTERVAL_MS, DEFAULT_MRF_FLUSH_INTERVAL)
+}
+
+/// Upper bound of the random resync retry-poll sleep
+/// ([`ENV_REPL_RESYNC_POLL_MAX_MS`], default 60s).
+pub(crate) fn resync_poll_max_sleep() -> Duration {
+    env_interval(ENV_REPL_RESYNC_POLL_MAX_MS, DEFAULT_RESYNC_POLL_MAX)
+}
+
+/// Resolve `name` as a millisecond interval: absent → `default` (silently);
+/// unparsable → `default` with a `warn!`; parsed but below [`MIN_INTERVAL`] →
+/// clamped to [`MIN_INTERVAL`] with a `warn!`.
+fn env_interval(name: &str, default: Duration) -> Duration {
+    let raw = match std::env::var(name) {
+        Ok(raw) => raw,
+        Err(std::env::VarError::NotPresent) => return default,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            warn!(
+                component = LOG_COMPONENT_ECSTORE,
+                subsystem = LOG_SUBSYSTEM_REPLICATION,
+                env = name,
+                default_ms = default.as_millis() as u64,
+                "replication timing override is not valid unicode — falling back to default"
+            );
+            return default;
+        }
+    };
+    match raw.trim().parse::<u64>() {
+        Ok(ms) => {
+            let value = Duration::from_millis(ms);
+            if value < MIN_INTERVAL {
+                warn!(
+                    component = LOG_COMPONENT_ECSTORE,
+                    subsystem = LOG_SUBSYSTEM_REPLICATION,
+                    env = name,
+                    value_ms = ms,
+                    min_ms = MIN_INTERVAL.as_millis() as u64,
+                    "replication timing override below minimum — clamping to avoid busy-spin"
+                );
+                MIN_INTERVAL
+            } else {
+                value
+            }
+        }
+        Err(_) => {
+            warn!(
+                component = LOG_COMPONENT_ECSTORE,
+                subsystem = LOG_SUBSYSTEM_REPLICATION,
+                env = name,
+                value = %raw,
+                default_ms = default.as_millis() as u64,
+                "invalid replication timing override — falling back to default"
+            );
+            default
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::env;
+
+    // SAFETY: this helper is only used from `#[serial]` tests, so no
+    // concurrent reader/writer can access the process environment while
+    // `env::set_var`/`env::remove_var` is active.
+    #[allow(unsafe_code)]
+    fn with_env<F: FnOnce()>(name: &str, value: Option<&str>, test_fn: F) {
+        let original = env::var_os(name);
+        match value {
+            Some(value) => unsafe { env::set_var(name, value) },
+            None => unsafe { env::remove_var(name) },
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test_fn));
+        match original {
+            Some(value) => unsafe { env::set_var(name, value) },
+            None => unsafe { env::remove_var(name) },
+        }
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
+    }
+
+    /// The env var names are a cross-process contract: `crates/e2e_test/src/common.rs`
+    /// (`replication_fast_env`) passes them by literal name to spawned server
+    /// processes. Renaming one must fail here first.
+    #[test]
+    fn env_var_names_are_a_cross_process_contract() {
+        assert_eq!(ENV_REPL_HEALTH_CHECK_INTERVAL_MS, "RUSTFS_REPL_HEALTH_CHECK_INTERVAL_MS");
+        assert_eq!(ENV_REPL_MRF_FLUSH_INTERVAL_MS, "RUSTFS_REPL_MRF_FLUSH_INTERVAL_MS");
+        assert_eq!(ENV_REPL_RESYNC_POLL_MAX_MS, "RUSTFS_REPL_RESYNC_POLL_MAX_MS");
+    }
+
+    #[test]
+    #[serial]
+    fn unset_env_uses_default() {
+        with_env(ENV_REPL_HEALTH_CHECK_INTERVAL_MS, None, || {
+            assert_eq!(health_check_interval(), Duration::from_secs(5));
+        });
+        with_env(ENV_REPL_MRF_FLUSH_INTERVAL_MS, None, || {
+            assert_eq!(mrf_flush_interval(), Duration::from_secs(10));
+        });
+        with_env(ENV_REPL_RESYNC_POLL_MAX_MS, None, || {
+            assert_eq!(resync_poll_max_sleep(), Duration::from_secs(60));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn valid_override_is_applied() {
+        with_env(ENV_REPL_HEALTH_CHECK_INTERVAL_MS, Some("250"), || {
+            assert_eq!(health_check_interval(), Duration::from_millis(250));
+        });
+        with_env(ENV_REPL_MRF_FLUSH_INTERVAL_MS, Some("100"), || {
+            assert_eq!(mrf_flush_interval(), Duration::from_millis(100));
+        });
+        with_env(ENV_REPL_RESYNC_POLL_MAX_MS, Some("500"), || {
+            assert_eq!(resync_poll_max_sleep(), Duration::from_millis(500));
+        });
+        // Surrounding whitespace is tolerated.
+        with_env(ENV_REPL_MRF_FLUSH_INTERVAL_MS, Some(" 750 "), || {
+            assert_eq!(mrf_flush_interval(), Duration::from_millis(750));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn invalid_override_falls_back_to_default() {
+        for bad in ["abc", "", "-5", "1.5", "10s", "99999999999999999999999999"] {
+            with_env(ENV_REPL_HEALTH_CHECK_INTERVAL_MS, Some(bad), || {
+                assert_eq!(health_check_interval(), Duration::from_secs(5), "input {bad:?}");
+            });
+            with_env(ENV_REPL_MRF_FLUSH_INTERVAL_MS, Some(bad), || {
+                assert_eq!(mrf_flush_interval(), Duration::from_secs(10), "input {bad:?}");
+            });
+            with_env(ENV_REPL_RESYNC_POLL_MAX_MS, Some(bad), || {
+                assert_eq!(resync_poll_max_sleep(), Duration::from_secs(60), "input {bad:?}");
+            });
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn zero_or_tiny_override_is_clamped_to_minimum() {
+        for tiny in ["0", "1", "9"] {
+            with_env(ENV_REPL_HEALTH_CHECK_INTERVAL_MS, Some(tiny), || {
+                assert_eq!(health_check_interval(), MIN_INTERVAL, "input {tiny:?}");
+            });
+            with_env(ENV_REPL_MRF_FLUSH_INTERVAL_MS, Some(tiny), || {
+                assert_eq!(mrf_flush_interval(), MIN_INTERVAL, "input {tiny:?}");
+            });
+            with_env(ENV_REPL_RESYNC_POLL_MAX_MS, Some(tiny), || {
+                assert_eq!(resync_poll_max_sleep(), MIN_INTERVAL, "input {tiny:?}");
+            });
+        }
+        // Exactly the minimum is accepted as-is.
+        with_env(ENV_REPL_HEALTH_CHECK_INTERVAL_MS, Some("10"), || {
+            assert_eq!(health_check_interval(), MIN_INTERVAL);
+        });
+    }
+}


### PR DESCRIPTION
## Related Issues

Part of rustfs/backlog#1147 (repl-4) under the test-strategy master plan rustfs/backlog#1155. No rustfs issue; N/A for `Fixes`.

## Summary of Changes

Three hardcoded replication background-loop timings are now overridable via environment variables so tests (repl-5/9/11) and operators can shorten them. **Defaults are unchanged** — with no env vars set, behavior is bit-identical to before.

| Env var | Controls | Default | Read at |
| --- | --- | --- | --- |
| `RUSTFS_REPL_HEALTH_CHECK_INTERVAL_MS` | remote-target health-check probe interval (`bucket_target_sys.rs` `heartbeat`) | 5000ms | heartbeat task start |
| `RUSTFS_REPL_MRF_FLUSH_INTERVAL_MS` | MRF persistence flush interval (`replication_pool.rs` `start_mrf_persister`) | 10000ms | persister task start |
| `RUSTFS_REPL_RESYNC_POLL_MAX_MS` | upper bound of the random resync retry-poll sleep (`replication_pool.rs` `start_resync_routine`) | 60000ms | routine start |

Semantics (implemented in the new `crates/ecstore/src/bucket/replication/replication_timing.rs`):

- Absent var → default, silently. Unparsable value (empty, non-numeric, negative, overflow) → default plus a structured `tracing::warn!`. Parsed value below **10ms** → clamped to 10ms plus a `warn!` (a `0`/near-zero override can never busy-spin a loop; `tokio::time::interval` also panics on a zero period). All defaults are far above the floor, so clamping never alters default behavior.
- Every value is read **once when the owning background task starts**; changing an env var mid-run does not affect running loops (documented at each read site).
- Resync sleep keeps its anti-busy-spin floor as `min(1s, max)`: the default keeps the historical "sleep at least one second" behavior exactly, while short test overrides stay short.
- The acceptance note mentions the 30min health-check reload constant (`DEFAULT_HEALTH_CHECK_RELOAD_DURATION`): it is currently referenced nowhere (declared-only), so there is no loop to override and no var was added — the acceptance's three named vars are implemented as specified. The now-dead `DEFAULT_HEALTH_CHECK_DURATION` const was removed (its 5s default moved into `replication_timing.rs`).

`crates/e2e_test/src/common.rs` gains `replication_fast_env()` returning the full short-interval set for fast e2e runs (200/100/250 ms), matching the `start_rustfs_server_with_env` signature. Per repl-4 scope it is not wired into any test yet (repl-5/9). The env names there are string literals because the arch guard (`check_architecture_migration_rules.sh` replication-facade rule) forbids `rustfs_ecstore::api::bucket::replication` imports from e2e_test, and the vars are a process-boundary contract anyway (passed to the spawned server); the names are pinned by the `env_var_names_are_a_cross_process_contract` unit test in `replication_timing.rs`, mirroring the existing `ENV_RUSTFS_BUILD_FEATURES` literal precedent in that file.

## Verification

- `cargo check -p rustfs-ecstore -p e2e_test`
- `cargo clippy -p rustfs-ecstore -p e2e_test --all-targets -- -D warnings`
- `cargo nextest run -p rustfs-ecstore --lib -E 'test(replication_timing) or test(replication_pool) or test(bucket_target_sys)'` — 37 passed (5 new: default/override/fallback/clamp/name-contract; env manipulation uses the repo's `#[serial]` + save/restore pattern from `bucket_lifecycle_ops.rs`)
- `cargo fmt --all` + `make pre-commit` — all checks pass

Adversarial validation (high-risk tier, one-line verdicts):

- Correctness: attacked zero/tiny/overflow/whitespace/non-numeric env values, empty `random_range` bound (floor 10 plus defensive `.max(1)`), and default equivalence (5s/10s/60s-max/1s-floor identical) — no break found.
- Security: env values are local operator input parsed as `u64` only; warn logs carry no secrets; no authz/deserialization surface — no break found.
- Concurrency/durability: env read once per task start (thread-safe read; no production `set_var`); tests are `#[serial]` and nextest runs one process per test; no lock or commit-path changes — no break found.
- Compatibility: no S3/on-disk/on-wire change; `RUSTFS_REPL_` names collide with nothing repo-wide; defaults unchanged for mixed-version clusters — no break found.
- Performance: three `env::var` reads at background-task startup only; warn fires once per task start on misconfiguration only; no hot-path work added — no break found.
- Test coverage: parse/fallback/clamp/name-contract all revert-detecting; residual gap: no test fails if a call site is reverted to its hardcoded value — accepted per repl-4 acceptance scope (unit tests cover parse+fallback; call-site wiring is exercised end-to-end by repl-5/9, which consume `replication_fast_env()`).

## Impact

Test/ops-only configuration knobs; no user-facing or API change. No deployment impact when the vars are unset. Meaning and defaults are documented as doc comments at the definition and each read site.

## Additional Notes

Env var naming and semantics follow the repl-4 acceptance in rustfs/backlog#1147. Do not merge without maintainer review.
