### PR TITLE
fix: auto-repair test_rename_data_shares_file_sync_limit hang on macOS

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -9039,7 +9039,11 @@ mod test {
             }
         }
 
-        let _probe = os::file_sync_probe::set_blocking(dir.path());
+        // Use the disk's canonicalized root path — on macOS, tempfile returns
+        // /var/folders/... while LocalDisk resolves to /private/var/folders/...
+        // via dunce::canonicalize. The probe's starts_with check would fail
+        // with the non-canonical path, causing wait_for_active to hang.
+        let _probe = os::file_sync_probe::set_blocking(&disk.root);
         let first = {
             let disk = disk.clone();
             tokio::spawn(async move {


### PR DESCRIPTION
## Problem

`test_rename_data_shares_file_sync_limit_across_one_disk` (introduced in #4734) hangs indefinitely on macOS.

## Root Cause

On macOS, `tempfile::tempdir()` returns `/var/folders/...` while `LocalDisk::new` resolves the root to `/private/var/folders/...` via `dunce::canonicalize` (because `/var` is a symlink to `/private/var` on macOS).

The test passed `dir.path()` (non-canonical) to `file_sync_probe::set_blocking()`. The probe's `enter()` function checks `path.starts_with(root)`, but `sync_file` receives paths derived from the canonicalized `disk.root`. Since `/private/var/folders/...` does not start with `/var/folders/...`, the probe never activated, `ACTIVE` stayed at 0, and `wait_for_active(16)` hung forever.

## Fix

Use `&disk.root` (the already-canonicalized path) instead of `dir.path()` when setting up the file_sync_probe. This ensures the probe's root prefix matches the paths that `sync_file` receives.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p rustfs-ecstore --tests -- -D warnings` ✅
- `cargo nextest run --all --exclude e2e_test` ✅ (8688 passed, 116 skipped — previously this test hung and blocked the entire suite)
- `cargo test --all --doc` ✅

Baseline: 5088a6cde4982e61e18abb5e6a6274af3f279a26
