### PR TITLE
chore(deps): localize workspace dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3926,7 +3926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5336,7 +5336,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8051,7 +8051,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10139,7 +10139,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10213,7 +10213,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11099,9 +11099,9 @@ dependencies = [
 
 [[package]]
 name = "starshard"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dafd0cbefb050fa7a7f95ac229f7978ed4c99866a1a5b62e34a154b52d73d77"
+checksum = "5d298eb1bb81d6e5ddf447f3d26698d6ac5e5b9502b03004dbc2a2e2f8b572b6"
 dependencies = [
  "async-trait",
  "hashbrown 0.17.1",
@@ -11373,10 +11373,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12477,7 +12477,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,8 +133,8 @@ rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.9" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"
-async_zip = { version = "0.0.18", default-features = false, features = ["tokio", "deflate"] }
-mysql_async = { version = "0.37", default-features = false, features = ["default-rustls", "tracing"] }
+async_zip = { default-features = false, version = "0.0.18" }
+mysql_async = { default-features = false, version = "0.37" }
 async-compression = { version = "0.4.42" }
 async-recursion = "1.1.1"
 async-trait = "0.1.89"
@@ -145,32 +145,32 @@ futures-core = "0.3.32"
 futures-lite = "2.6.1"
 futures-util = "0.3.32"
 pollster = "1.0.1"
-pulsar = { version = "6.8.0", default-features = false, features = ["tokio-rustls-runtime", "telemetry"] }
-lapin = { version = "4.10.0", default-features = false, features = ["tokio", "rustls", "rustls--aws_lc_rs"] }
-hyper = { version = "1.10.1", features = ["http2", "http1", "server"] }
-hyper-rustls = { version = "0.27.9", default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs", "webpki-roots"] }
-hyper-util = { version = "0.1.20", features = ["tokio", "server-auto", "server-graceful", "tracing"] }
+pulsar = { default-features = false, version = "6.8.0" }
+lapin = { default-features = false, version = "4.10.0" }
+hyper = { version = "1.10.1" }
+hyper-rustls = { default-features = false, version = "0.27.9" }
+hyper-util = { version = "0.1.20" }
 http = "1.4.2"
 http-body = "1.1.0"
 http-body-util = "0.1.4"
 minlz = "1.2.3"
-reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { default-features = false, version = "0.13.4" }
 rustfs-kafka-async = { version = "1.2.0" }
-socket2 = { version = "0.6.5", features = ["all"] }
-tokio = { version = "1.52.3", features = ["fs", "rt-multi-thread"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "tls12", "aws-lc-rs"] }
+socket2 = { version = "0.6.5" }
+tokio = { version = "1.52.3" }
+tokio-rustls = { default-features = false, version = "0.26.4" }
 tokio-stream = { version = "0.1.18" }
 tokio-test = "0.4.5"
-tokio-util = { version = "0.7.18", features = ["io", "compat"] }
-tonic = { version = "0.14.6", features = ["gzip", "deflate"] }
+tokio-util = { version = "0.7.18" }
+tonic = { version = "0.14.6" }
 tonic-prost = { version = "0.14.6" }
 tonic-prost-build = { version = "0.14.6" }
-tower = { version = "0.5.3", features = ["timeout"] }
-tower-http = { version = "0.7.0", features = ["cors"] }
+tower = { version = "0.5.3" }
+tower-http = { version = "0.7.0" }
 
 # Serialization and Data Formats
 apache-avro = "0.21.0"
-bytes = { version = "1.12.1", features = ["serde"] }
+bytes = { version = "1.12.1" }
 bytesize = "2.4.2"
 byteorder = "1.5.0"
 flatbuffers = "25.12.19"
@@ -179,8 +179,8 @@ prost = "0.14.4"
 quick-xml = "0.41.0"
 rmp = { version = "0.8.15" }
 rmp-serde = { version = "1.3.1" }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.150", features = ["raw_value"] }
+serde = { version = "1.0.228" }
+serde_json = { version = "1.0.150" }
 serde_urlencoded = "0.7.1"
 
 # Cryptography and Security
@@ -188,33 +188,33 @@ serde_urlencoded = "0.7.1"
 # matching stable releases are not available yet, while previous stable lines
 # have incompatible APIs. Keep them exact-pinned and monitor upstream for stable
 # releases.
-aes-gcm = { version = "=0.11.0", features = ["rand_core"] }
+aes-gcm = { version = "=0.11.0" }
 argon2 = { version = "=0.6.0-rc.8" }
 blake2 = "=0.11.0-rc.6"
 chacha20poly1305 = { version = "=0.11.0" }
 crc-fast = "1.10.0"
 hmac = { version = "0.13.0" }
-jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"] }
-openidconnect = { version = "4.0", default-features = false, features = ["accept-rfc3339-timestamps"] }
+jsonwebtoken = { version = "10.4.0" }
+openidconnect = { default-features = false, version = "4.0" }
 pbkdf2 = "0.13.0"
 rsa = { version = "=0.10.0-rc.18" }
-rustls = { version = "0.23.42", default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
+rustls = { default-features = false, version = "0.23.42" }
 rustls-native-certs = "0.8"
 rustls-pki-types = "1.15.0"
 sha1 = "0.11.0"
 sha2 = "0.11.0"
 subtle = "2.6"
-zeroize = { version = "1.9.0", features = ["derive"] }
+zeroize = { version = "1.9.0" }
 
 # Time and Date
-chrono = { version = "0.4.45", features = ["serde"] }
+chrono = { version = "0.4.45" }
 humantime = "2.4.0"
-jiff = { version = "0.2.32", features = ["serde"] }
-time = { version = "0.3.53", features = ["std", "parsing", "formatting", "macros", "serde"] }
+jiff = { version = "0.2.32" }
+time = { version = "0.3.53" }
 
 # Database
-deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
-tokio-postgres = { version = "0.7.18", default-features = false, features = ["runtime", "with-serde_json-1"] }
+deadpool-postgres = { version = "0.14" }
+tokio-postgres = { default-features = false, version = "0.7.18" }
 tokio-postgres-rustls = "0.14.0"
 
 # Utilities and Tools
@@ -225,22 +225,22 @@ atoi = "3.1.0"
 atomic_enum = "0.3.0"
 aws-config = { version = "1.9.0" }
 aws-credential-types = { version = "1.3.0" }
-aws-sdk-s3 = { version = "1.138.0", default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
-aws-smithy-http-client = { version = "1.2.0", default-features = false, features = ["default-client", "rustls-aws-lc"] }
-aws-smithy-runtime-api = { version = "1.13.0", features = ["http-1x"] }
+aws-sdk-s3 = { default-features = false, version = "1.138.0" }
+aws-smithy-http-client = { default-features = false, version = "1.2.0" }
+aws-smithy-runtime-api = { version = "1.13.0" }
 aws-smithy-types = { version = "1.6.1" }
 base64 = "0.22.1"
 base64-simd = "0.8.0"
 brotli = "8.0.4"
-clap = { version = "4.6.2", features = ["derive", "env"] }
-const-str = { version = "1.1.0", features = ["std", "proc"] }
+clap = { version = "4.6.2" }
+const-str = { version = "1.1.0" }
 convert_case = "0.11.0"
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { version = "0.8" }
 crossbeam-queue = "0.3.13"
 crossbeam-channel = "0.5.16"
 crossbeam-deque = "0.8.7"
 crossbeam-utils = "0.8.22"
-datafusion = { git = "https://github.com/apache/datafusion.git", rev = "dae03ee062b2abf986de8df12ea82fb1578a2d99", default-features = false }
+datafusion = { default-features = false, git = "https://github.com/apache/datafusion.git", rev = "dae03ee062b2abf986de8df12ea82fb1578a2d99" }
 derive_builder = "0.20.2"
 enumset = "1.1.13"
 faster-hex = "0.10.0"
@@ -248,11 +248,11 @@ flate2 = "1.1.9"
 glob = "0.3.3"
 google-cloud-storage = "1.16.0"
 google-cloud-auth = "1.14.0"
-hashbrown = { version = "0.17.1", features = ["serde", "rayon"] }
+hashbrown = { version = "0.17.1" }
 hex = "0.4.3"
 hex-simd = "0.8.0"
 highway = { version = "1.3.0" }
-ipnetwork = { version = "0.21.1", features = ["serde"] }
+ipnetwork = { version = "0.21.1" }
 lazy_static = "1.5.0"
 libc = "0.2.186"
 libsystemd = "0.7.2"
@@ -263,7 +263,7 @@ matchit = "0.9.2"
 md-5 = "0.11.0"
 md5 = "0.8.1"
 mime_guess = "2.0.5"
-moka = { version = "0.12.15", features = ["future"] }
+moka = { version = "0.12.15" }
 netif = "0.1.6"
 num_cpus = { version = "1.17.0" }
 nvml-wrapper = "0.12.1"
@@ -273,27 +273,27 @@ path-clean = "1.0.1"
 percent-encoding = "2.3.2"
 pin-project-lite = "0.2.17"
 pretty_assertions = "1.4.1"
-rand = { version = "0.10.2", features = ["serde"] }
+rand = { version = "0.10.2" }
 ratelimit = "0.10.1"
 rayon = "1.12.0"
-reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.0", features = ["simd-accel"] }
+reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.0" }
 #reed-solomon-erasure = { version = "6.0", features = ["simd-accel"], git = "https://github.com/houseme/reed-solomon-erasure",rev = "main" }
 reed-solomon-simd = "3.1.0"
 regex = { version = "1.13.1" }
-rumqttc = { package = "rumqttc-next", version = "0.33.2", features = ["websocket"] }
-redis = { version = "1.4.0", features = ["connection-manager", "tokio-rustls-comp", "tls-rustls-insecure"] }
-rustix = { version = "1.1.4", features = ["fs"] }
+rumqttc = { package = "rumqttc-next", version = "0.33.2" }
+redis = { version = "1.4.0" }
+rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { git = "https://github.com/s3s-project/s3s.git", rev = "ce69c3f10824535c7c24b2f71cdb2aaa4dffb5e0", features = ["minio"] }
+s3s = { git = "https://github.com/s3s-project/s3s.git", rev = "ce69c3f10824535c7c24b2f71cdb2aaa4dffb5e0" }
 serial_test = "3.5.0"
-shadow-rs = { version = "2.0.0", default-features = false }
+shadow-rs = { default-features = false, version = "2.0.0" }
 siphasher = "1.0.3"
-smallvec = { version = "1.15.2", features = ["serde"] }
+smallvec = { version = "1.15.2" }
 smartstring = "1.0.1"
 snap = "1.1.2"
-starshard = { version = "2.2.1", features = ["rayon", "async", "serde"] }
-strum = { version = "0.28.0", features = ["derive"] }
+starshard = { version = "2.2.2" }
+strum = { version = "0.28.0" }
 sysinfo = "0.39.6"
 temp-env = "0.3.6"
 tempfile = "3.27.0"
@@ -303,15 +303,15 @@ tracing = { version = "0.1.44" }
 tracing-appender = "0.2.5"
 tracing-error = "0.2.1"
 tracing-opentelemetry = { version = "0.33" }
-tracing-subscriber = { version = "0.3.23", features = ["env-filter", "time"] }
+tracing-subscriber = { version = "0.3.23" }
 transform-stream = "0.3.1"
 url = "2.5.8"
 urlencoding = "2.1.3"
-uuid = { version = "1.24.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+uuid = { version = "1.24.0" }
 vaultrs = { version = "0.8.0" }
 walkdir = "2.5.0"
 windows = { version = "0.62.2" }
-xxhash-rust = { version = "0.8.17", features = ["xxh64", "xxh3"] }
+xxhash-rust = { version = "0.8.17" }
 zip = "8.6.0"
 zstd = "0.13.3"
 
@@ -319,19 +319,19 @@ zstd = "0.13.3"
 metrics = "0.24.6"
 dial9-tokio-telemetry = "0.3"
 opentelemetry = { version = "0.32.0" }
-opentelemetry-appender-tracing = { version = "0.32.0", features = ["experimental_span_attributes", "experimental_metadata_attributes"] }
-opentelemetry-otlp = { version = "0.32.0", features = ["gzip-http", "reqwest-rustls"] }
-opentelemetry_sdk = { version = "0.32.1", features = ["rt-tokio"] }
-opentelemetry-semantic-conventions = { version = "0.32.1", features = ["semconv_experimental"] }
+opentelemetry-appender-tracing = { version = "0.32.0" }
+opentelemetry-otlp = { version = "0.32.0" }
+opentelemetry_sdk = { version = "0.32.1" }
+opentelemetry-semantic-conventions = { version = "0.32.1" }
 opentelemetry-stdout = { version = "0.32.0" }
-pyroscope = { version = "2.1.0", features = ["backend-pprof-rs"] }
+pyroscope = { version = "2.1.0" }
 
 # FTP and SFTP
-libunftp = { version = "0.23.0", features = ["experimental"] }
+libunftp = { version = "0.23.0" }
 unftp-core = "0.1.0"
-suppaftp = { version = "10.0.1", features = ["tokio", "tokio-rustls-aws-lc-rs"] }
+suppaftp = { version = "10.0.1" }
 rcgen = "0.14.8"
-russh = { version = "0.62.2", features = ["serde"] }
+russh = { version = "0.62.2" }
 russh-sftp = "2.3.0"
 
 # WebDAV
@@ -341,7 +341,7 @@ dav-server = "0.11.0"
 mimalloc = "0.1"
 hotpath = "0.21"
 # Snapshot testing for output format regression detection
-insta = { version = "1.48", features = ["yaml", "json"] }
+insta = { version = "1.48" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["rustfs"]

--- a/crates/audit/Cargo.toml
+++ b/crates/audit/Cargo.toml
@@ -29,13 +29,13 @@ categories = ["web-programming", "development-tools", "asynchronous", "api-bindi
 rustfs-targets = { workspace = true }
 rustfs-config = { workspace = true, features = ["audit", "constants", "server-config-model"] }
 rustfs-s3-types = { workspace = true }
-chrono = { workspace = true }
-const-str = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+const-str = { workspace = true, features = ["std", "proc"] }
 futures = { workspace = true }
-hashbrown = { workspace = true }
+hashbrown = { workspace = true, features = ["serde", "rayon"] }
 metrics = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "rt", "time", "macros"] }
 tracing = { workspace = true, features = ["std", "attributes"] }

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -26,14 +26,14 @@ categories = ["web-programming", "development-tools", "network-programming"]
 documentation = "https://docs.rs/rustfs-checksums/latest/rustfs_checksum/"
 
 [dependencies]
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }
 crc-fast = { workspace = true }
 http = { workspace = true }
 base64-simd = { workspace = true }
 md-5 = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
-xxhash-rust = { workspace = true }
+xxhash-rust = { workspace = true, features = ["xxh64", "xxh3"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -28,14 +28,14 @@ categories = ["web-programming", "development-tools", "data-structures"]
 workspace = true
 
 [dependencies]
-tokio = { workspace = true }
-tonic = { workspace = true }
-uuid = { workspace = true }
-chrono = { workspace = true }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
+tonic = { workspace = true, features = ["gzip", "deflate"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
+chrono = { workspace = true, features = ["serde"] }
 metrics = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 rmp-serde = { workspace = true }
-s3s = { workspace = true }
+s3s = { workspace = true, features = ["minio"] }
 tracing = { workspace = true }
 
 [lib]

--- a/crates/concurrency/Cargo.toml
+++ b/crates/concurrency/Cargo.toml
@@ -13,15 +13,15 @@ categories = ["concurrency", "filesystem"]
 [dependencies]
 # Internal crates
 rustfs-io-core = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 # Async runtime
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread"] }
 
 # Logging
 tracing = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
-serde_json = { workspace = true }
-tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+insta = { workspace = true, features = ["yaml", "json"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread", "fs"] }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -25,9 +25,9 @@ keywords = ["configuration", "settings", "management", "rustfs", "Minio"]
 categories = ["web-programming", "development-tools", "config"]
 
 [dependencies]
-const-str = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
+const-str = { workspace = true, optional = true, features = ["std", "proc"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true, features = ["raw_value"] }
 
 [lints]
 workspace = true

--- a/crates/credentials/Cargo.toml
+++ b/crates/credentials/Cargo.toml
@@ -27,11 +27,11 @@ categories = ["web-programming", "development-tools", "data-structures", "securi
 [dependencies]
 base64-simd = { workspace = true }
 hmac = { workspace = true }
-rand = { workspace = true }
-serde = { workspace = true }
-serde_json.workspace = true
+rand = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 sha2 = { workspace = true }
-time = { workspace = true, features = ["serde", "parsing", "formatting", "macros"] }
+time = { workspace = true, features = ["serde", "parsing", "formatting", "macros", "std"] }
 
 [lints]
 workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -29,23 +29,23 @@ documentation = "https://docs.rs/rustfs-crypto/latest/rustfs_crypto/"
 workspace = true
 
 [dependencies]
-aes-gcm = { workspace = true, optional = true }
+aes-gcm = { workspace = true, optional = true, features = ["rand_core"] }
 argon2 = { workspace = true, optional = true }
 chacha20poly1305 = { workspace = true, optional = true }
-jsonwebtoken = { workspace = true }
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 base64-simd = { workspace = true }
 pbkdf2 = { workspace = true, optional = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["serde"] }
 rsa = { workspace = true, features = ["sha2"] }
 serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true, optional = true }
 thiserror.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 
 
 [dev-dependencies]
 test-case.workspace = true
-time.workspace = true
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
 
 [features]
 default = ["crypto", "fips"]

--- a/crates/data-usage/Cargo.toml
+++ b/crates/data-usage/Cargo.toml
@@ -28,7 +28,7 @@ categories = ["data-structures", "filesystem"]
 workspace = true
 
 [dependencies]
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 path-clean = { workspace = true }
 rmp-serde = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/e2e_test/Cargo.toml
+++ b/crates/e2e_test/Cargo.toml
@@ -38,47 +38,47 @@ futures.workspace = true
 rustfs-lock.workspace = true
 rustfs-protos.workspace = true
 rmp-serde.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-tonic = { workspace = true }
-tokio = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+tonic = { workspace = true, features = ["gzip", "deflate"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 tokio-stream = { workspace = true }
 rustfs-madmin.workspace = true
 rustfs-filemeta.workspace = true
-bytes.workspace = true
+bytes = { workspace = true, features = ["serde"] }
 serial_test = { workspace = true }
-aws-sdk-s3.workspace = true
+aws-sdk-s3 = { workspace = true, default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
 aws-config = { workspace = true }
-aws-smithy-http-client.workspace = true
+aws-smithy-http-client = { workspace = true, default-features = false, features = ["default-client", "rustls-aws-lc"] }
 async-compression = { workspace = true, features = ["tokio", "bzip2", "xz"] }
 async-trait = { workspace = true }
 flate2.workspace = true
 http.workspace = true
 http-body-util.workspace = true
-hyper.workspace = true
-hyper-util.workspace = true
-reqwest = { workspace = true }
+hyper = { workspace = true, features = ["http2", "http1", "server"] }
+hyper-util = { workspace = true, features = ["tokio", "server-auto", "server-graceful", "tracing"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
 rustfs-signer.workspace = true
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-uuid = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 urlencoding.workspace = true
 walkdir.workspace = true
 base64 = { workspace = true }
-rand = { workspace = true }
-chrono = { workspace = true }
+rand = { workspace = true, features = ["serde"] }
+chrono = { workspace = true, features = ["serde"] }
 md5 = { workspace = true }
 sha2 = { workspace = true }
 astral-tokio-tar = { workspace = true }
-s3s = { workspace = true }
+s3s = { workspace = true, features = ["minio"] }
 zstd.workspace = true
-time.workspace = true
-suppaftp = { workspace = true, features = ["tokio", "rustls-aws-lc-rs"] }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+suppaftp = { workspace = true, features = ["tokio", "rustls-aws-lc-rs", "tokio-rustls-aws-lc-rs"] }
 rcgen.workspace = true
 local-ip-address.workspace = true
 anyhow.workspace = true
-rustls.workspace = true
-russh = { workspace = true }
+rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
+russh = { workspace = true, features = ["serde"] }
 russh-sftp = { workspace = true }
 zip.workspace = true
-clap.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -62,9 +62,9 @@ rustfs-s3-types = { workspace = true }
 rustfs-data-usage.workspace = true
 rustfs-object-capacity.workspace = true
 async-trait.workspace = true
-bytes.workspace = true
+bytes = { workspace = true, features = ["serde"] }
 byteorder = { workspace = true }
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 glob = { workspace = true }
 thiserror.workspace = true
 flatbuffers.workspace = true
@@ -72,22 +72,22 @@ futures.workspace = true
 futures-util.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
-serde.workspace = true
-time.workspace = true
+serde = { workspace = true, features = ["derive"] }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
 bytesize.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 quick-xml = { workspace = true, features = ["serialize", "async-tokio"] }
-s3s.workspace = true
+s3s = { workspace = true, features = ["minio"] }
 http.workspace = true
 opentelemetry.workspace = true
 http-body = { workspace = true }
 http-body-util.workspace = true
 url.workspace = true
-uuid = { workspace = true, features = ["v4", "fast-rng", "serde"] }
-reed-solomon-erasure = { workspace = true }
+uuid = { workspace = true, features = ["v4", "fast-rng", "serde", "macro-diagnostics"] }
+reed-solomon-erasure = { workspace = true, features = ["simd-accel"] }
 reed-solomon-simd = { workspace = true }
 lazy_static.workspace = true
-moka = { workspace = true }
+moka = { workspace = true, features = ["future"] }
 rustfs-lock.workspace = true
 rustfs-io-metrics.workspace = true
 regex = { workspace = true }
@@ -101,38 +101,38 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 hex-simd = { workspace = true }
 tempfile.workspace = true
-hyper.workspace = true
-hyper-util.workspace = true
-hyper-rustls.workspace = true
-rustls.workspace = true
+hyper = { workspace = true, features = ["http2", "http1", "server"] }
+hyper-util = { workspace = true, features = ["tokio", "server-auto", "server-graceful", "tracing"] }
+hyper-rustls = { workspace = true, default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs", "webpki-roots"] }
+rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
 rustls-pki-types.workspace = true
-tokio = { workspace = true, features = ["io-util", "sync", "signal"] }
-tonic.workspace = true
+tokio = { workspace = true, features = ["io-util", "sync", "signal", "fs", "rt-multi-thread"] }
+tonic = { workspace = true, features = ["gzip", "deflate"] }
 xxhash-rust = { workspace = true, features = ["xxh64", "xxh3"] }
-tower.workspace = true
+tower = { workspace = true, features = ["timeout"] }
 async-channel.workspace = true
 enumset = { workspace = true }
 num_cpus = { workspace = true }
-rand.workspace = true
+rand = { workspace = true, features = ["serde"] }
 pin-project-lite.workspace = true
 md-5.workspace = true
 memmap2 = { workspace = true }
 libc.workspace = true
 # "process" adds getrlimit for the io_uring fd-cache RLIMIT_NOFILE gate
 # (backlog#1178); "fs" comes from the workspace default.
-rustix = { workspace = true, features = ["process"] }
+rustix = { workspace = true, features = ["process", "fs"] }
 rustfs-madmin.workspace = true
-reqwest = { workspace = true }
-aes-gcm.workspace = true
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+aes-gcm = { workspace = true, features = ["rand_core"] }
 chacha20poly1305.workspace = true
-aws-sdk-s3 = { workspace = true }
+aws-sdk-s3 = { workspace = true, default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
 urlencoding = { workspace = true }
-smallvec = { workspace = true }
-shadow-rs.workspace = true
+smallvec = { workspace = true, features = ["serde"] }
+shadow-rs = { workspace = true, default-features = false }
 async-recursion.workspace = true
 aws-credential-types = { workspace = true }
 aws-smithy-types = { workspace = true }
-aws-smithy-runtime-api = { workspace = true }
+aws-smithy-runtime-api = { workspace = true, features = ["http-1x"] }
 parking_lot = { workspace = true }
 base64-simd.workspace = true
 serde_urlencoded.workspace = true
@@ -141,7 +141,7 @@ google-cloud-auth = { workspace = true }
 aws-config = { workspace = true }
 faster-hex = { workspace = true }
 ratelimit = { workspace = true }
-aws-smithy-http-client.workspace = true
+aws-smithy-http-client = { workspace = true, default-features = false, features = ["default-client", "rustls-aws-lc"] }
 
 # Observability and Metrics
 metrics = { workspace = true }
@@ -153,19 +153,19 @@ metrics = { workspace = true }
 rustfs-uring = "0.2.1"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util", "fs"] }
 criterion = { workspace = true, features = ["html_reports"] }
 temp-env = { workspace = true, features = ["async_closure"] }
-tracing-subscriber = { workspace = true, features = ["json"] }
+tracing-subscriber = { workspace = true, features = ["json", "env-filter", "time"] }
 serial_test = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 proptest = "1"
 rcgen.workspace = true
-insta = { workspace = true }
+insta = { workspace = true, features = ["yaml", "json"] }
 rustfs-crypto = { workspace = true }
 
 [build-dependencies]
-shadow-rs = { workspace = true, features = ["build", "metadata"] }
+shadow-rs = { workspace = true, default-features = false, features = ["build", "metadata"] }
 
 [[bench]]
 name = "erasure_benchmark"

--- a/crates/extension-schema/Cargo.toml
+++ b/crates/extension-schema/Cargo.toml
@@ -28,11 +28,11 @@ categories = ["web-programming", "development-tools"]
 doctest = false
 
 [dependencies]
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 
 [lints]
 workspace = true

--- a/crates/filemeta/Cargo.toml
+++ b/crates/filemeta/Cargo.toml
@@ -34,22 +34,22 @@ hotpath = { workspace = true, optional = true }
 crc-fast = { workspace = true }
 rmp.workspace = true
 rmp-serde.workspace = true
-serde.workspace = true
-time.workspace = true
-uuid = { workspace = true, features = ["v4", "fast-rng", "serde"] }
-tokio = { workspace = true, features = ["io-util", "macros", "sync"] }
-xxhash-rust = { workspace = true, features = ["xxh64"] }
-bytes.workspace = true
+serde = { workspace = true, features = ["derive"] }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "serde", "macro-diagnostics"] }
+tokio = { workspace = true, features = ["io-util", "macros", "sync", "fs", "rt-multi-thread"] }
+xxhash-rust = { workspace = true, features = ["xxh64", "xxh3"] }
+bytes = { workspace = true, features = ["serde"] }
 rustfs-utils = { workspace = true, features = ["hash", "http"] }
 byteorder = { workspace = true }
 tracing.workspace = true
 thiserror.workspace = true
-s3s.workspace = true
+s3s = { workspace = true, features = ["minio"] }
 regex.workspace = true
 arc-swap.workspace = true
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion = { workspace = true, features = ["html_reports"] }
 tempfile = { workspace = true }
 proptest = "1"
 

--- a/crates/heal/Cargo.toml
+++ b/crates/heal/Cargo.toml
@@ -34,27 +34,27 @@ rustfs-storage-api = { workspace = true }
 rustfs-common = { workspace = true }
 rustfs-madmin = { workspace = true }
 rustfs-utils = { workspace = true }
-tokio = { workspace = true, features = ["sync","io-util","time","macros"] }
-tokio-util = { workspace = true }
+tokio = { workspace = true, features = ["sync", "io-util", "time", "macros", "fs", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["io", "compat"] }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
-uuid = { workspace = true, features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }
 async-trait = { workspace = true }
 futures = { workspace = true }
 metrics = { workspace = true }
 base64 = { workspace = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 rustfs-test-utils = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
 http = { workspace = true }
 temp-env = { workspace = true }
-tokio = { workspace = true, features = ["test-util","fs"] }
+tokio = { workspace = true, features = ["test-util", "fs", "rt-multi-thread"] }
 
 [lib]
 doctest = false

--- a/crates/iam/Cargo.toml
+++ b/crates/iam/Cargo.toml
@@ -31,29 +31,29 @@ workspace = true
 [dependencies]
 rustfs-credentials = { workspace = true }
 rustfs-config = { workspace = true, features = ["constants", "server-config-model"] }
-tokio.workspace = true
-time = { workspace = true, features = ["serde-human-readable"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
+time = { workspace = true, features = ["serde-human-readable", "std", "parsing", "formatting", "macros", "serde"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 rustfs-ecstore = { workspace = true }
 rustfs-storage-api = { workspace = true }
 rustfs-policy.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 async-trait.workspace = true
 thiserror.workspace = true
 arc-swap = { workspace = true }
 rustfs-crypto = { workspace = true }
 futures.workspace = true
 base64-simd = { workspace = true }
-jsonwebtoken = { workspace = true }
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 tracing.workspace = true
 rustfs-madmin.workspace = true
 rustfs-utils = { workspace = true, features = ["path"] }
 rustfs-io-metrics.workspace = true
-tokio-util.workspace = true
+tokio-util = { workspace = true, features = ["io", "compat"] }
 pollster.workspace = true
-reqwest = { workspace = true }
-moka = { workspace = true }
-openidconnect = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+moka = { workspace = true, features = ["future"] }
+openidconnect = { workspace = true, default-features = false, features = ["accept-rfc3339-timestamps"] }
 http = { workspace = true }
 url = { workspace = true }
 

--- a/crates/io-core/Cargo.toml
+++ b/crates/io-core/Cargo.toml
@@ -28,15 +28,15 @@ categories = ["development-tools", "filesystem"]
 workspace = true
 
 [dependencies]
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "fs", "rt", "sync"] }
+tokio = { workspace = true, features = ["io-util", "fs", "rt", "sync", "rt-multi-thread"] }
 memmap2 = { workspace = true }
 rustfs-io-metrics = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 
 [lib]
 doctest = false

--- a/crates/io-metrics/Cargo.toml
+++ b/crates/io-metrics/Cargo.toml
@@ -33,14 +33,14 @@ metrics = { workspace = true }
 rustfs-s3-ops = { workspace = true }
 num_cpus = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync","rt"] }
+tokio = { workspace = true, features = ["sync", "rt", "fs", "rt-multi-thread"] }
 tracing = { workspace = true }
 sysinfo = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion = { workspace = true, features = ["html_reports"] }
 metrics-util = { version = "0.20", features = ["debugging"] }
-tokio = { workspace = true, features = ["test-util","rt","macros"] }
+tokio = { workspace = true, features = ["test-util", "rt", "macros", "fs", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -26,32 +26,32 @@ categories = ["authentication", "web-programming"]
 authors.workspace = true
 
 [dependencies]
-tokio = { workspace = true, features = ["full"] }
-reqwest = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-time = { workspace = true }
-moka = { workspace = true }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+moka = { workspace = true, features = ["future"] }
 rustfs-credentials = { workspace = true }
 rustfs-policy = { workspace = true }
 rustfs-utils = { workspace = true, features = ["egress"] }
 url = { workspace = true }
 # Middleware dependencies
-tower = { workspace = true }
+tower = { workspace = true, features = ["timeout"] }
 http = { workspace = true }
-hyper = { workspace = true, features = ["server"] }
+hyper = { workspace = true, features = ["server", "http2", "http1"] }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
-tower = { workspace = true, features = ["util"] }
-hyper = { workspace = true, features = ["server"] }
-serde_json = { workspace = true }
+tokio = { workspace = true, features = ["test-util", "fs", "rt-multi-thread"] }
+tower = { workspace = true, features = ["util", "timeout"] }
+hyper = { workspace = true, features = ["server", "http2", "http1"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 temp-env = { workspace = true }
 
 [[test]]

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -30,19 +30,19 @@ workspace = true
 [dependencies]
 # Core dependencies
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
-uuid = { workspace = true, features = ["serde"] }
-jiff = { workspace = true }
+tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+uuid = { workspace = true, features = ["serde", "v4", "fast-rng", "macro-diagnostics"] }
+jiff = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 
 # Cryptography
-aes-gcm = { workspace = true }
+aes-gcm = { workspace = true, features = ["rand_core"] }
 argon2 = { workspace = true }
 chacha20poly1305 = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["serde"] }
 base64 = { workspace = true }
 zeroize = { workspace = true, features = ["derive"] }
 
@@ -60,11 +60,11 @@ rustfs-utils = { workspace = true }
 rustfs-security-governance = { workspace = true }
 
 # HTTP client for Vault
-reqwest = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
 vaultrs = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
+insta = { workspace = true, features = ["yaml", "json"] }
 tempfile = { workspace = true }
 temp-env = { workspace = true }
 

--- a/crates/lifecycle/Cargo.toml
+++ b/crates/lifecycle/Cargo.toml
@@ -31,17 +31,17 @@ rustfs-common.workspace = true
 rustfs-config = { workspace = true, features = ["constants"] }
 rustfs-replication.workspace = true
 rustfs-storage-api.workspace = true
-s3s.workspace = true
-time.workspace = true
+s3s = { workspace = true, features = ["minio"] }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
 tracing.workspace = true
 url.workspace = true
-uuid = { workspace = true, features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }
 
 [dev-dependencies]
 proptest = "1"
 serial_test.workspace = true
 temp-env.workspace = true
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "fs", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/lock/Cargo.toml
+++ b/crates/lock/Cargo.toml
@@ -33,15 +33,15 @@ rustfs-io-metrics = { workspace = true }
 rustfs-utils = { workspace = true }
 async-trait.workspace = true
 futures.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-tokio.workspace = true
-tonic.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
+tonic = { workspace = true, features = ["gzip", "deflate"] }
 tracing.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 thiserror.workspace = true
 parking_lot.workspace = true
-smallvec.workspace = true
+smallvec = { workspace = true, features = ["serde"] }
 smartstring.workspace = true
 crossbeam-queue = { workspace = true }
 

--- a/crates/madmin/Cargo.toml
+++ b/crates/madmin/Cargo.toml
@@ -29,13 +29,13 @@ documentation = "https://docs.rs/rustfs-madmin/latest/rustfs_madmin/"
 workspace = true
 
 [dependencies]
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 humantime.workspace = true
-hyper.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+hyper = { workspace = true, features = ["http2", "http1", "server"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 sysinfo.workspace = true
-time.workspace = true
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
 
 [lib]
 doctest = false

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -36,14 +36,14 @@ arc-swap = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 form_urlencoded = { workspace = true }
-hashbrown = { workspace = true }
+hashbrown = { workspace = true, features = ["serde", "rayon"] }
 percent-encoding = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
-serde = { workspace = true }
-starshard = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+starshard = { workspace = true, features = ["rayon", "async", "serde"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "fs"] }
 tracing = { workspace = true }
 url = { workspace = true }
 metrics = { workspace = true }
@@ -56,12 +56,12 @@ metrics = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize", "serde-types", "encoding"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = { workspace = true, features = ["test-util", "fs", "rt-multi-thread"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
 axum = { workspace = true }
 rustfs-utils = { workspace = true, features = ["path"] }
-serde_json = { workspace = true }
-criterion = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
+criterion = { workspace = true, features = ["html_reports"] }
 
 [lints]
 workspace = true

--- a/crates/object-capacity/Cargo.toml
+++ b/crates/object-capacity/Cargo.toml
@@ -39,14 +39,14 @@ rustfs-config = { workspace = true, features = ["constants"] }
 rustfs-io-metrics = { workspace = true }
 rustfs-utils = { workspace = true, features = ["os"] }
 futures = { workspace = true }
-tokio = { workspace = true, features = ["sync", "time"] }
+tokio = { workspace = true, features = ["sync", "time", "fs", "rt-multi-thread"] }
 tracing = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 walkdir = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion = { workspace = true, features = ["html_reports"] }
 serial_test = { workspace = true }
 temp-env = { workspace = true, features = ["async_closure"] }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["test-util", "macros", "rt"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt", "fs", "rt-multi-thread"] }

--- a/crates/object-data-cache/Cargo.toml
+++ b/crates/object-data-cache/Cargo.toml
@@ -28,22 +28,22 @@ categories = ["web-programming", "development-tools"]
 doctest = false
 
 [dependencies]
-bytes.workspace = true
+bytes = { workspace = true, features = ["serde"] }
 metrics = { workspace = true }
 moka = { workspace = true, features = ["future"] }
-starshard.workspace = true
+starshard = { workspace = true, features = ["rayon", "async", "serde"] }
 sysinfo = { workspace = true, features = ["multithread"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync", "rt", "time"] }
+tokio = { workspace = true, features = ["sync", "rt", "time", "fs", "rt-multi-thread"] }
 tracing.workspace = true
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion = { workspace = true, features = ["html_reports"] }
 metrics-util = { version = "0.20", features = ["debugging"] }
 # `rt-multi-thread` lets the concurrency stress tests run tasks on real worker
 # threads, so they exercise true parallelism on the shared singleflight/index
 # state rather than only cooperative interleaving.
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time", "fs"] }
 
 [[bench]]
 name = "cache_bench"

--- a/crates/obs/Cargo.toml
+++ b/crates/obs/Cargo.toml
@@ -75,10 +75,10 @@ rustfs-security-governance = { workspace = true }
 rustfs-storage-api = { workspace = true }
 rustfs-utils = { workspace = true, features = ["ip"] }
 rustix = { workspace = true, features = ["fs", "stdio"] }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
 flate2 = { workspace = true }
 glob = { workspace = true }
-jiff = { workspace = true }
+jiff = { workspace = true, features = ["serde"] }
 metrics = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-deque = { workspace = true }
@@ -86,21 +86,21 @@ crossbeam-utils = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
 opentelemetry = { workspace = true }
-opentelemetry-appender-tracing = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+opentelemetry-appender-tracing = { workspace = true, features = ["experimental_span_attributes", "experimental_metadata_attributes"] }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 opentelemetry-stdout = { workspace = true }
-opentelemetry-otlp = { workspace = true }
-opentelemetry-semantic-conventions = { workspace = true }
+opentelemetry-otlp = { workspace = true, features = ["gzip-http", "reqwest-rustls"] }
+opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }
 percent-encoding = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 tracing = { workspace = true, features = ["std", "attributes"] }
 tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["registry", "std", "fmt", "env-filter", "tracing-log", "time", "local-time", "json"] }
 tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "rt", "time", "macros"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["io", "compat"] }
 dial9-tokio-telemetry = { workspace = true, optional = true }
 thiserror = { workspace = true }
 zstd = { workspace = true, features = ["zstdmt"] }
@@ -108,13 +108,13 @@ sysinfo = { workspace = true }
 nvml-wrapper = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "macos", all(target_os = "linux", target_env = "gnu", target_arch = "x86_64")))'.dependencies]
-pyroscope = { workspace = true, features = ["backend-pprof-rs"], optional = true }
+pyroscope = { workspace = true, optional = true, features = ["backend-pprof-rs"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
 tempfile = { workspace = true }
 temp-env = { workspace = true }

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -31,21 +31,21 @@ workspace = true
 [dependencies]
 rustfs-credentials = { workspace = true }
 rustfs-config = { workspace = true, features = ["constants", "opa"] }
-tokio = { workspace = true, features = ["full"] }
-time = { workspace = true, features = ["serde", "parsing", "formatting", "macros"] }
+tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+time = { workspace = true, features = ["serde", "parsing", "formatting", "macros", "std"] }
 serde = { workspace = true, features = ["derive", "rc"] }
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror.workspace = true
 strum = { workspace = true, features = ["derive"] }
 rustfs-crypto = { workspace = true }
 ipnetwork = { workspace = true, features = ["serde"] }
 base64-simd = { workspace = true }
-jsonwebtoken = { workspace = true }
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 regex = { workspace = true }
-reqwest.workspace = true
-chrono.workspace = true
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+chrono = { workspace = true, features = ["serde"] }
 tracing.workspace = true
-moka.workspace = true
+moka = { workspace = true, features = ["future"] }
 async-trait.workspace = true
 futures.workspace = true
 pollster.workspace = true

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -67,7 +67,7 @@ rustfs-storage-api = { workspace = true }
 rustfs-tls-runtime = { workspace = true, optional = true }
 
 # Async dependencies
-tokio = { workspace = true, features = ["fs", "io-util", "sync", "time"] }
+tokio = { workspace = true, features = ["fs", "io-util", "sync", "time", "rt-multi-thread"] }
 tracing = { workspace = true }
 futures-util = { workspace = true }
 
@@ -75,20 +75,20 @@ futures-util = { workspace = true }
 thiserror = { workspace = true }
 
 # Serialization
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 
 # Utilities
 async-trait = { workspace = true }
-time = { workspace = true }
-bytes = { workspace = true }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+bytes = { workspace = true, features = ["serde"] }
 
 # S3 API dependencies
-s3s = { workspace = true }
+s3s = { workspace = true, features = ["minio"] }
 
 # FTPS specific dependencies (optional)
-libunftp = { workspace = true, optional = true }
+libunftp = { workspace = true, optional = true, features = ["experimental"] }
 unftp-core = { workspace = true, optional = true }
-rustls = { workspace = true, optional = true }
+rustls = { workspace = true, default-features = false, optional = true, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
 
 # Swift specific dependencies (optional)
 rustfs-keystone = { workspace = true, optional = true }
@@ -96,15 +96,15 @@ rustfs-ecstore = { workspace = true, optional = true }
 rustfs-rio = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
-tower = { workspace = true, optional = true }
+tower = { workspace = true, optional = true, features = ["timeout"] }
 regex = { workspace = true, optional = true }
 percent-encoding = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
-uuid = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 futures = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
-tokio-util = { workspace = true, optional = true, features = ["rt"] }
-serde = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true, features = ["rt", "io", "compat"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
 urlencoding = { workspace = true, optional = true }
 md5 = { workspace = true, optional = true }
 quick-xml = { workspace = true, optional = true, features = ["serialize"] }
@@ -117,21 +117,21 @@ async-compression = { workspace = true, optional = true, features = ["tokio", "g
 
 # WebDAV specific dependencies (optional)
 dav-server = { workspace = true, optional = true }
-hyper = { workspace = true, optional = true }
-hyper-util = { workspace = true, optional = true }
-tokio-rustls = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true, features = ["http2", "http1", "server"] }
+hyper-util = { workspace = true, optional = true, features = ["tokio", "server-auto", "server-graceful", "tracing"] }
+tokio-rustls = { workspace = true, default-features = false, optional = true, features = ["logging", "tls12", "aws-lc-rs"] }
 
 # SFTP specific dependencies (optional)
-russh = { workspace = true, optional = true }
+russh = { workspace = true, optional = true, features = ["serde"] }
 russh-sftp = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
-socket2 = { workspace = true, optional = true }
+socket2 = { workspace = true, optional = true, features = ["all"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 proptest = "1"
-tracing-subscriber = { workspace = true }
-tokio = { workspace = true, features = ["test-util", "macros", "rt"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt", "fs", "rt-multi-thread"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/protos/Cargo.toml
+++ b/crates/protos/Cargo.toml
@@ -40,10 +40,10 @@ rustfs-tls-runtime.workspace = true
 rustfs-utils.workspace = true
 flatbuffers = { workspace = true }
 prost = { workspace = true }
-tonic = { workspace = true, features = ["transport", "tls-native-roots", "tls-aws-lc"] }
+tonic = { workspace = true, features = ["transport", "tls-native-roots", "tls-aws-lc", "gzip", "deflate"] }
 tonic-prost = { workspace = true }
 tonic-prost-build = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread"] }
 tracing = { workspace = true }
 
 [lib]

--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -26,17 +26,17 @@ categories = ["web-programming", "development-tools", "filesystem"]
 documentation = "https://docs.rs/rustfs-replication/latest/rustfs_replication/"
 
 [dependencies]
-bytes.workspace = true
+bytes = { workspace = true, features = ["serde"] }
 byteorder.workspace = true
 regex.workspace = true
 rmp.workspace = true
 rmp-serde.workspace = true
-s3s.workspace = true
-serde.workspace = true
-time.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+s3s = { workspace = true, features = ["minio"] }
+serde = { workspace = true, features = ["derive"] }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread"] }
 url.workspace = true
-uuid = { workspace = true, features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }
 
 [lints]
 workspace = true

--- a/crates/rio-v2/Cargo.toml
+++ b/crates/rio-v2/Cargo.toml
@@ -29,20 +29,20 @@ documentation = "https://docs.rs/rustfs-rio-v2/latest/rustfs_rio_v2/"
 workspace = true
 
 [dependencies]
-aes-gcm.workspace = true
-bytes.workspace = true
+aes-gcm = { workspace = true, features = ["rand_core"] }
+bytes = { workspace = true, features = ["serde"] }
 chacha20poly1305.workspace = true
 hex.workspace = true
 hmac.workspace = true
 minlz.workspace = true
 pin-project-lite.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["serde"] }
 rustfs-rio.workspace = true
 rustfs-utils.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 sha2.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 
 [dev-dependencies]
 rustfs-filemeta.workspace = true

--- a/crates/rio/Cargo.toml
+++ b/crates/rio/Cargo.toml
@@ -35,32 +35,32 @@ hotpath = ["dep:hotpath", "hotpath/hotpath"]
 [dependencies]
 hotpath = { workspace = true, optional = true }
 arc-swap.workspace = true
-tokio = { workspace = true, features = ["full"] }
-rand = { workspace = true }
+tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+rand = { workspace = true, features = ["serde"] }
 http.workspace = true
-aes-gcm = { workspace = true }
+aes-gcm = { workspace = true, features = ["rand_core"] }
 crc-fast = { workspace = true }
 pin-project-lite.workspace = true
-serde = { workspace = true }
-bytes.workspace = true
-reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+bytes = { workspace = true, features = ["serde"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
 rustls-pki-types.workspace = true
-tokio-util.workspace = true
+tokio-util = { workspace = true, features = ["io", "compat"] }
 faster-hex.workspace = true
 futures.workspace = true
 rustfs-config = { workspace = true, features = ["constants"] }
 rustfs-io-metrics.workspace = true
 rustfs-tls-runtime.workspace = true
 rustfs-utils = { workspace = true, features = ["io", "hash", "compress"] }
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 md-5 = { workspace = true }
 tracing.workspace = true
 thiserror.workspace = true
 base64.workspace = true
 sha1.workspace = true
 sha2.workspace = true
-xxhash-rust = { workspace = true }
-s3s.workspace = true
+xxhash-rust = { workspace = true, features = ["xxh64", "xxh3"] }
+s3s = { workspace = true, features = ["minio"] }
 hex-simd.workspace = true
 
 [dev-dependencies]

--- a/crates/s3-types/Cargo.toml
+++ b/crates/s3-types/Cargo.toml
@@ -28,8 +28,8 @@ categories = ["data-structures"]
 workspace = true
 
 [dependencies]
-serde = { workspace = true }
-serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 
 [lib]
 doctest = false

--- a/crates/s3select-api/Cargo.toml
+++ b/crates/s3select-api/Cargo.toml
@@ -28,22 +28,22 @@ documentation = "https://docs.rs/rustfs-s3select-api/latest/rustfs_s3select_api/
 [dependencies]
 metrics = { workspace = true }
 async-trait.workspace = true
-bytes.workspace = true
-chrono.workspace = true
+bytes = { workspace = true, features = ["serde"] }
+chrono = { workspace = true, features = ["serde"] }
 rustfs-common.workspace = true
-datafusion = { workspace = true, features = ["parquet", "recursive_protection", "sql"] }
+datafusion = { workspace = true, default-features = false, features = ["parquet", "recursive_protection", "sql"] }
 rustfs-ecstore.workspace = true
 rustfs-storage-api.workspace = true
 futures = { workspace = true }
 futures-core = { workspace = true }
 http.workspace = true
 pin-project-lite.workspace = true
-s3s.workspace = true
-serde_json = { workspace = true }
+s3s = { workspace = true, features = ["minio"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 parking_lot.workspace = true
-tokio.workspace = true
-tokio-util.workspace = true
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["io", "compat"] }
 tracing.workspace = true
 transform-stream.workspace = true
 url.workspace = true

--- a/crates/s3select-query/Cargo.toml
+++ b/crates/s3select-query/Cargo.toml
@@ -29,12 +29,12 @@ documentation = "https://docs.rs/rustfs-s3select-query/latest/rustfs_s3select_qu
 rustfs-s3select-api = { workspace = true }
 async-recursion = { workspace = true }
 async-trait.workspace = true
-datafusion = { workspace = true, features = ["parquet", "recursive_protection", "sql"] }
+datafusion = { workspace = true, default-features = false, features = ["parquet", "recursive_protection", "sql"] }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 parking_lot = { workspace = true }
-s3s.workspace = true
-tokio = { workspace = true }
+s3s = { workspace = true, features = ["minio"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 tracing = { workspace = true }
 
 [lib]

--- a/crates/scanner/Cargo.toml
+++ b/crates/scanner/Cargo.toml
@@ -33,32 +33,32 @@ workspace = true
 rustfs-config = { workspace = true, features = ["server-config-model"] }
 rustfs-common = { workspace = true }
 rustfs-utils = { workspace = true }
-tokio = { workspace = true, features = ["fs","sync","rt","time","macros"] }
+tokio = { workspace = true, features = ["fs", "sync", "rt", "time", "macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
-time = { workspace = true }
-chrono = { workspace = true }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+chrono = { workspace = true, features = ["serde"] }
 rmp-serde = { workspace = true }
 rustfs-filemeta = { workspace = true }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["io", "compat"] }
 rustfs-ecstore = { workspace = true }
 rustfs-storage-api = { workspace = true }
 http = { workspace = true }
-rand = { workspace = true }
-s3s = { workspace = true }
+rand = { workspace = true, features = ["serde"] }
+s3s = { workspace = true, features = ["minio"] }
 metrics = { workspace = true }
 rustfs-data-usage = { workspace = true }
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
 serial_test = { workspace = true }
 temp-env = { workspace = true }
-uuid = { workspace = true, features = ["v4", "serde"] }
-tokio = { workspace = true, features = ["test-util"] }
+uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }
+tokio = { workspace = true, features = ["test-util", "fs", "rt-multi-thread"] }
 # Enables the shared MockWarmBackend / xl.meta assertion helpers exposed via
 # the ecstore `api::tier::test_util` facade module (rustfs/backlog#1148 ilm-6).
 rustfs-ecstore = { workspace = true, features = ["test-util"] }

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -27,13 +27,13 @@ documentation = "https://docs.rs/rustfs-signer/latest/rustfs_signer/"
 
 [dependencies]
 tracing.workspace = true
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }
 http.workspace = true
-time.workspace = true
-hyper.workspace = true
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+hyper = { workspace = true, features = ["http2", "http1", "server"] }
 serde_urlencoded.workspace = true
 rustfs-utils = { workspace = true, features = ["full"] }
-s3s.workspace = true
+s3s = { workspace = true, features = ["minio"] }
 base64-simd.workspace = true
 thiserror.workspace = true
 

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -32,14 +32,14 @@ async-trait.workspace = true
 # Storage-facing replication contracts are isolated in src/replication.rs until
 # the underlying wire types can move without creating a replication/storage-api cycle.
 rustfs-filemeta.workspace = true
-serde.workspace = true
-time.workspace = true
-uuid.workspace = true
+serde = { workspace = true, features = ["derive"] }
+time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 [dev-dependencies]
-insta = { workspace = true }
-serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "rt"] }
+insta = { workspace = true, features = ["yaml", "json"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+tokio = { workspace = true, features = ["macros", "rt", "fs", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/targets/Cargo.toml
+++ b/crates/targets/Cargo.toml
@@ -19,45 +19,45 @@ rustfs-s3-types = { workspace = true }
 rustfs-utils = { workspace = true, features = ["egress"] }
 async-trait = { workspace = true }
 async-nats = { workspace = true }
-deadpool-postgres = { workspace = true }
-hyper = { workspace = true }
-hyper-rustls = { workspace = true }
-lapin = { workspace = true }
+deadpool-postgres = { workspace = true, features = ["rt_tokio_1"] }
+hyper = { workspace = true, features = ["http2", "http1", "server"] }
+hyper-rustls = { workspace = true, default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs", "webpki-roots"] }
+lapin = { workspace = true, default-features = false, features = ["tokio", "rustls", "rustls--aws_lc_rs"] }
 libc = { workspace = true }
-pulsar = { workspace = true }
+pulsar = { workspace = true, default-features = false, features = ["tokio-rustls-runtime", "telemetry"] }
 regex = { workspace = true }
-reqwest = { workspace = true }
-rumqttc = { workspace = true }
-redis = { workspace = true }
-rustls = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+rumqttc = { workspace = true, features = ["websocket"] }
+redis = { workspace = true, features = ["connection-manager", "tokio-rustls-comp", "tls-rustls-insecure"] }
+rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
 rustls-native-certs = { workspace = true }
-s3s = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
+s3s = { workspace = true, features = ["minio"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 sha2 = { workspace = true }
 snap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "sync", "time"] }
-tokio-postgres = { workspace = true }
+tokio-postgres = { workspace = true, default-features = false, features = ["runtime", "with-serde_json-1"] }
 tokio-postgres-rustls = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
-uuid = { workspace = true, features = ["v4", "v7", "serde"] }
+uuid = { workspace = true, features = ["v4", "v7", "serde", "fast-rng", "macro-diagnostics"] }
 sysinfo = { workspace = true, features = ["multithread"] }
 rustfs-kafka-async = { workspace = true }
-mysql_async = { workspace = true }
-chrono = { workspace = true }
+mysql_async = { workspace = true, default-features = false, features = ["default-rustls", "tracing"] }
+chrono = { workspace = true, features = ["serde"] }
 parking_lot = { workspace = true }
-hashbrown = { workspace = true }
+hashbrown = { workspace = true, features = ["serde", "rayon"] }
 arc-swap = { workspace = true }
 metrics = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion = { workspace = true, features = ["html_reports"] }
 tempfile = { workspace = true }
 rcgen = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
 
 [[bench]]
 name = "queue_store_benchmark"

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -28,10 +28,10 @@ documentation = "https://docs.rs/rustfs-test-utils/latest/rustfs_test_utils/"
 [dependencies]
 rustfs-ecstore = { workspace = true }
 rustfs-storage-api = { workspace = true }
-tokio = { workspace = true, features = ["fs", "rt"] }
-tokio-util = { workspace = true }
-tracing-subscriber = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
+tokio = { workspace = true, features = ["fs", "rt", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["io", "compat"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 [lints]
 workspace = true

--- a/crates/tls-runtime/Cargo.toml
+++ b/crates/tls-runtime/Cargo.toml
@@ -32,7 +32,7 @@ rustfs-common.workspace = true
 rustfs-config.workspace = true
 arc-swap.workspace = true
 metrics.workspace = true
-rustls.workspace = true
+rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
 rustls-pki-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
@@ -42,9 +42,9 @@ tracing.workspace = true
 
 [dev-dependencies]
 rcgen.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
 
 [lib]
 doctest = false

--- a/crates/trusted-proxies/Cargo.toml
+++ b/crates/trusted-proxies/Cargo.toml
@@ -28,23 +28,23 @@ categories = ["network-programming", "security", "web-programming"]
 async-trait = { workspace = true }
 axum = { workspace = true }
 http = { workspace = true }
-ipnetwork = { workspace = true }
+ipnetwork = { workspace = true, features = ["serde"] }
 metrics = { workspace = true }
 moka = { workspace = true, features = ["future", "sync"] }
-reqwest = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
 rustfs-config = { workspace = true }
 rustfs-utils = { workspace = true, features = ["net"] }
-serde.workspace = true
-serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "test-util"] }
-tower = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "test-util", "fs"] }
+tower = { workspace = true, features = ["timeout"] }
 tracing = { workspace = true }
 regex = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full", "test-util"] }
-tower = { workspace = true, features = ["util"] }
+tokio = { workspace = true, features = ["full", "test-util", "fs", "rt-multi-thread"] }
+tower = { workspace = true, features = ["util", "timeout"] }
 serial_test = { workspace = true }
 temp-env = { workspace = true }
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -28,7 +28,7 @@ categories = ["web-programming", "development-tools", "cryptography"]
 base64-simd = { workspace = true, optional = true }
 blake2 = { workspace = true, optional = true }
 brotli = { workspace = true, optional = true }
-bytes = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true, features = ["serde"] }
 crc-fast = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
@@ -36,21 +36,21 @@ hex-simd = { workspace = true, optional = true }
 highway = { workspace = true, optional = true }
 hmac = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
-hyper = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true, features = ["http2", "http1", "server"] }
 local-ip-address = { workspace = true, optional = true }
 lz4 = { workspace = true, optional = true }
 md-5 = { workspace = true, optional = true }
 netif = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
-rustix = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+rustix = { workspace = true, optional = true, features = ["fs"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
 sha1 = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 convert_case = { workspace = true, optional = true }
 siphasher = { workspace = true, optional = true }
 snap = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["io-util", "macros"] }
+tokio = { workspace = true, optional = true, features = ["io-util", "macros", "fs", "rt-multi-thread"] }
 tracing = { workspace = true }
 transform-stream = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
@@ -58,7 +58,7 @@ zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
 temp-env = { workspace = true }
 proptest = "1"
 

--- a/crates/zip/Cargo.toml
+++ b/crates/zip/Cargo.toml
@@ -41,7 +41,7 @@ async-compression = { workspace = true, features = [
     "zstd",
     "xz",
 ] }
-tokio = { workspace = true, features = ["fs","io-util","macros"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 tokio-stream = { workspace = true }
 astral-tokio-tar = { workspace = true }
 thiserror = { workspace = true }

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -104,7 +104,7 @@ rustfs-object-data-cache = { workspace = true }
 rustfs-concurrency = { workspace = true }
 rustfs-scanner = { workspace = true }
 tempfile = { workspace = true }
-starshard = { workspace = true }
+starshard = { workspace = true, features = ["rayon", "async", "serde"] }
 
 # Async Runtime and Networking
 async-trait = { workspace = true }
@@ -112,53 +112,53 @@ axum.workspace = true
 futures.workspace = true
 futures-lite.workspace = true
 futures-util.workspace = true
-hyper.workspace = true
-hyper-util.workspace = true
+hyper = { workspace = true, features = ["http2", "http1", "server"] }
+hyper-util = { workspace = true, features = ["tokio", "server-auto", "server-graceful", "tracing"] }
 http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
-reqwest = { workspace = true }
-socket2 = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "process", "io-util"] }
-tokio-rustls = { workspace = true }
-aws-sdk-s3 = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+socket2 = { workspace = true, features = ["all"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "process", "io-util", "fs"] }
+tokio-rustls = { workspace = true, default-features = false, features = ["logging", "tls12", "aws-lc-rs"] }
+aws-sdk-s3 = { workspace = true, default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
 tokio-stream.workspace = true
-tokio-util.workspace = true
-tonic = { workspace = true }
-tower.workspace = true
+tokio-util = { workspace = true, features = ["io", "compat"] }
+tonic = { workspace = true, features = ["gzip", "deflate"] }
+tower = { workspace = true, features = ["timeout"] }
 tower-http = { workspace = true, features = ["trace", "compression-full", "cors", "catch-panic", "timeout", "limit", "request-id", "add-extension"] }
 
 # Serialization and Data Formats
 apache-avro = { workspace = true }
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, features = ["serde"] }
 flatbuffers.workspace = true
 rmp-serde.workspace = true
 quick-xml.workspace = true
 rustfs-signer.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
 serde_urlencoded = { workspace = true }
 
 # Cryptography and Security
-rustls = { workspace = true }
+rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
 rustls-pki-types = { workspace = true }
 subtle = { workspace = true }
-jiff = { workspace = true }
-time = { workspace = true, features = ["parsing", "formatting", "serde"] }
+jiff = { workspace = true, features = ["serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "serde", "std", "macros"] }
 
 # Utilities and Tools
 astral-tokio-tar = { workspace = true }
 atoi = { workspace = true }
 atomic_enum = { workspace = true }
-async_zip = { workspace = true }
+async_zip = { workspace = true, default-features = false, features = ["tokio", "deflate"] }
 base64 = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 base64-simd.workspace = true
-clap = { workspace = true }
-const-str = { workspace = true }
-datafusion = { workspace = true, features = ["parquet", "recursive_protection", "sql"] }
+clap = { workspace = true, features = ["derive", "env"] }
+const-str = { workspace = true, features = ["std", "proc"] }
+datafusion = { workspace = true, default-features = false, features = ["parquet", "recursive_protection", "sql"] }
 hex-simd.workspace = true
 matchit = { workspace = true }
 md5.workspace = true
@@ -167,18 +167,18 @@ percent-encoding = { workspace = true }
 pin-project-lite.workspace = true
 parking_lot = { workspace = true }
 rust-embed = { workspace = true, features = ["interpolate-folder-path"] }
-s3s.workspace = true
-shadow-rs = { workspace = true, features = ["build", "metadata"] }
+s3s = { workspace = true, features = ["minio"] }
+shadow-rs = { workspace = true, default-features = false, features = ["build", "metadata"] }
 sysinfo = { workspace = true, features = ["multithread"] }
 thiserror = { workspace = true }
 tracing.workspace = true
 url = { workspace = true }
 urlencoding = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 zip = { workspace = true }
 libc = { workspace = true }
-rand = { workspace = true }
-aes-gcm = { workspace = true }
+rand = { workspace = true, features = ["serde"] }
+aes-gcm = { workspace = true, features = ["rand_core"] }
 chacha20poly1305 = { workspace = true }
 
 # Observability and Metrics
@@ -186,7 +186,7 @@ metrics = { workspace = true }
 opentelemetry = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 # Data structures
-hashbrown = { workspace = true }
+hashbrown = { workspace = true, features = ["serde", "rayon"] }
 mimalloc = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -196,17 +196,17 @@ libsystemd.workspace = true
 libmimalloc-sys = { version = "0.1.49", features = ["extended"] }
 
 [dev-dependencies]
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 aws-config = { workspace = true }
 anyhow = { workspace = true }
-insta = { workspace = true }
+insta = { workspace = true, features = ["yaml", "json"] }
 proptest = "1"
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "fs", "rt-multi-thread"] }
 temp-env = { workspace = true, features = ["async_closure"] }
-tracing-subscriber = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 rsa = { workspace = true }
 rcgen = { workspace = true }
 # Enables the shared MockWarmBackend / xl.meta assertion helpers exposed via
@@ -216,11 +216,12 @@ rustfs-ecstore = { workspace = true, features = ["test-util"] }
 [build-dependencies]
 http.workspace = true
 futures.workspace = true
-s3s = { workspace = true }
-clap = { workspace = true }
+s3s = { workspace = true, features = ["minio"] }
+clap = { workspace = true, features = ["derive", "env"] }
 hyper-util = { workspace = true, features = [
     "tokio",
     "server-auto",
     "server-graceful",
+    "tracing",
 ] }
-shadow-rs = { workspace = true, features = ["build"] }
+shadow-rs = { workspace = true, default-features = false, features = ["build"] }


### PR DESCRIPTION
## Related Issues
https://github.com/rustfs/backlog/issues/1292

## Summary of Changes
- Move workspace-level dependency feature lists into the member crates that consume each dependency so each crate declares the features it relies on directly.
- Keep `default-features = false` at the workspace root where Cargo requires it for inherited dependencies.
- Refresh dependencies with `cargo update --verbose` and `cargo upgrade --exclude ratelimit --verbose`, which updates `starshard` from `2.2.1` to `2.2.2` while keeping `ratelimit` excluded.
- Compare the effective dependency feature graph before and after the change; no member dependency feature/default-feature differences were introduced by the feature-localization step.

## Verification
- `cargo update --verbose`
- `cargo upgrade --exclude ratelimit --verbose`
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --workspace --all-targets`
- `cargo shear --locked --deny-warnings`
- Compared `cargo metadata --no-deps` and normalized `cargo tree -e features --workspace --prefix none` output against the parent commit.
- Ran the mechanical-change correctness adversary: attacked root feature residue, missing member-local features including target-specific dependencies, and manifest/build parseability; no break found.

## Impact
- No intended runtime behavior change from feature localization; the effective member dependency feature graph is preserved.
- The dependency refresh updates `starshard` to `2.2.2` and updates its lockfile transitive resolution.
- Root workspace dependencies are now easier to audit because they carry versions/sources plus required `default-features = false`, while feature lists live with the consuming crates.

## Additional Notes
- This PR is opened as a draft because the full `make pre-commit` gate has not been run for the dependency-manifest-only change. Focused verification passed and is listed above.
- Follow-up candidates found during analysis: remove redundant `tokio/full` plus child-feature declarations, and evaluate narrower `rustfs-utils` feature sets for crates that still use `rustfs-utils/full`.
