### PR TITLE
build(toolchain): switch Rust channel to stable

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -291,6 +291,7 @@ struct Md5 {
     hasher: md5::Md5,
 }
 
+#[allow(dead_code)]
 impl Md5 {
     fn update(&mut self, bytes: &[u8]) {
         use md5::Digest;

--- a/crates/data-usage/src/data_usage.rs
+++ b/crates/data-usage/src/data_usage.rs
@@ -434,7 +434,7 @@ impl ReplicationAllStats {
         if self.replica_size != 0 && self.replica_count != 0 {
             return false;
         }
-        for (_, v) in self.targets.iter() {
+        for v in self.targets.values() {
             if !v.empty() {
                 return false;
             }

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -2312,7 +2312,7 @@ pub fn gen_transition_objname(bucket: &str) -> Result<String, Error> {
     let mut hasher = Sha256::new();
     hasher.update(format!("{}/{}", runtime_sources::deployment_id().unwrap_or_default(), bucket).as_bytes());
     let hash = rustfs_utils::crypto::hex(hasher.finalize().as_slice());
-    let obj = format!("{}/{}/{}/{}", &hash[0..16], &us[0..2], &us[2..4], &us);
+    let obj = format!("{}/{}/{}/{}", &hash[0..16], &us[0..2], &us[2..4], us);
     Ok(obj)
 }
 

--- a/crates/ecstore/src/bucket/object_lock/objectlock_sys.rs
+++ b/crates/ecstore/src/bucket/object_lock/objectlock_sys.rs
@@ -250,10 +250,9 @@ pub async fn check_object_lock_for_deletion(
                 let now = objectlock::utc_now_ntp();
                 let retain_until = if let Some(days) = default_retention.days {
                     mod_time.saturating_add(time::Duration::days(days as i64))
-                } else if let Some(years) = default_retention.years {
-                    add_years(mod_time, years)
                 } else {
-                    return None; // No retention period specified
+                    let years = default_retention.years?;
+                    add_years(mod_time, years)
                 };
 
                 if retain_until.unix_timestamp() > now.unix_timestamp()

--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -1405,7 +1405,7 @@ pub(crate) async fn schedule_replication_delete(dv: DeletedObjectReplicationInfo
     }
 
     if let (Some(rs), Some(stats)) = (dv.delete_object.replication_state, runtime_sources::replication_stats()) {
-        for (k, _v) in rs.targets.iter() {
+        for k in rs.targets.keys() {
             let ri = ReplicatedTargetInfo {
                 arn: k.clone(),
                 size: 0,

--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -1348,7 +1348,7 @@ pub async fn replicate_delete<S: ReplicationStorage>(dobj: DeletedObjectReplicat
     let mut join_set = JoinSet::new();
 
     // Process each target
-    for (_, tgt_entry) in dsc.targets_map.iter() {
+    for tgt_entry in dsc.targets_map.values() {
         // Skip targets that should not be replicated
         if !tgt_entry.replicate {
             continue;

--- a/crates/ecstore/src/bucket/replication/replication_state.rs
+++ b/crates/ecstore/src/bucket/replication/replication_state.rs
@@ -208,7 +208,7 @@ impl ReplicationStats {
         let now = SystemTime::now();
 
         let cache_read = cache.read().await;
-        for (_bucket, stats) in cache_read.iter() {
+        for stats in cache_read.values() {
             for stat in stats.stats.values() {
                 // Now we can update the moving averages using interior mutability
                 stat.xfer_rate_lrg.measure.update_exponential_moving_average(now);

--- a/crates/ecstore/src/data_usage/mod.rs
+++ b/crates/ecstore/src/data_usage/mod.rs
@@ -1203,7 +1203,7 @@ pub async fn save_data_usage_cache(cache: &DataUsageCache, name: &str) -> crate:
 
     let name_clone = name.clone();
     tokio::spawn(async move {
-        let _ = save_config(store_clone, &format!("{}{}", &name_clone, ".bkp"), buf_clone).await;
+        let _ = save_config(store_clone, &format!("{}{}", name_clone, ".bkp"), buf_clone).await;
     });
     save_config(store, &name, buf).await?;
     Ok(())

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -5135,12 +5135,11 @@ impl LocalDisk {
                 }
 
                 let metadata =
-                    with_walk_stall_timeout(stall, self.read_metadata(bucket, format!("{}/{}", &current, &entry).as_str()))
-                        .await?;
+                    with_walk_stall_timeout(stall, self.read_metadata(bucket, format!("{}/{}", current, entry).as_str())).await?;
 
                 let entry = entry.strip_suffix(STORAGE_FORMAT_FILE).unwrap_or_default().to_owned();
                 let name = entry.trim_end_matches(SLASH_SEPARATOR);
-                let name = decode_dir_object(format!("{}/{}", &current, &name).as_str());
+                let name = decode_dir_object(format!("{}/{}", current, name).as_str());
 
                 if opts.limit <= 0 || metadata_counts_toward_limit(&metadata) {
                     *objs_returned += 1;
@@ -5252,7 +5251,7 @@ impl LocalDisk {
                 meta.name.push_str(GLOBAL_DIR_SUFFIX_WITH_SLASH);
             }
 
-            let fname = format!("{}/{}", &meta.name, STORAGE_FORMAT_FILE);
+            let fname = format!("{}/{}", meta.name, STORAGE_FORMAT_FILE);
 
             match with_walk_stall_timeout(stall, self.read_metadata(&opts.bucket, fname.as_str())).await {
                 Ok(res) => {
@@ -6647,8 +6646,8 @@ impl DiskAPI for LocalDisk {
         }
 
         // xl.meta path
-        let src_file_path = self.get_object_path(src_volume, format!("{}/{}", &src_path, STORAGE_FORMAT_FILE).as_str())?;
-        let dst_file_path = self.get_object_path(dst_volume, format!("{}/{}", &dst_path, STORAGE_FORMAT_FILE).as_str())?;
+        let src_file_path = self.get_object_path(src_volume, format!("{}/{}", src_path, STORAGE_FORMAT_FILE).as_str())?;
+        let dst_file_path = self.get_object_path(dst_volume, format!("{}/{}", dst_path, STORAGE_FORMAT_FILE).as_str())?;
 
         // data_dir path
         let has_data_dir_path = {
@@ -6664,11 +6663,11 @@ impl DiskAPI for LocalDisk {
             if let Some(data_dir) = has_data_dir {
                 let src_data_path = self.get_object_path(
                     src_volume,
-                    rustfs_utils::path::retain_slash(format!("{}/{}", &src_path, data_dir).as_str()).as_str(),
+                    rustfs_utils::path::retain_slash(format!("{}/{}", src_path, data_dir).as_str()).as_str(),
                 )?;
                 let dst_data_path = self.get_object_path(
                     dst_volume,
-                    rustfs_utils::path::retain_slash(format!("{}/{}", &dst_path, data_dir).as_str()).as_str(),
+                    rustfs_utils::path::retain_slash(format!("{}/{}", dst_path, data_dir).as_str()).as_str(),
                 )?;
 
                 Some((src_data_path, dst_data_path))
@@ -6776,7 +6775,7 @@ impl DiskAPI for LocalDisk {
             // rename below to report through the existing rollback path. Payload
             // durability is kept by both strict and relaxed.
             // Bound to a local so the borrow lives across the join! below.
-            let tmp_meta_rel_path = format!("{}/{}", &src_path, STORAGE_FORMAT_FILE);
+            let tmp_meta_rel_path = format!("{}/{}", src_path, STORAGE_FORMAT_FILE);
             let tmp_meta_write =
                 self.write_all_private(src_volume, &tmp_meta_rel_path, new_dst_buf.into(), tmp_meta_sync, src_file_parent);
             let shard_sync = async {
@@ -6850,7 +6849,7 @@ impl DiskAPI for LocalDisk {
                 && let Err(err) = self
                     .write_all_private(
                         dst_volume,
-                        &format!("{}/{}/{}", &dst_path, &old_data_dir, STORAGE_FORMAT_FILE_BACKUP),
+                        &format!("{}/{}/{}", dst_path, old_data_dir, STORAGE_FORMAT_FILE_BACKUP),
                         dst_buf.clone().into(),
                         backup_sync,
                         &skip_parent,
@@ -7326,7 +7325,7 @@ impl DiskAPI for LocalDisk {
             check_path_length(file_path.to_string_lossy().as_ref())?;
 
             let buf = self
-                .read_all(volume, format!("{}/{}", &path, STORAGE_FORMAT_FILE).as_str())
+                .read_all(volume, format!("{}/{}", path, STORAGE_FORMAT_FILE).as_str())
                 .await
                 .map_err(|e| {
                     if e == DiskError::FileNotFound && fi.version_id.is_some() {
@@ -7750,7 +7749,7 @@ impl DiskAPI for LocalDisk {
         let mut found = 0;
 
         for v in req.files.iter() {
-            let fpath = self.get_object_path(&req.bucket, format!("{}/{}", &req.prefix, v).as_str())?;
+            let fpath = self.get_object_path(&req.bucket, format!("{}/{}", req.prefix, v).as_str())?;
             let mut res = ReadMultipleResp {
                 bucket: req.bucket.clone(),
                 prefix: req.prefix.clone(),
@@ -12389,7 +12388,7 @@ mod test {
             .resolve_abs_path(Path::new(RUSTFS_META_TMP_DELETED_BUCKET))
             .expect("operation should succeed");
 
-        println!("ppp :{:?}", &tmpp);
+        println!("ppp :{:?}", tmpp);
 
         let volumes = vec!["a123", "b123", "c123"];
 
@@ -12413,7 +12412,7 @@ mod test {
             .resolve_abs_path(Path::new(RUSTFS_META_TMP_DELETED_BUCKET))
             .expect("operation should succeed");
 
-        println!("ppp :{:?}", &tmpp);
+        println!("ppp :{:?}", tmpp);
 
         let volumes = vec!["a123", "b123", "c123"];
 

--- a/crates/ecstore/src/layout/disks_layout.rs
+++ b/crates/ecstore/src/layout/disks_layout.rs
@@ -423,7 +423,7 @@ fn get_set_indexes<T: AsRef<str>>(
             if !has_set_drive_count {
                 return Err(Error::other(format!(
                     "Invalid set drive count {}. Acceptable values for {:?} number drives are {:?}",
-                    set_drive_count, common_size, &set_counts
+                    set_drive_count, common_size, set_counts
                 )));
             }
             set_drive_count
@@ -432,7 +432,7 @@ fn get_set_indexes<T: AsRef<str>>(
             if set_counts.is_empty() {
                 return Err(Error::other(format!(
                     "No symmetric distribution detected with input endpoints , drives {} cannot be spread symmetrically by any supported erasure set sizes {:?}",
-                    common_size, &set_counts
+                    common_size, set_counts
                 )));
             }
             // Final set size with all the symmetry accounted for.

--- a/crates/ecstore/src/layout/endpoints.rs
+++ b/crates/ecstore/src/layout/endpoints.rs
@@ -2209,7 +2209,7 @@ mod test {
                     if Some(&pools.setup_type) != test_case.expected_setup_type.as_ref() {
                         panic!(
                             "Test {}: setupType: expected = {:?}, got = {:?}",
-                            test_case.num, test_case.expected_setup_type, &pools.setup_type
+                            test_case.num, test_case.expected_setup_type, pools.setup_type
                         )
                     }
 

--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -222,7 +222,7 @@ impl SetDisks {
                         }
 
                         if !latest_meta.deleted && !latest_meta.is_remote() {
-                            for (_, part_errs) in data_errs_by_part.iter() {
+                            for part_errs in data_errs_by_part.values() {
                                 if count_part_not_success(part_errs) > latest_meta.erasure.parity_blocks {
                                     cannot_heal = true;
                                     break;

--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -43,7 +43,7 @@ use uuid::Uuid;
 use xxhash_rust::xxh64;
 
 // XL header specifies the format
-pub static XL_FILE_HEADER: [u8; 4] = [b'X', b'L', b'2', b' '];
+pub static XL_FILE_HEADER: [u8; 4] = *b"XL2 ";
 // pub static XL_FILE_VERSION_CURRENT: [u8; 4] = [0; 4];
 
 // Current version being written.

--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -2223,16 +2223,44 @@ impl HealManager {
                         let mut endpoints = Vec::new();
                         let mut seen_returning_sets = HashSet::new();
                         let local_disk_map = local_disk_map_read().await;
-                        for (_, disk_opt) in local_disk_map.iter() {
-                            if let Some(disk) = disk_opt {
-                                let endpoint = disk.endpoint();
-                                let runtime_state = disk.runtime_state();
-                                let set_disk_id =
-                                    crate::heal::utils::format_set_disk_id_from_i32(endpoint.pool_idx, endpoint.set_idx);
+                        for disk in local_disk_map.values().flatten() {
+                            let endpoint = disk.endpoint();
+                            let runtime_state = disk.runtime_state();
+                            let set_disk_id =
+                                crate::heal::utils::format_set_disk_id_from_i32(endpoint.pool_idx, endpoint.set_idx);
 
-                                // detect unformatted disk via get_disk_id()
-                                match disk.get_disk_id().await {
-                                    Err(DiskError::UnformattedDisk) => {
+                            // detect unformatted disk via get_disk_id()
+                            match disk.get_disk_id().await {
+                                Err(DiskError::UnformattedDisk) => {
+                                    candidate_count += 1;
+                                    debug!(
+                                        target: "rustfs::heal::manager",
+                                        event = EVENT_HEAL_AUTO_SCAN_DISK,
+                                        component = LOG_COMPONENT_HEAL,
+                                        subsystem = LOG_SUBSYSTEM_DISK_SCANNER,
+                                        endpoint = %endpoint,
+                                        disk_state = "unformatted",
+                                        "Heal auto-scan candidate detected"
+                                    );
+                                    endpoints.push(endpoint);
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        target: "rustfs::heal::manager",
+                                        event = EVENT_HEAL_AUTO_SCAN_DISK,
+                                        component = LOG_COMPONENT_HEAL,
+                                        subsystem = LOG_SUBSYSTEM_DISK_SCANNER,
+                                        endpoint = %endpoint,
+                                        disk_state = "check_failed",
+                                        error = ?e,
+                                        "Heal auto-scan disk inspection failed"
+                                    );
+                                }
+                                Ok(_) => {
+                                    if runtime_state.as_str() == "returning"
+                                        && let Some(set_disk_id) = set_disk_id
+                                        && seen_returning_sets.insert(set_disk_id.clone())
+                                    {
                                         candidate_count += 1;
                                         debug!(
                                             target: "rustfs::heal::manager",
@@ -2240,41 +2268,11 @@ impl HealManager {
                                             component = LOG_COMPONENT_HEAL,
                                             subsystem = LOG_SUBSYSTEM_DISK_SCANNER,
                                             endpoint = %endpoint,
-                                            disk_state = "unformatted",
-                                            "Heal auto-scan candidate detected"
+                                            set_disk_id,
+                                            disk_state = "returning",
+                                            "Heal auto-scan returning disk candidate detected"
                                         );
                                         endpoints.push(endpoint);
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            target: "rustfs::heal::manager",
-                                            event = EVENT_HEAL_AUTO_SCAN_DISK,
-                                            component = LOG_COMPONENT_HEAL,
-                                            subsystem = LOG_SUBSYSTEM_DISK_SCANNER,
-                                            endpoint = %endpoint,
-                                            disk_state = "check_failed",
-                                            error = ?e,
-                                            "Heal auto-scan disk inspection failed"
-                                        );
-                                    }
-                                    Ok(_) => {
-                                        if runtime_state.as_str() == "returning"
-                                            && let Some(set_disk_id) = set_disk_id
-                                            && seen_returning_sets.insert(set_disk_id.clone())
-                                        {
-                                            candidate_count += 1;
-                                            debug!(
-                                                target: "rustfs::heal::manager",
-                                                event = EVENT_HEAL_AUTO_SCAN_DISK,
-                                                component = LOG_COMPONENT_HEAL,
-                                                subsystem = LOG_SUBSYSTEM_DISK_SCANNER,
-                                                endpoint = %endpoint,
-                                                set_disk_id,
-                                                disk_state = "returning",
-                                                "Heal auto-scan returning disk candidate detected"
-                                            );
-                                            endpoints.push(endpoint);
-                                        }
                                     }
                                 }
                             }

--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -695,7 +695,7 @@ where
         let mut user_exists = false;
         let mut ret = Vec::new();
 
-        for (_, v) in users.iter() {
+        for v in users.values() {
             let is_derived = v.credentials.is_service_account() || v.credentials.is_temp();
 
             if !is_derived && v.credentials.access_key.as_str() == access_key {
@@ -713,7 +713,7 @@ where
         }
 
         let sts_accounts = Arc::clone(&cache.sts_accounts);
-        for (_, v) in sts_accounts.iter() {
+        for v in sts_accounts.values() {
             if v.credentials.parent_user == access_key {
                 user_exists = true;
                 if v.credentials.is_temp() && !v.credentials.is_service_account() {
@@ -1384,7 +1384,7 @@ where
             let mut service_accounts_to_delete = Vec::new();
             let mut temp_accounts_to_delete = HashSet::new();
             let cache = self.cache.snapshot();
-            for (_, v) in cache.users.iter() {
+            for v in cache.users.values() {
                 let u = &v.credentials;
                 if u.parent_user.as_str() == access_key {
                     if u.is_service_account() {
@@ -1396,7 +1396,7 @@ where
                     }
                 }
             }
-            for (_, v) in cache.sts_accounts.iter() {
+            for v in cache.sts_accounts.values() {
                 let u = &v.credentials;
                 if u.parent_user.as_str() == access_key {
                     temp_accounts_to_delete.insert(u.access_key.clone());
@@ -1972,14 +1972,14 @@ where
             let mut temp_accounts_to_delete = HashSet::new();
             if user_type == UserType::Reg {
                 let cache = self.cache.snapshot();
-                for (_, v) in cache.users.iter() {
+                for v in cache.users.values() {
                     let u = &v.credentials;
                     if u.parent_user.as_str() == name && u.is_service_account() {
                         service_accounts_to_delete.push(u.access_key.clone());
                     }
                 }
 
-                for (_, u) in cache.sts_accounts.iter() {
+                for u in cache.sts_accounts.values() {
                     let u = &u.credentials;
                     if u.parent_user.as_str() == name {
                         temp_accounts_to_delete.insert(u.access_key.clone());

--- a/crates/iam/src/store/object.rs
+++ b/crates/iam/src/store/object.rs
@@ -1251,7 +1251,7 @@ impl Store for ObjectStore {
                 };
             }
 
-            for (_, v) in items_cache.iter() {
+            for v in items_cache.values() {
                 let parent = v.credentials.parent_user.clone();
                 if !user_items_cache.contains_key(&parent) {
                     debug!(user = %parent, "IAM STS parent policy loaded");

--- a/crates/rio/src/compress_reader.rs
+++ b/crates/rio/src/compress_reader.rs
@@ -153,7 +153,7 @@ where
             }
             *this.buffer = out;
             *this.pos = 0;
-            this.temp_buffer.truncate(0); // More efficient way to clear
+            this.temp_buffer.clear(); // More efficient way to clear
             let to_copy = min(buf.remaining(), this.buffer.len());
             buf.put_slice(&this.buffer[..to_copy]);
             *this.pos += to_copy;

--- a/crates/trusted-proxies/src/utils/ip.rs
+++ b/crates/trusted-proxies/src/utils/ip.rs
@@ -178,9 +178,9 @@ impl IpUtils {
                 continue;
             }
 
-            match Self::parse_ip_or_cidr(part) {
-                Ok(network) => networks.push(network),
-                Err(e) => return Err(e),
+            {
+                let network = Self::parse_ip_or_cidr(part)?;
+                networks.push(network)
             }
         }
 

--- a/crates/utils/src/crypto.rs
+++ b/crates/utils/src/crypto.rs
@@ -147,7 +147,7 @@ fn test_base64_encoding_decoding() {
 
     let encoded_string = base64_encode_url_safe_no_pad(original_uuid_timestamp.as_bytes());
 
-    println!("Encoded: {}", &encoded_string);
+    println!("Encoded: {}", encoded_string);
 
     let decoded_bytes = base64_decode_url_safe_no_pad(encoded_string.as_bytes()).expect("operation should succeed");
     let decoded_string = String::from_utf8(decoded_bytes).expect("operation should succeed");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.96"
+channel = "stable"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]

--- a/rustfs/src/admin/handlers/pools.rs
+++ b/rustfs/src/admin/handlers/pools.rs
@@ -786,7 +786,7 @@ impl Operation for StartDecommission {
         if let Some(first_idx) = pools_indices.first().copied()
             && let Some(client) = decommission_peer_target(&endpoints, first_idx, "start decommission", audit)?
         {
-            let pool_context = format!("pools {:?}", &pools_indices);
+            let pool_context = format!("pools {:?}", pools_indices);
             client
                 .start_decommission(pools_indices.clone())
                 .await
@@ -819,7 +819,7 @@ impl Operation for StartDecommission {
             validate_start_decommission_guards(decommission_running, rebalance_running)?;
 
             if !pools_indices.is_empty() {
-                let pool_context = format!("pools {:?}", &pools_indices);
+                let pool_context = format!("pools {:?}", pools_indices);
                 store
                     .decommission(ctx.clone(), pools_indices.clone())
                     .await

--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -2538,7 +2538,7 @@ where
         }
 
         let canonical_path = canonicalize_admin_path(req.uri.path());
-        let uri = format!("{}|{}", &req.method, canonical_path.as_ref());
+        let uri = format!("{}|{}", req.method, canonical_path.as_ref());
 
         if let Ok(mat) = self.router.at(&uri) {
             let op: &T = mat.value;


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

This PR bundles two low-risk maintenance changes on the `houseme-patch-1` branch:

1. **Toolchain**: change the Rust channel in `rust-toolchain.toml` from the pinned `1.96` to the floating `stable` (currently resolves to `1.97.0`). This is a pin-to-float tradeoff: the toolchain now tracks stable and picks up later fixes automatically, at the cost of some build-reproducibility determinism. A benchmark A/B of `1.96.0` vs `1.97.0` on CPU-bound hot paths (ecstore reed-solomon SIMD, filemeta xl.meta serde) found no measurable runtime difference — the effect is within the measurement noise floor.

2. **Lint cleanup**: run `cargo clippy --fix --all-targets --all-features` and `cargo fix --lib --all-targets` across the workspace and resolve the leftover warnings by hand. All edits are mechanical, semantics-preserving lint fixes — no behavior change. Highlights:

- Collapse needless borrows in `format!` arguments, prefer the `?` operator over explicit `match ... => return Err(e)` / `else { return None }` early returns, and use `.values()` / `.flatten()` iterator adapters instead of `iter()` with discarded keys or nested `if let Some`.
- Rewrite the heal auto-scan disk loop via `manual_flatten` and re-indent the surrounding `tokio::select!` macro body by hand (rustfmt does not format macro interiors).
- Annotate the intentional dead-code `Md5` inherent methods (constructed only by the test factory) with `#[allow(dead_code)]`, consistent with the existing annotation on the struct.

## Verification

- `cargo clippy --fix --all-targets --all-features --allow-dirty -- -D warnings` (with `RUSTFLAGS="--cfg tokio_unstable"`, required because `--all-features` enables the default-off `dial9` telemetry feature)
- `cargo fix --lib --all-targets --allow-dirty`
- `cargo clippy -p rustfs-heal -p rustfs-checksums --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo check -p rustfs-heal` — passes

## Impact

No user-facing, API, compatibility, or configuration impact. Pure lint/style cleanup plus a build-toolchain channel change.

## Additional Notes

The lint fixes touch 21 files across many crates but every hunk is an equivalent rewrite produced by `clippy --fix` / `cargo fix` (or a hand-applied version of the suggestion it could not auto-apply), so the diff is broad but shallow.
