### PR TITLE
ci: route build jobs through matrix runner labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,11 +136,13 @@ jobs:
             echo "⚡ Manual/scheduled build detected"
           fi
 
-          echo "should_build=$should_build" >> $GITHUB_OUTPUT
-          echo "build_type=$build_type" >> $GITHUB_OUTPUT
-          echo "version=$version" >> $GITHUB_OUTPUT
-          echo "short_sha=$short_sha" >> $GITHUB_OUTPUT
-          echo "is_prerelease=$is_prerelease" >> $GITHUB_OUTPUT
+          {
+            echo "should_build=$should_build"
+            echo "build_type=$build_type"
+            echo "version=$version"
+            echo "short_sha=$short_sha"
+            echo "is_prerelease=$is_prerelease"
+          } >> "$GITHUB_OUTPUT"
 
           echo "📊 Build Summary:"
           echo "  - Should build: $should_build"
@@ -220,7 +222,7 @@ jobs:
     name: Build RustFS
     needs: [ build-check, prepare-platform-matrix ]
     if: needs.build-check.outputs.should_build == 'true' && needs.prepare-platform-matrix.result == 'success'
-    runs-on: ${{ matrix.platform == 'linux' && fromJSON('["self-hosted","linux","sm-standard-2"]') || matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -493,7 +495,7 @@ jobs:
             if [[ "${{ matrix.platform }}" == "windows" ]]; then
               dir
             else
-              ls -lh ${PACKAGE_NAME}.zip
+              ls -lh "${PACKAGE_NAME}.zip"
             fi
           else
             echo "❌ Failed to create package: ${PACKAGE_NAME}.zip"
@@ -542,11 +544,13 @@ jobs:
             fi
           fi
 
-          echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "package_file=${PACKAGE_NAME}.zip" >> $GITHUB_OUTPUT
-          echo "latest_files=${LATEST_FILES}" >> $GITHUB_OUTPUT
-          echo "build_type=${BUILD_TYPE}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          {
+            echo "package_name=${PACKAGE_NAME}"
+            echo "package_file=${PACKAGE_NAME}.zip"
+            echo "latest_files=${LATEST_FILES}"
+            echo "build_type=${BUILD_TYPE}"
+            echo "version=${VERSION}"
+          } >> "$GITHUB_OUTPUT"
 
           echo "📦 Package created: ${PACKAGE_NAME}.zip"
           if [[ -n "$LATEST_FILES" ]]; then
@@ -743,8 +747,8 @@ jobs:
             RELEASE_URL=$(gh release view "$TAG" --json url --jq '.url')
           fi
 
-          echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
-          echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
           echo "Created release: $RELEASE_URL"
 
   # Prepare and upload release assets
@@ -793,9 +797,9 @@ jobs:
           cd ./release-assets
 
           # Generate checksums for all files (including latest versions)
-          if ls *.zip >/dev/null 2>&1; then
-            sha256sum *.zip > SHA256SUMS
-            sha512sum *.zip > SHA512SUMS
+          if compgen -G "*.zip" >/dev/null; then
+            sha256sum -- *.zip > SHA256SUMS
+            sha512sum -- *.zip > SHA512SUMS
           fi
 
           cd ..

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -247,13 +247,15 @@ jobs:
             esac
           fi
 
-          echo "should_build=$should_build" >> $GITHUB_OUTPUT
-          echo "should_push=$should_push" >> $GITHUB_OUTPUT
-          echo "build_type=$build_type" >> $GITHUB_OUTPUT
-          echo "version=$version" >> $GITHUB_OUTPUT
-          echo "short_sha=$short_sha" >> $GITHUB_OUTPUT
-          echo "is_prerelease=$is_prerelease" >> $GITHUB_OUTPUT
-          echo "create_latest=$create_latest" >> $GITHUB_OUTPUT
+          {
+            echo "should_build=$should_build"
+            echo "should_push=$should_push"
+            echo "build_type=$build_type"
+            echo "version=$version"
+            echo "short_sha=$short_sha"
+            echo "is_prerelease=$is_prerelease"
+            echo "create_latest=$create_latest"
+          } >> "$GITHUB_OUTPUT"
 
           echo "🐳 Docker Build Summary:"
           echo "  - Should build: $should_build"
@@ -320,7 +322,6 @@ jobs:
         run: |
           BUILD_TYPE="${{ needs.build-check.outputs.build_type }}"
           VERSION="${{ needs.build-check.outputs.version }}"
-          SHORT_SHA="${{ needs.build-check.outputs.short_sha }}"
           CREATE_LATEST="${{ needs.build-check.outputs.create_latest }}"
           VARIANT_SUFFIX="${{ matrix.suffix }}"
 
@@ -343,8 +344,8 @@ jobs:
               ;;
           esac
 
-          echo "docker_release=$DOCKER_RELEASE" >> $GITHUB_OUTPUT
-          echo "docker_channel=$DOCKER_CHANNEL" >> $GITHUB_OUTPUT
+          echo "docker_release=$DOCKER_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "docker_channel=$DOCKER_CHANNEL" >> "$GITHUB_OUTPUT"
 
           echo "🐳 Docker build parameters:"
           echo "  - Original version: $VERSION"
@@ -376,7 +377,7 @@ jobs:
           fi
 
           # Output tags
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
           # Generate labels
           LABELS="org.opencontainers.image.title=RustFS"
@@ -387,7 +388,7 @@ jobs:
           LABELS="$LABELS,org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           LABELS="$LABELS,org.opencontainers.image.build-type=$BUILD_TYPE"
 
-          echo "labels=$LABELS" >> $GITHUB_OUTPUT
+          echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
 
           echo "🐳 Generated Docker tags:"
           echo "$TAGS" | tr ',' '\n' | sed 's/^/  - /'


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Route `build-rustfs` jobs through `matrix.os` so Linux build targets request the runner label selected by the platform matrix instead of always requesting the hard-coded `self-hosted`, `linux`, and `sm-standard-2` label set.
- Keep macOS and Windows behavior unchanged because their matrix entries already carry the GitHub runner labels in `os`.
- Clean up existing ShellCheck findings in the build and Docker workflows so repo-wide `actionlint` passes for this workflow change.

## Verification
- `actionlint .github/workflows/build.yml`
- `actionlint`
- `git diff --check`

## Impact
Linux release build jobs now request `sm-standard-2` through the same matrix field used by the other platforms, which allows the runner scale-set label to be changed in the matrix and avoids queuing on an unmatched hard-coded self-hosted label combination. No Rust code, release artifact format, or Docker image build behavior is changed.

## Additional Notes
Adversarial validation attacked runner label routing, macOS/Windows runner compatibility, actionlint label coverage, and mechanical ShellCheck cleanup scope; no break found. The Docker workflow edits are limited to quoting `$GITHUB_OUTPUT`, removing an unused local variable, and preserving the generated outputs.