### PR TITLE
fix(ci): restore lifecycle debug day to 10s to fix flaky expiration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,6 +543,13 @@ jobs:
   # cannot be applied to the s3-implemented-tests lane above because a global
   # RUSTFS_ILM_DEBUG_DAY_SECS also shrinks the x-amz-expiration header those tests
   # assert on (test_lifecycle_expiration_header_*). Hence a separate server here.
+  #
+  # RUSTFS_ILM_DEBUG_DAY_SECS MUST stay equal to the s3-tests lc_debug_interval
+  # default (10s). test_lifecycle_expiration polls the Days=1 rule with a
+  # 4*lc_interval window while the Days=5 rule fires at 5*debug_day; observing
+  # the intermediate 4-object plateau requires 4*lc_interval < 5*debug_day, i.e.
+  # debug_day > 8. A smaller value lets the Days=5 rule fire inside the Days=1
+  # poll window so the count collapses straight to 2 and the test fails (#4764).
   s3-lifecycle-behavior-tests:
     name: S3 Lifecycle Behavior Tests
     needs: [ build-rustfs-debug-binary ]
@@ -572,7 +579,7 @@ jobs:
           MAXFAIL=0 \
           XDIST=0 \
           IMPLEMENTED_TESTS_FILE=scripts/s3-tests/lifecycle_behavior_tests.txt \
-          RUSTFS_ILM_DEBUG_DAY_SECS=2 \
+          RUSTFS_ILM_DEBUG_DAY_SECS=10 \
           RUSTFS_ILM_PROCESS_TIME=1 \
           RUSTFS_SCANNER_ENABLED=true \
           RUSTFS_SCANNER_CYCLE=2 \


### PR DESCRIPTION
## Related Issues

Fixes the flaky `S3 Lifecycle Behavior Tests` lane failing on unrelated PRs (e.g. run in #4764: `test_lifecycle_expiration - assert 2 == 4`).

## Root Cause

#4755 lowered `RUSTFS_ILM_DEBUG_DAY_SECS` from `10` to `2` in the lifecycle behavior lane, but the ceph/s3-tests `lc_debug_interval` stayed at its default of `10`.

`test_lifecycle_expiration` (and `test_lifecyclev2_expiration`) create objects under `expire1/` (`Days=1`), `keep2/`, and `expire3/` (`Days=5`), then poll for the intermediate plateau where `expire1/` has expired but `expire3/` has not — a count of `4`. The polling patch waits for that with a `4*lc_interval` (40s) window, which is safe **only while** the `Days=5` rule fires later than that window:

```
4 * lc_interval  <  5 * debug_day      (observability invariant)
```

With `debug_day=2`, the `Days=5` rule fires at `5*2 = 10s` — **inside** the 40s poll window — so the count drops straight from 6 to 2 and the poll returns 2 instead of 4:

```
assert len(expire1_objects) == 4
E   assert 2 == 4
```

`test_lifecyclev2_expiration` has identical logic and passed in the same run, confirming this is a race, not a deterministic break.

## Fix

Restore `RUSTFS_ILM_DEBUG_DAY_SECS=10`, which:
- satisfies the invariant (`40 < 50`), and
- matches the documented value in [`scripts/s3-tests/lifecycle_behavior_tests.txt`](scripts/s3-tests/lifecycle_behavior_tests.txt) ("1 day = 10s, matches s3-tests lc_debug_interval") — #4755 changed the workflow but not the doc.

A guard comment on the job documents the invariant so a future "speed it up" change can't silently reintroduce the race. `RUSTFS_ILM_PROCESS_TIME=1` and the polling patch from #4755 are kept.

## Verification

- YAML/shell change only; the env-var continuation chain is unchanged (comment lives at YAML level, not inside the `run:` chain).
- Restores the pre-#4755 debug-day value that the lane ran green on.

## Impact

CI-only. No runtime behavior or public API changes.