### PR TITLE
fix(tier): reject reserved names STANDARD/RRS in TierConfigMgr::add (backlog#1148 ilm-4)

### DIFF
--- a/crates/ecstore/src/services/tier/tier.rs
+++ b/crates/ecstore/src/services/tier/tier.rs
@@ -41,7 +41,7 @@ use crate::error::{Error, Result, StorageError};
 use crate::services::tier::{
     tier_admin::TierCreds,
     tier_config::{TierConfig, TierType},
-    tier_handlers::{ERR_TIER_ALREADY_EXISTS, ERR_TIER_NAME_NOT_UPPERCASE, ERR_TIER_NOT_FOUND},
+    tier_handlers::{ERR_TIER_ALREADY_EXISTS, ERR_TIER_NAME_NOT_UPPERCASE, ERR_TIER_NOT_FOUND, ERR_TIER_RESERVED_NAME},
     warm_backend::{check_warm_backend, new_warm_backend},
 };
 use crate::storage_api_contracts::{
@@ -761,6 +761,16 @@ impl TierConfigMgr {
         let tier_name = &tier_config.name;
         if tier_name != tier_name.to_uppercase().as_str() {
             return Err(ERR_TIER_NAME_NOT_UPPERCASE.clone());
+        }
+
+        // Reject AWS/MinIO reserved storage-class names as remote-tier names.
+        // MinIO reserves STANDARD and REDUCED_REDUNDANCY (RRS); a tier must not
+        // shadow them. The comparison is case-insensitive to match MinIO parity
+        // and to stay robust regardless of the uppercase gate above.
+        if tier_name.eq_ignore_ascii_case(crate::config::storageclass::STANDARD)
+            || tier_name.eq_ignore_ascii_case(crate::config::storageclass::RRS)
+        {
+            return Err(ERR_TIER_RESERVED_NAME.clone());
         }
 
         let (_, b) = self.is_tier_name_in_use(tier_name);
@@ -1612,28 +1622,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_add_does_not_reserve_standard_name_regression_anchor() {
-        // Regression anchor: RustFS does *not* currently reject the AWS-reserved
-        // tier names (STANDARD / REDUCED_REDUNDANCY). `add` accepts "STANDARD"
-        // (uppercase, not in use) and only fails later at backend construction
-        // because the payload is absent -- proving no reserved-name guard fired.
-        // If a reserved-name check is ever added, this assertion should flip to
-        // `ERR_TIER_RESERVED_NAME` and this comment be removed.
-        let mut mgr = empty_mgr();
-        let tier = TierConfig {
-            version: "v1".to_string(),
-            tier_type: TierType::Unsupported,
-            name: "STANDARD".to_string(),
-            ..Default::default()
-        };
-        let err = mgr
-            .add(tier, true)
-            .await
-            .expect_err("no backend payload => construction error");
-        assert_eq!(
-            err.code, ERR_TIER_TYPE_UNSUPPORTED.code,
-            "STANDARD is not specially rejected; it reaches the type check"
-        );
+    async fn test_add_rejects_reserved_names() {
+        // Supersedes the former `test_add_does_not_reserve_standard_name_regression_anchor`
+        // (added by PR #4713 to pin the pre-fix behavior). RustFS now rejects the
+        // AWS/MinIO reserved storage-class names STANDARD and REDUCED_REDUNDANCY
+        // (RRS) as remote-tier names, matching MinIO parity.
+        //
+        // `tier_type` is deliberately `Unsupported`: before the guard existed,
+        // "STANDARD" reached `new_warm_backend` and failed with
+        // `ERR_TIER_TYPE_UNSUPPORTED`. Asserting `ERR_TIER_RESERVED_NAME` here
+        // proves the reserved-name guard fires *before* the type/backend check.
+        for reserved in [crate::config::storageclass::STANDARD, crate::config::storageclass::RRS] {
+            let mut mgr = empty_mgr();
+            let tier = TierConfig {
+                version: "v1".to_string(),
+                tier_type: TierType::Unsupported,
+                name: reserved.to_string(),
+                ..Default::default()
+            };
+            let err = mgr.add(tier, true).await.expect_err("reserved tier name must be rejected");
+            assert_eq!(
+                err.code, ERR_TIER_RESERVED_NAME.code,
+                "reserved tier name {reserved} must be rejected before the type check"
+            );
+            assert!(mgr.tiers.is_empty(), "rejected reserved tier {reserved} must not be persisted");
+        }
     }
 
     // ---- edit -----------------------------------------------------------

--- a/rustfs/src/admin/handlers/tier.rs
+++ b/rustfs/src/admin/handlers/tier.rs
@@ -17,7 +17,7 @@ use crate::admin::runtime_sources::object_store_from_extensions;
 use crate::admin::storage_api::tier::{
     AdminError, DailyAllTierStats, ERR_TIER_ALREADY_EXISTS, ERR_TIER_BACKEND_IN_USE, ERR_TIER_BACKEND_NOT_EMPTY,
     ERR_TIER_CONNECT_ERR, ERR_TIER_INVALID_CREDENTIALS, ERR_TIER_MISSING_CREDENTIALS, ERR_TIER_NAME_NOT_UPPERCASE,
-    ERR_TIER_NOT_FOUND, TierConfig, TierCreds, TierType, storageclass,
+    ERR_TIER_NOT_FOUND, ERR_TIER_RESERVED_NAME, TierConfig, TierCreds, TierType,
 };
 use crate::{
     admin::runtime_sources::{current_daily_tier_stats, current_notification_system, current_tier_config_handle},
@@ -311,22 +311,6 @@ impl Operation for AddTier {
                 s3_error!(InvalidRequest, "invalid force flag")
             })?;
         }
-        match args.name.as_str() {
-            storageclass::STANDARD | storageclass::RRS => {
-                warn!(
-                    event = EVENT_ADMIN_TIER_STATE,
-                    component = LOG_COMPONENT_ADMIN,
-                    subsystem = LOG_SUBSYSTEM_TIER,
-                    action = "add_tier",
-                    tier_name = %args.name,
-                    result = "reserved_name_rejected",
-                    "admin tier state"
-                );
-                return Err(s3_error!(InvalidRequest, "Cannot use reserved tier name"));
-            }
-            &_ => (),
-        }
-
         let Some(store) = object_store_from_extensions(&req.extensions) else {
             return Err(s3_error!(InternalError, "object store is not initialized"));
         };
@@ -350,7 +334,18 @@ impl Operation for AddTier {
                 ));
             }
             if let Err(err) = tier_config_mgr.add(args, force).await {
-                return if err.code == ERR_TIER_ALREADY_EXISTS.code {
+                return if err.code == ERR_TIER_RESERVED_NAME.code {
+                    warn!(
+                        event = EVENT_ADMIN_TIER_STATE,
+                        component = LOG_COMPONENT_ADMIN,
+                        subsystem = LOG_SUBSYSTEM_TIER,
+                        action = "add_tier",
+                        tier_name = %tier_name_for_log,
+                        result = "reserved_name_rejected",
+                        "admin tier state"
+                    );
+                    Err(s3_error!(InvalidRequest, "Cannot use reserved tier name"))
+                } else if err.code == ERR_TIER_ALREADY_EXISTS.code {
                     Err(S3Error::with_message(
                         S3ErrorCode::Custom("TierNameAlreadyExist".into()),
                         "tier name already exists",

--- a/rustfs/src/admin/storage_api.rs
+++ b/rustfs/src/admin/storage_api.rs
@@ -378,9 +378,7 @@ pub(crate) mod versioning_sys {
 pub(crate) mod storageclass {
     pub(crate) const INLINE_BLOCK_ENV: &str = super::ecstore_config::storageclass::INLINE_BLOCK_ENV;
     pub(crate) const OPTIMIZE_ENV: &str = super::ecstore_config::storageclass::OPTIMIZE_ENV;
-    pub(crate) const RRS: &str = super::ecstore_config::storageclass::RRS;
     pub(crate) const RRS_ENV: &str = super::ecstore_config::storageclass::RRS_ENV;
-    pub(crate) const STANDARD: &str = super::ecstore_config::storageclass::STANDARD;
     pub(crate) const STANDARD_ENV: &str = super::ecstore_config::storageclass::STANDARD_ENV;
 
     pub(crate) type Config = super::ecstore_config::storageclass::Config;
@@ -449,6 +447,7 @@ pub(crate) static ERR_TIER_INVALID_CREDENTIALS: AdminErrorRef =
 pub(crate) static ERR_TIER_NAME_NOT_UPPERCASE: AdminErrorRef =
     AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_NAME_NOT_UPPERCASE);
 pub(crate) static ERR_TIER_NOT_FOUND: AdminErrorRef = AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_NOT_FOUND);
+pub(crate) static ERR_TIER_RESERVED_NAME: AdminErrorRef = AdminErrorRef(|| &ecstore_tier::tier_handlers::ERR_TIER_RESERVED_NAME);
 
 pub(crate) mod data_usage {
     use std::sync::Arc;
@@ -584,10 +583,9 @@ pub(crate) mod runtime {
 }
 
 pub(crate) mod tier {
-    pub(crate) use super::storageclass;
     pub(crate) use super::{
         AdminError, DailyAllTierStats, ERR_TIER_ALREADY_EXISTS, ERR_TIER_BACKEND_IN_USE, ERR_TIER_BACKEND_NOT_EMPTY,
         ERR_TIER_CONNECT_ERR, ERR_TIER_INVALID_CREDENTIALS, ERR_TIER_MISSING_CREDENTIALS, ERR_TIER_NAME_NOT_UPPERCASE,
-        ERR_TIER_NOT_FOUND, TierConfig, TierCreds, TierType,
+        ERR_TIER_NOT_FOUND, ERR_TIER_RESERVED_NAME, TierConfig, TierCreds, TierType,
     };
 }


### PR DESCRIPTION
## What

While implementing **ilm-4** (test-strategy backlog#1148, tests landed in #4713), the new state-machine coverage surfaced a real product bug: `ERR_TIER_RESERVED_NAME` is defined but `TierConfigMgr::add` never consulted it, so the **core** silently accepted the AWS/MinIO-reserved storage-class names `STANDARD` and `REDUCED_REDUNDANCY` (RRS) as remote-tier names — contrary to MinIO parity.

This PR wires the guard in and flips the regression anchor from asserting acceptance to asserting rejection.

## Changes

- **`crates/ecstore/src/services/tier/tier.rs`** — `TierConfigMgr::add` now rejects reserved names (`STANDARD`, `REDUCED_REDUNDANCY`) **case-insensitively** with `ERR_TIER_RESERVED_NAME`. The check is the authoritative guard: it fires after the uppercase gate and before duplicate detection / backend construction.
- **`rustfs/src/admin/handlers/tier.rs`** — map `ERR_TIER_RESERVED_NAME` in the `AddTier` error handling (returns `InvalidRequest` / "Cannot use reserved tier name", unchanged client-facing behavior + telemetry). Removed the now-redundant handler-level pre-check so the core is the single source of truth and the mapping is reachable.
- **`rustfs/src/admin/storage_api.rs`** — expose `ERR_TIER_RESERVED_NAME` to the admin layer; drop the dead `storageclass::{STANDARD,RRS}` shim re-exports that the removed pre-check was the only consumer of.

## Supersedes the regression anchor

Supersedes `test_add_does_not_reserve_standard_name_regression_anchor` (added by #4713 to pin the pre-fix behavior). It is renamed to `test_add_rejects_reserved_names` and now asserts rejection with `ERR_TIER_RESERVED_NAME` for **both** reserved names, and that the rejected tier is not persisted. Reverting the core guard makes the test fail (revert-detecting).

## Coordination

- **Stacked on #4713** (`overtrue/ilm4-tierconfig-unit-tests`), which adds the anchor test this PR modifies. #4713 must merge first; GitHub will auto-retarget this PR's base to `main` once it does.
- Behavior note: a reserved-name request now rejects *after* `reload()` (consistent with how duplicate-name rejection already flows through `add`).

## Verification

- `cargo test -p rustfs-ecstore --lib services::tier::tier::tests` — 29 passed (incl. flipped `test_add_rejects_reserved_names`)
- `cargo clippy -p rustfs-ecstore --all-targets` — clean
- `cargo clippy -p rustfs --all-targets` — clean
- `scripts/check_logging_guardrails.sh`, `check_layer_dependencies.sh`, `check_architecture_migration_rules.sh` — pass
- AGENTS.md adversarial validation (correctness / security / compatibility / test-coverage) — no break found

## Not covered

The admin `AddTier` end-to-end path has no existing unit test (handler tests only cover helpers, as they need a live object store); the mapping mirrors the removed pre-check's exact response, and the core guard carries the regression coverage.