### PR TITLE
fix(test): isolate health tests from minimal-response env var race

### DIFF
--- a/rustfs/src/admin/handlers/health.rs
+++ b/rustfs/src/admin/handlers/health.rs
@@ -88,6 +88,7 @@ impl Operation for HealthCheckHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use temp_env::with_var;
 
     #[test]
@@ -285,6 +286,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_health_payload_minimal_mode_returns_status_and_ready_only() {
         let health = health_check_state(true, false, true, true, HealthProbe::Readiness);
         with_var(rustfs_config::ENV_HEALTH_MINIMAL_RESPONSE_ENABLE, Some("true"), || {
@@ -309,20 +311,23 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_health_payload_includes_degraded_reasons() {
-        let health = health_check_state(false, false, false, true, HealthProbe::Readiness);
-        let payload = build_health_payload(HealthPayloadContext {
-            health,
-            storage_ready: false,
-            iam_ready: false,
-            lock_quorum_ready: false,
-            degraded_reasons: &[crate::server::ReadinessDegradedReason::StorageAndIamUnavailable],
-            service: "rustfs-endpoint",
-            uptime: None,
-            kms_ready: None,
-            include_dependency_details: true,
+        with_var(rustfs_config::ENV_HEALTH_MINIMAL_RESPONSE_ENABLE, Some("false"), || {
+            let health = health_check_state(false, false, false, true, HealthProbe::Readiness);
+            let payload = build_health_payload(HealthPayloadContext {
+                health,
+                storage_ready: false,
+                iam_ready: false,
+                lock_quorum_ready: false,
+                degraded_reasons: &[crate::server::ReadinessDegradedReason::StorageAndIamUnavailable],
+                service: "rustfs-endpoint",
+                uptime: None,
+                kms_ready: None,
+                include_dependency_details: true,
+            });
+            assert_eq!(payload["degradedReasons"][0], "storage_and_iam_unavailable");
         });
-        assert_eq!(payload["degradedReasons"][0], "storage_and_iam_unavailable");
     }
 
     #[test]
@@ -343,43 +348,55 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_health_response_parts_get_includes_payload() {
-        let report = crate::server::DependencyReadinessReport {
-            readiness: crate::server::DependencyReadiness {
-                storage_ready: false,
-                iam_ready: true,
-                lock_quorum_ready: true,
-                peer_health_ready: true,
-            },
-            degraded_reasons: vec![crate::server::ReadinessDegradedReason::StorageQuorumUnavailable],
-        };
-        let parts =
-            build_health_response_parts(Method::GET, HealthProbe::Readiness, Some(&report), "rustfs-endpoint", None, None);
-        assert_eq!(parts.status_code, StatusCode::SERVICE_UNAVAILABLE);
-        let payload = parts.payload.expect("GET should include payload");
-        assert_eq!(payload["status"], "degraded");
-        assert_eq!(payload["ready"], false);
-        assert_eq!(payload["degradedReasons"][0], "storage_quorum_unavailable");
+        with_var(rustfs_config::ENV_HEALTH_MINIMAL_RESPONSE_ENABLE, Some("false"), || {
+            let report = crate::server::DependencyReadinessReport {
+                readiness: crate::server::DependencyReadiness {
+                    storage_ready: false,
+                    iam_ready: true,
+                    lock_quorum_ready: true,
+                    peer_health_ready: true,
+                },
+                degraded_reasons: vec![crate::server::ReadinessDegradedReason::StorageQuorumUnavailable],
+            };
+            let parts =
+                build_health_response_parts(Method::GET, HealthProbe::Readiness, Some(&report), "rustfs-endpoint", None, None);
+            assert_eq!(parts.status_code, StatusCode::SERVICE_UNAVAILABLE);
+            let payload = parts.payload.expect("GET should include payload");
+            assert_eq!(payload["status"], "degraded");
+            assert_eq!(payload["ready"], false);
+            assert_eq!(payload["degradedReasons"][0], "storage_quorum_unavailable");
+        });
     }
 
     #[test]
+    #[serial]
     fn test_build_health_response_parts_readiness_marks_kms_not_ready() {
-        let report = crate::server::DependencyReadinessReport {
-            readiness: crate::server::DependencyReadiness {
-                storage_ready: true,
-                iam_ready: true,
-                lock_quorum_ready: true,
-                peer_health_ready: true,
-            },
-            degraded_reasons: Vec::new(),
-        };
-        let parts =
-            build_health_response_parts(Method::GET, HealthProbe::Readiness, Some(&report), "rustfs-endpoint", None, Some(false));
-        assert_eq!(parts.status_code, StatusCode::SERVICE_UNAVAILABLE);
-        let payload = parts.payload.expect("GET should include payload");
-        assert_eq!(payload["ready"], false);
-        assert_eq!(payload["details"]["lock"]["ready"], true);
-        assert_eq!(payload["details"]["kms"]["ready"], false);
-        assert_eq!(payload["degradedReasons"][0], "kms_not_ready");
+        with_var(rustfs_config::ENV_HEALTH_MINIMAL_RESPONSE_ENABLE, Some("false"), || {
+            let report = crate::server::DependencyReadinessReport {
+                readiness: crate::server::DependencyReadiness {
+                    storage_ready: true,
+                    iam_ready: true,
+                    lock_quorum_ready: true,
+                    peer_health_ready: true,
+                },
+                degraded_reasons: Vec::new(),
+            };
+            let parts = build_health_response_parts(
+                Method::GET,
+                HealthProbe::Readiness,
+                Some(&report),
+                "rustfs-endpoint",
+                None,
+                Some(false),
+            );
+            assert_eq!(parts.status_code, StatusCode::SERVICE_UNAVAILABLE);
+            let payload = parts.payload.expect("GET should include payload");
+            assert_eq!(payload["ready"], false);
+            assert_eq!(payload["details"]["lock"]["ready"], true);
+            assert_eq!(payload["details"]["kms"]["ready"], false);
+            assert_eq!(payload["degradedReasons"][0], "kms_not_ready");
+        });
     }
 }


### PR DESCRIPTION
## Problem

The hourly automated verification on `95819cb98` (`origin/main`) found a flaky test failure in the `rustfs` crate lib tests:

```
test admin::handlers::health::tests::test_build_health_payload_includes_degraded_reasons ... FAILED
assertion `left == right` failed
  left: Null
 right: "storage_and_iam_unavailable"
```

A second test (`test_build_health_response_parts_get_includes_payload`) also failed intermittently with the same root cause.

## Root Cause

`test_build_health_payload_minimal_mode_returns_status_and_ready_only` uses `temp_env::with_var` to set `RUSTFS_HEALTH_MINIMAL_RESPONSE_ENABLE=true`. Since `temp_env` uses `std::env::set_var` (process-global), this leaks across parallel test threads. Three sibling tests that expect full (non-minimal) payloads can see the env var and get stripped-down responses missing `degradedReasons` / `details`.

## Fix

Wrap the three affected tests with `with_var(ENV_HEALTH_MINIMAL_RESPONSE_ENABLE, Some("false"), || { ... })` to pin the env var deterministically.

**Tests fixed:**
- `test_build_health_payload_includes_degraded_reasons`
- `test_build_health_response_parts_get_includes_payload`
- `test_build_health_response_parts_readiness_marks_kms_not_ready`

## Verification

- `cargo test -p rustfs --lib admin::handlers::health::tests` — 21/21 pass
- `cargo test -p rustfs --lib` — 2189 passed, 0 failed, 49 ignored
- `cargo fmt --all --check` — clean
- `make clippy-check` — passes

## Notes

The `embedded_multi_instance_test` also fails on `origin/main` due to a separate pre-existing global-state issue (write-once `OnceLock` for region in parallel tests). That test is unrelated to this fix.
