### PR TITLE
fix(ecstore): gate metrics::gauge import behind cfg(target_os = linux)

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -35,7 +35,9 @@ use crate::disk::{
 use crate::erasure::coding::{self, bitrot_verify};
 use crate::runtime::sources as runtime_sources;
 use bytes::Bytes;
-use metrics::{counter, gauge};
+use metrics::counter;
+#[cfg(target_os = "linux")]
+use metrics::gauge;
 use parking_lot::{Mutex as ParkingLotMutex, RwLock as ParkingLotRwLock};
 use rustfs_filemeta::{
     Cache, FileInfo, FileInfoOpts, FileMeta, MetaCacheEntry, MetacacheWriter, ObjectPartInfo, Opts, RawFileInfo, UpdateFn,


### PR DESCRIPTION
## Problem

`make pre-pr` fails on non-Linux targets (e.g. macOS) with:

```
error: unused import: `gauge`
  --> crates/ecstore/src/disk/local.rs:38:24
```

The `gauge` macro from `metrics` is only used inside the `UringBackend` impl block (lines 3119–3121), which is gated behind `#[cfg(target_os = "linux")]`. On non-Linux targets the import is unused, and clippy (with `-D unused-imports`) rejects the build.

## Fix

Split the combined `use metrics::{counter, gauge}` import so that:
- `counter` remains unconditional (used throughout the crate)
- `gauge` is gated behind `#[cfg(target_os = "linux")]` (matching the UringBackend block)

## Verification

- [x] `make pre-commit` — all guardrails + clippy pass
- [x] `make test` — 8675 tests passed, 116 skipped
- [x] `s3s-e2e` — all 27 S3 compatibility tests passed

Baseline: `a8eed1c44dfdcdb99d1330eba0dd1d7de4970515`
