### PR TITLE
ci: fix migration-gate count guard failing on every PR (nextest JSON counting)

### DIFF
--- a/scripts/check_migration_gate_count.sh
+++ b/scripts/check_migration_gate_count.sh
@@ -54,12 +54,18 @@ if [[ "$mode" == "all" || "$mode" == "check" ]]; then
         exit 1
     fi
 
-    # Human-format list: binary headers start at column 0, one test per
-    # 4-space-indented line. A nextest failure aborts via set -e with its
-    # stderr visible; an output-format change collapses the count to 0 and
-    # fails loudly rather than silently passing.
-    list_output="$(cargo nextest list -p rustfs-ecstore --lib -E "$MIGRATION_GATE_FILTER")"
-    count="$(printf '%s\n' "$list_output" | grep -c '^    ' || true)"
+    # Count via the structured JSON listing, not the human format: the
+    # human format's indentation varies across nextest versions (CI's newer
+    # nextest emitted a layout where no line matched '^    ', collapsing the
+    # count to 0 and failing every PR). A nextest failure aborts via set -e
+    # with its stderr visible; a JSON schema change makes jq fail loudly
+    # rather than silently passing.
+    count="$(cargo nextest list -p rustfs-ecstore --lib -E "$MIGRATION_GATE_FILTER" --message-format json \
+        | jq '[."rust-suites"[].testcases[] | select(."filter-match".status == "matches")] | length')"
+    if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+        echo "error: could not parse nextest JSON listing (got count: '$count')" >&2
+        exit 1
+    fi
 
     if ((count < floor)); then
         echo "error: migration gate selects $count tests, below the committed floor of $floor." >&2


### PR DESCRIPTION
## Summary

**Every PR based on current main fails "Test and Lint"** at the migration-gate count guard introduced in #4673: `migration gate selects 0 tests, below the committed floor of 571` (observed on #4683, #4674, #4677, #4680 — including docs/script-only diffs, proving it's not a rename).

Root cause: the guard counted tests by grepping the **human list format** for 4-space indentation. The nextest version installed on CI emits a different layout, so the grep matched nothing and the fail-closed design fired on the wrong signal (locally, nextest 0.9.101 still matches — which is why #4673's local verification passed).

Fix: count via `cargo nextest list --message-format json | jq '[...filter-match.status == "matches"] | length'` — stable across nextest versions; a JSON schema change fails loudly instead of silently passing. Numeric sanity check added.

Local verification: human/JSON/JSON-non-ignored counts all agree at 572 on the full filter; `check` mode passes (floor 571); shellcheck clean.

After merging, the four red PRs need a branch update to re-run on clean main (I'll handle it).

Refs rustfs/backlog#1153 (infra-12 follow-up), rustfs/backlog#1155.