### PR TITLE
fix(object-data-cache): make the GET key write-unique and dedup the lookup

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -1614,6 +1614,7 @@ mod tests {
                     ..Default::default()
                 },
                 buffered_body: None,
+                body_source: Default::default(),
             })
         }
 

--- a/crates/ecstore/src/client/object_api_utils.rs
+++ b/crates/ecstore/src/client/object_api_utils.rs
@@ -150,6 +150,7 @@ pub fn new_getobjectreader<'a>(
                 object_info: oi.clone(),
                 stream: Box::new(input_reader),
                 buffered_body: None,
+                body_source: Default::default(),
             };
             r
             //})

--- a/crates/ecstore/src/config/com.rs
+++ b/crates/ecstore/src/config/com.rs
@@ -1824,6 +1824,7 @@ mod tests {
                 }),
                 object_info: self.object_info(bucket, object),
                 buffered_body: None,
+                body_source: Default::default(),
             })
         }
 
@@ -3042,6 +3043,7 @@ mod tests {
                 stream: Box::new(Cursor::new(data)),
                 object_info,
                 buffered_body: None,
+                body_source: Default::default(),
             })
         }
 

--- a/crates/ecstore/src/data_movement/mod.rs
+++ b/crates/ecstore/src/data_movement/mod.rs
@@ -1240,6 +1240,7 @@ mod tests {
             stream: Box::new(Cursor::new(raw_payload.clone())),
             object_info: object_info.clone(),
             buffered_body: None,
+            body_source: Default::default(),
         };
 
         let mut data = data_movement_put_object_reader("bucket-a", &object_info, rd, "test_migration")

--- a/crates/ecstore/src/object_api/readers.rs
+++ b/crates/ecstore/src/object_api/readers.rs
@@ -275,10 +275,49 @@ impl PutObjReader {
     }
 }
 
+/// Provenance of a [`GetObjectReader`] with respect to the app-layer object
+/// data cache hook, so the app layer can avoid repeating the cache lookup the
+/// ecstore GET probe already ran after fresh metadata resolution (backlog#1121
+/// / ODC-16). One hook-served GET must record exactly one lookup, not two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GetObjectBodySource {
+    /// The cache hook did not probe this read: the hook is unregistered, or the
+    /// read is ineligible under the fail-closed allow-list. The app layer runs
+    /// its own cache lookup, as before.
+    #[default]
+    Unprobed,
+    /// The hook probed after fresh metadata resolution and did not serve a body
+    /// (a genuine miss, or a length-defensive rejection). Its miss is
+    /// authoritative, so the app layer must skip the lookup and only build a
+    /// plan to fill.
+    HookMissed,
+    /// `buffered_body` is exactly the body the hook served from the cache. The
+    /// app layer serves it directly as the object-data-cache source, with no
+    /// second lookup and no re-fill.
+    HookServed,
+}
+
 pub struct GetObjectReader {
     pub stream: Box<dyn AsyncRead + Unpin + Send + Sync>,
     pub object_info: ObjectInfo,
     pub buffered_body: Option<Bytes>,
+    /// Cache-hook provenance; defaults to [`GetObjectBodySource::Unprobed`] for
+    /// every reader that never passed through the app-layer cache probe.
+    pub body_source: GetObjectBodySource,
+}
+
+impl GetObjectReader {
+    /// True when `buffered_body` is the body the cache hook served. The app
+    /// layer serves it as the object-data-cache source without a second lookup.
+    pub fn is_cache_hook_served(&self) -> bool {
+        matches!(self.body_source, GetObjectBodySource::HookServed)
+    }
+
+    /// True when the cache hook probed this read (whether it served a body or
+    /// missed). The app layer must not repeat the lookup in either case.
+    pub fn cache_hook_probed(&self) -> bool {
+        !matches!(self.body_source, GetObjectBodySource::Unprobed)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -532,6 +571,7 @@ impl ReadPlan {
                     stream: reader,
                     object_info: oi.clone(),
                     buffered_body: None,
+                    body_source: GetObjectBodySource::Unprobed,
                 },
                 self.storage_offset,
                 self.storage_length,
@@ -586,6 +626,7 @@ impl ReadPlan {
                         stream: final_reader,
                         object_info,
                         buffered_body: None,
+                        body_source: GetObjectBodySource::Unprobed,
                     },
                     self.storage_offset,
                     self.storage_length,
@@ -687,6 +728,7 @@ impl ReadPlan {
                         stream: final_reader,
                         object_info,
                         buffered_body: None,
+                        body_source: GetObjectBodySource::Unprobed,
                     },
                     self.storage_offset,
                     self.storage_length,

--- a/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
+++ b/crates/ecstore/src/services/rebalance/rebalance_unit_tests.rs
@@ -141,6 +141,7 @@ impl MigrationBackendSpy {
             stream: Box::new(Cursor::new(vec![0_u8; 3])),
             object_info: ObjectInfo::default(),
             buffered_body: None,
+            body_source: Default::default(),
         }
     }
 }

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -22,6 +22,7 @@
 use super::super::*;
 
 use crate::disk::OldCurrentSize;
+use crate::object_api::GetObjectBodySource;
 
 /// Length of the full plaintext body when — and only when — this read's output
 /// is exactly the object's complete plaintext, so the app-layer body cache may
@@ -170,6 +171,7 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                 stream: Box::new(Cursor::new(Vec::new())),
                 object_info,
                 buffered_body: Some(Bytes::new()),
+                body_source: GetObjectBodySource::Unprobed,
             };
             return Ok(reader);
         }
@@ -256,6 +258,7 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                         stream: Box::new(Cursor::new(body.clone())),
                         object_info,
                         buffered_body: Some(body),
+                        body_source: GetObjectBodySource::Unprobed,
                     };
                     return Ok(reader);
                 }
@@ -338,6 +341,7 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                     stream: Box::new(Cursor::new(body.clone())),
                     object_info,
                     buffered_body: Some(body),
+                    body_source: GetObjectBodySource::Unprobed,
                 };
                 return Ok(reader);
             }
@@ -389,23 +393,39 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
         // object `ReadTransform::Compressed` sets `object_info.size` to the
         // decompressed length, and consumers such as UploadPartCopy read the
         // copy length straight off that field (backlog#1109).
+        // Records whether the app-layer cache probe ran for this read, so the
+        // app layer does not repeat the lookup it already performed after fresh
+        // metadata resolution (backlog#1121 / ODC-16). It stays `Unprobed` when
+        // the read is ineligible under the allow-list or the hook is not
+        // registered; the direct-memory and streaming readers built below carry
+        // it forward.
+        let mut body_source = GetObjectBodySource::Unprobed;
         if let Some(plaintext_len) = full_object_plaintext_len(&range, opts, &object_info)
             && let Some(hook) = get_object_body_cache_hook()
-            && let Some(body) = hook.lookup(bucket, object, &object_info).await
-            && i64::try_from(body.len()).is_ok_and(|len| len == plaintext_len)
         {
-            record_get_object_reader_path_observation(GET_OBJECT_PATH_BODY_CACHE, object_class, size_bucket);
-            let mut object_info = object_info;
-            object_info.size = plaintext_len;
-            let reader = GetObjectReader {
-                stream: Box::new(Cursor::new(body.clone())),
-                object_info,
-                buffered_body: Some(body),
-            };
-            if lock_optimization_enabled {
-                release_materialized_read_lock(bucket, object, read_lock_guard.take());
+            match hook.lookup(bucket, object, &object_info).await {
+                Some(body) if i64::try_from(body.len()).is_ok_and(|len| len == plaintext_len) => {
+                    record_get_object_reader_path_observation(GET_OBJECT_PATH_BODY_CACHE, object_class, size_bucket);
+                    let mut object_info = object_info;
+                    object_info.size = plaintext_len;
+                    let reader = GetObjectReader {
+                        stream: Box::new(Cursor::new(body.clone())),
+                        object_info,
+                        buffered_body: Some(body),
+                        body_source: GetObjectBodySource::HookServed,
+                    };
+                    if lock_optimization_enabled {
+                        release_materialized_read_lock(bucket, object, read_lock_guard.take());
+                    }
+                    return Ok(reader);
+                }
+                // Probed after fresh metadata resolution but no usable body: a
+                // genuine miss, or a length-defensive rejection. The miss is
+                // authoritative, so the app layer must not look up again.
+                _ => {
+                    body_source = GetObjectBodySource::HookMissed;
+                }
             }
-            return Ok(reader);
         }
 
         let direct_memory_decision = get_small_object_direct_memory_decision(&range, &object_info, &fi, opts);
@@ -435,6 +455,7 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                     stream: Box::new(Cursor::new(body.clone())),
                     object_info,
                     buffered_body: Some(body),
+                    body_source,
                 };
                 if lock_optimization_enabled {
                     release_materialized_read_lock(bucket, object, read_lock_guard.take());
@@ -476,6 +497,7 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                 stream: Box::new(Cursor::new(body.clone())),
                 object_info,
                 buffered_body: Some(body),
+                body_source,
             };
             if lock_optimization_enabled {
                 release_materialized_read_lock(bucket, object, read_lock_guard.take());
@@ -508,7 +530,10 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                             size_bucket,
                         );
                         record_get_object_reader_path_observation(GET_OBJECT_PATH_CODEC_STREAMING, object_class, size_bucket);
-                        let (reader, _offset, _length) = GetObjectReader::new(stream, range, &object_info, opts, &h).await?;
+                        let (mut reader, _offset, _length) = GetObjectReader::new(stream, range, &object_info, opts, &h).await?;
+                        // Carry the hook probe result so the app layer skips its
+                        // now-redundant lookup on the streaming miss path (ODC-16).
+                        reader.body_source = body_source;
                         return Ok(finish_set_disk_read_lock(
                             reader,
                             read_lock_guard.take(),
@@ -543,7 +568,10 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
         let (rd, wd) = tokio::io::duplex(duplex_buffer_size);
         debug!(bucket, object, duplex_buffer_size, "Created duplex pipe for object data transfer");
 
-        let (reader, offset, length) = GetObjectReader::new(Box::new(rd), range, &object_info, opts, &h).await?;
+        let (mut reader, offset, length) = GetObjectReader::new(Box::new(rd), range, &object_info, opts, &h).await?;
+        // Carry the hook probe result so the app layer skips its now-redundant
+        // lookup on the streaming miss path (ODC-16).
+        reader.body_source = body_source;
 
         // let disks = disks.clone();
         let bucket = bucket.to_owned();
@@ -2232,6 +2260,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
             stream: Box::new(pr),
             object_info: oi,
             buffered_body: None,
+            body_source: GetObjectBodySource::Unprobed,
         });
 
         let cloned_bucket = bucket.to_string();
@@ -3145,7 +3174,7 @@ mod body_cache_hook_e2e_tests {
     use crate::ecstore_validation_blackbox::make_local_set_disks;
     use crate::io_support::rio::{HashReader, compression_metadata_value, compression_reader};
     use crate::object_api::{
-        GetObjectBodyCacheHook, ObjectInfo, ObjectOptions, PutObjReader, clear_get_object_body_cache_hook,
+        GetObjectBodyCacheHook, GetObjectBodySource, ObjectInfo, ObjectOptions, PutObjReader, clear_get_object_body_cache_hook,
         register_get_object_body_cache_hook,
     };
     use crate::set_disk::SetDisks;
@@ -3255,6 +3284,90 @@ mod body_cache_hook_e2e_tests {
     /// to keep the object off the inline / direct-memory fast paths.
     fn compressible_plaintext() -> Vec<u8> {
         b"rustfs-body-cache-e2e-regression-".repeat(20_000)
+    }
+
+    /// Writes a plain (uncompressed, unencrypted) object of `data`, large enough
+    /// to keep it off the inline fast path so the cache hook is actually probed.
+    async fn put_plain_object(set_disks: &Arc<SetDisks>, bucket: &str, object: &str, data: &[u8]) {
+        let opts = ObjectOptions {
+            no_lock: true,
+            ..Default::default()
+        };
+        let stream = HashReader::from_stream(Cursor::new(data.to_vec()), data.len() as i64, data.len() as i64, None, None, false)
+            .expect("hash reader over plain bytes");
+        let mut reader = PutObjReader::new(stream);
+        set_disks
+            .make_bucket(bucket, &MakeBucketOptions::default())
+            .await
+            .expect("bucket should be created");
+        set_disks
+            .put_object(bucket, object, &mut reader, &opts)
+            .await
+            .expect("plain object should be written");
+    }
+
+    /// ODC-16: a cache-hook hit must mark the reader `HookServed` so the app
+    /// layer serves the buffered body without a second lookup. A large plain
+    /// object stays off the inline fast path, so the hook is genuinely probed.
+    #[tokio::test]
+    #[serial_test::serial(body_cache_hook)]
+    async fn plain_cache_hit_marks_reader_hook_served() {
+        let (_dirs, set_disks) = make_local_set_disks(4, 2).await;
+        let bucket = "e2e-body-cache-hook-served";
+        let object = "plain.bin";
+        let payload = b"rustfs-hook-served-payload-".repeat(40_000);
+        put_plain_object(&set_disks, bucket, object, &payload).await;
+
+        let _guard = HookGuard::install(bucket, object, Bytes::from(payload.clone()));
+        let opts = ObjectOptions {
+            no_lock: true,
+            ..Default::default()
+        };
+        let mut reader = set_disks
+            .get_object_reader(bucket, object, None, HeaderMap::new(), &opts)
+            .await
+            .expect("object reader should open");
+
+        assert_eq!(
+            reader.body_source,
+            GetObjectBodySource::HookServed,
+            "a hook hit must mark the reader HookServed"
+        );
+        assert!(reader.buffered_body.is_some(), "a hook-served reader carries the cache body");
+        let mut body = Vec::new();
+        reader.stream.read_to_end(&mut body).await.expect("object should stream");
+        assert_eq!(body, payload, "the hook-served body must be the primed plaintext");
+    }
+
+    /// ODC-16: when the hook is registered but misses this object, the reader
+    /// must be marked `HookMissed` so the app layer skips its now-redundant
+    /// lookup (the hook's miss ran after fresh metadata resolution).
+    #[tokio::test]
+    #[serial_test::serial(body_cache_hook)]
+    async fn plain_cache_miss_marks_reader_hook_missed() {
+        let (_dirs, set_disks) = make_local_set_disks(4, 2).await;
+        let bucket = "e2e-body-cache-hook-missed";
+        let object = "plain.bin";
+        let payload = b"rustfs-hook-missed-payload-".repeat(40_000);
+        put_plain_object(&set_disks, bucket, object, &payload).await;
+
+        // Register a hook primed for a DIFFERENT object, so this read is probed
+        // (hook registered + eligible) but the probe misses.
+        let _guard = HookGuard::install(bucket, "other-object", Bytes::from_static(b"unrelated"));
+        let opts = ObjectOptions {
+            no_lock: true,
+            ..Default::default()
+        };
+        let reader = set_disks
+            .get_object_reader(bucket, object, None, HeaderMap::new(), &opts)
+            .await
+            .expect("object reader should open");
+
+        assert_eq!(
+            reader.body_source,
+            GetObjectBodySource::HookMissed,
+            "a probed miss must mark the reader HookMissed"
+        );
     }
 
     /// backlog#1108: a raw data-movement read (decommission/rebalance copy) must

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -572,6 +572,7 @@ mod tests {
                 stream: Box::new(Cursor::new(self.read_payload.clone())),
                 object_info: self.object_info(bucket, object, self.read_payload.len()),
                 buffered_body: None,
+                body_source: Default::default(),
             })
         }
 

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -2195,6 +2195,7 @@ mod tests {
                 stream: Box::new(Cursor::new(Vec::<u8>::new())),
                 object_info: ObjectInfo::default(),
                 buffered_body: None,
+                body_source: Default::default(),
             };
 
             let reader = ECStore::attach_read_lock_guard(reader, Some(read_guard));
@@ -2234,6 +2235,7 @@ mod tests {
                 stream: Box::new(Cursor::new(vec![1, 2, 3])),
                 object_info: ObjectInfo::default(),
                 buffered_body: None,
+                body_source: Default::default(),
             };
 
             let reader = ECStore::attach_read_lock_guard(reader, Some(read_guard));
@@ -2270,6 +2272,7 @@ mod tests {
                 stream: Box::new(Cursor::new(vec![1, 2, 3])),
                 object_info: ObjectInfo::default(),
                 buffered_body: Some(Bytes::from_static(b"123")),
+                body_source: Default::default(),
             };
 
             let reader = ECStore::attach_read_lock_guard(reader, Some(read_guard));
@@ -2306,6 +2309,7 @@ mod tests {
                 stream: Box::new(Cursor::new(vec![1, 2, 3])),
                 object_info: ObjectInfo::default(),
                 buffered_body: None,
+                body_source: Default::default(),
             };
 
             let mut reader = ECStore::attach_read_lock_guard(reader, Some(read_guard));

--- a/crates/object-data-cache/src/cache.rs
+++ b/crates/object-data-cache/src/cache.rs
@@ -45,6 +45,16 @@ pub struct ObjectDataCache {
     backend: ObjectDataCacheBackendKind,
     config: Arc<ObjectDataCacheConfig>,
     stats: Arc<ObjectDataCacheStats>,
+    /// Effective fill ceiling in bytes: a body larger than this is planned
+    /// `SkipTooLarge` even when it fits `max_entry_bytes`. The app layer sets it
+    /// to `min(max_entry_bytes, seek-support threshold, 64 MiB buffer cap)` so a
+    /// `max_entry_bytes` above the in-memory GET fill limits is not reported as
+    /// eligible while fill could never materialize it (backlog#1129 / ODC-24).
+    /// `0` means "no additional clamp" — eligibility rests on `max_entry_bytes`
+    /// alone (the default, used by engine-level tests). The concurrency-driven
+    /// shrink of the fill threshold is dynamic and cannot be captured at plan
+    /// time; this static ceiling is the conservative floor.
+    fill_ceiling_bytes: u64,
     /// Monotonic origin for the cache-state publish debounce.
     created_at: Instant,
     /// Millis since `created_at` of the last cache-state gauge publish, or `0`
@@ -62,6 +72,7 @@ impl ObjectDataCache {
             backend: ObjectDataCacheBackendKind::Noop(NoopBackend),
             config,
             stats,
+            fill_ceiling_bytes: 0,
             created_at: Instant::now(),
             last_entry_publish_ms: AtomicU64::new(0),
         }
@@ -82,9 +93,30 @@ impl ObjectDataCache {
             backend,
             config: Arc::new(config),
             stats,
+            fill_ceiling_bytes: 0,
             created_at: Instant::now(),
             last_entry_publish_ms: AtomicU64::new(0),
         })
+    }
+
+    /// Sets the effective fill ceiling (backlog#1129 / ODC-24). The app layer
+    /// applies this at startup so a body above the in-memory GET fill limits is
+    /// planned `SkipTooLarge` instead of being reported eligible. `0` disables
+    /// the extra clamp.
+    #[must_use]
+    pub fn with_fill_ceiling_bytes(mut self, fill_ceiling_bytes: u64) -> Self {
+        self.fill_ceiling_bytes = fill_ceiling_bytes;
+        self
+    }
+
+    /// Effective size above which a body is planned `SkipTooLarge`:
+    /// `max_entry_bytes` clamped by the fill ceiling when one is set.
+    fn effective_size_ceiling(&self) -> u64 {
+        if self.fill_ceiling_bytes == 0 {
+            self.config.max_entry_bytes
+        } else {
+            self.config.max_entry_bytes.min(self.fill_ceiling_bytes)
+        }
     }
 
     /// Produces a lightweight GET plan from request metadata.
@@ -100,7 +132,11 @@ impl ObjectDataCache {
             return ObjectDataCacheGetPlan::Disabled;
         }
 
-        if request.size > self.config.max_entry_bytes {
+        // ODC-24: clamp eligibility to the effective fill ceiling, not just
+        // `max_entry_bytes`. A body in the gap between `max_entry_bytes` and the
+        // in-memory GET fill limits could never fill, so admitting it here would
+        // report it "eligible" while it kept a permanent 0% hit rate.
+        if request.size > self.effective_size_ceiling() {
             record_plan_decision(self.backend.as_metric_label(), self.config.mode, "skip", "too_large", request.size);
             return ObjectDataCacheGetPlan::SkipTooLarge;
         }
@@ -108,12 +144,13 @@ impl ObjectDataCache {
         record_plan_decision(self.backend.as_metric_label(), self.config.mode, "cacheable", "eligible", request.size);
 
         ObjectDataCacheGetPlan::Cacheable {
-            key: ObjectDataCacheKey::new(
+            key: ObjectDataCacheKey::with_mod_time(
                 request.bucket,
                 request.object,
                 request.version_id.as_deref(),
                 request.etag,
                 request.size,
+                request.mod_time_unix_nanos,
                 request.body_variant,
             ),
         }
@@ -308,6 +345,10 @@ pub struct ObjectDataCacheGetRequest<'a> {
     pub etag: &'a str,
     /// Object size in bytes.
     pub size: u64,
+    /// Resolved version's modification time as Unix nanoseconds, or `0` when
+    /// absent. Carried into the key so it is write-unique (backlog#1111 /
+    /// ODC-06).
+    pub mod_time_unix_nanos: i128,
     /// Supported response body variant.
     pub body_variant: ObjectDataCacheBodyVariant,
 }
@@ -466,6 +507,7 @@ mod tests {
             version_id: None,
             etag,
             size,
+            mod_time_unix_nanos: 0,
             body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
         }
     }
@@ -645,6 +687,7 @@ mod tests {
             version_id: None,
             etag: "etag",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
 
@@ -653,5 +696,57 @@ mod tests {
 
         assert_eq!(fill, ObjectDataCacheFillResult::SkippedSizeMismatch);
         assert!(matches!(lookup, ObjectDataCacheLookup::Miss));
+    }
+
+    #[test]
+    fn plan_clamps_size_eligibility_to_fill_ceiling() {
+        // ODC-24 (backlog#1129): a body in the gap between `max_entry_bytes` and
+        // the effective fill ceiling must plan `SkipTooLarge`, not `Cacheable`,
+        // so it stops being reported as eligible while it can never fill.
+        let config = ObjectDataCacheConfig {
+            mode: ObjectDataCacheMode::HitOnly,
+            max_bytes: 32 * 1024 * 1024,
+            max_memory_percent: 0,
+            max_entry_bytes: 16 * 1024 * 1024,
+            ..ObjectDataCacheConfig::default()
+        };
+        let cache = ObjectDataCache::new(config)
+            .expect("clamped cache config should initialize")
+            .with_fill_ceiling_bytes(4 * 1024 * 1024);
+
+        // Within the ceiling: eligible.
+        assert!(matches!(
+            cache.plan_get(plain_request("bucket", "object", "etag", 4 * 1024 * 1024)),
+            ObjectDataCacheGetPlan::Cacheable { .. }
+        ));
+        // In the gap (ceiling < size <= max_entry_bytes): skipped as too large.
+        assert_eq!(
+            cache.plan_get(plain_request("bucket", "object", "etag", 4 * 1024 * 1024 + 1)),
+            ObjectDataCacheGetPlan::SkipTooLarge
+        );
+        assert_eq!(
+            cache.plan_get(plain_request("bucket", "object", "etag", 16 * 1024 * 1024)),
+            ObjectDataCacheGetPlan::SkipTooLarge
+        );
+    }
+
+    #[test]
+    fn plan_carries_mod_time_into_key() {
+        // ODC-06: the resolved modification time must reach the key so two
+        // writes with identical etag + size derive different keys.
+        let cache = hit_only_cache();
+        let request = ObjectDataCacheGetRequest {
+            bucket: "bucket",
+            object: "object",
+            version_id: None,
+            etag: "etag",
+            size: 5,
+            mod_time_unix_nanos: 42,
+            body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
+        };
+        let ObjectDataCacheGetPlan::Cacheable { key } = cache.plan_get(request) else {
+            panic!("plan should be cacheable");
+        };
+        assert_eq!(key.mod_time_unix_nanos, 42);
     }
 }

--- a/crates/object-data-cache/src/key.rs
+++ b/crates/object-data-cache/src/key.rs
@@ -26,6 +26,16 @@ pub enum ObjectDataCacheBodyVariant {
 }
 
 /// Stable cache key for a reusable object body.
+///
+/// The key is *write-unique*, not merely *content-unique* (backlog#1111 /
+/// ODC-06). `etag + size` alone identify content: for an unversioned overwrite
+/// two same-length payloads that collide on MD5 would derive the identical key,
+/// so a GET on a node that never observed the overwrite could serve the old
+/// bytes for up to the TTL, and the same collision turns the
+/// fill-after-invalidation race (backlog#1118) into a serving bug. Including
+/// the resolved version's modification time distinguishes two writes even under
+/// an MD5 collision, because an overwrite advances `mod_time`. `etag + size`
+/// stay in the key as belt-and-braces.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ObjectDataCacheKey {
     /// Bucket name.
@@ -38,6 +48,11 @@ pub struct ObjectDataCacheKey {
     pub etag: Arc<str>,
     /// Object size in bytes.
     pub size: u64,
+    /// Resolved version's modification time as Unix nanoseconds
+    /// (`OffsetDateTime::unix_timestamp_nanos`), or `0` when absent. This is the
+    /// write-unique component: an overwrite advances `mod_time`, so the key
+    /// changes even when `etag + size` are unchanged (an MD5 collision).
+    pub mod_time_unix_nanos: i128,
     /// Cached body semantics.
     pub body_variant: ObjectDataCacheBodyVariant,
 }
@@ -52,13 +67,17 @@ pub struct ObjectDataCacheIdentity {
 }
 
 impl ObjectDataCacheKey {
-    /// Creates a new stable object data cache key.
-    pub fn new(
+    /// Creates a stable object data cache key with an explicit modification
+    /// time. This is the full constructor; the production GET planner uses it so
+    /// the key is write-unique (backlog#1111 / ODC-06).
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_mod_time(
         bucket: impl Into<Arc<str>>,
         object: impl Into<Arc<str>>,
         version_id: Option<&str>,
         etag: impl Into<Arc<str>>,
         size: u64,
+        mod_time_unix_nanos: i128,
         body_variant: ObjectDataCacheBodyVariant,
     ) -> Self {
         Self {
@@ -67,8 +86,23 @@ impl ObjectDataCacheKey {
             version_id: version_id.map_or_else(|| Arc::<str>::from(NULL_VERSION_ID), Arc::<str>::from),
             etag: etag.into(),
             size,
+            mod_time_unix_nanos,
             body_variant,
         }
+    }
+
+    /// Creates a stable object data cache key with no modification time
+    /// (`mod_time_unix_nanos == 0`). Retained for callers that key purely by
+    /// content identity (index/backend tests).
+    pub fn new(
+        bucket: impl Into<Arc<str>>,
+        object: impl Into<Arc<str>>,
+        version_id: Option<&str>,
+        etag: impl Into<Arc<str>>,
+        size: u64,
+        body_variant: ObjectDataCacheBodyVariant,
+    ) -> Self {
+        Self::with_mod_time(bucket, object, version_id, etag, size, 0, body_variant)
     }
 
     /// Returns true when this key targets the canonical unversioned body variant.
@@ -110,6 +144,51 @@ mod tests {
             ObjectDataCacheKey::new("bucket", "object", Some("3d2"), "etag", 42, ObjectDataCacheBodyVariant::FullObjectPlainV1);
 
         assert_ne!(latest, versioned);
+    }
+
+    #[test]
+    fn key_distinguishes_writes_by_mod_time() {
+        // ODC-06 (backlog#1111): two writes with identical etag + size (an MD5
+        // collision on an unversioned overwrite) must derive different keys once
+        // the modification time differs, so a stale node cannot serve old bytes.
+        let old = ObjectDataCacheKey::with_mod_time(
+            "bucket",
+            "object",
+            None,
+            "etag",
+            42,
+            1_000,
+            ObjectDataCacheBodyVariant::FullObjectPlainV1,
+        );
+        let new = ObjectDataCacheKey::with_mod_time(
+            "bucket",
+            "object",
+            None,
+            "etag",
+            42,
+            2_000,
+            ObjectDataCacheBodyVariant::FullObjectPlainV1,
+        );
+
+        assert_ne!(old, new, "keys differing only by mod_time must not collide");
+        // Same mod_time still collapses to one key (a true re-read of one write).
+        let new_again = ObjectDataCacheKey::with_mod_time(
+            "bucket",
+            "object",
+            None,
+            "etag",
+            42,
+            2_000,
+            ObjectDataCacheBodyVariant::FullObjectPlainV1,
+        );
+        assert_eq!(new, new_again);
+    }
+
+    #[test]
+    fn key_new_defaults_mod_time_to_zero() {
+        let key = ObjectDataCacheKey::new("bucket", "object", None, "etag", 42, ObjectDataCacheBodyVariant::FullObjectPlainV1);
+
+        assert_eq!(key.mod_time_unix_nanos, 0);
     }
 
     #[test]

--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -1237,6 +1237,7 @@ mod tests {
                 stream: Box::new(Cursor::new(data)),
                 object_info: ObjectInfo::default(),
                 buffered_body: None,
+                body_source: Default::default(),
             })
         }
 

--- a/rustfs/src/app/object_data_cache/adapter.rs
+++ b/rustfs/src/app/object_data_cache/adapter.rs
@@ -44,9 +44,14 @@ pub(crate) struct ObjectDataCacheAdapter {
 
 impl ObjectDataCacheAdapter {
     /// Creates an adapter from validated cache configuration.
+    ///
+    /// ODC-24 (backlog#1129): the engine's size eligibility is clamped to the
+    /// in-memory GET fill limits so a `max_entry_bytes` above them is not
+    /// reported as eligible while fill could never materialize the body.
     pub(crate) fn new(config: ObjectDataCacheConfig) -> Result<Self, ObjectDataCacheConfigError> {
+        let fill_ceiling = resolve_fill_ceiling_bytes(config.max_entry_bytes);
         Ok(Self {
-            cache: Arc::new(ObjectDataCache::new(config)?),
+            cache: Arc::new(ObjectDataCache::new(config)?.with_fill_ceiling_bytes(fill_ceiling)),
         })
     }
 
@@ -124,8 +129,37 @@ impl ObjectDataCacheAdapter {
 
 impl ObjectDataCacheAdapter {
     fn from_config_or_disabled(config: ObjectDataCacheConfig, source: &str) -> Arc<Self> {
+        let mode = config.mode;
+        let max_entry_bytes = config.max_entry_bytes;
+        // `Self::new` applies the ODC-24 fill-ceiling clamp; this startup path
+        // only adds the resolved-config logging on top.
         match Self::new(config) {
-            Ok(adapter) => Arc::new(adapter),
+            Ok(adapter) => {
+                if !adapter.is_disabled() {
+                    let ceiling = resolve_fill_ceiling_bytes(max_entry_bytes);
+                    // ODC-19: log the resolved mode at startup, and warn when the
+                    // operator explicitly selected the never-filling HitOnly mode.
+                    tracing::info!(source, ?mode, "object data cache enabled");
+                    // ODC-24: warn when the excess above the effective ceiling is inert.
+                    if max_entry_bytes > ceiling {
+                        warn!(
+                            source,
+                            max_entry_bytes,
+                            effective_fill_ceiling = ceiling,
+                            "RUSTFS_OBJECT_DATA_CACHE_MAX_ENTRY_BYTES exceeds the in-memory GET fill limit; \
+                             bodies above the effective cap are planned SkipTooLarge"
+                        );
+                    }
+                    if mode == ObjectDataCacheMode::HitOnly {
+                        warn!(
+                            source,
+                            "object data cache mode 'hit_only' never populates the cache; it only \
+                             serves as a runtime-downgrade target and keeps a permanent 0% hit rate"
+                        );
+                    }
+                }
+                Arc::new(adapter)
+            }
             Err(err) => {
                 warn!(
                     error = %err,
@@ -136,6 +170,17 @@ impl ObjectDataCacheAdapter {
             }
         }
     }
+}
+
+/// Resolves the effective fill ceiling from the app-layer in-memory GET fill
+/// limits: `min(max_entry_bytes, seek-support threshold, 64 MiB buffer cap)`
+/// (backlog#1129 / ODC-24). The concurrency-driven shrink of the fill threshold
+/// is dynamic and cannot be captured here, so this static ceiling is the
+/// conservative floor.
+fn resolve_fill_ceiling_bytes(max_entry_bytes: u64) -> u64 {
+    let seek_threshold = crate::app::object_usecase::object_seek_support_threshold() as u64;
+    let hard_cap = u64::try_from(crate::app::object_usecase::MAX_GET_OBJECT_MEMORY_BUFFER_BYTES).unwrap_or(u64::MAX);
+    max_entry_bytes.min(seek_threshold).min(hard_cap)
 }
 
 impl Default for ObjectDataCacheAdapter {
@@ -210,9 +255,13 @@ fn object_data_cache_config_from_values(values: ObjectDataCacheEnvValues) -> Obj
             config.mode = ObjectDataCacheMode::Disabled;
         }
         Some(true) if !mode_explicit => {
-            // Enable flag without an explicit mode: start at the safest
-            // enabled stage instead of silently staying disabled.
-            config.mode = ObjectDataCacheMode::HitOnly;
+            // Enable flag without an explicit mode: start at the safest stage
+            // that actually populates the cache. `HitOnly` never fills, so it
+            // would keep a permanent 0% hit rate and pay per-GET overhead for
+            // nothing (backlog#1124 / ODC-19). `FillBufferedOnly` fills only
+            // from bodies the GET path already buffered — no extra
+            // materialization — so it is both safe and effective.
+            config.mode = ObjectDataCacheMode::FillBufferedOnly;
         }
         _ => {}
     }
@@ -382,13 +431,66 @@ mod tests {
     }
 
     #[test]
-    fn object_data_cache_enable_true_without_mode_defaults_to_hit_only() {
+    fn object_data_cache_enable_true_without_mode_defaults_to_fill_buffered_only() {
+        // ODC-19 (backlog#1124): ENABLE=true with no explicit mode must default
+        // to a mode that actually populates the cache. HitOnly never fills.
         let config = object_data_cache_config_from_values(ObjectDataCacheEnvValues {
             enabled: Some(true),
             ..ObjectDataCacheEnvValues::default()
         });
 
-        assert_eq!(config.mode, ObjectDataCacheMode::HitOnly);
+        assert_eq!(config.mode, ObjectDataCacheMode::FillBufferedOnly);
+    }
+
+    #[test]
+    fn resolve_fill_ceiling_clamps_large_max_entry_bytes() {
+        // ODC-24 (backlog#1129): a max_entry_bytes above the in-memory GET fill
+        // limits is clamped down; the ceiling never exceeds the 64 MiB hard cap.
+        let huge = 512 * 1024 * 1024;
+        let ceiling = super::resolve_fill_ceiling_bytes(huge);
+        assert!(ceiling < huge, "a huge max_entry_bytes must be clamped down");
+        assert!(
+            ceiling <= u64::try_from(crate::app::object_usecase::MAX_GET_OBJECT_MEMORY_BUFFER_BYTES).unwrap(),
+            "the ceiling must not exceed the 64 MiB hard cap"
+        );
+    }
+
+    #[test]
+    fn resolve_fill_ceiling_leaves_small_max_entry_bytes_untouched() {
+        // A small max_entry_bytes is already below the fill limits, so it is the
+        // binding constraint and passes through unchanged.
+        assert_eq!(super::resolve_fill_ceiling_bytes(4096), 4096);
+    }
+
+    #[test]
+    fn startup_adapter_clamps_plan_eligibility_to_fill_ceiling() {
+        // ODC-24: an adapter built on the startup path with a `max_entry_bytes`
+        // above the in-memory GET fill limits must plan a gap-sized object
+        // `SkipTooLarge`, not `Cacheable` — otherwise it reports eligible while
+        // it can never fill.
+        let adapter = ObjectDataCacheAdapter::from_config_or_disabled(
+            ObjectDataCacheConfig {
+                mode: ObjectDataCacheMode::HitOnly,
+                max_bytes: 200 * 1024 * 1024,
+                max_memory_percent: 0,
+                max_entry_bytes: 128 * 1024 * 1024,
+                ..ObjectDataCacheConfig::default()
+            },
+            "test",
+        );
+
+        // 32 MiB is within max_entry_bytes (128 MiB) but above the effective
+        // ceiling (<= 64 MiB hard cap, and the 10 MiB default seek threshold).
+        let plan = adapter.plan_get(rustfs_object_data_cache::ObjectDataCacheGetRequest {
+            bucket: "bucket",
+            object: "object",
+            version_id: None,
+            etag: "etag",
+            size: 32 * 1024 * 1024,
+            mod_time_unix_nanos: 0,
+            body_variant: rustfs_object_data_cache::ObjectDataCacheBodyVariant::FullObjectPlainV1,
+        });
+        assert_eq!(plan, rustfs_object_data_cache::ObjectDataCacheGetPlan::SkipTooLarge);
     }
 
     #[test]
@@ -453,7 +555,7 @@ mod tests {
         temp_env::with_vars(vars, || {
             let config = object_data_cache_config_from_env().expect("valid numeric env should be applied");
 
-            assert_eq!(config.mode, ObjectDataCacheMode::HitOnly);
+            assert_eq!(config.mode, ObjectDataCacheMode::FillBufferedOnly);
             assert_eq!(config.max_entry_bytes, 2_097_152);
         });
     }

--- a/rustfs/src/app/object_data_cache/body.rs
+++ b/rustfs/src/app/object_data_cache/body.rs
@@ -124,6 +124,7 @@ mod tests {
             version_id: None,
             etag: "etag",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
         let fill = adapter.cache().fill_body(&plan, Bytes::from_static(b"hello")).await;

--- a/rustfs/src/app/object_data_cache/invalidation.rs
+++ b/rustfs/src/app/object_data_cache/invalidation.rs
@@ -144,6 +144,7 @@ mod tests {
             version_id: None,
             etag: "etag",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
         let fill = adapter.fill_body(&plan, Bytes::from_static(b"hello")).await;
@@ -170,6 +171,7 @@ mod tests {
             version_id: None,
             etag: "etag-a",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
         let plan_b = adapter.plan_get(rustfs_object_data_cache::ObjectDataCacheGetRequest {
@@ -178,6 +180,7 @@ mod tests {
             version_id: None,
             etag: "etag-b",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
         let _ = adapter.fill_body(&plan_a, Bytes::from_static(b"aaaaa")).await;

--- a/rustfs/src/app/object_data_cache/planner.rs
+++ b/rustfs/src/app/object_data_cache/planner.rs
@@ -81,12 +81,21 @@ pub(crate) fn build_get_object_body_cache_plan(
         .version_id
         .filter(|version_id| !version_id.is_nil())
         .map(|version_id| version_id.to_string());
+    // ODC-06 (backlog#1111): carry the resolved version's modification time into
+    // the key so an unversioned overwrite (which advances mod_time) cannot be
+    // served the stale body under an MD5 collision. Absent mod_time maps to 0.
+    let mod_time_unix_nanos = request
+        .info
+        .mod_time
+        .map(|mod_time| mod_time.unix_timestamp_nanos())
+        .unwrap_or(0);
     let engine_request = ObjectDataCacheGetRequest {
         bucket: request.bucket,
         object: request.key,
         version_id,
         etag,
         size,
+        mod_time_unix_nanos,
         body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
     };
 
@@ -240,6 +249,89 @@ mod tests {
         );
 
         assert!(matches!(plan, GetObjectBodyCachePlan::Skip));
+    }
+
+    fn cacheable_key(plan: &GetObjectBodyCachePlan) -> rustfs_object_data_cache::ObjectDataCacheKey {
+        match plan {
+            GetObjectBodyCachePlan::Cacheable(rustfs_object_data_cache::ObjectDataCacheGetPlan::Cacheable { key }) => key.clone(),
+            other => panic!("expected a cacheable plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hook_and_planner_derive_identical_keys() {
+        // ODC-16 correctness guard: the ecstore hook and the usecase planner both
+        // route through build_get_object_body_cache_plan, so for the same object
+        // they must derive byte-identical keys — otherwise every GET misses. The
+        // hook builds its request with response_content_length = get_actual_size;
+        // the usecase builds the same for a plain, non-range GET.
+        let adapter = enabled_adapter();
+        let info = crate::storage::storage_api::StorageObjectInfo {
+            etag: Some("etag".to_string()),
+            size: 4,
+            actual_size: 4,
+            mod_time: Some(time::OffsetDateTime::from_unix_timestamp_nanos(1_234_567_890).unwrap()),
+            ..Default::default()
+        };
+
+        let hook_request = GetObjectBodyCacheRequest {
+            bucket: "bucket",
+            key: "object",
+            info: &info,
+            response_content_length: info.get_actual_size().expect("actual size"),
+            has_range: false,
+            part_number: None,
+            encryption_applied: false,
+        };
+        let usecase_request = GetObjectBodyCacheRequest {
+            bucket: "bucket",
+            key: "object",
+            info: &info,
+            response_content_length: 4,
+            has_range: false,
+            part_number: None,
+            encryption_applied: false,
+        };
+
+        let hook_key = cacheable_key(&build_get_object_body_cache_plan(&adapter, hook_request));
+        let usecase_key = cacheable_key(&build_get_object_body_cache_plan(&adapter, usecase_request));
+
+        assert_eq!(hook_key, usecase_key, "hook and planner must derive the same key");
+        // ODC-06: the modification time flows into the key.
+        assert_eq!(hook_key.mod_time_unix_nanos, 1_234_567_890);
+    }
+
+    #[test]
+    fn planner_key_changes_with_mod_time() {
+        // ODC-06 (backlog#1111): an unversioned overwrite advances mod_time, so
+        // the same etag + size must derive a different key.
+        let adapter = enabled_adapter();
+        let mut info = crate::storage::storage_api::StorageObjectInfo {
+            etag: Some("etag".to_string()),
+            size: 4,
+            actual_size: 4,
+            mod_time: Some(time::OffsetDateTime::from_unix_timestamp_nanos(1_000).unwrap()),
+            ..Default::default()
+        };
+        let make_request = |info: &crate::storage::storage_api::StorageObjectInfo| {
+            build_get_object_body_cache_plan(
+                &adapter,
+                GetObjectBodyCacheRequest {
+                    bucket: "bucket",
+                    key: "object",
+                    info,
+                    response_content_length: 4,
+                    has_range: false,
+                    part_number: None,
+                    encryption_applied: false,
+                },
+            )
+        };
+        let old_key = cacheable_key(&make_request(&info));
+        info.mod_time = Some(time::OffsetDateTime::from_unix_timestamp_nanos(2_000).unwrap());
+        let new_key = cacheable_key(&make_request(&info));
+
+        assert_ne!(old_key, new_key, "keys differing only by mod_time must not collide");
     }
 
     #[test]

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -206,7 +206,7 @@ use crate::app::object_data_cache::{
 type S3StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 const ACCEPT_RANGES_BYTES: &str = "bytes";
-const MAX_GET_OBJECT_MEMORY_BUFFER_BYTES: i64 = 64 * 1024 * 1024;
+pub(crate) const MAX_GET_OBJECT_MEMORY_BUFFER_BYTES: i64 = 64 * 1024 * 1024;
 const MEDIUM_CONCURRENCY_GET_OBJECT_MEMORY_BUFFER_BYTES: i64 = 8 * 1024 * 1024;
 const HIGH_CONCURRENCY_GET_OBJECT_MEMORY_BUFFER_BYTES: i64 = 4 * 1024 * 1024;
 const VERY_HIGH_CONCURRENCY_GET_OBJECT_MEMORY_BUFFER_BYTES: i64 = 1024 * 1024;
@@ -337,6 +337,12 @@ struct GetObjectReadSetup {
     info: ObjectInfo,
     final_stream: DynReader,
     buffered_body: Option<Bytes>,
+    /// ODC-16: `buffered_body` is the body the ecstore cache hook served, so the
+    /// app layer serves it as the object-data-cache source without a re-lookup.
+    cache_hook_served: bool,
+    /// ODC-16: the cache hook probed this read (served or missed), so the app
+    /// layer must skip its own lookup.
+    cache_hook_probed: bool,
     rs: Option<HTTPRangeSpec>,
     content_type: Option<ContentType>,
     last_modified: Option<Timestamp>,
@@ -1497,7 +1503,7 @@ where
     Ok(ChunkedBytesReader::new(chunks))
 }
 
-fn object_seek_support_threshold() -> usize {
+pub(crate) fn object_seek_support_threshold() -> usize {
     static OBJECT_SEEK_SUPPORT_THRESHOLD: OnceLock<usize> = OnceLock::new();
     *OBJECT_SEEK_SUPPORT_THRESHOLD.get_or_init(|| {
         rustfs_utils::get_env_usize(
@@ -2730,6 +2736,11 @@ impl DefaultObjectUsecase {
             );
         }
 
+        // ODC-16: capture whether the ecstore cache hook already probed this
+        // read, so the app layer does not repeat the lookup it ran after fresh
+        // metadata resolution.
+        let cache_hook_served = reader.is_cache_hook_served();
+        let cache_hook_probed = reader.cache_hook_probed();
         let info = reader.object_info;
         let stream = reader.stream;
         let buffered_body = reader.buffered_body;
@@ -2843,6 +2854,8 @@ impl DefaultObjectUsecase {
             info,
             final_stream,
             buffered_body,
+            cache_hook_served,
+            cache_hook_probed,
             rs,
             content_type,
             last_modified,
@@ -3140,6 +3153,8 @@ impl DefaultObjectUsecase {
         has_range: bool,
         encryption_applied: bool,
         buffered_body: Option<Bytes>,
+        cache_hook_served: bool,
+        cache_hook_probed: bool,
         bucket: &str,
         key: &str,
         mut lifecycle: GetObjectBodyLifecycle,
@@ -3158,16 +3173,35 @@ impl DefaultObjectUsecase {
         };
         let cache_plan = build_get_object_body_cache_plan(cache_adapter, cache_request);
 
-        match lookup_get_object_body_cache_hit(cache_adapter, &cache_plan).await {
-            GetObjectBodyCacheLookup::Hit(bytes) => {
-                return Ok(Self::build_memory_bytes_blob(
-                    bytes,
-                    response_content_length,
-                    GET_MEMORY_BODY_SOURCE_OBJECT_DATA_CACHE,
-                    lifecycle,
-                ));
+        // ODC-16 (backlog#1121): when the ecstore hook already served this body
+        // from the cache, serve it straight through as the object-data-cache
+        // source. Re-running the lookup here would record a second hit, double
+        // the hit_bytes, and do redundant moka work for one hook-served GET.
+        if cache_hook_served && let Some(bytes) = buffered_body.clone() {
+            return Ok(Self::build_memory_bytes_blob(
+                bytes,
+                response_content_length,
+                GET_MEMORY_BODY_SOURCE_OBJECT_DATA_CACHE,
+                lifecycle,
+            ));
+        }
+
+        // ODC-16: only look up when the hook did not probe this read. When it did
+        // probe (a served body handled above, or a miss), its result is
+        // authoritative because it ran after fresh metadata resolution, so the
+        // app layer skips its own lookup and only uses the plan to fill.
+        if !cache_hook_probed {
+            match lookup_get_object_body_cache_hit(cache_adapter, &cache_plan).await {
+                GetObjectBodyCacheLookup::Hit(bytes) => {
+                    return Ok(Self::build_memory_bytes_blob(
+                        bytes,
+                        response_content_length,
+                        GET_MEMORY_BODY_SOURCE_OBJECT_DATA_CACHE,
+                        lifecycle,
+                    ));
+                }
+                GetObjectBodyCacheLookup::Disabled | GetObjectBodyCacheLookup::Skip | GetObjectBodyCacheLookup::Miss => {}
             }
-            GetObjectBodyCacheLookup::Disabled | GetObjectBodyCacheLookup::Skip | GetObjectBodyCacheLookup::Miss => {}
         }
 
         if let Some(buffered_body) = buffered_body {
@@ -4059,6 +4093,8 @@ impl DefaultObjectUsecase {
         event_info: Option<ObjectInfo>,
         final_stream: DynReader,
         buffered_body: Option<Bytes>,
+        cache_hook_served: bool,
+        cache_hook_probed: bool,
         rs: Option<HTTPRangeSpec>,
         content_type: Option<ContentType>,
         last_modified: Option<Timestamp>,
@@ -4111,6 +4147,8 @@ impl DefaultObjectUsecase {
             rs.is_some(),
             encryption_applied,
             buffered_body,
+            cache_hook_served,
+            cache_hook_probed,
             bucket,
             key,
             lifecycle,
@@ -4277,6 +4315,8 @@ impl DefaultObjectUsecase {
             info,
             final_stream,
             buffered_body,
+            cache_hook_served,
+            cache_hook_probed,
             rs,
             content_type,
             last_modified,
@@ -4309,6 +4349,8 @@ impl DefaultObjectUsecase {
                 event_info,
                 final_stream,
                 buffered_body,
+                cache_hook_served,
+                cache_hook_probed,
                 rs,
                 content_type,
                 last_modified,
@@ -7124,6 +7166,7 @@ mod tests {
             version_id: None,
             etag,
             size,
+            mod_time_unix_nanos: 0,
             body_variant: rustfs_object_data_cache::ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
         for _ in 0..400 {
@@ -7534,6 +7577,7 @@ mod tests {
             version_id: None,
             etag: "etag",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: rustfs_object_data_cache::ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
         let fill = adapter.cache().fill_body(&plan, Bytes::from_static(b"hello")).await;
@@ -7552,6 +7596,8 @@ mod tests {
             false,
             false,
             None,
+            false,
+            false,
             "test-bucket",
             "cached-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7592,6 +7638,7 @@ mod tests {
             version_id: None,
             etag: "etag",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: rustfs_object_data_cache::ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
         let fill = adapter.cache().fill_body(&plan, Bytes::from_static(b"oops")).await;
@@ -7608,6 +7655,8 @@ mod tests {
             false,
             false,
             None,
+            false,
+            false,
             "test-bucket",
             "cached-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7665,6 +7714,8 @@ mod tests {
             false,
             false,
             Some(Bytes::from_static(b"hello")),
+            false,
+            false,
             "test-bucket",
             "cached-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7688,6 +7739,8 @@ mod tests {
             false,
             false,
             None,
+            false,
+            false,
             "test-bucket",
             "cached-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7733,6 +7786,7 @@ mod tests {
             version_id: None,
             etag: "etag",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: rustfs_object_data_cache::ObjectDataCacheBodyVariant::FullObjectPlainV1,
         });
 
@@ -7748,6 +7802,8 @@ mod tests {
             false,
             false,
             Some(Bytes::from_static(b"oops")),
+            false,
+            false,
             "test-bucket",
             "cached-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7764,6 +7820,143 @@ mod tests {
         assert!(
             matches!(lookup, rustfs_object_data_cache::ObjectDataCacheLookup::Miss),
             "size-mismatched buffered body must not be filled into cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_get_object_body_with_cache_hook_served_records_no_second_lookup() {
+        // ODC-16 (backlog#1121): a hook-served GET must record exactly one
+        // lookup — the ecstore hook's. The app layer, handed the cache body as
+        // buffered_body with cache_hook_served=true, must serve it directly
+        // without a second lookup (which would double the hits and hit_bytes).
+        let reads = Arc::new(AtomicUsize::new(0));
+        let reader = ReadProbeReader {
+            reads: Arc::clone(&reads),
+        };
+        let info = ObjectInfo {
+            size: 5,
+            etag: Some("etag".to_string()),
+            ..Default::default()
+        };
+        let adapter =
+            crate::app::object_data_cache::ObjectDataCacheAdapter::new(rustfs_object_data_cache::ObjectDataCacheConfig {
+                mode: rustfs_object_data_cache::ObjectDataCacheMode::FillBufferedOnly,
+                max_bytes: 8_388_608,
+                min_free_memory_percent: 0,
+                ..rustfs_object_data_cache::ObjectDataCacheConfig::default()
+            })
+            .expect("fill-enabled cache adapter should initialize");
+        let plan = adapter.plan_get(rustfs_object_data_cache::ObjectDataCacheGetRequest {
+            bucket: "test-bucket",
+            object: "hook-served",
+            version_id: None,
+            etag: "etag",
+            size: 5,
+            mod_time_unix_nanos: 0,
+            body_variant: rustfs_object_data_cache::ObjectDataCacheBodyVariant::FullObjectPlainV1,
+        });
+        let hit_body = Bytes::from_static(b"hello");
+        assert_eq!(
+            adapter.cache().fill_body(&plan, hit_body.clone()).await,
+            rustfs_object_data_cache::ObjectDataCacheFillResult::Inserted
+        );
+
+        // Simulate the ecstore hook: it performs exactly one lookup after fresh
+        // metadata resolution, hits, and hands the body forward as buffered_body.
+        assert!(matches!(
+            adapter.lookup_body(&plan).await,
+            rustfs_object_data_cache::ObjectDataCacheLookup::Hit(_)
+        ));
+        let lookups_after_hook = adapter.cache().stats().lookups;
+        assert_eq!(lookups_after_hook, 1, "the hook performs exactly one lookup");
+
+        let _body = DefaultObjectUsecase::build_get_object_body_with_cache(
+            &adapter,
+            reader,
+            &info,
+            5,
+            128 * 1024,
+            false,
+            1,
+            None,
+            false,
+            false,
+            Some(hit_body),
+            /* cache_hook_served */ true,
+            /* cache_hook_probed */ true,
+            "test-bucket",
+            "hook-served",
+            GetObjectBodyLifecycle::disabled(),
+        )
+        .await
+        .expect("hook-served body handoff should succeed");
+
+        assert_eq!(
+            adapter.cache().stats().lookups,
+            lookups_after_hook,
+            "a hook-served GET must not record a second lookup in the app layer"
+        );
+        assert_eq!(
+            reads.load(AtomicOrdering::Relaxed),
+            0,
+            "hook-served body handoff must not read from the fallback reader"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_get_object_body_with_cache_hook_miss_skips_app_lookup() {
+        // ODC-16: when the hook probed and missed, its miss is authoritative
+        // (it ran after fresh metadata resolution), so the app layer must not
+        // run a second lookup — it only fills from the buffered body.
+        let reads = Arc::new(AtomicUsize::new(0));
+        let reader = ReadProbeReader {
+            reads: Arc::clone(&reads),
+        };
+        let info = ObjectInfo {
+            size: 5,
+            etag: Some("etag".to_string()),
+            ..Default::default()
+        };
+        let adapter =
+            crate::app::object_data_cache::ObjectDataCacheAdapter::new(rustfs_object_data_cache::ObjectDataCacheConfig {
+                mode: rustfs_object_data_cache::ObjectDataCacheMode::FillBufferedOnly,
+                max_bytes: 8_388_608,
+                min_free_memory_percent: 0,
+                ..rustfs_object_data_cache::ObjectDataCacheConfig::default()
+            })
+            .expect("fill-enabled cache adapter should initialize");
+
+        let lookups_before = adapter.cache().stats().lookups;
+        let _body = DefaultObjectUsecase::build_get_object_body_with_cache(
+            &adapter,
+            reader,
+            &info,
+            5,
+            128 * 1024,
+            false,
+            1,
+            None,
+            false,
+            false,
+            Some(Bytes::from_static(b"hello")),
+            /* cache_hook_served */ false,
+            /* cache_hook_probed */ true,
+            "test-bucket",
+            "hook-missed",
+            GetObjectBodyLifecycle::disabled(),
+        )
+        .await
+        .expect("hook-miss buffered-body handoff should succeed");
+
+        assert_eq!(
+            adapter.cache().stats().lookups,
+            lookups_before,
+            "a hook-probed miss must not trigger an app-layer lookup"
+        );
+        assert_eq!(
+            reads.load(AtomicOrdering::Relaxed),
+            0,
+            "buffered-body handoff must not read from the fallback reader"
         );
     }
 
@@ -7805,6 +7998,8 @@ mod tests {
             false,
             false,
             None,
+            false,
+            false,
             "test-bucket",
             "materialized-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7828,6 +8023,8 @@ mod tests {
             false,
             false,
             None,
+            false,
+            false,
             "test-bucket",
             "materialized-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7885,6 +8082,8 @@ mod tests {
             false,
             false,
             None,
+            false,
+            false,
             "test-bucket",
             "mismatch-object",
             GetObjectBodyLifecycle::disabled(),
@@ -7932,6 +8131,8 @@ mod tests {
             false,
             false,
             None,
+            false,
+            false,
             "test-bucket",
             "too-large-object",
             GetObjectBodyLifecycle::disabled(),
@@ -8679,6 +8880,8 @@ mod tests {
                 Some(info),
                 wrap_reader(tokio::io::empty()),
                 None,
+                false,
+                false,
                 None,
                 None,
                 None,


### PR DESCRIPTION
## Summary

Four defects on the GET path of the object data cache: the key was content-unique rather than write-unique, every cacheable GET performed the same lookup twice, the documented "enable" default selected a mode that can never hit, and a size knob above the fill thresholds was silently inert.

## The key is now write-unique (backlog [#1111](https://github.com/rustfs/backlog/issues/1111))

`ObjectDataCacheKey` carried no write-unique component. For an unversioned overwrite, uniqueness rested entirely on MD5 collision resistance: two same-length payloads with the same MD5 produce the same key, so a node that did not observe the overwrite serves the old bytes for up to TTL. The same collision turns the fill-after-invalidation race into a serving bug.

Added `mod_time_unix_nanos: i128`. `mod_time` already exists on `ObjectInfo` and both derivation sites already hold it, so this costs one field and no extra metadata fan-out. `etag + size` stay as belt-and-braces.

The two derivation sites must produce an **identical** key or every GET misses. They do, by construction — both route through `build_get_object_body_cache_plan`, the single derivation point — and `hook_and_planner_derive_identical_keys` proves it rather than assuming it.

`ObjectDataCacheKey::new` keeps its 6-arg signature (delegating with `mod_time = 0`); `with_mod_time` is the full constructor. That kept `moka_backend.rs`, `index.rs`, `entry.rs` and `singleflight.rs` untouched.

This also collapses the residual window from backlog [#1118](https://github.com/rustfs/backlog/issues/1118): even if a stale entry survives a fill-after-invalidation race, its `mod_time` cannot match the new version's metadata, so no later GET can resolve to it.

## One GET, one lookup (backlog [#1121](https://github.com/rustfs/backlog/issues/1121))

The ecstore hook probe ran `build_get_object_body_cache_plan` + `lookup_get_object_body_cache_hit`. On a hit the body landed in `GetObjectReader.buffered_body` and the flow continued into `build_get_object_body_with_cache`, which built the same plan and looked up **again**. Each `lookup_body` increments `stats.lookups`/`hits` and emits `lookup_total` + `hit_bytes`, so one hook-served GET deterministically recorded 2 hits, 2× hit_bytes and 2 lookups. Misses doubled the same way, and the second moka lookup was pure waste.

`GetObjectReader` gains a `GetObjectBodySource` field — `Unprobed` / `HookMissed` / `HookServed` — plus two bool accessors. An enum rather than a newtype because three states must be distinguished, and the accessors let the rustfs layer consume two plain bools **without** exporting the enum through ecstore's public API. Construction sites default to `Unprobed`; the probe stamps the real value.

A hook-served body is now returned directly, and the usecase lookup runs only when the request never passed the hook. The hook's miss is authoritative — it ran after the same fresh metadata resolution.

## `ENABLE=true` no longer selects a mode that cannot hit (backlog [#1124](https://github.com/rustfs/backlog/issues/1124))

In `HitOnly`, `fill_enabled()` is false, so nothing is ever inserted and the mode is fixed at construction. A `HitOnly` cache is therefore permanently empty: every GET pays hook registration, plan, lookup and gauge churn for a 0% hit rate, forever. That was the default for `RUSTFS_OBJECT_DATA_CACHE_ENABLE=true` with no explicit mode.

The default is now `FillBufferedOnly` — fills only from bodies the GET path already buffered, no extra materialization. The resolved mode is logged at startup, and choosing `HitOnly` explicitly now warns that it never populates the cache and is only meaningful as a runtime-downgrade target.

## `max_entry_bytes` above the fill ceiling is no longer inert (backlog [#1129](https://github.com/rustfs/backlog/issues/1129))

`plan_get` admitted any `size <= max_entry_bytes`, but materialize fill is gated by `should_materialize_get_object_body_for_cache`, which reuses `object_seek_support_threshold()` (10 MiB default), hard-capped at `MAX_GET_OBJECT_MEMORY_BUFFER_BYTES` (64 MiB). Objects in the gap were planned `Cacheable` — the metric said "eligible" — never filled, and showed a permanent 0% hit rate.

The adapter computes `effective_fill_ceiling = min(max_entry_bytes, seek_threshold, MAX_GET_OBJECT_MEMORY_BUFFER_BYTES)` and warns at startup when the excess is inert; `plan_get` clamps eligibility to it, so ineligible sizes take `SkipTooLarge` and stop being reported as cacheable.

The ceiling lives on the `ObjectDataCache` engine struct rather than `ObjectDataCacheConfig`: adding a required config field would have broken the full struct literals in `moka_backend.rs` and `memory.rs`. The concurrency-driven shrink is dynamic and cannot be captured at plan time, so the static ceiling is the conservative floor — noted in a comment.

## Mutation testing

| mutation | failing test |
|---|---|
| `effective_size_ceiling` → `max_entry_bytes` | `plan_clamps_size_eligibility_to_fill_ceiling` (`left: Cacheable{…4194305…}`, `right: SkipTooLarge`) |
| planner forces `mod_time_unix_nanos = 0` | `planner_key_changes_with_mod_time`, `hook_and_planner_derive_identical_keys` |
| engine drops `request.mod_time_unix_nanos` | `plan_carries_mod_time_into_key` (`left: 0`, `right: 42`) |
| default back to `HitOnly` | `..._defaults_to_fill_buffered_only` |
| **disable the hook-served early return AND force the usecase lookup unconditional** | `hook_served_records_no_second_lookup` (2 lookups), `hook_miss_skips_app_lookup` |
| `HookServed`/`HookMissed` → `Unprobed` | `plain_cache_hit_marks_reader_hook_served`, `plain_cache_miss_marks_reader_hook_missed` |

The double-lookup row needed **both** guards disabled: the served early-return sits before the lookup gate, so mutating the gate alone leaves the test green. The tests assert on `stats().lookups`, not merely that a hit occurred.

The three P0 `body_cache_hook_e2e_tests` (raw-data-movement, compressed-hit-size, restore-read) are untouched and still pass; two new e2e cases cover the reader marking.

## Verification

```
cargo test -p rustfs-object-data-cache               79 passed
cargo test -p rustfs-ecstore body_cache             13 passed
cargo test -p rustfs object_data_cache              35 passed
cargo test -p rustfs build_get_object_body_with_cache 9 passed
cargo clippy -p rustfs-object-data-cache -p rustfs-ecstore -p rustfs --all-targets -- -D warnings   clean
make pre-commit                                      passed
```

Verified on top of the current `main` (merged, no conflicts), not a stale base.

## Merge note

`fix/odc-invalidation-coverage` (the sibling wave-3 branch) adds `rustfs/src/app/object_data_cache/mutation_hook.rs`, whose test constructs `ObjectDataCacheGetRequest`. Once this PR lands, that branch needs one line — `mod_time_unix_nanos: 0,` — in that literal. Text merge is clean and `cargo check` passes without it; only `cargo test` catches it. Verified jointly in an integration worktree.

Part of the object-data-cache audit, backlog [#1107](https://github.com/rustfs/backlog/issues/1107).