### PR TITLE
fix(perf): keep build_ref_binary stdout clean and fail fast on missing baseline

### DIFF
--- a/scripts/run_hotpath_warp_ab.sh
+++ b/scripts/run_hotpath_warp_ab.sh
@@ -186,10 +186,15 @@ build_ref_binary() {
   local ref="$1" dest="$OUT_DIR/rustfs-baseline"
   if [[ -n "$BASELINE_BIN" ]]; then echo "$BASELINE_BIN"; return; fi
   local wt="$OUT_DIR/baseline-worktree"
-  run git worktree add --detach "$wt" "$ref"
-  run bash -c "cd '$wt' && cargo build --release --bin rustfs"
-  run cp "$wt/target/release/rustfs" "$dest" 2>/dev/null || true
-  run git worktree remove --force "$wt" 2>/dev/null || true
+  # This function returns the binary path on stdout, so every command's
+  # stdout must be routed to stderr: `git worktree add` prints "HEAD is now
+  # at …" on stdout, which polluted the captured path and made the rig exec
+  # a two-line string as the binary (2026-07-10 dispatch run failure).
+  run git worktree add --detach "$wt" "$ref" >&2
+  run bash -c "cd '$wt' && cargo build --release --bin rustfs" >&2
+  run cp "$wt/target/release/rustfs" "$dest" 2>/dev/null >&2 || true
+  run git worktree remove --force "$wt" 2>/dev/null >&2 || true
+  [[ "$DRY_RUN" == "true" || -x "$dest" ]] || { echo "error: baseline binary missing at $dest (baseline build failed?)" >&2; return 1; }
   echo "$dest"
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4669 (perf-1, rustfs/backlog#1152): the first post-merge dispatch verification ([run 29087503110](https://github.com/rustfs/rustfs/actions/runs/29087503110)) got past the old 60s-health failure (ran 1h12m, proving #4669's fix) but died in the measurement phase: **the baseline server exited 1s after spawn with 'No such file or directory'**.

Root cause (from the server-log artifact #4669 added — the diagnosability worked): `build_ref_binary()` returns the binary path on **stdout**, but `git worktree add` prints `HEAD is now at …` on stdout too, so the captured `BASELINE_BIN` became a two-line string and the rig exec'd it as a path:

```
binary=HEAD is now at f83f9ada fix(ecstore): reclaim page cache after io_uring reads (#4662)
/home/runner/_work/rustfs/rustfs/target/hotpath-ab/20260710T105343Z/rustfs-baseline
```

## Changes
- Route every command's stdout inside `build_ref_binary()` to stderr; only the path is printed on stdout (with a comment explaining why).
- Fail fast with a clear error if the baseline binary is missing after the build (exempt in `--dry-run`, which never builds).
- Fix the `mis-reports` typo in docs/operations/hotpath-warp-ab-runbook.md that failed the Typos check on #4669.

## Verification
- `bash -n` + shellcheck clean; `--help` exits 0.
- End-to-end: dispatch [run 29094184933](https://github.com/rustfs/rustfs/actions/runs/29094184933) is executing this exact fix (the old PR branch ref now carries it); it should clear baseline spawn and reach measurement/gate. Will report the outcome on this PR.

Refs rustfs/backlog#1152 (perf-1 follow-up), rustfs/backlog#1155.