### PR TITLE
test(e2e): quarantine deterministically failing webhook redelivery test

### DIFF
--- a/crates/e2e_test/src/notification_webhook_test.rs
+++ b/crates/e2e_test/src/notification_webhook_test.rs
@@ -525,6 +525,7 @@ async fn test_webhook_event_delivery_and_filtering() -> TestResult {
 /// durable store and is redelivered once the endpoint comes back.
 #[tokio::test]
 #[serial]
+#[ignore = "FAILING deterministically on main since it landed (#4821): the target is created but never appears in /rustfs/admin/v3/target/arns, so wait_for_target_registered times out. Quarantined per the flake policy; remove with the fix for rustfs#4852"]
 async fn test_webhook_redelivers_event_after_target_recovers() -> TestResult {
     init_logging();
 


### PR DESCRIPTION
## Related Issues

rustfs#4852 (deterministic e2e failure on main; quarantine per the flake policy in docs/testing/README.md).

## Summary of Changes

Quarantines `notification_webhook_test::test_webhook_redelivers_event_after_target_recovers` with `#[ignore]` + an issue link. The test has failed deterministically on every run since it landed in #4821 — including main's own push CI (runs 29390384824 and 29394493304) and both attempts on unrelated PR #4837 — with `target peri1redeliver was not registered in admin ARNs`. Server logs show the webhook target is created in the runtime within ~50ms, but it never appears in `/rustfs/admin/v3/target/arns` within the test's 10s poll when the endpoint is deliberately unreachable; the sibling test with a reachable endpoint passes consistently. Full evidence is on the issue.

Because the failure is deterministic, a `retries` quarantine in nextest.toml cannot help; `#[ignore]` with the tracked issue is the policy-compliant form. This restores a green `End-to-End Tests` gate for every open PR. The notify/e2e owner removes the ignore together with the fix for #4852 (either register unreachable-endpoint targets in the ARN list eagerly, or bind the endpoint during registration and drop it afterwards).

## Verification

Attribute-only change to one test (adds `#[ignore = ...]`); `cargo fmt --all --check` clean. The e2e-smoke lane will list the test as skipped; nothing else changes.

## Impact

CI-only: unblocks the repo-wide PR e2e gate that has been red since 2026-07-15 05:16 UTC. No product code touched.

## Additional Notes

N/A
