### PR TITLE
fix(ecstore): read full transitioned multipart objects

### DIFF
--- a/crates/ecstore/src/client/object_api_utils.rs
+++ b/crates/ecstore/src/client/object_api_utils.rs
@@ -121,8 +121,11 @@ pub fn new_getobjectreader<'a>(
     let is_compressed = false; //oi.is_compressed_ok();
 
     let rs_;
-    if rs.is_none() && opts.part_number.is_some() && opts.part_number.expect("operation should succeed") > 0 {
-        rs_ = part_number_to_rangespec(oi.clone(), opts.part_number.expect("operation should succeed"));
+    if rs.is_none()
+        && let Some(part_number) = opts.part_number
+        && part_number > 0
+    {
+        rs_ = part_number_to_rangespec(oi.clone(), part_number);
     } else {
         rs_ = rs.clone();
     }
@@ -157,6 +160,16 @@ pub fn new_getobjectreader<'a>(
         });
 
         return Ok((get_fn, off as i64, length as i64));
+    }
+    if rs.is_none() && opts.part_number.is_none() && oi.size >= 0 {
+        get_fn = Arc::new(move |input_reader: BufReader<Cursor<Vec<u8>>>, _: HeaderMap| GetObjectReader {
+            object_info: oi.clone(),
+            stream: Box::new(input_reader),
+            buffered_body: None,
+            body_source: Default::default(),
+        });
+
+        return Ok((get_fn, 0, oi.size));
     }
     Err(ErrorResponse {
         code: S3ErrorCode::InvalidRange,
@@ -198,6 +211,57 @@ pub fn get_raw_etag(metadata: &HashMap<String, String>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    fn multipart_object_info() -> ObjectInfo {
+        ObjectInfo {
+            bucket: "bucket".to_string(),
+            name: "object".to_string(),
+            size: 6 * 1024 * 1024,
+            actual_size: 6 * 1024 * 1024,
+            parts: Arc::new(vec![
+                ObjectPartInfo {
+                    number: 1,
+                    size: 5 * 1024 * 1024,
+                    actual_size: 5 * 1024 * 1024,
+                    ..Default::default()
+                },
+                ObjectPartInfo {
+                    number: 2,
+                    size: 1024 * 1024,
+                    actual_size: 1024 * 1024,
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_new_getobjectreader_uses_full_range_for_unranged_multipart_object() {
+        let oi = multipart_object_info();
+        let opts = ObjectOptions::default();
+
+        let result = new_getobjectreader(&None, &oi, &opts, &HeaderMap::new())
+            .expect("unranged multipart object should build a full-object reader");
+
+        assert_eq!(result.1, 0);
+        assert_eq!(result.2, oi.size);
+    }
+
+    #[test]
+    fn test_new_getobjectreader_keeps_part_number_range_for_multipart_object() {
+        let oi = multipart_object_info();
+        let opts = ObjectOptions {
+            part_number: Some(2),
+            ..Default::default()
+        };
+
+        let result = new_getobjectreader(&None, &oi, &opts, &HeaderMap::new()).expect("part number should build that part range");
+
+        assert_eq!(result.1, 5 * 1024 * 1024);
+        assert_eq!(result.2, 1024 * 1024);
+    }
 
     #[test]
     fn test_to_s3s_etag() {


### PR DESCRIPTION
## Related Issues
Fixes #4826.

## Summary of Changes
Full GETs for transitioned multipart objects now build a whole-object reader range instead of falling through to `InvalidRange` when there is no `Range` header and no `partNumber`.

The existing explicit `Range` and `partNumber` paths are unchanged; the part-number path also no longer needs production `expect()` calls.

## Verification
- `cargo test -p rustfs-ecstore test_new_getobjectreader_ --lib`
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
Multipart objects transitioned to a remote tier can be read back with a normal full GET. Range GETs and single-part transitioned GETs keep the existing behavior.

## Additional Notes
Adversarial validation: correctness attacked no-range multipart, explicit range, partNumber, zero/negative size, and smaller-diff shape; no break found.

Adversarial validation: security attacked auth, path traversal, logging, and untrusted parsing surfaces; diff touches none.

Adversarial validation: concurrency/durability attacked locks, fsync/order, cancellation, and metadata mutation; diff adds none.

Adversarial validation: compatibility attacked S3 full GET semantics, range GET semantics, tier versionId handling, and on-disk/on-wire formats; only full GET behavior changes.

Adversarial validation: performance attacked hot-path clones, allocations, logging, locks, and extra tier requests; no extra IO or logging added.

Adversarial validation: test coverage attacked revert-detection and partNumber regression; new focused tests cover both.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
