### PR TITLE
chore(release): prepare 1.0.0-beta.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,7 +3687,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -8845,7 +8845,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8977,7 +8977,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8999,7 +8999,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "chrono",
  "metrics",
@@ -9028,7 +9028,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "insta",
  "rustfs-io-core",
@@ -9040,7 +9040,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "const-str",
  "serde",
@@ -9049,7 +9049,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9062,7 +9062,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9082,7 +9082,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aes-gcm",
  "async-channel",
@@ -9227,7 +9227,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -9236,7 +9236,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9262,7 +9262,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9292,7 +9292,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9328,7 +9328,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "bytes",
  "memmap2",
@@ -9340,7 +9340,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "criterion",
  "metrics",
@@ -9403,7 +9403,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "bytes",
  "futures",
@@ -9429,7 +9429,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "rustfs-common",
@@ -9479,7 +9479,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9500,7 +9500,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "chrono",
  "humantime",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9546,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "criterion",
  "futures",
@@ -9564,7 +9564,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "bytes",
  "criterion",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9632,7 +9632,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9660,7 +9660,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -9719,7 +9719,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "flatbuffers",
  "prost 0.14.4",
@@ -9737,7 +9737,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "byteorder",
  "bytes",
@@ -9754,7 +9754,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9791,7 +9791,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -9813,14 +9813,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "rustfs-s3-types",
 ]
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -9828,7 +9828,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9855,7 +9855,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9871,7 +9871,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9903,14 +9903,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9926,7 +9926,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "insta",
@@ -9940,7 +9940,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -9990,7 +9990,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "arc-swap",
  "metrics",
@@ -10010,7 +10010,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -10046,7 +10046,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "base64-simd",
  "blake2 0.11.0-rc.6",
@@ -10085,7 +10085,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.96.0"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -84,50 +84,50 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.8" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.8" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.8" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.8" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.8" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.8" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.8" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.8" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.8" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.8" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.8" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.8" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.8" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.8" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.8" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.8" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.8" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.8" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.8" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.8" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.8" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.8" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.8" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.8" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.8" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.8" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.8" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.8" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.8" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.8" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.8" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.8" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.8" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.8" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.8" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.8" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.8" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.8" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.8" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.8" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.8" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.8" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.8" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.8" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.9" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.9" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.9" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.9" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.9" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.9" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.9" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.9" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.9" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.9" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.9" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.9" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.9" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.9" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.9" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.9" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.9" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.9" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.9" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.9" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.9" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.9" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.9" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.9" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.9" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.9" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.9" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.9" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.9" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.9" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.9" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.9" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.9" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.9" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.9" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.9" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.9" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.9" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.9" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.9" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.9" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.9" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.9" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.9" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.8
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.9
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.8
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.9
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.8";
+            version = "1.0.0-beta.9";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.8.0"
-appVersion: "1.0.0-beta.8"
+version: "0.9.0"
+appVersion: "1.0.0-beta.9"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -2,7 +2,7 @@
 %global _empty_manifest_terminate_build 0
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.8
+Release:        beta.9
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -57,6 +57,9 @@ install %_builddir/%{name}-%{version}-%{release}/target/%_arch/%_arch-unknown-li
 %_bindir/rustfs
 
 %changelog
+* Tue Jul 14 2026 houseme <housemecn@gmail.com>
+- Update RPM package to RustFS 1.0.0-beta.9
+
 * Wed Jun 10 2026 houseme <housemecn@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.8
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Bump the workspace release from `1.0.0-beta.8` to `1.0.0-beta.9`. This is a version-only release bump with no functional code changes.

- `Cargo.toml` / `Cargo.lock`: bump `[workspace.package].version` and all internal workspace crate dependency versions to `1.0.0-beta.9`.
- `README.md` / `README_ZH.md`: update the versioned Docker run example to `rustfs/rustfs:1.0.0-beta.9`.
- `flake.nix`: bump package version to `1.0.0-beta.9`.
- `helm/rustfs/Chart.yaml`: `appVersion` -> `1.0.0-beta.9`, chart `version` -> `0.9.0` (per `beta.N -> 0.N.0` mapping).
- `rustfs.spec`: `Release` -> `beta.9` and a new changelog entry for `1.0.0-beta.9`.

## Verification

- `cargo fmt --all --check`
- `make pre-commit` — passed (all crates compiled at `v1.0.0-beta.9`)

## Impact

Release/version metadata only. No behavior, API, or on-disk format changes. Docker doc tag is `1.0.0-beta.9` (no `v` prefix); Helm chart version advances to `0.9.0`.

## Additional Notes

N/A
