### PR TITLE
docs(object-data-cache): state the correctness boundary and timing channel

### DIFF
--- a/crates/config/src/constants/runtime.rs
+++ b/crates/config/src/constants/runtime.rs
@@ -120,6 +120,25 @@ pub const ENV_OBJECT_SEEK_SUPPORT_THRESHOLD: &str = "RUSTFS_OBJECT_SEEK_SUPPORT_
 pub const DEFAULT_OBJECT_SEEK_SUPPORT_THRESHOLD: usize = 10 * 1024 * 1024;
 
 // Object data cache configuration
+
+/// Enables the in-memory object body cache, which serves whole-object GET
+/// responses without an erasure read.
+///
+/// # Timing side channel
+///
+/// A cache hit skips the erasure read, bitrot verification and decode, so it is
+/// reliably faster than a miss. Any principal authorized to read an object can
+/// therefore infer, by timing a single GET, whether *someone* read that object
+/// within the entry's lifetime (see `RUSTFS_OBJECT_DATA_CACHE_TTL_SECS` and
+/// `..._TIME_TO_IDLE_SECS`).
+///
+/// This never crosses an authorization boundary — the probe requires read
+/// access to the exact bucket and object, checked before the cache is consulted
+/// — but it does disclose co-tenants' recent access patterns on objects the
+/// observer may already read. Leave the cache disabled where access-pattern
+/// confidentiality matters, such as a bucket shared read-only between competing
+/// tenants. Timing noise is not a viable mitigation: it would cost exactly the
+/// latency the cache exists to save.
 pub const ENV_OBJECT_DATA_CACHE_ENABLE: &str = "RUSTFS_OBJECT_DATA_CACHE_ENABLE";
 pub const ENV_OBJECT_DATA_CACHE_MODE: &str = "RUSTFS_OBJECT_DATA_CACHE_MODE";
 pub const ENV_OBJECT_DATA_CACHE_MAX_BYTES: &str = "RUSTFS_OBJECT_DATA_CACHE_MAX_BYTES";

--- a/crates/object-data-cache/src/lib.rs
+++ b/crates/object-data-cache/src/lib.rs
@@ -12,11 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Engine-only object body cache contracts for RustFS.
+//! Engine-only object body cache for RustFS.
 //!
-//! This crate intentionally contains only a minimal skeleton for the initial
-//! rollout phase. App-layer semantics and storage-specific read paths stay in
-//! the `rustfs` crate.
+//! App-layer semantics and storage-specific read paths stay in the `rustfs`
+//! crate; this crate owns the key, the eviction backend and the metrics.
+//!
+//! # Correctness boundary
+//!
+//! An entry is keyed by object identity — bucket, object, version, etag, size
+//! and body variant — and every lookup runs after the caller has resolved fresh
+//! metadata from a read quorum. Serving a hit is therefore sound because the
+//! key matched metadata that was just read, not because the entry was recently
+//! invalidated. Invalidation is process-local and is **hygiene**: it frees
+//! capacity promptly, but the key is what keeps a stale body from being served.
+//!
+//! # Timing side channel
+//!
+//! A cache hit skips the erasure read, bitrot verification and decode, so it is
+//! reliably faster than a miss. Any principal authorized to read an object can
+//! therefore infer, by timing a single GET, whether *someone* read that object
+//! within the entry's lifetime (`ttl` / `time_to_idle`).
+//!
+//! This never crosses an authorization boundary: the probe requires read access
+//! to the exact bucket and object, which is checked before the cache is
+//! consulted. It does leak co-tenants' recent access patterns on objects the
+//! observer may already read. Deployments where access-pattern confidentiality
+//! matters — a bucket shared read-only between competing tenants — should leave
+//! the cache disabled for those buckets. Adding timing noise is not a viable
+//! mitigation: it would cost exactly the latency the cache exists to save.
 
 pub mod backend;
 pub mod cache;


### PR DESCRIPTION
## Summary

Two documentation gaps on the object data cache: the crate still called itself "a minimal skeleton for the initial rollout phase" — untrue for several releases — and neither the crate nor the operator-facing env var said anything about what the cache does or does not guarantee. This records the two things a reader has to know before touching it.

## The correctness boundary

A hit is sound because the key matched metadata the caller just resolved from a read quorum, not because invalidation ran. Process-local invalidation is hygiene that frees capacity promptly; the key is what keeps a stale body from being served. Anyone tempted to weaken the key meets that sentence first, in the crate rustdoc.

## The timing side channel (backlog [#1139](https://github.com/rustfs/backlog/issues/1139))

A hit skips the erasure read, bitrot verify and decode, so it is reliably faster than a miss. A principal authorized to read an object can time a single GET and learn whether *someone* read that object within the entry's lifetime.

This crosses no authorization boundary — the probe needs read access to that exact object, checked before the cache is consulted — but it does disclose a co-tenant's recent access pattern on objects the observer may already read. The finding's conclusion was to **document** this accepted risk, not mitigate it: timing noise would cost precisely the latency the cache exists to save.

Recorded where operators look — on `RUSTFS_OBJECT_DATA_CACHE_ENABLE` in `crates/config/src/constants/runtime.rs`, which previously had no rustdoc at all while its neighbours did — with the guidance to leave the cache disabled for buckets where access-pattern confidentiality matters (e.g. a bucket shared read-only between competing tenants).

The docs deliberately do **not** state what mode `ENABLE=true` defaults to: PR #4693 changes that default from the never-hitting `HitOnly` to `FillBufferedOnly`, and hard-coding it here would go stale on that merge.

## Scope

Documentation only — `crates/object-data-cache/src/lib.rs` and `crates/config/src/constants/runtime.rs`. No code paths change.

```
cargo clippy -p rustfs-object-data-cache -p rustfs-config --all-targets -- -D warnings   clean
make pre-commit                                                                          passed
```

Note: `cargo doc` on `rustfs-object-data-cache` currently emits one warning from `crates/object-data-cache/src/memory.rs` (a public doc linking a private item), pre-existing on `main` and **not** touched by this PR. It is fixed by the sibling wave-3 branch (PR #4694) and will clear when that lands; CI does not run `cargo doc` with `-D warnings`, so it is not gating.

Part of the object-data-cache audit, backlog [#1107](https://github.com/rustfs/backlog/issues/1107).

