### PR TITLE
test(ilm): scope restore e2e object under the rule's test/ prefix

### DIFF
--- a/rustfs/src/app/lifecycle_transition_api_test.rs
+++ b/rustfs/src/app/lifecycle_transition_api_test.rs
@@ -1541,7 +1541,11 @@ async fn restore_object_usecase_reports_ongoing_conflict_and_completion() {
     let backend = register_mock_tier(&tier_name).await;
 
     let bucket = format!("test-api-restore-{}", &Uuid::new_v4().simple().to_string()[..8]);
-    let object = "restore/api-object.bin";
+    // Must live under the `test/` prefix: `set_bucket_lifecycle_transition_with_tier`
+    // scopes the transition rule to `<Filter><Prefix>test/</Prefix>`, so an object
+    // outside it never matches, is never enqueued, and never transitions — the
+    // setup `wait_for_transition` would then time out before the restore assertions.
+    let object = "test/restore/api-object.bin";
     let payload: Vec<u8> = (0..128 * 1024).map(|i| (i % 251) as u8).collect();
 
     create_test_bucket(&ecstore, bucket.as_str()).await;


### PR DESCRIPTION
Refs #4860

## What

`restore_object_usecase_reports_ongoing_conflict_and_completion` (in `rustfs/src/app/lifecycle_transition_api_test.rs`, the `#[ignore]`d ILM integration suite run by the **ILM Integration (serial)** lane) fails **deterministically** — it panics at its *setup* step, `object should transition before the restore API runs` (line 1558), because the object never reaches transition status `complete` within the 15s `TRANSITION_WAIT_TIMEOUT`, before the restore behaviour under test even runs.

## Root cause

The test object key is `restore/api-object.bin`, but `set_bucket_lifecycle_transition_with_tier` scopes the transition rule to `<Filter><Prefix>test/</Prefix>`. An object outside that prefix never matches the rule, so `enqueue_transition_for_existing_objects` never enqueues it and it never transitions — `wait_for_transition` then times out.

Confirmed with a temporary diagnostic probe on the timeout path:

```
put_count=0  get_count=0  transitioned_object.status=""
listed=[("restore/api-object.bin", <null-vid>, <mtime>, status="")]
```

i.e. the mock tier received zero puts and the object carried no transitioned state. Every other transition test in this file already keys its objects under `test/`. The break shipped in #4860 because that PR’s ILM serial lane was `skipping` on the merge run, so the test never actually executed in CI; since then it has been failing the lane on every PR (unrelated to those PRs’ own changes).

## Fix

Key the object as `test/restore/api-object.bin` so it matches the rule. The restore API call, tier copy-back, ongoing/conflict/completion assertions, and the local-GET check are all unchanged — they address the object by bucket+key, and the remote tier object name is generated internally.

## Verification

- `cargo fmt --all` — clean.
- `cargo nextest run --run-ignored ignored-only -E "package(rustfs) and test(restore_object_usecase_reports_ongoing_conflict_and_completion)"` — now **passes** in ~4.4s (was a 15s timeout failure).
- Full binary `cargo nextest run --run-ignored ignored-only -E "package(rustfs) and test(lifecycle_transition_api_test)"` — 21/21 pass.
