### PR TITLE
ci: add zip packaging fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -440,14 +440,6 @@ jobs:
             PACKAGE_NAME="${PACKAGE_BASENAME}-v${PACKAGE_VERSION}"
           fi
 
-          # Create zip packages for all platforms
-          # Ensure zip is available
-          if ! command -v zip &> /dev/null; then
-            if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-              sudo apt-get update && sudo apt-get install -y zip
-            fi
-          fi
-
           cd target/${{ matrix.target }}/release
           # Determine the binary name based on platform
           if [[ "${{ matrix.platform }}" == "windows" ]]; then
@@ -478,8 +470,31 @@ jobs:
               # Unix systems use zip command
               zip "$dst" "$src"
             else
-              echo "❌ No zip utility available"
-              exit 1
+              local python_bin="python3"
+              if ! command -v "$python_bin" >/dev/null 2>&1; then
+                python_bin="python"
+              fi
+              if ! command -v "$python_bin" >/dev/null 2>&1; then
+                echo "❌ No zip utility or Python fallback available"
+                exit 1
+              fi
+
+              "$python_bin" - "$src" "$dst" <<'PY'
+          import os
+          import stat
+          import sys
+          import zipfile
+
+          src, dst = sys.argv[1], sys.argv[2]
+          info = zipfile.ZipInfo(os.path.basename(src))
+          mode = os.stat(src).st_mode
+          info.external_attr = (mode & 0o777) << 16
+          if stat.S_ISREG(mode):
+              info.file_size = os.path.getsize(src)
+
+          with open(src, "rb") as source, zipfile.ZipFile(dst, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+              archive.writestr(info, source.read())
+          PY
             fi
           }
 


### PR DESCRIPTION
## Related Issues
Follow-up to #4871.

## Summary of Changes
- Add a Python `zipfile` fallback for release packaging when the runner does not provide the `zip` utility.
- Preserve the packaged binary name and executable permissions in the fallback archive.
- Remove the old `ubuntu-latest`-only `apt-get install zip` branch, which did not cover custom Linux runner labels such as `sm-standard-4`.

## Verification
- `actionlint .github/workflows/build.yml`
- Local fallback simulation with `zip` removed from `PATH`, confirming the archive contains `rustfs` with `0o755` permissions.

## Impact
Linux release packaging can complete on custom runners that have Python but do not preinstall `zip`.

## Additional Notes
The failing job reported `No zip utility available` while packaging `rustfs-linux-aarch64-gnu-dev-5ef2731.zip`; this keeps packaging independent of the runner image's `zip` package.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
