### PR TITLE
feat(ecstore): make GET codec-streaming a single rollout switch (backlog#1183)

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -429,7 +429,13 @@ const ENV_RUSTFS_GET_OBJECT_METADATA_CACHE_MAX_ENTRIES: &str = "RUSTFS_GET_OBJEC
 // --- Codec Streaming Configuration ---
 
 const ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE: &str = "RUSTFS_GET_CODEC_STREAMING_ENABLE";
-const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE: bool = false; // Disabled until rollout gates are ready
+// Emergency kill-switch, not the primary enablement knob. The single switch that
+// turns codec streaming on/off is `RUSTFS_GET_CODEC_STREAMING_ROLLOUT` (default
+// `off`). This flag defaults to `true` and only exists to force-disable the fast
+// path regardless of rollout (set to `false`). Body/header compatibility is
+// confirmed by the GET codec-streaming parity e2e net + bench A/B (backlog#1183),
+// so it no longer gates enablement. See `get_codec_streaming_reader_gate`.
+const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE: bool = true;
 
 const ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE: &str = "RUSTFS_GET_CODEC_STREAMING_MIN_SIZE";
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE: usize = MI_B;
@@ -439,6 +445,10 @@ const DEFAULT_RUSTFS_GET_CODEC_STREAMING_RUSTFS_MIN_SIZE: usize = MI_B;
 const ENV_RUSTFS_GET_CODEC_STREAMING_ENGINE: &str = "RUSTFS_GET_CODEC_STREAMING_ENGINE";
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENGINE: &str = GET_CODEC_STREAMING_ENGINE_LEGACY;
 
+// Primary single switch for the codec-streaming GET fast path. `off` (default)
+// keeps GET on the legacy duplex path; `on` (aliases `full`/`production`, plus
+// the legacy `internal`/`benchmark`) opts it in. Combine with
+// `..._ROLLOUT_PCT` for a partial (percentage-based) rollout.
 const ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT: &str = "RUSTFS_GET_CODEC_STREAMING_ROLLOUT";
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_ROLLOUT: &str = "off";
 
@@ -918,18 +928,35 @@ fn get_codec_streaming_engine() -> GetCodecStreamingEngine {
 fn get_codec_streaming_rollout() -> GetCodecStreamingRollout {
     let rollout = rustfs_utils::get_env_str(ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, DEFAULT_RUSTFS_GET_CODEC_STREAMING_ROLLOUT);
     match rollout.trim() {
+        // Clean production token. `internal`/`benchmark` remain accepted aliases
+        // for backward compatibility; all three opt the fast path in.
+        value
+            if value.eq_ignore_ascii_case("on")
+                || value.eq_ignore_ascii_case("full")
+                || value.eq_ignore_ascii_case("production") =>
+        {
+            GetCodecStreamingRollout::On
+        }
         value if value.eq_ignore_ascii_case("internal") => GetCodecStreamingRollout::Internal,
         value if value.eq_ignore_ascii_case("benchmark") => GetCodecStreamingRollout::Benchmark,
         _ => GetCodecStreamingRollout::Off,
     }
 }
 
+/// Emergency kill-switch (defaults to `true`). Set
+/// `RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED=false` to force the fast path
+/// off. Body compatibility is confirmed by the parity e2e net + bench (backlog#1183),
+/// so this no longer gates enablement — the `..._ROLLOUT` switch does.
 fn is_get_codec_streaming_body_compat_confirmed() -> bool {
-    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, false)
+    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, true)
 }
 
+/// Emergency kill-switch (defaults to `true`). Set
+/// `RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED=false` to force the fast path
+/// off. Header compatibility is confirmed by the parity e2e net + bench (backlog#1183),
+/// so this no longer gates enablement — the `..._ROLLOUT` switch does.
 fn is_get_codec_streaming_header_compat_confirmed() -> bool {
-    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, false)
+    rustfs_utils::get_env_bool(ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, true)
 }
 
 fn build_get_codec_streaming_decode_engine(erasure: coding::Erasure) -> std::io::Result<CodecStreamingDecodeEngine> {
@@ -954,7 +981,11 @@ enum GetCodecStreamingDecision {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GetCodecStreamingRollout {
+    /// Default. Codec streaming disabled; GET uses the legacy duplex path.
     Off,
+    /// Production enablement token (`on`/`full`/`production`).
+    On,
+    /// Backward-compatible aliases that also opt the fast path in.
     Internal,
     Benchmark,
 }

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -4840,13 +4840,62 @@ mod tests {
     }
 
     #[test]
-    fn codec_streaming_reader_gate_defaults_to_disabled() {
+    fn codec_streaming_reader_gate_defaults_to_off() {
+        // With no env set the `..._ROLLOUT` switch defaults to `off`, so GET stays
+        // on the legacy duplex path. The compat kill-switches now default to
+        // confirmed (backlog#1183), so the fallback reason is the rollout switch,
+        // not the retired `Disabled`/`*Unconfirmed` reasons.
         temp_env::with_vars(
             [
                 (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, None::<&str>),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, None::<&str>),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, None::<&str>),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
+            ],
+            || {
+                let fi = codec_streaming_test_fileinfo(1024, 1);
+                let object_info = codec_streaming_test_object_info(&fi);
+
+                assert_eq!(
+                    codec_streaming_reader_gate_for_test(&None, &object_info, &fi, true).decision,
+                    GetCodecStreamingDecision::Fallback(GetCodecStreamingFallbackReason::RolloutNotOptedIn)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn codec_streaming_reader_gate_enabled_by_rollout_switch_alone() {
+        // The single switch: `..._ROLLOUT=on` opts the fast path in with the
+        // ENABLE / *_COMPAT_CONFIRMED kill-switches left unset (they default on).
+        temp_env::with_vars(
+            [
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, Some("on")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_BODY_COMPAT_CONFIRMED, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_HEADER_COMPAT_CONFIRMED, None::<&str>),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
+            ],
+            || {
+                let fi = codec_streaming_test_fileinfo(1024, 1);
+                let object_info = codec_streaming_test_object_info(&fi);
+
+                assert_eq!(
+                    codec_streaming_reader_gate_for_test(&None, &object_info, &fi, true).decision,
+                    GetCodecStreamingDecision::Use
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn codec_streaming_reader_gate_force_disabled_by_enable_kill_switch() {
+        // Even with the rollout switch on, `ENABLE=false` force-disables the fast path.
+        temp_env::with_vars(
+            [
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ENABLE, Some("false")),
+                (ENV_RUSTFS_GET_CODEC_STREAMING_ROLLOUT, Some("on")),
                 (ENV_RUSTFS_GET_CODEC_STREAMING_MIN_SIZE, Some("1")),
             ],
             || {


### PR DESCRIPTION
## What

Staged rollout step for backlog#1183: make enabling the zero-duplex GET codec-streaming fast path a **single switch** — `RUSTFS_GET_CODEC_STREAMING_ROLLOUT` (default `off`) — instead of the previous four-condition gate (`ENABLE` + `ROLLOUT` + two `..._COMPAT_CONFIRMED`).

## Why

The two `..._COMPAT_CONFIRMED` gates existed to demand empirical proof that codec streaming is byte- and header-identical to the legacy duplex path. That proof now exists: the parity e2e net (#4745) plus the bench A/B on backlog#1183 (throughput/p99-neutral, byte-identical). So the confirmations are baked in, and enablement collapses to one operator-facing knob.

## Changes

- Add a clean production rollout token `on` (aliases `full`/`production`); the legacy `internal`/`benchmark` tokens remain accepted.
- Flip `DEFAULT_RUSTFS_GET_CODEC_STREAMING_ENABLE` and the two `..._COMPAT_CONFIRMED` defaults to `true`. They are retained as **emergency kill-switches** (set any to `false` to force the fast path off) but no longer gate enablement — the rollout switch does.

## No production behavior change

With no env set, the rollout switch defaults to `off`, so GET stays on the legacy duplex path exactly as before. This PR does **not** flip the hard default; that is deferred to a follow-up after a production soak. The staged intent (per backlog#1183 go decision): reduce the gate to one switch now, flip the default later.

## Intentional semantics change (call-out for review)

With the rollout switch opted in (`on`/`internal`/`benchmark`), codec streaming now activates **without** also setting the two `..._COMPAT_CONFIRMED` vars — previously those defaulted to `false` and blocked activation as a second safety layer. Since compatibility is confirmed, that second layer is removed. Any deployment that had set `ROLLOUT=internal/benchmark` but deliberately withheld the COMPAT vars to stay on legacy would now activate codec streaming; default is `off` and no such persistent deployment is known.

## Verification

`cargo test -p rustfs-ecstore --lib codec_streaming` (39 pass, incl. the new revert-detectors), `cargo check -p rustfs --tests`, `cargo clippy --all-targets -p rustfs-ecstore`, `cargo fmt` — all clean. New tests: `codec_streaming_reader_gate_defaults_to_off` (no env → `RolloutNotOptedIn`, i.e. still off), `codec_streaming_reader_gate_enabled_by_rollout_switch_alone` (`ROLLOUT=on` alone → `Use`; reverting any of the three default flips or the `on` token turns this red), `codec_streaming_reader_gate_force_disabled_by_enable_kill_switch` (`ENABLE=false` still force-disables). Ran the six-role adversarial validation (AGENTS.md): default-OFF preservation, `should_use_codec_streaming` default-true inertness (no external callers, only consulted after the rollout gate), enum exhaustiveness, and metrics-label stability — no blocking findings; the one semantics change is documented above.

Depends on the parity evidence in #4745; both branch off `main` and are independent (the e2e test uses `ROLLOUT=internal`, still valid here).