### PR TITLE
fix(make): align clippy-check with CI to fix macOS pre-pr gate

### DIFF
--- a/.config/make/lint-fmt.mak
+++ b/.config/make/lint-fmt.mak
@@ -15,7 +15,7 @@ fmt-check: core-deps fmt-deps ## Check code formatting
 .PHONY: clippy-check
 clippy-check: core-deps ## Run clippy checks
 	@echo "🔍 Running clippy checks..."
-	cargo clippy --all-targets --all-features -- -D warnings
+	cargo clippy --all-targets -- -D warnings
 
 .PHONY: clippy-fix
 clippy-fix: core-deps ## Apply clippy fixes


### PR DESCRIPTION
## Problem

`make pre-pr` fails on macOS since PR #4663 merged (`refactor(obs): make dial9 telemetry opt-in`).

**Root cause:** PR #4663 moved `--cfg tokio_unstable` out of `.cargo/config.toml` and made the `dial9` feature opt-in. The Makefile's `clippy-check` target uses `cargo clippy --all-targets --all-features`, which activates:
- `dial9` (requires `--cfg tokio_unstable`, enforced by `crates/obs/build.rs`)
- `dial9-taskdump` (requires `tokio/taskdump`, Linux-only)

Meanwhile CI runs `cargo clippy --all-targets -- -D warnings` (no `--all-features`), so CI was unaffected.

## Fix

Remove `--all-features` from the Makefile's `clippy-check` target to align with CI.

## Verification

- ✅ `make fmt-check` — clean
- ✅ `make clippy-check` — passes (with fix)
- ✅ `make quick-check` — compiles successfully
- ✅ All guard scripts pass (unsafe-code, architecture-migration, logging-guardrails, tokio-io-uring, doc-paths)
- ✅ `cargo nextest run --workspace --exclude e2e_test` — 8570 passed, 114 skipped
- ✅ `cargo test --workspace --exclude e2e_test --doc` — all doctests pass

## Related

- PR #4663 — introduced the opt-in dial9 feature
- PR #4688 — removes `dial9-taskdump` feature entirely (complementary fix)
