### PR TITLE
ci: quarantine walk_dir stall-budget flake under the ci profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -78,6 +78,13 @@ filter = 'package(rustfs-ecstore) & test(/^store::bucket::tests::bucket_delete_(
 test-group = 'ecstore-serial-flaky'
 retries = 2
 
+# QUARANTINE: OPEN rustfs#4690 — walk_dir stall-budget accounting test depends
+# on producer/consumer timing windows that stretch past the budget on loaded
+# CI runners (regression test for rustfs#4644; failed on a zero-Rust-diff PR).
+[[profile.ci.overrides]]
+filter = 'package(rustfs-ecstore) & test(walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget)'
+retries = 2
+
 # ---------------------------------------------------------------------------
 # e2e-smoke profile — PR smoke subset of the e2e_test crate (backlog#1149 ci-4)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
First real application of the flake policy (docs/testing/README.md, landed in #4666):

- `walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget` failed on the rio-v2 lane of #4674 ([run 29099382470](https://github.com/rustfs/rustfs/actions/runs/29099382470)) — a PR with zero Rust changes, so the diff cannot be the cause. Timing-window test (regression net for #4644) under runner load.
- Per policy: issue opened (rustfs#4690), quarantine entry with issue link (this PR, `retries = 2` under `[profile.ci]` only), 30-day fix-or-delete clock started.
- Local `default` profile unaffected (never retries). Verified the profile still parses via `cargo nextest list --profile ci`.

Refs rustfs/backlog#1149 (ci-10), rustfs#4690.