### PR TITLE
chore(ecstore): switch rustfs-uring to crates.io 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,7 +3966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5376,7 +5376,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8094,7 +8094,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10032,7 +10032,8 @@ dependencies = [
 [[package]]
 name = "rustfs-uring"
 version = "0.1.0"
-source = "git+https://github.com/rustfs/uring?rev=719b245f9bb24e838de8639c19858df2690f3ae1#719b245f9bb24e838de8639c19858df2690f3ae1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93a938838b26259162f23283de9d02922dc7b66d3a3c48a4db6036a44e9cf29"
 dependencies = [
  "io-uring",
  "libc",
@@ -10158,7 +10159,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10232,7 +10233,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11396,7 +11397,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12497,7 +12498,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -140,12 +140,12 @@ aws-smithy-http-client.workspace = true
 # Observability and Metrics
 metrics = { workspace = true }
 
-# Runtime-probed io_uring read backend (backlog#1104). Linux-only, git
-# dependency until rustfs-uring is production-ready and published. The guard
+# Runtime-probed io_uring read backend (backlog#1104). Linux-only, from
+# crates.io once rustfs-uring 0.1.0 is published. The guard
 # scripts/check_no_tokio_io_uring.sh allows an explicit io-uring integration;
 # only the tokio "io-uring" runtime feature is banned.
 [target.'cfg(target_os = "linux")'.dependencies]
-rustfs-uring = { git = "https://github.com/rustfs/uring", rev = "719b245f9bb24e838de8639c19858df2690f3ae1" }
+rustfs-uring = "0.1.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/deny.toml
+++ b/deny.toml
@@ -40,9 +40,6 @@ allow-git = [
     # Pinned to a specific commit in workspace Cargo.toml.
     # "https://github.com/rustfs/s3s",
     "https://github.com/apache/datafusion.git",
-    # Runtime-probed io_uring read backend (backlog#1104), Linux-only.
-    # Pinned to a specific commit in crates/ecstore/Cargo.toml.
-    "https://github.com/rustfs/uring",
 ]
 
 [bans]


### PR DESCRIPTION
> **Draft / blocked.** Merge only **after** `rustfs-uring` 0.1.0 is on crates.io. Until then cargo cannot resolve `rustfs-uring = "0.1.0"`, so CI will be **red by design** — that is not a defect in this change.

## What

Prepared ahead of the [rustfs-uring](https://github.com/rustfs/uring) 0.1.0 release. Flips ecstore's dependency from the pinned git revision to the published crate, and drops the now-unneeded git-source allowance.

```diff
- rustfs-uring = { git = "https://github.com/rustfs/uring", rev = "719b245…" }
+ rustfs-uring = "0.1.0"
```
Plus: remove `"https://github.com/rustfs/uring"` from `deny.toml`'s `allow-git` (no git source anymore).

## Why now

The crate is publish-ready (see rustfs/uring#10): complete metadata, all deps on crates.io, no git/path deps. Having this PR ready means the switch is a one-step follow-up the moment 0.1.0 is cut.

## Merge procedure (after publish)

1. `cargo update -p rustfs-uring --precise 0.1.0` — regenerates Cargo.lock. **Cargo.lock is deliberately not touched here**: a registry entry carries a checksum that cannot be written before the crate exists on crates.io.
2. Push the updated Cargo.lock.
3. CI turns green → mark ready → merge.

## Scope / non-changes

- **No code change.**
- `scripts/check_no_tokio_io_uring.sh` unaffected (it bans only tokio's io-uring *runtime feature*, not an explicit `rustfs-uring` dependency).
- `audit.yml`'s `allow-dependencies-licenses` for rustfs-uring is left in place — first-party Apache-2.0 either way.

Paired with rustfs/uring#10 (metadata/docs made publish-ready).