### PR TITLE
fix(ecstore): gate gauge import on Linux

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -35,7 +35,9 @@ use crate::disk::{
 use crate::erasure::coding::{self, bitrot_verify};
 use crate::runtime::sources as runtime_sources;
 use bytes::Bytes;
-use metrics::{counter, gauge};
+use metrics::counter;
+#[cfg(target_os = "linux")]
+use metrics::gauge;
 use parking_lot::{Mutex as ParkingLotMutex, RwLock as ParkingLotRwLock};
 use rustfs_filemeta::{
     Cache, FileInfo, FileInfoOpts, FileMeta, MetaCacheEntry, MetacacheWriter, ObjectPartInfo, Opts, RawFileInfo, UpdateFn,


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Gate the io_uring gauge macro import to Linux, matching its Linux-only call sites. This restores `-D warnings` builds on macOS after #4733.

## Verification

- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`
- `make pre-pr`

## Impact

No runtime behavior change. Non-Linux builds no longer fail on an unused import.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
