### PR TITLE
test(e2e): fix webhook redelivery setup

### DIFF
--- a/crates/e2e_test/src/notification_webhook_test.rs
+++ b/crates/e2e_test/src/notification_webhook_test.rs
@@ -537,15 +537,20 @@ async fn test_webhook_redelivers_event_after_target_recovers() -> TestResult {
     let client = env.create_s3_client();
     client.create_bucket().bucket(bucket).send().await?;
 
-    // Reserve a port but leave it unbound: the webhook endpoint is
-    // unreachable (connection refused -> retryable NotConnected), so the first
-    // delivery attempts fail and the event is persisted to the queue store.
-    let port = RustFSTestEnvironment::find_available_port().await?;
+    // Register the target while it is reachable, then stop the collector so the
+    // object event is persisted to the queue store while delivery is offline.
+    let listener = TcpListener::bind("0.0.0.0:0").await?;
+    let port = listener.local_addr()?.port();
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let handle = serve_event_collector(listener, tx.clone());
     let endpoint_ip = local_ip()?;
     let endpoint = format!("http://{endpoint_ip}.nip.io:{port}/events");
     configure_webhook_target(&env, target, &endpoint).await?;
     wait_for_target_registered(&env, target).await?;
     put_notification_config(&client, bucket, target, "uploads/", ".dat").await?;
+
+    handle.abort();
+    let _ = handle.await;
 
     let key = "uploads/redeliver.dat";
     client
@@ -559,7 +564,6 @@ async fn test_webhook_redelivers_event_after_target_recovers() -> TestResult {
     // Bring the endpoint up on the reserved port; the replay worker retries with
     // exponential backoff and delivers the queued event.
     let listener = TcpListener::bind(("0.0.0.0", port)).await?;
-    let (tx, mut rx) = mpsc::unbounded_channel();
     let handle = serve_event_collector(listener, tx);
 
     let redelivered = wait_for_event(&mut rx, key, "s3:ObjectCreated:", Duration::from_secs(45)).await?;


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Start the webhook collector before registering the notification target so the target can become active and appear in the admin ARN list.
- Stop and await the collector before writing the object, then restore it on the same port to verify durable redelivery.
- Remove the free-port reservation gap by binding directly to an ephemeral port.

## Verification

- `cargo fmt --all --check`
- Isolated `cargo build -p rustfs`
- Targeted E2E execution did not complete locally because the test helper expects the binary under the workspace `target` directory while the isolated build used `CARGO_TARGET_DIR`; CI verification is pending.
- `make pre-commit` is pending while this PR is in draft.

## Impact

Test-only change. No production API, storage format, configuration, or runtime behavior changes.

## Additional Notes

This fixes the deterministic CI failure introduced by #4821, where the test configured an unreachable webhook and then waited for it to appear in the active target ARN list.
