### PR TITLE
chore(deps): bump rustfs-uring to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10032,13 +10032,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-uring"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358fe7987fc6b4a98dd65d4f6a7785f4f1af41daf027d14ae4b5a94eadba6348"
+checksum = "0486e62d0efe25db95c00aeacb2da84368adcba299216cda99fcb11328061c84"
 dependencies = [
  "io-uring",
  "libc",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -146,7 +146,7 @@ metrics = { workspace = true }
 # crates.io. The guard scripts/check_no_tokio_io_uring.sh allows an explicit
 # io-uring integration; only the tokio "io-uring" runtime feature is banned.
 [target.'cfg(target_os = "linux")'.dependencies]
-rustfs-uring = "0.2.0"
+rustfs-uring = "0.2.1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }


### PR DESCRIPTION
## What

Bump the `rustfs-uring` dependency in `crates/ecstore` from `0.2.0` to `0.2.1`, now that 0.2.1 is published on crates.io. Follows on from #4730 (the 0.2.0 bump).

## Why

`rustfs-uring` 0.2.1 routes the read driver's runtime diagnostics (submit-error, CQ-overflow, bounded-drain, shutdown-timeout) through `tracing` with structured fields instead of `eprintln!`, unifying them with the RustFS tracing pipeline for filterable observability. The upstream release is [rustfs/uring#14](https://github.com/rustfs/uring/pull/14) (cutting [rustfs/uring#13](https://github.com/rustfs/uring/pull/13)).

## Compatibility

No public API changed across the bump — `UringDriver::probe_and_start_sharded`, `read_at`, and `read_at_direct` keep their 0.2.0 signatures; the read path and cancel-safety ownership model are untouched. It is a drop-in patch bump. The dependency is `cfg(target_os = "linux")`-only, so the code path is exercised on Linux CI, not on macOS builds.

## Lockfile change

`Cargo.lock` is scoped to the `rustfs-uring` entry alone: version, checksum, and — new in 0.2.1 — an added `tracing` dependency in the package's dependency list. `tracing` is already in the workspace graph (ecstore itself depends on it), so no new external crate is pulled in. The recorded checksum matches the crates.io index entry for 0.2.1, and `cargo update -p rustfs-uring --precise 0.2.1 --dry-run` reports nothing further to change (the lockfile entry is self-consistent). Unrelated lockfile drift is deliberately left out so the diff maps one-to-one to the dependency bump.

## Testing

- Verified `rustfs-uring 0.2.1` is present on the crates.io sparse index and that the lockfile checksum matches it exactly.
- Confirmed the added `tracing` dependency is correctly recorded via a self-consistent `--dry-run` resolve.

Full Linux build/type-check runs in CI (the crate is Linux-only and needs an io_uring-capable toolchain the local macOS host lacks).
