### PR TITLE
test(replication): lock outbound checksum consistency for XXHash/SHA-512/MD5

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
+++ b/crates/ecstore/src/bucket/replication/replication_target_boundary.rs
@@ -585,4 +585,43 @@ mod tests {
 
         assert!(err.to_string().contains(ERR_REPLICATION_MANAGED_SSE_UNSUPPORTED));
     }
+
+    // T3 (#1264): the outbound replication path forwards a stored object checksum into
+    // user_metadata via decrypt_checksums, which is algorithm-agnostic. This locks that
+    // the AWS 2026-04 additional algorithms (XXHash3/64/128, SHA-512, MD5) are forwarded
+    // identically to the classic five — i.e. replication treats the new algorithms
+    // consistently, with no new-algorithm-specific gap on the outbound side.
+    #[test]
+    fn replication_put_object_options_forwards_new_algorithm_checksums_like_classic() {
+        use rustfs_rio::{Checksum, ChecksumType};
+
+        let payload = b"replication checksum consistency payload";
+        let cases = [
+            // classic five (baseline)
+            ("CRC32", ChecksumType::CRC32),
+            ("SHA256", ChecksumType::SHA256),
+            // AWS 2026-04 additional algorithms
+            ("XXHASH3", ChecksumType::XXHASH3),
+            ("XXHASH64", ChecksumType::XXHASH64),
+            ("XXHASH128", ChecksumType::XXHASH128),
+            ("SHA512", ChecksumType::SHA512),
+            ("MD5", ChecksumType::MD5),
+        ];
+
+        for (name, ty) in cases {
+            let checksum = Checksum::new_from_data(ty, payload).expect("compute checksum");
+            let object_info = ObjectInfo {
+                checksum: Some(checksum.to_bytes(&[])),
+                ..Default::default()
+            };
+
+            let (opts, _is_multipart) = replication_put_object_options("", &object_info).expect("build replication put options");
+
+            assert_eq!(
+                opts.user_metadata.get(name),
+                Some(&checksum.encoded),
+                "replication must forward the {name} checksum into user_metadata identically to the classic algorithms"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Adds a consistency test at the outbound replication put-options boundary (`replication_put_object_options`) confirming that the AWS 2026-04 additional checksum algorithms (XXHash3/64/128, SHA-512, MD5) are forwarded into replication `user_metadata` identically to the classic five (CRC32/CRC32C/SHA1/SHA256/CRC64NVME).

Context: the outbound replication path routes a stored object checksum through the algorithm-agnostic `decrypt_checksums -> user_metadata` flow, so the additional algorithms (already handled by `rustfs-rio::read_checksums`) need no new-algorithm-specific handling. A prior investigation of the outbound side found no functional gap: the per-algorithm `ChecksumMode` selection path is dormant (`opts.checksum` is never set to a specific algorithm; tiering uses Content-MD5; the `add_crc` bool is dead code), so extending `ChecksumMode` was unnecessary. This test locks the consistency against regressions.

## Verification

- `cargo test -p rustfs-ecstore --lib replication_put_object_options_forwards_new_algorithm_checksums_like_classic` — 1 passed.
- `cargo fmt` + typos clean.

## Impact

Test-only. No production code change, no behavior/compatibility/config impact.

## Additional Notes

Pre-existing observation (out of scope): replication forwards checksums under their display-name key (`CRC32`/`XXHASH3`), which the outbound client serializes as `x-amz-meta-<name>` custom metadata rather than a real `x-amz-checksum-*` header. This is identical for the classic and new algorithms and predates this change; if it should become a real checksum header, that is a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
