### PR TITLE
test(cache): assert visible state after clear

### DIFF
--- a/crates/object-data-cache/src/moka_backend.rs
+++ b/crates/object-data-cache/src/moka_backend.rs
@@ -940,22 +940,28 @@ mod tests {
         const ITERS: usize = 400;
         const KEYS: usize = 6; // small pool → heavy contention on shared identities
 
+        let stress_plans: Arc<Vec<_>> = Arc::new(
+            (0..KEYS)
+                .map(|k| versioned_plan(&format!("object-{}", k % 3), &format!("v{k}"), &format!("etag-{k}")))
+                .collect(),
+        );
         let mut handles = Vec::new();
         for t in 0..TASKS {
             let backend = Arc::clone(&backend);
+            let stress_plans = Arc::clone(&stress_plans);
             handles.push(tokio::spawn(async move {
                 for i in 0..ITERS {
                     let k = (t + i) % KEYS;
                     let object = format!("object-{}", k % 3);
-                    let plan = versioned_plan(&object, &format!("v{k}"), &format!("etag-{k}"));
+                    let plan = &stress_plans[k];
                     // Deterministic per-(task,iter) mix: mostly fills, plus
                     // lookups and invalidations racing against them.
                     match (t + i) % 4 {
                         0 | 1 => {
-                            let _ = backend.fill_body(&plan, Bytes::from_static(b"hello")).await;
+                            let _ = backend.fill_body(plan, Bytes::from_static(b"hello")).await;
                         }
                         2 => {
-                            let _ = backend.lookup_body(&plan).await;
+                            let _ = backend.lookup_body(plan).await;
                         }
                         _ => {
                             let identity = ObjectDataCacheIdentity::new("bucket", object.as_str());
@@ -995,7 +1001,17 @@ mod tests {
         );
 
         let _ = backend.clear().await;
-        assert_eq!(backend.entry_count(), 0, "clear() must drop every entry");
+        for plan in stress_plans.iter().chain(std::iter::once(&clean)) {
+            assert!(
+                matches!(backend.lookup_body(plan).await, ObjectDataCacheLookup::Miss),
+                "clear() must make every exercised key unobservable"
+            );
+        }
+        assert!(
+            backend.cache.iter().next().is_none(),
+            "clear() must expose no entries through iteration (approximate entry count: {})",
+            backend.entry_count()
+        );
     }
 
     /// A memory-constrained container (low snapshot) must reject an entire


### PR DESCRIPTION
## Related Issues

Fixes #4863.

## Summary of Changes

- Preserve the complete six-key concurrency stress plan set for post-clear verification.
- Assert that every exercised key is a cache miss after `clear()`.
- Assert that cache iteration exposes no entries while retaining Moka's approximate entry count only as failure diagnostics.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-object-data-cache moka_backend_concurrency_storm_leaves_no_leaked_state`
- `cargo clippy -p rustfs-object-data-cache --all-targets -- -D warnings`
- `make pre-commit`
- Independent correctness and test-coverage adversarial review: no findings.

## Impact

Test-only change. Production cache behavior, API compatibility, configuration, and deployment behavior are unchanged.

## Additional Notes

The previous exact `entry_count() == 0` assertion could fail because Moka documents its entry count as approximate. The replacement assertions verify the user-visible cache invariant directly without retries, ignores, or CI allowances.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
