### PR TITLE
ci(mint): set RUSTFS_UNSAFE_BYPASS_DISK_CHECK so the mint container boots

### DIFF
--- a/.github/workflows/mint.yml
+++ b/.github/workflows/mint.yml
@@ -135,6 +135,10 @@ jobs:
         run: |
           docker network inspect rustfs-net >/dev/null 2>&1 || docker network create rustfs-net
           docker rm -f rustfs-mint >/dev/null 2>&1 || true
+          # The four disks share one physical device on the runner (a single
+          # loopback filesystem), so the local physical-disk-independence guard
+          # would refuse to start. Bypass it — this is the CI use case the guard
+          # explicitly sanctions via RUSTFS_UNSAFE_BYPASS_DISK_CHECK.
           docker run -d --name rustfs-mint \
             --network rustfs-net \
             -p 9000:9000 \
@@ -142,6 +146,7 @@ jobs:
             -e RUSTFS_ACCESS_KEY="${S3_ACCESS_KEY}" \
             -e RUSTFS_SECRET_KEY="${S3_SECRET_KEY}" \
             -e RUSTFS_VOLUMES="/data/rustfs{0...3}" \
+            -e RUSTFS_UNSAFE_BYPASS_DISK_CHECK=true \
             -v /tmp/rustfs-mint:/data \
             rustfs-ci
 


### PR DESCRIPTION
## What

Set `RUSTFS_UNSAFE_BYPASS_DISK_CHECK=true` on the `rustfs-mint` container in `mint.yml` so the server boots under CI.

## Why

The mint harness maps four `RUSTFS_VOLUMES` data directories (`/data/rustfs{0...3}`) onto a single runner device. The startup physical-disk-independence guard (`crates/ecstore/src/layout/endpoints.rs`) treats that as a misconfiguration and aborts with a `[FATAL]` before mint ever runs. The weekly scheduled run [29183544431](https://github.com/rustfs/rustfs/actions/runs/29183544431) (2026-07-12) crashed at `Wait for RustFS ready`:

```
[FATAL] Server runtime failed: local erasure endpoints must use distinct physical disks;
detected shared devices [nvme0n1 => /data/rustfs0, /data/rustfs1, /data/rustfs2, /data/rustfs3].
... Set RUSTFS_UNSAFE_BYPASS_DISK_CHECK=true only for local testing or CI to bypass this safety check
```

The Phase-0 infra fix (#4668) already moved mint onto `ubuntu-latest` and got buildx green, and #4768 added the same bypass to the e2e-s3tests harness — but #4768 did not touch `mint.yml`, so mint still can't start. The scheduled-failure alert opened issue #4774 for this.

The bypass is exactly the CI use case the guard's own error message sanctions. This mirrors the single-node handling in `e2e-s3tests.yml` (#4768).

## Scope

One env var plus an explanatory comment. mint remains report-only (per-suite baseline gating is tracked separately as ci-3). Completes the ci-2 acceptance that a mint core run actually produces `log.json` and the per-suite PASS/FAIL/NA summary.

## Verification

`workflow_dispatch` on this branch (mode=core) — run link to be posted once the mint stage completes and the summary table is produced.
