### PR TITLE
fix(logging): rate limit the GetObject I/O queue congestion WARN

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -179,7 +179,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
@@ -2322,6 +2322,57 @@ async fn resolve_put_object_expiration(bucket: &str, obj_info: &ObjectInfo) -> O
     build_put_object_expiration_header(&event)
 }
 
+/// Cadence for the "I/O queue congestion detected" WARN. Under sustained
+/// overload (client concurrency at or above the disk-read permit pool) every
+/// GET observes >=80% utilization, so an unthrottled WARN floods the log
+/// from the already saturated hot path; congestion metrics stay per-request.
+const IO_QUEUE_CONGESTION_WARN_INTERVAL_MS: u64 = 5_000;
+
+/// At-most-one-WARN-per-interval limiter for the I/O queue congestion log.
+/// Callers supply monotonic milliseconds so tests can drive the clock.
+struct IoQueueCongestionWarnThrottle {
+    /// Timestamp of the last emitted WARN; `u64::MAX` until the first one.
+    last_warn_ms: AtomicU64,
+    /// Congested requests left unlogged since the last emitted WARN.
+    suppressed: AtomicU64,
+}
+
+impl IoQueueCongestionWarnThrottle {
+    const fn new() -> Self {
+        Self {
+            last_warn_ms: AtomicU64::new(u64::MAX),
+            suppressed: AtomicU64::new(0),
+        }
+    }
+
+    /// Claim the right to emit one WARN. Returns the number of events
+    /// suppressed since the previous emission, or `None` while the interval
+    /// window is still closed (the event is counted, not logged).
+    fn claim(&self, now_ms: u64) -> Option<u64> {
+        let last = self.last_warn_ms.load(Ordering::Relaxed);
+        let window_open = last == u64::MAX || now_ms.saturating_sub(last) >= IO_QUEUE_CONGESTION_WARN_INTERVAL_MS;
+        if window_open
+            && self
+                .last_warn_ms
+                .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            Some(self.suppressed.swap(0, Ordering::Relaxed))
+        } else {
+            self.suppressed.fetch_add(1, Ordering::Relaxed);
+            None
+        }
+    }
+
+    /// Monotonic milliseconds since the first call, for production callers.
+    fn now_ms() -> u64 {
+        static ANCHOR: OnceLock<std::time::Instant> = OnceLock::new();
+        ANCHOR.get_or_init(std::time::Instant::now).elapsed().as_millis() as u64
+    }
+}
+
+static IO_QUEUE_CONGESTION_WARN_THROTTLE: IoQueueCongestionWarnThrottle = IoQueueCongestionWarnThrottle::new();
+
 #[derive(Clone, Default)]
 pub struct DefaultObjectUsecase {
     context: Option<Arc<AppContext>>,
@@ -2594,16 +2645,22 @@ impl DefaultObjectUsecase {
         let queue_utilization = queue_snapshot.utilization_percent();
 
         if queue_snapshot.is_congested(80.0) {
-            warn!(
-                bucket = %bucket,
-                key = %key,
-                queue_utilization = format!("{:.1}%", queue_utilization),
-                permits_in_use = queue_status.permits_in_use,
-                total_permits = queue_status.total_permits,
-                "I/O queue congestion detected"
-            );
-
+            // Metrics count every congested request; only the WARN is rate
+            // limited, because under saturation every GET crosses the
+            // threshold and per-request WARNs flood the log.
             rustfs_io_metrics::record_io_queue_congestion();
+
+            if let Some(suppressed_warns) = IO_QUEUE_CONGESTION_WARN_THROTTLE.claim(IoQueueCongestionWarnThrottle::now_ms()) {
+                warn!(
+                    bucket = %bucket,
+                    key = %key,
+                    queue_utilization = format!("{:.1}%", queue_utilization),
+                    permits_in_use = queue_status.permits_in_use,
+                    total_permits = queue_status.total_permits,
+                    suppressed_warns,
+                    "I/O queue congestion detected"
+                );
+            }
         }
 
         Self::ensure_get_object_not_timed_out(wrapper, timeout_config, bucket, key, GetObjectTimeoutStage::BeforeRead)?;
@@ -6750,6 +6807,20 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, ReadBuf};
+
+    #[test]
+    fn io_queue_congestion_warn_throttle_emits_once_per_interval() {
+        let throttle = IoQueueCongestionWarnThrottle::new();
+        // The first congested request logs immediately.
+        assert_eq!(throttle.claim(0), Some(0));
+        // Requests inside the window are counted, not logged.
+        assert_eq!(throttle.claim(1), None);
+        assert_eq!(throttle.claim(IO_QUEUE_CONGESTION_WARN_INTERVAL_MS - 1), None);
+        // The next emission reports how many stayed silent.
+        assert_eq!(throttle.claim(IO_QUEUE_CONGESTION_WARN_INTERVAL_MS), Some(2));
+        assert_eq!(throttle.claim(IO_QUEUE_CONGESTION_WARN_INTERVAL_MS + 1), None);
+    }
+
     fn build_request<T>(input: T, method: Method) -> S3Request<T> {
         S3Request {
             input,


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
N/A

## Summary of Changes
Under sustained GET overload (client concurrency >= the disk-read permit pool, default `DEFAULT_OBJECT_MAX_CONCURRENT_DISK_READS = 64`) every request observes >=80% permit utilization, so `acquire_get_object_io_planning` emitted the "I/O queue congestion detected" WARN once per GET — 454,823 lines in 70 minutes measured with warp at 64 concurrency against a single node — stacking log serialization and flush overhead on the already saturated hot path.

- Rate limit the WARN to at most one per 5 seconds using a lock-free CAS throttle (`IoQueueCongestionWarnThrottle`); the first congestion event still logs immediately.
- The emitted WARN carries a new `suppressed_warns` field with the number of congested requests that stayed silent since the previous emission, so the sampled line still conveys the event rate.
- `rustfs_io_metrics::record_io_queue_congestion()` intentionally stays outside the throttle and keeps counting every congested request. The message text is unchanged, so existing greps and alerts still match.

## Verification
- `cargo fmt --all --check`
- `./scripts/check_logging_guardrails.sh`
- `cargo nextest run -p rustfs io_queue_congestion` (new unit test: first emission, in-window suppression and counting, window reopen)
- `make pre-pr`

## Impact
Log volume for the congestion WARN drops from per-request to at most one line per 5 seconds per process, with `suppressed_warns` accounting for the gap. Metrics and alerting based on `record_io_queue_congestion` are unaffected. No API or configuration changes.

## Additional Notes
Throttle design: `compare_exchange` on a millisecond timestamp guarantees a single winner per window (consecutive emitted WARNs are at least one interval apart), the `u64::MAX` sentinel makes the first congestion event log immediately, and losers only `fetch_add` a suppressed counter — Relaxed ordering is sufficient since no data depends on these atomics. The non-congested path is unchanged; the congested path trades a per-request `format!` + WARN for one atomic load plus one CAS or `fetch_add`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
