### PR TITLE
docs(obs): align OtelConfig doc defaults with actual constants

### DIFF
--- a/crates/obs/src/config.rs
+++ b/crates/obs/src/config.rs
@@ -148,14 +148,14 @@ pub struct OtelConfig {
     pub metrics_export_enabled: Option<bool>,
     /// Whether to export logs via OTLP (default: `true`).
     pub logs_export_enabled: Option<bool>,
-    /// Whether to export profiles via pyroscope (default: `false`).
+    /// Whether to export profiles via pyroscope (default: `true`).
     pub profiling_export_enabled: Option<bool>,
     /// **[OTLP-only]** Mirror all signals to stdout in addition to OTLP export.
     /// Only applies when an OTLP endpoint is configured.
     pub use_stdout: Option<bool>,
-    /// Fraction of traces to sample, `0.0`–`1.0` (default: `0.1`).
+    /// Fraction of traces to sample, `0.0`–`1.0` (default: `1.0`).
     pub sample_ratio: Option<f64>,
-    /// Metrics export interval in seconds (default: `15`).
+    /// Metrics export interval in seconds (default: `30`).
     pub meter_interval: Option<u64>,
     /// OTel `service.name` attribute (default: `APP_NAME`).
     pub service_name: Option<String>,
@@ -165,7 +165,7 @@ pub struct OtelConfig {
     pub environment: Option<String>,
 
     // ── Local logging ─────────────────────────────────────────────────────────
-    /// Minimum log level directive (default: `info`).
+    /// Minimum log level directive (default: `error`).
     /// Respects `RUST_LOG` syntax when set via environment.
     pub logger_level: Option<String>,
     /// When `true`, a stdout JSON layer is always attached regardless of the
@@ -177,7 +177,8 @@ pub struct OtelConfig {
     /// Base name for log files (without date suffix), e.g. `rustfs`.
     /// Used for both rolling-appender naming and cleanup scanning.
     pub log_filename: Option<String>,
-    /// Rotation time granularity: `"hourly"` or `"daily"` (default: `"daily"`).
+    /// Rotation time granularity: `"minutely"`, `"hourly"`, or `"daily"`
+    /// (default: `"hourly"`; any unrecognized value falls back to `"daily"`).
     pub log_rotation_time: Option<String>,
     /// Number of rolling log files to retain (default: `30`).
     /// Used by both the rolling-appender (as a loose upper bound) and the
@@ -214,7 +215,7 @@ pub struct OtelConfig {
     pub log_delete_empty_files: Option<bool>,
     /// A file younger than this many seconds is never touched (default: `3600`).
     pub log_min_file_age_seconds: Option<u64>,
-    /// How often the background cleanup task runs, in seconds (default: `21600`).
+    /// How often the background cleanup task runs, in seconds (default: `1800`).
     pub log_cleanup_interval_seconds: Option<u64>,
     /// Log what *would* be deleted without actually removing anything
     /// (default: `false`).


### PR DESCRIPTION
## What

Six doc-comments on `OtelConfig` fields (`crates/obs/src/config.rs`) declared default values that disagreed with the constants the runtime actually applies in `extract_otel_config_from_env`. This corrects the comments to match the real defaults.

| Field | Doc said | Actual constant | Value |
|---|---|---|---|
| `profiling_export_enabled` | `false` | `DEFAULT_OBS_PROFILING_EXPORT_ENABLED` | `true` |
| `sample_ratio` | `0.1` | `SAMPLE_RATIO` | `1.0` |
| `meter_interval` | `15` | `METER_INTERVAL` | `30` |
| `logger_level` | `info` | `DEFAULT_LOG_LEVEL` | `error` |
| `log_rotation_time` | `daily` | `DEFAULT_LOG_ROTATION_TIME` | `hourly` |
| `log_cleanup_interval_seconds` | `21600` | `DEFAULT_OBS_LOG_CLEANUP_INTERVAL_SECONDS` | `1800` |

For `log_rotation_time` the comment now also documents the full accepted set (`minutely`/`hourly`/`daily`) and the daily fallback for unrecognized values.

## Why

The declared defaults are what operators read when configuring logging from source. The mismatches would mislead anyone reasoning about behavior without running the code — e.g. assuming trace sampling defaults to 10% (it's 100%) or that logs default to `info` (they default to `error`).

## Scope

Doc-comment only. No behavior change; runtime defaults were and remain the constants above.

## Verification

- `cargo fmt --all`
- `scripts/check_logging_guardrails.sh` ✅