### PR TITLE
fix(test): add missing mod_time_unix_nanos field in mutation_hook test helper

### DIFF
--- a/rustfs/src/app/object_data_cache/mutation_hook.rs
+++ b/rustfs/src/app/object_data_cache/mutation_hook.rs
@@ -81,6 +81,7 @@ mod tests {
             version_id: None,
             etag: "etag",
             size: 5,
+            mod_time_unix_nanos: 0,
             body_variant: ObjectDataCacheBodyVariant::FullObjectPlainV1,
         }
     }


### PR DESCRIPTION
## Problem

Latest `main` (`a32af463e`) added the `mod_time_unix_nanos` field to `ObjectDataCacheGetRequest` (backlog#1111 / ODC-06) but missed the test helper in `mutation_hook.rs`, causing a compile error under `cargo clippy --all-targets`.

## Fix

Added the missing `mod_time_unix_nanos: 0` field to the `request()` test helper in `rustfs/src/app/object_data_cache/mutation_hook.rs:83`.

## Verification

- ✅ `cargo fmt --all --check` — clean
- ✅ `cargo clippy --all-targets -- -D warnings` — passes
- ✅ `unsafe-code-check`, `architecture-migration-check`, `logging-guardrails-check`, `tokio-io-uring-check`, `doc-paths-check` — all pass
- ✅ `cargo nextest run --all --exclude e2e_test` — 8610 passed, 114 skipped, 0 failed
- ✅ `cargo test --all --doc` — all doctests pass
- ✅ `s3s-e2e` — all suites PASSED (Basic + Advanced)
