### PR TITLE
docs: fix 'mis-reports' typo breaking the Typos check on main

### DIFF
--- a/docs/operations/hotpath-warp-ab-runbook.md
+++ b/docs/operations/hotpath-warp-ab-runbook.md
@@ -129,7 +129,7 @@ the gate table) into the GitHub step summary.
 Readiness polling waits up to `--health-timeout` seconds (default **180**),
 which must outlast the server's own startup-readiness budget
 (`RUSTFS_STARTUP_READINESS_MAX_WAIT_SECS`, default 120s) — a shorter poll on a
-slow shared runner mis-reports a slow cold start as a failure. In local mode the
+slow shared runner misreports a slow cold start as a failure. In local mode the
 rig also fails fast if the server process exits before becoming healthy instead
 of polling out the full budget.
 


### PR DESCRIPTION
One-line fix: `mis-reports` → `misreports` in docs/operations/hotpath-warp-ab-runbook.md:132 (entered main via #4669).

**Every PR based on current main fails the Typos required-style check because of this** (observed on #4674, #4677, #4680). Merging this unblocks them all. #4683 carries the same fix and will rebase trivially.

Refs rustfs/backlog#1152.