### PR TITLE
ci: pull replication tests out of e2e-smoke (loopback targets fail every PR)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -138,13 +138,16 @@ test-group = 'e2e-reliability'
 # silently unrun) until it is explicitly blessed as fast here. Keep the two
 # regexes byte-identical. Count invariant: 20 here + 16 nightly = 36 total
 # (authority: `cargo nextest list`; docs/testing/e2e-suite-inventory.md).
+# NOTE (2026-07-11): the 20 fast bucket-replication admin-path tests were
+# pulled OUT of this PR smoke lane — they set a remote replication target at a
+# loopback endpoint (127.0.0.1, a second local server), which RustFS's target
+# SSRF guard rejects by default ("outbound URL host '127.0.0.1' is not
+# allowed: loopback address"), so they failed on EVERY PR after repl-1 (#4712)
+# merged. All replication e2e tests now run only in the e2e-repl-nightly lane
+# below until the nightly job is configured to allow loopback targets (repl-1
+# follow-up, backlog#1147). Restore an allowlist clause here once that lands.
 [profile.e2e-smoke]
-default-filter = """
-    package(e2e_test) & (
-        test(/^(delete_marker_migration_semantics|version_id_regression|list_objects_v2_pagination|list_object_versions_regression|list_objects_duplicates|list_buckets_double_slash|leading_slash_key|special_chars|create_bucket_region|delete_objects_versioning|head_object_consistency|head_object_range|copy_object_metadata|copy_source_invalid_date|content_encoding|anonymous_access|bucket_policy_check)_test::/)
-        | test(/^replication_extension_test::(test_replication_check_succeeds_with_remote_target|test_replication_check_rejects_target_without_object_lock|test_set_remote_target_rejects_unversioned_source_bucket|test_replication_check_rejects_unversioned_source_bucket|test_replication_check_rejects_missing_replication_config|test_replication_check_rejects_invalid_bucket|test_set_remote_target_rejects_same_bucket_on_same_deployment|test_set_remote_target_rejects_unversioned_target_bucket|test_set_remote_target_update_requires_arn|test_set_remote_target_update_rejects_missing_target|test_set_remote_target_rejects_invalid_target_url|test_set_remote_target_rejects_self_signed_https_target_without_skip_tls_verify|test_set_remote_target_rejects_private_ca_https_target_without_ca_cert_pem|test_list_remote_targets_rejects_empty_bucket|test_list_remote_targets_rejects_invalid_bucket|test_remove_remote_target_rejects_missing_target|test_remove_remote_target_rejects_missing_arn|test_remove_remote_target_rejects_invalid_bucket|test_remove_remote_target_rejects_target_used_by_replication|test_delete_bucket_replication_removes_remote_target)$/)
-    )
-"""
+default-filter = 'package(e2e_test) & test(/^(delete_marker_migration_semantics|version_id_regression|list_objects_v2_pagination|list_object_versions_regression|list_objects_duplicates|list_buckets_double_slash|leading_slash_key|special_chars|create_bucket_region|delete_objects_versioning|head_object_consistency|head_object_range|copy_object_metadata|copy_source_invalid_date|content_encoding|anonymous_access|bucket_policy_check)_test::/)'
 fail-fast = false
 
 # ---------------------------------------------------------------------------
@@ -182,12 +185,13 @@ fail-fast = false
 # labor with ci-5's future e2e-full merge gate: these tests run ONLY here, not
 # double-run there. TODO(ci-7): fold this interim repl-owned lane into the ci
 # domain's consolidated scheduled e2e workflow once it exists.
+# Runs ALL replication_extension_test tests (the 20 fast admin-path tests were
+# moved back here from e2e-smoke on 2026-07-11 — see the note on e2e-smoke
+# above). The nightly job must be configured to allow loopback replication
+# targets (repl-1 follow-up) for these to pass; keeping them out of the per-PR
+# gate un-blocks all PRs in the meantime.
 [profile.e2e-repl-nightly]
-default-filter = """
-    package(e2e_test)
-    & test(/^replication_extension_test::/)
-    & !test(/^replication_extension_test::(test_replication_check_succeeds_with_remote_target|test_replication_check_rejects_target_without_object_lock|test_set_remote_target_rejects_unversioned_source_bucket|test_replication_check_rejects_unversioned_source_bucket|test_replication_check_rejects_missing_replication_config|test_replication_check_rejects_invalid_bucket|test_set_remote_target_rejects_same_bucket_on_same_deployment|test_set_remote_target_rejects_unversioned_target_bucket|test_set_remote_target_update_requires_arn|test_set_remote_target_update_rejects_missing_target|test_set_remote_target_rejects_invalid_target_url|test_set_remote_target_rejects_self_signed_https_target_without_skip_tls_verify|test_set_remote_target_rejects_private_ca_https_target_without_ca_cert_pem|test_list_remote_targets_rejects_empty_bucket|test_list_remote_targets_rejects_invalid_bucket|test_remove_remote_target_rejects_missing_target|test_remove_remote_target_rejects_missing_arn|test_remove_remote_target_rejects_invalid_bucket|test_remove_remote_target_rejects_target_used_by_replication|test_delete_bucket_replication_removes_remote_target)$/)
-"""
+default-filter = 'package(e2e_test) & test(/^replication_extension_test::/)'
 fail-fast = false
 
 [profile.e2e-repl-nightly.junit]


### PR DESCRIPTION
## Urgent: un-blocks all PRs

repl-1 (#4712) added 20 bucket-replication admin-path tests to the **e2e-smoke PR lane**. They set a remote replication target at a **loopback endpoint** (127.0.0.1, a second local server), which RustFS's target SSRF guard rejects by default:

```
target endpoint is not allowed: outbound URL host '127.0.0.1' is not allowed: loopback address
```

repl-1's local verification was inconclusive under machine load, so it shipped broken. **Every PR based on post-repl-1 main now fails `End-to-End Tests`** (observed on #4707; blocks #4708/#4709/#4710/#4713–#4717).

## Fix
- `e2e-smoke` default-filter → back to the 17 functional modules from ci-4 (63 tests), **no replication**.
- `e2e-repl-nightly` → now the **full** `replication_extension_test` set (all 36; dropped the allowlist split).
- Verified locally: `cargo nextest list --profile e2e-smoke` → 0 replication; `--profile e2e-repl-nightly` → 36 replication.

## Follow-up (not this PR)
The nightly replication lane needs the server configured to **allow loopback replication targets** (an env/flag to relax the SSRF guard for the test harness) for these 36 to actually pass there. Tracked as a repl-1 follow-up under backlog#1147. This PR only removes them from the per-PR gate to restore a green main.

Refs rustfs/backlog#1147 (repl-1 follow-up), #1155.