### PR TITLE
fix(cache): drain pending removals during clear

### DIFF
--- a/crates/object-data-cache/src/moka_backend.rs
+++ b/crates/object-data-cache/src/moka_backend.rs
@@ -330,8 +330,15 @@ impl MokaBackend {
     /// index). Rare admin `clear()` path only.
     pub async fn clear(&self) -> ObjectDataCacheInvalidationResult {
         let removed = self.index.remove_matching(|_| true).await.len();
-        self.cache.invalidate_all();
         self.cache.run_pending_tasks().await;
+        self.cache.invalidate_all();
+        for _ in 0..8 {
+            self.cache.run_pending_tasks().await;
+            if self.cache.entry_count() == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
         Self::invalidation_result(removed)
     }
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
CI failed on main in `rustfs-object-data-cache` because `clear()` could return with one Moka entry still pending after a prior invalidation. This drains pending Moka removals before `invalidate_all()` and then runs a bounded post-clear drain until the entry count reaches zero.

## Verification
- `CARGO_TARGET_DIR=/tmp/rustfs-daily-bug-scan-target cargo test -p rustfs-object-data-cache moka_backend::tests::moka_backend_concurrency_storm_leaves_no_leaked_state -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/rustfs-daily-bug-scan-target cargo test -p rustfs-object-data-cache`
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/rustfs-daily-bug-scan-target make pre-commit`

## Impact
Admin/cache clear waits a little longer for Moka maintenance to finish; GET/fill hot paths are unchanged.

## Additional Notes
Adversarial validation: correctness, concurrency, performance, and test coverage reviewed; no break found.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
