### PR TITLE
chore(deps): bump rustfs-uring to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10031,9 +10031,9 @@ dependencies = [
 
 [[package]]
 name = "rustfs-uring"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93a938838b26259162f23283de9d02922dc7b66d3a3c48a4db6036a44e9cf29"
+checksum = "358fe7987fc6b4a98dd65d4f6a7785f4f1af41daf027d14ae4b5a94eadba6348"
 dependencies = [
  "io-uring",
  "libc",

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -141,11 +141,10 @@ aws-smithy-http-client.workspace = true
 metrics = { workspace = true }
 
 # Runtime-probed io_uring read backend (backlog#1104). Linux-only, from
-# crates.io once rustfs-uring 0.1.0 is published. The guard
-# scripts/check_no_tokio_io_uring.sh allows an explicit io-uring integration;
-# only the tokio "io-uring" runtime feature is banned.
+# crates.io. The guard scripts/check_no_tokio_io_uring.sh allows an explicit
+# io-uring integration; only the tokio "io-uring" runtime feature is banned.
 [target.'cfg(target_os = "linux")'.dependencies]
-rustfs-uring = "0.1.0"
+rustfs-uring = "0.2.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }


### PR DESCRIPTION
## What

Bump the `rustfs-uring` dependency in `crates/ecstore` from `0.1.0` to `0.2.0`, now that 0.2.0 is published on crates.io.

## Why

`rustfs-uring` 0.2.0 ships the read-driver hardening from the [rustfs/backlog#1160](https://github.com/rustfs/backlog/issues/1160) adversarial audit — cancel-safety and graceful-degradation fixes on the Linux io_uring read path (bounded-drain that no longer strands awaiting `ReadHandle`s, non-transient `ring.submit()` errors that shut a shard down instead of spinning forever, O_DIRECT short-read disambiguation via `fstat`, time-bounded startup probe, and more). The upstream work landed in [rustfs/uring#12](https://github.com/rustfs/uring/pull/12). This bump is what actually delivers those fixes to the production binary, since ecstore pins the crate from crates.io.

## Compatibility

The public API ecstore consumes is unchanged across the bump — `UringDriver::probe_and_start_sharded`, `read_at`, and `read_at_direct` keep their 0.1.0 signatures (verified against the published 0.2.0 crate source). 0.2.0 only adds public surface (e.g. `StatsSnapshot::submit_errors`); nothing ecstore uses was removed. It is a drop-in bump. The dependency is `cfg(target_os = "linux")`-only, so the code path is exercised on Linux CI, not on macOS builds.

## Scope of the lockfile change

`Cargo.lock` is intentionally scoped to the `rustfs-uring` entry alone (version + checksum). Running `cargo update` locally also wanted to pull in unrelated lockfile drift (windows-sys, base64, itertools, a missing object-data-cache dev-dep) that predates this change; that drift is left out of this PR so the diff maps one-to-one to the dependency bump. The recorded checksum matches the crates.io index entry for 0.2.0.

## Testing

- Verified `rustfs-uring 0.2.0` is present on the crates.io sparse index and that the lockfile checksum matches it exactly.
- Confirmed the four ecstore call sites resolve against the published 0.2.0 API by diffing the crate source signatures.
- `cargo update -p rustfs-uring --precise 0.2.0 --dry-run` reports nothing further to change — the lockfile entry is self-consistent.

Full Linux build/type-check runs in CI (the crate is Linux-only and needs an io_uring-capable toolchain the local macOS host lacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)