### PR TITLE
fix(ci): evaluate ILM every scanner cycle in lifecycle behavior lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,15 @@ jobs:
   # the intermediate 4-object plateau requires 4*lc_interval < 5*debug_day, i.e.
   # debug_day > 8. A smaller value lets the Days=5 rule fire inside the Days=1
   # poll window so the count collapses straight to 2 and the test fails (#4764).
+  #
+  # RUSTFS_DATA_USAGE_UPDATE_DIR_CYCLES=1 is also required. A compacted directory
+  # is only re-descended (and its objects re-evaluated for ILM) once every
+  # DATA_USAGE_UPDATE_DIR_CYCLES scanner cycles (default 16). At the accelerated
+  # RUSTFS_SCANNER_CYCLE=2 that is ~32s between evaluations, so a Days=1 object
+  # that becomes due at debug_day (10s) is not actually expired until the next
+  # ~32s boundary (~42s), landing just past the 4*lc_interval (40s) poll window
+  # and making the count stall at 6 (#4767). Forcing every-cycle re-descent
+  # evaluates ILM within ~2s of the due time, well inside the poll window.
   s3-lifecycle-behavior-tests:
     name: S3 Lifecycle Behavior Tests
     needs: [ build-rustfs-debug-binary ]
@@ -583,6 +592,7 @@ jobs:
           RUSTFS_ILM_PROCESS_TIME=1 \
           RUSTFS_SCANNER_ENABLED=true \
           RUSTFS_SCANNER_CYCLE=2 \
+          RUSTFS_DATA_USAGE_UPDATE_DIR_CYCLES=1 \
           RUSTFS_SCANNER_START_DELAY_SECS=0 \
           RUSTFS_API_STALE_UPLOADS_CLEANUP_INTERVAL=2s \
           S3_PORT="${S3_PORT}" \


### PR DESCRIPTION
## Problem

The `S3 Lifecycle Behavior Tests` lane flakes intermittently, with lifecycle counts stalling one plateau behind the expected value:

- `test_lifecycle_expiration` → `assert 6 == 4` (Days=1 objects not yet gone)
- `test_lifecyclev2_expiration` → `assert 4 == 2`
- `test_lifecycle_deletemarker_expiration` → `assert 3 == 2`

Example failing run: https://github.com/rustfs/rustfs/actions/runs/29181573221/job/86620820040

## Root cause

A **compacted** directory is only re-descended — and its objects re-evaluated against ILM rules — once every `DATA_USAGE_UPDATE_DIR_CYCLES` scanner cycles (default **16**), see [`crates/scanner/src/scanner_folder.rs`](https://github.com/rustfs/rustfs/blob/main/crates/scanner/src/scanner_folder.rs) (`h.mod_(next_cycle, data_usage_update_dir_cycles())` gate). At the lane's accelerated `RUSTFS_SCANNER_CYCLE=2`, that is **~32s between ILM evaluations** of a given prefix.

From the failing run's `rustfs.log` (bucket `rustfs-ifjbbhdmdaacflb8kbnq8n-1`):

| event | time | age |
|---|---|---|
| 6 objects PUT | 05:54:39.4 | T0 |
| poll window ends (4×lc_interval = 40s) | ~05:55:19.6 | +40s |
| **expire1/{foo,bar} actually deleted** (Days=1) | **05:55:21.65** | **+42s** |
| expire3/{foo,bar} deleted (Days=5) | 05:55:55.97 | +76s |

A Days=1 object becomes due at `debug_day` (10s) but isn't expired until the next ~32s re-descent boundary (~42s) — landing just past the test's 40s poll window, so the list still returns the pre-expiry count. Slightly slower runners push the same effect onto the Days=5 / delete-marker windows too.

## Fix

Set `RUSTFS_DATA_USAGE_UPDATE_DIR_CYCLES=1` for this debug-only lane so compacted directories are re-descended **every** cycle and ILM fires within ~2s of the due time, comfortably inside the poll window.

- Lane-scoped, debug server only — does not change the product default (16).
- Does **not** touch the delicate `4*lc_interval < 5*debug_day` plateau invariant restored in #4766; it only closes the gap between "object due" and "object actually evaluated".
- Fixes all three failing cases, which share the same evaluation-cadence cause.

## Verification

- `actionlint .github/workflows/ci.yml` clean.
- `mod_(_, 1)` returns `true` (`cycles == 1` branch), so the `if !mod_ { skip }` gate never skips → every-cycle re-descent, as intended.