### PR TITLE
test: quarantine embedded delete flake

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -101,6 +101,12 @@ retries = 2
 filter = 'package(rustfs-ecstore) & test(walk_dir_does_not_charge_consumer_backpressure_to_the_stall_budget)'
 retries = 2
 
+# QUARANTINE: OPEN rustfs#4740 — the embedded S3 test intermittently observes
+# BucketNotEmpty immediately after an acknowledged unversioned object delete.
+[[profile.ci.overrides]]
+filter = 'package(rustfs) & binary(embedded_test) & test(test_embedded_server_basic_s3_operations)'
+retries = 2
+
 # Serialize the 4-disk reliability / degraded-read e2e tests under the ci
 # profile too (see the e2e-reliability test-group note near the top). Not a
 # quarantine: no retries, just single-threaded so several 4-disk servers never


### PR DESCRIPTION
## Related Issues

Fixes #4740

## Summary of Changes

- Quarantine only the flaky embedded S3 delete test under the CI nextest profile.
- Keep local runs retry-free so the first failure remains visible during development.

## Verification

- `cargo nextest list --profile ci -p rustfs -E 'binary(embedded_test) & test(test_embedded_server_basic_s3_operations)'`
- `make pre-commit`
- Mechanical correctness adversary: selector scope, CI-only placement, local behavior, and issue lifecycle checked; no break found.

## Impact

CI may retry this one test up to twice and records the flaky marker in JUnit. No production behavior, test coverage, or other CI lane changes.

## Additional Notes

Remove this override when #4740 is fixed.
