### PR TITLE
test(ecstore): extend rename_data/write_metadata crash-consistency coverage

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -1416,6 +1416,10 @@ fn should_fail_before_old_metadata_backup(_dst_path: &str) -> bool {
 /// build, but the arming static and [`should_crash_rename_data_at`] are
 /// `#[cfg(test)]`; in production the guard is a const-`false` no-op, so the
 /// injection points compile away to nothing.
+// The `After<step>` naming is deliberate: every crash point names the
+// commit-sequence step it fires immediately after, so the shared prefix is the
+// point, not noise.
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RenameDataCrashPoint {
     /// After the data dir has been renamed into its destination but before the
@@ -1426,6 +1430,14 @@ pub(crate) enum RenameDataCrashPoint {
     /// commit rename that makes the new version visible. Still pre-commit, so a
     /// crash here must also leave the object readable as the old version.
     AfterBackupBeforeMetaCommit,
+    /// After the xl.meta commit rename has made the new version visible, in the
+    /// same window the graceful [`should_fail_after_metadata_commit`] failpoint
+    /// covers — but as a hard power loss with **no** rollback. The commit rename
+    /// already landed on disk, so a crash here must leave the object readable as
+    /// the *new* version. This is the post-commit counterpart to the two
+    /// pre-commit points above, closing the "old or new, never mixed" invariant
+    /// (rustfs/backlog#878) from the new-version side.
+    AfterMetaCommit,
 }
 
 #[cfg(test)]
@@ -6438,6 +6450,15 @@ impl DiskAPI for LocalDisk {
                 return Err(DiskError::Unexpected);
             }
 
+            // Crash-consistency injection: hard power loss immediately after the
+            // xl.meta commit rename but before the durability fsync. Unlike the
+            // graceful failpoint above, no rollback runs — the commit rename is
+            // already on disk, so the harness asserts the object reads back as
+            // the new version.
+            if should_crash_rename_data_at(RenameDataCrashPoint::AfterMetaCommit, dst_path) {
+                return Err(DiskError::Unexpected);
+            }
+
             // Persist the directory entries for both the data dir and xl.meta renames;
             // without this the commit itself can vanish on power loss. Relaxed tiers
             // accept that window (documented in docs/operations/durability-modes.md).
@@ -7657,6 +7678,24 @@ mod test {
                 .await;
 
             match crash {
+                Some(RenameDataCrashPoint::AfterMetaCommit) => {
+                    // Hard power loss right after the xl.meta commit rename: the
+                    // commit landed and no rollback ran, so the object must read
+                    // back as the new version — whether or not an old version
+                    // preceded it. This is the new-version half of the "old or
+                    // new, never mixed" invariant (rustfs/backlog#878).
+                    assert!(result.is_err(), "{mode:?}/AfterMetaCommit: an armed crash must surface as an error");
+                    let fi = read.expect("new version must be readable after a post-commit crash");
+                    assert_eq!(
+                        fi.data_dir,
+                        Some(new_data_dir),
+                        "{mode:?}/AfterMetaCommit: read must resolve to the committed new data dir, never roll back to the old one"
+                    );
+                    assert!(
+                        object_dir.join(new_data_dir.to_string()).exists(),
+                        "{mode:?}/AfterMetaCommit: new data dir must remain on disk after the commit rename"
+                    );
+                }
                 Some(point) => {
                     assert!(result.is_err(), "{mode:?}/{point:?}: an armed crash must surface as an error");
                     match &old_meta {
@@ -7745,6 +7784,32 @@ mod test {
             run_scenario(DurabilityMode::Strict, None, true).await;
             run_scenario(DurabilityMode::Relaxed, None, true).await;
             run_scenario(DurabilityMode::Strict, None, false).await;
+        }
+
+        // Post-commit hard-crash points: the counterpart to the pre-commit
+        // cases above. A crash right after the xl.meta commit rename (no
+        // rollback) must leave the *new* version readable, closing the "old or
+        // new, never mixed" invariant from the new-version side. Relaxed is
+        // exercised alongside Strict so the durability relaxations are held to
+        // the same invariant.
+        #[tokio::test]
+        async fn overwrite_post_commit_crash_keeps_new_version_strict() {
+            run_scenario(DurabilityMode::Strict, Some(RenameDataCrashPoint::AfterMetaCommit), true).await;
+        }
+
+        #[tokio::test]
+        async fn overwrite_post_commit_crash_keeps_new_version_relaxed() {
+            run_scenario(DurabilityMode::Relaxed, Some(RenameDataCrashPoint::AfterMetaCommit), true).await;
+        }
+
+        #[tokio::test]
+        async fn fresh_post_commit_crash_keeps_new_version_strict() {
+            run_scenario(DurabilityMode::Strict, Some(RenameDataCrashPoint::AfterMetaCommit), false).await;
+        }
+
+        #[tokio::test]
+        async fn fresh_post_commit_crash_keeps_new_version_relaxed() {
+            run_scenario(DurabilityMode::Relaxed, Some(RenameDataCrashPoint::AfterMetaCommit), false).await;
         }
     }
 


### PR DESCRIPTION
## Summary

Extends the `rename_data` crash-consistency harness (rustfs/backlog#935, hard rule from rustfs/backlog#878: *partial commit → object must be old or new, never mixed*) to close four coverage gaps. The harness previously armed only two **pre-commit** points on `rename_data`, asserting the **old** version survives — leaving the new-version side, multi-version lineage, and the entire metadata-only commit path (`write_all_meta`) uncovered.

### 1. Post-commit hard crash (`rename_data`)
`RenameDataCrashPoint::AfterMetaCommit` — a crash immediately after the xl.meta commit rename, before the durability fsync. Asserts the object reads back as the **new** version (overwrite/fresh × strict/relaxed). Distinct from the existing `should_fail_after_metadata_commit` *failpoint*, which exercises the graceful in-process rollback (restores old); a real crash runs no rollback and the commit stays on disk. The `fresh` cases pin that the point is genuinely post-commit.

### 2. Multi-version lineage (`rename_data`)
Seeds two prior committed versions, then crashes committing a third. `rename_data` merges into the existing xl.meta (reads dst, `add_version`), so this pins that the merge **preserves unrelated versions** at every crash point, and the third version is present iff the commit rename landed.

### 3. Delete markers (`write_metadata` → `write_all_meta`)
A versioned DELETE commits via `write_metadata` → `write_all_meta`, an atomic xl.meta temp+rename that **never goes through `rename_data`** and had no crash point. Adds `WriteMetaCrashPoint` (`AfterTmpBeforeRename` / `AfterMetaRename`) and tests asserting a crash mid-commit leaves the object either at its prior version (delete marker absent) or with the delete marker committed — never a torn xl.meta.

### 4. Version removal (`delete_version`)
The removal counterpart: `delete_version`, when other versions remain, rewrites the reduced xl.meta through the same atomic `write_all_meta`, so `WriteMetaCrashPoint` covers it too. Asserts a crash mid-removal leaves the xl.meta atomically old-or-new (removed version still listed pre-commit, gone post-commit) and never disturbs an unrelated version.

All injection points are `#[cfg(test)]`-gated and compile to a const-`false` no-op in production (identical mechanism to the existing crash points) — **zero production behavior change**.

## Validation

- `cargo test -p rustfs-ecstore crash_consistency` — **24 passed** (5 pre-existing + 19 new)
- `cargo test -p rustfs-ecstore --lib disk::local::test` — **146 passed** (no regression from the shared `write_all_meta` injection)
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- arch guards (layer deps / unsafe / logging / doc paths / migration rules) clean

Test-only coverage addition; the only non-test change is a handful of `#[cfg(test)]`-gated injection guards that vanish in release builds.
