### PR TITLE
fix(cache): drain entries before clear returns

### DIFF
--- a/crates/object-data-cache/src/moka_backend.rs
+++ b/crates/object-data-cache/src/moka_backend.rs
@@ -331,6 +331,7 @@ impl MokaBackend {
     pub async fn clear(&self) -> ObjectDataCacheInvalidationResult {
         let removed = self.index.remove_matching(|_| true).await.len();
         self.cache.invalidate_all();
+        self.cache.run_pending_tasks().await;
         Self::invalidation_result(removed)
     }
 
@@ -536,6 +537,7 @@ mod tests {
         assert_eq!(result, ObjectDataCacheInvalidationResult::Removed { keys: 2 });
         assert!(matches!(backend.lookup_body(&plan_a).await, ObjectDataCacheLookup::Miss));
         assert!(matches!(backend.lookup_body(&plan_b).await, ObjectDataCacheLookup::Miss));
+        assert_eq!(backend.entry_count(), 0, "clear must drain cached entries before returning");
         assert_eq!(backend.index.identity_count().await, 0, "clear must empty the identity index");
     }
 
@@ -954,9 +956,7 @@ mod tests {
             "invalidation must still win after a concurrency storm"
         );
 
-        // clear() plus a moka drain empties both the cache and the identity index.
         let _ = backend.clear().await;
-        backend.cache.run_pending_tasks().await;
         assert_eq!(backend.entry_count(), 0, "clear() must drop every entry");
     }
 


### PR DESCRIPTION
## Related Issues

Fixes #4749

## Summary of Changes

Wait for Moka maintenance after invalidating all entries so `clear().await` does not return with stale cache entries.

## Verification

- `cargo nextest run -p rustfs-object-data-cache -E 'test(moka_backend_clear_removes_everything) | test(moka_backend_concurrency_storm_leaves_no_leaked_state)'`
- `cargo clippy --all-targets -p rustfs-object-data-cache -- -D warnings`
- `cargo fmt --all --check`

## Impact

Cache clear now has synchronous completion semantics. Lookup and fill paths are unchanged.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
