### PR TITLE
fix(ci): widen Days=5 expiration poll window to 8*lc_interval

### DIFF
--- a/scripts/s3-tests/lifecycle_behavior_tests.txt
+++ b/scripts/s3-tests/lifecycle_behavior_tests.txt
@@ -20,8 +20,21 @@
 #   RUSTFS_ILM_DEBUG_DAY_SECS=10   (1 "day" = 10s, matches s3-tests lc_debug_interval)
 #   RUSTFS_SCANNER_ENABLED=true
 #   RUSTFS_SCANNER_CYCLE=2         (scan every 2s, well under a debug-day)
+#   RUSTFS_DATA_USAGE_UPDATE_DIR_CYCLES=1  (re-descend compacted dirs every cycle so
+#                                  ILM is evaluated ~every 2s, not once per 16 cycles;
+#                                  without this a Days=1 object due at 10s is not
+#                                  expired until the next ~32s boundary — #4772)
 #   RUSTFS_SCANNER_START_DELAY_SECS=0
 #   RUSTFS_API_STALE_UPLOADS_CLEANUP_INTERVAL=2s  (multipart abort lane)
+#
+# Polling windows (patches/0002): each assertion polls list_objects until the
+# expected count is reached or a N*lc_interval deadline elapses. The Days=5
+# (expire3) window uses 8*lc_interval rather than 5: its deadline only starts
+# after the Days=1 poll returns (~1 debug-day in), so a 5*lc_interval window left
+# only ~1 debug-day of slack past the Days=5 due time — a single slow scanner
+# cycle (observed ~13s under CI load) could push the expiry just past it and
+# stall the count at 4 (assert 4 == 2). 8*lc_interval restores comfortable slack;
+# the target count (2) is terminal so a wider window never over-expires.
 #
 # Point run.sh at this file with IMPLEMENTED_TESTS_FILE=<this path>.
 #

--- a/scripts/s3-tests/patches/0002-lifecycle-behavior-polling.patch
+++ b/scripts/s3-tests/patches/0002-lifecycle-behavior-polling.patch
@@ -51,7 +51,7 @@ index bf2f2b1..f3ef394 100644
 +    keep2_objects = client.list_objects(Bucket=bucket_name).get('Contents', [])
 +    expire3_objects = _wait_for_lifecycle_count(
 +        lambda: client.list_objects(Bucket=bucket_name).get('Contents', []),
-+        2, 5*lc_interval)
++        2, 8*lc_interval)
  
      assert len(init_objects) == 6
      assert len(expire1_objects) == 4
@@ -76,7 +76,7 @@ index bf2f2b1..f3ef394 100644
 +    keep2_objects = client.list_objects_v2(Bucket=bucket_name).get('Contents', [])
 +    expire3_objects = _wait_for_lifecycle_count(
 +        lambda: client.list_objects_v2(Bucket=bucket_name).get('Contents', []),
-+        2, 5*lc_interval)
++        2, 8*lc_interval)
  
      assert len(init_objects) == 6
      assert len(expire1_objects) == 4


### PR DESCRIPTION
Follow-up to #4772. Tracks the residual described in [rustfs/backlog#1186](https://github.com/rustfs/backlog/issues/1186).

## Problem

After #4772 forced every-cycle ILM evaluation (`RUSTFS_DATA_USAGE_UPDATE_DIR_CYCLES=1`), the `Days=1` plateau in the lifecycle behavior lane became reliable — but `test_lifecycle_expiration` / `test_lifecyclev2_expiration` still flaked **intermittently (~1/6 of main runs)** on the *second* assertion:

```
assert len(expire1_objects) == 4   # passes now
assert len(expire3_objects) == 2   # E   assert 4 == 2
```

i.e. the `Days=5` (`expire3/`) objects were not expired within their poll window.

## Root cause

The polling helper (`patches/0002`):

```python
expire1_objects = _wait_for_lifecycle_count(list, 4, 4*lc_interval)  # Days=1
keep2_objects   = list()
expire3_objects = _wait_for_lifecycle_count(list, 2, 5*lc_interval)  # Days=5  <-- deadline starts HERE
```

The `expire3` deadline starts only **after** the `Days=1` poll returns (~1 debug-day into the test). With `N=5` and `lc_interval == debug_day`, the window-end and the due time both carry `5*debug_day`, so they cancel:

```
slack = window_end - due
      = (t_expire1_return + 5*lc_interval) - (t_expire3_created + 5*debug_day)
      = t_expire1_return - t_expire3_created            (the 5*D terms cancel)
      ≈ 1 debug-day  ≈ 9s
```

So bumping `debug_day`/`lc_interval` together does **not** help this window. A single slow scanner cycle — observed spacing blew out to **~13s** under CI load, since `dir_cycles=1` makes every cycle a full deep descent — exceeds the ~9s slack and pushes the `expire3` expiry just past the deadline, stalling the count at 4.

Evidence (post-#4772 failing run `29185941050`, 08:49Z): `expire3` due ~`08:55:55`, poll window ends ~`08:56:05`, but scanner cycles ran `…08:55:50 → 08:56:03` (a 13s gap straddling the due time) → expiry missed the window.

## Fix

Widen the two `expire3` windows from `5*lc_interval` to `8*lc_interval`:

```
slack ≈ 8*lc_interval - (t_expire3_created - t_lifecycle_applied) - 4*debug_day ≈ 10*8 - 41 ≈ 39s
```

~39s of slack, comfortably above the ~13s observed cycle jitter.

- **Test-only, lane-scoped.** Does not touch `RUSTFS_ILM_DEBUG_DAY_SECS` or the `4*lc_interval < 5*debug_day` plateau invariant restored in #4766.
- **Cannot over-expire.** The `expire3` target count (2) is terminal — nothing expires after it (`keep2/` never expires) — so a wider window only adds patience, never changes the asserted result. It also early-returns the moment the count reaches 2, so successful runs are not slowed.
- Also documents the #4772 `RUSTFS_DATA_USAGE_UPDATE_DIR_CYCLES=1` knob and this window-sizing rationale in `scripts/s3-tests/lifecycle_behavior_tests.txt`.

## Verification

- Change is confined to the added lines of `patches/0002`; hunk headers/line-counts unchanged, so the patch still applies cleanly.
- The lane's own run is the end-to-end check; the two affected cases exercise this path directly.