### PR TITLE
refactor(obs): drop the dial9 S3 config left stranded by the upload revert

### DIFF
--- a/crates/obs/src/telemetry/dial9/config.rs
+++ b/crates/obs/src/telemetry/dial9/config.rs
@@ -84,12 +84,6 @@ pub struct Dial9Config {
 
     /// Number of rotated files to keep
     pub rotation_count: usize,
-
-    /// Optional S3 bucket for uploading sealed trace segments
-    pub s3_bucket: Option<String>,
-
-    /// Optional key prefix for uploaded segments
-    pub s3_prefix: Option<String>,
 }
 
 impl Default for Dial9Config {
@@ -100,27 +94,28 @@ impl Default for Dial9Config {
             file_prefix: DEFAULT_RUNTIME_DIAL9_FILE_PREFIX.to_string(),
             max_file_size: DEFAULT_RUNTIME_DIAL9_MAX_FILE_SIZE,
             rotation_count: DEFAULT_RUNTIME_DIAL9_ROTATION_COUNT,
-            s3_bucket: None,
-            s3_prefix: None,
         }
     }
 }
 
 impl Dial9Config {
-    /// Create configuration from environment variables.
+    /// Create configuration from environment variables, recording the resulting
+    /// trace location so metrics can report it even on a disabled binary.
     pub fn from_env() -> Self {
-        let enabled = is_enabled();
+        let config = if is_enabled() {
+            Self::from_env_enabled()
+        } else {
+            Self::default()
+        };
+        dial9_runtime_state().record_config(&config);
+        config
+    }
 
-        if !enabled {
-            let config = Self::default();
-            dial9_runtime_state().record_config(&config);
-            return config;
-        }
-
+    /// Build the enabled configuration from the environment, warning about any
+    /// knob that is set but cannot be honoured.
+    fn from_env_enabled() -> Self {
         let raw_max_file_size = get_env_opt_u64(ENV_RUNTIME_DIAL9_MAX_FILE_SIZE);
         let raw_rotation_count = get_env_opt_usize(ENV_RUNTIME_DIAL9_ROTATION_COUNT);
-        let max_file_size = sanitize_max_file_size(raw_max_file_size.unwrap_or(DEFAULT_RUNTIME_DIAL9_MAX_FILE_SIZE));
-        let rotation_count = sanitize_rotation_count(raw_rotation_count.unwrap_or(DEFAULT_RUNTIME_DIAL9_ROTATION_COUNT));
 
         if raw_max_file_size == Some(0) {
             warn!(
@@ -143,22 +138,24 @@ impl Dial9Config {
             );
         }
 
-        let s3_bucket = get_env_opt_str(ENV_RUNTIME_DIAL9_S3_BUCKET).filter(|s| !s.is_empty());
-        let s3_prefix = get_env_opt_str(ENV_RUNTIME_DIAL9_S3_PREFIX).filter(|s| !s.is_empty());
-        warn_unusable_s3_upload(s3_bucket.as_deref(), s3_prefix.as_deref());
+        // S3 upload is not built (see `warn_unusable_s3_upload`); read the knobs
+        // only to warn, and drop them rather than carrying dead configuration.
+        warn_unusable_s3_upload(
+            get_env_opt_str(ENV_RUNTIME_DIAL9_S3_BUCKET)
+                .filter(|s| !s.is_empty())
+                .as_deref(),
+            get_env_opt_str(ENV_RUNTIME_DIAL9_S3_PREFIX)
+                .filter(|s| !s.is_empty())
+                .as_deref(),
+        );
 
-        let config = Self {
-            enabled,
+        Self {
+            enabled: true,
             output_dir: get_env_str(ENV_RUNTIME_DIAL9_OUTPUT_DIR, DEFAULT_RUNTIME_DIAL9_OUTPUT_DIR),
             file_prefix: get_env_str(ENV_RUNTIME_DIAL9_FILE_PREFIX, DEFAULT_RUNTIME_DIAL9_FILE_PREFIX),
-            max_file_size,
-            rotation_count,
-            s3_bucket,
-            s3_prefix,
-        };
-
-        dial9_runtime_state().record_config(&config);
-        config
+            max_file_size: sanitize_max_file_size(raw_max_file_size.unwrap_or(DEFAULT_RUNTIME_DIAL9_MAX_FILE_SIZE)),
+            rotation_count: sanitize_rotation_count(raw_rotation_count.unwrap_or(DEFAULT_RUNTIME_DIAL9_ROTATION_COUNT)),
+        }
     }
 
     /// Get the base path for trace files.
@@ -169,11 +166,6 @@ impl Dial9Config {
     /// Total on-disk byte budget across all retained segments.
     pub fn total_disk_budget(&self) -> u64 {
         total_rotation_size(self.max_file_size, self.rotation_count)
-    }
-
-    /// Whether S3 upload of sealed segments is both requested and usable.
-    pub fn s3_upload_requested(&self) -> bool {
-        self.s3_bucket.is_some()
     }
 }
 

--- a/crates/obs/src/telemetry/dial9/enabled.rs
+++ b/crates/obs/src/telemetry/dial9/enabled.rs
@@ -51,11 +51,6 @@ impl Dial9SessionGuard {
     pub fn is_active(&self) -> bool {
         self.guard.is_enabled()
     }
-
-    /// The configuration this session was built from.
-    pub fn config(&self) -> &Dial9Config {
-        &self.config
-    }
 }
 
 impl std::fmt::Debug for Dial9SessionGuard {


### PR DESCRIPTION
## Summary

A follow-up cleanup to the dial9 integration, split out from #4688 because it could not be rebased onto `main` cleanly until #4688 landed (both rewrote `Dial9Config::from_env`). Now that #4688 is merged, this applies with zero conflicts.

Pure dead-code removal, no behavior change.

## What was stranded

#4663 added a full S3 upload path for sealed trace segments — config fields, env parsing, and the `with_s3_uploader` wiring. It then reverted the wiring when `dial9`'s `worker-s3` feature turned out to pull in a `rustls-webpki` carrying RUSTSEC-2026-0098/-0099/-0104 (backlog#1157, D9-14). The revert stopped at `enabled.rs` and left the config layer half torn down:

- `Dial9Config.s3_bucket` / `s3_prefix` — two fields with **zero consumers** (only written, never read)
- `Dial9Config::s3_upload_requested()` — a method with **zero callers**
- `Dial9SessionGuard::config()` — likewise **zero callers**

All three verified dead by grep across the workspace.

## Change

Since S3 upload cannot be built at all, `Dial9Config` should not model it. Drop the two fields and both dead accessors. `from_env` still reads `RUSTFS_RUNTIME_DIAL9_S3_{BUCKET,PREFIX}` and warns about them — an operator who set them deserves to know why they do nothing, and that warning is deliberate (D9-14) — but it drops the values instead of storing configuration nothing reads.

While here, collapse `from_env`'s two `record_config` calls into one by extracting `from_env_enabled`, so the enabled and disabled paths share a single publish point.

`Dial9Config` drops from 8 fields to 6; net −13 lines.

## Not a behavior change

The S3 warning fires identically (same trigger, same fields, same message). Every other config field and code path is untouched. The `warn_unusable_s3_upload` helper and its RUSTSEC explanation stay exactly as they were.

## Verification

- `cargo clippy -p rustfs-obs --all-targets -- -D warnings` clean, both default and `--features dial9`
- Tests: `rustfs-obs` 236 (default) / 237 (`dial9`), `rustfs-config` 24 — all pass
- `make pre-commit` passes

Tracking: rustfs/backlog#1157 (part of the D9-14 cleanup)
