### PR TITLE
fix(rustfs): gate mimalloc JSON helpers off Windows

### DIFF
--- a/rustfs/src/memory_observability.rs
+++ b/rustfs/src/memory_observability.rs
@@ -17,6 +17,7 @@ use rustfs_io_metrics::{
     record_cpu_usage, record_memory_usage, record_process_memory_split,
 };
 use serde::Serialize;
+#[cfg(any(test, not(target_os = "windows")))]
 use serde_json::Value;
 use std::collections::HashMap;
 #[cfg(not(target_os = "windows"))]
@@ -213,6 +214,7 @@ fn read_cgroup_memory_snapshot() -> Option<CgroupMemorySnapshot> {
     read_cgroup_v2().or_else(read_cgroup_v1)
 }
 
+#[cfg(any(test, not(target_os = "windows")))]
 fn numeric_json_value(value: &Value) -> Option<u64> {
     match value {
         Value::Number(number) => number
@@ -223,6 +225,7 @@ fn numeric_json_value(value: &Value) -> Option<u64> {
     }
 }
 
+#[cfg(any(test, not(target_os = "windows")))]
 fn numeric_json_field(value: &Value, field: &str) -> Option<u64> {
     match value {
         Value::Object(fields) => fields
@@ -234,6 +237,7 @@ fn numeric_json_field(value: &Value, field: &str) -> Option<u64> {
     }
 }
 
+#[cfg(any(test, not(target_os = "windows")))]
 fn mimalloc_stat_field(value: &Value, metric: &str, field: &str) -> Option<u64> {
     match value {
         Value::Object(fields) => {
@@ -250,10 +254,12 @@ fn mimalloc_stat_field(value: &Value, metric: &str, field: &str) -> Option<u64> 
     }
 }
 
+#[cfg(any(test, not(target_os = "windows")))]
 fn mimalloc_stat_current(value: &Value, metric: &str) -> Option<u64> {
     mimalloc_stat_field(value, metric, "current")
 }
 
+#[cfg(any(test, not(target_os = "windows")))]
 fn parse_mimalloc_stats_json(stats_json: &str) -> Option<AllocatorMemoryObservation> {
     let value = serde_json::from_str::<Value>(stats_json).ok()?;
     let observation = AllocatorMemoryObservation {


### PR DESCRIPTION
## Related Issues

https://github.com/rustfs/rustfs/actions/runs/29419860212/job/87387431696

## Summary of Changes

- Gate the mimalloc JSON helper import and parser helpers behind `#[cfg(any(test, not(target_os = "windows")))]` so non-test Windows builds no longer emit dead_code warnings for the non-Windows allocator path.

- Preserve the existing test-only parser coverage by keeping those helpers compiled under `#[cfg(test)]`.
## Verification
- `cargo check -p rustfs --lib --target x86_64-pc-windows-gnu --message-format short` (failed on this host because the `x86_64-pc-windows-gnu` standard library is not installed; no Rust code error was reported before toolchain resolution stopped the check)

## Impact
- Removes Windows-only dead_code warnings from `rustfs/src/memory_observability.rs` without changing runtime behavior on non-Windows platforms.

## Additional Notes
- Draft PR because full RustFS validation has not been run in this session.
- The only attempted Windows-target verification was blocked by the missing local target standard library.








