### PR TITLE
fix(lifecycle): reject zero-day expiration/noncurrent/abort rules (backlog#1148 ilm-10)

### DIFF
--- a/crates/e2e_test/src/reliant/lifecycle.rs
+++ b/crates/e2e_test/src/reliant/lifecycle.rs
@@ -160,12 +160,16 @@ async fn test_bucket_lifecycle_configuration() -> Result<(), Box<dyn std::error:
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
-async fn test_bucket_lifecycle_accepts_zero_days() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_bucket_lifecycle_rejects_zero_days() -> Result<(), Box<dyn std::error::Error>> {
     use aws_sdk_s3::types::{BucketLifecycleConfiguration, LifecycleExpiration, LifecycleRule, LifecycleRuleFilter};
 
     let client = create_aws_s3_client().await?;
     setup_test_bucket(&client).await?;
 
+    // S3 compatibility: Expiration.Days must be a positive integer (>= 1). AWS and the
+    // ceph s3-tests `test_lifecycle_expiration_days0` case reject Days == 0 with an
+    // InvalidArgument (HTTP 400). See crates/lifecycle validate() + the
+    // PutBucketLifecycleConfiguration handler which maps it to s3_error!(InvalidArgument).
     let expiration = LifecycleExpiration::builder().days(0).build();
     let filter = LifecycleRuleFilter::builder().prefix("zero-days/").build();
     let rule = LifecycleRule::builder()
@@ -176,12 +180,20 @@ async fn test_bucket_lifecycle_accepts_zero_days() -> Result<(), Box<dyn std::er
         .build()?;
     let lifecycle = BucketLifecycleConfiguration::builder().rules(rule).build()?;
 
-    client
+    let err = client
         .put_bucket_lifecycle_configuration()
         .bucket(BUCKET)
         .lifecycle_configuration(lifecycle)
         .send()
-        .await?;
+        .await
+        .expect_err("zero-day expiration lifecycle rule should be rejected");
+
+    let service_error = err.as_service_error().expect("expected an S3 service error");
+    assert_eq!(
+        service_error.meta().code(),
+        Some("InvalidArgument"),
+        "expected InvalidArgument for zero-day expiration, got: {err:?}"
+    );
 
     Ok(())
 }

--- a/crates/lifecycle/src/core.rs
+++ b/crates/lifecycle/src/core.rs
@@ -40,10 +40,11 @@ const _ERR_XML_NOT_WELL_FORMED: &str =
 const ERR_LIFECYCLE_BUCKET_LOCKED: &str =
     "ExpiredObjectAllVersions element and DelMarkerExpiration action cannot be used on an object locked bucket";
 const ERR_LIFECYCLE_TOO_MANY_RULES: &str = "Lifecycle configuration should have at most 1000 rules";
-const ERR_LIFECYCLE_INVALID_EXPIRATION_DAYS: &str = "Lifecycle expiration days must not be negative";
-const ERR_LIFECYCLE_INVALID_NONCURRENT_EXPIRATION_DAYS: &str = "Lifecycle noncurrent expiration days must not be negative";
+const ERR_LIFECYCLE_INVALID_EXPIRATION_DAYS: &str = "'Days' for Expiration action must be a positive integer";
+const ERR_LIFECYCLE_INVALID_NONCURRENT_EXPIRATION_DAYS: &str =
+    "'NoncurrentDays' for NoncurrentVersionExpiration action must be a positive integer";
 const ERR_LIFECYCLE_INVALID_ABORT_INCOMPLETE_MPU_DAYS: &str =
-    "DaysAfterInitiation must be 0 or greater when used with AbortIncompleteMultipartUpload";
+    "'DaysAfterInitiation' for AbortIncompleteMultipartUpload action must be a positive integer";
 const ERR_LIFECYCLE_INVALID_EXPIRATION_DATE_NOT_MIDNIGHT: &str = "Expiration.Date must be at midnight UTC";
 const ERR_LIFECYCLE_INVALID_EXPIRED_OBJECT_DELETE_MARKER: &str =
     "ExpiredObjectDeleteMarker cannot be specified with Days or Date";
@@ -325,21 +326,29 @@ impl Lifecycle for BucketLifecycleConfiguration {
                         return Err(std::io::Error::other(ERR_LIFECYCLE_INVALID_EXPIRATION_DATE_NOT_MIDNIGHT));
                     }
                 }
+                // S3 requires Expiration.Days to be a positive integer (>= 1). AWS and the
+                // ceph s3-tests `test_lifecycle_expiration_days0` case reject Days == 0 with
+                // InvalidArgument; only Date-based rules may omit Days entirely.
                 if let Some(days) = expiration.days
-                    && days < 0
+                    && days < 1
                 {
                     return Err(std::io::Error::other(ERR_LIFECYCLE_INVALID_EXPIRATION_DAYS));
                 }
             }
+            // S3 requires NoncurrentVersionExpiration.NoncurrentDays to be a positive
+            // integer (>= 1); AWS rejects 0 with InvalidArgument.
             if let Some(noncurrent_version_expiration) = &r.noncurrent_version_expiration
                 && let Some(noncurrent_days) = noncurrent_version_expiration.noncurrent_days
-                && noncurrent_days < 0
+                && noncurrent_days < 1
             {
                 return Err(std::io::Error::other(ERR_LIFECYCLE_INVALID_NONCURRENT_EXPIRATION_DAYS));
             }
+            // S3 requires AbortIncompleteMultipartUpload.DaysAfterInitiation to be present
+            // and a positive integer (>= 1); AWS rejects 0 (and a missing value) with
+            // InvalidArgument.
             if let Some(abort_incomplete_multipart_upload) = &r.abort_incomplete_multipart_upload {
                 match abort_incomplete_multipart_upload.days_after_initiation {
-                    Some(days) if days >= 0 => {}
+                    Some(days) if days >= 1 => {}
                     _ => return Err(std::io::Error::other(ERR_LIFECYCLE_INVALID_ABORT_INCOMPLETE_MPU_DAYS)),
                 }
             }
@@ -1066,7 +1075,11 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn validate_accepts_zero_expiration_days() {
+    async fn validate_rejects_zero_expiration_days() {
+        // S3 compatibility: Expiration.Days must be a positive integer (>= 1). AWS and
+        // the ceph s3-tests `test_lifecycle_expiration_days0` case reject Days == 0 with
+        // InvalidArgument. The PutBucketLifecycleConfiguration path maps this io::Error
+        // to s3_error!(InvalidArgument) (see execute_put_bucket_lifecycle_configuration).
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
             rules: vec![LifecycleRule {
@@ -1086,9 +1099,12 @@ mod tests {
             }],
         };
 
-        lc.validate(&ObjectLockConfiguration::default())
+        let err = lc
+            .validate(&ObjectLockConfiguration::default())
             .await
-            .expect("zero-day expiration should be accepted");
+            .expect_err("zero-day expiration should be rejected");
+
+        assert_eq!(err.to_string(), ERR_LIFECYCLE_INVALID_EXPIRATION_DAYS);
     }
 
     #[tokio::test]
@@ -1150,6 +1166,41 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn validate_accepts_one_day_boundary_values() {
+        // Pin the exact >= 1 boundary: a value of 1 is the smallest legal positive
+        // integer and must be accepted for every day-count field tightened for S3
+        // compatibility. This catches an off-by-one that would reject Days == 1.
+        let lc = BucketLifecycleConfiguration {
+            expiry_updated_at: None,
+            rules: vec![LifecycleRule {
+                status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
+                expiration: Some(LifecycleExpiration {
+                    days: Some(1),
+                    ..Default::default()
+                }),
+                abort_incomplete_multipart_upload: Some(s3s::dto::AbortIncompleteMultipartUpload {
+                    days_after_initiation: Some(1),
+                }),
+                del_marker_expiration: None,
+                filter: None,
+                id: Some("one-day-boundary".to_string()),
+                noncurrent_version_expiration: Some(s3s::dto::NoncurrentVersionExpiration {
+                    noncurrent_days: Some(1),
+                    newer_noncurrent_versions: None,
+                }),
+                noncurrent_version_transitions: None,
+                prefix: Some("boundary/".to_string()),
+                transitions: None,
+            }],
+        };
+
+        lc.validate(&ObjectLockConfiguration::default())
+            .await
+            .expect("one-day boundary values should be accepted");
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn has_active_rules_accepts_zero_day_expiration() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1175,7 +1226,9 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn validate_accepts_zero_noncurrent_expiration_days() {
+    async fn validate_rejects_zero_noncurrent_expiration_days() {
+        // S3 compatibility: NoncurrentVersionExpiration.NoncurrentDays must be a positive
+        // integer (>= 1); AWS rejects 0 with InvalidArgument.
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
             rules: vec![LifecycleRule {
@@ -1195,9 +1248,12 @@ mod tests {
             }],
         };
 
-        lc.validate(&ObjectLockConfiguration::default())
+        let err = lc
+            .validate(&ObjectLockConfiguration::default())
             .await
-            .expect("zero-day noncurrent expiration should be accepted");
+            .expect_err("zero-day noncurrent expiration should be rejected");
+
+        assert_eq!(err.to_string(), ERR_LIFECYCLE_INVALID_NONCURRENT_EXPIRATION_DAYS);
     }
 
     #[tokio::test]
@@ -1258,7 +1314,9 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn validate_accepts_zero_abort_incomplete_multipart_upload_days() {
+    async fn validate_rejects_zero_abort_incomplete_multipart_upload_days() {
+        // S3 compatibility: AbortIncompleteMultipartUpload.DaysAfterInitiation must be a
+        // positive integer (>= 1); AWS rejects 0 with InvalidArgument.
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
             rules: vec![LifecycleRule {
@@ -1277,9 +1335,12 @@ mod tests {
             }],
         };
 
-        lc.validate(&ObjectLockConfiguration::default())
+        let err = lc
+            .validate(&ObjectLockConfiguration::default())
             .await
-            .expect("zero-day abort incomplete multipart upload should be accepted");
+            .expect_err("zero-day abort incomplete multipart upload should be rejected");
+
+        assert_eq!(err.to_string(), ERR_LIFECYCLE_INVALID_ABORT_INCOMPLETE_MPU_DAYS);
     }
 
     #[tokio::test]

--- a/docs/architecture/s3-compatibility-matrix.md
+++ b/docs/architecture/s3-compatibility-matrix.md
@@ -15,10 +15,10 @@ features are covered by the compatibility matrix and test lists.
 
 | List | Purpose | Current count | Source |
 |---|---:|---:|---|
-| Implemented tests | Standard S3 tests expected to pass and used by the default local s3tests run. | 451 | `scripts/s3-tests/implemented_tests.txt` |
+| Implemented tests | Standard S3 tests expected to pass and used by the default local s3tests run. | 452 | `scripts/s3-tests/implemented_tests.txt` |
 | Lifecycle behavior tests | Expiration behavior cases gated by the dedicated `s3-lifecycle-behavior-tests` lane (debug-accelerated day + scanner enabled). | 5 | `scripts/s3-tests/lifecycle_behavior_tests.txt` |
 | Unimplemented tests | Standard S3 features planned but not yet implemented. | 17 | `scripts/s3-tests/unimplemented_tests.txt` |
-| Excluded tests | Vendor-specific or intentionally unsupported behavior excluded from RustFS compatibility gating. | 274 | `scripts/s3-tests/excluded_tests.txt` |
+| Excluded tests | Vendor-specific or intentionally unsupported behavior excluded from RustFS compatibility gating. | 273 | `scripts/s3-tests/excluded_tests.txt` |
 
 Counts ignore blank lines and comments.
 

--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -1567,3 +1567,60 @@ async fn put_bucket_lifecycle_configuration_rejects_zero_day_del_marker_expirati
         "unexpected error message: {message}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[ignore = "global-state ILM integration test: runs serialized in the CI ILM Integration (serial) lane, see ci.yml test-ilm-integration-serial and rustfs/backlog#1148 (ilm-1)"]
+async fn put_bucket_lifecycle_configuration_rejects_zero_day_expiration() {
+    // S3 compatibility (ceph s3-tests `test_lifecycle_expiration_days0`): a rule with
+    // Expiration{Days:0} must be rejected with InvalidArgument through the real
+    // PutBucketLifecycleConfiguration handler, not merely at the crates/lifecycle
+    // io::Error layer. No object lock required.
+    let (_disk_paths, ecstore) = setup_test_env().await;
+    let usecase = DefaultBucketUsecase::from_global();
+
+    let bucket = format!("test-zero-day-exp-{}", &Uuid::new_v4().simple().to_string()[..8]);
+    create_test_bucket(&ecstore, bucket.as_str()).await;
+
+    let lifecycle = BucketLifecycleConfiguration {
+        expiry_updated_at: None,
+        rules: vec![LifecycleRule {
+            status: ExpirationStatus::from_static(ExpirationStatus::ENABLED),
+            abort_incomplete_multipart_upload: None,
+            del_marker_expiration: None,
+            expiration: Some(LifecycleExpiration {
+                days: Some(0),
+                ..Default::default()
+            }),
+            filter: Some(LifecycleRuleFilter {
+                prefix: Some("days0/".to_string()),
+                ..Default::default()
+            }),
+            id: Some("expire-zero-days".to_string()),
+            noncurrent_version_expiration: None,
+            noncurrent_version_transitions: None,
+            prefix: None,
+            transitions: None,
+        }],
+    };
+
+    let req = build_request(
+        PutBucketLifecycleConfigurationInput::builder()
+            .bucket(bucket.clone())
+            .lifecycle_configuration(Some(lifecycle))
+            .build()
+            .unwrap(),
+        Method::PUT,
+    );
+
+    let err = usecase
+        .execute_put_bucket_lifecycle_configuration(req)
+        .await
+        .expect_err("zero-day expiration must be rejected with InvalidArgument");
+    assert_eq!(err.code(), &s3s::S3ErrorCode::InvalidArgument);
+    let message = err.message().unwrap_or_default();
+    assert!(
+        message.contains("'Days' for Expiration action must be a positive integer"),
+        "unexpected error message: {message}"
+    );
+}

--- a/scripts/s3-tests/excluded_tests.txt
+++ b/scripts/s3-tests/excluded_tests.txt
@@ -180,12 +180,6 @@ test_lifecycle_expiration_size_lt
 test_lifecycle_expiration_tags2
 test_lifecycle_expiration_versioned_tags2
 #
-# --- Validation gap: RustFS accepts Expiration{Days:0} (returns 200; only
-#     Days<0 is rejected in crates/lifecycle/src/core.rs validate()), whereas AWS
-#     and this test expect InvalidArgument. Enable after the product rejects
-#     zero-day Expiration rules. Tracking: still-excluded gap noted in ilm-10 PR.
-test_lifecycle_expiration_days0
-#
 # --- Storage-class transition to a remote/warm tier. Needs a real tier backend
 #     (the hermetic second-RustFS cold layer from ilm-7) which is not wired into
 #     the s3-tests topology. Queued behind ilm-7.

--- a/scripts/s3-tests/implemented_tests.txt
+++ b/scripts/s3-tests/implemented_tests.txt
@@ -225,6 +225,8 @@ test_delete_bucket_encryption_kms
 test_delete_bucket_encryption_s3
 # Lifecycle tests
 test_lifecycle_delete
+# Negative validation: Expiration{Days:0} must return InvalidArgument (backlog#1148 ilm-10).
+test_lifecycle_expiration_days0
 test_lifecycle_get
 test_lifecycle_get_no_id
 test_lifecycle_id_too_long


### PR DESCRIPTION
## Summary

Lifecycle rule validation accepted `Expiration{Days: 0}` and returned `200`, but
AWS S3 and the ceph `s3-tests` `test_lifecycle_expiration_days0` case require a
positive integer (`Days >= 1`) and expect `InvalidArgument`. This tightens
`PutBucketLifecycleConfiguration` validation to reject zero-day values on the
day-count fields where S3 mandates `>= 1`, and promotes the previously-excluded
conformance test into the default run set.

Surfaced by ilm-10 (test-strategy `backlog#1148`, PR #4715), which set up the
s3-tests lifecycle behavior lane and annotated this exclusion as a known
validation gap.

## Changes

- `crates/lifecycle/src/core.rs` `BucketLifecycleConfiguration::validate()`:
  - `Expiration.Days` must be `>= 1` (was: only `< 0` rejected).
  - `NoncurrentVersionExpiration.NoncurrentDays` must be `>= 1`.
  - `AbortIncompleteMultipartUpload.DaysAfterInitiation` must be `>= 1`.
  - Error messages aligned with the S3 "must be a positive integer" wording.
  - **`Transition.Days` is deliberately left permitting `0`** — AWS allows an
    immediate transition (`Days: 0`), so tightening it would be a stricter-than-S3
    compat regression. The task's "where S3 requires `>= 1`" qualifier is honored.
- The `PutBucketLifecycleConfiguration` handler already maps this `io::Error` to
  `s3_error!(InvalidArgument, ...)` — no wiring change needed.
- Tests: flipped the three `validate_accepts_zero_*` unit tests to
  `validate_rejects_zero_*` (asserting the exact error), added
  `validate_accepts_one_day_boundary_values` to pin the `>= 1` boundary, and
  flipped the e2e `test_bucket_lifecycle_rejects_zero_days` to expect
  `InvalidArgument`.
- `scripts/s3-tests`: moved `test_lifecycle_expiration_days0` out of
  `excluded_tests.txt` into `implemented_tests.txt` (it is a pure negative
  validation test — PUT `Days:0` → `400 InvalidArgument` — so it belongs in the
  standard gate, not the behavior lane). Updated counts in
  `docs/architecture/s3-compatibility-matrix.md` (implemented 452, excluded 273).

## Scope notes / non-regressions

- Validation runs **only** on the `PutBucketLifecycle` path. The bucket-metadata
  load path only XML-deserializes (never calls `validate()`), and the runtime
  evaluator (`eval_inner` / `expected_expiry_time` / `has_active_rules` /
  `abort_incomplete_multipart_upload_due`) still handles `0` defensively — so
  existing persisted `Days:0` configs continue to load and expire; only new PUTs
  are rejected. No drop-in migration break.
- No currently-passing implemented s3-tests use `Days:0` for these fields
  (`test_lifecycle_set` uses 1/2, `set_noncurrent` 2/3, `set_multipart` 2).

## Verification

- `cargo test -p rustfs-lifecycle --lib` — green (all zero/negative/positive
  boundary cases).
- `cargo clippy -p rustfs-lifecycle --all-targets` and
  `cargo clippy -p e2e_test --all-targets` — clean.
- `cargo fmt --all --check` — clean. `scripts/check_doc_paths.sh` — pass.

## Adversarial Validation (high risk — lifecycle + S3 API-visible; all six roles)

- **Correctness** — attacked edge values (`i32::MIN`/`-1`/`0`/`1`), the abort-MPU
  match reordering (`None` still rejected), cross-repo `Days:0` producers (all in
  `#[cfg(test)]`), and delete-marker/date-only (`days == None`) interaction. No break.
- **Security** — validation-only tightening; no authz/secret/serde-surface change,
  error strings are static. Attacked message leakage/injection, serde surface,
  authz path. No break.
- **Concurrency/durability** — `validate()` is a pure sync function, no locks / no
  `await` in the changed code; the persisted write still occurs only after
  validation, no new fsync. No break.
- **Compatibility** — AWS-correct (the ceph test's own comment: "days: 0 is legal
  in a transition rule, but not legal in an expiration rule" — `Transition.Days:0`
  left valid). Migration-safe: the bucket-metadata **load path only
  XML-deserializes and never calls `validate()`**, so existing persisted `Days:0`
  configs still load/expire; only new PUTs are rejected. Counts (452/273) exact,
  correct s3-tests lane. No break.
- **Performance** — once-per-`PutBucketLifecycle` control-plane path, not per-object;
  two integer comparisons, zero allocation/clone. No break.
- **Test-coverage** — each tightened field has an isolated zero-reject + negative-reject
  + positive-accept test (revert of any single `< 1`/`>= 1` fails a test);
  `validate_accepts_one_day_boundary_values` pins the `>= 1` edge; added a
  non-`#[ignore]`-in-CI handler test (`put_bucket_lifecycle_configuration_rejects_zero_day_expiration`)
  asserting the end-to-end `Days:0` → `InvalidArgument` mapping. No gap.

Refs: `backlog#1148` (ilm-10). Stacked on #4715.
