### PR TITLE
fix(ecstore): harden rollback transaction recovery

### DIFF
--- a/crates/e2e_test/src/reliant/grpc_lock_server.rs
+++ b/crates/e2e_test/src/reliant/grpc_lock_server.rs
@@ -230,6 +230,44 @@ impl NodeService for MinimalLockNodeService {
         }
     }
 
+    async fn refresh_batch(
+        &self,
+        request: Request<BatchGenerallyLockRequest>,
+    ) -> Result<Response<BatchGenerallyLockResponse>, Status> {
+        let request = request.into_inner();
+        let mut results = vec![lock_result_from_error("request was not processed"); request.args.len()];
+        let mut lock_ids = Vec::with_capacity(request.args.len());
+        let mut valid_indices = Vec::with_capacity(request.args.len());
+
+        for (idx, arg) in request.args.iter().enumerate() {
+            match serde_json::from_str::<LockRequest>(arg) {
+                Ok(args) => {
+                    lock_ids.push(args.lock_id);
+                    valid_indices.push(idx);
+                }
+                Err(err) => {
+                    results[idx] = lock_result_from_error(format!("can not decode args, err: {err}"));
+                }
+            }
+        }
+
+        for (result_idx, result) in self.lock_client.refresh_locks_batch(&lock_ids).await.into_iter().enumerate() {
+            let Some(request_idx) = valid_indices.get(result_idx) else {
+                break;
+            };
+            results[*request_idx] = match result {
+                Ok(success) => GenerallyLockResult {
+                    success,
+                    error_info: None,
+                    lock_info: None,
+                },
+                Err(err) => lock_result_from_error(format!("can not refresh, err: {err}")),
+            };
+        }
+
+        Ok(Response::new(BatchGenerallyLockResponse { results }))
+    }
+
     async fn lock_batch(
         &self,
         request: Request<BatchGenerallyLockRequest>,

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -180,6 +180,10 @@ name = "rename_data_meta_benchmark"
 harness = false
 
 [[bench]]
+name = "rename_transaction_benchmark"
+harness = false
+
+[[bench]]
 name = "single_block_non_inline_benchmark"
 harness = false
 

--- a/crates/ecstore/benches/rename_transaction_benchmark.rs
+++ b/crates/ecstore/benches/rename_transaction_benchmark.rs
@@ -1,0 +1,148 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use rustfs_filemeta::{FileInfo, FileMeta};
+use std::{fs, hint::black_box, sync::Arc, time::Duration};
+use tempfile::TempDir;
+use time::OffsetDateTime;
+use tokio::runtime::Runtime;
+use uuid::Uuid;
+
+mod storage_api;
+
+use storage_api::rename_transaction::{DiskAPI, Endpoint, LocalDisk, RUSTFS_META_TMP_BUCKET, STORAGE_FORMAT_FILE};
+
+struct RenameCase {
+    _root: TempDir,
+    disk: Arc<LocalDisk>,
+    incoming: Option<FileInfo>,
+}
+
+fn metadata(file_info: FileInfo) -> Vec<u8> {
+    let mut metadata = FileMeta::new();
+    metadata
+        .add_version(file_info)
+        .expect("benchmark metadata should accept version");
+    metadata.marshal_msg().expect("benchmark metadata should encode")
+}
+
+fn file_info(name: &str, contents: &'static [u8]) -> FileInfo {
+    FileInfo {
+        name: name.to_string(),
+        version_id: Some(Uuid::new_v4()),
+        data: Some(Bytes::from_static(contents)),
+        size: contents.len() as i64,
+        mod_time: Some(OffsetDateTime::now_utc()),
+        ..Default::default()
+    }
+}
+
+fn setup_case(runtime: &Runtime, overwrite: bool) -> RenameCase {
+    let root = tempfile::tempdir().expect("benchmark temp dir should be created");
+    let endpoint = Endpoint::try_from(root.path().to_str().expect("benchmark path should be utf8"))
+        .expect("benchmark endpoint should parse");
+    let disk = Arc::new(
+        runtime
+            .block_on(LocalDisk::new(&endpoint, false))
+            .expect("benchmark disk should initialize"),
+    );
+    fs::create_dir_all(root.path().join(RUSTFS_META_TMP_BUCKET).join("source")).expect("benchmark source should be created");
+    fs::create_dir_all(root.path().join("bucket").join("object")).expect("benchmark destination should be created");
+
+    let incoming = file_info("object", b"new");
+    fs::write(
+        root.path()
+            .join(RUSTFS_META_TMP_BUCKET)
+            .join("source")
+            .join(STORAGE_FORMAT_FILE),
+        metadata(incoming.clone()),
+    )
+    .expect("benchmark source metadata should be written");
+    if overwrite {
+        fs::write(
+            root.path().join("bucket").join("object").join(STORAGE_FORMAT_FILE),
+            metadata(file_info("object", b"old")),
+        )
+        .expect("benchmark destination metadata should be written");
+    }
+
+    RenameCase {
+        _root: root,
+        disk,
+        incoming: Some(incoming),
+    }
+}
+
+fn bench_rename_transaction(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("benchmark runtime should initialize");
+    let mut group = c.benchmark_group("rename_transaction");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(5));
+
+    for overwrite in [false, true] {
+        let case_name = if overwrite { "overwrite" } else { "new_object" };
+        group.bench_with_input(BenchmarkId::new("legacy", case_name), &overwrite, |b, overwrite| {
+            b.iter_batched_ref(
+                || setup_case(&runtime, *overwrite),
+                |case| {
+                    runtime.block_on(async {
+                        black_box(
+                            case.disk
+                                .rename_data(
+                                    RUSTFS_META_TMP_BUCKET,
+                                    "source",
+                                    case.incoming.take().expect("benchmark input should be present"),
+                                    "bucket",
+                                    "object",
+                                )
+                                .await
+                                .expect("legacy rename should succeed"),
+                        );
+                    });
+                },
+                BatchSize::PerIteration,
+            );
+        });
+        group.bench_with_input(BenchmarkId::new("transaction", case_name), &overwrite, |b, overwrite| {
+            b.iter_batched_ref(
+                || setup_case(&runtime, *overwrite),
+                |case| {
+                    runtime.block_on(async {
+                        black_box(
+                            case.disk
+                                .rename_data_with_rollback(
+                                    RUSTFS_META_TMP_BUCKET,
+                                    "source",
+                                    case.incoming.take().expect("benchmark input should be present"),
+                                    "bucket",
+                                    "object",
+                                    Uuid::new_v4(),
+                                )
+                                .await
+                                .expect("transaction rename should succeed"),
+                        );
+                    });
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_rename_transaction);
+criterion_main!(benches);

--- a/crates/ecstore/benches/storage_api/mod.rs
+++ b/crates/ecstore/benches/storage_api/mod.rs
@@ -26,6 +26,10 @@ pub(crate) mod erasure {
     pub(crate) use super::{BitrotReader, BitrotWriter, Erasure, calc_shard_size};
 }
 
+pub(crate) mod rename_transaction {
+    pub(crate) use rustfs_ecstore::api::disk::{DiskAPI, Endpoint, LocalDisk, RUSTFS_META_TMP_BUCKET, STORAGE_FORMAT_FILE};
+}
+
 pub(crate) mod single_block_non_inline {
     pub(crate) use super::{BitrotWriterWrapper, CustomWriter, Erasure};
 }

--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -269,13 +269,14 @@ pub mod data_usage {
 
 pub mod disk {
     pub use crate::disk::disk_store::get_object_disk_read_timeout;
-    pub use crate::disk::local::ScanGuard;
+    pub use crate::disk::local::{LocalDisk, ScanGuard};
     pub use crate::disk::{
         BATCH_READ_VERSION_MAX_ITEMS, BUCKET_META_PREFIX, BatchReadVersionItem, BatchReadVersionReq, BatchReadVersionResp,
         CheckPartsResp, DeleteOptions, Disk, DiskAPI, DiskInfo, DiskInfoOptions, DiskLocation, DiskOption, DiskStore,
-        FileInfoVersions, FileReader, FileWriter, HEALING_MARKER_PATH, OldCurrentSize, RUSTFS_META_BUCKET, ReadMultipleReq,
-        ReadMultipleResp, ReadOptions, RenameDataResp, STORAGE_FORMAT_FILE, UpdateMetadataOpts, VolumeInfo, WalkDirOptions,
-        new_disk, validate_batch_read_version_item_count,
+        FileInfoVersions, FileReader, FileWriter, HEALING_MARKER_PATH, OldCurrentSize, RUSTFS_META_BUCKET,
+        RUSTFS_META_TMP_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions, RenameDataPayload, RenameDataResp,
+        STORAGE_FORMAT_FILE, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, decode_delete_options_payload,
+        decode_rename_data_payload, new_disk, validate_batch_read_version_item_count,
     };
     pub use bytes::Bytes;
     pub use endpoint::Endpoint;

--- a/crates/ecstore/src/cluster/rpc/client.rs
+++ b/crates/ecstore/src/cluster/rpc/client.rs
@@ -17,7 +17,8 @@ use crate::disk::error::{DiskError, Error as DiskErrorType};
 use crate::runtime::sources as runtime_sources;
 use http::Method;
 use rustfs_protos::{
-    ChannelClass, create_new_channel, get_channel_for_class, proto_gen::node_service::node_service_client::NodeServiceClient,
+    ChannelClass, create_new_channel, get_channel_for_class, get_transaction_channel,
+    proto_gen::node_service::node_service_client::NodeServiceClient,
 };
 use std::{error::Error, io::ErrorKind};
 use tonic::{service::interceptor::InterceptedService, transport::Channel};
@@ -69,6 +70,20 @@ pub async fn node_service_time_out_client_no_auth(
     addr: &String,
 ) -> Result<NodeServiceClient<InterceptedService<Channel, TonicInterceptor>>, Box<dyn Error>> {
     node_service_time_out_client(addr, TonicInterceptor::NoOp(NoOpInterceptor)).await
+}
+
+/// Build a client on the dedicated transaction channel. Connection and
+/// keepalive timeouts still apply, but no per-RPC deadline can make the caller
+/// abandon a server-side protected mutation before its final response.
+pub async fn node_service_transaction_client(
+    addr: &str,
+    interceptor: TonicInterceptor,
+) -> Result<NodeServiceClient<InterceptedService<Channel, TonicInterceptor>>, Box<dyn Error>> {
+    let channel = get_transaction_channel(addr).await?;
+    let max_message_size = rustfs_protos::internode_rpc_max_message_size();
+    Ok(NodeServiceClient::with_interceptor(channel, interceptor)
+        .max_decoding_message_size(max_message_size)
+        .max_encoding_message_size(max_message_size))
 }
 
 pub(crate) fn is_network_like_disk_error(err: &DiskErrorType) -> bool {

--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -14,7 +14,7 @@
 
 use crate::cluster::rpc::client::{
     TonicInterceptor, gen_tonic_signature_interceptor, is_network_like_disk_error, node_service_time_out_client,
-    node_service_time_out_client_for_class, node_service_time_out_client_no_auth,
+    node_service_time_out_client_for_class, node_service_time_out_client_no_auth, node_service_transaction_client,
 };
 use crate::cluster::rpc::internode_data_transport::{
     InternodeDataTransport, ReadStreamRequest, WalkDirStreamRequest, WriteStreamRequest,
@@ -22,14 +22,15 @@ use crate::cluster::rpc::internode_data_transport::{
 use crate::disk::error::{Error, Result};
 use crate::disk::{
     BatchReadVersionReq, BatchReadVersionResp, CheckPartsResp, DeleteOptions, DiskAPI, DiskInfo, DiskInfoOptions, DiskLocation,
-    DiskOption, FileInfoVersions, FileReader, FileWriter, ReadMultipleReq, ReadMultipleResp, ReadOptions, RenameDataResp,
-    UpdateMetadataOpts, VolumeInfo, WalkDirOptions, batch_read_version_one_by_one,
+    DiskOption, FileInfoVersions, FileReader, FileWriter, RENAME_DATA_ENVELOPE_MAGIC, ReadMultipleReq, ReadMultipleResp,
+    ReadOptions, RenameDataResp, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, batch_read_version_one_by_one,
     disk_store::{
         DEFAULT_RUSTFS_DRIVE_ACTIVE_MONITORING, ENV_RUSTFS_DRIVE_ACTIVE_MONITORING, SKIP_IF_SUCCESS_BEFORE,
         get_drive_active_check_interval, get_drive_active_check_timeout, get_drive_disk_info_timeout, get_drive_list_dir_timeout,
         get_drive_metadata_timeout, get_drive_walkdir_stall_timeout, get_drive_walkdir_timeout, get_max_timeout_duration,
         get_object_disk_read_timeout,
     },
+    encode_delete_options_envelope, encode_rename_data_envelope,
     endpoint::Endpoint,
     health_state::{RuntimeDriveHealthState, get_drive_returning_probe_interval, record_drive_runtime_state},
     validate_batch_read_version_item_count,
@@ -42,6 +43,7 @@ use metrics::counter;
 use rustfs_filemeta::{FileInfo, ObjectPartInfo, RawFileInfo};
 use rustfs_protos::ChannelClass;
 use rustfs_protos::evict_failed_connection;
+use rustfs_protos::proto_gen::node_service::Error as RpcError;
 use rustfs_protos::proto_gen::node_service::RenamePartRequest;
 use rustfs_protos::proto_gen::node_service::{
     BatchReadVersionRequest, BatchReadVersionResponse, CheckPartsRequest, DeletePathsRequest, DeleteRequest,
@@ -56,7 +58,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicU8, AtomicU32, Ordering},
     },
     time::Duration,
 };
@@ -96,6 +98,89 @@ const LOG_COMPONENT_ECSTORE: &str = "ecstore";
 const LOG_SUBSYSTEM_REMOTE_DISK: &str = "remote_disk";
 const EVENT_REMOTE_DISK_HEALTH: &str = "remote_disk_health";
 const EVENT_REMOTE_DISK_RPC: &str = "remote_disk_rpc";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum RenameRollbackCapability {
+    Unknown = 0,
+    TransactionV1 = 1,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum DeleteRollbackCapability {
+    Unknown = 0,
+    EnvelopeV1 = 1,
+}
+
+impl DeleteRollbackCapability {
+    fn record_supported(value: &AtomicU8) {
+        value.store(Self::EnvelopeV1 as u8, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    fn load(value: &AtomicU8) -> Self {
+        match value.load(Ordering::Acquire) {
+            1 => Self::EnvelopeV1,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl RenameRollbackCapability {
+    fn record_supported(value: &AtomicU8) {
+        value.store(Self::TransactionV1 as u8, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    fn load(value: &AtomicU8) -> Self {
+        match value.load(Ordering::Acquire) {
+            1 => Self::TransactionV1,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+enum RenameDataRpcOutcome {
+    Success(RenameDataResp),
+    TransactionUnsupported,
+}
+
+const RENAME_DATA_LEGACY_JSON_PROBE: &str = "\"rustfs-rename-transaction-v1\"";
+const DELETE_OPTIONS_DECODE_ERROR_PREFIX: &str = "io error decode DeleteOptions failed: ";
+const RENAME_TRANSACTION_UNSUPPORTED: &str = "peer does not support rollback-protected rename transactions";
+const DELETE_TRANSACTION_UNSUPPORTED: &str = "peer does not support rollback-protected delete transactions";
+
+// RUSTFS_COMPAT_TODO(RPC-4300-RENAME): exact predecessor detection lets the current transactional rename fail closed without retrying a weaker mutation. Do not cache rejection: the peer may be upgraded behind a reused RemoteDisk. Remove after the minimum peer accepts transaction envelopes for one full release window.
+fn is_legacy_rename_envelope_rejection(error: &RpcError) -> bool {
+    let msgpack_rejection = format!(
+        "io error decode FileInfo failed: io error decode FileInfo msgpack failed: invalid type: integer `{RENAME_DATA_ENVELOPE_MAGIC}`, expected a string"
+    );
+    let pre_bin_rejection = format!(
+        "io error decode FileInfo failed: invalid type: string {RENAME_DATA_LEGACY_JSON_PROBE}, expected struct FileInfo"
+    );
+    error.code == DiskError::other("").to_u32()
+        && (error.error_info == msgpack_rejection || error.error_info == pre_bin_rejection)
+}
+
+fn is_delete_options_envelope_rejection(error: &RpcError) -> bool {
+    error.code == DiskError::other("").to_u32() && error.error_info.starts_with(DELETE_OPTIONS_DECODE_ERROR_PREFIX)
+}
+
+fn normalize_delete_versions_errors(errors: Vec<String>, expected_len: usize) -> Vec<Option<Error>> {
+    if errors.len() != expected_len {
+        let error = Error::other(format!(
+            "delete_versions response cardinality mismatch: expected {expected_len}, got {}",
+            errors.len()
+        ));
+        return vec![Some(error); expected_len];
+    }
+
+    errors
+        .into_iter()
+        .map(|error| if error.is_empty() { None } else { Some(Error::other(error)) })
+        .collect()
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BatchMetadataRpcMode {
@@ -188,6 +273,8 @@ pub struct RemoteDisk {
     /// Cancellation token for monitoring tasks
     cancel_token: CancellationToken,
     data_transport: Arc<dyn InternodeDataTransport>,
+    rename_rollback_capability: AtomicU8,
+    delete_rollback_capability: AtomicU8,
 }
 
 // ── Connection lifecycle (grpc-optimization P3) ──
@@ -315,6 +402,8 @@ impl RemoteDisk {
             health: Arc::new(DiskHealthTracker::new()),
             cancel_token: CancellationToken::new(),
             data_transport,
+            rename_rollback_capability: AtomicU8::new(RenameRollbackCapability::Unknown as u8),
+            delete_rollback_capability: AtomicU8::new(DeleteRollbackCapability::Unknown as u8),
         };
         record_drive_runtime_state(ep, RuntimeDriveHealthState::Online);
 
@@ -806,8 +895,88 @@ impl RemoteDisk {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<T>>,
     {
+        self.execute_with_timeout_for_op_and_health_action_inner(op, operation, timeout_duration, failure_health_action, false)
+            .await
+    }
+
+    async fn execute_transaction_to_completion<T, F, Fut>(
+        &self,
+        op: &'static str,
+        operation: F,
+        timeout_duration: Duration,
+        failure_health_action: FailureHealthAction,
+        bypass_faulty_short_circuit: bool,
+    ) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        if self.health.is_faulty() && !bypass_faulty_short_circuit {
+            return Err(DiskError::FaultyDisk);
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i64;
+        self.health.last_started.store(now, Ordering::Relaxed);
+        let _waiting_guard = self.health.waiting_guard();
+        let mut operation = Box::pin(operation());
+
+        let operation_result = if timeout_duration == Duration::ZERO {
+            operation.await
+        } else {
+            tokio::select! {
+                biased;
+                result = &mut operation => result,
+                _ = time::sleep(timeout_duration) => {
+                    counter!(
+                        "rustfs_drive_op_timeout_total",
+                        "endpoint" => self.endpoint.to_string(),
+                        "op" => op.to_string()
+                    )
+                    .increment(1);
+                    if failure_health_action == FailureHealthAction::MarkFailure {
+                        self.mark_faulty_and_evict("transaction_deadline_exceeded").await;
+                    }
+                    warn!(
+                        event = EVENT_REMOTE_DISK_RPC,
+                        component = LOG_COMPONENT_ECSTORE,
+                        subsystem = LOG_SUBSYSTEM_REMOTE_DISK,
+                        endpoint = %self.endpoint,
+                        addr = %self.addr,
+                        op,
+                        timeout_ms = timeout_duration.as_millis(),
+                        state = "deadline_exceeded_waiting_for_completion",
+                        "Remote disk transaction exceeded its deadline; waiting for the final outcome"
+                    );
+                    operation.await
+                }
+            }
+        };
+
+        if operation_result.is_ok() {
+            self.health.log_success();
+        }
+        self.handle_network_like_error(op, timeout_duration, &operation_result, failure_health_action)
+            .await;
+        operation_result
+    }
+
+    async fn execute_with_timeout_for_op_and_health_action_inner<T, F, Fut>(
+        &self,
+        op: &'static str,
+        operation: F,
+        timeout_duration: Duration,
+        failure_health_action: FailureHealthAction,
+        bypass_faulty_short_circuit: bool,
+    ) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
         // Check if disk is faulty
-        if self.health.is_faulty() {
+        if self.health.is_faulty() && !bypass_faulty_short_circuit {
             debug!(
                 event = EVENT_REMOTE_DISK_HEALTH,
                 component = LOG_COMPONENT_ECSTORE,
@@ -987,6 +1156,12 @@ impl RemoteDisk {
             .map_err(|err| Error::other(format!("can not get client, err: {err}")))
     }
 
+    async fn get_transaction_client(&self) -> Result<NodeServiceClient<InterceptedService<Channel, TonicInterceptor>>> {
+        node_service_transaction_client(&self.addr, TonicInterceptor::Signature(gen_tonic_signature_interceptor()))
+            .await
+            .map_err(|err| Error::other(format!("can not get transaction client, err: {err}")))
+    }
+
     /// Client for large `bytes`-carrying RPCs (ReadAll/WriteAll/ReadMultiple/BatchReadVersion).
     /// Routes onto the isolated bulk channel pool so large transfers cannot head-of-line block
     /// lock/health RPCs (grpc-optimization P1). Falls back to the control channel when isolation
@@ -1032,10 +1207,27 @@ fn compat_json<T: Serialize>(value: &T) -> Result<String> {
     Ok(serde_json::to_string(value)?)
 }
 
+// RUSTFS_COMPAT_TODO(RPC-4300): ordinary delete options retain JSON for rolling upgrades while transactional options are envelope-only and fail closed. Remove after the minimum peer decodes named msgpack options for one full release window.
+fn delete_options_compat_json(opts: &DeleteOptions) -> Result<String> {
+    if opts.requires_delete_rollback_protocol() {
+        return Ok(String::new());
+    }
+    // Old peers ignore opts_bin entirely. Keep this JSON even in msgpack-only
+    // mode until every supported rolling-upgrade predecessor decodes opts_bin.
+    Ok(serde_json::to_string(opts)?)
+}
+
 fn encode_msgpack_named<T: Serialize>(value: &T) -> Result<Vec<u8>> {
     let mut serializer = rmp_serde::Serializer::new(Vec::with_capacity(MSGPACK_ENCODE_CAPACITY_HINT)).with_struct_map();
     value.serialize(&mut serializer)?;
     Ok(serializer.into_inner())
+}
+
+fn encode_delete_options_msgpack(opts: &DeleteOptions) -> Result<Vec<u8>> {
+    if opts.requires_delete_rollback_protocol() {
+        return encode_delete_options_envelope(opts.clone());
+    }
+    encode_msgpack_named(opts)
 }
 
 fn decode_msgpack_or_json<T: DeserializeOwned>(binary: &[u8], json: &str, value_name: &'static str) -> Result<T> {
@@ -1147,6 +1339,67 @@ fn decode_batch_read_version_response_items(
     }
 
     Ok(batch_read_version_resps)
+}
+
+impl RemoteDisk {
+    async fn send_rename_data_payload(
+        &self,
+        src: (&str, &str),
+        dst: (&str, &str),
+        file_info: String,
+        file_info_bin: Vec<u8>,
+        detect_legacy_rejection: bool,
+        transaction: bool,
+    ) -> Result<RenameDataRpcOutcome> {
+        let (src_volume, src_path) = src;
+        let (dst_volume, dst_path) = dst;
+        let operation = || async move {
+            let mut client = if transaction {
+                self.get_transaction_client().await?
+            } else {
+                self.get_client().await?
+            };
+            let request = Request::new(RenameDataRequest {
+                disk: self.endpoint.to_string(),
+                src_volume: src_volume.to_string(),
+                src_path: src_path.to_string(),
+                file_info,
+                dst_volume: dst_volume.to_string(),
+                dst_path: dst_path.to_string(),
+                file_info_bin: file_info_bin.into(),
+            });
+
+            let response = client.rename_data(request).await?.into_inner();
+            if !response.success {
+                let error = response.error.unwrap_or_default();
+                if detect_legacy_rejection && is_legacy_rename_envelope_rejection(&error) {
+                    return Ok(RenameDataRpcOutcome::TransactionUnsupported);
+                }
+                return Err(error.into());
+            }
+
+            let rename_data_resp = decode_msgpack_or_json::<RenameDataResp>(
+                &response.rename_data_resp_bin,
+                &response.rename_data_resp,
+                "RenameDataResp",
+            )?;
+            Ok(RenameDataRpcOutcome::Success(rename_data_resp))
+        };
+
+        if transaction {
+            self.execute_transaction_to_completion(
+                "rename_data_transaction",
+                operation,
+                get_max_timeout_duration(),
+                FailureHealthAction::MarkFailure,
+                false,
+            )
+            .await
+        } else {
+            self.execute_with_timeout_for_op("rename_data", operation, get_max_timeout_duration())
+                .await
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -1425,6 +1678,9 @@ impl DiskAPI for RemoteDisk {
         force_del_marker: bool,
         opts: DeleteOptions,
     ) -> Result<()> {
+        opts.validate_delete_rollback()?;
+        let is_transaction = opts.requires_delete_rollback_protocol();
+        let is_compensation = opts.is_compensation();
         trace!(
             event = EVENT_REMOTE_DISK_RPC,
             component = LOG_COMPONENT_ECSTORE,
@@ -1437,173 +1693,170 @@ impl DiskAPI for RemoteDisk {
             "Remote disk RPC started"
         );
 
-        self.execute_with_timeout(
-            || async {
-                // `_bin` support for DeleteVersion is new (grpc-optimization P2); always dual-write
-                // JSON + msgpack until its fallback counter has read zero across a release window.
-                let file_info_bin = encode_msgpack(&fi)?;
-                let opts_bin = encode_msgpack(&opts)?;
-                let file_info = serde_json::to_string(&fi)?;
-                let opts = serde_json::to_string(&opts)?;
+        let operation = || async {
+            let file_info_bin = Bytes::from(encode_msgpack(&fi)?);
+            let file_info = serde_json::to_string(&fi)?;
+            let opts_json = delete_options_compat_json(&opts)?;
+            let opts_bin = Bytes::from(encode_delete_options_msgpack(&opts)?);
 
-                let mut client = self
-                    .get_client()
-                    .await
-                    .map_err(|err| Error::other(format!("can not get client, err: {err}")))?;
-                let request = Request::new(DeleteVersionRequest {
-                    disk: self.endpoint.to_string(),
-                    volume: volume.to_string(),
-                    path: path.to_string(),
-                    file_info,
-                    force_del_marker,
-                    opts,
-                    file_info_bin: file_info_bin.into(),
-                    opts_bin: opts_bin.into(),
-                });
+            let mut client = if is_transaction {
+                self.get_transaction_client().await?
+            } else {
+                self.get_client().await?
+            };
+            let request = Request::new(DeleteVersionRequest {
+                disk: self.endpoint.to_string(),
+                volume: volume.to_string(),
+                path: path.to_string(),
+                file_info,
+                force_del_marker,
+                opts: opts_json,
+                file_info_bin,
+                opts_bin,
+            });
 
-                let response = client.delete_version(request).await?.into_inner();
+            let response = client.delete_version(request).await?.into_inner();
+            if is_transaction && response.error.as_ref().is_some_and(is_delete_options_envelope_rejection) {
+                return Err(Error::other(DELETE_TRANSACTION_UNSUPPORTED));
+            }
+            if is_transaction && response.success {
+                DeleteRollbackCapability::record_supported(&self.delete_rollback_capability);
+            }
 
-                if !response.success {
-                    return Err(response.error.unwrap_or_default().into());
-                }
+            if !response.success {
+                return Err(response.error.unwrap_or_default().into());
+            }
 
-                // let raw_file_info = serde_json::from_str::<RawFileInfo>(&response.raw_file_info)?;
+            // let raw_file_info = serde_json::from_str::<RawFileInfo>(&response.raw_file_info)?;
 
-                Ok(())
-            },
-            get_max_timeout_duration(),
-        )
-        .await
+            Ok(())
+        };
+        if is_transaction {
+            self.execute_transaction_to_completion(
+                if is_compensation {
+                    "delete_version_compensation"
+                } else {
+                    "delete_version_transaction"
+                },
+                operation,
+                get_max_timeout_duration(),
+                if is_compensation {
+                    FailureHealthAction::IgnoreFailure
+                } else {
+                    FailureHealthAction::MarkFailure
+                },
+                is_compensation,
+            )
+            .await
+        } else {
+            self.execute_with_timeout_for_op("delete_version", operation, get_max_timeout_duration())
+                .await
+        }
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
     async fn delete_versions(&self, volume: &str, versions: Vec<FileInfoVersions>, opts: DeleteOptions) -> Vec<Option<Error>> {
+        let expected_len = versions.len();
+        if let Err(err) = opts.validate_delete_rollback() {
+            return vec![Some(err); expected_len];
+        }
+        let is_transaction = opts.requires_delete_rollback_protocol();
+        let is_compensation = opts.is_compensation();
         trace!(
             event = EVENT_REMOTE_DISK_RPC,
             component = LOG_COMPONENT_ECSTORE,
             subsystem = LOG_SUBSYSTEM_REMOTE_DISK,
             endpoint = %self.endpoint,
             volume,
-            version_count = versions.len(),
+            version_count = expected_len,
             op = "delete_versions",
             state = "started",
             "Remote disk RPC started"
         );
 
-        if self.health.is_faulty() {
-            return vec![Some(DiskError::FaultyDisk); versions.len()];
+        if self.health.is_faulty() && !is_compensation {
+            return vec![Some(DiskError::FaultyDisk); expected_len];
         }
 
-        // `_bin` support for DeleteVersions is new (grpc-optimization P2); always dual-write JSON +
-        // msgpack until its fallback counter has read zero across a release window.
-        let opts_bin = match encode_msgpack(&opts) {
+        let opts_bin = match encode_delete_options_msgpack(&opts) {
             Ok(opts_bin) => opts_bin,
-            Err(err) => {
-                let mut errors = Vec::with_capacity(versions.len());
-                for _ in 0..versions.len() {
-                    errors.push(Some(Error::other(err.to_string())));
-                }
-                return errors;
-            }
+            Err(err) => return vec![Some(Error::other(err.to_string())); expected_len],
         };
-        let opts = match serde_json::to_string(&opts) {
-            Ok(opts) => opts,
-            Err(err) => {
-                let mut errors = Vec::with_capacity(versions.len());
-                for _ in 0..versions.len() {
-                    errors.push(Some(Error::other(err.to_string())));
-                }
-                return errors;
-            }
+        let opts_json = match delete_options_compat_json(&opts) {
+            Ok(opts_json) => opts_json,
+            Err(err) => return vec![Some(Error::other(err.to_string())); expected_len],
         };
-        let mut versions_str = Vec::with_capacity(versions.len());
-        let mut versions_bin = Vec::with_capacity(versions.len());
-        for file_info_versions in versions.iter() {
+        let mut versions_str = Vec::with_capacity(expected_len);
+        let mut versions_bin = Vec::with_capacity(expected_len);
+        for file_info_versions in &versions {
             versions_str.push(match serde_json::to_string(file_info_versions) {
                 Ok(versions_str) => versions_str,
-                Err(err) => {
-                    let mut errors = Vec::with_capacity(versions.len());
-                    for _ in 0..versions.len() {
-                        errors.push(Some(Error::other(err.to_string())));
-                    }
-                    return errors;
-                }
+                Err(err) => return vec![Some(Error::other(err.to_string())); expected_len],
             });
             versions_bin.push(match encode_msgpack(file_info_versions) {
                 Ok(versions_bin) => Bytes::from(versions_bin),
-                Err(err) => {
-                    let mut errors = Vec::with_capacity(versions.len());
-                    for _ in 0..versions.len() {
-                        errors.push(Some(Error::other(err.to_string())));
-                    }
-                    return errors;
-                }
+                Err(err) => return vec![Some(Error::other(err.to_string())); expected_len],
             });
         }
-        let mut client = match self.get_client().await {
-            Ok(client) => client,
-            Err(err) => {
-                let mut errors = Vec::with_capacity(versions.len());
-                for _ in 0..versions.len() {
-                    errors.push(Some(Error::other(err.to_string())));
-                }
-                return errors;
+
+        let operation = || async {
+            let mut client = if is_transaction {
+                self.get_transaction_client().await?
+            } else {
+                self.get_client().await?
+            };
+            let request = Request::new(DeleteVersionsRequest {
+                disk: self.endpoint.to_string(),
+                volume: volume.to_string(),
+                versions: versions_str,
+                opts: opts_json,
+                versions_bin,
+                opts_bin: Bytes::from(opts_bin),
+            });
+            let response = client
+                .delete_versions(request)
+                .await
+                .map_err(|err| Error::other(format!("delete_versions failed: {err}")))?
+                .into_inner();
+            if is_transaction && response.error.as_ref().is_some_and(is_delete_options_envelope_rejection) {
+                return Err(Error::other(DELETE_TRANSACTION_UNSUPPORTED));
             }
+            if is_transaction && response.success {
+                DeleteRollbackCapability::record_supported(&self.delete_rollback_capability);
+            }
+            Ok(response)
         };
-
-        let request = Request::new(DeleteVersionsRequest {
-            disk: self.endpoint.to_string(),
-            volume: volume.to_string(),
-            versions: versions_str,
-            opts,
-            versions_bin,
-            opts_bin: opts_bin.into(),
-        });
-
-        // TODO: use Error not string
-
-        let result = self
-            .execute_with_timeout(
-                || async {
-                    client
-                        .delete_versions(request)
-                        .await
-                        .map_err(|err| Error::other(format!("delete_versions failed: {err}")))
+        let result = if is_transaction {
+            self.execute_transaction_to_completion(
+                if is_compensation {
+                    "delete_versions_compensation"
+                } else {
+                    "delete_versions_transaction"
                 },
+                operation,
                 get_max_timeout_duration(),
+                if is_compensation {
+                    FailureHealthAction::IgnoreFailure
+                } else {
+                    FailureHealthAction::MarkFailure
+                },
+                is_compensation,
             )
-            .await;
+            .await
+        } else {
+            self.execute_with_timeout_for_op("delete_versions", operation, get_max_timeout_duration())
+                .await
+        };
 
         let response = match result {
             Ok(response) => response,
-            Err(err) => {
-                let mut errors = Vec::with_capacity(versions.len());
-                for _ in 0..versions.len() {
-                    errors.push(Some(err.clone()));
-                }
-                return errors;
-            }
+            Err(err) => return vec![Some(err); expected_len],
         };
 
-        let response = response.into_inner();
         if !response.success {
-            let mut errors = Vec::with_capacity(versions.len());
-            for _ in 0..versions.len() {
-                errors.push(Some(Error::other(response.error.clone().map(|e| e.error_info).unwrap_or_default())));
-            }
-            return errors;
+            return vec![Some(Error::other(response.error.map(|error| error.error_info).unwrap_or_default())); expected_len];
         }
-        response
-            .errors
-            .iter()
-            .map(|error| {
-                if error.is_empty() {
-                    None
-                } else {
-                    Some(Error::other(error.to_string()))
-                }
-            })
-            .collect()
+        normalize_delete_versions_errors(response.errors, expected_len)
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -1621,16 +1874,14 @@ impl DiskAPI for RemoteDisk {
         );
         let paths = paths.to_owned();
 
-        self.execute_with_timeout(
-            || async {
-                let mut client = self
-                    .get_client()
-                    .await
-                    .map_err(|err| Error::other(format!("can not get client, err: {err}")))?;
+        self.execute_with_timeout_for_op(
+            "delete_paths",
+            || async move {
+                let mut client = self.get_client().await?;
                 let request = Request::new(DeletePathsRequest {
                     disk: self.endpoint.to_string(),
                     volume: volume.to_string(),
-                    paths: paths.clone(),
+                    paths,
                 });
 
                 let response = client.delete_paths(request).await?.into_inner();
@@ -1994,42 +2245,51 @@ impl DiskAPI for RemoteDisk {
             "Remote disk RPC started"
         );
 
-        self.execute_with_timeout_for_op(
-            "rename_data",
-            || async {
-                let file_info = compat_json(&fi)?;
-                let file_info_bin = encode_msgpack_named(&fi)?;
-                let mut client = self
-                    .get_client()
-                    .await
-                    .map_err(|err| Error::other(format!("can not get client, err: {err}")))?;
-                let request = Request::new(RenameDataRequest {
-                    disk: self.endpoint.to_string(),
-                    src_volume: src_volume.to_string(),
-                    src_path: src_path.to_string(),
-                    file_info,
-                    dst_volume: dst_volume.to_string(),
-                    dst_path: dst_path.to_string(),
-                    file_info_bin: file_info_bin.into(),
-                });
+        // Legacy peers may ignore file_info_bin entirely, so this compatibility
+        // path must retain JSON even when msgpack-only mode is enabled.
+        let file_info = serde_json::to_string(&fi)?;
+        let file_info_bin = encode_msgpack_named(&fi)?;
+        match self
+            .send_rename_data_payload((src_volume, src_path), (dst_volume, dst_path), file_info, file_info_bin, false, false)
+            .await?
+        {
+            RenameDataRpcOutcome::Success(response) => Ok(response),
+            RenameDataRpcOutcome::TransactionUnsupported => Err(DiskError::Unexpected),
+        }
+    }
 
-                let response = client.rename_data(request).await?.into_inner();
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn rename_data_with_rollback(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+        rollback_token: Uuid,
+    ) -> Result<RenameDataResp> {
+        if rollback_token.is_nil() {
+            return Err(DiskError::other("rename rollback token must not be nil"));
+        }
 
-                if !response.success {
-                    return Err(response.error.unwrap_or_default().into());
-                }
-
-                let rename_data_resp = decode_msgpack_or_json::<RenameDataResp>(
-                    &response.rename_data_resp_bin,
-                    &response.rename_data_resp,
-                    "RenameDataResp",
-                )?;
-
-                Ok(rename_data_resp)
-            },
-            get_max_timeout_duration(),
-        )
-        .await
+        let envelope = encode_rename_data_envelope(&fi, rollback_token)?;
+        match self
+            .send_rename_data_payload(
+                (src_volume, src_path),
+                (dst_volume, dst_path),
+                RENAME_DATA_LEGACY_JSON_PROBE.to_string(),
+                envelope,
+                true,
+                true,
+            )
+            .await?
+        {
+            RenameDataRpcOutcome::Success(response) => {
+                RenameRollbackCapability::record_supported(&self.rename_rollback_capability);
+                Ok(response)
+            }
+            RenameDataRpcOutcome::TransactionUnsupported => Err(Error::other(RENAME_TRANSACTION_UNSUPPORTED)),
+        }
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -3128,6 +3388,242 @@ mod tests {
         assert!(!BatchMetadataRpcMode::Off.should_fallback_on_unimplemented());
         assert!(BatchMetadataRpcMode::Auto.should_fallback_on_unimplemented());
         assert!(!BatchMetadataRpcMode::On.should_fallback_on_unimplemented());
+    }
+
+    #[test]
+    fn legacy_rename_envelope_rejection_match_is_exact() {
+        let expected = RpcError {
+            code: DiskError::other("").to_u32(),
+            error_info: format!(
+                "io error decode FileInfo failed: io error decode FileInfo msgpack failed: invalid type: integer `{RENAME_DATA_ENVELOPE_MAGIC}`, expected a string"
+            ),
+        };
+        assert!(is_legacy_rename_envelope_rejection(&expected));
+
+        let mut unrelated = expected;
+        unrelated.error_info.push_str(" (different)");
+        assert!(!is_legacy_rename_envelope_rejection(&unrelated));
+
+        let pre_bin = RpcError {
+            code: DiskError::other("").to_u32(),
+            error_info:
+                "io error decode FileInfo failed: invalid type: string \"rustfs-rename-transaction-v1\", expected struct FileInfo"
+                    .to_string(),
+        };
+        assert!(is_legacy_rename_envelope_rejection(&pre_bin));
+    }
+
+    #[test]
+    fn rollback_capability_cache_accepts_only_positive_evidence() {
+        let rename = AtomicU8::new(RenameRollbackCapability::Unknown as u8);
+        let delete = AtomicU8::new(DeleteRollbackCapability::Unknown as u8);
+
+        assert_eq!(RenameRollbackCapability::load(&rename), RenameRollbackCapability::Unknown);
+        assert_eq!(DeleteRollbackCapability::load(&delete), DeleteRollbackCapability::Unknown);
+
+        // A rejection must leave the cache unknown so a reused RemoteDisk probes
+        // the peer again after a rolling upgrade. Unknown/stale values likewise
+        // cannot become positive capability evidence.
+        rename.store(2, Ordering::Release);
+        delete.store(2, Ordering::Release);
+        assert_eq!(RenameRollbackCapability::load(&rename), RenameRollbackCapability::Unknown);
+        assert_eq!(DeleteRollbackCapability::load(&delete), DeleteRollbackCapability::Unknown);
+
+        RenameRollbackCapability::record_supported(&rename);
+        DeleteRollbackCapability::record_supported(&delete);
+        assert_eq!(RenameRollbackCapability::load(&rename), RenameRollbackCapability::TransactionV1);
+        assert_eq!(DeleteRollbackCapability::load(&delete), DeleteRollbackCapability::EnvelopeV1);
+    }
+
+    #[test]
+    fn delete_options_compat_json_requires_msgpack_for_delete_rollback() {
+        let rollback_dir = Uuid::new_v4();
+        let forward_delete = DeleteOptions {
+            old_data_dir: Some(rollback_dir),
+            ..Default::default()
+        };
+        let rollback_delete = DeleteOptions {
+            undo_write: true,
+            undo_delete: true,
+            old_data_dir: Some(rollback_dir),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            delete_options_compat_json(&forward_delete).expect("forward delete options should encode"),
+            ""
+        );
+        assert_eq!(
+            delete_options_compat_json(&rollback_delete).expect("rollback delete options should encode"),
+            ""
+        );
+    }
+
+    #[test]
+    fn delete_options_compat_json_requires_envelope_for_write_rollback() {
+        let opts = DeleteOptions {
+            undo_write: true,
+            old_data_dir: Some(Uuid::new_v4()),
+            ..Default::default()
+        };
+
+        let json = delete_options_compat_json(&opts).expect("write rollback options should encode");
+        assert!(json.is_empty());
+    }
+
+    #[derive(Debug, serde::Deserialize, serde::Serialize)]
+    struct PreRollbackDeleteOptions {
+        recursive: bool,
+        immediate: bool,
+        undo_write: bool,
+        old_data_dir: Option<Uuid>,
+    }
+
+    #[derive(Debug, serde::Deserialize, serde::Serialize)]
+    struct MergedDeleteOptions {
+        recursive: bool,
+        immediate: bool,
+        undo_write: bool,
+        undo_delete: bool,
+        old_data_dir: Option<Uuid>,
+    }
+
+    #[test]
+    fn delete_options_msgpack_decodes_legacy_compact_payload() {
+        for old_data_dir in [None, Some(Uuid::new_v4())] {
+            let legacy = PreRollbackDeleteOptions {
+                recursive: true,
+                immediate: false,
+                undo_write: true,
+                old_data_dir,
+            };
+            let encoded = encode_msgpack(&legacy).expect("legacy delete options should encode");
+            let decoded = crate::disk::decode_delete_options_payload(&encoded, "");
+
+            if old_data_dir.is_none() {
+                assert!(decoded.is_err(), "malformed legacy undo without rollback state must fail closed");
+                continue;
+            }
+            let decoded = decoded.expect("current delete options should decode valid pre-rollback compact msgpack");
+
+            assert!(decoded.recursive);
+            assert!(!decoded.immediate);
+            assert!(decoded.undo_write);
+            assert_eq!(decoded.old_data_dir, old_data_dir);
+            assert!(!decoded.undo_delete);
+        }
+
+        let merged = MergedDeleteOptions {
+            recursive: false,
+            immediate: true,
+            undo_write: true,
+            undo_delete: true,
+            old_data_dir: Some(Uuid::new_v4()),
+        };
+        let encoded = encode_msgpack(&merged).expect("merged delete options should encode");
+        let decoded = crate::disk::decode_delete_options_payload(&encoded, "")
+            .expect("current delete options should decode merged compact msgpack");
+        rmp_serde::from_slice::<PreRollbackDeleteOptions>(&encoded)
+            .expect_err("pre-rollback peer must reject merged compact layout before mutation");
+        assert!(decoded.undo_delete);
+        assert_eq!(decoded.old_data_dir, merged.old_data_dir);
+    }
+
+    #[test]
+    fn delete_options_envelope_rejection_match_requires_decode_boundary() {
+        let expected = RpcError {
+            code: DiskError::other("").to_u32(),
+            error_info: "io error decode DeleteOptions failed: invalid type: integer, expected struct".to_string(),
+        };
+        assert!(is_delete_options_envelope_rejection(&expected));
+
+        let mut post_mutation = expected.clone();
+        post_mutation.error_info = "delete version failed after metadata commit".to_string();
+        assert!(!is_delete_options_envelope_rejection(&post_mutation));
+
+        let mut embedded = expected.clone();
+        embedded.error_info = format!("wrapper: {DELETE_OPTIONS_DECODE_ERROR_PREFIX}invalid envelope");
+        assert!(!is_delete_options_envelope_rejection(&embedded));
+
+        let mut wrong_code = expected;
+        wrong_code.code = DiskError::FaultyDisk.to_u32();
+        assert!(!is_delete_options_envelope_rejection(&wrong_code));
+    }
+
+    #[test]
+    fn delete_versions_response_cardinality_must_match_request() {
+        let exact = normalize_delete_versions_errors(vec![String::new(), "failed".to_string()], 2);
+        assert!(exact[0].is_none());
+        assert!(exact[1].as_ref().is_some_and(|error| error.to_string().contains("failed")));
+
+        for response in [vec![String::new()], vec![String::new(), String::new(), String::new()]] {
+            let errors = normalize_delete_versions_errors(response, 2);
+            assert_eq!(errors.len(), 2);
+            assert!(errors.iter().all(Option::is_some));
+            assert!(errors.iter().all(|error| {
+                error
+                    .as_ref()
+                    .is_some_and(|error| error.to_string().contains("cardinality mismatch"))
+            }));
+        }
+    }
+
+    #[test]
+    fn delete_options_msgpack_allows_legacy_decode_for_compatible_options() {
+        let opts = DeleteOptions {
+            recursive: true,
+            immediate: true,
+            ..Default::default()
+        };
+
+        let encoded = encode_delete_options_msgpack(&opts).expect("compatible delete options should encode");
+        let current_decoded: DeleteOptions =
+            rmp_serde::from_slice(&encoded).expect("current delete options should decode named msgpack");
+        let pre_rollback_decoded: PreRollbackDeleteOptions =
+            rmp_serde::from_slice(&encoded).expect("pre-rollback delete options should ignore added fields");
+        let merged_decoded: MergedDeleteOptions =
+            rmp_serde::from_slice(&encoded).expect("merged delete options should ignore appended fields");
+
+        assert!(current_decoded.recursive);
+        assert!(current_decoded.immediate);
+        assert!(!current_decoded.undo_write);
+        assert!(!current_decoded.undo_delete);
+        assert!(pre_rollback_decoded.recursive);
+        assert!(pre_rollback_decoded.immediate);
+        assert!(!pre_rollback_decoded.undo_write);
+        assert_eq!(pre_rollback_decoded.old_data_dir, None);
+        assert_eq!(merged_decoded.old_data_dir, None);
+    }
+
+    #[test]
+    fn delete_options_msgpack_rejects_legacy_decode_for_delete_rollback() {
+        let rollback_dir = Uuid::new_v4();
+        let rollback_options = [
+            DeleteOptions {
+                old_data_dir: Some(rollback_dir),
+                ..Default::default()
+            },
+            DeleteOptions {
+                undo_write: true,
+                undo_delete: true,
+                old_data_dir: Some(rollback_dir),
+                ..Default::default()
+            },
+        ];
+
+        for opts in rollback_options {
+            let encoded = encode_delete_options_msgpack(&opts).expect("delete rollback options should encode");
+            let current_decoded = crate::disk::decode_delete_options_payload(&encoded, "")
+                .expect("current delete rollback options should decode the transaction envelope");
+            let pre_rollback_err = rmp_serde::from_slice::<PreRollbackDeleteOptions>(&encoded)
+                .expect_err("pre-rollback options must reject the transaction envelope");
+            let merged_err = rmp_serde::from_slice::<MergedDeleteOptions>(&encoded)
+                .expect_err("merged options must reject the transaction envelope");
+
+            assert_eq!(current_decoded.old_data_dir, opts.old_data_dir);
+            assert!(!pre_rollback_err.to_string().is_empty());
+            assert!(!merged_err.to_string().is_empty());
+        }
     }
 
     #[test]
@@ -4263,6 +4759,30 @@ mod tests {
             remote_disk.is_online().await,
             "successful no-timeout operation should keep remote disk online"
         );
+    }
+
+    #[tokio::test]
+    async fn transaction_executor_waits_for_final_result_after_deadline() {
+        let remote_disk = new_remote_disk_with_transport(Arc::new(RecordingInternodeDataTransport::default())).await;
+        let started = tokio::time::Instant::now();
+
+        let result = remote_disk
+            .execute_transaction_to_completion(
+                "transaction-test",
+                || async {
+                    tokio::time::sleep(Duration::from_millis(40)).await;
+                    Ok::<_, Error>(7)
+                },
+                Duration::from_millis(5),
+                FailureHealthAction::IgnoreFailure,
+                true,
+            )
+            .await
+            .expect("transaction should return its final result");
+
+        assert_eq!(result, 7);
+        assert!(started.elapsed() >= Duration::from_millis(35));
+        assert_eq!(remote_disk.health.waiting_count(), 0);
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/cluster/rpc/remote_locker.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_locker.rs
@@ -15,8 +15,9 @@
 use crate::cluster::rpc::client::{TonicInterceptor, gen_tonic_signature_interceptor, node_service_time_out_client};
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::{StreamExt, stream};
 use rustfs_lock::{
-    LockClient, LockError, LockInfo, LockRequest, LockResponse, LockStats, LockStatus, LockType, Result,
+    LockClient, LockError, LockInfo, LockRequest, LockResponse, LockStats, LockStatus, LockType, MAX_DELETE_LIST, Result,
     types::{LockId, LockMetadata, LockPriority},
 };
 use rustfs_protos::proto_gen::node_service::{BatchGenerallyLockRequest, GenerallyLockRequest, PingRequest};
@@ -24,12 +25,28 @@ use rustfs_protos::{
     ConnectionEvictionLogLevel, evict_failed_connection_with_log_level, models::PingBodyBuilder,
     proto_gen::node_service::node_service_client::NodeServiceClient,
 };
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 use tokio::time::timeout;
 use tonic::Request;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing::{debug, info, warn};
+
+const REFRESH_UNARY_FALLBACK_CONCURRENCY: usize = 32;
+
+async fn run_refresh_fallback_bounded<Fut, T>(futures: impl IntoIterator<Item = Fut>) -> Vec<T>
+where
+    Fut: Future<Output = T>,
+{
+    stream::iter(futures)
+        .buffered(REFRESH_UNARY_FALLBACK_CONCURRENCY)
+        .collect()
+        .await
+}
+
+fn refresh_batch_chunks<T>(items: &[T]) -> impl Iterator<Item = &[T]> {
+    items.chunks(MAX_DELETE_LIST)
+}
 
 /// Remote lock client implementation
 #[derive(Debug, Clone)]
@@ -43,7 +60,7 @@ impl RemoteClient {
     }
 
     pub fn from_url(url: url::Url) -> Self {
-        Self { addr: url.to_string() }
+        Self::new(url.to_string())
     }
 
     fn build_ping_request() -> PingRequest {
@@ -305,6 +322,76 @@ impl RemoteClient {
             wait_start_time: None,
         }
     }
+
+    async fn refresh_locks_chunk(&self, lock_ids: &[LockId]) -> Vec<Result<bool>> {
+        let refresh_requests = lock_ids.iter().map(Self::create_unlock_request).collect::<Vec<_>>();
+        let resource_summary = Self::summarize_resources(&refresh_requests);
+        let args = match refresh_requests
+            .iter()
+            .map(|request| {
+                serde_json::to_string(request).map_err(|err| LockError::internal(format!("Failed to serialize request: {err}")))
+            })
+            .collect::<Result<Vec<_>>>()
+        {
+            Ok(args) => args,
+            Err(err) => {
+                return lock_ids.iter().map(|_| Err(LockError::internal(err.to_string()))).collect();
+            }
+        };
+        let request = BatchGenerallyLockRequest { args };
+
+        let mut client = match self.get_client().await {
+            Ok(client) => client,
+            Err(err) => {
+                return lock_ids.iter().map(|_| Err(LockError::internal(err.to_string()))).collect();
+            }
+        };
+        match timeout(Self::rpc_timeout(), client.refresh_batch(Request::new(request))).await {
+            Ok(Ok(response)) => {
+                let response = response.into_inner();
+                lock_ids
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| match response.results.get(index) {
+                        Some(result) if result.error_info.is_none() => Ok(result.success),
+                        Some(result) => Err(LockError::internal(result.error_info.clone().unwrap_or_default())),
+                        None => Err(LockError::internal("refresh batch response index out of range")),
+                    })
+                    .collect()
+            }
+            Ok(Err(status)) if status.code() == tonic::Code::Unimplemented => {
+                // RUSTFS_COMPAT_TODO(RPC-4300-LOCK-REFRESH): unary fallback supports rolling upgrades. Remove after every supported predecessor implements RefreshBatch.
+                // Do not cache negative capability evidence: a peer may be
+                // upgraded in place while this long-lived client remains.
+                // Re-probing once per heartbeat lets the batch path recover
+                // automatically without weakening the bounded unary fallback.
+                run_refresh_fallback_bounded(lock_ids.iter().cloned().map(|lock_id| {
+                    let client = self.clone();
+                    async move { client.refresh(&lock_id).await }
+                }))
+                .await
+            }
+            Ok(Err(status)) => {
+                let reason = status.to_string();
+                if Self::is_transport_failure(&status) {
+                    self.evict_connection("refresh_batch", &reason, &resource_summary).await;
+                }
+                lock_ids
+                    .iter()
+                    .map(|_| Err(LockError::internal(format!("refresh_batch RPC failed: {reason}"))))
+                    .collect()
+            }
+            Err(_) => {
+                let timeout = Self::rpc_timeout();
+                self.evict_connection("refresh_batch", "RPC timed out", &resource_summary)
+                    .await;
+                lock_ids
+                    .iter()
+                    .map(|_| Err(LockError::timeout("remote refresh batch", timeout)))
+                    .collect()
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -436,7 +523,7 @@ impl LockClient for RemoteClient {
     }
 
     async fn refresh(&self, lock_id: &LockId) -> Result<bool> {
-        info!("remote refresh for {}", lock_id);
+        debug!("remote refresh for {}", lock_id);
         let refresh_request = Self::create_unlock_request(lock_id);
         let mut client = self.get_client().await?;
         let resource_summary = refresh_request.resource.to_string();
@@ -452,6 +539,18 @@ impl LockClient for RemoteClient {
             return Err(LockError::internal(error_info));
         }
         Ok(resp.success)
+    }
+
+    async fn refresh_locks_batch(&self, lock_ids: &[LockId]) -> Vec<Result<bool>> {
+        if lock_ids.is_empty() {
+            return Vec::new();
+        }
+
+        let mut results = Vec::with_capacity(lock_ids.len());
+        for chunk in refresh_batch_chunks(lock_ids) {
+            results.extend(self.refresh_locks_chunk(chunk).await);
+        }
+        results
     }
 
     async fn force_release(&self, lock_id: &LockId) -> Result<bool> {
@@ -570,9 +669,49 @@ mod tests {
     use super::*;
     use crate::runtime::sources as runtime_sources;
     use rustfs_lock::{ObjectKey, types::LockPriority};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering as AtomicOrdering},
+    };
     use tokio::net::TcpListener;
     use tokio::task::JoinHandle;
     use tonic::transport::Endpoint as TonicEndpoint;
+
+    #[tokio::test]
+    async fn refresh_fallback_is_bounded_and_preserves_order() {
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let futures = (0..100).map(|index| {
+            let in_flight = Arc::clone(&in_flight);
+            let max_in_flight = Arc::clone(&max_in_flight);
+            async move {
+                let current = in_flight.fetch_add(1, AtomicOrdering::SeqCst) + 1;
+                max_in_flight.fetch_max(current, AtomicOrdering::SeqCst);
+                tokio::time::sleep(Duration::from_millis((5 - index % 5) as u64)).await;
+                in_flight.fetch_sub(1, AtomicOrdering::SeqCst);
+                index
+            }
+        });
+
+        let results = run_refresh_fallback_bounded(futures).await;
+
+        assert_eq!(results, (0..100).collect::<Vec<_>>());
+        assert!(max_in_flight.load(AtomicOrdering::SeqCst) > 1);
+        assert!(max_in_flight.load(AtomicOrdering::SeqCst) <= REFRESH_UNARY_FALLBACK_CONCURRENCY);
+    }
+
+    #[test]
+    fn refresh_batches_are_capped_and_preserve_order() {
+        let items = (0..(MAX_DELETE_LIST * 2 + 17)).collect::<Vec<_>>();
+        let chunks = refresh_batch_chunks(&items).collect::<Vec<_>>();
+
+        assert_eq!(
+            chunks.iter().map(|chunk| chunk.len()).collect::<Vec<_>>(),
+            [MAX_DELETE_LIST, MAX_DELETE_LIST, 17]
+        );
+        assert!(chunks.iter().all(|chunk| chunk.len() <= MAX_DELETE_LIST));
+        assert_eq!(chunks.into_iter().flatten().copied().collect::<Vec<_>>(), items);
+    }
 
     async fn spawn_hanging_listener() -> Option<(String, JoinHandle<()>)> {
         let listener = match TcpListener::bind("127.0.0.1:0").await {

--- a/crates/ecstore/src/disk/disk_store.rs
+++ b/crates/ecstore/src/disk/disk_store.rs
@@ -27,6 +27,7 @@ use crate::runtime::sources as runtime_sources;
 use bytes::Bytes;
 use metrics::counter;
 use rustfs_filemeta::{FileInfo, ObjectPartInfo, RawFileInfo};
+use std::future::Future;
 #[cfg(not(test))]
 use std::sync::OnceLock;
 use std::{
@@ -37,7 +38,10 @@ use std::{
     },
     time::Duration,
 };
-use tokio::{sync::RwLock, time};
+use tokio::{
+    sync::{RwLock, Semaphore},
+    time,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -50,11 +54,66 @@ const LOG_SUBSYSTEM_DISK: &str = "disk";
 const EVENT_DISK_HEALTH_CHECK_FAILED: &str = "disk_health_check_failed";
 const EVENT_DISK_RECOVERY_PROBE_STATE: &str = "disk_recovery_probe_state";
 const EVENT_DISK_TIMEOUT_POLICY_FALLBACK: &str = "disk_timeout_policy_fallback";
+const MAX_PROTECTED_LOCAL_MUTATIONS: usize = 256;
+static PROTECTED_LOCAL_MUTATIONS: std::sync::LazyLock<Arc<Semaphore>> =
+    std::sync::LazyLock::new(|| Arc::new(Semaphore::new(MAX_PROTECTED_LOCAL_MUTATIONS)));
+
+async fn run_protected_local_mutation<T, F>(operation: &'static str, future: F) -> Result<T>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+{
+    let permit = Arc::clone(&PROTECTED_LOCAL_MUTATIONS)
+        .acquire_owned()
+        .await
+        .map_err(|err| DiskError::other(format!("{operation} supervisor unavailable: {err}")))?;
+    tokio::spawn(async move {
+        let _permit = permit;
+        future.await
+    })
+    .await
+    .map_err(|err| DiskError::other(format!("{operation} task failed: {err}")))
+}
+
+async fn delete_versions_tracked(
+    wrapper: &LocalDiskWrapper,
+    volume: &str,
+    versions: Vec<FileInfoVersions>,
+    opts: DeleteOptions,
+) -> Vec<Option<Error>> {
+    if wrapper.health.is_faulty() {
+        return vec![Some(DiskError::FaultyDisk); versions.len()];
+    }
+    if let Err(err) = wrapper.check_disk_stale().await {
+        return vec![Some(err); versions.len()];
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as i64;
+    wrapper.health.last_started.store(now, Ordering::Relaxed);
+    wrapper.health.increment_waiting();
+    let result = wrapper.disk.delete_versions(volume, versions, opts).await;
+    wrapper.health.decrement_waiting();
+    if result.iter().all(Option::is_none) {
+        wrapper
+            .health
+            .record_operation_success(&wrapper.endpoint(), "operation_success");
+    }
+    result
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TimeoutHealthAction {
     MarkFailure,
     IgnoreFailure,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TimeoutCompletionAction {
+    Cancel,
+    WaitForCompletion,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -862,6 +921,7 @@ impl LocalDiskWrapper {
                     undo_write: false,
                     undo_delete: false,
                     old_data_dir: None,
+                    rename_rollback_token: None,
                 },
             )
             .await?;
@@ -1049,8 +1109,14 @@ impl LocalDiskWrapper {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<T>>,
     {
-        self.track_disk_health_with_op_and_timeout_action(op, operation, timeout_duration, TimeoutHealthAction::MarkFailure)
-            .await
+        self.track_disk_health_with_op_and_timeout_actions(
+            op,
+            operation,
+            timeout_duration,
+            TimeoutHealthAction::MarkFailure,
+            TimeoutCompletionAction::Cancel,
+        )
+        .await
     }
 
     async fn track_disk_health_with_op_and_timeout_action<T, F, Fut>(
@@ -1059,6 +1125,48 @@ impl LocalDiskWrapper {
         operation: F,
         timeout_duration: Duration,
         timeout_health_action: TimeoutHealthAction,
+    ) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        self.track_disk_health_with_op_and_timeout_actions(
+            op,
+            operation,
+            timeout_duration,
+            timeout_health_action,
+            TimeoutCompletionAction::Cancel,
+        )
+        .await
+    }
+
+    async fn track_disk_health_with_op_until_complete<T, F, Fut>(
+        &self,
+        op: &'static str,
+        operation: F,
+        timeout_duration: Duration,
+    ) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        self.track_disk_health_with_op_and_timeout_actions(
+            op,
+            operation,
+            timeout_duration,
+            TimeoutHealthAction::MarkFailure,
+            TimeoutCompletionAction::WaitForCompletion,
+        )
+        .await
+    }
+
+    async fn track_disk_health_with_op_and_timeout_actions<T, F, Fut>(
+        &self,
+        op: &'static str,
+        operation: F,
+        timeout_duration: Duration,
+        timeout_health_action: TimeoutHealthAction,
+        timeout_completion_action: TimeoutCompletionAction,
     ) -> Result<T>
     where
         F: FnOnce() -> Fut,
@@ -1083,7 +1191,7 @@ impl LocalDiskWrapper {
         // Record operation start
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_nanos() as i64;
         self.health.last_started.store(now, Ordering::Relaxed);
         let _waiting_guard = self.health.waiting_guard();
@@ -1095,8 +1203,11 @@ impl LocalDiskWrapper {
             }
             return result;
         }
-        // Execute the operation with timeout
-        let result = tokio::time::timeout(timeout_duration, operation()).await;
+        // Keep ownership of protected mutations after the timeout so a
+        // non-cancellable spawn_blocking section cannot commit after this call
+        // has returned and compensation has started.
+        let mut operation = Box::pin(operation());
+        let result = tokio::time::timeout(timeout_duration, operation.as_mut()).await;
 
         match result {
             Ok(operation_result) => {
@@ -1129,6 +1240,9 @@ impl LocalDiskWrapper {
                     reason = "operation_timeout",
                     "Disk operation timed out"
                 );
+                if timeout_completion_action == TimeoutCompletionAction::WaitForCompletion {
+                    let _ = operation.await;
+                }
                 Err(DiskError::Timeout)
             }
         }
@@ -1288,6 +1402,22 @@ impl DiskAPI for LocalDiskWrapper {
         force_del_marker: bool,
         opts: DeleteOptions,
     ) -> Result<()> {
+        let protect_from_cancellation = opts.requires_delete_rollback_protocol();
+        if protect_from_cancellation {
+            let wrapper = self.clone();
+            let volume = volume.to_string();
+            let path = path.to_string();
+            return run_protected_local_mutation("delete version", async move {
+                wrapper
+                    .track_disk_health_with_op_until_complete(
+                        "delete_version",
+                        || async { wrapper.disk.delete_version(&volume, &path, fi, force_del_marker, opts).await },
+                        get_max_timeout_duration(),
+                    )
+                    .await
+            })
+            .await?;
+        }
         self.track_disk_health(
             || async { self.disk.delete_version(volume, path, fi, force_del_marker, opts).await },
             get_max_timeout_duration(),
@@ -1296,35 +1426,21 @@ impl DiskAPI for LocalDiskWrapper {
     }
 
     async fn delete_versions(&self, volume: &str, versions: Vec<FileInfoVersions>, opts: DeleteOptions) -> Vec<Option<Error>> {
-        // Check if disk is faulty before proceeding
-        if self.health.is_faulty() {
-            return vec![Some(DiskError::FaultyDisk); versions.len()];
+        let result_len = versions.len();
+        let protect_from_cancellation = opts.requires_delete_rollback_protocol();
+        if protect_from_cancellation {
+            let wrapper = self.clone();
+            let volume = volume.to_string();
+            return match run_protected_local_mutation("delete versions", async move {
+                delete_versions_tracked(&wrapper, &volume, versions, opts).await
+            })
+            .await
+            {
+                Ok(result) => result,
+                Err(err) => vec![Some(err); result_len],
+            };
         }
-
-        // Check if disk is stale
-        if let Err(e) = self.check_disk_stale().await {
-            return vec![Some(e); versions.len()];
-        }
-
-        // Record operation start
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as i64;
-        self.health.last_started.store(now, Ordering::Relaxed);
-        self.health.increment_waiting();
-
-        // Execute the operation
-        let result = self.disk.delete_versions(volume, versions, opts).await;
-
-        self.health.decrement_waiting();
-        let has_err = result.iter().any(|e| e.is_some());
-        if !has_err {
-            // Log success and decrement waiting counter
-            self.health.record_operation_success(&self.endpoint(), "operation_success");
-        }
-
-        result
+        delete_versions_tracked(self, volume, versions, opts).await
     }
 
     async fn delete_paths(&self, volume: &str, paths: &[String]) -> Result<()> {
@@ -1382,6 +1498,40 @@ impl DiskAPI for LocalDiskWrapper {
             get_max_timeout_duration(),
         )
         .await
+    }
+
+    async fn rename_data_with_rollback(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+        rollback_token: Uuid,
+    ) -> Result<RenameDataResp> {
+        if rollback_token.is_nil() {
+            return Err(DiskError::other("rename rollback token must not be nil"));
+        }
+        let wrapper = self.clone();
+        let src_volume = src_volume.to_string();
+        let src_path = src_path.to_string();
+        let dst_volume = dst_volume.to_string();
+        let dst_path = dst_path.to_string();
+        run_protected_local_mutation("rename data", async move {
+            wrapper
+                .track_disk_health_with_op_until_complete(
+                    "rename_data",
+                    || async {
+                        wrapper
+                            .disk
+                            .rename_data_with_rollback(&src_volume, &src_path, fi, &dst_volume, &dst_path, rollback_token)
+                            .await
+                    },
+                    get_max_timeout_duration(),
+                )
+                .await
+        })
+        .await?
     }
 
     async fn list_dir(&self, origvolume: &str, volume: &str, dir_path: &str, count: i32) -> Result<Vec<String>> {
@@ -1548,6 +1698,38 @@ mod tests {
         let _ = task.await;
 
         assert_eq!(wrapper.health.waiting_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn protected_local_mutation_outlives_caller_cancellation() {
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_entered = Arc::clone(&entered);
+        let task_release = Arc::clone(&release);
+        let task_completed = Arc::clone(&completed);
+
+        let caller = tokio::spawn(async move {
+            run_protected_local_mutation("test mutation", async move {
+                task_entered.notify_one();
+                task_release.notified().await;
+                task_completed.store(true, Ordering::Release);
+                Ok::<(), DiskError>(())
+            })
+            .await
+        });
+        entered.notified().await;
+        caller.abort();
+        assert!(caller.await.expect_err("caller task should be cancelled").is_cancelled());
+
+        release.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !completed.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("protected mutation should continue after caller cancellation");
     }
 
     impl AsyncWrite for PendingWriter {
@@ -1853,6 +2035,56 @@ mod tests {
         assert_eq!(result.expect_err("operation should time out"), DiskError::Timeout);
         assert_eq!(wrapper.runtime_state(), RuntimeDriveHealthState::Online);
         assert!(!wrapper.health.is_faulty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn protected_timeout_waits_for_mutation_terminal_state() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let endpoint =
+            Endpoint::try_from(dir.path().to_str().expect("temp dir should be valid UTF-8")).expect("endpoint should parse");
+        let disk = Arc::new(LocalDisk::new(&endpoint, false).await.expect("local disk should be created"));
+        let wrapper = LocalDiskWrapper::new(disk, false);
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_entered = Arc::clone(&entered);
+        let task_release = Arc::clone(&release);
+        let task_completed = Arc::clone(&completed);
+
+        let mutation = tokio::spawn(async move {
+            wrapper
+                .track_disk_health_with_op_until_complete(
+                    "rename_data",
+                    || async move {
+                        task_entered.notify_one();
+                        task_release.notified().await;
+                        task_completed.store(true, Ordering::Release);
+                        Ok(())
+                    },
+                    Duration::from_secs(1),
+                )
+                .await
+        });
+        entered.notified().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+
+        assert!(!mutation.is_finished(), "a timed-out protected mutation must remain supervised");
+        assert!(
+            !completed.load(Ordering::Acquire),
+            "the mutation must still be pending at the health timeout"
+        );
+
+        release.notify_one();
+        let err = mutation
+            .await
+            .expect("protected mutation task should join")
+            .expect_err("elapsed health deadline should remain visible to the caller");
+        assert_eq!(err, DiskError::Timeout);
+        assert!(
+            completed.load(Ordering::Acquire),
+            "the mutation must reach terminal state before timeout is returned"
+        );
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -19,9 +19,10 @@ use crate::disk::disk_store::{get_drive_walkdir_stall_timeout, get_object_disk_r
 use crate::disk::{
     BUCKET_META_PREFIX, CHECK_PART_FILE_CORRUPT, CHECK_PART_FILE_NOT_FOUND, CHECK_PART_SUCCESS, CHECK_PART_UNKNOWN,
     CHECK_PART_VOLUME_NOT_FOUND, CheckPartsResp, DeleteOptions, DiskAPI, DiskInfo, DiskInfoOptions, DiskLocation, DiskMetrics,
-    FileInfoVersions, FileReader, FileWriter, MmapCopyStageMetrics, OldCurrentSize, RUSTFS_META_BUCKET, RUSTFS_META_TMP_BUCKET,
-    RUSTFS_META_TMP_DELETED_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions, RenameDataResp, STORAGE_FORMAT_FILE,
-    STORAGE_FORMAT_FILE_BACKUP, UpdateMetadataOpts, VolumeInfo, WalkDirOptions, conv_part_err_to_int,
+    FileInfoVersions, FileReader, FileWriter, MmapCopyStageMetrics, OldCurrentSize, RENAME_DATA_ABSENT_MARKER,
+    RUSTFS_META_BUCKET, RUSTFS_META_TMP_BUCKET, RUSTFS_META_TMP_DELETED_BUCKET, ReadMultipleReq, ReadMultipleResp, ReadOptions,
+    RenameDataResp, STORAGE_FORMAT_FILE, STORAGE_FORMAT_FILE_BACKUP, UpdateMetadataOpts, VolumeInfo, WalkDirOptions,
+    conv_part_err_to_int,
     endpoint::Endpoint,
     error::{DiskError, Error, FileAccessDeniedWithContext, Result},
     error_conv::{to_access_error, to_file_error, to_unformatted_disk_error, to_volume_error},
@@ -36,7 +37,7 @@ use bytes::Bytes;
 use metrics::counter;
 #[cfg(target_os = "linux")]
 use metrics::gauge;
-use parking_lot::RwLock as ParkingLotRwLock;
+use parking_lot::{Mutex as ParkingLotMutex, RwLock as ParkingLotRwLock};
 use rustfs_filemeta::{
     Cache, FileInfo, FileInfoOpts, FileMeta, MetaCacheEntry, MetacacheWriter, ObjectPartInfo, Opts, RawFileInfo, UpdateFn,
     get_file_info, read_xl_meta_no_data_sync,
@@ -47,6 +48,7 @@ use rustfs_utils::path::{
     GLOBAL_DIR_SUFFIX, GLOBAL_DIR_SUFFIX_WITH_SLASH, SLASH_SEPARATOR, clean, decode_dir_object, encode_dir_object, has_suffix,
     path_join, path_join_buf,
 };
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -65,7 +67,7 @@ use tokio::fs::{self, File};
 #[cfg(not(unix))]
 use tokio::io::AsyncReadExt;
 use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWrite, AsyncWriteExt, ErrorKind, ReadBuf};
-use tokio::sync::{Notify, RwLock, Semaphore};
+use tokio::sync::{Mutex as TokioMutex, Notify, OwnedMutexGuard, RwLock, Semaphore};
 use tokio::time::{Instant, Sleep, interval_at, timeout};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -75,13 +77,42 @@ const STALE_TMP_OBJECT_EXPIRY: Duration = Duration::from_secs(24 * 60 * 60);
 const RUSTFS_META_TMP_OLD_BUCKET: &str = ".rustfs.sys/tmp-old";
 const INLINE_METADATA_ROLLBACK_DIR_XOR: u128 = 0x7275737466735f696e6c696e655f7262;
 const DELETE_MARKER_ROLLBACK_FILE: &str = "xl.meta.delete-marker.rollback";
+const ROLLBACK_COMMIT_DIGEST_FILE: &str = "xl.meta.commit.sha256";
+const ROLLBACK_COMMIT_ABSENT_FILE: &str = "xl.meta.commit.absent";
+const ROLLBACK_COMMIT_ABSENT_CONTENT: &[u8] = b"rustfs-rollback-commit-absent-v1";
 const STARTUP_CLEANUP_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 const ENV_BITROT_SIZE_MISMATCH_RETRY_COUNT: &str = "RUSTFS_BITROT_SIZE_MISMATCH_RETRY_COUNT";
 const ENV_BITROT_SIZE_MISMATCH_RETRY_DELAY_MS: &str = "RUSTFS_BITROT_SIZE_MISMATCH_RETRY_DELAY_MS";
 const DEFAULT_BITROT_SIZE_MISMATCH_RETRY_COUNT: u64 = 2;
 const DEFAULT_BITROT_SIZE_MISMATCH_RETRY_DELAY_MS: u64 = 100;
 
-fn inline_metadata_rollback_dir(version_id: Uuid, meta: &FileMeta) -> Uuid {
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RollbackTransactionKey {
+    volume: String,
+    path: String,
+}
+
+struct RollbackTransactionGuard {
+    _guard: OwnedMutexGuard<()>,
+    mutex: Arc<TokioMutex<()>>,
+    registry: Arc<ParkingLotMutex<HashMap<RollbackTransactionKey, std::sync::Weak<TokioMutex<()>>>>>,
+    key: RollbackTransactionKey,
+}
+
+impl Drop for RollbackTransactionGuard {
+    fn drop(&mut self) {
+        let mut registry = self.registry.lock();
+        if Arc::strong_count(&self.mutex) == 2
+            && registry
+                .get(&self.key)
+                .is_some_and(|registered| registered.ptr_eq(&Arc::downgrade(&self.mutex)))
+        {
+            registry.remove(&self.key);
+        }
+    }
+}
+
+fn metadata_rollback_dir(version_id: Uuid, meta: &FileMeta) -> Uuid {
     let used_data_dirs: HashSet<Uuid> = meta.get_data_dirs().unwrap_or_default().into_iter().flatten().collect();
     let base = version_id.as_u128() ^ INLINE_METADATA_ROLLBACK_DIR_XOR;
     let mut salt = 0u128;
@@ -103,6 +134,107 @@ fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
     }
 }
 
+fn xl_meta_state(data: &[u8]) -> XlMetaState {
+    XlMetaState::Metadata(Sha256::digest(data).into())
+}
+
+fn read_xl_meta_state_std(path: &Path) -> std::io::Result<XlMetaState> {
+    match std::fs::read(path) {
+        Ok(data) => Ok(xl_meta_state(&data)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(XlMetaState::Absent),
+        Err(err) => Err(err),
+    }
+}
+
+fn read_optional_file_std(path: &Path) -> std::io::Result<Option<Vec<u8>>> {
+    match std::fs::read(path) {
+        Ok(data) => Ok(Some(data)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn write_rollback_file_std(path: &Path, data: &[u8], sync: bool) -> std::io::Result<()> {
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)?;
+    std::io::Write::write_all(&mut file, data)?;
+    if sync {
+        file.sync_data()?;
+    }
+    Ok(())
+}
+
+fn write_rollback_commit_state_std(rollback_dir: &Path, state: XlMetaState, sync: bool) -> std::io::Result<()> {
+    let digest_path = rollback_dir.join(ROLLBACK_COMMIT_DIGEST_FILE);
+    let absent_path = rollback_dir.join(ROLLBACK_COMMIT_ABSENT_FILE);
+    match state {
+        XlMetaState::Metadata(digest) => {
+            remove_file_if_exists(&absent_path)?;
+            write_rollback_file_std(&digest_path, &digest, sync)?;
+        }
+        XlMetaState::Absent => {
+            remove_file_if_exists(&digest_path)?;
+            write_rollback_file_std(&absent_path, ROLLBACK_COMMIT_ABSENT_CONTENT, sync)?;
+        }
+    }
+    if sync {
+        os::fsync_dir_std(rollback_dir)?;
+    }
+    Ok(())
+}
+
+async fn write_rollback_commit_state(object_dir: &Path, rollback_token: Uuid, state: XlMetaState, sync: bool) -> Result<()> {
+    let rollback_dir = object_dir.join(rollback_token.to_string());
+    tokio::task::spawn_blocking(move || write_rollback_commit_state_std(&rollback_dir, state, sync))
+        .await
+        .map_err(DiskError::from)?
+        .map_err(to_file_error)?;
+    Ok(())
+}
+
+fn read_rollback_commit_state_std(rollback_dir: &Path) -> std::io::Result<XlMetaState> {
+    let digest = read_optional_file_std(&rollback_dir.join(ROLLBACK_COMMIT_DIGEST_FILE))?;
+    let absent = read_optional_file_std(&rollback_dir.join(ROLLBACK_COMMIT_ABSENT_FILE))?;
+    match (digest, absent) {
+        (Some(digest), None) => {
+            let digest: [u8; 32] = digest
+                .try_into()
+                .map_err(|_| std::io::Error::new(ErrorKind::InvalidData, "invalid rollback commit SHA-256 digest"))?;
+            Ok(XlMetaState::Metadata(digest))
+        }
+        (None, Some(marker)) if marker == ROLLBACK_COMMIT_ABSENT_CONTENT => Ok(XlMetaState::Absent),
+        (None, Some(_)) => Err(std::io::Error::new(ErrorKind::InvalidData, "invalid rollback commit absent marker")),
+        (None, None) => Err(std::io::Error::new(ErrorKind::InvalidData, "rollback commit fence is missing")),
+        (Some(_), Some(_)) => Err(std::io::Error::new(ErrorKind::InvalidData, "rollback commit fence is ambiguous")),
+    }
+}
+
+fn validate_rollback_fence_std(
+    rollback_dir: &Path,
+    xl_path: &Path,
+    previous_state: XlMetaState,
+) -> std::io::Result<RollbackFenceMatch> {
+    let forward_state = read_rollback_commit_state_std(rollback_dir)?;
+    let current_state = read_xl_meta_state_std(xl_path)?;
+    if current_state == forward_state {
+        return Ok(RollbackFenceMatch::Forward);
+    }
+    if current_state == previous_state {
+        return Ok(RollbackFenceMatch::Previous);
+    }
+    Err(std::io::Error::other(
+        "rollback fence rejected metadata modified after the forward transaction",
+    ))
+}
+
+fn remove_rollback_commit_state_std(rollback_dir: &Path) -> std::io::Result<()> {
+    remove_file_if_exists(&rollback_dir.join(ROLLBACK_COMMIT_DIGEST_FILE))?;
+    remove_file_if_exists(&rollback_dir.join(ROLLBACK_COMMIT_ABSENT_FILE))
+}
+
 fn remove_dir_all_if_exists(path: &Path) -> std::io::Result<()> {
     match std::fs::remove_dir_all(path) {
         Ok(()) => Ok(()),
@@ -111,33 +243,214 @@ fn remove_dir_all_if_exists(path: &Path) -> std::io::Result<()> {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PreviousState {
+    Absent,
+    Present,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum XlMetaState {
+    Absent,
+    Metadata([u8; 32]),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RollbackFenceMatch {
+    Forward,
+    Previous,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MetadataSnapshotMethod {
+    Existing,
+    HardLink,
+    Copy,
+}
+
+fn is_hard_link_unsupported(err: &std::io::Error) -> bool {
+    matches!(
+        err.raw_os_error(),
+        Some(libc::EXDEV) | Some(libc::EPERM) | Some(libc::EMLINK) | Some(libc::ENOSYS) | Some(libc::EOPNOTSUPP)
+    ) || matches!(err.kind(), ErrorKind::CrossesDevices | ErrorKind::Unsupported)
+}
+
+fn install_metadata_backup_std<F>(
+    source: &Path,
+    backup: &Path,
+    sync: bool,
+    hard_link: F,
+) -> std::io::Result<MetadataSnapshotMethod>
+where
+    F: FnOnce(&Path, &Path) -> std::io::Result<()>,
+{
+    if backup.exists() {
+        return Ok(MetadataSnapshotMethod::Existing);
+    }
+
+    match hard_link(source, backup) {
+        Ok(()) => return Ok(MetadataSnapshotMethod::HardLink),
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => return Ok(MetadataSnapshotMethod::Existing),
+        Err(err) if !is_hard_link_unsupported(&err) => return Err(err),
+        Err(_) => {}
+    }
+
+    let copy_tmp = backup.with_extension("bkp.copying");
+    remove_file_if_exists(&copy_tmp)?;
+    std::fs::copy(source, &copy_tmp)?;
+    if sync {
+        std::fs::File::open(&copy_tmp)?.sync_data()?;
+    }
+    std::fs::rename(&copy_tmp, backup)?;
+    Ok(MetadataSnapshotMethod::Copy)
+}
+
+fn create_metadata_backup_snapshot_std(
+    xl_path: &Path,
+    rollback_token: Uuid,
+    sync: bool,
+) -> std::io::Result<MetadataSnapshotMethod> {
+    let object_dir = xl_path
+        .parent()
+        .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidInput, "missing object metadata parent"))?;
+    let rollback_dir = object_dir.join(rollback_token.to_string());
+    let backup_path = rollback_dir.join(STORAGE_FORMAT_FILE_BACKUP);
+    std::fs::create_dir_all(&rollback_dir)?;
+    let method = install_metadata_backup_std(xl_path, &backup_path, sync, |source, backup| std::fs::hard_link(source, backup))?;
+    if sync {
+        os::fsync_dir_std(&rollback_dir)?;
+        os::fsync_dir_std(object_dir)?;
+    }
+    Ok(method)
+}
+
+fn create_rename_rollback_snapshot_std(
+    xl_path: &Path,
+    rollback_token: Uuid,
+    sync: bool,
+) -> std::io::Result<(PreviousState, MetadataSnapshotMethod)> {
+    let object_dir = xl_path
+        .parent()
+        .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidInput, "missing object metadata parent"))?;
+    let rollback_dir = object_dir.join(rollback_token.to_string());
+    let backup_path = rollback_dir.join(STORAGE_FORMAT_FILE_BACKUP);
+    let absent_marker = rollback_dir.join(RENAME_DATA_ABSENT_MARKER);
+
+    if backup_path.exists() {
+        return Ok((PreviousState::Present, MetadataSnapshotMethod::Existing));
+    }
+    if absent_marker.exists() {
+        return Ok((PreviousState::Absent, MetadataSnapshotMethod::Existing));
+    }
+
+    std::fs::create_dir_all(&rollback_dir)?;
+    let result = if xl_path.exists() {
+        (
+            PreviousState::Present,
+            create_metadata_backup_snapshot_std(xl_path, rollback_token, sync)?,
+        )
+    } else {
+        // Absence is state, not payload. Persisting the marker's directory
+        // entry below is sufficient; syncing file contents would add an extra
+        // fdatasync to every first PUT without improving rollback semantics.
+        std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&absent_marker)?;
+        (PreviousState::Absent, MetadataSnapshotMethod::Existing)
+    };
+
+    if sync && result.0 == PreviousState::Absent {
+        os::fsync_dir_std(&rollback_dir)?;
+        os::fsync_dir_std(object_dir)?;
+    }
+    Ok(result)
+}
+
+fn restore_rename_rollback_std(
+    object_dir: &Path,
+    xl_path: &Path,
+    rollback_token: Uuid,
+    validate_fence: bool,
+    sync: bool,
+) -> std::io::Result<Option<PreviousState>> {
+    let rollback_dir = object_dir.join(rollback_token.to_string());
+    let backup_path = rollback_dir.join(STORAGE_FORMAT_FILE_BACKUP);
+    let absent_marker = rollback_dir.join(RENAME_DATA_ABSENT_MARKER);
+
+    let (previous_state, previous_xl_state) = if backup_path.exists() {
+        (PreviousState::Present, read_xl_meta_state_std(&backup_path)?)
+    } else if absent_marker.exists() {
+        (PreviousState::Absent, XlMetaState::Absent)
+    } else if !rollback_dir.exists() {
+        return Ok(None);
+    } else {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidData,
+            "rename rollback state is missing its previous metadata marker",
+        ));
+    };
+
+    let restore_metadata =
+        !validate_fence || validate_rollback_fence_std(&rollback_dir, xl_path, previous_xl_state)? == RollbackFenceMatch::Forward;
+    if restore_metadata {
+        match previous_state {
+            PreviousState::Present => std::fs::rename(&backup_path, xl_path)?,
+            PreviousState::Absent => remove_file_if_exists(xl_path)?,
+        }
+        remove_file_if_exists(&backup_path)?;
+        if sync {
+            os::fsync_dir_std(object_dir)?;
+            os::fsync_dir_std(&rollback_dir)?;
+        }
+    } else {
+        remove_file_if_exists(&backup_path)?;
+    }
+
+    remove_file_if_exists(&absent_marker)?;
+    remove_rollback_commit_state_std(&rollback_dir)?;
+    std::fs::remove_dir(&rollback_dir)?;
+    if sync {
+        os::fsync_dir_std(object_dir)?;
+    }
+    Ok(Some(previous_state))
+}
+
 fn rollback_committed_rename_std(
     dst_file_path: &Path,
     new_data_path: Option<&Path>,
-    rollback_data_dir: Option<Uuid>,
+    rollback_token: Option<Uuid>,
+    sync: bool,
 ) -> std::io::Result<()> {
-    if let Some(old_data_dir) = rollback_data_dir {
+    if let Some(rollback_token) = rollback_token {
         let Some(dst_parent) = dst_file_path.parent() else {
             return Err(std::io::Error::new(ErrorKind::InvalidInput, "missing object metadata parent"));
         };
-        let backup_path = dst_parent.join(old_data_dir.to_string()).join(STORAGE_FORMAT_FILE_BACKUP);
-        std::fs::rename(backup_path, dst_file_path)?;
+        if restore_rename_rollback_std(dst_parent, dst_file_path, rollback_token, false, sync)?.is_none() {
+            return Err(std::io::Error::new(ErrorKind::NotFound, "rename rollback state is missing"));
+        }
     } else {
         remove_file_if_exists(dst_file_path)?;
     }
 
     if let Some(new_data_path) = new_data_path {
         remove_dir_all_if_exists(new_data_path)?;
+        if sync {
+            let parent = new_data_path
+                .parent()
+                .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidInput, "missing renamed data parent"))?;
+            os::fsync_dir_std(parent)?;
+        }
     }
 
     Ok(())
 }
 
-async fn write_metadata_rollback_backup(object_dir: &Path, rollback_dir: Uuid, data: &[u8]) -> Result<()> {
-    let backup_dir = object_dir.join(rollback_dir.to_string());
-    fs::create_dir_all(&backup_dir).await.map_err(to_file_error)?;
-    fs::write(backup_dir.join(STORAGE_FORMAT_FILE_BACKUP), data)
+async fn write_metadata_rollback_backup(object_dir: &Path, rollback_dir: Uuid, sync: bool) -> Result<()> {
+    let xl_path = object_dir.join(STORAGE_FORMAT_FILE);
+    tokio::task::spawn_blocking(move || create_metadata_backup_snapshot_std(&xl_path, rollback_dir, sync))
         .await
+        .map_err(DiskError::from)?
         .map_err(to_file_error)?;
     Ok(())
 }
@@ -147,17 +460,34 @@ async fn restore_metadata_backup(object_dir: &Path, xl_path: &Path, rollback_dir
     rename_all(&backup_path, xl_path, object_dir).await
 }
 
-async fn restore_delete_rollback(object_dir: &Path, xl_path: &Path, rollback_dir: Uuid) -> Result<()> {
+async fn restore_delete_rollback(
+    object_dir: &Path,
+    xl_path: &Path,
+    rollback_dir: Uuid,
+    validate_fence: bool,
+    sync: bool,
+) -> Result<()> {
     let rollback_path = object_dir.join(rollback_dir.to_string());
     let mut staged_paths = Vec::new();
-    let mut remove_new_metadata = false;
+    let mut previous_state = None;
+    let mut has_commit_fence = false;
     match fs::read_dir(&rollback_path).await {
         Ok(mut entries) => {
             while let Some(entry) = entries.next_entry().await.map_err(to_file_error)? {
                 let name = entry.file_name();
                 if name == DELETE_MARKER_ROLLBACK_FILE {
-                    remove_new_metadata = true;
-                } else if name != STORAGE_FORMAT_FILE_BACKUP {
+                    if previous_state.is_some() {
+                        return Err(DiskError::other("delete rollback previous metadata state is ambiguous"));
+                    }
+                    previous_state = Some(XlMetaState::Absent);
+                } else if name == STORAGE_FORMAT_FILE_BACKUP {
+                    if previous_state.is_some() {
+                        return Err(DiskError::other("delete rollback previous metadata state is ambiguous"));
+                    }
+                    previous_state = Some(xl_meta_state(&fs::read(entry.path()).await.map_err(to_file_error)?));
+                } else if name == ROLLBACK_COMMIT_DIGEST_FILE || name == ROLLBACK_COMMIT_ABSENT_FILE {
+                    has_commit_fence = true;
+                } else {
                     staged_paths.push((entry.path(), object_dir.join(name)));
                 }
             }
@@ -166,43 +496,76 @@ async fn restore_delete_rollback(object_dir: &Path, xl_path: &Path, rollback_dir
         Err(err) => return Err(to_file_error(err).into()),
     }
 
-    let had_staged_paths = !staged_paths.is_empty();
+    let Some(previous_state) = previous_state else {
+        if staged_paths.is_empty() && !has_commit_fence {
+            fs::remove_dir(&rollback_path).await.map_err(to_file_error)?;
+            if sync {
+                os::fsync_dir(object_dir).await.map_err(to_file_error)?;
+            }
+            return Ok(());
+        }
+        return Err(DiskError::other("delete rollback state is missing its previous metadata marker"));
+    };
+
+    let fence_match = if validate_fence {
+        let rollback_path_for_fence = rollback_path.clone();
+        let xl_path_for_fence = xl_path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            validate_rollback_fence_std(&rollback_path_for_fence, &xl_path_for_fence, previous_state)
+        })
+        .await
+        .map_err(DiskError::from)?
+        .map_err(to_file_error)?
+    } else {
+        RollbackFenceMatch::Forward
+    };
+
+    // Restore data directory entries and make them durable before publishing
+    // metadata that references them.
     for (src, dst) in staged_paths {
         rename_all(&src, &dst, object_dir).await?;
     }
+    if sync {
+        os::fsync_dir(&rollback_path).await.map_err(to_file_error)?;
+        os::fsync_dir(object_dir).await.map_err(to_file_error)?;
+    }
 
     let backup_path = rollback_path.join(STORAGE_FORMAT_FILE_BACKUP);
-    match rename_all(&backup_path, xl_path, object_dir).await {
-        Ok(()) => {
-            let _ = fs::remove_dir(&rollback_path).await;
-            Ok(())
+    if fence_match == RollbackFenceMatch::Forward {
+        match previous_state {
+            XlMetaState::Metadata(_) => rename_all(&backup_path, xl_path, object_dir).await?,
+            XlMetaState::Absent => match fs::remove_file(xl_path).await {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                Err(err) => return Err(to_file_error(err).into()),
+            },
         }
-        // A missing backup only means "remove the newly-created delete marker"
-        // when the marker proves there was no old metadata to restore.
-        Err(DiskError::FileNotFound) if remove_new_metadata => match fs::remove_file(xl_path).await {
-            Ok(()) => {
-                let _ = fs::remove_file(rollback_path.join(DELETE_MARKER_ROLLBACK_FILE)).await;
-                let _ = fs::remove_dir(&rollback_path).await;
-                Ok(())
-            }
-            Err(err) if err.kind() == ErrorKind::NotFound => {
-                let _ = fs::remove_file(rollback_path.join(DELETE_MARKER_ROLLBACK_FILE)).await;
-                let _ = fs::remove_dir(&rollback_path).await;
-                Ok(())
-            }
-            Err(err) => Err(to_file_error(err).into()),
-        },
-        Err(DiskError::FileNotFound) if had_staged_paths => Err(DiskError::FileNotFound),
-        Err(DiskError::FileNotFound) => match fs::metadata(xl_path).await {
-            Ok(_) => {
-                let _ = fs::remove_dir(&rollback_path).await;
-                Ok(())
-            }
-            Err(err) if err.kind() == ErrorKind::NotFound => Err(DiskError::FileNotFound),
-            Err(err) => Err(to_file_error(err).into()),
-        },
-        Err(err) => Err(err),
+        if sync {
+            os::fsync_dir(&rollback_path).await.map_err(to_file_error)?;
+            os::fsync_dir(object_dir).await.map_err(to_file_error)?;
+        }
     }
+
+    // A hard-link backup rename can be a no-op when xl.meta already names the
+    // same inode. Consume every transaction entry explicitly before removing
+    // the token directory.
+    for path in [
+        backup_path,
+        rollback_path.join(DELETE_MARKER_ROLLBACK_FILE),
+        rollback_path.join(ROLLBACK_COMMIT_DIGEST_FILE),
+        rollback_path.join(ROLLBACK_COMMIT_ABSENT_FILE),
+    ] {
+        match fs::remove_file(path).await {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => return Err(to_file_error(err).into()),
+        }
+    }
+    fs::remove_dir(&rollback_path).await.map_err(to_file_error)?;
+    if sync {
+        os::fsync_dir(object_dir).await.map_err(to_file_error)?;
+    }
+    Ok(())
 }
 
 async fn restore_delete_rollback_after_error(
@@ -218,7 +581,15 @@ async fn restore_delete_rollback_after_error(
         return err;
     };
 
-    if let Err(restore_err) = restore_delete_rollback(object_dir, xl_path, rollback_dir).await {
+    if let Err(restore_err) = restore_delete_rollback(
+        object_dir,
+        xl_path,
+        rollback_dir,
+        false,
+        effective_durability(volume).syncs_commit_metadata(),
+    )
+    .await
+    {
         warn!(
             volume,
             path,
@@ -1402,7 +1773,7 @@ fn mmap_page_size() -> Result<u64> {
 #[cfg(test)]
 static RENAME_DATA_FAIL_BEFORE_OLD_METADATA_BACKUP: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 #[cfg(test)]
-static RENAME_DATA_FAIL_AFTER_METADATA_COMMIT: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+static RENAME_DATA_FAIL_AFTER_METADATA_COMMIT: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
 #[cfg(test)]
 static DELETE_VERSION_FAIL_AFTER_DATA_STAGED: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
 
@@ -1415,9 +1786,10 @@ fn set_rename_data_fail_before_old_metadata_backup(dst_path: &str) {
 
 #[cfg(test)]
 fn set_rename_data_fail_after_metadata_commit(dst_path: &str) {
-    *RENAME_DATA_FAIL_AFTER_METADATA_COMMIT
+    RENAME_DATA_FAIL_AFTER_METADATA_COMMIT
         .lock()
-        .expect("test failpoint lock should not be poisoned") = Some(dst_path.to_string());
+        .expect("test failpoint lock should not be poisoned")
+        .push(dst_path.to_string());
 }
 
 #[cfg(test)]
@@ -1443,11 +1815,11 @@ fn should_fail_before_old_metadata_backup(dst_path: &str) -> bool {
 
 #[cfg(test)]
 fn should_fail_after_metadata_commit(dst_path: &str) -> bool {
-    let mut target = RENAME_DATA_FAIL_AFTER_METADATA_COMMIT
+    let mut targets = RENAME_DATA_FAIL_AFTER_METADATA_COMMIT
         .lock()
         .expect("test failpoint lock should not be poisoned");
-    if target.as_deref() == Some(dst_path) {
-        target.take();
+    if let Some(index) = targets.iter().position(|target| target == dst_path) {
+        targets.swap_remove(index);
         true
     } else {
         false
@@ -3609,6 +3981,7 @@ pub struct LocalDisk {
     // pub format_last_check: Mutex<Option<OffsetDateTime>>,
     startup_cleanup_ready: Arc<AtomicU32>,
     startup_cleanup_notify: Arc<Notify>,
+    rollback_transactions: Arc<ParkingLotMutex<HashMap<RollbackTransactionKey, std::sync::Weak<TokioMutex<()>>>>>,
     exit_signal: Option<tokio::sync::broadcast::Sender<()>>,
     io_backend: Arc<dyn LocalIoBackend>,
     file_sync_permits: Arc<Semaphore>,
@@ -3684,6 +4057,30 @@ fn resolve_local_disk_root(ep_path: &str) -> Result<PathBuf> {
 }
 
 impl LocalDisk {
+    async fn lock_rollback_transaction(&self, volume: &str, path: &str) -> RollbackTransactionGuard {
+        let key = RollbackTransactionKey {
+            volume: volume.to_string(),
+            path: path.to_string(),
+        };
+        let mutex = {
+            let mut registry = self.rollback_transactions.lock();
+            if let Some(mutex) = registry.get(&key).and_then(std::sync::Weak::upgrade) {
+                mutex
+            } else {
+                let mutex = Arc::new(TokioMutex::new(()));
+                registry.insert(key.clone(), Arc::downgrade(&mutex));
+                mutex
+            }
+        };
+        let guard = Arc::clone(&mutex).lock_owned().await;
+        RollbackTransactionGuard {
+            _guard: guard,
+            mutex,
+            registry: Arc::clone(&self.rollback_transactions),
+            key,
+        }
+    }
+
     pub async fn new(ep: &Endpoint, cleanup: bool) -> Result<Self> {
         debug!(
             event = EVENT_DISK_LOCAL_STARTUP_CLEANUP,
@@ -3845,6 +4242,7 @@ impl LocalDisk {
             current_dir: Arc::new(OnceLock::new()),
             startup_cleanup_ready,
             startup_cleanup_notify,
+            rollback_transactions: Arc::new(ParkingLotMutex::new(HashMap::new())),
             exit_signal: None,
             io_backend: build_local_io_backend(root.clone()),
             file_sync_permits: os::disk_file_sync_limiter(&root),
@@ -4590,17 +4988,60 @@ impl LocalDisk {
     }
 
     async fn delete_versions_internal(&self, volume: &str, path: &str, fis: &[FileInfo], opts: &DeleteOptions) -> Result<()> {
+        opts.validate_delete_rollback()?;
+        let transaction_token = opts.rename_rollback_token.or(opts.old_data_dir);
+        let _transaction_guard = match transaction_token {
+            Some(_) => Some(self.lock_rollback_transaction(volume, path).await),
+            None => None,
+        };
+
         let volume_dir = self.get_bucket_path(volume)?;
         let xlpath = self.get_object_path(volume, format!("{path}/{STORAGE_FORMAT_FILE}").as_str())?;
         let object_dir = xlpath
             .parent()
             .ok_or_else(|| DiskError::other("missing object metadata parent"))?;
 
+        if let Some(rollback_token) = opts.rename_rollback_token {
+            let sync = effective_durability(volume).syncs_commit_metadata();
+            let object_dir_for_restore = object_dir.to_path_buf();
+            let xlpath = xlpath.clone();
+            let previous_state = tokio::task::spawn_blocking(move || {
+                restore_rename_rollback_std(&object_dir_for_restore, &xlpath, rollback_token, true, sync)
+            })
+            .await
+            .map_err(DiskError::from)?
+            .map_err(to_file_error)?;
+            if previous_state.is_some() {
+                for fi in fis {
+                    if let Some(new_data_dir) = fi.data_dir {
+                        let new_data_path = self.get_object_path(volume, &format!("{path}/{new_data_dir}"))?;
+                        if let Err(err) = self.move_to_trash(&new_data_path, true, false).await
+                            && err != DiskError::FileNotFound
+                            && err != DiskError::VolumeNotFound
+                        {
+                            return Err(err);
+                        }
+                    }
+                }
+                if sync {
+                    os::fsync_dir(object_dir).await.map_err(to_file_error)?;
+                }
+            }
+            return Ok(());
+        }
+
         if let Some(rollback_dir) = opts.old_data_dir
             && opts.undo_write
         {
             if opts.undo_delete {
-                return restore_delete_rollback(object_dir, &xlpath, rollback_dir).await;
+                return restore_delete_rollback(
+                    object_dir,
+                    &xlpath,
+                    rollback_dir,
+                    true,
+                    effective_durability(volume).syncs_commit_metadata(),
+                )
+                .await;
             }
 
             return restore_metadata_backup(object_dir, &xlpath, rollback_dir).await;
@@ -4617,7 +5058,8 @@ impl LocalDisk {
         fm.unmarshal_msg(&data)?;
         let rollback_dir = opts.old_data_dir;
         if let Some(rollback_dir) = rollback_dir {
-            write_metadata_rollback_backup(object_dir, rollback_dir, &data).await?;
+            write_metadata_rollback_backup(object_dir, rollback_dir, effective_durability(volume).syncs_commit_metadata())
+                .await?;
         }
 
         for fi in fis.iter() {
@@ -4714,53 +5156,69 @@ impl LocalDisk {
             }
         }
 
-        // Remove xl.meta when no versions remain
-        if fm.versions.is_empty() {
-            if let Err(err) = self.delete_file(&volume_dir, &xlpath, true, false).await {
-                return Err(restore_delete_rollback_after_error(
-                    object_dir,
-                    &xlpath,
-                    rollback_dir,
-                    volume,
-                    path,
-                    "delete_versions_commit_delete",
-                    err,
-                )
-                .await);
-            }
-            return Ok(());
-        }
-
-        // Update xl.meta atomically: a concurrent reader or crash mid-write must
-        // never observe a truncated xl.meta for versions that were not deleted.
-        let buf = match fm.marshal_msg() {
-            Ok(buf) => buf,
-            Err(err) => {
-                let err: DiskError = err.into();
-                return Err(restore_delete_rollback_after_error(
-                    object_dir,
-                    &xlpath,
-                    rollback_dir,
-                    volume,
-                    path,
-                    "delete_versions_metadata_encode",
-                    err,
-                )
-                .await);
+        // Keep the exact forward terminal state so compensation can reject a
+        // stale rollback after another writer has changed xl.meta.
+        let committed_metadata = if fm.versions.is_empty() {
+            None
+        } else {
+            match fm.marshal_msg() {
+                Ok(buf) => Some(buf),
+                Err(err) => {
+                    let err: DiskError = err.into();
+                    return Err(restore_delete_rollback_after_error(
+                        object_dir,
+                        &xlpath,
+                        rollback_dir,
+                        volume,
+                        path,
+                        "delete_versions_metadata_encode",
+                        err,
+                    )
+                    .await);
+                }
             }
         };
-
-        if let Err(err) = self
-            .write_all_meta(volume, format!("{path}/{STORAGE_FORMAT_FILE}").as_str(), &buf, true)
+        if let Some(rollback_dir) = rollback_dir {
+            let forward_state = committed_metadata
+                .as_deref()
+                .map(xl_meta_state)
+                .unwrap_or(XlMetaState::Absent);
+            if let Err(err) = write_rollback_commit_state(
+                object_dir,
+                rollback_dir,
+                forward_state,
+                effective_durability(volume).syncs_commit_metadata(),
+            )
             .await
-        {
+            {
+                return Err(restore_delete_rollback_after_error(
+                    object_dir,
+                    &xlpath,
+                    Some(rollback_dir),
+                    volume,
+                    path,
+                    "delete_versions_commit_fence",
+                    err,
+                )
+                .await);
+            }
+        }
+        let commit_result = if let Some(buf) = committed_metadata.as_deref() {
+            // Update xl.meta atomically: a concurrent reader or crash mid-write
+            // must never observe a truncated surviving version set.
+            self.write_all_meta(volume, format!("{path}/{STORAGE_FORMAT_FILE}").as_str(), buf, true)
+                .await
+        } else {
+            self.delete_file(&volume_dir, &xlpath, true, false).await
+        };
+        if let Err(err) = commit_result {
             return Err(restore_delete_rollback_after_error(
                 object_dir,
                 &xlpath,
                 rollback_dir,
                 volume,
                 path,
-                "delete_versions_commit_write",
+                "delete_versions_commit",
                 err,
             )
             .await);
@@ -6560,7 +7018,6 @@ impl DiskAPI for LocalDisk {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
     async fn rename_data(
         &self,
         src_volume: &str,
@@ -6569,7 +7026,30 @@ impl DiskAPI for LocalDisk {
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
+        self.rename_data_with_rollback(src_volume, src_path, fi, dst_volume, dst_path, Uuid::nil())
+            .await
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn rename_data_with_rollback(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+        rollback_token: Uuid,
+    ) -> Result<RenameDataResp> {
         crate::hp_guard!("LocalDisk::rename_data");
+        let transaction_token = (!rollback_token.is_nil()).then_some(rollback_token);
+        if transaction_token.is_some_and(|token| fi.data_dir == Some(token)) {
+            return Err(DiskError::other("rename rollback token collides with the incoming data directory"));
+        }
+        let _transaction_guard = match transaction_token {
+            Some(_) => Some(self.lock_rollback_transaction(dst_volume, dst_path).await),
+            None => None,
+        };
+
         // Snapshot the destination part paths before `fi` is consumed below. These
         // are the descriptors a reader may hold for the version this call is about
         // to replace (backlog#1145); readers build the identical string in
@@ -6701,13 +7181,24 @@ impl DiskAPI for LocalDisk {
 
             let version_id = fi.version_id.unwrap_or_default();
             let has_old_data_dir = xlmeta.find_unshared_data_dir_for_version(Some(version_id));
-            let old_version_exists = xlmeta.find_version(Some(version_id)).is_ok();
-            let rollback_data_dir = has_old_data_dir.or_else(|| {
-                if old_version_exists && has_dst_buf.is_some() {
-                    Some(inline_metadata_rollback_dir(version_id, &xlmeta))
-                } else {
-                    None
-                }
+            if transaction_token.is_some_and(|token| {
+                xlmeta
+                    .get_data_dirs()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .flatten()
+                    .any(|data_dir| data_dir == token)
+            }) {
+                return Err(DiskError::other("rename rollback token collides with an existing data directory"));
+            }
+            let rollback_state_dir = transaction_token.or_else(|| {
+                has_old_data_dir.or_else(|| {
+                    if has_dst_buf.is_some() {
+                        Some(metadata_rollback_dir(version_id, &xlmeta))
+                    } else {
+                        None
+                    }
+                })
             });
             if let Some(old_data_dir) = has_old_data_dir.as_ref() {
                 let _ = xlmeta.data.remove_two(version_id, *old_data_dir);
@@ -6715,6 +7206,7 @@ impl DiskAPI for LocalDisk {
             xlmeta.add_version(fi)?;
             let version_signature = rename_data_versions_signature(&xlmeta);
             let new_dst_buf = xlmeta.marshal_msg()?;
+            let forward_state = transaction_token.map(|_| xl_meta_state(&new_dst_buf));
 
             let src_file_parent = src_file_path.parent().unwrap_or(src_volume_dir.as_path());
             // This tmp xl.meta is renamed onto dst_file_path at the commit
@@ -6802,39 +7294,48 @@ impl DiskAPI for LocalDisk {
                 return Err(DiskError::Unexpected);
             }
 
-            // The rollback backup stays where it is written (no rename) and is
-            // the sole restore source for a later undo_write, so under strict
-            // it keeps SyncMode::FileAndDir: contents and directory entry both
-            // durable. It is part of the metadata commit machinery, so relaxed
-            // tiers leave it to the page cache like the xl.meta it mirrors.
-            let backup_sync = if durability.syncs_commit_metadata() {
-                SyncMode::FileAndDir
-            } else {
-                SyncMode::None
-            };
-            if let Some(old_data_dir) = rollback_data_dir
-                && let Some(dst_buf) = has_dst_buf.as_ref()
-                && let Err(err) = self
-                    .write_all_private(
-                        dst_volume,
-                        &format!("{}/{}/{}", dst_path, old_data_dir, STORAGE_FORMAT_FILE_BACKUP),
-                        dst_buf.clone().into(),
-                        backup_sync,
-                        &skip_parent,
-                    )
-                    .await
-            {
-                if let Some((_, dst_data_path)) = has_data_dir_path.as_ref() {
-                    let _ = self.delete_file(&dst_volume_dir, dst_data_path, false, false).await;
+            if let Some(rollback_state_dir) = rollback_state_dir {
+                let dst_file_path_for_snapshot = dst_file_path.clone();
+                let sync = durability.syncs_commit_metadata();
+                let snapshot = tokio::task::spawn_blocking(move || {
+                    create_rename_rollback_snapshot_std(&dst_file_path_for_snapshot, rollback_state_dir, sync)
+                })
+                .await
+                .map_err(DiskError::from)?;
+                if let Err(err) = snapshot {
+                    if let Some((_, dst_data_path)) = has_data_dir_path.as_ref() {
+                        let _ = self.delete_file(&dst_volume_dir, dst_data_path, false, false).await;
+                    }
+                    info!(
+                        event = EVENT_DISK_LOCAL_RENAME_REJECTED,
+                        component = LOG_COMPONENT_ECSTORE,
+                        subsystem = LOG_SUBSYSTEM_DISK_LOCAL,
+                        reason = "create_metadata_rollback_snapshot_failed",
+                        error = ?err,
+                        "Disk local rename flow failed"
+                    );
+                    return Err(to_file_error(err).into());
                 }
-                info!(
-                    event = EVENT_DISK_LOCAL_RENAME_REJECTED,
-                    component = LOG_COMPONENT_ECSTORE,
-                    subsystem = LOG_SUBSYSTEM_DISK_LOCAL,
-                    reason = "write_old_metadata_backup_failed",
-                    error = ?err,
-                    "Disk local rename flow failed"
-                );
+            }
+
+            if let (Some(rollback_token), Some(forward_state)) = (transaction_token, forward_state)
+                && let Err(err) = write_rollback_commit_state(
+                    dst_file_path
+                        .parent()
+                        .ok_or_else(|| DiskError::other("missing object metadata parent"))?,
+                    rollback_token,
+                    forward_state,
+                    durability.syncs_commit_metadata(),
+                )
+                .await
+            {
+                rollback_committed_rename_std(
+                    &dst_file_path,
+                    has_data_dir_path.as_ref().map(|(_, dst_data_path)| dst_data_path.as_path()),
+                    rollback_state_dir,
+                    durability.syncs_commit_metadata(),
+                )
+                .map_err(to_file_error)?;
                 return Err(err);
             }
 
@@ -6865,8 +7366,13 @@ impl DiskAPI for LocalDisk {
 
             let committed_new_data_path = has_data_dir_path.as_ref().map(|(_, dst_data_path)| dst_data_path.as_path());
             if should_fail_after_metadata_commit(dst_path) {
-                rollback_committed_rename_std(&dst_file_path, committed_new_data_path, rollback_data_dir)
-                    .map_err(to_file_error)?;
+                rollback_committed_rename_std(
+                    &dst_file_path,
+                    committed_new_data_path,
+                    rollback_state_dir,
+                    durability.syncs_commit_metadata(),
+                )
+                .map_err(to_file_error)?;
                 return Err(DiskError::Unexpected);
             }
 
@@ -6886,8 +7392,13 @@ impl DiskAPI for LocalDisk {
                 && let Some(parent) = dst_file_path.parent()
                 && let Err(err) = os::fsync_dir(parent).await
             {
-                rollback_committed_rename_std(&dst_file_path, committed_new_data_path, rollback_data_dir)
-                    .map_err(to_file_error)?;
+                rollback_committed_rename_std(
+                    &dst_file_path,
+                    committed_new_data_path,
+                    rollback_state_dir,
+                    durability.syncs_commit_metadata(),
+                )
+                .map_err(to_file_error)?;
                 // The commit rename changed the dst part inodes before this fsync
                 // failed and rolled them back; drop any fd cached during that
                 // window so readers re-open the restored inode (rustfs/backlog#1177).
@@ -6914,8 +7425,13 @@ impl DiskAPI for LocalDisk {
                         break;
                     }
                     if let Err(err) = os::fsync_dir(dir).await {
-                        rollback_committed_rename_std(&dst_file_path, committed_new_data_path, rollback_data_dir)
-                            .map_err(to_file_error)?;
+                        rollback_committed_rename_std(
+                            &dst_file_path,
+                            committed_new_data_path,
+                            rollback_state_dir,
+                            durability.syncs_commit_metadata(),
+                        )
+                        .map_err(to_file_error)?;
                         // Same post-commit rollback window as above — drop cached
                         // dst part fds so readers re-open the restored inode
                         // (rustfs/backlog#1177).
@@ -6957,7 +7473,7 @@ impl DiskAPI for LocalDisk {
             }
 
             Ok(RenameDataResp {
-                old_data_dir: rollback_data_dir,
+                old_data_dir: has_old_data_dir,
                 sign: version_signature,
                 old_current_size,
             })
@@ -7005,13 +7521,24 @@ impl DiskAPI for LocalDisk {
 
                 let version_id = fi.version_id.unwrap_or_default();
                 let old_data_dir = xlmeta.find_unshared_data_dir_for_version(Some(version_id));
-                let old_version_exists = xlmeta.find_version(Some(version_id)).is_ok();
-                let rollback_data_dir = old_data_dir.or_else(|| {
-                    if old_version_exists && has_dst_buf.is_some() {
-                        Some(inline_metadata_rollback_dir(version_id, &xlmeta))
-                    } else {
-                        None
-                    }
+                if transaction_token.is_some_and(|token| {
+                    xlmeta
+                        .get_data_dirs()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .flatten()
+                        .any(|data_dir| data_dir == token)
+                }) {
+                    return Err(std::io::Error::other("rename rollback token collides with an existing data directory"));
+                }
+                let rollback_state_dir = transaction_token.or_else(|| {
+                    old_data_dir.or_else(|| {
+                        if has_dst_buf.is_some() {
+                            Some(metadata_rollback_dir(version_id, &xlmeta))
+                        } else {
+                            None
+                        }
+                    })
                 });
                 if let Some(d) = old_data_dir.as_ref() {
                     let _ = xlmeta.data.remove_two(version_id, *d);
@@ -7019,6 +7546,7 @@ impl DiskAPI for LocalDisk {
                 xlmeta.add_version(fi)?;
                 let version_signature = rename_data_versions_signature(&xlmeta);
                 let new_buf = xlmeta.marshal_msg()?;
+                let forward_state = transaction_token.map(|_| xl_meta_state(&new_buf));
 
                 // Write new xl.meta + rename. Inline objects carry their data
                 // inside xl.meta, so this whole sequence is a metadata commit:
@@ -7038,33 +7566,18 @@ impl DiskAPI for LocalDisk {
                 if sync {
                     f.sync_data()?;
                 }
-                if let Some(old_dir) = rollback_data_dir.as_ref()
-                    && let Some(ref buf) = has_dst_buf
-                    && let Some(dst_parent) = dst.parent()
-                {
-                    let old_path = dst_parent.join(old_dir.to_string()).join(STORAGE_FORMAT_FILE_BACKUP);
-                    let old_parent = old_path.parent().map(|p| p.to_path_buf());
-                    if let Some(ref old_parent) = old_parent {
-                        std::fs::create_dir_all(old_parent)?;
-                    }
-                    // This rollback backup is the sole restore source for a later
-                    // undo_write when the set-level write quorum fails. Persist it as
-                    // durably as the new xl.meta written above (and as the non-inline
-                    // branch does): a bare std::fs::write leaves both the bytes and the
-                    // new directory entry in the page cache, so a crash before a
-                    // rollback could restore a lost or truncated backup.
-                    let mut backup = std::fs::OpenOptions::new()
-                        .create(true)
-                        .write(true)
-                        .truncate(true)
-                        .open(&old_path)
-                        .map_err(to_file_error)?;
-                    std::io::Write::write_all(&mut backup, buf).map_err(to_file_error)?;
-                    if sync {
-                        backup.sync_data().map_err(to_file_error)?;
-                        if let Some(ref old_parent) = old_parent {
-                            os::fsync_dir_std(old_parent).map_err(to_file_error)?;
-                        }
+                if let Some(rollback_state_dir) = rollback_state_dir {
+                    create_rename_rollback_snapshot_std(&dst, rollback_state_dir, sync).map_err(to_file_error)?;
+                }
+                if let (Some(rollback_token), Some(forward_state)) = (transaction_token, forward_state) {
+                    let object_dir = dst
+                        .parent()
+                        .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidInput, "missing object metadata parent"))?;
+                    if let Err(err) =
+                        write_rollback_commit_state_std(&object_dir.join(rollback_token.to_string()), forward_state, sync)
+                    {
+                        rollback_committed_rename_std(&dst, None, rollback_state_dir, sync)?;
+                        return Err(err);
                     }
                 }
 
@@ -7082,7 +7595,7 @@ impl DiskAPI for LocalDisk {
                 }?;
 
                 if should_fail_after_metadata_commit(&dst_path_for_failpoint) {
-                    rollback_committed_rename_std(&dst, None, rollback_data_dir)?;
+                    rollback_committed_rename_std(&dst, None, rollback_state_dir, sync)?;
                     return Err(std::io::Error::other("test fail after metadata commit"));
                 }
 
@@ -7091,7 +7604,7 @@ impl DiskAPI for LocalDisk {
                     && let Some(dst_parent) = dst.parent()
                     && let Err(err) = os::fsync_dir_std(dst_parent)
                 {
-                    rollback_committed_rename_std(&dst, None, rollback_data_dir)?;
+                    rollback_committed_rename_std(&dst, None, rollback_state_dir, sync)?;
                     return Err(err);
                 }
 
@@ -7109,7 +7622,7 @@ impl DiskAPI for LocalDisk {
                             break;
                         }
                         if let Err(err) = os::fsync_dir_std(ancestor_dir) {
-                            rollback_committed_rename_std(&dst, None, rollback_data_dir)?;
+                            rollback_committed_rename_std(&dst, None, rollback_state_dir, sync)?;
                             return Err(err);
                         }
                         if ancestor_dir == bucket_dir.as_path() {
@@ -7120,7 +7633,7 @@ impl DiskAPI for LocalDisk {
                 }
 
                 Ok::<(Option<Uuid>, Option<Vec<u8>>, Option<OldCurrentSize>), std::io::Error>((
-                    rollback_data_dir,
+                    old_data_dir,
                     version_signature,
                     old_current_size,
                 ))
@@ -7270,19 +7783,47 @@ impl DiskAPI for LocalDisk {
                 .map_err(|e| to_access_error(e, DiskError::VolumeAccessDenied))?;
         }
 
+        let mut first_error = None;
         for path in paths.iter() {
-            let file_path = self.get_object_path(volume, path)?;
+            let _transaction_guard = match path.rsplit_once(SLASH_SEPARATOR) {
+                Some((object, token)) => match Uuid::parse_str(token) {
+                    Ok(token) if !token.is_nil() => Some(self.lock_rollback_transaction(volume, object).await),
+                    _ => None,
+                },
+                None => None,
+            };
+            let file_path = match self.get_object_path(volume, path) {
+                Ok(file_path) => file_path,
+                Err(err) => {
+                    first_error.get_or_insert(err);
+                    continue;
+                }
+            };
 
-            check_path_length(file_path.to_string_lossy().as_ref())?;
+            if let Err(err) = check_path_length(file_path.to_string_lossy().as_ref()) {
+                first_error.get_or_insert(err);
+                continue;
+            }
 
-            self.move_to_trash(&file_path, false, false).await?;
+            match self.move_to_trash(&file_path, false, false).await {
+                Ok(()) => {
+                    // A cached io_uring descriptor under a just-removed path would keep
+                    // its inode readable; drop it (rustfs/backlog#1175).
+                    self.io_backend.invalidate_cached_fds_under(volume, path);
 
-            // A cached io_uring descriptor under a just-removed path would keep
-            // its inode readable; drop it (rustfs/backlog#1175).
-            self.io_backend.invalidate_cached_fds_under(volume, path);
+                    if let Some(parent) = file_path.parent()
+                        && let Err(err) = self.delete_file(&volume_dir, &parent.to_path_buf(), false, false).await
+                    {
+                        first_error.get_or_insert(err);
+                    }
+                }
+                Err(err) => {
+                    first_error.get_or_insert(err);
+                }
+            }
         }
 
-        Ok(())
+        first_error.map_or(Ok(()), Err)
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -7471,6 +8012,8 @@ impl DiskAPI for LocalDisk {
         force_del_marker: bool,
         opts: DeleteOptions,
     ) -> Result<()> {
+        opts.validate_delete_rollback()?;
+
         if path.starts_with(SLASH_SEPARATOR) {
             return self
                 .delete(
@@ -7485,6 +8028,12 @@ impl DiskAPI for LocalDisk {
                 .await;
         }
 
+        let transaction_token = opts.rename_rollback_token.or(opts.old_data_dir);
+        let _transaction_guard = match transaction_token {
+            Some(_) => Some(self.lock_rollback_transaction(volume, path).await),
+            None => None,
+        };
+
         let volume_dir = self.get_bucket_path(volume)?;
 
         let file_path = self.get_object_path(volume, path)?;
@@ -7492,11 +8041,47 @@ impl DiskAPI for LocalDisk {
         check_path_length(file_path.to_string_lossy().as_ref())?;
 
         let xl_path = path_join(&[file_path.as_path(), Path::new(STORAGE_FORMAT_FILE)]);
+        if let Some(rollback_token) = opts.rename_rollback_token {
+            let sync = effective_durability(volume).syncs_commit_metadata();
+            let object_dir = file_path.clone();
+            let xl_path_for_restore = xl_path.clone();
+            let previous_state = tokio::task::spawn_blocking(move || {
+                restore_rename_rollback_std(&object_dir, &xl_path_for_restore, rollback_token, true, sync)
+            })
+            .await
+            .map_err(DiskError::from)?
+            .map_err(to_file_error)?;
+
+            if previous_state.is_some() {
+                if let Some(new_data_dir) = fi.data_dir {
+                    let new_data_path = path_join(&[file_path.as_path(), Path::new(new_data_dir.to_string().as_str())]);
+                    check_path_length(new_data_path.to_string_lossy().as_ref())?;
+                    if let Err(err) = self.move_to_trash(&new_data_path, true, false).await
+                        && err != DiskError::FileNotFound
+                        && err != DiskError::VolumeNotFound
+                    {
+                        return Err(err);
+                    }
+                }
+                if sync {
+                    os::fsync_dir(file_path.as_path()).await.map_err(to_file_error)?;
+                }
+            }
+            return Ok(());
+        }
+
         if let Some(old_data_dir) = opts.old_data_dir
             && opts.undo_write
         {
             if opts.undo_delete {
-                restore_delete_rollback(file_path.as_path(), &xl_path, old_data_dir).await?;
+                restore_delete_rollback(
+                    file_path.as_path(),
+                    &xl_path,
+                    old_data_dir,
+                    true,
+                    effective_durability(volume).syncs_commit_metadata(),
+                )
+                .await?;
             } else {
                 restore_metadata_backup(file_path.as_path(), &xl_path, old_data_dir).await?;
             }
@@ -7526,16 +8111,63 @@ impl DiskAPI for LocalDisk {
                 }
 
                 if fi.deleted && force_del_marker {
+                    let mut delete_marker_meta = FileMeta::new();
+                    delete_marker_meta.add_version(fi)?;
+                    let committed_metadata = delete_marker_meta.marshal_msg()?;
                     if let Some(rollback_dir) = rollback_dir {
                         let rollback_path = file_path.join(rollback_dir.to_string());
-                        fs::create_dir_all(&rollback_path).await.map_err(to_file_error)?;
-                        fs::write(rollback_path.join(DELETE_MARKER_ROLLBACK_FILE), [])
-                            .await
-                            .map_err(to_file_error)?;
+                        let object_dir = file_path.clone();
+                        let sync = effective_durability(volume).syncs_commit_metadata();
+                        tokio::task::spawn_blocking(move || {
+                            std::fs::create_dir_all(&rollback_path)?;
+                            write_rollback_file_std(&rollback_path.join(DELETE_MARKER_ROLLBACK_FILE), &[], sync)?;
+                            if sync {
+                                os::fsync_dir_std(&rollback_path)?;
+                                os::fsync_dir_std(&object_dir)?;
+                            }
+                            Ok::<(), std::io::Error>(())
+                        })
+                        .await
+                        .map_err(DiskError::from)?
+                        .map_err(to_file_error)?;
+                        if let Err(err) = write_rollback_commit_state(
+                            file_path.as_path(),
+                            rollback_dir,
+                            xl_meta_state(&committed_metadata),
+                            sync,
+                        )
+                        .await
+                        {
+                            return Err(restore_delete_rollback_after_error(
+                                file_path.as_path(),
+                                &xl_path,
+                                Some(rollback_dir),
+                                volume,
+                                path,
+                                "delete_marker_commit_fence",
+                                err,
+                            )
+                            .await);
+                        }
                     }
-                    if let Err(err) = self.write_metadata("", volume, path, fi).await {
+                    if let Err(err) = self
+                        .write_all_meta(
+                            volume,
+                            format!("{path}{SLASH_SEPARATOR}{STORAGE_FORMAT_FILE}").as_str(),
+                            &committed_metadata,
+                            true,
+                        )
+                        .await
+                    {
                         if let Some(rollback_dir) = rollback_dir
-                            && let Err(restore_err) = restore_delete_rollback(file_path.as_path(), &xl_path, rollback_dir).await
+                            && let Err(restore_err) = restore_delete_rollback(
+                                file_path.as_path(),
+                                &xl_path,
+                                rollback_dir,
+                                false,
+                                effective_durability(volume).syncs_commit_metadata(),
+                            )
+                            .await
                         {
                             warn!(
                                 volume,
@@ -7561,7 +8193,12 @@ impl DiskAPI for LocalDisk {
         let mut meta = FileMeta::load(&buf)?;
         let old_dir = meta.delete_version(&fi)?;
         if let Some(rollback_dir) = rollback_dir {
-            write_metadata_rollback_backup(file_path.as_path(), rollback_dir, &buf).await?;
+            write_metadata_rollback_backup(
+                file_path.as_path(),
+                rollback_dir,
+                effective_durability(volume).syncs_commit_metadata(),
+            )
+            .await?;
         }
 
         if let Some(uuid) = old_dir {
@@ -7649,8 +8286,10 @@ impl DiskAPI for LocalDisk {
             self.io_backend.invalidate_cached_fds_under(volume, &format!("{path}/{uuid}"));
         }
 
-        let commit_result = if !meta.versions.is_empty() {
-            let buf = match meta.marshal_msg() {
+        let committed_metadata = if meta.versions.is_empty() {
+            None
+        } else {
+            Some(match meta.marshal_msg() {
                 Ok(buf) => buf,
                 Err(err) => {
                     let err: DiskError = err.into();
@@ -7665,8 +8304,35 @@ impl DiskAPI for LocalDisk {
                     )
                     .await);
                 }
-            };
-            self.write_all_meta(volume, format!("{path}{SLASH_SEPARATOR}{STORAGE_FORMAT_FILE}").as_str(), &buf, true)
+            })
+        };
+        if let Some(rollback_dir) = rollback_dir {
+            let forward_state = committed_metadata
+                .as_deref()
+                .map(xl_meta_state)
+                .unwrap_or(XlMetaState::Absent);
+            if let Err(err) = write_rollback_commit_state(
+                file_path.as_path(),
+                rollback_dir,
+                forward_state,
+                effective_durability(volume).syncs_commit_metadata(),
+            )
+            .await
+            {
+                return Err(restore_delete_rollback_after_error(
+                    file_path.as_path(),
+                    &xl_path,
+                    Some(rollback_dir),
+                    volume,
+                    path,
+                    "delete_version_commit_fence",
+                    err,
+                )
+                .await);
+            }
+        }
+        let commit_result = if let Some(buf) = committed_metadata.as_deref() {
+            self.write_all_meta(volume, format!("{path}{SLASH_SEPARATOR}{STORAGE_FORMAT_FILE}").as_str(), buf, true)
                 .await
         } else {
             self.delete_file(&volume_dir, &xl_path, true, false).await
@@ -7962,7 +8628,7 @@ mod test {
     }
 
     #[test]
-    fn inline_metadata_rollback_dir_avoids_real_data_dir_collision() {
+    fn metadata_rollback_dir_avoids_real_data_dir_collision() {
         let target_version = Uuid::parse_str("11111111-2222-3333-4444-555555555555").expect("version id should parse");
         let colliding_dir = Uuid::from_u128(target_version.as_u128() ^ INLINE_METADATA_ROLLBACK_DIR_XOR);
         let other_version = Uuid::parse_str("66666666-7777-8888-9999-aaaaaaaaaaaa").expect("version id should parse");
@@ -7971,9 +8637,390 @@ mod test {
         meta.add_version(test_file_info("object", other_version, Some(colliding_dir), None))
             .expect("test metadata should accept file info");
 
-        let rollback_dir = inline_metadata_rollback_dir(target_version, &meta);
+        let rollback_dir = metadata_rollback_dir(target_version, &meta);
         assert_ne!(rollback_dir, colliding_dir);
         assert!(!rollback_dir.is_nil());
+    }
+
+    #[test]
+    fn metadata_backup_snapshot_uses_hard_link_and_preserves_old_contents() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let object_dir = dir.path().join("object");
+        std::fs::create_dir_all(&object_dir).expect("object dir should be created");
+        let xl_path = object_dir.join(STORAGE_FORMAT_FILE);
+        std::fs::write(&xl_path, b"old-metadata").expect("old metadata should be written");
+        let rollback_token = Uuid::new_v4();
+
+        let method =
+            create_metadata_backup_snapshot_std(&xl_path, rollback_token, false).expect("metadata snapshot should be created");
+        assert_eq!(method, MetadataSnapshotMethod::HardLink);
+        let backup_path = object_dir.join(rollback_token.to_string()).join(STORAGE_FORMAT_FILE_BACKUP);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_eq!(
+                std::fs::metadata(&xl_path).expect("xl metadata should stat").ino(),
+                std::fs::metadata(&backup_path).expect("backup should stat").ino()
+            );
+        }
+
+        let replacement = object_dir.join("xl.meta.new");
+        std::fs::write(&replacement, b"new-metadata").expect("replacement metadata should be written");
+        std::fs::rename(&replacement, &xl_path).expect("replacement metadata should commit");
+        assert_eq!(std::fs::read(&backup_path).expect("backup should remain readable"), b"old-metadata");
+    }
+
+    #[tokio::test]
+    async fn rollback_transaction_lock_serializes_same_object_across_tokens() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = Arc::new(LocalDisk::new(&endpoint, false).await.expect("local disk should be created"));
+        let first = disk.lock_rollback_transaction("bucket", "object").await;
+        let waiting_disk = Arc::clone(&disk);
+        let waiter = tokio::spawn(async move { waiting_disk.lock_rollback_transaction("bucket", "object").await });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished(), "same-object transaction must wait for the active disk mutation");
+
+        drop(first);
+        let second = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiting transaction should resume after release")
+            .expect("waiting transaction task should not fail");
+        drop(second);
+        assert!(disk.rollback_transactions.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_paths_serializes_transaction_cleanup_and_continues_after_error() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = Arc::new(LocalDisk::new(&endpoint, false).await.expect("local disk should be created"));
+        ensure_test_volume(&disk, "bucket").await;
+        let token = Uuid::new_v4();
+        let transaction_path = format!("object/{token}");
+        std::fs::create_dir_all(dir.path().join("bucket").join(&transaction_path))
+            .expect("transaction directory should be created");
+
+        let active = disk.lock_rollback_transaction("bucket", "object").await;
+        let cleanup_disk = Arc::clone(&disk);
+        let cleanup_path = transaction_path.clone();
+        let cleanup = tokio::spawn(async move { cleanup_disk.delete_paths("bucket", &[cleanup_path]).await });
+        tokio::task::yield_now().await;
+        assert!(!cleanup.is_finished(), "cleanup must wait for the active transaction");
+        drop(active);
+        cleanup
+            .await
+            .expect("cleanup task should not fail")
+            .expect("transaction cleanup should succeed");
+        assert!(!dir.path().join("bucket/object").exists());
+
+        let trailing = format!("other/{}", Uuid::new_v4());
+        std::fs::create_dir_all(dir.path().join("bucket").join(&trailing)).expect("trailing cleanup directory should be created");
+        let error = disk
+            .delete_paths("bucket", &["x".repeat(5000), trailing.clone()])
+            .await
+            .expect_err("batch should preserve the first cleanup error");
+        assert!(!error.to_string().is_empty());
+        assert!(
+            !dir.path().join("bucket").join(trailing).exists(),
+            "cleanup must continue after an earlier path fails"
+        );
+    }
+
+    #[test]
+    fn metadata_backup_snapshot_copies_only_when_hard_links_are_unsupported() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let source = dir.path().join("xl.meta");
+        let backup_dir = dir.path().join("rollback");
+        let backup = backup_dir.join(STORAGE_FORMAT_FILE_BACKUP);
+        std::fs::create_dir_all(&backup_dir).expect("backup dir should be created");
+        std::fs::write(&source, b"metadata").expect("source metadata should be written");
+
+        let method =
+            install_metadata_backup_std(&source, &backup, false, |_, _| Err(std::io::Error::from_raw_os_error(libc::EOPNOTSUPP)))
+                .expect("unsupported hard link should fall back to copy");
+        assert_eq!(method, MetadataSnapshotMethod::Copy);
+        assert_eq!(std::fs::read(&backup).expect("copied backup should be readable"), b"metadata");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_ne!(
+                std::fs::metadata(&source).expect("source should stat").ino(),
+                std::fs::metadata(&backup).expect("backup should stat").ino()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rename_transaction_rejects_incoming_data_dir_token_collision() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
+        ensure_test_volume(&disk, "bucket").await;
+
+        let rollback_token = Uuid::new_v4();
+        let file_info = test_file_info("object", Uuid::new_v4(), Some(rollback_token), None);
+        let error = disk
+            .rename_data_with_rollback(RUSTFS_META_TMP_BUCKET, "tmp-object", file_info, "bucket", "object", rollback_token)
+            .await
+            .expect_err("transaction token must not alias incoming shard data");
+
+        assert!(error.to_string().contains("incoming data directory"));
+        assert!(!dir.path().join("bucket/object/xl.meta").exists());
+        assert!(!dir.path().join("bucket/object").join(rollback_token.to_string()).exists());
+    }
+
+    #[tokio::test]
+    async fn rename_rollback_rejects_metadata_written_after_forward_commit() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
+        ensure_test_volume(&disk, "bucket").await;
+
+        let object = "fenced-rename";
+        let object_dir = dir.path().join("bucket").join(object);
+        fs::create_dir_all(&object_dir).await.expect("object dir should be created");
+        let old_fi = test_file_info(object, Uuid::new_v4(), None, Some(Bytes::from_static(b"old")));
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), test_meta(old_fi))
+            .await
+            .expect("old metadata should be written");
+
+        let rollback_token = Uuid::new_v4();
+        let committed_fi = test_file_info(object, Uuid::new_v4(), None, Some(Bytes::from_static(b"forward")));
+        disk.rename_data_with_rollback(
+            RUSTFS_META_TMP_BUCKET,
+            "tmp-fenced-rename",
+            committed_fi.clone(),
+            "bucket",
+            object,
+            rollback_token,
+        )
+        .await
+        .expect("forward rename should commit");
+
+        let newer_fi = test_file_info(object, Uuid::new_v4(), None, Some(Bytes::from_static(b"newer")));
+        let newer_meta = test_meta(newer_fi);
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), &newer_meta)
+            .await
+            .expect("newer metadata should be written");
+
+        let err = disk
+            .delete_version(
+                "bucket",
+                object,
+                committed_fi,
+                false,
+                DeleteOptions {
+                    undo_write: true,
+                    rename_rollback_token: Some(rollback_token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("stale rename rollback must fail closed");
+
+        assert!(err.to_string().contains("rollback fence rejected"));
+        assert_eq!(
+            fs::read(object_dir.join(STORAGE_FORMAT_FILE))
+                .await
+                .expect("newer metadata should remain"),
+            newer_meta
+        );
+        assert!(
+            object_dir.join(rollback_token.to_string()).exists(),
+            "rejected rollback state must be retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_rollback_rejects_metadata_written_after_forward_commit() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        ensure_test_volume(&disk, "bucket").await;
+
+        let object = "fenced-delete";
+        let object_dir = dir.path().join("bucket").join(object);
+        let old_data_dir = Uuid::new_v4();
+        fs::create_dir_all(object_dir.join(old_data_dir.to_string()))
+            .await
+            .expect("old data dir should be created");
+        fs::write(object_dir.join(old_data_dir.to_string()).join("part.1"), b"old")
+            .await
+            .expect("old data should be written");
+        let old_fi = test_file_info(object, Uuid::new_v4(), Some(old_data_dir), None);
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), test_meta(old_fi.clone()))
+            .await
+            .expect("old metadata should be written");
+
+        let rollback_token = Uuid::new_v4();
+        disk.delete_version(
+            "bucket",
+            object,
+            old_fi.clone(),
+            false,
+            DeleteOptions {
+                old_data_dir: Some(rollback_token),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("forward delete should commit");
+
+        let newer_data_dir = Uuid::new_v4();
+        fs::create_dir_all(object_dir.join(newer_data_dir.to_string()))
+            .await
+            .expect("newer data dir should be created");
+        fs::write(object_dir.join(newer_data_dir.to_string()).join("part.1"), b"newer")
+            .await
+            .expect("newer data should be written");
+        let newer_meta = test_meta(test_file_info(object, Uuid::new_v4(), Some(newer_data_dir), None));
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), &newer_meta)
+            .await
+            .expect("newer metadata should be written");
+
+        let err = disk
+            .delete_version(
+                "bucket",
+                object,
+                old_fi,
+                false,
+                DeleteOptions {
+                    undo_write: true,
+                    undo_delete: true,
+                    old_data_dir: Some(rollback_token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("stale delete rollback must fail closed");
+
+        assert!(err.to_string().contains("rollback fence rejected"));
+        assert_eq!(
+            fs::read(object_dir.join(STORAGE_FORMAT_FILE))
+                .await
+                .expect("newer metadata should remain"),
+            newer_meta
+        );
+        assert_eq!(
+            fs::read(object_dir.join(newer_data_dir.to_string()).join("part.1"))
+                .await
+                .expect("newer data should remain"),
+            b"newer"
+        );
+        assert!(
+            object_dir.join(rollback_token.to_string()).exists(),
+            "rejected rollback state must be retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_versions_rollback_rejects_metadata_written_after_forward_commit() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        ensure_test_volume(&disk, "bucket").await;
+
+        let object = "fenced-delete-versions";
+        let object_dir = dir.path().join("bucket").join(object);
+        fs::create_dir_all(&object_dir).await.expect("object dir should be created");
+        let old_fi = test_file_info(object, Uuid::new_v4(), None, Some(Bytes::from_static(b"old")));
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), test_meta(old_fi.clone()))
+            .await
+            .expect("old metadata should be written");
+
+        let rollback_token = Uuid::new_v4();
+        disk.delete_versions_internal(
+            "bucket",
+            object,
+            std::slice::from_ref(&old_fi),
+            &DeleteOptions {
+                old_data_dir: Some(rollback_token),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("forward batch delete should commit");
+
+        let newer_meta = test_meta(test_file_info(object, Uuid::new_v4(), None, Some(Bytes::from_static(b"newer"))));
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), &newer_meta)
+            .await
+            .expect("newer metadata should be written");
+
+        let err = disk
+            .delete_versions_internal(
+                "bucket",
+                object,
+                &[old_fi],
+                &DeleteOptions {
+                    undo_write: true,
+                    undo_delete: true,
+                    old_data_dir: Some(rollback_token),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("stale batch delete rollback must fail closed");
+
+        assert!(err.to_string().contains("rollback fence rejected"));
+        assert_eq!(
+            fs::read(object_dir.join(STORAGE_FORMAT_FILE))
+                .await
+                .expect("newer metadata should remain"),
+            newer_meta
+        );
+        assert!(
+            object_dir.join(rollback_token.to_string()).exists(),
+            "rejected batch rollback state must be retained"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn strict_delete_rollback_fsyncs_data_before_metadata_cleanup() {
+        let _mode = durability_mode_override::set(DurabilityMode::Strict);
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let object_dir = dir.path().join("object");
+        let rollback_token = Uuid::new_v4();
+        let rollback_path = object_dir.join(rollback_token.to_string());
+        let old_data_dir = Uuid::new_v4();
+        fs::create_dir_all(rollback_path.join(old_data_dir.to_string()))
+            .await
+            .expect("staged old data dir should be created");
+        fs::write(rollback_path.join(old_data_dir.to_string()).join("part.1"), b"old")
+            .await
+            .expect("staged old data should be written");
+
+        let old_meta = b"old-metadata".to_vec();
+        let forward_meta = b"forward-metadata".to_vec();
+        fs::write(rollback_path.join(STORAGE_FORMAT_FILE_BACKUP), &old_meta)
+            .await
+            .expect("old metadata backup should be written");
+        let xl_path = object_dir.join(STORAGE_FORMAT_FILE);
+        fs::write(&xl_path, &forward_meta)
+            .await
+            .expect("forward metadata should be written");
+        write_rollback_commit_state_std(&rollback_path, xl_meta_state(&forward_meta), false)
+            .expect("forward commit fence should be written");
+
+        restore_delete_rollback(&object_dir, &xl_path, rollback_token, true, true)
+            .await
+            .expect("strict rollback should restore old state");
+
+        assert_eq!(fs::read(&xl_path).await.expect("old metadata should be restored"), old_meta);
+        assert_eq!(
+            fs::read(object_dir.join(old_data_dir.to_string()).join("part.1"))
+                .await
+                .expect("old data should be restored"),
+            b"old"
+        );
+        assert!(os::fsync_dir_recorder::was_fsynced(&rollback_path));
+        assert!(os::fsync_dir_recorder::was_fsynced(&object_dir));
+        assert!(!rollback_path.exists(), "durable rollback cleanup must consume the transaction directory");
     }
 
     async fn ensure_test_volume(disk: &LocalDisk, volume: &str) {
@@ -10239,12 +11286,13 @@ mod test {
         let bucket = "bucket";
         let object = "inline-post-commit-object";
         let tmp_object = "tmp-inline-post-commit-write";
-        let version_id = Uuid::parse_str("99999999-9999-9999-9999-999999999999").expect("version id should parse");
+        let old_version_id = Uuid::parse_str("99999999-9999-9999-9999-999999999999").expect("version id should parse");
+        let new_version_id = Uuid::parse_str("aaaaaaaa-9999-9999-9999-999999999999").expect("version id should parse");
 
         ensure_test_volume(&disk, bucket).await;
         ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
 
-        let old_fi = test_file_info(object, version_id, None, Some(Bytes::from_static(b"inline-old")));
+        let old_fi = test_file_info(object, old_version_id, None, Some(Bytes::from_static(b"inline-old")));
         let old_meta = test_meta(old_fi);
         let dst_object_dir = dir.path().join(bucket).join(object);
         fs::create_dir_all(&dst_object_dir)
@@ -10260,7 +11308,7 @@ mod test {
             .expect("tmp object dir should be created");
 
         set_rename_data_fail_after_metadata_commit(object);
-        let new_fi = test_file_info(object, version_id, None, Some(Bytes::from_static(b"inline-new")));
+        let new_fi = test_file_info(object, new_version_id, None, Some(Bytes::from_static(b"inline-new")));
         let result = disk
             .rename_data(RUSTFS_META_TMP_BUCKET, tmp_object, new_fi, bucket, object)
             .await;
@@ -10270,6 +11318,61 @@ mod test {
             .await
             .expect("old metadata should still be readable");
         assert_eq!(restored_meta, old_meta);
+    }
+
+    #[tokio::test]
+    async fn test_rename_data_non_inline_new_version_post_commit_error_restores_old_metadata() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+
+        let bucket = "bucket";
+        let object = "non-inline-new-version-post-commit-object";
+        let tmp_object = "tmp-non-inline-new-version-post-commit-write";
+        let old_version_id = Uuid::parse_str("bbbbbbbb-9999-9999-9999-999999999999").expect("version id should parse");
+        let new_version_id = Uuid::parse_str("cccccccc-9999-9999-9999-999999999999").expect("version id should parse");
+        let new_data_dir = Uuid::parse_str("dddddddd-9999-9999-9999-999999999999").expect("data dir should parse");
+
+        ensure_test_volume(&disk, bucket).await;
+        ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
+
+        let old_fi = test_file_info(object, old_version_id, None, Some(Bytes::from_static(b"inline-old")));
+        let old_meta = test_meta(old_fi);
+        let dst_object_dir = dir.path().join(bucket).join(object);
+        fs::create_dir_all(&dst_object_dir)
+            .await
+            .expect("object dir should be created");
+        fs::write(dst_object_dir.join(STORAGE_FORMAT_FILE), old_meta.clone())
+            .await
+            .expect("old metadata should be written");
+
+        let tmp_data_dir = dir
+            .path()
+            .join(RUSTFS_META_TMP_BUCKET)
+            .join(tmp_object)
+            .join(new_data_dir.to_string());
+        fs::create_dir_all(&tmp_data_dir)
+            .await
+            .expect("tmp data dir should be created");
+        fs::write(tmp_data_dir.join("part.1"), b"new-data")
+            .await
+            .expect("tmp part should be written");
+
+        set_rename_data_fail_after_metadata_commit(object);
+        let mut new_fi = test_file_info(object, new_version_id, Some(new_data_dir), None);
+        new_fi.size = 8;
+        let result = disk
+            .rename_data(RUSTFS_META_TMP_BUCKET, tmp_object, new_fi, bucket, object)
+            .await;
+
+        assert!(result.is_err());
+        let restored_meta = fs::read(dst_object_dir.join(STORAGE_FORMAT_FILE))
+            .await
+            .expect("old metadata should still be readable");
+        assert_eq!(restored_meta, old_meta);
+        assert!(!dst_object_dir.join(new_data_dir.to_string()).exists());
     }
 
     #[tokio::test]
@@ -10598,6 +11701,88 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_invalid_delete_rollback_options_do_not_mutate_object() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+
+        let bucket = "bucket";
+        let object = "dir/invalid-delete-rollback";
+        let version_id = Uuid::parse_str("91919191-1111-2222-3333-444444444444").expect("version id should parse");
+        let data_dir = Uuid::parse_str("92929292-1111-2222-3333-444444444444").expect("data dir should parse");
+        let rollback_dir = Uuid::parse_str("93939393-1111-2222-3333-444444444444").expect("rollback dir should parse");
+
+        ensure_test_volume(&disk, bucket).await;
+
+        let object_dir = dir.path().join(bucket).join(object);
+        let data_path = object_dir.join(data_dir.to_string());
+        fs::create_dir_all(&data_path).await.expect("data dir should be created");
+        fs::write(data_path.join("part.1"), b"old-data")
+            .await
+            .expect("part data should be written");
+
+        let old_fi = test_file_info(object, version_id, Some(data_dir), None);
+        let old_meta = test_meta(old_fi.clone());
+        fs::write(object_dir.join(STORAGE_FORMAT_FILE), old_meta.clone())
+            .await
+            .expect("old metadata should be written");
+        let invalid_options = || DeleteOptions {
+            undo_delete: true,
+            old_data_dir: Some(rollback_dir),
+            ..Default::default()
+        };
+        let err = disk
+            .delete_version(bucket, object, old_fi.clone(), false, invalid_options())
+            .await
+            .expect_err("invalid single-delete rollback should fail");
+        assert!(err.contains_io_error_kind(ErrorKind::InvalidInput));
+        assert_eq!(
+            fs::read(object_dir.join(STORAGE_FORMAT_FILE))
+                .await
+                .expect("metadata should remain after rejected single delete"),
+            old_meta
+        );
+        assert_eq!(
+            fs::read(data_path.join("part.1"))
+                .await
+                .expect("data should remain after rejected single delete"),
+            b"old-data"
+        );
+
+        let errs = disk
+            .delete_versions(
+                bucket,
+                vec![FileInfoVersions {
+                    name: object.to_string(),
+                    versions: vec![old_fi],
+                    ..Default::default()
+                }],
+                invalid_options(),
+            )
+            .await;
+        let err = errs
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("invalid batch-delete rollback should fail");
+        assert!(err.contains_io_error_kind(ErrorKind::InvalidInput));
+        assert_eq!(
+            fs::read(object_dir.join(STORAGE_FORMAT_FILE))
+                .await
+                .expect("metadata should remain after rejected batch delete"),
+            old_meta
+        );
+        assert_eq!(
+            fs::read(data_path.join("part.1"))
+                .await
+                .expect("data should remain after rejected batch delete"),
+            b"old-data"
+        );
+    }
+
+    #[tokio::test]
     async fn test_delete_version_rollback_restores_staged_data_dir() {
         use tempfile::tempdir;
 
@@ -10625,6 +11810,13 @@ mod test {
         fs::write(object_dir.join(STORAGE_FORMAT_FILE), old_meta.clone())
             .await
             .expect("old metadata should be written");
+        #[cfg(unix)]
+        let old_metadata_inode = {
+            use std::os::unix::fs::MetadataExt;
+            std::fs::metadata(object_dir.join(STORAGE_FORMAT_FILE))
+                .expect("old metadata should stat")
+                .ino()
+        };
 
         disk.delete_version(
             bucket,
@@ -10647,6 +11839,17 @@ mod test {
                 .join(STORAGE_FORMAT_FILE_BACKUP)
                 .exists()
         );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_eq!(
+                std::fs::metadata(object_dir.join(rollback_dir.to_string()).join(STORAGE_FORMAT_FILE_BACKUP))
+                    .expect("rollback metadata should stat")
+                    .ino(),
+                old_metadata_inode,
+                "delete rollback metadata should be a hard-link snapshot"
+            );
+        }
         assert!(
             object_dir
                 .join(rollback_dir.to_string())
@@ -12762,6 +13965,7 @@ mod test {
             undo_write: false,
             undo_delete: false,
             old_data_dir: None,
+            rename_rollback_token: None,
         };
         disk.delete("test-volume", "test-file.txt", delete_opts)
             .await

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -38,6 +38,13 @@ pub const FORMAT_CONFIG_FILE: &str = "format.json";
 pub const HEALING_MARKER_PATH: &str = "healing.bin";
 pub const STORAGE_FORMAT_FILE: &str = "xl.meta";
 pub const STORAGE_FORMAT_FILE_BACKUP: &str = "xl.meta.bkp";
+pub const RENAME_DATA_ABSENT_MARKER: &str = "xl.meta.absent.rollback";
+pub const RENAME_DATA_ABSENT_MARKER_CONTENT: &[u8] = b"rustfs-rename-absent-v1";
+
+pub(crate) const RENAME_DATA_ENVELOPE_MAGIC: u64 = 0x5255_5354_4653_3433;
+const RENAME_DATA_ENVELOPE_VERSION: u8 = 1;
+pub(crate) const DELETE_OPTIONS_ENVELOPE_MAGIC: u64 = 0x5255_5354_4445_4c31;
+const DELETE_OPTIONS_ENVELOPE_VERSION: u8 = 1;
 
 use crate::cluster::rpc::RemoteDisk;
 use crate::cluster::rpc::build_internode_data_transport_from_env;
@@ -52,7 +59,7 @@ use local::LocalDisk;
 use rustfs_filemeta::{FileInfo, ObjectPartInfo, RawFileInfo};
 use rustfs_madmin::info_commands::DiskMetrics;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, io::Cursor, path::PathBuf, sync::Arc};
 use time::OffsetDateTime;
 use tokio::io::{AsyncRead, AsyncWrite};
 use uuid::Uuid;
@@ -284,6 +291,30 @@ impl DiskAPI for Disk {
         match self {
             Disk::Local(local_disk) => local_disk.rename_data(src_volume, src_path, fi, dst_volume, dst_path).await,
             Disk::Remote(remote_disk) => remote_disk.rename_data(src_volume, src_path, fi, dst_volume, dst_path).await,
+        }
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn rename_data_with_rollback(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+        rollback_token: Uuid,
+    ) -> Result<RenameDataResp> {
+        match self {
+            Disk::Local(local_disk) => {
+                local_disk
+                    .rename_data_with_rollback(src_volume, src_path, fi, dst_volume, dst_path, rollback_token)
+                    .await
+            }
+            Disk::Remote(remote_disk) => {
+                remote_disk
+                    .rename_data_with_rollback(src_volume, src_path, fi, dst_volume, dst_path, rollback_token)
+                    .await
+            }
         }
     }
 
@@ -597,7 +628,26 @@ pub trait DiskAPI: Debug + Send + Sync + 'static {
         file_info: FileInfo,
         dst_volume: &str,
         dst_path: &str,
-    ) -> Result<RenameDataResp>;
+    ) -> Result<RenameDataResp> {
+        self.rename_data_with_rollback(src_volume, src_path, file_info, dst_volume, dst_path, Uuid::nil())
+            .await
+    }
+    async fn rename_data_with_rollback(
+        &self,
+        _src_volume: &str,
+        _src_path: &str,
+        _file_info: FileInfo,
+        _dst_volume: &str,
+        _dst_path: &str,
+        rollback_token: Uuid,
+    ) -> Result<RenameDataResp> {
+        if rollback_token.is_nil() {
+            return Err(DiskError::other("rename rollback token must not be nil"));
+        }
+        Err(DiskError::other(
+            "rename rollback transactions are not supported by this disk implementation",
+        ))
+    }
 
     // File operations.
     // Read every file and directory within the folder
@@ -878,6 +928,79 @@ pub struct RenameDataResp {
     pub old_current_size: Option<OldCurrentSize>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct RenameDataEnvelope {
+    magic: u64,
+    version: u8,
+    rollback_token: Uuid,
+    file_info: FileInfo,
+}
+
+#[derive(Serialize)]
+struct RenameDataEnvelopeRef<'a> {
+    magic: u64,
+    version: u8,
+    rollback_token: Uuid,
+    file_info: &'a FileInfo,
+}
+
+#[derive(Debug)]
+pub struct RenameDataPayload {
+    pub file_info: FileInfo,
+    pub rollback_token: Option<Uuid>,
+}
+
+pub fn encode_rename_data_envelope(file_info: &FileInfo, rollback_token: Uuid) -> Result<Vec<u8>> {
+    Ok(rmp_serde::to_vec(&RenameDataEnvelopeRef {
+        magic: RENAME_DATA_ENVELOPE_MAGIC,
+        version: RENAME_DATA_ENVELOPE_VERSION,
+        rollback_token,
+        file_info,
+    })?)
+}
+
+fn has_envelope_discriminator(binary: &[u8]) -> bool {
+    let mut cursor = Cursor::new(binary);
+    if rmp::decode::read_array_len(&mut cursor).is_ok() && rmp::decode::read_int::<u64, _>(&mut cursor).is_ok() {
+        return true;
+    }
+
+    rmp_serde::from_slice::<std::collections::BTreeMap<String, serde::de::IgnoredAny>>(binary)
+        .is_ok_and(|fields| fields.contains_key("magic"))
+}
+
+pub fn decode_rename_data_payload(binary: &[u8], json: &str) -> Result<RenameDataPayload> {
+    if binary.is_empty() {
+        return Ok(RenameDataPayload {
+            file_info: serde_json::from_str(json)?,
+            rollback_token: None,
+        });
+    }
+
+    if has_envelope_discriminator(binary) {
+        let envelope: RenameDataEnvelope = rmp_serde::from_slice(binary)
+            .map_err(|err| DiskError::other(format!("decode rename data envelope failed: {err}")))?;
+        if envelope.magic != RENAME_DATA_ENVELOPE_MAGIC {
+            return Err(DiskError::other("rename data envelope magic mismatch"));
+        }
+        if envelope.version != RENAME_DATA_ENVELOPE_VERSION {
+            return Err(DiskError::other(format!("unsupported rename data envelope version {}", envelope.version)));
+        }
+        if envelope.rollback_token.is_nil() {
+            return Err(DiskError::other("rename data envelope contains a nil rollback token"));
+        }
+        return Ok(RenameDataPayload {
+            file_info: envelope.file_info,
+            rollback_token: Some(envelope.rollback_token),
+        });
+    }
+
+    Ok(RenameDataPayload {
+        file_info: rmp_serde::from_slice(binary)?,
+        rollback_token: None,
+    })
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeleteOptions {
     pub recursive: bool,
@@ -886,6 +1009,105 @@ pub struct DeleteOptions {
     #[serde(default)]
     pub undo_delete: bool,
     pub old_data_dir: Option<Uuid>,
+    #[serde(default)]
+    pub rename_rollback_token: Option<Uuid>,
+}
+
+const INVALID_DELETE_ROLLBACK_OPTIONS: &str = "undo_delete requires undo_write and old_data_dir";
+const INVALID_WRITE_ROLLBACK_OPTIONS: &str = "undo_write requires rollback state";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DeleteOptionsEnvelope {
+    magic: u64,
+    version: u8,
+    options: DeleteOptions,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyDeleteOptions {
+    recursive: bool,
+    immediate: bool,
+    undo_write: bool,
+    old_data_dir: Option<Uuid>,
+}
+
+impl DeleteOptions {
+    pub(crate) fn requires_delete_rollback_protocol(&self) -> bool {
+        self.undo_write || self.undo_delete || self.old_data_dir.is_some() || self.rename_rollback_token.is_some()
+    }
+
+    pub(crate) fn validate_delete_rollback(&self) -> Result<()> {
+        if self.undo_write && self.old_data_dir.is_none() && self.rename_rollback_token.is_none() {
+            return Err(DiskError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                INVALID_WRITE_ROLLBACK_OPTIONS,
+            )));
+        }
+        if self.undo_delete && (!self.undo_write || self.old_data_dir.is_none()) {
+            return Err(DiskError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                INVALID_DELETE_ROLLBACK_OPTIONS,
+            )));
+        }
+        if self.rename_rollback_token.is_some() && (!self.undo_write || self.undo_delete || self.old_data_dir.is_some()) {
+            return Err(DiskError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "rename_rollback_token requires undo_write without delete rollback fields",
+            )));
+        }
+        if self.rename_rollback_token.is_some_and(|token| token.is_nil()) {
+            return Err(DiskError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "rename_rollback_token must not be nil",
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn is_compensation(&self) -> bool {
+        self.undo_write
+    }
+}
+
+pub(crate) fn encode_delete_options_envelope(options: DeleteOptions) -> Result<Vec<u8>> {
+    Ok(rmp_serde::to_vec(&DeleteOptionsEnvelope {
+        magic: DELETE_OPTIONS_ENVELOPE_MAGIC,
+        version: DELETE_OPTIONS_ENVELOPE_VERSION,
+        options,
+    })?)
+}
+
+pub fn decode_delete_options_payload(binary: &[u8], json: &str) -> Result<DeleteOptions> {
+    let options = if binary.is_empty() {
+        serde_json::from_str(json)?
+    } else if has_envelope_discriminator(binary) {
+        let envelope: DeleteOptionsEnvelope = rmp_serde::from_slice(binary)
+            .map_err(|err| DiskError::other(format!("decode delete options envelope failed: {err}")))?;
+        if envelope.magic != DELETE_OPTIONS_ENVELOPE_MAGIC {
+            return Err(DiskError::other("delete options envelope magic mismatch"));
+        }
+        if envelope.version != DELETE_OPTIONS_ENVELOPE_VERSION {
+            return Err(DiskError::other(format!(
+                "unsupported delete options envelope version {}",
+                envelope.version
+            )));
+        }
+        envelope.options
+    } else if let Ok(options) = rmp_serde::from_slice::<DeleteOptions>(binary) {
+        options
+    } else {
+        let legacy: LegacyDeleteOptions = rmp_serde::from_slice(binary)?;
+        DeleteOptions {
+            recursive: legacy.recursive,
+            immediate: legacy.immediate,
+            undo_write: legacy.undo_write,
+            old_data_dir: legacy.old_data_dir,
+            ..Default::default()
+        }
+    };
+
+    options.validate_delete_rollback()?;
+    Ok(options)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -996,6 +1218,98 @@ mod tests {
     use local::LocalDisk;
     use tokio::fs;
     use uuid::Uuid;
+
+    fn rename_payload_file_info() -> FileInfo {
+        FileInfo {
+            volume: "bucket".to_string(),
+            name: "object".to_string(),
+            version_id: Some(Uuid::new_v4()),
+            size: 7,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rename_data_envelope_is_rejected_by_legacy_file_info_decoder() {
+        let file_info = rename_payload_file_info();
+        let encoded = encode_rename_data_envelope(&file_info, Uuid::new_v4()).expect("rename envelope should encode");
+        let error = rmp_serde::from_slice::<FileInfo>(&encoded)
+            .expect_err("legacy FileInfo decoder must reject the transaction envelope");
+
+        assert_eq!(
+            error.to_string(),
+            format!("invalid type: integer `{RENAME_DATA_ENVELOPE_MAGIC}`, expected a string")
+        );
+    }
+
+    #[test]
+    fn rename_data_payload_decodes_new_and_legacy_encodings() {
+        let file_info = rename_payload_file_info();
+        let rollback_token = Uuid::new_v4();
+        let envelope = encode_rename_data_envelope(&file_info, rollback_token).expect("rename envelope should encode");
+        let decoded = decode_rename_data_payload(&envelope, "").expect("rename envelope should decode");
+        assert_eq!(decoded.file_info, file_info);
+        assert_eq!(decoded.rollback_token, Some(rollback_token));
+
+        let legacy_compact = rmp_serde::to_vec(&file_info).expect("legacy compact FileInfo should encode");
+        let decoded = decode_rename_data_payload(&legacy_compact, "").expect("legacy compact FileInfo should decode");
+        assert_eq!(decoded.file_info, file_info);
+        assert_eq!(decoded.rollback_token, None);
+
+        let legacy_named = rmp_serde::to_vec_named(&file_info).expect("legacy named FileInfo should encode");
+        let decoded = decode_rename_data_payload(&legacy_named, "").expect("legacy named FileInfo should decode");
+        assert_eq!(decoded.file_info, file_info);
+        assert_eq!(decoded.rollback_token, None);
+
+        let legacy_json = serde_json::to_string(&file_info).expect("legacy JSON FileInfo should encode");
+        let decoded = decode_rename_data_payload(&[], &legacy_json).expect("legacy JSON FileInfo should decode");
+        assert_eq!(decoded.file_info, file_info);
+        assert_eq!(decoded.rollback_token, None);
+    }
+
+    #[test]
+    fn rename_data_payload_rejects_nil_transaction_token() {
+        let file_info = rename_payload_file_info();
+        let envelope = encode_rename_data_envelope(&file_info, Uuid::nil()).expect("rename envelope should encode");
+        let error = decode_rename_data_payload(&envelope, "").expect_err("nil transaction token must fail closed");
+
+        assert!(error.to_string().contains("nil rollback token"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn rename_data_payload_never_falls_back_after_envelope_discriminator() {
+        let file_info = rename_payload_file_info();
+        let truncated = rmp_serde::to_vec(&(RENAME_DATA_ENVELOPE_MAGIC, RENAME_DATA_ENVELOPE_VERSION))
+            .expect("truncated envelope should encode");
+        assert!(decode_rename_data_payload(&truncated, "").is_err());
+
+        let wrong_magic = rmp_serde::to_vec(&RenameDataEnvelope {
+            magic: RENAME_DATA_ENVELOPE_MAGIC + 1,
+            version: RENAME_DATA_ENVELOPE_VERSION,
+            rollback_token: Uuid::new_v4(),
+            file_info: file_info.clone(),
+        })
+        .expect("wrong-magic envelope should encode");
+        let error = decode_rename_data_payload(&wrong_magic, "").expect_err("wrong envelope magic must fail closed");
+        assert!(error.to_string().contains("magic mismatch"));
+
+        let mut polyglot = serde_json::to_value(&file_info)
+            .expect("FileInfo should convert to a value")
+            .as_object()
+            .expect("FileInfo should encode as a map")
+            .clone();
+        polyglot.insert("magic".to_string(), RENAME_DATA_ENVELOPE_MAGIC.into());
+        polyglot.insert("version".to_string(), RENAME_DATA_ENVELOPE_VERSION.into());
+        polyglot.insert(
+            "rollback_token".to_string(),
+            serde_json::to_value(Uuid::new_v4()).expect("UUID should encode"),
+        );
+        let polyglot = rmp_serde::to_vec_named(&polyglot).expect("polyglot payload should encode");
+        assert!(
+            decode_rename_data_payload(&polyglot, "").is_err(),
+            "a named map with magic must not fall back to FileInfo"
+        );
+    }
 
     /// Test DiskLocation validation
     #[test]
@@ -1126,6 +1440,7 @@ mod tests {
             undo_write: true,
             undo_delete: false,
             old_data_dir: Some(Uuid::new_v4()),
+            rename_rollback_token: None,
         };
 
         assert!(opts.recursive);
@@ -1133,6 +1448,128 @@ mod tests {
         assert!(opts.undo_write);
         assert!(!opts.undo_delete);
         assert!(opts.old_data_dir.is_some());
+    }
+
+    #[test]
+    fn delete_options_detect_delete_rollback_protocol_requirement() {
+        assert!(!DeleteOptions::default().requires_delete_rollback_protocol());
+        assert!(
+            DeleteOptions {
+                undo_write: true,
+                old_data_dir: Some(Uuid::new_v4()),
+                ..Default::default()
+            }
+            .requires_delete_rollback_protocol()
+        );
+        assert!(
+            DeleteOptions {
+                old_data_dir: Some(Uuid::new_v4()),
+                ..Default::default()
+            }
+            .requires_delete_rollback_protocol()
+        );
+        assert!(
+            DeleteOptions {
+                undo_write: true,
+                undo_delete: true,
+                old_data_dir: Some(Uuid::new_v4()),
+                ..Default::default()
+            }
+            .requires_delete_rollback_protocol()
+        );
+
+        assert!(
+            DeleteOptions {
+                undo_delete: true,
+                ..Default::default()
+            }
+            .validate_delete_rollback()
+            .is_err()
+        );
+        assert!(
+            DeleteOptions {
+                undo_write: true,
+                ..Default::default()
+            }
+            .validate_delete_rollback()
+            .is_err()
+        );
+        assert!(
+            DeleteOptions {
+                undo_write: true,
+                rename_rollback_token: Some(Uuid::nil()),
+                ..Default::default()
+            }
+            .validate_delete_rollback()
+            .is_err()
+        );
+        assert!(
+            DeleteOptions {
+                undo_delete: true,
+                old_data_dir: Some(Uuid::new_v4()),
+                ..Default::default()
+            }
+            .validate_delete_rollback()
+            .is_err()
+        );
+        assert!(
+            DeleteOptions {
+                undo_write: true,
+                undo_delete: true,
+                old_data_dir: Some(Uuid::new_v4()),
+                ..Default::default()
+            }
+            .validate_delete_rollback()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn delete_options_payload_decodes_legacy_compact_and_named_encodings() {
+        let options = DeleteOptions {
+            recursive: true,
+            immediate: true,
+            ..Default::default()
+        };
+
+        for encoded in [
+            rmp_serde::to_vec(&options).expect("compact DeleteOptions should encode"),
+            rmp_serde::to_vec_named(&options).expect("named DeleteOptions should encode"),
+        ] {
+            let decoded = decode_delete_options_payload(&encoded, "").expect("legacy DeleteOptions should decode");
+            assert!(decoded.recursive);
+            assert!(decoded.immediate);
+        }
+    }
+
+    #[test]
+    fn delete_options_payload_never_falls_back_after_envelope_discriminator() {
+        let options = DeleteOptions::default();
+        let truncated = rmp_serde::to_vec(&(DELETE_OPTIONS_ENVELOPE_MAGIC, DELETE_OPTIONS_ENVELOPE_VERSION))
+            .expect("truncated envelope should encode");
+        assert!(decode_delete_options_payload(&truncated, "").is_err());
+
+        let wrong_magic = rmp_serde::to_vec_named(&DeleteOptionsEnvelope {
+            magic: DELETE_OPTIONS_ENVELOPE_MAGIC + 1,
+            version: DELETE_OPTIONS_ENVELOPE_VERSION,
+            options: options.clone(),
+        })
+        .expect("wrong-magic envelope should encode");
+        let error = decode_delete_options_payload(&wrong_magic, "").expect_err("wrong envelope magic must fail closed");
+        assert!(error.to_string().contains("magic mismatch"));
+
+        let mut polyglot = serde_json::to_value(&options)
+            .expect("DeleteOptions should convert to a value")
+            .as_object()
+            .expect("DeleteOptions should encode as a map")
+            .clone();
+        polyglot.insert("magic".to_string(), DELETE_OPTIONS_ENVELOPE_MAGIC.into());
+        polyglot.insert("version".to_string(), DELETE_OPTIONS_ENVELOPE_VERSION.into());
+        let polyglot = rmp_serde::to_vec_named(&polyglot).expect("polyglot payload should encode");
+        assert!(
+            decode_delete_options_payload(&polyglot, "").is_err(),
+            "a named map with magic must not fall back to DeleteOptions"
+        );
     }
 
     /// Test ReadOptions structure

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -2591,16 +2591,15 @@ impl SetDisks {
         data_count
     }
 
-    #[tracing::instrument(level = "debug", skip(disks, file_infos))]
+    #[tracing::instrument(level = "trace", skip_all)]
     #[allow(clippy::type_complexity)]
     pub(in crate::set_disk) async fn rename_data(
         disks: &[Option<DiskStore>],
-        src_bucket: &str,
-        src_object: &str,
+        src: (&str, &str),
         file_infos: &[FileInfo],
-        dst_bucket: &str,
-        dst_object: &str,
+        dst: (&str, &str),
         write_quorum: usize,
+        object_lock_guard: Option<ObjectLockDiagGuard>,
     ) -> disk::error::Result<(
         Vec<Option<DiskStore>>,
         RenameConvergence,
@@ -2608,6 +2607,55 @@ impl SetDisks {
         Vec<Option<DiskStore>>,
         Option<OldCurrentSize>,
     )> {
+        let disks = disks.to_vec();
+        let (src_bucket, src_object) = src;
+        let src_bucket = src_bucket.to_string();
+        let src_object = src_object.to_string();
+        let file_infos = file_infos.to_vec();
+        let (dst_bucket, dst_object) = dst;
+        let dst_bucket = dst_bucket.to_string();
+        let dst_object = dst_object.to_string();
+        cancellation_shield(async move {
+            // Keep the namespace guard alive until the forward fan-out and every
+            // required compensation/cleanup RPC have reached a terminal result.
+            // In particular, cancellation may move this whole future to the
+            // shielded executor, but it must never detach a rollback from the
+            // guard that fences the destination namespace.
+            Self::rename_data_inner(
+                &disks,
+                (&src_bucket, &src_object),
+                &file_infos,
+                (&dst_bucket, &dst_object),
+                write_quorum,
+                object_lock_guard.as_ref(),
+            )
+            .await
+        })
+        .await
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn rename_data_inner(
+        disks: &[Option<DiskStore>],
+        src: (&str, &str),
+        file_infos: &[FileInfo],
+        dst: (&str, &str),
+        write_quorum: usize,
+        object_lock_guard: Option<&ObjectLockDiagGuard>,
+    ) -> disk::error::Result<(
+        Vec<Option<DiskStore>>,
+        RenameConvergence,
+        Option<Uuid>,
+        Vec<Option<DiskStore>>,
+        Option<OldCurrentSize>,
+    )> {
+        if disks.len() != file_infos.len() {
+            return Err(DiskError::Unexpected);
+        }
+        let (src_bucket, src_object) = src;
+        let (dst_bucket, dst_object) = dst;
+
+        let rollback_token = Uuid::new_v4();
         let mut futures = Vec::with_capacity(disks.len());
 
         let mut errs = Vec::with_capacity(disks.len());
@@ -2624,7 +2672,6 @@ impl SetDisks {
             let src_object = src_object.clone();
             let dst_object = dst_object.clone();
             let dst_bucket = dst_bucket.clone();
-
             futures.push(tokio::spawn(async move {
                 // Test-only introspection guard: counts this task as in-flight for
                 // the whole body. Compiles to `()` in production (no behavior).
@@ -2643,12 +2690,18 @@ impl SetDisks {
                 // A no-op immediately-ready future in production.
                 Self::rename_fanout_barrier(&dst_object, i, rename_fanout_barrier_phase::RENAME).await;
 
-                if let Some(disk) = disk {
-                    disk.rename_data(&src_bucket, &src_object, file_info, &dst_bucket, &dst_object)
+                let result = if let Some(disk) = disk {
+                    disk.rename_data_with_rollback(&src_bucket, &src_object, file_info, &dst_bucket, &dst_object, rollback_token)
                         .await
                 } else {
                     Err(DiskError::DiskNotFound)
-                }
+                };
+
+                // A task can fail after the disk accepted the commit but before
+                // the coordinator observes its receipt. The test seam reproduces
+                // that exact ambiguous outcome; it is a no-op in production.
+                Self::rename_fanout_completion_fault(&dst_object, i);
+                result
             }));
         }
 
@@ -2658,19 +2711,41 @@ impl SetDisks {
 
         let results = join_all(futures).await;
 
-        for (idx, result) in results.iter().enumerate() {
-            match result.as_ref().map_err(|_| DiskError::Unexpected)? {
-                Ok(res) => {
+        let mut task_join_failed = false;
+        for (idx, result) in results.into_iter().enumerate() {
+            match result {
+                Ok(Ok(res)) => {
                     data_dirs[idx] = res.old_data_dir;
-                    disk_versions[idx].clone_from(&res.sign);
+                    disk_versions[idx] = res.sign;
                     old_current_sizes[idx] = res.old_current_size;
                     errs.push(None);
                 }
-                Err(e) => {
-                    errs.push(Some(e.clone()));
+                Ok(Err(err)) => {
+                    errs.push(Some(err));
+                }
+                Err(join_err) => {
+                    // Join failure is not proof that the disk did not commit: a
+                    // task may panic after the RPC/filesystem mutation completed.
+                    // Preserve the slot and force whole-transaction compensation.
+                    task_join_failed = true;
+                    errs.push(Some(DiskError::Unexpected));
+                    warn!(
+                        target: "rustfs_ecstore::set_disk",
+                        dst_bucket = %dst_bucket,
+                        dst_object = %dst_object,
+                        disk_index = idx,
+                        error = %join_err,
+                        "rename_data task failed with an ambiguous commit outcome"
+                    );
                 }
             }
         }
+
+        // The lease can be lost while the per-disk commit fan-out is in flight.
+        // Treat that as ambiguous even if write quorum replied successfully: a
+        // new writer may already own the namespace, so this coordinator must not
+        // ACK or discard rollback state.
+        let lock_lost = object_lock_guard.is_some_and(ObjectLockDiagGuard::is_lock_lost);
 
         if issue3031_diag_enabled() {
             let success_count = errs.iter().filter(|err| err.is_none()).count();
@@ -2700,20 +2775,30 @@ impl SetDisks {
             );
         }
 
-        let mut futures = Vec::with_capacity(disks.len());
-        if let Some(ret_err) = reduce_write_quorum_errs(&errs, OBJECT_OP_IGNORED_ERRS, write_quorum) {
-            for (i, err) in errs.iter().enumerate() {
-                if err.is_some() {
-                    continue;
-                }
+        let quorum_error = reduce_write_quorum_errs(&errs, OBJECT_OP_IGNORED_ERRS, write_quorum);
+        let terminal_error = if lock_lost {
+            Some(DiskError::other("namespace lock quorum was lost during rename_data commit"))
+        } else if task_join_failed {
+            Some(DiskError::Unexpected)
+        } else {
+            quorum_error
+        };
 
-                if let Some(disk) = disks[i].as_ref() {
+        let mut futures = Vec::with_capacity(disks.len());
+        if let Some(ret_err) = terminal_error {
+            // Every disk that received the forward request is a possible commit,
+            // including slots whose task/RPC returned an error. Conditional
+            // rollback by transaction token makes this safe for non-committers.
+            for (i, disk) in disks.iter().enumerate() {
+                if let Some(disk) = disk.as_ref() {
                     let fi = file_infos[i].clone();
-                    let old_data_dir = data_dirs[i];
                     let disk = disk.clone();
                     let dst_bucket = dst_bucket.clone();
                     let dst_object = dst_object.clone();
                     futures.push(tokio::spawn(async move {
+                        #[allow(clippy::let_unit_value)]
+                        let _fanout_task_guard = Self::rename_fanout_task_guard(&dst_object);
+                        Self::rename_fanout_barrier(&dst_object, i, rename_fanout_barrier_phase::ROLLBACK).await;
                         disk.delete_version(
                             &dst_bucket,
                             &dst_object,
@@ -2721,7 +2806,7 @@ impl SetDisks {
                             false,
                             DeleteOptions {
                                 undo_write: true,
-                                old_data_dir,
+                                rename_rollback_token: Some(rollback_token),
                                 ..Default::default()
                             },
                         )
@@ -2763,6 +2848,31 @@ impl SetDisks {
                 );
             }
             return Err(ret_err);
+        }
+
+        let rollback_cleanup_path = format!("{dst_object}/{rollback_token}");
+        let cleanup_paths = [rollback_cleanup_path];
+        let cleanup_results = join_all(disks.iter().enumerate().filter_map(|(disk_index, disk)| {
+            disk.as_ref().map(|disk| {
+                let cleanup_paths = &cleanup_paths;
+                let dst_bucket = Arc::clone(&dst_bucket);
+                let dst_object = Arc::clone(&dst_object);
+                async move {
+                    #[allow(clippy::let_unit_value)]
+                    let _fanout_task_guard = Self::rename_fanout_task_guard(&dst_object);
+                    Self::rename_fanout_barrier(&dst_object, disk_index, rename_fanout_barrier_phase::CLEANUP).await;
+                    disk.delete_paths(&dst_bucket, cleanup_paths).await
+                }
+            })
+        }))
+        .await;
+        let cleanup_error_count = cleanup_results.iter().filter(|result| result.is_err()).count();
+        if cleanup_error_count > 0 {
+            warn!(
+                bucket = %dst_bucket,
+                cleanup_error_count,
+                "rename transaction cleanup reported errors"
+            );
         }
 
         let data_dir = Self::reduce_common_data_dir(&data_dirs, write_quorum);
@@ -2995,7 +3105,8 @@ impl SetDisks {
 
     /// Test-only awaitable pause point for the rename/commit fan-out (backlog#1325,
     /// serving the barrier-style acceptances of #1312 / #1319 / #1313). `phase` is
-    /// [`rename_fanout_barrier::PHASE_RENAME`] or `PHASE_CLEANUP`. When a test has
+    /// [`rename_fanout_barrier::PHASE_RENAME`], `PHASE_ROLLBACK`, or
+    /// `PHASE_CLEANUP`. When a test has
     /// armed a barrier for `object` at this `(disk_index, phase)`, the spawned
     /// fan-out task blocks here until the test releases it, so the test can await
     /// the pause point and then introspect in-flight background disk work. In
@@ -3011,6 +3122,16 @@ impl SetDisks {
     #[inline(always)]
     #[allow(clippy::unused_async)]
     async fn rename_fanout_barrier(_object: &str, _disk_index: usize, _phase: &'static str) {}
+
+    #[cfg(test)]
+    #[inline]
+    fn rename_fanout_completion_fault(object: &str, disk_index: usize) {
+        rename_fanout_barrier::panic_after_rename_if_armed(object, disk_index);
+    }
+
+    #[cfg(not(test))]
+    #[inline(always)]
+    fn rename_fanout_completion_fault(_object: &str, _disk_index: usize) {}
 
     /// Test-only RAII counter for one in-flight rename/commit fan-out task
     /// (backlog#1325). Held for the whole spawned task body so a test observing
@@ -4130,6 +4251,8 @@ pub(in crate::set_disk) mod disk_call_counters {
 pub(in crate::set_disk) mod rename_fanout_barrier_phase {
     /// The per-disk `rename_data` phase of the write-commit fan-out.
     pub const RENAME: &str = "rename";
+    /// Compensation after an ambiguous or sub-quorum rename outcome.
+    pub const ROLLBACK: &str = "rollback";
     /// The per-disk old-data-dir cleanup phase of the commit fan-out.
     pub const CLEANUP: &str = "cleanup";
 }
@@ -4148,8 +4271,8 @@ pub(in crate::set_disk) mod rename_fanout_barrier_phase {
 ///    [`checkpoint`] until the test releases it. The test awaits the pause via
 ///    [`BarrierHandle::wait_until_paused`] (a deterministic `Notify` handshake —
 ///    no sleeps) and resumes it via [`BarrierHandle::release`]. At most one
-///    barrier is armed per object at a time, matching the single-scope style of
-///    `disk_call_counters`.
+///    barrier is armed per object and phase, allowing a test to observe forward
+///    commit and its later compensation independently.
 ///
 /// 2. **Background-task introspection.** A test [`observe_tasks`] for `object`;
 ///    each instrumented fan-out task then holds a [`TaskGuard`] for its whole
@@ -4175,7 +4298,7 @@ pub(in crate::set_disk) mod rename_fanout_barrier {
     use std::sync::{Arc, Mutex, OnceLock};
     use tokio::sync::Notify;
 
-    pub use super::rename_fanout_barrier_phase::{CLEANUP as PHASE_CLEANUP, RENAME as PHASE_RENAME};
+    pub use super::rename_fanout_barrier_phase::{CLEANUP as PHASE_CLEANUP, RENAME as PHASE_RENAME, ROLLBACK as PHASE_ROLLBACK};
 
     /// One armed barrier: the fan-out task matching `(disk_index, phase)` pauses.
     struct Armed {
@@ -4191,10 +4314,13 @@ pub(in crate::set_disk) mod rename_fanout_barrier {
 
     #[derive(Default)]
     struct Registry {
-        /// object -> armed barrier (at most one per object).
-        armed: HashMap<String, Armed>,
+        /// (object, phase) -> armed barrier. Tests may coordinate a forward
+        /// pause and its later rollback pause for the same object.
+        armed: HashMap<(String, &'static str), Armed>,
         /// object -> live in-flight fan-out task count, only for observed objects.
         observed: HashMap<String, Arc<AtomicUsize>>,
+        /// object -> disk whose task panics after its disk call returned.
+        panic_after_rename: HashMap<String, usize>,
     }
 
     fn registry() -> &'static Mutex<Registry> {
@@ -4206,12 +4332,47 @@ pub(in crate::set_disk) mod rename_fanout_barrier {
         registry().lock().expect("rename fan-out barrier registry poisoned")
     }
 
+    /// RAII failpoint for an ambiguous task outcome: the selected task panics
+    /// only after its disk rename returned.
+    #[must_use]
+    pub struct PanicAfterRenameGuard {
+        object: String,
+    }
+
+    pub fn panic_after_rename(object: &str, disk_index: usize) -> PanicAfterRenameGuard {
+        lock().panic_after_rename.insert(object.to_string(), disk_index);
+        PanicAfterRenameGuard {
+            object: object.to_string(),
+        }
+    }
+
+    impl Drop for PanicAfterRenameGuard {
+        fn drop(&mut self) {
+            lock().panic_after_rename.remove(&self.object);
+        }
+    }
+
+    pub(in crate::set_disk) fn panic_after_rename_if_armed(object: &str, disk_index: usize) {
+        let armed = {
+            let mut registry = lock();
+            registry
+                .panic_after_rename
+                .get(object)
+                .copied()
+                .filter(|armed_index| *armed_index == disk_index)
+                .and_then(|_| registry.panic_after_rename.remove(object))
+                .is_some()
+        };
+        assert!(!armed, "injected panic after rename commit");
+    }
+
     /// RAII handle for one armed barrier. Dropping it disarms the barrier and
     /// releases any still-parked task, so a panicking or forgetful test can never
     /// leave a spawned fan-out task wedged.
     #[must_use]
     pub struct BarrierHandle {
         object: String,
+        phase: &'static str,
         arrived: Arc<Notify>,
         release: Arc<Notify>,
         paused: Arc<AtomicBool>,
@@ -4224,7 +4385,7 @@ pub(in crate::set_disk) mod rename_fanout_barrier {
         let release = Arc::new(Notify::new());
         let paused = Arc::new(AtomicBool::new(false));
         lock().armed.insert(
-            object.to_string(),
+            (object.to_string(), phase),
             Armed {
                 disk_index,
                 phase,
@@ -4235,6 +4396,7 @@ pub(in crate::set_disk) mod rename_fanout_barrier {
         );
         BarrierHandle {
             object: object.to_string(),
+            phase,
             arrived,
             release,
             paused,
@@ -4268,7 +4430,7 @@ pub(in crate::set_disk) mod rename_fanout_barrier {
             // Unblock any task still parked at the checkpoint before disarming, so
             // a dropped handle can never wedge a spawned fan-out task.
             self.release.notify_one();
-            lock().armed.remove(&self.object);
+            lock().armed.remove(&(self.object.clone(), self.phase));
         }
     }
 
@@ -4279,7 +4441,7 @@ pub(in crate::set_disk) mod rename_fanout_barrier {
     pub(in crate::set_disk) async fn checkpoint(object: &str, disk_index: usize, phase: &'static str) {
         let hooks = {
             let reg = lock();
-            match reg.armed.get(object) {
+            match reg.armed.get(&(object.to_string(), phase)) {
                 Some(a) if a.disk_index == disk_index && a.phase == phase => {
                     Some((a.arrived.clone(), a.release.clone(), a.paused.clone()))
                 }
@@ -4619,7 +4781,7 @@ mod tests {
 
         // Run the real rename fan-out concurrently with the control flow so we can
         // introspect while it is parked at the first disk's rename checkpoint.
-        let rename_fut = SetDisks::rename_data(&disks, bucket, object, &file_infos, bucket, object, DISKS - 1);
+        let rename_fut = SetDisks::rename_data(&disks, (bucket, object), &file_infos, (bucket, object), DISKS - 1, None);
         let control_fut = async {
             tokio::time::timeout(BARRIER_PAUSE_GUARD, barrier.wait_until_paused())
                 .await
@@ -4632,6 +4794,114 @@ mod tests {
 
         // The fan-out has fully joined -> every task guard has dropped.
         assert_eq!(tracker.running(), 0, "no background rename task may remain once the fan-out has drained");
+
+        drop(dirs);
+    }
+
+    #[tokio::test]
+    async fn rename_lock_loss_drains_rollback_before_releasing_guard() {
+        const DISKS: usize = 4;
+        let bucket = "rename-lock-loss-bucket";
+        let object = "rename-lock-loss-object";
+        let (dirs, disks) = call_counter_local_disks(bucket, DISKS).await;
+        let set = io_primitives_test_set(disks.clone(), DISKS / 2).await;
+        let file_infos = rename_barrier_fileinfos(object, DISKS);
+        let guard = set
+            .acquire_write_lock_diag("rename_lock_loss_test", bucket, object)
+            .await
+            .expect("test namespace lock should be acquired");
+        let lock_lost = guard.lock_lost_signal_for_test();
+        let guard_dropped = guard.drop_signal_for_test();
+        let tracker = rename_fanout_barrier::observe_tasks(object);
+        let forward_barrier = rename_fanout_barrier::arm(object, 0, rename_fanout_barrier::PHASE_RENAME);
+        let rollback_barrier = rename_fanout_barrier::arm(object, 0, rename_fanout_barrier::PHASE_ROLLBACK);
+
+        let rename_fut = SetDisks::rename_data(&disks, (bucket, object), &file_infos, (bucket, object), DISKS - 1, Some(guard));
+        let control_fut = async {
+            tokio::time::timeout(BARRIER_PAUSE_GUARD, forward_barrier.wait_until_paused())
+                .await
+                .expect("rename fan-out must reach the armed forward barrier");
+            lock_lost.store(true, std::sync::atomic::Ordering::SeqCst);
+            forward_barrier.release();
+
+            tokio::time::timeout(BARRIER_PAUSE_GUARD, rollback_barrier.wait_until_paused())
+                .await
+                .expect("rename compensation must reach the armed rollback barrier");
+            assert!(tracker.running() >= 1, "rollback RPC must still be tracked while paused");
+            assert!(
+                !guard_dropped.load(std::sync::atomic::Ordering::SeqCst),
+                "namespace guard must remain alive while rollback is in flight"
+            );
+            rollback_barrier.release();
+        };
+        let (result, ()) = tokio::join!(rename_fut, control_fut);
+
+        let err = result.expect_err("lock loss during forward must prevent a successful ACK");
+        assert!(
+            err.to_string().contains("namespace lock quorum was lost"),
+            "lock-loss failure should remain distinguishable: {err}"
+        );
+        assert!(
+            guard_dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "namespace guard should release after rollback reaches a terminal result"
+        );
+        assert_eq!(tracker.running(), 0, "no rollback RPC may outlive rename_data");
+
+        drop(dirs);
+    }
+
+    #[tokio::test]
+    async fn rename_success_drains_transaction_cleanup_before_releasing_guard() {
+        const DISKS: usize = 4;
+        let bucket = "rename-cleanup-guard-bucket";
+        let object = "rename-cleanup-guard-object";
+        let (dirs, disks) = call_counter_local_disks(bucket, DISKS).await;
+        let set = io_primitives_test_set(disks.clone(), DISKS / 2).await;
+        let mut file_infos = rename_barrier_fileinfos(object, DISKS);
+        for file_info in &mut file_infos {
+            file_info.volume = bucket.to_string();
+            file_info.data = Some(Bytes::from_static(b"new"));
+            file_info.size = 3;
+            file_info.erasure.index = 0;
+            file_info.mod_time = Some(time::OffsetDateTime::now_utc());
+        }
+        let guard = set
+            .acquire_write_lock_diag("rename_cleanup_guard_test", bucket, object)
+            .await
+            .expect("test namespace lock should be acquired");
+        let guard_dropped = guard.drop_signal_for_test();
+        let tracker = rename_fanout_barrier::observe_tasks(object);
+        let cleanup_barrier = rename_fanout_barrier::arm(object, 0, rename_fanout_barrier::PHASE_CLEANUP);
+
+        let rename_fut = SetDisks::rename_data(
+            &disks,
+            (bucket, "staged-inline-object"),
+            &file_infos,
+            (bucket, object),
+            DISKS - 1,
+            Some(guard),
+        );
+        tokio::pin!(rename_fut);
+        tokio::select! {
+            result = &mut rename_fut => panic!("rename completed before transaction cleanup: {result:?}"),
+            paused = tokio::time::timeout(BARRIER_PAUSE_GUARD, cleanup_barrier.wait_until_paused()) => {
+                paused.expect("successful rename must reach transaction cleanup");
+            }
+        }
+        assert!(tracker.running() >= 1, "cleanup operation must still be tracked while paused");
+        assert!(
+            !guard_dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "namespace guard must remain alive while cleanup is in flight"
+        );
+        cleanup_barrier.release();
+        let result = rename_fut.await;
+
+        result.expect("inline rename should commit successfully");
+        assert!(
+            guard_dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "namespace guard should release after cleanup reaches a terminal result"
+        );
+        assert_eq!(tracker.running(), 0, "no cleanup operation may outlive rename_data");
 
         drop(dirs);
     }
@@ -4697,7 +4967,7 @@ mod tests {
         // barrier ignored the object key) would surface as a timeout.
         let _ = tokio::time::timeout(
             BARRIER_PAUSE_GUARD,
-            SetDisks::rename_data(&disks, bucket, other_object, &file_infos, bucket, other_object, DISKS - 1),
+            SetDisks::rename_data(&disks, (bucket, other_object), &file_infos, (bucket, other_object), DISKS - 1, None),
         )
         .await
         .expect("fan-out for an unarmed object must not pause");

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -160,6 +160,7 @@ use rustfs_utils::{
 };
 use s3s::header::{X_AMZ_OBJECT_LOCK_LEGAL_HOLD, X_AMZ_OBJECT_LOCK_MODE, X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE, X_AMZ_RESTORE};
 use sha2::{Digest, Sha256};
+use std::future::Future;
 use std::hash::Hash;
 use std::mem::{self};
 use std::pin::Pin;
@@ -177,7 +178,7 @@ use std::{
 use time::OffsetDateTime;
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader, ReadBuf},
-    sync::{RwLock, broadcast},
+    sync::{OwnedSemaphorePermit, RwLock, Semaphore, broadcast},
 };
 use tokio::{
     select,
@@ -189,11 +190,226 @@ use tracing::error;
 use tracing::{Instrument, debug, info, warn};
 use uuid::Uuid;
 
+struct DistDeleteBatchLockLease {
+    lock_ids_by_client: Vec<Vec<rustfs_lock::LockId>>,
+    clients: Vec<Arc<dyn LockClient>>,
+    lost_objects: Arc<parking_lot::Mutex<HashSet<String>>>,
+    cancel: CancellationToken,
+    heartbeat: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl DistDeleteBatchLockLease {
+    fn empty(clients: Vec<Arc<dyn LockClient>>) -> Self {
+        Self {
+            lock_ids_by_client: vec![Vec::new(); clients.len()],
+            clients,
+            lost_objects: Arc::new(parking_lot::Mutex::new(HashSet::new())),
+            cancel: CancellationToken::new(),
+            heartbeat: None,
+        }
+    }
+
+    fn lost_objects(&self) -> HashSet<String> {
+        self.lost_objects.lock().clone()
+    }
+
+    async fn stop_heartbeat(&mut self) {
+        self.cancel.cancel();
+        if let Some(heartbeat) = self.heartbeat.take()
+            && let Err(err) = heartbeat.await
+            && !err.is_cancelled()
+        {
+            warn!("distributed delete lock heartbeat task failed: {}", err);
+        }
+    }
+}
+
+impl Drop for DistDeleteBatchLockLease {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(heartbeat) = self.heartbeat.take() {
+            heartbeat.abort();
+        }
+
+        let lock_ids_by_client = std::mem::take(&mut self.lock_ids_by_client);
+        if lock_ids_by_client.iter().all(Vec::is_empty) {
+            return;
+        }
+        let clients = self.clients.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let cleanup = handle.spawn(async move {
+                join_all(clients.into_iter().zip(lock_ids_by_client).filter_map(|(client, lock_ids)| {
+                    if lock_ids.is_empty() {
+                        None
+                    } else {
+                        Some(async move {
+                            if let Err(err) = client.release_locks_batch(&lock_ids).await {
+                                warn!(lock_count = lock_ids.len(), "failed to release dropped distributed delete lease: {}", err);
+                            }
+                        })
+                    }
+                }))
+                .await;
+            });
+            drop(cleanup);
+        }
+    }
+}
+
+fn spawn_dist_delete_batch_lock_heartbeat(
+    heartbeat_entries_by_client: Vec<Vec<(String, rustfs_lock::LockId, tokio::time::Instant)>>,
+    clients: Vec<Arc<dyn LockClient>>,
+    held_count_by_object: HashMap<String, usize>,
+    write_quorum: usize,
+    lost_objects: Arc<parking_lot::Mutex<HashSet<String>>>,
+    cancel: CancellationToken,
+    refresh_interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = interval(refresh_interval);
+        let mut confirmed_until: Vec<Vec<_>> = heartbeat_entries_by_client
+            .iter()
+            .map(|entries| entries.iter().map(|(_, _, expires_at)| *expires_at).collect())
+            .collect();
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await;
+        loop {
+            select! {
+                _ = cancel.cancelled() => return,
+                _ = ticker.tick() => {}
+            }
+
+            let refresh_started = tokio::time::Instant::now();
+            let refreshes = join_all(clients.iter().zip(&heartbeat_entries_by_client).map(|(client, entries)| {
+                let client = client.clone();
+                let lock_ids = entries.iter().map(|(_, lock_id, _)| lock_id.clone()).collect::<Vec<_>>();
+                async move { client.refresh_locks_batch(&lock_ids).await }
+            }));
+            let results = select! {
+                _ = cancel.cancelled() => return,
+                results = refreshes => results,
+            };
+
+            let now = tokio::time::Instant::now();
+            let mut unavailable_by_object = HashMap::<String, usize>::new();
+            for (client_index, entries) in heartbeat_entries_by_client.iter().enumerate() {
+                let client_results = results.get(client_index);
+                for (entry_index, (object, _, _)) in entries.iter().enumerate() {
+                    match client_results.and_then(|results| results.get(entry_index)) {
+                        Some(Ok(true)) => {
+                            let expires_at = refresh_started + rustfs_lock::fast_lock::DEFAULT_LOCK_TIMEOUT;
+                            confirmed_until[client_index][entry_index] = expires_at;
+                            if now >= expires_at {
+                                *unavailable_by_object.entry(object.clone()).or_default() += 1;
+                            }
+                        }
+                        Some(Ok(false)) => {
+                            *unavailable_by_object.entry(object.clone()).or_default() += 1;
+                        }
+                        Some(Err(_)) | None if now >= confirmed_until[client_index][entry_index] => {
+                            *unavailable_by_object.entry(object.clone()).or_default() += 1;
+                        }
+                        Some(Err(_)) | None => {}
+                    }
+                }
+            }
+
+            for (object, unavailable) in unavailable_by_object {
+                let held_count = held_count_by_object.get(&object).copied().unwrap_or_default();
+                if unavailable > held_count.saturating_sub(write_quorum) && lost_objects.lock().insert(object.clone()) {
+                    warn!(
+                        object = %object,
+                        held_count,
+                        unavailable,
+                        write_quorum,
+                        "distributed delete lock refresh lost quorum"
+                    );
+                }
+            }
+        }
+    })
+}
+
 type ListObjectsV2Info = StorageListObjectsV2Info<ObjectInfo>;
 type ListObjectVersionsInfo = StorageListObjectVersionsInfo<ObjectInfo>;
 type ObjectInfoOrErr = StorageObjectInfoOrErr<ObjectInfo, Error>;
 type WalkOptions = StorageWalkOptions<fn(&FileInfo) -> bool>;
 type InlineBitrotReader = coding::BitrotReader<crate::io_support::bitrot::ShardReader>;
+const MAX_SHIELDED_SET_TRANSACTIONS: usize = 256;
+static SHIELDED_SET_TRANSACTIONS: std::sync::LazyLock<Arc<Semaphore>> =
+    std::sync::LazyLock::new(|| Arc::new(Semaphore::new(MAX_SHIELDED_SET_TRANSACTIONS)));
+
+struct CancellationShield<F>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    future: Option<Pin<Box<F>>>,
+    permit: Option<OwnedSemaphorePermit>,
+    polling: bool,
+}
+
+impl<F> Future for CancellationShield<F>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.polling = true;
+        let poll = self
+            .future
+            .as_mut()
+            .expect("cancellation shield polled after completion")
+            .as_mut()
+            .poll(cx);
+        self.polling = false;
+        if poll.is_ready() {
+            self.future.take();
+        }
+        poll
+    }
+}
+
+impl<F> Drop for CancellationShield<F>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    fn drop(&mut self) {
+        if self.polling {
+            return;
+        }
+        if let Some(future) = self.future.take()
+            && let Ok(handle) = tokio::runtime::Handle::try_current()
+        {
+            let permit = self.permit.take();
+            let task = handle.spawn(async move {
+                let _permit = permit;
+                future.await
+            });
+            drop(task);
+        }
+    }
+}
+
+pub(in crate::set_disk) async fn cancellation_shield<F>(future: F) -> F::Output
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let permit = Arc::clone(&SHIELDED_SET_TRANSACTIONS)
+        .acquire_owned()
+        .await
+        .expect("shielded transaction semaphore must remain open");
+    CancellationShield {
+        future: Some(Box::pin(future)),
+        permit: Some(permit),
+        polling: false,
+    }
+    .await
+}
 
 const LOG_COMPONENT_ECSTORE: &str = "ecstore";
 const LOG_SUBSYSTEM_SET_DISK: &str = "set_disk";
@@ -226,6 +442,10 @@ const ENV_ISSUE3031_DIAG_ENABLE: &str = "RUSTFS_ISSUE3031_DIAG_ENABLE";
 
 struct ObjectLockDiagGuard {
     guard: NamespaceLockGuard,
+    #[cfg(test)]
+    forced_lock_lost: Arc<std::sync::atomic::AtomicBool>,
+    #[cfg(test)]
+    dropped_for_test: Arc<std::sync::atomic::AtomicBool>,
     enabled: bool,
     op: &'static str,
     bucket: Option<String>,
@@ -247,6 +467,10 @@ impl ObjectLockDiagGuard {
     ) -> Self {
         Self {
             guard,
+            #[cfg(test)]
+            forced_lock_lost: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            #[cfg(test)]
+            dropped_for_test: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             enabled,
             op,
             bucket,
@@ -261,12 +485,39 @@ impl ObjectLockDiagGuard {
     /// refresh-quorum loss (backlog#899 Phase 2). Callers fence their commit
     /// point on this so a stale lock holder does not race a double-write.
     fn is_lock_lost(&self) -> bool {
-        self.guard.is_lock_lost()
+        if self.guard.is_lock_lost() {
+            return true;
+        }
+
+        #[cfg(test)]
+        if self.forced_lock_lost.load(std::sync::atomic::Ordering::SeqCst) {
+            return true;
+        }
+
+        false
+    }
+
+    #[cfg(test)]
+    fn force_lock_lost_for_test(&self) {
+        self.forced_lock_lost.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn lock_lost_signal_for_test(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        Arc::clone(&self.forced_lock_lost)
+    }
+
+    #[cfg(test)]
+    fn drop_signal_for_test(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        Arc::clone(&self.dropped_for_test)
     }
 }
 
 impl Drop for ObjectLockDiagGuard {
     fn drop(&mut self) {
+        #[cfg(test)]
+        self.dropped_for_test.store(true, std::sync::atomic::Ordering::SeqCst);
+
         if !self.enabled || self.guard.is_released() {
             return;
         }
@@ -2494,7 +2745,7 @@ impl SetDisks {
     async fn acquire_dist_delete_object_locks_batch(
         &self,
         batch: &rustfs_lock::BatchLockRequest,
-    ) -> (HashMap<(String, String), String>, HashSet<String>, Vec<Vec<rustfs_lock::LockId>>) {
+    ) -> (HashMap<(String, String), String>, HashSet<String>, DistDeleteBatchLockLease) {
         let requests: Vec<rustfs_lock::LockRequest> = batch
             .requests
             .iter()
@@ -2511,7 +2762,8 @@ impl SetDisks {
             1
         };
 
-        let mut lock_ids_by_object: Vec<Vec<(usize, rustfs_lock::LockId)>> = vec![Vec::new(); requests.len()];
+        let mut lock_ids_by_object: Vec<Vec<(usize, rustfs_lock::LockId, tokio::time::Instant)>> =
+            vec![Vec::new(); requests.len()];
         let mut errors_by_object: Vec<Option<String>> = vec![None; requests.len()];
         #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         enum ObjectLockResolution {
@@ -2524,6 +2776,7 @@ impl SetDisks {
         let mut pending_clients = self.lockers.len();
         let mut unresolved_objects = requests.len();
         let mut cleanup_lock_ids_by_client = vec![Vec::new(); self.lockers.len()];
+        let conservative_confirmed_until = tokio::time::Instant::now() + rustfs_lock::fast_lock::DEFAULT_LOCK_TIMEOUT;
 
         let mut pending = tokio::task::JoinSet::new();
         for (client_idx, client) in self.lockers.iter().cloned().enumerate() {
@@ -2549,7 +2802,7 @@ impl SetDisks {
                                         .as_ref()
                                         .map(|lock_info| lock_info.id.clone())
                                         .unwrap_or_else(|| request.lock_id.clone());
-                                    lock_ids_by_object[req_idx].push((client_idx, lock_id));
+                                    lock_ids_by_object[req_idx].push((client_idx, lock_id, conservative_confirmed_until));
                                 }
                                 Some(response) => {
                                     if errors_by_object[req_idx].is_none() {
@@ -2702,20 +2955,28 @@ impl SetDisks {
 
         let mut failed_map = HashMap::new();
         let mut locked_objects = HashSet::new();
-        let mut held_lock_ids_by_client = vec![Vec::new(); self.lockers.len()];
+        let mut lease = DistDeleteBatchLockLease::empty(self.lockers.clone());
+        let mut heartbeat_entries_by_client = vec![Vec::new(); self.lockers.len()];
+        let mut held_count_by_object = HashMap::new();
         let mut rollback_lock_ids_by_client = vec![Vec::new(); self.lockers.len()];
 
         for (req_idx, req) in batch.requests.iter().enumerate() {
             let success_count = lock_ids_by_object[req_idx].len();
             match resolution_by_object[req_idx] {
                 ObjectLockResolution::Succeeded => {
-                    for (client_idx, lock_id) in lock_ids_by_object[req_idx].drain(..) {
-                        held_lock_ids_by_client[client_idx].push(lock_id);
+                    held_count_by_object.insert(req.key.object.as_ref().to_string(), lock_ids_by_object[req_idx].len());
+                    for (client_idx, lock_id, confirmed_until) in lock_ids_by_object[req_idx].drain(..) {
+                        lease.lock_ids_by_client[client_idx].push(lock_id.clone());
+                        heartbeat_entries_by_client[client_idx].push((
+                            req.key.object.as_ref().to_string(),
+                            lock_id,
+                            confirmed_until,
+                        ));
                     }
                     locked_objects.insert(req.key.object.as_ref().to_string());
                 }
                 ObjectLockResolution::Pending | ObjectLockResolution::Failed => {
-                    for (client_idx, lock_id) in lock_ids_by_object[req_idx].drain(..) {
+                    for (client_idx, lock_id, _) in lock_ids_by_object[req_idx].drain(..) {
                         rollback_lock_ids_by_client[client_idx].push(lock_id);
                     }
                     failed_map.insert(
@@ -2734,7 +2995,19 @@ impl SetDisks {
 
         self.release_dist_delete_object_locks_batch(rollback_lock_ids_by_client).await;
 
-        (failed_map, locked_objects, held_lock_ids_by_client)
+        if heartbeat_entries_by_client.iter().any(|entries| !entries.is_empty()) {
+            lease.heartbeat = Some(spawn_dist_delete_batch_lock_heartbeat(
+                heartbeat_entries_by_client,
+                self.lockers.clone(),
+                held_count_by_object,
+                write_quorum,
+                Arc::clone(&lease.lost_objects),
+                lease.cancel.clone(),
+                rustfs_lock::fast_lock::DEFAULT_LOCK_REFRESH_INTERVAL,
+            ));
+        }
+
+        (failed_map, locked_objects, lease)
     }
 
     async fn release_dist_delete_object_locks_batch(&self, lock_ids_by_client: Vec<Vec<rustfs_lock::LockId>>) {
@@ -3777,10 +4050,41 @@ mod tests {
     use rustfs_lock::{LockError, LockInfo, LockResponse, LockStats};
     use serial_test::serial;
     use std::collections::HashMap;
+    use std::sync::atomic::Ordering;
     use tempfile::TempDir;
     use time::OffsetDateTime;
     use tokio::fs;
     use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn cancellation_shield_finishes_transaction_after_parent_abort() {
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_entered = Arc::clone(&entered);
+        let task_release = Arc::clone(&release);
+        let task_completed = Arc::clone(&completed);
+
+        let parent = tokio::spawn(async move {
+            cancellation_shield(async move {
+                task_entered.notify_one();
+                task_release.notified().await;
+                task_completed.store(true, Ordering::Release);
+            })
+            .await;
+        });
+        entered.notified().await;
+        parent.abort();
+        release.notify_one();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !completed.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("shielded transaction should finish after parent abort");
+    }
 
     #[test]
     fn complete_part_error_maps_confirmed_missing_to_invalid_part() {
@@ -3852,6 +4156,99 @@ mod tests {
 
         async fn is_online(&self) -> bool {
             false
+        }
+
+        async fn is_local(&self) -> bool {
+            false
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RefreshErrorClient;
+
+    #[async_trait::async_trait]
+    impl LockClient for RefreshErrorClient {
+        async fn acquire_lock(&self, _request: &rustfs_lock::LockRequest) -> rustfs_lock::Result<LockResponse> {
+            Err(LockError::internal("unused acquire"))
+        }
+
+        async fn release(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<bool> {
+            Ok(false)
+        }
+
+        async fn refresh(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<bool> {
+            Err(LockError::internal("simulated refresh outage"))
+        }
+
+        async fn force_release(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<bool> {
+            Ok(false)
+        }
+
+        async fn check_status(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<Option<LockInfo>> {
+            Ok(None)
+        }
+
+        async fn get_stats(&self) -> rustfs_lock::Result<LockStats> {
+            Ok(LockStats::default())
+        }
+
+        async fn close(&self) -> rustfs_lock::Result<()> {
+            Ok(())
+        }
+
+        async fn is_online(&self) -> bool {
+            false
+        }
+
+        async fn is_local(&self) -> bool {
+            false
+        }
+    }
+
+    #[derive(Debug)]
+    struct BatchRefreshCountingClient {
+        batch_calls: Arc<std::sync::atomic::AtomicUsize>,
+        refreshed: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl LockClient for BatchRefreshCountingClient {
+        async fn acquire_lock(&self, _request: &rustfs_lock::LockRequest) -> rustfs_lock::Result<LockResponse> {
+            Err(LockError::internal("unused acquire"))
+        }
+
+        async fn release(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<bool> {
+            Ok(false)
+        }
+
+        async fn refresh(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<bool> {
+            panic!("batch heartbeat must not fan out through unary refresh")
+        }
+
+        async fn refresh_locks_batch(&self, lock_ids: &[rustfs_lock::LockId]) -> Vec<rustfs_lock::Result<bool>> {
+            self.batch_calls.fetch_add(1, Ordering::Relaxed);
+            self.refreshed.fetch_add(lock_ids.len(), Ordering::Relaxed);
+            lock_ids.iter().map(|_| Ok(true)).collect()
+        }
+
+        async fn force_release(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<bool> {
+            Ok(false)
+        }
+
+        async fn check_status(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<Option<LockInfo>> {
+            Ok(None)
+        }
+
+        async fn get_stats(&self) -> rustfs_lock::Result<LockStats> {
+            Ok(LockStats::default())
+        }
+
+        async fn close(&self) -> rustfs_lock::Result<()> {
+            Ok(())
+        }
+
+        async fn is_online(&self) -> bool {
+            true
         }
 
         async fn is_local(&self) -> bool {
@@ -3989,7 +4386,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rename_data_quorum_failure_rolls_back_destination_object() {
+    async fn test_rename_data_join_error_rolls_back_destination_object() {
         let dir = tempfile::tempdir().expect("tempdir should be created");
         let disk_root = dir.path().join("disk0");
         fs::create_dir_all(&disk_root).await.expect("disk root should be created");
@@ -4057,9 +4454,11 @@ mod tests {
 
         let disks = vec![Some(disk), None];
         let file_infos = vec![new_fi.clone(), new_fi];
-        let result = SetDisks::rename_data(&disks, RUSTFS_META_TMP_BUCKET, tmp_object, &file_infos, bucket, object, 2).await;
+        let _panic_after_commit = crate::set_disk::core::io_primitives::rename_fanout_barrier::panic_after_rename(object, 0);
+        let result =
+            SetDisks::rename_data(&disks, (RUSTFS_META_TMP_BUCKET, tmp_object), &file_infos, (bucket, object), 2, None).await;
 
-        assert!(result.is_err());
+        assert!(result.is_err(), "an ambiguous task failure must fail the transaction");
         let restored_meta = fs::read(object_dir.join(STORAGE_FORMAT_FILE))
             .await
             .expect("destination metadata should remain readable");
@@ -4128,7 +4527,8 @@ mod tests {
 
         let disks = vec![Some(disk), None];
         let file_infos = vec![new_fi.clone(), new_fi];
-        let result = SetDisks::rename_data(&disks, RUSTFS_META_TMP_BUCKET, tmp_object, &file_infos, bucket, object, 2).await;
+        let result =
+            SetDisks::rename_data(&disks, (RUSTFS_META_TMP_BUCKET, tmp_object), &file_infos, (bucket, object), 2, None).await;
 
         assert!(result.is_err());
         let restored_meta = fs::read(object_dir.join(STORAGE_FORMAT_FILE))
@@ -5243,17 +5643,17 @@ mod tests {
             .add_write_lock(ObjectKey::new("bucket", "object-a"))
             .add_write_lock(ObjectKey::new("bucket", "object-b"));
 
-        let (failed_map, locked_objects, held_lock_ids_by_client) =
-            set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
+        let (failed_map, locked_objects, mut lease) = set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
 
         assert!(failed_map.is_empty());
         assert_eq!(locked_objects.len(), 2);
         assert!(locked_objects.contains("object-a"));
         assert!(locked_objects.contains("object-b"));
-        assert_eq!(held_lock_ids_by_client.iter().map(Vec::len).sum::<usize>(), batch.requests.len() * 2);
+        assert_eq!(lease.lock_ids_by_client.iter().map(Vec::len).sum::<usize>(), batch.requests.len() * 2);
 
+        lease.stop_heartbeat().await;
         set_disks
-            .release_dist_delete_object_locks_batch(held_lock_ids_by_client)
+            .release_dist_delete_object_locks_batch(std::mem::take(&mut lease.lock_ids_by_client))
             .await;
 
         let local_lock_1 = NamespaceLock::with_local_manager("node-1".to_string(), manager1);
@@ -5272,6 +5672,126 @@ mod tests {
         drop(guard_2);
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_dist_delete_batch_lock_heartbeat_detects_quorum_loss() {
+        let object = "slow-delete".to_string();
+        let resource = ObjectKey::new("bucket", object.clone());
+        let entries = vec![
+            vec![(
+                object.clone(),
+                rustfs_lock::LockId::new_unique(&resource),
+                tokio::time::Instant::now() + rustfs_lock::fast_lock::DEFAULT_LOCK_TIMEOUT,
+            )],
+            vec![(
+                object.clone(),
+                rustfs_lock::LockId::new_unique(&resource),
+                tokio::time::Instant::now() + rustfs_lock::fast_lock::DEFAULT_LOCK_TIMEOUT,
+            )],
+        ];
+        let clients = vec![
+            Arc::new(FailingClient) as Arc<dyn LockClient>,
+            Arc::new(FailingClient) as Arc<dyn LockClient>,
+        ];
+        let lost_objects = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let cancel = CancellationToken::new();
+        let heartbeat = spawn_dist_delete_batch_lock_heartbeat(
+            entries,
+            clients,
+            HashMap::from([(object.clone(), 2)]),
+            2,
+            Arc::clone(&lost_objects),
+            cancel.clone(),
+            Duration::from_secs(1),
+        );
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert!(lost_objects.lock().contains(&object));
+
+        cancel.cancel();
+        heartbeat.await.expect("heartbeat should stop cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dist_delete_batch_lock_heartbeat_expires_unconfirmed_refreshes() {
+        let object = "unconfirmed-delete".to_string();
+        let resource = ObjectKey::new("bucket", object.clone());
+        let entries = vec![vec![(
+            object.clone(),
+            rustfs_lock::LockId::new_unique(&resource),
+            tokio::time::Instant::now() + rustfs_lock::fast_lock::DEFAULT_LOCK_TIMEOUT,
+        )]];
+        let clients = vec![Arc::new(RefreshErrorClient) as Arc<dyn LockClient>];
+        let lost_objects = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let cancel = CancellationToken::new();
+        let heartbeat = spawn_dist_delete_batch_lock_heartbeat(
+            entries,
+            clients,
+            HashMap::from([(object.clone(), 1)]),
+            1,
+            Arc::clone(&lost_objects),
+            cancel.clone(),
+            rustfs_lock::fast_lock::DEFAULT_LOCK_REFRESH_INTERVAL,
+        );
+
+        tokio::task::yield_now().await;
+        for _ in 0..3 {
+            tokio::time::advance(rustfs_lock::fast_lock::DEFAULT_LOCK_REFRESH_INTERVAL).await;
+            tokio::task::yield_now().await;
+        }
+        assert!(lost_objects.lock().contains(&object));
+
+        cancel.cancel();
+        heartbeat.await.expect("heartbeat should stop cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_dist_delete_batch_lock_heartbeat_batches_thousand_keys_per_locker() {
+        const OBJECT_COUNT: usize = 1000;
+        let batch_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let refreshed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let client = Arc::new(BatchRefreshCountingClient {
+            batch_calls: Arc::clone(&batch_calls),
+            refreshed: Arc::clone(&refreshed),
+        }) as Arc<dyn LockClient>;
+        let entries = vec![
+            (0..OBJECT_COUNT)
+                .map(|index| {
+                    let object = format!("object-{index:04}");
+                    let resource = ObjectKey::new("bucket", object.clone());
+                    (
+                        object,
+                        rustfs_lock::LockId::new_unique(&resource),
+                        tokio::time::Instant::now() + rustfs_lock::fast_lock::DEFAULT_LOCK_TIMEOUT,
+                    )
+                })
+                .collect::<Vec<_>>(),
+        ];
+        let held_count_by_object = entries[0].iter().map(|(object, _, _)| (object.clone(), 1)).collect();
+        let lost_objects = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        let cancel = CancellationToken::new();
+        let heartbeat = spawn_dist_delete_batch_lock_heartbeat(
+            entries,
+            vec![client],
+            held_count_by_object,
+            1,
+            Arc::clone(&lost_objects),
+            cancel.clone(),
+            Duration::from_secs(1),
+        );
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(batch_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(refreshed.load(Ordering::Relaxed), OBJECT_COUNT);
+        assert!(lost_objects.lock().is_empty());
+
+        cancel.cancel();
+        heartbeat.await.expect("heartbeat should stop cleanly");
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_acquire_dist_delete_object_locks_batch_rolls_back_when_quorum_not_reached() {
@@ -5286,12 +5806,11 @@ mod tests {
             .with_all_or_nothing(false)
             .add_write_lock(ObjectKey::new("bucket", "object-a"));
 
-        let (failed_map, locked_objects, held_lock_ids_by_client) =
-            set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
+        let (failed_map, locked_objects, lease) = set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
 
         assert!(locked_objects.is_empty());
         assert!(failed_map.contains_key(&("bucket".to_string(), "object-a".to_string())));
-        assert_eq!(held_lock_ids_by_client.iter().map(Vec::len).sum::<usize>(), 0);
+        assert_eq!(lease.lock_ids_by_client.iter().map(Vec::len).sum::<usize>(), 0);
 
         let local_lock = NamespaceLock::with_local_manager("node-1".to_string(), manager);
         let guard = local_lock
@@ -5328,8 +5847,7 @@ mod tests {
             .add_write_lock(ObjectKey::new("bucket", "object-b"));
 
         let started = Instant::now();
-        let (failed_map, locked_objects, held_lock_ids_by_client) =
-            set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
+        let (failed_map, locked_objects, mut lease) = set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
 
         assert!(
             started.elapsed() < Duration::from_millis(150),
@@ -5338,8 +5856,9 @@ mod tests {
         assert!(failed_map.is_empty());
         assert_eq!(locked_objects.len(), 2);
 
+        lease.stop_heartbeat().await;
         set_disks
-            .release_dist_delete_object_locks_batch(held_lock_ids_by_client)
+            .release_dist_delete_object_locks_batch(std::mem::take(&mut lease.lock_ids_by_client))
             .await;
 
         tokio::time::sleep(Duration::from_millis(350)).await;
@@ -5381,8 +5900,7 @@ mod tests {
             .add_write_lock(ObjectKey::new("bucket", "object-b"));
 
         let started = Instant::now();
-        let (failed_map, locked_objects, held_lock_ids_by_client) =
-            set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
+        let (failed_map, locked_objects, lease) = set_disks.acquire_dist_delete_object_locks_batch(&batch).await;
 
         assert!(
             started.elapsed() < Duration::from_millis(150),
@@ -5391,7 +5909,7 @@ mod tests {
         assert!(locked_objects.is_empty());
         assert!(failed_map.contains_key(&("bucket".to_string(), "object-a".to_string())));
         assert!(failed_map.contains_key(&("bucket".to_string(), "object-b".to_string())));
-        assert_eq!(held_lock_ids_by_client.iter().map(Vec::len).sum::<usize>(), 0);
+        assert_eq!(lease.lock_ids_by_client.iter().map(Vec::len).sum::<usize>(), 0);
 
         tokio::time::sleep(Duration::from_millis(350)).await;
 

--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -1435,12 +1435,11 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
         // `get_object_info` lookup, so the backfill has no consumer here yet.
         let (online_disks, convergence, op_old_dir, cleanup_disks, _) = Self::rename_data(
             &shuffle_disks,
-            RUSTFS_META_MULTIPART_BUCKET,
-            &upload_id_path,
+            (RUSTFS_META_MULTIPART_BUCKET, &upload_id_path),
             &parts_metadatas,
-            bucket,
-            object,
+            (bucket, object),
             write_quorum,
+            object_lock_guard.take(),
         )
         .await?;
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -72,6 +72,251 @@ fn full_object_plaintext_len(range: &Option<HTTPRangeSpec>, opts: &ObjectOptions
     Some(object_info.size)
 }
 
+#[cfg(test)]
+static AMBIGUOUS_DELETE_FAILURES: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<(String, usize)>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+#[cfg(test)]
+const BATCH_DELETE_SCALE_TEST_PREFIX: &str = "aggregation-scale-";
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BatchDeleteTestPhase {
+    Forward,
+    Rollback,
+    Cleanup,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BatchDeleteTestCall {
+    phase: BatchDeleteTestPhase,
+    disk_index: usize,
+    item_count: usize,
+}
+
+#[cfg(test)]
+static BATCH_DELETE_TEST_CALLS: std::sync::LazyLock<std::sync::Mutex<Vec<BatchDeleteTestCall>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+
+#[cfg(test)]
+fn record_batch_delete_test_call(
+    phase: BatchDeleteTestPhase,
+    disk_index: usize,
+    item_count: usize,
+    contains_scale_test_item: bool,
+) {
+    if contains_scale_test_item {
+        BATCH_DELETE_TEST_CALLS
+            .lock()
+            .expect("batch delete test call lock should not be poisoned")
+            .push(BatchDeleteTestCall {
+                phase,
+                disk_index,
+                item_count,
+            });
+    }
+}
+
+#[cfg(test)]
+fn clear_batch_delete_test_calls() {
+    BATCH_DELETE_TEST_CALLS
+        .lock()
+        .expect("batch delete test call lock should not be poisoned")
+        .clear();
+}
+
+#[cfg(test)]
+fn batch_delete_test_calls() -> Vec<BatchDeleteTestCall> {
+    BATCH_DELETE_TEST_CALLS
+        .lock()
+        .expect("batch delete test call lock should not be poisoned")
+        .clone()
+}
+
+#[cfg(test)]
+fn inject_ambiguous_delete_failure(object: &str, disk_index: usize) {
+    AMBIGUOUS_DELETE_FAILURES
+        .lock()
+        .expect("ambiguous delete failpoint lock should not be poisoned")
+        .insert((object.to_string(), disk_index));
+}
+
+#[cfg(test)]
+fn take_ambiguous_delete_failure(object: &str, disk_index: usize) -> bool {
+    AMBIGUOUS_DELETE_FAILURES
+        .lock()
+        .expect("ambiguous delete failpoint lock should not be poisoned")
+        .remove(&(object.to_string(), disk_index))
+}
+
+#[cfg(test)]
+fn inject_single_delete_result(object: &str, disk_index: usize, result: disk::error::Result<()>) -> disk::error::Result<()> {
+    if result.is_ok() && take_ambiguous_delete_failure(object, disk_index) {
+        Err(DiskError::Unexpected)
+    } else {
+        result
+    }
+}
+
+#[cfg(test)]
+fn inject_batch_delete_results(
+    disk_index: usize,
+    versions: &[FileInfoVersions],
+    mut results: Vec<Option<DiskError>>,
+) -> Vec<Option<DiskError>> {
+    for (index, version) in versions.iter().enumerate() {
+        if take_ambiguous_delete_failure(&version.name, disk_index) {
+            results[index] = Some(DiskError::Unexpected);
+        }
+    }
+    results
+}
+
+/// Normalize one disk's `DeleteVersions` response to the request cardinality.
+/// A short response is a protocol/implementation failure for every omitted
+/// entry, not permission to index past the returned vector or assume success.
+fn normalize_delete_versions_results(results: Vec<Option<DiskError>>, expected_len: usize) -> Vec<Option<DiskError>> {
+    if results.len() == expected_len {
+        return results;
+    }
+
+    (0..expected_len).map(|_| Some(DiskError::Unexpected)).collect()
+}
+
+async fn delete_object_version_with_guard(
+    set: &SetDisks,
+    bucket: &str,
+    object: &str,
+    fi: &FileInfo,
+    force_del_marker: bool,
+    object_lock_guard: Option<&ObjectLockDiagGuard>,
+) -> Result<()> {
+    let disks = set.disk_inventory().await;
+    let write_quorum = disks.len() / 2 + 1;
+    let rollback_dir = Uuid::new_v4();
+
+    let mut futures = Vec::with_capacity(disks.len());
+    let mut errs = Vec::with_capacity(disks.len());
+
+    for (disk_index, disk) in disks.iter().enumerate() {
+        #[cfg(not(test))]
+        let _ = disk_index;
+        futures.push(async move {
+            if let Some(disk) = disk {
+                let result = disk
+                    .delete_version(
+                        bucket,
+                        object,
+                        fi.clone(),
+                        force_del_marker,
+                        DeleteOptions {
+                            old_data_dir: Some(rollback_dir),
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+                #[cfg(test)]
+                let result = inject_single_delete_result(object, disk_index, result);
+                result
+            } else {
+                Err(DiskError::DiskNotFound)
+            }
+        });
+    }
+
+    let results = join_all(futures).await;
+    for result in results {
+        match result {
+            Ok(_) => errs.push(None),
+            Err(err) => errs.push(Some(err)),
+        }
+    }
+
+    // The lease may be lost while the delete fan-out is in flight. Even if
+    // write quorum replied successfully, this coordinator can no longer ACK:
+    // another writer may own the namespace. Preserve rollback state and use
+    // the token-conditional undo on every possible committer.
+    let lock_lost = object_lock_guard.is_some_and(ObjectLockDiagGuard::is_lock_lost);
+    let quorum_result = if lock_lost {
+        Err(StorageError::NamespaceLockQuorumUnavailable {
+            mode: "delete_object_commit",
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            required: 1,
+            achieved: 0,
+        })
+    } else {
+        resolve_tiered_decommission_write_quorum_result(&errs, write_quorum, bucket, object)
+    };
+
+    if quorum_result.is_err() {
+        let mut rollback_futures = Vec::new();
+        for disk in &disks {
+            let Some(disk) = disk.as_ref() else {
+                continue;
+            };
+
+            let disk = disk.clone();
+            let bucket = bucket.to_string();
+            let object = object.to_string();
+            let fi = fi.clone();
+            rollback_futures.push(async move {
+                if let Err(err) = disk
+                    .delete_version(
+                        &bucket,
+                        &object,
+                        fi,
+                        force_del_marker,
+                        DeleteOptions {
+                            undo_write: true,
+                            undo_delete: true,
+                            old_data_dir: Some(rollback_dir),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                {
+                    warn!(
+                        bucket = %bucket,
+                        object = %object,
+                        rollback_dir = %rollback_dir,
+                        error = ?err,
+                        "failed to roll back delete after write quorum failure"
+                    );
+                }
+            });
+        }
+
+        join_all(rollback_futures).await;
+    } else {
+        let mut cleanup_futures = Vec::new();
+        for disk in disks.iter().flatten() {
+            let disk = disk.clone();
+            let bucket = bucket.to_string();
+            let object = object.to_string();
+            cleanup_futures.push(async move {
+                let rollback_path = format!("{object}/{rollback_dir}");
+                if let Err(err) = disk.delete_paths(&bucket, &[rollback_path]).await
+                    && err != DiskError::FileNotFound
+                    && err != DiskError::VolumeNotFound
+                {
+                    warn!(
+                        bucket = %bucket,
+                        object = %object,
+                        rollback_dir = %rollback_dir,
+                        error = ?err,
+                        "failed to clean delete rollback state after quorum success"
+                    );
+                }
+            });
+        }
+        join_all(cleanup_futures).await;
+    }
+
+    quorum_result
+}
+
 #[async_trait::async_trait]
 impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
     type Error = Error;
@@ -1001,12 +1246,11 @@ impl SetDisks {
             let rename_stage_start = Instant::now();
             let (online_disks, _, op_old_dir, cleanup_disks, old_current_size) = Self::rename_data(
                 &shuffle_disks,
-                RUSTFS_META_TMP_BUCKET,
-                tmp_dir.as_str(),
+                (RUSTFS_META_TMP_BUCKET, tmp_dir.as_str()),
                 &parts_metadatas,
-                bucket,
-                object,
+                (bucket, object),
                 write_quorum,
+                object_lock_guard.take(),
             )
             .await?;
             let rename_stage_ms = rename_stage_start.elapsed().as_millis() as u64;
@@ -1398,128 +1642,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
     }
     #[tracing::instrument(skip(self))]
     async fn delete_object_version(&self, bucket: &str, object: &str, fi: &FileInfo, force_del_marker: bool) -> Result<()> {
-        let disks = self.disk_inventory().await;
-        let write_quorum = disks.len() / 2 + 1;
-        let rollback_dir = Uuid::new_v4();
-
-        let mut futures = Vec::with_capacity(disks.len());
-        let mut errs = Vec::with_capacity(disks.len());
-
-        for disk in disks.iter() {
-            futures.push(async move {
-                if let Some(disk) = disk {
-                    match disk
-                        .delete_version(
-                            bucket,
-                            object,
-                            fi.clone(),
-                            force_del_marker,
-                            DeleteOptions {
-                                old_data_dir: Some(rollback_dir),
-                                ..Default::default()
-                            },
-                        )
-                        .await
-                    {
-                        Ok(r) => Ok(r),
-                        Err(e) => Err(e),
-                    }
-                } else {
-                    Err(DiskError::DiskNotFound)
-                }
-            });
-        }
-
-        let results = join_all(futures).await;
-        for result in results {
-            match result {
-                Ok(_) => {
-                    errs.push(None);
-                }
-                Err(e) => {
-                    errs.push(Some(e));
-                }
-            }
-        }
-
-        let quorum_result = resolve_tiered_decommission_write_quorum_result(&errs, write_quorum, bucket, object);
-        let should_rollback = quorum_result.is_err();
-        let mut rollback_futures = Vec::new();
-        for (index, err) in errs.iter().enumerate() {
-            // backlog#1158: when rolling back, fan the idempotent undo out to every
-            // online disk (each self-decides from its staged backup: restore if the
-            // rollback dir is present, no-op otherwise). This covers a disk that
-            // staged + applied the delete and *then* errored, which the plain
-            // `err.is_some()` skip would leave deleted while its peers were restored.
-            // On success only the successful disks' backup dirs need cleaning; errored
-            // disks' residue is reclaimed by heal/scanner.
-            if !should_rollback && err.is_some() {
-                continue;
-            }
-
-            let Some(disk) = disks[index].as_ref() else {
-                continue;
-            };
-
-            let disk = disk.clone();
-            let bucket = bucket.to_string();
-            let object = object.to_string();
-            let fi = fi.clone();
-            rollback_futures.push(async move {
-                if should_rollback {
-                    if let Err(err) = disk
-                        .delete_version(
-                            &bucket,
-                            &object,
-                            fi,
-                            force_del_marker,
-                            DeleteOptions {
-                                undo_write: true,
-                                undo_delete: true,
-                                old_data_dir: Some(rollback_dir),
-                                ..Default::default()
-                            },
-                        )
-                        .await
-                    {
-                        warn!(
-                            bucket = %bucket,
-                            object = %object,
-                            rollback_dir = %rollback_dir,
-                            error = ?err,
-                            "failed to roll back delete after write quorum failure"
-                        );
-                    }
-                } else {
-                    let rollback_path = format!("{object}/{rollback_dir}");
-                    if let Err(err) = disk
-                        .delete(
-                            &bucket,
-                            &rollback_path,
-                            DeleteOptions {
-                                recursive: true,
-                                immediate: true,
-                                ..Default::default()
-                            },
-                        )
-                        .await
-                        && err != DiskError::FileNotFound
-                        && err != DiskError::VolumeNotFound
-                    {
-                        warn!(
-                            bucket = %bucket,
-                            object = %object,
-                            rollback_dir = %rollback_dir,
-                            error = ?err,
-                            "failed to clean delete rollback state after quorum success"
-                        );
-                    }
-                }
-            });
-        }
-
-        join_all(rollback_futures).await;
-        quorum_result
+        delete_object_version_with_guard(self, bucket, object, fi, force_del_marker, None).await
     }
 
     #[tracing::instrument(skip(self))]
@@ -1529,307 +1652,370 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
         objects: Vec<ObjectToDelete>,
         opts: ObjectOptions,
     ) -> (Vec<DeletedObject>, Vec<Option<Error>>) {
-        for object in &objects {
-            self.invalidate_get_object_metadata_cache(bucket, &object.object_name).await;
-        }
-
-        // Default return value
-        let mut del_objects = vec![DeletedObject::default(); objects.len()];
-
-        let mut del_errs = Vec::with_capacity(objects.len());
-
-        for _ in 0..objects.len() {
-            del_errs.push(None)
-        }
-
-        // Acquire locks in batch mode (best effort, matching previous behavior)
-        let mut batch = rustfs_lock::BatchLockRequest::new(self.locker_owner.as_str()).with_all_or_nothing(false);
-        let mut unique_objects: HashSet<String> = HashSet::new();
-        for dobj in &objects {
-            if unique_objects.insert(dobj.object_name.clone()) {
-                batch = batch.add_write_lock(ObjectKey::new(bucket, dobj.object_name.clone()));
-            }
-        }
-        let unique_lock_count = batch.requests.len();
-
-        let mut failed_map = HashMap::new();
-        let mut _local_batch_guards: Vec<FastLockGuard> = Vec::with_capacity(batch.requests.len());
-        let mut locked_objects = HashSet::new();
-
-        let dist_erasure = runtime_sources::setup_is_dist_erasure().await;
-        let mut dist_batch_lock_ids = vec![Vec::new(); self.lockers.len()];
-
-        if opts.no_lock {
-            locked_objects = unique_objects;
-        } else if dist_erasure {
-            (failed_map, locked_objects, dist_batch_lock_ids) = self.acquire_dist_delete_object_locks_batch(&batch).await;
-        } else {
-            let batch_result = self.local_lock_manager.acquire_locks_batch(batch).await;
-            _local_batch_guards = batch_result.guards;
-
-            for key in batch_result.successful_locks {
-                locked_objects.insert(key.object.as_ref().to_string());
+        let set = self.clone();
+        let bucket = bucket.to_string();
+        cancellation_shield(async move {
+            let bucket = bucket.as_str();
+            for object in &objects {
+                set.invalidate_get_object_metadata_cache(bucket, &object.object_name).await;
             }
 
-            for (key, err) in batch_result.failed_locks {
-                failed_map.insert((key.bucket.as_ref().to_string(), key.object.as_ref().to_string()), format!("{err:?}"));
-            }
-        }
+            // Default return value
+            let mut del_objects = vec![DeletedObject::default(); objects.len()];
 
-        if issue3031_diag_enabled() {
-            let failed_lock_count = failed_map.len();
-            let locked_object_count = locked_objects.len();
-            let dist_lock_id_count = dist_batch_lock_ids.iter().map(Vec::len).sum::<usize>();
-            warn!(
-                target: "rustfs_ecstore::set_disk",
-                bucket = %bucket,
-                requested_object_count = objects.len(),
-                unique_lock_count,
-                locked_object_count,
-                failed_lock_count,
-                dist_erasure,
-                dist_lock_id_count,
-                failed_objects = ?failed_map.keys().collect::<Vec<_>>(),
-                "issue3031_delete_objects_lock_batch_context"
-            );
-        }
+            let mut del_errs = Vec::with_capacity(objects.len());
 
-        // Mark failures for objects that could not be locked
-        for (i, dobj) in objects.iter().enumerate() {
-            if let Some(err) = failed_map.get(&(bucket.to_string(), dobj.object_name.clone())) {
-                del_errs[i] = Some(Error::other(err.to_string()));
-            }
-        }
-
-        let ver_cfg = BucketVersioningSys::get(bucket).await.unwrap_or_default();
-
-        // backlog#929 (HP-8): the per-object stat below exists solely to feed
-        // check_object_lock_delete (#4297). Resolve the bucket lock
-        // configuration once (in-memory cache) and skip the whole stat fanout
-        // for buckets without Object Lock; unknown metadata fails closed and
-        // keeps the stat, so the #4297 protection is preserved verbatim for
-        // every object-lock-enabled bucket.
-        let object_lock_checks_required = object_lock_delete_check_required(metadata_sys::get(bucket).await.ok().as_deref());
-
-        let mut vers_map: HashMap<&String, FileInfoVersions> = HashMap::new();
-
-        for (i, dobj) in objects.iter().enumerate() {
-            if del_errs[i].is_some() {
-                continue;
+            for _ in 0..objects.len() {
+                del_errs.push(None)
             }
 
-            let explicit_null_version = is_explicit_null_version(dobj.version_id);
-            let version_id = delete_file_info_version_id(dobj.version_id);
-            if object_lock_checks_required {
-                let check_opts = ObjectOptions {
-                    version_id: version_id.map(|version_id| version_id.to_string()),
-                    versioned: ver_cfg.prefix_enabled(dobj.object_name.as_str()),
-                    version_suspended: ver_cfg.suspended(),
-                    object_lock_delete: opts.object_lock_delete.clone(),
-                    no_lock: true,
-                    ..Default::default()
-                };
-                let (goi, _write_quorum, gerr) = self.get_object_info_and_quorum(bucket, &dobj.object_name, &check_opts).await;
-                if gerr.is_none()
-                    && let Err(err) = check_object_lock_delete(bucket, &dobj.object_name, &goi, &check_opts).await
-                {
-                    del_errs[i] = Some(err);
+            // Acquire locks in batch mode (best effort, matching previous behavior)
+            let mut batch = rustfs_lock::BatchLockRequest::new(set.locker_owner.as_str()).with_all_or_nothing(false);
+            let mut unique_objects: HashSet<String> = HashSet::new();
+            for dobj in &objects {
+                if unique_objects.insert(dobj.object_name.clone()) {
+                    batch = batch.add_write_lock(ObjectKey::new(bucket, dobj.object_name.clone()));
+                }
+            }
+            let unique_lock_count = batch.requests.len();
+
+            let mut failed_map = HashMap::new();
+            let mut _local_batch_guards: Vec<FastLockGuard> = Vec::with_capacity(batch.requests.len());
+            let mut locked_objects = HashSet::new();
+
+            let dist_erasure = runtime_sources::setup_is_dist_erasure().await;
+            let mut dist_batch_lock_lease = DistDeleteBatchLockLease::empty(set.lockers.clone());
+
+            if opts.no_lock {
+                locked_objects = unique_objects;
+            } else if dist_erasure {
+                (failed_map, locked_objects, dist_batch_lock_lease) = set.acquire_dist_delete_object_locks_batch(&batch).await;
+            } else {
+                let batch_result = set.local_lock_manager.acquire_locks_batch(batch).await;
+                _local_batch_guards = batch_result.guards;
+
+                for key in batch_result.successful_locks {
+                    locked_objects.insert(key.object.as_ref().to_string());
+                }
+
+                for (key, err) in batch_result.failed_locks {
+                    failed_map.insert((key.bucket.as_ref().to_string(), key.object.as_ref().to_string()), format!("{err:?}"));
+                }
+            }
+
+            if issue3031_diag_enabled() {
+                let failed_lock_count = failed_map.len();
+                let locked_object_count = locked_objects.len();
+                let dist_lock_id_count = dist_batch_lock_lease.lock_ids_by_client.iter().map(Vec::len).sum::<usize>();
+                warn!(
+                    target: "rustfs_ecstore::set_disk",
+                    bucket = %bucket,
+                    requested_object_count = objects.len(),
+                    unique_lock_count,
+                    locked_object_count,
+                    failed_lock_count,
+                    dist_erasure,
+                    dist_lock_id_count,
+                    failed_objects = ?failed_map.keys().collect::<Vec<_>>(),
+                    "issue3031_delete_objects_lock_batch_context"
+                );
+            }
+
+            // Mark failures for objects that could not be locked
+            for (i, dobj) in objects.iter().enumerate() {
+                if let Some(err) = failed_map.get(&(bucket.to_string(), dobj.object_name.clone())) {
+                    del_errs[i] = Some(Error::other(err.to_string()));
+                }
+            }
+
+            let ver_cfg = BucketVersioningSys::get(bucket).await.unwrap_or_default();
+
+            // backlog#929 (HP-8): the per-object stat below exists solely to feed
+            // check_object_lock_delete (#4297). Resolve the bucket lock
+            // configuration once (in-memory cache) and skip the whole stat fanout
+            // for buckets without Object Lock; unknown metadata fails closed and
+            // keeps the stat, so the #4297 protection is preserved verbatim for
+            // every object-lock-enabled bucket.
+            let object_lock_checks_required = object_lock_delete_check_required(metadata_sys::get(bucket).await.ok().as_deref());
+
+            let mut vers_map: HashMap<&String, FileInfoVersions> = HashMap::new();
+
+            for (i, dobj) in objects.iter().enumerate() {
+                if del_errs[i].is_some() {
                     continue;
                 }
-            }
 
-            let mut vr = FileInfo {
-                name: dobj.object_name.clone(),
-                version_id,
-                idx: i,
-                replication_state_internal: Some(dobj.replication_state()),
-                ..Default::default()
-            };
-
-            vr.set_tier_free_version_id(&Uuid::new_v4().to_string());
-
-            // Delete
-            // del_objects[i].object_name.clone_from(&vr.name);
-            // del_objects[i].version_id = vr.version_id.map(|v| v.to_string());
-
-            if dobj.version_id.is_none() {
-                let (suspended, versioned) = (ver_cfg.suspended(), ver_cfg.prefix_enabled(dobj.object_name.as_str()));
-                if suspended || versioned {
-                    vr.mod_time = Some(OffsetDateTime::now_utc());
-                    vr.deleted = true;
-                    if versioned {
-                        vr.version_id = Some(Uuid::new_v4());
+                let explicit_null_version = is_explicit_null_version(dobj.version_id);
+                let version_id = delete_file_info_version_id(dobj.version_id);
+                if object_lock_checks_required {
+                    let check_opts = ObjectOptions {
+                        version_id: version_id.map(|version_id| version_id.to_string()),
+                        versioned: ver_cfg.prefix_enabled(dobj.object_name.as_str()),
+                        version_suspended: ver_cfg.suspended(),
+                        object_lock_delete: opts.object_lock_delete.clone(),
+                        no_lock: true,
+                        ..Default::default()
+                    };
+                    let (goi, _write_quorum, gerr) = set.get_object_info_and_quorum(bucket, &dobj.object_name, &check_opts).await;
+                    if gerr.is_none()
+                        && let Err(err) = check_object_lock_delete(bucket, &dobj.object_name, &goi, &check_opts).await
+                    {
+                        del_errs[i] = Some(err);
+                        continue;
                     }
                 }
-            }
 
-            let v = {
-                if vers_map.contains_key(&dobj.object_name) {
-                    let val = vers_map.get_mut(&dobj.object_name).unwrap();
-                    val.versions.push(vr.clone());
-                    val.clone()
+                let mut vr = FileInfo {
+                    name: dobj.object_name.clone(),
+                    version_id,
+                    idx: i,
+                    replication_state_internal: Some(dobj.replication_state()),
+                    ..Default::default()
+                };
+
+                vr.set_tier_free_version_id(&Uuid::new_v4().to_string());
+
+                // Delete
+                // del_objects[i].object_name.clone_from(&vr.name);
+                // del_objects[i].version_id = vr.version_id.map(|v| v.to_string());
+
+                if dobj.version_id.is_none() {
+                    let (suspended, versioned) = (ver_cfg.suspended(), ver_cfg.prefix_enabled(dobj.object_name.as_str()));
+                    if suspended || versioned {
+                        vr.mod_time = Some(OffsetDateTime::now_utc());
+                        vr.deleted = true;
+                        if versioned {
+                            vr.version_id = Some(Uuid::new_v4());
+                        }
+                    }
+                }
+
+                let v = {
+                    if vers_map.contains_key(&dobj.object_name) {
+                        let val = vers_map.get_mut(&dobj.object_name).unwrap();
+                        val.versions.push(vr.clone());
+                        val.clone()
+                    } else {
+                        FileInfoVersions {
+                            name: vr.name.clone(),
+                            versions: vec![vr.clone()],
+                            ..Default::default()
+                        }
+                    }
+                };
+
+                if vr.deleted {
+                    del_objects[i] = DeletedObject {
+                        delete_marker: vr.deleted,
+                        delete_marker_version_id: vr.version_id,
+                        delete_marker_mtime: vr.mod_time,
+                        object_name: vr.name.clone(),
+                        replication_state: vr.replication_state_internal.clone(),
+                        ..Default::default()
+                    }
                 } else {
-                    FileInfoVersions {
-                        name: vr.name.clone(),
-                        versions: vec![vr.clone()],
+                    del_objects[i] = DeletedObject {
+                        object_name: vr.name.clone(),
+                        version_id: if explicit_null_version {
+                            Some(Uuid::nil())
+                        } else {
+                            vr.version_id
+                        },
+                        replication_state: vr.replication_state_internal.clone(),
                         ..Default::default()
                     }
                 }
-            };
 
-            if vr.deleted {
-                del_objects[i] = DeletedObject {
-                    delete_marker: vr.deleted,
-                    delete_marker_version_id: vr.version_id,
-                    delete_marker_mtime: vr.mod_time,
-                    object_name: vr.name.clone(),
-                    replication_state: vr.replication_state_internal.clone(),
-                    ..Default::default()
+                // Only add to vers_map if we hold the lock
+                if locked_objects.contains(&dobj.object_name) {
+                    vers_map.insert(&dobj.object_name, v);
                 }
-            } else {
-                del_objects[i] = DeletedObject {
-                    object_name: vr.name.clone(),
-                    version_id: if explicit_null_version {
-                        Some(Uuid::nil())
+            }
+
+            let mut vers = Vec::with_capacity(vers_map.len());
+
+            for (_, mut fi_vers) in vers_map {
+                fi_vers.versions.sort_by_key(|a| a.deleted);
+
+                if let Some(index) = fi_vers.versions.iter().position(|fi| fi.deleted) {
+                    fi_vers.versions.truncate(index + 1);
+                }
+
+                vers.push(fi_vers);
+            }
+
+            let lost_before_forward = dist_batch_lock_lease.lost_objects();
+            if !lost_before_forward.is_empty() {
+                vers.retain(|fi_vers| {
+                    if !lost_before_forward.contains(&fi_vers.name) {
+                        return true;
+                    }
+                    for fi in &fi_vers.versions {
+                        del_errs[fi.idx] = Some(Error::other("distributed delete lock quorum was lost"));
+                    }
+                    false
+                });
+            }
+
+            let rollback_dir = Uuid::new_v4();
+
+            let disks = set.disks.read().await;
+
+            let disks = disks.clone();
+
+            let mut futures = Vec::with_capacity(disks.len());
+
+            // let mut errors = Vec::with_capacity(disks.len());
+
+            for (disk_index, disk) in disks.iter().enumerate() {
+                let vers = vers.clone();
+                futures.push(async move {
+                    if let Some(disk) = disk {
+                        #[cfg(test)]
+                        record_batch_delete_test_call(
+                            BatchDeleteTestPhase::Forward,
+                            disk_index,
+                            vers.len(),
+                            vers.iter()
+                                .any(|versions| versions.name.starts_with(BATCH_DELETE_SCALE_TEST_PREFIX)),
+                        );
+                        let requested_len = vers.len();
+                        #[cfg(test)]
+                        let injected_versions = vers.clone();
+                        let results = disk
+                            .delete_versions(
+                                bucket,
+                                vers,
+                                DeleteOptions {
+                                    old_data_dir: Some(rollback_dir),
+                                    ..Default::default()
+                                },
+                            )
+                            .await;
+                        let returned_len = results.len();
+                        if returned_len != requested_len {
+                            warn!(
+                                disk_index,
+                                requested_len, returned_len, "delete_versions returned a result vector with unexpected length"
+                            );
+                        }
+                        let results = normalize_delete_versions_results(results, requested_len);
+                        #[cfg(test)]
+                        let results = inject_batch_delete_results(disk_index, &injected_versions, results);
+                        results
                     } else {
-                        vr.version_id
-                    },
-                    replication_state: vr.replication_state_internal.clone(),
-                    ..Default::default()
-                }
-            }
-
-            // Only add to vers_map if we hold the lock
-            if locked_objects.contains(&dobj.object_name) {
-                vers_map.insert(&dobj.object_name, v);
-            }
-        }
-
-        let mut vers = Vec::with_capacity(vers_map.len());
-
-        for (_, mut fi_vers) in vers_map {
-            fi_vers.versions.sort_by_key(|a| a.deleted);
-
-            if let Some(index) = fi_vers.versions.iter().position(|fi| fi.deleted) {
-                fi_vers.versions.truncate(index + 1);
-            }
-
-            vers.push(fi_vers);
-        }
-
-        let rollback_dir = Uuid::new_v4();
-
-        let disks = self.disks.read().await;
-
-        let disks = disks.clone();
-
-        let mut futures = Vec::with_capacity(disks.len());
-
-        // let mut errors = Vec::with_capacity(disks.len());
-
-        for disk in disks.iter() {
-            let vers = vers.clone();
-            futures.push(async move {
-                if let Some(disk) = disk {
-                    disk.delete_versions(
-                        bucket,
-                        vers,
-                        DeleteOptions {
-                            old_data_dir: Some(rollback_dir),
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                } else {
-                    let mut errs = Vec::with_capacity(vers.len());
-                    for _ in 0..vers.len() {
-                        errs.push(Some(DiskError::DiskNotFound));
+                        let mut errs = Vec::with_capacity(vers.len());
+                        for _ in 0..vers.len() {
+                            errs.push(Some(DiskError::DiskNotFound));
+                        }
+                        errs
                     }
-                    errs
-                }
-            });
-        }
+                });
+            }
 
-        let results = join_all(futures).await;
+            let results = join_all(futures).await;
+            let lost_during_forward = dist_batch_lock_lease.lost_objects();
 
-        let mut del_obj_errs: Vec<Vec<Option<DiskError>>> = vec![vec![None; objects.len()]; disks.len()];
+            let mut del_obj_errs: Vec<Vec<Option<DiskError>>> = vec![vec![None; objects.len()]; disks.len()];
 
-        // For each disk delete all objects
-        for (disk_idx, errors) in results.into_iter().enumerate() {
-            // Deletion results for all objects
-            for idx in 0..vers.len() {
-                if errors[idx].is_some() {
-                    for fi in vers[idx].versions.iter() {
-                        del_obj_errs[disk_idx][fi.idx] = errors[idx].clone();
+            // For each disk delete all objects
+            for (disk_idx, errors) in results.into_iter().enumerate() {
+                // Deletion results for all objects
+                for (idx, versions) in vers.iter().enumerate() {
+                    let error = errors.get(idx).cloned().unwrap_or(Some(DiskError::Unexpected));
+                    if error.is_some() {
+                        for fi in &versions.versions {
+                            del_obj_errs[disk_idx][fi.idx] = error.clone();
+                        }
                     }
                 }
             }
-        }
 
-        for obj_idx in 0..objects.len() {
-            let mut disk_err = vec![None; disks.len()];
-
-            for disk_idx in 0..disks.len() {
-                if del_obj_errs[disk_idx][obj_idx].is_some() {
-                    disk_err[disk_idx] = del_obj_errs[disk_idx][obj_idx].clone();
+            for obj_idx in 0..objects.len() {
+                if lost_during_forward.contains(&objects[obj_idx].object_name) {
+                    del_errs[obj_idx] = Some(Error::other("distributed delete lock quorum was lost"));
+                    continue;
                 }
-            }
+                let mut disk_err = vec![None; disks.len()];
 
-            let mut has_err = reduce_write_quorum_errs(&disk_err, OBJECT_OP_IGNORED_ERRS, disks.len() / 2 + 1);
-            if let Some(err) = has_err.clone() {
-                let er = err.into();
-                if (is_err_object_not_found(&er) || is_err_version_not_found(&er)) && !del_objects[obj_idx].delete_marker {
-                    has_err = None;
+                for disk_idx in 0..disks.len() {
+                    if del_obj_errs[disk_idx][obj_idx].is_some() {
+                        disk_err[disk_idx] = del_obj_errs[disk_idx][obj_idx].clone();
+                    }
                 }
-            } else {
-                del_objects[obj_idx].found = true;
-            }
 
-            if let Some(err) = has_err {
-                if del_objects[obj_idx].version_id.is_some() {
-                    del_errs[obj_idx] = Some(to_object_err(
-                        err.into(),
-                        vec![
-                            bucket,
-                            &objects[obj_idx].object_name.clone(),
-                            &objects[obj_idx].version_id.unwrap_or_default().to_string(),
-                        ],
-                    ));
+                let mut has_err = reduce_write_quorum_errs(&disk_err, OBJECT_OP_IGNORED_ERRS, disks.len() / 2 + 1);
+                if let Some(err) = has_err.clone() {
+                    let er = err.into();
+                    if (is_err_object_not_found(&er) || is_err_version_not_found(&er)) && !del_objects[obj_idx].delete_marker {
+                        has_err = None;
+                    }
                 } else {
-                    del_errs[obj_idx] = Some(to_object_err(err.into(), vec![bucket, &objects[obj_idx].object_name.clone()]));
+                    del_objects[obj_idx].found = true;
+                }
+
+                if let Some(err) = has_err {
+                    if del_objects[obj_idx].version_id.is_some() {
+                        del_errs[obj_idx] = Some(to_object_err(
+                            err.into(),
+                            vec![
+                                bucket,
+                                &objects[obj_idx].object_name.clone(),
+                                &objects[obj_idx].version_id.unwrap_or_default().to_string(),
+                            ],
+                        ));
+                    } else {
+                        del_errs[obj_idx] = Some(to_object_err(err.into(), vec![bucket, &objects[obj_idx].object_name.clone()]));
+                    }
                 }
             }
-        }
 
-        self.record_capacity_scope_if_needed(opts.capacity_scope_token, &disks);
+            set.record_capacity_scope_if_needed(opts.capacity_scope_token, &disks);
 
-        let mut rollback_futures = Vec::new();
-        for fi_vers in &vers {
-            // delete_versions commits one xl.meta per object group, so rollback must use the same boundary.
-            let should_rollback = fi_vers.versions.iter().any(|fi| del_errs[fi.idx].is_some());
-            for (disk_idx, disk) in disks.iter().enumerate() {
-                // backlog#1158: on rollback, include every online disk so a disk that
-                // staged + applied the delete and then errored is still restored (the
-                // disk-side undo is idempotent, no-op when nothing was staged). On
-                // success, skip the errored disks and only clean up successful ones.
-                if !should_rollback && fi_vers.versions.iter().any(|fi| del_obj_errs[disk_idx][fi.idx].is_some()) {
-                    continue;
-                }
+            // A failed RPC has an ambiguous commit outcome, so compensate every disk
+            // that received the forward request. Both rollback and cleanup are
+            // idempotent when that disk never created rollback state.
+            let rollback_versions: Vec<_> = vers
+                .iter()
+                .filter(|fi_vers| fi_vers.versions.iter().any(|fi| del_errs[fi.idx].is_some()))
+                .cloned()
+                .collect();
+            let cleanup_paths: Vec<_> = vers
+                .iter()
+                .filter(|fi_vers| fi_vers.versions.iter().all(|fi| del_errs[fi.idx].is_none()))
+                .map(|fi_vers| format!("{}/{rollback_dir}", fi_vers.name))
+                .collect();
 
-                let Some(disk) = disk.as_ref() else {
-                    continue;
-                };
+            if !rollback_versions.is_empty() {
+                let mut rollback_futures = Vec::new();
+                for (disk_index, disk) in disks.iter().enumerate() {
+                    #[cfg(not(test))]
+                    let _ = disk_index;
+                    let Some(disk) = disk.as_ref() else {
+                        continue;
+                    };
 
-                let disk = disk.clone();
-                let bucket = bucket.to_string();
-                let object = fi_vers.name.clone();
-                let versions = fi_vers.clone();
-                rollback_futures.push(async move {
-                    if should_rollback {
+                    let disk = disk.clone();
+                    let bucket = bucket.to_string();
+                    let rollback_versions = rollback_versions.clone();
+                    rollback_futures.push(async move {
+                        #[cfg(test)]
+                        record_batch_delete_test_call(
+                            BatchDeleteTestPhase::Rollback,
+                            disk_index,
+                            rollback_versions.len(),
+                            rollback_versions
+                                .iter()
+                                .any(|versions| versions.name.starts_with(BATCH_DELETE_SCALE_TEST_PREFIX)),
+                        );
+                        let mut rollback_objects = Vec::with_capacity(rollback_versions.len());
+                        for versions in &rollback_versions {
+                            rollback_objects.push(versions.name.clone());
+                        }
                         let errs = disk
                             .delete_versions(
                                 &bucket,
-                                vec![versions],
+                                rollback_versions,
                                 DeleteOptions {
                                     undo_write: true,
                                     undo_delete: true,
@@ -1838,7 +2024,11 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
                                 },
                             )
                             .await;
-                        if let Some(err) = errs.into_iter().flatten().next() {
+                        for (object, err) in rollback_objects
+                            .into_iter()
+                            .zip(errs)
+                            .filter_map(|(object, err)| err.map(|err| (object, err)))
+                        {
                             warn!(
                                 bucket = %bucket,
                                 object = %object,
@@ -1847,192 +2037,222 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
                                 "failed to roll back batch delete after write quorum failure"
                             );
                         }
-                    } else {
-                        let rollback_path = format!("{object}/{rollback_dir}");
-                        if let Err(err) = disk
-                            .delete(
-                                &bucket,
-                                &rollback_path,
-                                DeleteOptions {
-                                    recursive: true,
-                                    immediate: true,
-                                    ..Default::default()
-                                },
-                            )
-                            .await
+                    });
+                }
+                join_all(rollback_futures).await;
+            }
+
+            if !cleanup_paths.is_empty() {
+                let cleanup_paths = Arc::new(cleanup_paths);
+                let mut cleanup_futures = Vec::new();
+                for (_disk_index, disk) in disks
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, disk)| disk.as_ref().map(|disk| (index, disk)))
+                {
+                    let disk = disk.clone();
+                    let bucket = bucket.to_string();
+                    let cleanup_paths = Arc::clone(&cleanup_paths);
+                    cleanup_futures.push(async move {
+                        #[cfg(test)]
+                        record_batch_delete_test_call(
+                            BatchDeleteTestPhase::Cleanup,
+                            _disk_index,
+                            cleanup_paths.len(),
+                            cleanup_paths
+                                .iter()
+                                .any(|path| path.starts_with(BATCH_DELETE_SCALE_TEST_PREFIX)),
+                        );
+                        if let Err(err) = disk.delete_paths(&bucket, cleanup_paths.as_slice()).await
                             && err != DiskError::FileNotFound
                             && err != DiskError::VolumeNotFound
                         {
                             warn!(
                                 bucket = %bucket,
-                                object = %object,
                                 rollback_dir = %rollback_dir,
                                 error = ?err,
                                 "failed to clean batch delete rollback state after quorum success"
                             );
                         }
-                    }
-                });
+                    });
+                }
+                join_all(cleanup_futures).await;
             }
-        }
 
-        join_all(rollback_futures).await;
+            // TODO: add_partial
 
-        // TODO: add_partial
-
-        if dist_erasure {
-            self.release_dist_delete_object_locks_batch(dist_batch_lock_ids).await;
-        }
-
-        for (object, err) in objects.iter().zip(del_errs.iter()) {
-            if err.is_none() {
-                self.invalidate_get_object_metadata_cache(bucket, &object.object_name).await;
+            if dist_erasure {
+                dist_batch_lock_lease.stop_heartbeat().await;
+                set.release_dist_delete_object_locks_batch(std::mem::take(&mut dist_batch_lock_lease.lock_ids_by_client))
+                    .await;
             }
-        }
 
-        (del_objects, del_errs)
+            for (object, err) in objects.iter().zip(del_errs.iter()) {
+                if err.is_none() {
+                    set.invalidate_get_object_metadata_cache(bucket, &object.object_name).await;
+                }
+            }
+
+            (del_objects, del_errs)
+        })
+        .await
     }
 
     #[tracing::instrument(skip(self))]
     async fn delete_object(&self, bucket: &str, object: &str, mut opts: ObjectOptions) -> Result<ObjectInfo> {
-        self.invalidate_get_object_metadata_cache(bucket, object).await;
+        let set = self.clone();
+        let bucket = bucket.to_string();
+        let object = object.to_string();
+        cancellation_shield(async move {
+            let bucket = bucket.as_str();
+            let object = object.as_str();
+            set.invalidate_get_object_metadata_cache(bucket, object).await;
 
-        // Guard lock for single object delete
-        let _lock_guard = if (!opts.delete_prefix || opts.delete_prefix_object) && !opts.no_lock {
-            Some(self.acquire_write_lock_diag("delete_object", bucket, object).await?)
-        } else {
-            None
-        };
-        if opts.delete_prefix {
-            self.delete_prefix(bucket, object)
-                .await
-                .map_err(|e| to_object_err(e.into(), vec![bucket, object]))?;
-
-            self.get_object_metadata_cache.invalidate_all();
-            return Ok(ObjectInfo::default());
-        }
-
-        // TODO: Lifecycle
-
-        let mut version_found = true;
-        let (mut goi, write_quorum, gerr) = self.get_object_info_and_quorum(bucket, object, &opts).await;
-        if let Some(err) = &gerr
-            && goi.name.is_empty()
-        {
-            if should_force_delete_marker_for_missing_version(&opts) {
-                version_found = false;
-            } else {
-                return Err(err.clone());
-            }
-        }
-
-        if version_found {
-            check_object_lock_delete(bucket, object, &goi, &opts).await?;
-        }
-
-        let otd = ObjectToDelete {
-            object_name: object.to_string(),
-            version_id: opts
-                .version_id
-                .clone()
-                .map(|v| Uuid::parse_str(v.as_str()).ok().unwrap_or_default()),
-            ..Default::default()
-        };
-
-        let dsc = if should_preserve_delete_replication_state(&opts) {
-            ReplicateDecision::default()
-        } else {
-            ReplicationObjectBridge::check_delete(bucket, &otd, &goi, &opts, gerr.map(|e| e.to_string())).await
-        };
-
-        if dsc.replicate_any() {
-            opts.set_delete_replication_state(dsc);
-            goi.replication_decision = opts
-                .delete_replication
-                .as_ref()
-                .map(|v| v.replicate_decision_str.clone())
-                .unwrap_or_default();
-        }
-
-        let (mark_delete, mut delete_marker) = resolve_delete_version_state(&opts, &goi, version_found);
-
-        let mod_time = if let Some(mt) = opts.mod_time {
-            mt
-        } else {
-            OffsetDateTime::now_utc()
-        };
-
-        let find_vid = Uuid::new_v4();
-
-        if mark_delete && (opts.versioned || opts.version_suspended) {
-            if !delete_marker {
-                delete_marker = opts.version_suspended && opts.version_id.is_none();
-            }
-
-            let mut fi = FileInfo {
-                name: object.to_string(),
-                deleted: delete_marker,
-                mark_deleted: mark_delete,
-                mod_time: Some(mod_time),
-                replication_state_internal: opts.delete_replication.as_ref().map(replication_state_to_filemeta),
-                ..Default::default() // TODO: Transition
-            };
-
-            fi.set_tier_free_version_id(&find_vid.to_string());
-
-            if opts.skip_free_version {
-                fi.set_skip_tier_free_version();
-            }
-
-            fi.version_id = if let Some(vid) = opts.version_id.as_ref() {
-                Some(Uuid::parse_str(vid.as_str())?)
-            } else if opts.versioned {
-                Some(Uuid::new_v4())
+            // Guard lock for single object delete
+            let lock_guard = if (!opts.delete_prefix || opts.delete_prefix_object) && !opts.no_lock {
+                Some(set.acquire_write_lock_diag("delete_object", bucket, object).await?)
             } else {
                 None
             };
+            if opts.delete_prefix {
+                set.delete_prefix(bucket, object)
+                    .await
+                    .map_err(|e| to_object_err(e.into(), vec![bucket, object]))?;
 
-            self.delete_object_version(bucket, object, &fi, should_force_delete_marker_for_missing_version(&opts))
+                set.get_object_metadata_cache.invalidate_all();
+                return Ok(ObjectInfo::default());
+            }
+
+            // TODO: Lifecycle
+
+            let mut version_found = true;
+            let (mut goi, write_quorum, gerr) = set.get_object_info_and_quorum(bucket, object, &opts).await;
+            if let Some(err) = &gerr
+                && goi.name.is_empty()
+            {
+                if should_force_delete_marker_for_missing_version(&opts) {
+                    version_found = false;
+                } else {
+                    return Err(err.clone());
+                }
+            }
+
+            if version_found {
+                check_object_lock_delete(bucket, object, &goi, &opts).await?;
+            }
+
+            let otd = ObjectToDelete {
+                object_name: object.to_string(),
+                version_id: opts
+                    .version_id
+                    .clone()
+                    .map(|v| Uuid::parse_str(v.as_str()).ok().unwrap_or_default()),
+                ..Default::default()
+            };
+
+            let dsc = if should_preserve_delete_replication_state(&opts) {
+                ReplicateDecision::default()
+            } else {
+                ReplicationObjectBridge::check_delete(bucket, &otd, &goi, &opts, gerr.map(|e| e.to_string())).await
+            };
+
+            if dsc.replicate_any() {
+                opts.set_delete_replication_state(dsc);
+                goi.replication_decision = opts
+                    .delete_replication
+                    .as_ref()
+                    .map(|v| v.replicate_decision_str.clone())
+                    .unwrap_or_default();
+            }
+
+            let (mark_delete, mut delete_marker) = resolve_delete_version_state(&opts, &goi, version_found);
+
+            let mod_time = if let Some(mt) = opts.mod_time {
+                mt
+            } else {
+                OffsetDateTime::now_utc()
+            };
+
+            let find_vid = Uuid::new_v4();
+
+            if mark_delete && (opts.versioned || opts.version_suspended) {
+                if !delete_marker {
+                    delete_marker = opts.version_suspended && opts.version_id.is_none();
+                }
+
+                let mut fi = FileInfo {
+                    name: object.to_string(),
+                    deleted: delete_marker,
+                    mark_deleted: mark_delete,
+                    mod_time: Some(mod_time),
+                    replication_state_internal: opts.delete_replication.as_ref().map(replication_state_to_filemeta),
+                    ..Default::default() // TODO: Transition
+                };
+
+                fi.set_tier_free_version_id(&find_vid.to_string());
+
+                if opts.skip_free_version {
+                    fi.set_skip_tier_free_version();
+                }
+
+                fi.version_id = if let Some(vid) = opts.version_id.as_ref() {
+                    Some(Uuid::parse_str(vid.as_str())?)
+                } else if opts.versioned {
+                    Some(Uuid::new_v4())
+                } else {
+                    None
+                };
+
+                delete_object_version_with_guard(
+                    &set,
+                    bucket,
+                    object,
+                    &fi,
+                    should_force_delete_marker_for_missing_version(&opts),
+                    lock_guard.as_ref(),
+                )
                 .await
                 .map_err(|e| to_object_err(e, vec![bucket, object]))?;
 
-            let disks = self.disk_inventory().await;
-            self.record_capacity_scope_if_needed(opts.capacity_scope_token, &disks);
+                let disks = set.disk_inventory().await;
+                set.record_capacity_scope_if_needed(opts.capacity_scope_token, &disks);
 
-            let mut oi = ObjectInfo::from_file_info(&fi, bucket, object, opts.versioned || opts.version_suspended);
-            oi.replication_decision = goi.replication_decision;
-            self.invalidate_get_object_metadata_cache(bucket, object).await;
-            return Ok(oi);
-        }
+                let mut oi = ObjectInfo::from_file_info(&fi, bucket, object, opts.versioned || opts.version_suspended);
+                oi.replication_decision = goi.replication_decision;
+                set.invalidate_get_object_metadata_cache(bucket, object).await;
+                return Ok(oi);
+            }
 
-        // Create a single object deletion request
-        let mut dfi = FileInfo {
-            name: object.to_string(),
-            version_id: opts.version_id.as_ref().and_then(|v| Uuid::parse_str(v).ok()),
-            mark_deleted: mark_delete,
-            deleted: delete_marker,
-            mod_time: Some(mod_time),
-            replication_state_internal: opts.delete_replication.as_ref().map(replication_state_to_filemeta),
-            ..Default::default()
-        };
+            // Create a single object deletion request
+            let mut dfi = FileInfo {
+                name: object.to_string(),
+                version_id: opts.version_id.as_ref().and_then(|v| Uuid::parse_str(v).ok()),
+                mark_deleted: mark_delete,
+                deleted: delete_marker,
+                mod_time: Some(mod_time),
+                replication_state_internal: opts.delete_replication.as_ref().map(replication_state_to_filemeta),
+                ..Default::default()
+            };
 
-        dfi.set_tier_free_version_id(&find_vid.to_string());
+            dfi.set_tier_free_version_id(&find_vid.to_string());
 
-        if opts.skip_free_version {
-            dfi.set_skip_tier_free_version();
-        }
+            if opts.skip_free_version {
+                dfi.set_skip_tier_free_version();
+            }
 
-        self.delete_object_version(bucket, object, &dfi, opts.delete_marker)
-            .await
-            .map_err(|e| to_object_err(e, vec![bucket, object]))?;
+            delete_object_version_with_guard(&set, bucket, object, &dfi, opts.delete_marker, lock_guard.as_ref())
+                .await
+                .map_err(|e| to_object_err(e, vec![bucket, object]))?;
 
-        let disks = self.disk_inventory().await;
-        self.record_capacity_scope_if_needed(opts.capacity_scope_token, &disks);
+            let disks = set.disk_inventory().await;
+            set.record_capacity_scope_if_needed(opts.capacity_scope_token, &disks);
 
-        let mut obj_info = ObjectInfo::from_file_info(&dfi, bucket, object, opts.versioned || opts.version_suspended);
-        obj_info.size = goi.size;
-        self.invalidate_get_object_metadata_cache(bucket, object).await;
-        Ok(obj_info)
+            let mut obj_info = ObjectInfo::from_file_info(&dfi, bucket, object, opts.versioned || opts.version_suspended);
+            obj_info.size = goi.size;
+            set.invalidate_get_object_metadata_cache(bucket, object).await;
+            Ok(obj_info)
+        })
+        .await
     }
 
     #[tracing::instrument(skip(self))]
@@ -2864,6 +3084,248 @@ mod put_object_tags_early_stop_regression_tests {
             },
         )
         .await;
+    }
+}
+
+#[cfg(test)]
+mod delete_rollback_ambiguous_outcome_tests {
+    use super::hermetic_set_disks_support::hermetic_set_disks;
+    use super::*;
+    use crate::disk::{DiskAPI as _, ReadOptions, STORAGE_FORMAT_FILE_BACKUP};
+    use std::path::Path;
+
+    async fn put_plain_object(set_disks: &Arc<SetDisks>, bucket: &str, object: &str) {
+        let mut reader = PutObjReader::from_vec(vec![7_u8; 1024]);
+        set_disks
+            .put_object(bucket, object, &mut reader, &ObjectOptions::default())
+            .await
+            .expect("plain object should be written");
+    }
+
+    fn contains_metadata_backup(path: &Path) -> bool {
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return false;
+        };
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry.file_name() == STORAGE_FORMAT_FILE_BACKUP || (entry_path.is_dir() && contains_metadata_backup(&entry_path)) {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn delete_versions_response_cardinality_mismatch_fails_closed() {
+        for results in [vec![], vec![None, None], vec![None, None, None, None]] {
+            let normalized = normalize_delete_versions_results(results, 3);
+            assert_eq!(normalized, vec![Some(DiskError::Unexpected); 3]);
+        }
+
+        let exact = vec![None, Some(DiskError::FileNotFound), None];
+        assert_eq!(normalize_delete_versions_results(exact.clone(), 3), exact);
+    }
+
+    #[tokio::test]
+    async fn single_delete_lock_loss_after_forward_rolls_back_before_return() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "single-delete-lock-loss-bucket";
+        let object = "single-delete-lock-loss-object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+        put_plain_object(&set_disks, bucket, object).await;
+
+        let guard = set_disks
+            .acquire_write_lock_diag("single_delete_lock_loss_test", bucket, object)
+            .await
+            .expect("test namespace lock should be acquired");
+        // The production signal is set by the distributed heartbeat. This test
+        // flag is consulted at the same post-forward fence inside
+        // delete_object_version, making the rollback branch deterministic.
+        guard.force_lock_lost_for_test();
+        let fi = FileInfo {
+            name: object.to_string(),
+            mod_time: Some(OffsetDateTime::now_utc()),
+            ..Default::default()
+        };
+
+        let err = delete_object_version_with_guard(&set_disks, bucket, object, &fi, false, Some(&guard))
+            .await
+            .expect_err("lease loss after forward must not ACK the delete");
+        assert!(
+            matches!(err, StorageError::NamespaceLockQuorumUnavailable { .. }),
+            "lease loss must remain a retryable namespace-lock error: {err:?}"
+        );
+
+        for (disk_index, disk) in disk_stores.iter().enumerate() {
+            disk.read_version("", bucket, object, "", &ReadOptions::default())
+                .await
+                .unwrap_or_else(|read_err| panic!("disk {disk_index} must be restored before the guard is released: {read_err}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn single_delete_rolls_back_disks_with_ambiguous_forward_errors() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "ambiguous-single-delete-bucket";
+        let object = "ambiguous-single-delete-object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+        put_plain_object(&set_disks, bucket, object).await;
+
+        inject_ambiguous_delete_failure(object, 0);
+        inject_ambiguous_delete_failure(object, 1);
+        set_disks
+            .delete_object(bucket, object, ObjectOptions::default())
+            .await
+            .expect_err("two ambiguous outcomes must fail the three-of-four write quorum");
+
+        for (disk_index, disk) in disk_stores.iter().enumerate() {
+            disk.read_version("", bucket, object, "", &ReadOptions::default())
+                .await
+                .unwrap_or_else(|err| panic!("disk {disk_index} must restore the object after quorum failure: {err}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_delete_rolls_back_ambiguous_object_and_cleans_success_state() {
+        let (temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "ambiguous-batch-delete-bucket";
+        let rollback_object = "ambiguous-batch-rollback-object";
+        let committed_object = "ambiguous-batch-committed-object";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+        put_plain_object(&set_disks, bucket, rollback_object).await;
+        put_plain_object(&set_disks, bucket, committed_object).await;
+
+        inject_ambiguous_delete_failure(rollback_object, 0);
+        inject_ambiguous_delete_failure(rollback_object, 1);
+        let objects = vec![
+            ObjectToDelete {
+                object_name: rollback_object.to_string(),
+                ..Default::default()
+            },
+            ObjectToDelete {
+                object_name: committed_object.to_string(),
+                ..Default::default()
+            },
+        ];
+        let (_deleted, errors) = set_disks.delete_objects(bucket, objects, ObjectOptions::default()).await;
+
+        assert!(errors[0].is_some(), "ambiguous object must report the quorum failure");
+        assert!(errors[1].is_none(), "independent object must commit successfully");
+        for (disk_index, disk) in disk_stores.iter().enumerate() {
+            disk.read_version("", bucket, rollback_object, "", &ReadOptions::default())
+                .await
+                .unwrap_or_else(|err| panic!("disk {disk_index} must restore the failed batch object: {err}"));
+            disk.read_version("", bucket, committed_object, "", &ReadOptions::default())
+                .await
+                .expect_err("the successful batch object must stay deleted");
+        }
+        let cleanup_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let active_backups = temp_dirs.iter().any(|temp_dir| {
+                [rollback_object, committed_object]
+                    .iter()
+                    .any(|object| contains_metadata_backup(&temp_dir.path().join(bucket).join(object)))
+            });
+            if !active_backups {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < cleanup_deadline,
+                "batch delete must eventually remove active rollback metadata"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn thousand_key_batch_aggregates_forward_rollback_and_cleanup_per_disk() {
+        const OBJECT_COUNT: usize = 1000;
+        const DISK_COUNT: usize = 4;
+
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(DISK_COUNT).await;
+        let bucket = "batch-delete-scale-bucket";
+        for disk in &disk_stores {
+            disk.make_volume(bucket).await.expect("bucket volume should be created");
+        }
+
+        clear_batch_delete_test_calls();
+        let objects: Vec<_> = (0..OBJECT_COUNT)
+            .map(|index| ObjectToDelete {
+                object_name: format!("{BATCH_DELETE_SCALE_TEST_PREFIX}{index:04}"),
+                ..Default::default()
+            })
+            .collect();
+        inject_ambiguous_delete_failure(&objects[0].object_name, 0);
+        inject_ambiguous_delete_failure(&objects[0].object_name, 1);
+
+        let (_deleted, errors) = set_disks
+            .delete_objects(
+                bucket,
+                objects,
+                ObjectOptions {
+                    no_lock: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(errors[0].is_some(), "the injected object must fail write quorum");
+        assert!(
+            errors[1..].iter().all(Option::is_none),
+            "unaffected objects must retain successful results"
+        );
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let calls = batch_delete_test_calls();
+            if calls
+                .iter()
+                .filter(|call| call.phase == BatchDeleteTestPhase::Cleanup)
+                .count()
+                == DISK_COUNT
+            {
+                assert_eq!(
+                    calls
+                        .iter()
+                        .filter(|call| call.phase == BatchDeleteTestPhase::Forward)
+                        .map(|call| call.item_count)
+                        .collect::<Vec<_>>(),
+                    vec![OBJECT_COUNT; DISK_COUNT],
+                    "forward delete must issue one full batch per disk"
+                );
+                assert_eq!(
+                    calls
+                        .iter()
+                        .filter(|call| call.phase == BatchDeleteTestPhase::Rollback)
+                        .map(|call| call.item_count)
+                        .collect::<Vec<_>>(),
+                    vec![1; DISK_COUNT],
+                    "rollback must issue one failed-object batch per disk"
+                );
+                assert_eq!(
+                    calls
+                        .iter()
+                        .filter(|call| call.phase == BatchDeleteTestPhase::Cleanup)
+                        .map(|call| call.item_count)
+                        .collect::<Vec<_>>(),
+                    vec![OBJECT_COUNT - 1; DISK_COUNT],
+                    "cleanup must issue one successful-object path batch per disk"
+                );
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "batch cleanup calls did not complete before the deadline"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        clear_batch_delete_test_calls();
     }
 }
 

--- a/crates/lock/src/client/mod.rs
+++ b/crates/lock/src/client/mod.rs
@@ -48,6 +48,11 @@ pub trait LockClient: Send + Sync + std::fmt::Debug {
     /// Refresh lock
     async fn refresh(&self, lock_id: &LockId) -> Result<bool>;
 
+    /// Refresh multiple locks. Per-lock results preserve not-found and backend errors independently.
+    async fn refresh_locks_batch(&self, lock_ids: &[LockId]) -> Vec<Result<bool>> {
+        join_all(lock_ids.iter().map(|lock_id| self.refresh(lock_id))).await
+    }
+
     /// Force release lock
     async fn force_release(&self, lock_id: &LockId) -> Result<bool>;
 

--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -172,35 +172,39 @@ pub struct DistributedLockGuard {
     lock_lost: Arc<LockLostSignal>,
 }
 
+struct HeartbeatConfig {
+    interval: Duration,
+    lease_ttl: Duration,
+    initial_confirmed_until: tokio::time::Instant,
+    refresh_quorum: usize,
+    owner: String,
+    resource: ObjectKey,
+}
+
 impl DistributedLockGuard {
     /// Create a new guard.
     ///
     /// - `lock_id` is the id returned to the caller (`lock_id()`).
     /// - `entries` is the full list of underlying (LockId, client) pairs
     ///   that should be released when this guard is dropped.
-    /// - `refresh_interval`: `Some` spawns a heartbeat that refreshes every entry on that
-    ///   cadence; `None` (degenerate/single-client, or interval derived away) spawns nothing.
-    /// - `refresh_quorum`: minimum refreshes that must keep succeeding; if `not_found` exceeds
-    ///   `entries.len() - refresh_quorum` the guard is declared lost.
-    /// - `owner`/`resource`: diagnostics only.
-    pub(crate) fn new(
+    /// - `heartbeat`: `Some` spawns lease renewal; `None` is used by paths that
+    ///   do not need renewal. The config keeps TTL, quorum, and diagnostics
+    ///   together so they cannot drift between construction and the task.
+    fn new(
         lock_id: LockId,
         entries: Vec<(LockId, Arc<dyn LockClient>)>,
         lock_type: LockType,
-        refresh_interval: Option<Duration>,
-        refresh_quorum: usize,
-        owner: String,
-        resource: ObjectKey,
+        heartbeat: Option<HeartbeatConfig>,
     ) -> Self {
         record_lock_held_acquire(lock_type);
         let lock_lost = Arc::new(LockLostSignal::default());
-        let refresh_task = refresh_interval.and_then(|interval| {
+        let refresh_task = heartbeat.and_then(|heartbeat| {
             // Only spawn when a tokio runtime is available; guard construction off-runtime
             // (e.g. some tests) simply skips the heartbeat.
             tokio::runtime::Handle::try_current().ok().map(|handle| {
                 let entries = entries.clone();
                 let lock_lost = lock_lost.clone();
-                handle.spawn(Self::run_heartbeat(entries, interval, refresh_quorum, lock_lost, owner, resource))
+                handle.spawn(Self::run_heartbeat(entries, heartbeat, lock_lost))
             })
         });
         Self {
@@ -214,20 +218,18 @@ impl DistributedLockGuard {
     }
 
     /// Heartbeat loop: every `interval`, refresh all entries and classify the outcomes.
-    /// `Ok(true)` = refreshed, `Ok(false)` = not_found, `Err` = RPC jitter (ignored, absorbed by
-    /// the ttl > interval margin and retried next tick). Declares the lock lost when
-    /// `not_found > entries.len() - refresh_quorum`. Phase 1 does not release on loss: the guarded
-    /// operation is still running, and tearing the lock down here would only widen the window.
+    /// `Ok(true)` refreshes the confirmed lease, `Ok(false)` invalidates it
+    /// immediately, and `Err` is tolerated only until the previous confirmation
+    /// expires. Phase 1 does not release on loss: the guarded operation is still
+    /// running, and tearing the lock down here would only widen the window.
     async fn run_heartbeat(
         entries: Vec<(LockId, Arc<dyn LockClient>)>,
-        interval: Duration,
-        refresh_quorum: usize,
+        heartbeat: HeartbeatConfig,
         lock_lost: Arc<LockLostSignal>,
-        owner: String,
-        resource: ObjectKey,
     ) {
-        let tolerable_not_found = entries.len().saturating_sub(refresh_quorum);
-        let mut ticker = tokio::time::interval(interval);
+        let tolerable_not_found = entries.len().saturating_sub(heartbeat.refresh_quorum);
+        let mut confirmed_until = vec![heartbeat.initial_confirmed_until; entries.len()];
+        let mut ticker = tokio::time::interval(heartbeat.interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         // The first tick fires immediately; skip it so the first refresh lands one interval
         // after acquisition rather than right away.
@@ -235,6 +237,7 @@ impl DistributedLockGuard {
         loop {
             ticker.tick().await;
 
+            let refresh_started = tokio::time::Instant::now();
             let results = join_all(entries.iter().map(|(lock_id, client)| {
                 let lock_id = lock_id.clone();
                 let client = client.clone();
@@ -242,26 +245,39 @@ impl DistributedLockGuard {
             }))
             .await;
 
+            let now = tokio::time::Instant::now();
             let mut refreshed = 0usize;
-            let mut not_found = 0usize;
-            for result in &results {
+            let mut unavailable = 0usize;
+            for (index, result) in results.iter().enumerate() {
                 match result {
-                    Ok(true) => refreshed += 1,
-                    Ok(false) => not_found += 1,
-                    // RPC jitter: count as neither; the ttl > interval margin covers a transient
-                    // dip and the next tick retries.
+                    Ok(true) => {
+                        let expires_at = refresh_started + heartbeat.lease_ttl;
+                        confirmed_until[index] = expires_at;
+                        if now < expires_at {
+                            refreshed += 1;
+                        } else {
+                            unavailable += 1;
+                        }
+                    }
+                    Ok(false) => unavailable += 1,
+                    // A transient RPC error remains tolerated while the last
+                    // confirmed lease is valid. Once that TTL expires, the
+                    // backend may have granted the resource to another owner,
+                    // so treating the old guard as valid would permit a stale
+                    // writer to commit.
+                    Err(_) if now >= confirmed_until[index] => unavailable += 1,
                     Err(_) => {}
                 }
             }
 
-            if not_found > tolerable_not_found {
+            if unavailable > tolerable_not_found {
                 warn!(
-                    resource = %resource,
-                    owner = %owner,
+                    resource = %heartbeat.resource,
+                    owner = %heartbeat.owner,
                     refreshed,
-                    not_found,
+                    unavailable,
                     entries = entries.len(),
-                    refresh_quorum,
+                    refresh_quorum = heartbeat.refresh_quorum,
                     "lock refresh lost quorum"
                 );
                 record_lock_refresh_quorum_lost();
@@ -419,6 +435,11 @@ impl DistributedLock {
             return Err(LockError::internal("No lock clients available"));
         }
 
+        // Use the beginning of acquisition as the conservative initial lease
+        // confirmation point. Individual backends may grant at different times;
+        // starting the TTL at guard construction would overestimate the oldest
+        // lease and could briefly treat an expired guard as valid.
+        let acquisition_started = tokio::time::Instant::now();
         let required_quorum = self.required_quorum(request.lock_type);
         let LockAcquireQuorumResult {
             response: resp,
@@ -443,10 +464,14 @@ impl DistributedLock {
                 aggregate_lock_id,
                 individual_locks,
                 request.lock_type,
-                refresh_interval,
-                required_quorum,
-                request.owner.clone(),
-                request.resource.clone(),
+                refresh_interval.map(|interval| HeartbeatConfig {
+                    interval,
+                    lease_ttl: request.ttl,
+                    initial_confirmed_until: acquisition_started + request.ttl,
+                    refresh_quorum: required_quorum,
+                    owner: request.owner.clone(),
+                    resource: request.resource.clone(),
+                }),
             )))
         } else {
             // Check if it's a timeout or quorum failure
@@ -1020,9 +1045,10 @@ mod tests {
 
     #[derive(Clone, Copy, Debug)]
     enum RefreshOutcome {
-        Alive,    // Ok(true)  refresh succeeded
-        NotFound, // Ok(false) remote already lost the lock (reclaimed / never held)
-        RpcError, // Err        RPC jitter
+        Alive,                  // Ok(true)  refresh succeeded
+        DelayedAlive(Duration), // Ok(true) after response delay
+        NotFound,               // Ok(false) remote already lost the lock (reclaimed / never held)
+        RpcError,               // Err        RPC jitter
     }
 
     /// Counting test client: acquires successfully and echoes back request.lock_id as
@@ -1071,6 +1097,10 @@ mod tests {
             self.refresh_calls.fetch_add(1, Ordering::SeqCst);
             match self.outcome {
                 RefreshOutcome::Alive => Ok(true),
+                RefreshOutcome::DelayedAlive(delay) => {
+                    tokio::time::sleep(delay).await;
+                    Ok(true)
+                }
                 RefreshOutcome::NotFound => Ok(false),
                 RefreshOutcome::RpcError => Err(LockError::internal("refresh rpc jitter")),
             }
@@ -1239,9 +1269,10 @@ mod tests {
         );
     }
 
-    // A5 -- refresh RPC jitter (Err) is not counted as not_found; the lock is not declared lost.
+    // A5 -- refresh RPC jitter is tolerated within the last confirmed TTL, but
+    // must fence the guard once that TTL expires.
     #[tokio::test]
-    async fn heartbeat_rpc_error_not_counted_as_lock_lost() {
+    async fn heartbeat_rpc_error_fences_after_confirmed_lease_expires() {
         let (clients, _counters) = counting_clients(&[
             RefreshOutcome::RpcError,
             RefreshOutcome::RpcError,
@@ -1258,7 +1289,37 @@ mod tests {
 
         assert!(
             !guard.is_lock_lost(),
-            "RPC jitter (Err) must NOT be counted as not_found; lock must not be declared lost"
+            "transient RPC jitter within the confirmed lease TTL must be tolerated"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            guard.is_lock_lost(),
+            "RPC errors beyond the last confirmed lease TTL must fence the stale guard"
+        );
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn delayed_refresh_success_does_not_extend_lease_from_response_time() {
+        let delay = Duration::from_millis(120);
+        let (clients, _counters) = counting_clients(&[
+            RefreshOutcome::DelayedAlive(delay),
+            RefreshOutcome::DelayedAlive(delay),
+            RefreshOutcome::DelayedAlive(delay),
+            RefreshOutcome::DelayedAlive(delay),
+        ]);
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "delayed-refresh"), LockType::Exclusive, "owner")
+            .with_ttl(Duration::from_millis(60))
+            .with_refresh_interval(Duration::from_millis(10));
+
+        let guard = lock.acquire_guard(&request).await.unwrap().unwrap();
+        tokio::time::sleep(Duration::from_millis(170)).await;
+
+        assert!(
+            guard.is_lock_lost(),
+            "a success response received after request-start + TTL must not revive an expired lease"
         );
         drop(guard);
     }

--- a/crates/protos/src/generated/proto_gen/node_service.rs
+++ b/crates/protos/src/generated/proto_gen/node_service.rs
@@ -1884,6 +1884,21 @@ pub mod node_service_client {
                 .insert(GrpcMethod::new("node_service.NodeService", "Refresh"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn refresh_batch(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BatchGenerallyLockRequest>,
+        ) -> std::result::Result<tonic::Response<super::BatchGenerallyLockResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| tonic::Status::unknown(format!("Service was not ready: {}", e.into())))?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/node_service.NodeService/RefreshBatch");
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("node_service.NodeService", "RefreshBatch"));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn lock_batch(
             &mut self,
             request: impl tonic::IntoRequest<super::BatchGenerallyLockRequest>,
@@ -2699,6 +2714,10 @@ pub mod node_service_server {
             &self,
             request: tonic::Request<super::GenerallyLockRequest>,
         ) -> std::result::Result<tonic::Response<super::GenerallyLockResponse>, tonic::Status>;
+        async fn refresh_batch(
+            &self,
+            request: tonic::Request<super::BatchGenerallyLockRequest>,
+        ) -> std::result::Result<tonic::Response<super::BatchGenerallyLockResponse>, tonic::Status>;
         async fn lock_batch(
             &self,
             request: tonic::Request<super::BatchGenerallyLockRequest>,
@@ -4054,6 +4073,34 @@ pub mod node_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = RefreshSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(accept_compression_encodings, send_compression_encodings)
+                            .apply_max_message_size_config(max_decoding_message_size, max_encoding_message_size);
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/node_service.NodeService/RefreshBatch" => {
+                    #[allow(non_camel_case_types)]
+                    struct RefreshBatchSvc<T: NodeService>(pub Arc<T>);
+                    impl<T: NodeService> tonic::server::UnaryService<super::BatchGenerallyLockRequest> for RefreshBatchSvc<T> {
+                        type Response = super::BatchGenerallyLockResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::BatchGenerallyLockRequest>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { <T as NodeService>::refresh_batch(&inner, request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = RefreshBatchSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(accept_compression_encodings, send_compression_encodings)

--- a/crates/protos/src/lib.rs
+++ b/crates/protos/src/lib.rs
@@ -192,10 +192,29 @@ fn bulk_channel_pool_size() -> usize {
 /// acquisitions across the pool.
 static BULK_CHANNEL_CURSOR: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChannelRequestTimeout {
+    Default,
+    Disabled,
+}
+
+impl ChannelRequestTimeout {
+    fn duration(self) -> Option<Duration> {
+        match self {
+            Self::Default => Some(internode_rpc_timeout()),
+            Self::Disabled => None,
+        }
+    }
+}
+
 /// Connection-cache key for the `idx`-th bulk channel to `addr`. The NUL separator cannot appear
 /// in a URL, so a bulk key never collides with the control key (the bare `addr`).
 fn bulk_cache_key(addr: &str, idx: usize) -> String {
     format!("{addr}\u{0}bulk\u{0}{idx}")
+}
+
+fn transaction_cache_key(addr: &str) -> String {
+    format!("{addr}\u{0}transaction")
 }
 
 /// Acquire a cached-or-newly-dialed channel for the given peer and channel class.
@@ -221,7 +240,21 @@ pub async fn get_channel_for_class(addr: &str, class: ChannelClass) -> Result<Ch
         debug!("Using cached bulk gRPC channel {} for: {}", idx, addr);
         return Ok(channel);
     }
-    build_channel(addr, &cache_key).await
+    build_channel(addr, &cache_key, ChannelRequestTimeout::Default).await
+}
+
+/// Acquire a dedicated transaction channel without a per-RPC request timeout.
+///
+/// Connect timeout, TLS, TCP keepalive, and HTTP/2 keepalive remain enabled. The
+/// separate cache key prevents ordinary RPCs from accidentally inheriting the
+/// transaction channel's completion semantics.
+pub async fn get_transaction_channel(addr: &str) -> Result<Channel, Box<dyn Error>> {
+    let cache_key = transaction_cache_key(addr);
+    if let Some(channel) = cached_connection(&cache_key).await {
+        debug!("Using cached transaction gRPC channel for: {}", addr);
+        return Ok(channel);
+    }
+    build_channel(addr, &cache_key, ChannelRequestTimeout::Disabled).await
 }
 
 /// Creates a new gRPC channel with optimized keepalive settings for cluster resilience.
@@ -235,7 +268,7 @@ pub async fn get_channel_for_class(addr: &str, class: ChannelClass) -> Result<Ch
 /// - RPC timeout: `DEFAULT_INTERNODE_RPC_TIMEOUT_SECS` (10s)
 pub async fn create_new_channel(addr: &str) -> Result<Channel, Box<dyn Error>> {
     // The control channel is cached under the bare address, preserving the legacy key.
-    build_channel(addr, addr).await
+    build_channel(addr, addr, ChannelRequestTimeout::Default).await
 }
 
 /// Dial a new gRPC channel to `dial_addr` and cache it under `cache_key`.
@@ -244,15 +277,17 @@ pub async fn create_new_channel(addr: &str) -> Result<Channel, Box<dyn Error>> {
 /// `cache_key` is the connection-cache key. They are identical for control channels and differ
 /// for isolated bulk channels (see [`bulk_cache_key`]), letting several physically distinct
 /// channels to the same peer be cached independently.
-async fn build_channel(dial_addr: &str, cache_key: &str) -> Result<Channel, Box<dyn Error>> {
+async fn build_channel(
+    dial_addr: &str,
+    cache_key: &str,
+    request_timeout: ChannelRequestTimeout,
+) -> Result<Channel, Box<dyn Error>> {
     debug!("Creating new gRPC channel to: {} (cache key: {})", dial_addr, cache_key);
     let dial_started_at = Instant::now();
     let connect_timeout = internode_connect_timeout();
     let tcp_keepalive = internode_tcp_keepalive();
     let http2_keepalive_interval = internode_http2_keep_alive_interval();
     let http2_keepalive_timeout = internode_http2_keep_alive_timeout();
-    let rpc_timeout = internode_rpc_timeout();
-
     let mut connector = Endpoint::from_shared(dial_addr.to_string())?
         // Fast connection timeout for dead peer detection
         .connect_timeout(connect_timeout)
@@ -265,9 +300,13 @@ async fn build_channel(dial_addr: &str, cache_key: &str) -> Result<Channel, Box<
         // How long to wait for PING ACK before considering connection dead
         .keep_alive_timeout(http2_keepalive_timeout)
         // Send PINGs even when no active streams (critical for idle connections)
-        .keep_alive_while_idle(true)
-        // Overall timeout for any RPC - fail fast on unresponsive peers
-        .timeout(rpc_timeout);
+        .keep_alive_while_idle(true);
+
+    if let Some(timeout) = request_timeout.duration() {
+        // Ordinary RPCs fail fast on unresponsive peers. Transaction RPCs omit
+        // this layer so callers can observe their final server-side outcome.
+        connector = connector.timeout(timeout);
+    }
 
     // Raise HTTP/2 flow-control windows above the 64KiB library default so larger unary
     // responses (ReadMultiple/BatchReadVersion) are not throttled by the BDP. Mirrors the
@@ -391,6 +430,10 @@ pub async fn evict_failed_connection_with_log_level(addr: &str, log_level: Conne
     evict_connection_with_log_level(addr, cache_log_level).await;
     TLS_GENERATION_CACHE.lock().await.remove(addr);
 
+    let transaction_key = transaction_cache_key(addr);
+    evict_connection_with_log_level(&transaction_key, cache_log_level).await;
+    TLS_GENERATION_CACHE.lock().await.remove(&transaction_key);
+
     // An RPC-triggered eviction is a peer-failure signal; feed it into the online/offline state so
     // the peer flips offline after enough consecutive failures (grpc-optimization P3).
     runtime_sources::record_peer_unreachable(addr, internode_offline_failure_threshold());
@@ -443,6 +486,18 @@ mod tests {
         assert!(k0.starts_with(addr));
         // The NUL separator cannot appear in a URL, so a bulk key never equals a real address.
         assert!(k0.contains('\u{0}'));
+    }
+
+    #[test]
+    fn transaction_channel_has_distinct_cache_and_timeout_policy() {
+        let addr = "https://node-a:9000";
+        let transaction_key = transaction_cache_key(addr);
+
+        assert_ne!(transaction_key, addr);
+        assert!(transaction_key.starts_with(addr));
+        assert!(transaction_key.contains('\u{0}'));
+        assert!(ChannelRequestTimeout::Default.duration().is_some());
+        assert_eq!(ChannelRequestTimeout::Disabled.duration(), None);
     }
 
     #[test]

--- a/crates/protos/src/node.proto
+++ b/crates/protos/src/node.proto
@@ -908,6 +908,7 @@ service NodeService {
   rpc UnLock(GenerallyLockRequest) returns (GenerallyLockResponse) {};
   rpc ForceUnLock(GenerallyLockRequest) returns (GenerallyLockResponse) {};
   rpc Refresh(GenerallyLockRequest) returns (GenerallyLockResponse) {};
+  rpc RefreshBatch(BatchGenerallyLockRequest) returns (BatchGenerallyLockResponse) {};
   rpc LockBatch(BatchGenerallyLockRequest) returns (BatchGenerallyLockResponse) {};
   rpc UnLockBatch(BatchGenerallyLockRequest) returns (BatchGenerallyLockResponse) {};
 

--- a/docs/architecture/compat-cleanup-register.md
+++ b/docs/architecture/compat-cleanup-register.md
@@ -11,8 +11,28 @@ for later deletion.
 ```
 
 ## Open Items
+- #4648 walk-dir stream completion capability: old clients can append fallback output to an already-used metacache writer after a terminal body error, so servers emit terminal walk errors only to clients that sign the walk_dir_stream_completion=error-v1 query capability and its request-body digest. Remove the legacy clean-EOF path after the minimum supported RustFS peer version always advertises this capability.
 
-- `#4648` walk-dir stream completion capability: old clients can append fallback output to an already-used metacache writer after a terminal body error, so servers emit terminal walk errors only to clients that sign the `walk_dir_stream_completion=error-v1` query capability and its request-body digest. Remove the legacy clean-EOF path after the minimum supported RustFS peer version always advertises this capability.
+- `RUSTFS_COMPAT_TODO(RPC-4300)`
+  - Task: `RPC-4300`
+  - Files: `crates/ecstore/src/cluster/rpc/remote_disk.rs`, `crates/ecstore/src/disk/mod.rs`
+  - Why: delete rollback requests use a versioned envelope and fail closed before mutation on peers that cannot decode it. The unsafe 5-field transactional retry was removed; an exact decode-boundary rejection only caches the peer as unsupported, while ordinary non-transactional requests remain dual-encoded.
+  - Removal condition: remove the exact rejection matcher and unsupported-peer capability cache after the minimum supported rolling-upgrade predecessor handles delete rollback envelope version 1 for one full release window.
+  - Status: planned cleanup.
+
+- `RUSTFS_COMPAT_TODO(RPC-4300-RENAME)`
+  - Task: `RPC-4300-RENAME`
+  - Files: `crates/ecstore/src/cluster/rpc/remote_disk.rs`, `crates/ecstore/src/disk/mod.rs`, `rustfs/src/storage/rpc/node_service/disk.rs`
+  - Why: new senders detect predecessors that reject the versioned rename transaction envelope, cache that peer as unsupported, and fail closed. The unsafe legacy pre-stage and blind rollback fallback was removed.
+  - Removal condition: remove the exact decode-error matcher and unsupported-peer capability cache after the minimum supported rolling-upgrade predecessor accepts rename transaction envelope version 1 for one full release window.
+  - Status: planned cleanup.
+
+- `RUSTFS_COMPAT_TODO(RPC-4300-LOCK-REFRESH)`
+  - Task: `RPC-4300-LOCK-REFRESH`
+  - Files: `crates/ecstore/src/cluster/rpc/remote_locker.rs`, `crates/protos/src/node.proto`, `rustfs/src/storage/rpc/node_service/lock.rs`
+  - Why: long 1000-key deletes require one batched lease refresh per locker; rolling upgrades fall back to unary refresh when a predecessor does not implement the batch method.
+  - Removal condition: remove the unary fallback after every supported rolling-upgrade predecessor implements the batch refresh method. Negative capability evidence is intentionally not cached so an in-place peer upgrade can recover the batch path.
+  - Status: planned cleanup.
 
 ## Review Checklist
 

--- a/docs/operations/internode-msgpack-json-convergence-runbook.md
+++ b/docs/operations/internode-msgpack-json-convergence-runbook.md
@@ -84,16 +84,22 @@ first**. The following mapping is verified against the current code.
 ### `_bin` support added THIS release — converge after their own window
 
 The `DeleteVersion`/`DeleteVersions` protos had **no `_bin` fields**. They gained additive
-`*_bin` fields plus bin-first server decoders in this release, and the client now dual-writes
-them. They are **kept out** of the msgpack-only set (always dual-write) until their own
-fallback counter has read zero across a window with the new decoders fully deployed.
+`*_bin` fields plus bin-first server decoders in this release. Legacy-safe requests keep
+dual-writing until their own fallback counter has read zero across a window with the new
+decoders fully deployed. Delete rollback requests are the exception: they send a versioned
+MessagePack envelope and an empty JSON field so every predecessor rejects the request before
+mutation instead of decoding a shifted tuple layout. This fail-closed rejection is not visible
+in the JSON fallback counter. On a decode-boundary rejection only, the client retries the
+five-field compact layout supported by the #4300 predecessor; older four-field peers reject that
+layout at the fourth field before mutation. This retry is forbidden for rename compensation because
+the five-field layout cannot carry its transaction token. The discovered per-peer capability is cached.
 
 | Direction | Message / field | Status |
 |---|---|---|
 | request | `DeleteVersion.file_info` (`FileInfo`) | `_bin` added; dual-write; converge after window |
-| request | `DeleteVersion.opts` (`DeleteOptions`) | `_bin` added; dual-write; converge after window |
+| request | `DeleteVersion.opts` (`DeleteOptions`) | `_bin` added; dual-write unless delete rollback requires fail-closed compatibility |
 | request | `DeleteVersions.versions` (`FileInfoVersions`) | `_bin` added; dual-write; converge after window |
-| request | `DeleteVersions.opts` (`DeleteOptions`) | `_bin` added; dual-write; converge after window |
+| request | `DeleteVersions.opts` (`DeleteOptions`) | `_bin` added; dual-write unless delete rollback requires fail-closed compatibility |
 
 > Any `*_bin` proto field not in the tables above must be mapped to a confirmed `_bin`-first
 > peer decoder before it is added to the convergence set.

--- a/rustfs/src/storage/rpc/node_service.rs
+++ b/rustfs/src/storage/rpc/node_service.rs
@@ -536,6 +536,13 @@ impl Node for NodeService {
         self.handle_refresh(request).await
     }
 
+    async fn refresh_batch(
+        &self,
+        request: Request<BatchGenerallyLockRequest>,
+    ) -> Result<Response<BatchGenerallyLockResponse>, Status> {
+        self.handle_refresh_batch(request).await
+    }
+
     async fn lock_batch(
         &self,
         request: Request<BatchGenerallyLockRequest>,

--- a/rustfs/src/storage/rpc/node_service/disk.rs
+++ b/rustfs/src/storage/rpc/node_service/disk.rs
@@ -15,7 +15,8 @@
 use super::NodeService;
 use crate::storage::storage_api::rpc_consumer::node_service::{
     BatchReadVersionReq, BatchReadVersionResp, DeleteOptions, DiskError, DiskInfoOptions, FileInfoVersions, ReadMultipleReq,
-    ReadMultipleResp, ReadOptions, StorageDiskRpcExt as _, UpdateMetadataOpts, validate_batch_read_version_item_count,
+    ReadMultipleResp, ReadOptions, StorageDiskRpcExt as _, UpdateMetadataOpts, decode_delete_options_payload,
+    decode_rename_data_payload, validate_batch_read_version_item_count,
 };
 use crate::storage::storage_api::runtime_sources_consumer::runtime_sources;
 use bytes::Bytes;
@@ -26,13 +27,50 @@ use rustfs_io_metrics::internode_metrics::{
 };
 use rustfs_protos::proto_gen::node_service::*;
 use serde::de::DeserializeOwned;
-use std::io::Cursor;
+use std::{
+    future::Future,
+    io::Cursor,
+    sync::{Arc, LazyLock},
+};
+use tokio::sync::Semaphore;
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
 /// Initial capacity hint (bytes) for msgpack encode buffers, sized to cover a typical single-
 /// version `FileInfo` without repeated growth reallocations. Larger payloads still grow as needed.
 const MSGPACK_ENCODE_CAPACITY_HINT: usize = 512;
+const MAX_PROTECTED_DISK_MUTATIONS: usize = 256;
+static PROTECTED_DISK_MUTATIONS: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(MAX_PROTECTED_DISK_MUTATIONS)));
+
+fn validate_delete_versions_result_count(expected: usize, actual: usize) -> std::result::Result<(), DiskError> {
+    if actual == expected {
+        return Ok(());
+    }
+
+    Err(DiskError::other(format!(
+        "delete versions returned {actual} result(s) for {expected} request(s)"
+    )))
+}
+
+async fn run_protected_disk_mutation<T, F>(operation: &'static str, future: F) -> std::result::Result<T, DiskError>
+where
+    T: Send + 'static,
+    F: Future<Output = T> + Send + 'static,
+{
+    // Admission must not await in the request task: tonic may cancel that task
+    // before a rollback is handed to the supervisor. Reject saturation before
+    // mutation instead, then immediately detach every admitted operation.
+    let permit = Arc::clone(&PROTECTED_DISK_MUTATIONS)
+        .try_acquire_owned()
+        .map_err(|err| DiskError::other(format!("{operation} supervisor saturated: {err}")))?;
+    tokio::spawn(async move {
+        let _permit = permit;
+        future.await
+    })
+    .await
+    .map_err(|err| DiskError::other(format!("{operation} task failed: {err}")))
+}
 
 fn decode_msgpack_or_json<T: DeserializeOwned>(
     binary: &[u8],
@@ -327,7 +365,7 @@ impl NodeService {
                     }
                 };
             }
-            let opts = match decode_msgpack_or_json::<DeleteOptions>(&request.opts_bin, &request.opts, "DeleteOptions") {
+            let opts = match decode_delete_options_payload(&request.opts_bin, &request.opts) {
                 Ok(opts) => opts,
                 Err(err) => {
                     return Ok(Response::new(DeleteVersionsResponse {
@@ -337,10 +375,37 @@ impl NodeService {
                     }));
                 }
             };
+            let expected_result_count = versions.len();
 
-            let errors = disk
-                .delete_versions(&request.volume, versions, opts)
+            let volume = request.volume;
+            let protect_from_rpc_cancellation =
+                opts.old_data_dir.is_some() || opts.undo_write || opts.undo_delete || opts.rename_rollback_token.is_some();
+            let errors = if protect_from_rpc_cancellation {
+                match run_protected_disk_mutation("delete versions", async move {
+                    disk.delete_versions(&volume, versions, opts).await
+                })
                 .await
+                {
+                    Ok(errors) => errors,
+                    Err(err) => {
+                        return Ok(Response::new(DeleteVersionsResponse {
+                            success: false,
+                            errors: Vec::new(),
+                            error: Some(err.into()),
+                        }));
+                    }
+                }
+            } else {
+                disk.delete_versions(&volume, versions, opts).await
+            };
+            if let Err(err) = validate_delete_versions_result_count(expected_result_count, errors.len()) {
+                return Ok(Response::new(DeleteVersionsResponse {
+                    success: false,
+                    errors: Vec::new(),
+                    error: Some(err.into()),
+                }));
+            }
+            let errors = errors
                 .into_iter()
                 .map(|error| match error {
                     Some(e) => e.to_string(),
@@ -378,7 +443,7 @@ impl NodeService {
                     }));
                 }
             };
-            let opts = match decode_msgpack_or_json::<DeleteOptions>(&request.opts_bin, &request.opts, "DeleteOptions") {
+            let opts = match decode_delete_options_payload(&request.opts_bin, &request.opts) {
                 Ok(opts) => opts,
                 Err(err) => {
                     return Ok(Response::new(DeleteVersionResponse {
@@ -388,10 +453,30 @@ impl NodeService {
                     }));
                 }
             };
-            match disk
-                .delete_version(&request.volume, &request.path, file_info, request.force_del_marker, opts)
+            let volume = request.volume;
+            let path = request.path;
+            let force_del_marker = request.force_del_marker;
+            let protect_from_rpc_cancellation =
+                opts.old_data_dir.is_some() || opts.undo_write || opts.undo_delete || opts.rename_rollback_token.is_some();
+            let result = if protect_from_rpc_cancellation {
+                match run_protected_disk_mutation("delete version", async move {
+                    disk.delete_version(&volume, &path, file_info, force_del_marker, opts).await
+                })
                 .await
-            {
+                {
+                    Ok(result) => result,
+                    Err(err) => {
+                        return Ok(Response::new(DeleteVersionResponse {
+                            success: false,
+                            raw_file_info: String::new(),
+                            error: Some(err.into()),
+                        }));
+                    }
+                }
+            } else {
+                disk.delete_version(&volume, &path, file_info, force_del_marker, opts).await
+            };
+            match result {
                 Ok(raw_file_info) => match serde_json::to_string(&raw_file_info) {
                     Ok(raw_file_info) => Ok(Response::new(DeleteVersionResponse {
                         success: true,
@@ -775,8 +860,11 @@ impl NodeService {
     ) -> Result<Response<RenameDataResponse>, Status> {
         let request = request.into_inner();
         if let Some(disk) = self.find_disk(&request.disk).await {
-            let file_info = match decode_msgpack_or_json::<FileInfo>(&request.file_info_bin, &request.file_info, "FileInfo") {
-                Ok(file_info) => file_info,
+            if request.file_info_bin.is_empty() {
+                global_internode_metrics().record_msgpack_json_fallback(INTERNODE_MSGPACK_DIRECTION_REQUEST, "FileInfo");
+            }
+            let payload = match decode_rename_data_payload(&request.file_info_bin, &request.file_info) {
+                Ok(payload) => payload,
                 Err(err) => {
                     return Ok(Response::new(RenameDataResponse {
                         success: false,
@@ -786,10 +874,51 @@ impl NodeService {
                     }));
                 }
             };
-            match disk
-                .rename_data(&request.src_volume, &request.src_path, file_info, &request.dst_volume, &request.dst_path)
-                .await
-            {
+            let src_volume = request.src_volume;
+            let src_path = request.src_path;
+            let dst_volume = request.dst_volume;
+            let dst_path = request.dst_path;
+            let protect_from_rpc_cancellation = payload.rollback_token.is_some();
+            let operation = async move {
+                if let Some(rollback_token) = payload.rollback_token {
+                    crate::storage::storage_api::rpc_consumer::node_service::StorageDiskRpcExt::rename_data_with_rollback(
+                        disk.as_ref(),
+                        &src_volume,
+                        &src_path,
+                        payload.file_info,
+                        &dst_volume,
+                        &dst_path,
+                        rollback_token,
+                    )
+                    .await
+                } else {
+                    crate::storage::storage_api::rpc_consumer::node_service::StorageDiskRpcExt::rename_data(
+                        disk.as_ref(),
+                        &src_volume,
+                        &src_path,
+                        payload.file_info,
+                        &dst_volume,
+                        &dst_path,
+                    )
+                    .await
+                }
+            };
+            let result = if protect_from_rpc_cancellation {
+                match run_protected_disk_mutation("rename data", operation).await {
+                    Ok(result) => result,
+                    Err(err) => {
+                        return Ok(Response::new(RenameDataResponse {
+                            success: false,
+                            rename_data_resp: String::new(),
+                            rename_data_resp_bin: Vec::new().into(),
+                            error: Some(err.into()),
+                        }));
+                    }
+                }
+            } else {
+                operation.await
+            };
+            match result {
                 Ok(rename_data_resp) => {
                     let rename_data_resp_json = compat_response_json(&rename_data_resp);
                     let rename_data_resp_bin = encode_msgpack_named(&rename_data_resp, "RenameDataResp");
@@ -1176,16 +1305,29 @@ impl NodeService {
 mod tests {
     use super::{
         decode_msgpack_or_json, encode_batch_read_version_response_payloads, encode_msgpack,
-        encode_read_multiple_response_payloads,
+        encode_read_multiple_response_payloads, run_protected_disk_mutation, validate_delete_versions_result_count,
     };
     use crate::storage::storage_api::ReadMultipleResp;
     use crate::storage::storage_api::rpc_consumer::node_service::BatchReadVersionResp;
     use serde::{Deserialize, Serialize};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use tokio::sync::Notify;
 
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct SamplePayload {
         name: String,
         count: u32,
+    }
+
+    #[test]
+    fn delete_versions_result_count_must_match_request_count() {
+        assert!(validate_delete_versions_result_count(0, 0).is_ok());
+        assert!(validate_delete_versions_result_count(3, 3).is_ok());
+        assert!(validate_delete_versions_result_count(3, 2).is_err());
+        assert!(validate_delete_versions_result_count(3, 4).is_err());
     }
 
     #[test]
@@ -1213,6 +1355,36 @@ mod tests {
                 count: 7,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn protected_disk_mutation_survives_parent_cancellation() {
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let completed = Arc::new(AtomicBool::new(false));
+        let task_entered = Arc::clone(&entered);
+        let task_release = Arc::clone(&release);
+        let task_completed = Arc::clone(&completed);
+
+        let parent = tokio::spawn(async move {
+            run_protected_disk_mutation("test mutation", async move {
+                task_entered.notify_one();
+                task_release.notified().await;
+                task_completed.store(true, Ordering::Release);
+            })
+            .await
+        });
+        entered.notified().await;
+        parent.abort();
+        release.notify_one();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !completed.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("protected mutation should finish after its parent is cancelled");
     }
 
     #[test]

--- a/rustfs/src/storage/rpc/node_service/lock.rs
+++ b/rustfs/src/storage/rpc/node_service/lock.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::NodeService;
-use rustfs_lock::LockRequest;
+use rustfs_lock::{LockRequest, MAX_DELETE_LIST};
 use rustfs_protos::proto_gen::node_service::*;
 use tonic::{Request, Response, Status};
 
@@ -31,6 +31,15 @@ fn lock_result_from_error(error: impl Into<String>) -> GenerallyLockResult {
         error_info: Some(error.into()),
         lock_info: None,
     }
+}
+
+fn validate_refresh_batch_len(len: usize) -> Result<(), Status> {
+    if len > MAX_DELETE_LIST {
+        return Err(Status::resource_exhausted(format!(
+            "refresh batch contains {len} locks; maximum is {MAX_DELETE_LIST}"
+        )));
+    }
+    Ok(())
 }
 
 /// Delegate a refresh RPC to the node's lock backend (`LocalClient::refresh`).
@@ -78,6 +87,29 @@ fn lock_result_from_release(lock_id: &rustfs_lock::LockId, success: bool) -> Gen
     } else {
         lock_result_from_error(format!("lock not found for release: {lock_id}"))
     }
+}
+
+fn lock_result_from_refresh(result: rustfs_lock::Result<bool>) -> GenerallyLockResult {
+    match result {
+        Ok(success) => GenerallyLockResult {
+            success,
+            error_info: None,
+            lock_info: None,
+        },
+        Err(err) => lock_result_from_error(format!("can not refresh lock: {err}")),
+    }
+}
+
+async fn refresh_locks_batch(
+    lock_client: &std::sync::Arc<dyn rustfs_lock::client::LockClient>,
+    lock_ids: &[rustfs_lock::LockId],
+) -> Vec<GenerallyLockResult> {
+    lock_client
+        .refresh_locks_batch(lock_ids)
+        .await
+        .into_iter()
+        .map(lock_result_from_refresh)
+        .collect()
 }
 
 impl NodeService {
@@ -300,15 +332,55 @@ impl NodeService {
 
         Ok(Response::new(BatchGenerallyLockResponse { results }))
     }
+
+    pub(super) async fn handle_refresh_batch(
+        &self,
+        request: Request<BatchGenerallyLockRequest>,
+    ) -> Result<Response<BatchGenerallyLockResponse>, Status> {
+        validate_refresh_batch_len(request.get_ref().args.len())?;
+        let request = request.into_inner();
+        let mut results = vec![lock_result_from_error("request was not processed"); request.args.len()];
+        let mut lock_ids = Vec::with_capacity(request.args.len());
+        let mut valid_indices = Vec::with_capacity(request.args.len());
+
+        for (idx, arg) in request.args.iter().enumerate() {
+            match serde_json::from_str::<LockRequest>(arg) {
+                Ok(args) => {
+                    lock_ids.push(args.lock_id);
+                    valid_indices.push(idx);
+                }
+                Err(err) => results[idx] = lock_result_from_error(format!("can not decode args, err: {err}")),
+            }
+        }
+
+        if !lock_ids.is_empty() {
+            let lock_client = self.get_lock_client()?;
+            for (result_idx, result) in refresh_locks_batch(&lock_client, &lock_ids).await.into_iter().enumerate() {
+                if let Some(request_idx) = valid_indices.get(result_idx) {
+                    results[*request_idx] = result;
+                }
+            }
+        }
+
+        Ok(Response::new(BatchGenerallyLockResponse { results }))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{lock_result_from_release, lock_result_from_response};
+    use super::{lock_result_from_release, lock_result_from_response, refresh_locks_batch, validate_refresh_batch_len};
 
     fn test_lock_id() -> rustfs_lock::LockId {
         rustfs_lock::LockRequest::new(rustfs_lock::ObjectKey::new("bucket", "object"), rustfs_lock::LockType::Exclusive, "owner")
             .lock_id
+    }
+
+    #[test]
+    fn refresh_batch_enforces_request_limit() {
+        assert!(validate_refresh_batch_len(rustfs_lock::MAX_DELETE_LIST).is_ok());
+        let status =
+            validate_refresh_batch_len(rustfs_lock::MAX_DELETE_LIST + 1).expect_err("oversized refresh batch should be rejected");
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
     }
 
     #[test]
@@ -324,6 +396,30 @@ mod tests {
                 .expect("missing release should include error")
                 .contains("lock not found for release")
         );
+    }
+
+    #[tokio::test]
+    async fn refresh_locks_batch_preserves_per_lock_results() {
+        use rustfs_lock::{GlobalLockManager, LockClient, LockType, ObjectKey, client::local::LocalClient};
+        use std::{sync::Arc, time::Duration};
+
+        let manager = Arc::new(GlobalLockManager::new());
+        let client: Arc<dyn LockClient> = Arc::new(LocalClient::with_manager(manager));
+        let request = rustfs_lock::LockRequest::new(ObjectKey::new("bucket", "held"), LockType::Exclusive, "owner")
+            .with_ttl(Duration::from_secs(30));
+        let held = client
+            .acquire_lock(&request)
+            .await
+            .expect("lock acquisition should succeed")
+            .lock_info
+            .expect("successful lock should include info")
+            .id;
+        let missing = rustfs_lock::LockId::new_unique(&ObjectKey::new("bucket", "missing"));
+
+        let results = refresh_locks_batch(&client, &[held, missing]).await;
+        assert!(results[0].success);
+        assert!(!results[1].success);
+        assert!(results[1].error_info.is_none());
     }
 
     #[test]

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -226,6 +226,7 @@ pub(crate) mod rpc_consumer {
             get_local_server_property, load_bucket_metadata, reload_transition_tier_config, remove_bucket_metadata,
             set_bucket_metadata, validate_batch_read_version_item_count,
         };
+        pub(crate) use rustfs_ecstore::api::disk::{decode_delete_options_payload, decode_rename_data_payload};
         pub(crate) type StorageResult<T> = super::super::Result<T>;
 
         #[cfg(test)]
@@ -912,6 +913,15 @@ pub(crate) trait StorageDiskRpcExt {
         dst_volume: &str,
         dst_path: &str,
     ) -> DiskResult<RenameDataResp>;
+    async fn rename_data_with_rollback(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        file_info: rustfs_filemeta::FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+        rollback_token: uuid::Uuid,
+    ) -> DiskResult<RenameDataResp>;
     async fn list_dir(&self, origvolume: &str, volume: &str, dir_path: &str, count: i32) -> DiskResult<Vec<String>>;
     async fn read_file_stream(&self, volume: &str, path: &str, offset: usize, length: usize) -> DiskResult<FileReader>;
     async fn rename_file(&self, src_volume: &str, src_path: &str, dst_volume: &str, dst_path: &str) -> DiskResult<()>;
@@ -1042,6 +1052,27 @@ where
         dst_path: &str,
     ) -> DiskResult<RenameDataResp> {
         ecstore_disk::DiskAPI::rename_data(self, src_volume, src_path, file_info, dst_volume, dst_path).await
+    }
+
+    async fn rename_data_with_rollback(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        file_info: rustfs_filemeta::FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+        rollback_token: uuid::Uuid,
+    ) -> DiskResult<RenameDataResp> {
+        ecstore_disk::DiskAPI::rename_data_with_rollback(
+            self,
+            src_volume,
+            src_path,
+            file_info,
+            dst_volume,
+            dst_path,
+            rollback_token,
+        )
+        .await
     }
 
     async fn list_dir(&self, origvolume: &str, volume: &str, dir_path: &str, count: i32) -> DiskResult<Vec<String>> {


### PR DESCRIPTION
## Related Issues

Follow-up to #4300.

## Summary of Changes

This PR hardens distributed delete and rename transactions when a disk mutation succeeds but its RPC response is lost, a namespace lease expires, or only part of the erasure set completes. The failure is similar to a bank transfer whose receipt was lost: the coordinator cannot safely assume either "committed" or "not committed", so retrying or rolling back blindly can overwrite a newer value.

### Failure shape

```mermaid
sequenceDiagram
    participant C as Coordinator
    participant S as Disk RPC supervisor
    participant D as Local disk
    C->>S: Forward mutation (transaction token)
    S-->>C: Connection lost; outcome is unknown
    C->>S: Rollback (same token)
    S->>D: Rollback reaches the object first
    D-->>S: Snapshot is absent; rollback is a no-op
    S->>D: Detached forward reaches the object later
    D-->>D: Mutation commits after failure was returned
```

### Implemented V1 hardening

```mermaid
flowchart LR
    A["Versioned request + UUID token"] --> B["Dedicated transaction RPC channel"]
    B --> C["Per-object transaction mutex"]
    C --> D["Persist previous state and expected forward SHA-256"]
    D --> E["Commit data and xl.meta"]
    E --> F{"Quorum and lease still valid?"}
    F -- "yes" --> G["Synchronous idempotent cleanup"]
    F -- "no or ambiguous" --> H["Conditional rollback"]
    H --> I["Restore data + fsync, then metadata + fsync"]
    I --> J["Reject rollback if current state is newer"]
```

The implementation:

- persists rollback snapshots and the exact expected forward `xl.meta` digest before commit, then rejects stale rollback when the current object is neither the forward state nor the previous state
- restores data directories before metadata and honors strict durability ordering before deleting transaction state
- serializes local work by object across transaction tokens and keeps admitted server mutations alive after caller cancellation
- compensates every disk with an ambiguous forward outcome, retains namespace guards until compensation and cleanup finish, and treats task join failure as ambiguous rather than as `DiskNotFound`
- removes unsafe legacy rename pre-staging, blind rollback, and five-field transactional delete retries; malformed envelopes, invalid magic/version/token, response-cardinality mismatches, and unsupported peers fail closed
- caches only positive peer capabilities, so an in-place peer upgrade can recover without retaining unsafe negative evidence
- batches delete and lock-refresh work at 1,000 items, bounds unary refresh fallback to 32 concurrent calls, preserves result order, and rejects oversized server requests
- computes lock expiry from the refresh request start and never revives a lease after its last confirmed TTL
- keeps the public object-operation trait shape unchanged while passing the lease guard through private transaction helpers

### Remaining V2 boundary

V1 materially reduces unsafe rollback behavior, but it does not fully fence a stale forward writer. Complete safety requires a persistent per-object lifecycle:

```mermaid
flowchart LR
    R["Reserve<br/>token + disk + object + expected state + request digest"] --> F["Forward<br/>CAS under the object mutex"]
    F --> D{"Durable terminal decision"}
    D -- "commit" --> C["Commit"]
    D -- "abort" --> A["Abort / restore"]
    C --> Z["Finalize / cleanup"]
    A --> Z
```

`Reserve -> Forward -> Commit/Abort -> Finalize` must make duplicate phases join or replay the same durable result, prevent rollback from overtaking a detached forward, reject stale fencing epochs before mutation, and reserve compensation capacity through the terminal phase. This PR intentionally remains Draft until that boundary and the performance gates below are completed.

## Verification

- `make pre-commit`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-lock` (108 tests)
- `cargo clippy -p rustfs-lock --all-targets -- -D warnings`
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings`
- `cargo test -p rustfs-protos` (6 tests)
- `cargo check -p rustfs --lib`
- focused ecstore regressions for capability evidence, versioned rename/delete envelopes, exact response cardinality, stale rollback rejection, strict rollback fsync ordering, cancellation, namespace-guard lifetime, bounded refresh fallback, 1,000-key aggregation, and ambiguous cleanup outcomes
- focused node-service regressions for exact delete result cardinality, protected mutation cancellation, and refresh-batch request limits
- `make pre-pr` was not rerun for this Draft update; the remaining V2 correctness work and current-diff performance A/B gates are explicit blockers

## Impact

There is no intended S3 API or public Rust trait break. Internode transactional delete and rename requests use explicit versioned envelopes and fail before mutation when a peer cannot represent safe rollback state; ordinary non-transactional compatibility remains unchanged. `RefreshBatch` falls back to bounded unary refresh only when an older peer returns `Unimplemented`.

The stronger path adds whole-`xl.meta` SHA-256 work, transaction-state persistence, strict `sync_data`/`fsync_dir`, and synchronous all-disk cleanup. These operations improve rollback durability but can increase PUT, single-delete, and 1,000-key DeleteObjects tail latency.

Performance remains a Draft blocker: the previously published local rename numbers predate the final SHA-256 commit fence and do not include synchronous all-disk cleanup or the serial 1,000-key delete path. Current-diff strict/relaxed microbenchmarks plus gh-1 PUT and DeleteObjects p50/p95/p99 A/B tests are required in healthy, partial-failure, rollback, and slow-cleanup conditions before this PR is Ready.

## Additional Notes

This PR is not merge-ready. Three P1 boundaries remain:

1. a rollback can overtake a detached delayed forward, observe no transaction state, return success, and allow the old forward to commit afterward
2. the forward envelope has no authoritative fencing epoch or acknowledged reservation, so an expired lease holder can overwrite a newer owner
3. forward and compensation share a global 256-slot supervisor, so unrelated forward saturation can reject every compensation before mutation

Persistent recovery across process or power restart is also deferred to the V2 lifecycle; startup UUID scanning is not a safe substitute.

High-risk adversarial validation:

- Correctness: attacked malformed envelopes, nil tokens, exact response cardinality, quorum/ambiguous outcomes, and stale rollback; implemented V1 failures are covered, while stale-forward ordering remains a blocker.
- Security: attacked untrusted RPC decoding, downgrade fallback, token validation, and diagnostic logging; transaction envelopes validate before mutation, unsafe downgrade retries are removed, and no credential surface changed.
- Concurrency/durability: attacked stale-lease forwards, disconnected-RPC compensation ordering, supervisor saturation, cancellation, and crash ordering; blocking failures remain because rollback can overtake a detached forward, stale holders lack a forward fencing epoch, and the shared supervisor can reject compensation.
- Compatibility: attacked current, predecessor, malformed, JSON, and MessagePack paths; V1 compatibility fails closed for unsafe transactional writes, caches only positive evidence, and V2 must never retry through the weaker V1 mutation path.
- Performance: attacked hashing, fsync ordering, lock hold time, all-disk cleanup, unary fallback fan-out, and 1,000-key delete serialization; final current-diff microbenchmarks and gh-1 service A/B data remain required.
- Test coverage: named regressions exercise the implemented V1 behavior, but V2 must add deterministic rollback-overtakes-forward, stale-fencing-epoch, compensation-saturation, restart-recovery, and current-diff performance gates.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.