### PR TITLE
fix(error): map StorageError::NotModified correctly

### DIFF
--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -269,6 +269,7 @@ impl From<StorageError> for ApiError {
             StorageError::InvalidPart(_, _, _) => S3ErrorCode::InvalidPart,
             StorageError::EntityTooSmall(_, _, _) => S3ErrorCode::EntityTooSmall,
             StorageError::PreconditionFailed => S3ErrorCode::PreconditionFailed,
+            StorageError::NotModified => S3ErrorCode::NotModified,
             StorageError::InvalidRangeSpec(_) => S3ErrorCode::InvalidRange,
             _ => S3ErrorCode::InternalError,
         };
@@ -478,6 +479,7 @@ mod tests {
             (StorageError::VolumeNotFound, S3ErrorCode::NoSuchBucket),
             (StorageError::FileNotFound, S3ErrorCode::NoSuchKey),
             (StorageError::FileVersionNotFound, S3ErrorCode::NoSuchVersion),
+            (StorageError::NotModified, S3ErrorCode::NotModified),
             (StorageError::MalformedUploadID("test".into()), S3ErrorCode::InvalidArgument),
             (
                 StorageError::InvalidUploadID("bucket".into(), "object".into(), "uploadid".into()),


### PR DESCRIPTION
## Related Issues

Fixes #4616
Replaces #4619, which cannot be merged because its author has not signed the CLA.

## Summary of Changes

Map `StorageError::NotModified` to `S3ErrorCode::NotModified` instead of falling through to `S3ErrorCode::InternalError`.

This fixes conditional `HEAD Object` requests, such as browser requests with a matching `If-None-Match` header, returning `500 InternalError` with message `Not modified`. With this mapping in place, the response follows the expected S3 `NotModified` / HTTP 304 path.

Also extends the existing storage error mapping test coverage for `StorageError::NotModified`.

## Verification

- `git diff --check`
- Focused test is covered by PR CI: `cargo test -p rustfs --lib test_api_error_from_storage_error_mappings`

## Impact

Conditional object metadata requests that resolve to `NotModified` now return the correct S3 error code instead of `InternalError`.

No deployment, configuration, or compatibility changes are required.

## Additional Notes

This is an independent reimplementation of the behavior requested in #4619 because that PR is blocked by the CLA requirement.