### PR TITLE
fix(ecstore): skip deferred readers without sources

### DIFF
--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -1275,6 +1275,10 @@ pub(in crate::set_disk) fn fill_deferred_bitrot_readers(
             continue;
         }
 
+        if files[idx].data.is_none() && disks[idx].is_none() {
+            continue;
+        }
+
         let inline_data = files[idx].data.clone();
         let disk = disks[idx].clone();
         let data_dir = files[idx].data_dir.unwrap_or_default();

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -4096,6 +4096,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bitrot_reader_setup_skips_deferred_slots_without_a_source() {
+        let setup = setup_inline_bitrot_readers_with_env(
+            vec![Some(b"aaaa"), Some(b"bbbb"), None, Some(b"dddd")],
+            2,
+            2,
+            BitrotReaderSetupMode::ReadQuorum,
+            true,
+        )
+        .await;
+
+        assert!(setup.has_setup_quorum(2, 2, BitrotReaderSetupMode::ReadQuorum));
+        assert_eq!(setup.available_shards(), 2);
+        assert_eq!(setup.deferred_shards(), 1);
+        assert!(setup.readers[2].is_none(), "a slot without inline data or a disk has no usable source");
+        assert!(matches!(setup.errors[2], Some(DiskError::DiskNotFound)));
+        assert!(setup.deferred_stripe_handles[2].is_none());
+        assert!(setup.readers[3].is_some(), "an inline shard remains available as a deferred fallback");
+        assert!(setup.deferred_stripe_handles[3].is_some());
+    }
+
+    #[tokio::test]
     async fn bitrot_reader_setup_preference_uses_data_blocks_first_without_env() {
         let setup = setup_inline_bitrot_readers_with_preference(
             vec![Some(b"aaaa"), Some(b"bbbb"), Some(b"cccc"), Some(b"dddd")],


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Skip deferred bitrot-reader slots that have neither inline shard data nor an available disk source.
- Preserve the existing `DiskNotFound` state for source-less slots instead of installing a reader that can only fail when reconstruction opens it.
- Add a regression test covering a missing source alongside a valid inline deferred fallback.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore --lib bitrot_reader_setup_skips_deferred_slots_without_a_source -- --nocapture`
- `cargo test -p rustfs-ecstore`
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`
- `scripts/check_logging_guardrails.sh`
- `make pre-commit`
- `make pre-pr`

## Impact

A source-less erasure slot is no longer advertised as a deferred fallback after the initial read quorum is satisfied. Quorum calculation and ready-reader accounting are unchanged, while reconstruction avoids a deterministic late `NotFound` from an impossible deferred open.

Adversarial validation:
- Correctness: attacked read-quorum and quorum-minus-one setup, inline-only and disk-only sources, missing slots, and minimal-diff alternatives; no break found.
- Security: attacked path/auth/deserialization and diagnostic leakage surfaces; the diff introduces none.
- Concurrency/durability: attacked lock, cancellation, and persistence ordering; the synchronous guard adds no shared state or I/O.
- Compatibility: attacked public API, S3 behavior, and on-disk/on-wire formats; none change.
- Performance: attacked GET hot-path allocations, clones, logging, and I/O; the guard removes impossible reader construction.
- Test coverage: reverted the guard and observed `bitrot_reader_setup_skips_deferred_slots_without_a_source` fail (deferred count 2 instead of 1); the test also proves a real inline fallback remains.

## Additional Notes

The change is intentionally limited to deferred reader filling and does not alter eager reader scheduling or EC quorum rules.