### PR TITLE
chore(deps): simplify dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11600,7 +11600,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/crates/audit/Cargo.toml
+++ b/crates/audit/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["web-programming", "development-tools", "asynchronous", "api-bindi
 
 [dependencies]
 rustfs-targets = { workspace = true }
-rustfs-config = { workspace = true, features = ["audit", "constants", "server-config-model"] }
+rustfs-config = { workspace = true, features = ["audit", "server-config-model"] }
 rustfs-s3-types = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 const-str = { workspace = true, features = ["std", "proc"] }
@@ -37,7 +37,7 @@ metrics = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "rt", "time", "macros"] }
+tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "time", "macros"] }
 tracing = { workspace = true, features = ["std", "attributes"] }
 
 [dev-dependencies]

--- a/crates/credentials/Cargo.toml
+++ b/crates/credentials/Cargo.toml
@@ -31,7 +31,7 @@ rand = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 sha2 = { workspace = true }
-time = { workspace = true, features = ["serde", "parsing", "formatting", "macros", "std"] }
+time = { workspace = true, features = ["serde", "parsing", "formatting", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 
 [dev-dependencies]
 test-case.workspace = true
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 
 [features]
 default = ["crypto", "fips"]

--- a/crates/e2e_test/Cargo.toml
+++ b/crates/e2e_test/Cargo.toml
@@ -57,7 +57,7 @@ http.workspace = true
 http-body-util.workspace = true
 hyper = { workspace = true, features = ["http2", "http1", "server"] }
 hyper-util = { workspace = true, features = ["tokio", "server-auto", "server-graceful", "tracing"] }
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "multipart"] }
 rustfs-signer.workspace = true
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }

--- a/crates/e2e_test/Cargo.toml
+++ b/crates/e2e_test/Cargo.toml
@@ -49,7 +49,7 @@ bytes = { workspace = true, features = ["serde"] }
 serial_test = { workspace = true }
 aws-sdk-s3 = { workspace = true, default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }
 aws-config = { workspace = true }
-aws-smithy-http-client = { workspace = true, default-features = false, features = ["default-client", "rustls-aws-lc"] }
+aws-smithy-http-client = { workspace = true, default-features = false, features = ["rustls-aws-lc"] }
 async-compression = { workspace = true, features = ["tokio", "bzip2", "xz"] }
 async-trait = { workspace = true }
 flate2.workspace = true
@@ -72,8 +72,8 @@ sha2 = { workspace = true }
 astral-tokio-tar = { workspace = true }
 s3s = { workspace = true, features = ["minio"] }
 zstd.workspace = true
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
-suppaftp = { workspace = true, features = ["tokio", "rustls-aws-lc-rs", "tokio-rustls-aws-lc-rs"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
+suppaftp = { workspace = true, features = ["rustls-aws-lc-rs", "tokio-rustls-aws-lc-rs"] }
 rcgen.workspace = true
 local-ip-address.workspace = true
 anyhow.workspace = true

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -122,7 +122,7 @@ libc.workspace = true
 # (backlog#1178); "fs" comes from the workspace default.
 rustix = { workspace = true, features = ["process", "fs"] }
 rustfs-madmin.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "http2", "system-proxy"] }
 aes-gcm = { workspace = true, features = ["rand_core"] }
 chacha20poly1305.workspace = true
 aws-sdk-s3 = { workspace = true, default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"] }

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -49,7 +49,7 @@ rustfs-signer.workspace = true
 rustfs-storage-api.workspace = true
 rustfs-tls-runtime.workspace = true
 rustfs-checksums.workspace = true
-rustfs-config = { workspace = true, features = ["constants", "notify", "audit", "server-config-model"] }
+rustfs-config = { workspace = true, features = ["notify", "audit", "server-config-model"] }
 rustfs-concurrency.workspace = true
 rustfs-credentials = { workspace = true }
 rustfs-common.workspace = true
@@ -73,7 +73,7 @@ futures-util.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 serde = { workspace = true, features = ["derive"] }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 bytesize.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 quick-xml = { workspace = true, features = ["serialize", "async-tokio"] }
@@ -141,7 +141,7 @@ google-cloud-auth = { workspace = true }
 aws-config = { workspace = true }
 faster-hex = { workspace = true }
 ratelimit = { workspace = true }
-aws-smithy-http-client = { workspace = true, default-features = false, features = ["default-client", "rustls-aws-lc"] }
+aws-smithy-http-client = { workspace = true, default-features = false, features = ["rustls-aws-lc"] }
 
 # Observability and Metrics
 metrics = { workspace = true }

--- a/crates/filemeta/Cargo.toml
+++ b/crates/filemeta/Cargo.toml
@@ -35,7 +35,7 @@ crc-fast = { workspace = true }
 rmp.workspace = true
 rmp-serde.workspace = true
 serde = { workspace = true, features = ["derive"] }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 uuid = { workspace = true, features = ["v4", "fast-rng", "serde", "macro-diagnostics"] }
 tokio = { workspace = true, features = ["io-util", "macros", "sync", "fs", "rt-multi-thread"] }
 xxhash-rust = { workspace = true, features = ["xxh64", "xxh3"] }

--- a/crates/iam/Cargo.toml
+++ b/crates/iam/Cargo.toml
@@ -51,7 +51,7 @@ rustfs-utils = { workspace = true, features = ["path"] }
 rustfs-io-metrics.workspace = true
 tokio-util = { workspace = true, features = ["io", "compat"] }
 pollster.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "http2", "system-proxy"] }
 moka = { workspace = true, features = ["future"] }
 openidconnect = { workspace = true, default-features = false, features = ["accept-rfc3339-timestamps"] }
 http = { workspace = true }

--- a/crates/iam/Cargo.toml
+++ b/crates/iam/Cargo.toml
@@ -30,9 +30,9 @@ workspace = true
 
 [dependencies]
 rustfs-credentials = { workspace = true }
-rustfs-config = { workspace = true, features = ["constants", "server-config-model"] }
+rustfs-config = { workspace = true, features = ["server-config-model"] }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
-time = { workspace = true, features = ["serde-human-readable", "std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["serde-human-readable", "macros"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 rustfs-ecstore = { workspace = true }
 rustfs-storage-api = { workspace = true }

--- a/crates/io-core/Cargo.toml
+++ b/crates/io-core/Cargo.toml
@@ -30,7 +30,7 @@ workspace = true
 [dependencies]
 bytes = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "fs", "rt", "sync", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "fs", "sync", "rt-multi-thread"] }
 memmap2 = { workspace = true }
 rustfs-io-metrics = { workspace = true }
 tracing = { workspace = true }

--- a/crates/io-metrics/Cargo.toml
+++ b/crates/io-metrics/Cargo.toml
@@ -33,14 +33,14 @@ metrics = { workspace = true }
 rustfs-s3-ops = { workspace = true }
 num_cpus = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "rt", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread"] }
 tracing = { workspace = true }
 sysinfo = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
 metrics-util = { version = "0.20", features = ["debugging"] }
-tokio = { workspace = true, features = ["test-util", "rt", "macros", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["test-util", "macros", "fs", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -26,8 +26,8 @@ categories = ["authentication", "web-programming"]
 authors.workspace = true
 
 [dependencies]
-tokio = { workspace = true, features = ["full"] }
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "http2", "system-proxy", "json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
@@ -48,7 +48,7 @@ bytes = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["test-util", "fs", "macros", "rt", "time"] }
 tower = { workspace = true, features = ["util", "timeout"] }
 hyper = { workspace = true, features = ["server", "http2", "http1"] }
 serde_json = { workspace = true, features = ["raw_value"] }

--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -26,13 +26,13 @@ categories = ["authentication", "web-programming"]
 authors.workspace = true
 
 [dependencies]
-tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["full"] }
 reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 moka = { workspace = true, features = ["future"] }
 rustfs-credentials = { workspace = true }
 rustfs-policy = { workspace = true }

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -30,7 +30,7 @@ workspace = true
 [dependencies]
 # Core dependencies
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["serde", "v4", "fast-rng", "macro-diagnostics"] }
 jiff = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -30,7 +30,7 @@ workspace = true
 [dependencies]
 # Core dependencies
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 uuid = { workspace = true, features = ["serde", "v4", "fast-rng", "macro-diagnostics"] }
 jiff = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
@@ -60,7 +60,7 @@ rustfs-utils = { workspace = true }
 rustfs-security-governance = { workspace = true }
 
 # HTTP client for Vault
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "http2", "system-proxy"] }
 vaultrs = { workspace = true }
 
 [dev-dependencies]

--- a/crates/lifecycle/Cargo.toml
+++ b/crates/lifecycle/Cargo.toml
@@ -32,7 +32,7 @@ rustfs-config = { workspace = true, features = ["constants"] }
 rustfs-replication.workspace = true
 rustfs-storage-api.workspace = true
 s3s = { workspace = true, features = ["minio"] }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }
@@ -41,7 +41,7 @@ uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnos
 proptest = "1"
 serial_test.workspace = true
 temp-env.workspace = true
-tokio = { workspace = true, features = ["macros", "rt", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "fs", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/madmin/Cargo.toml
+++ b/crates/madmin/Cargo.toml
@@ -35,7 +35,7 @@ hyper = { workspace = true, features = ["http2", "http1", "server"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 sysinfo.workspace = true
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 
 [lib]
 doctest = false

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -26,7 +26,7 @@ categories = ["web-programming", "development-tools", "filesystem"]
 documentation = "https://docs.rs/rustfs-notify/latest/rustfs_notify/"
 
 [dependencies]
-rustfs-config = { workspace = true, features = ["notify", "constants", "server-config-model"] }
+rustfs-config = { workspace = true, features = ["notify", "server-config-model"] }
 rustfs-ecstore = { workspace = true }
 rustfs-s3-types = { workspace = true }
 rustfs-s3-ops = { workspace = true }

--- a/crates/object-capacity/Cargo.toml
+++ b/crates/object-capacity/Cargo.toml
@@ -49,4 +49,4 @@ criterion = { workspace = true, features = ["html_reports"] }
 serial_test = { workspace = true }
 temp-env = { workspace = true, features = ["async_closure"] }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["test-util", "macros", "rt", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["test-util", "macros", "fs", "rt-multi-thread"] }

--- a/crates/object-data-cache/Cargo.toml
+++ b/crates/object-data-cache/Cargo.toml
@@ -34,7 +34,7 @@ moka = { workspace = true, features = ["future"] }
 starshard = { workspace = true, features = ["rayon", "async", "serde"] }
 sysinfo = { workspace = true, features = ["multithread"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync", "rt", "time", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["sync", "time", "fs", "rt-multi-thread"] }
 tracing.workspace = true
 
 [dev-dependencies]
@@ -43,7 +43,7 @@ metrics-util = { version = "0.20", features = ["debugging"] }
 # `rt-multi-thread` lets the concurrency stress tests run tasks on real worker
 # threads, so they exercise true parallelism on the shared singleflight/index
 # state rather than only cooperative interleaving.
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time", "fs"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "fs"] }
 
 [[bench]]
 name = "cache_bench"

--- a/crates/obs/Cargo.toml
+++ b/crates/obs/Cargo.toml
@@ -99,7 +99,7 @@ tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "tracing-log", "time", "local-time", "json"] }
-tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "time", "macros"] }
+tokio = { workspace = true, features = ["sync", "rt-multi-thread", "time", "macros"] }
 tokio-util = { workspace = true, features = ["io", "compat"] }
 dial9-tokio-telemetry = { workspace = true, optional = true }
 thiserror = { workspace = true }
@@ -115,6 +115,5 @@ libc = { workspace = true }
 
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }
 temp-env = { workspace = true }

--- a/crates/obs/Cargo.toml
+++ b/crates/obs/Cargo.toml
@@ -60,7 +60,7 @@ workspace = true
 [dependencies]
 rustfs-audit = { workspace = true }
 rustfs-common = { workspace = true }
-rustfs-config = { workspace = true, features = ["constants", "observability"] }
+rustfs-config = { workspace = true, features = ["observability"] }
 # NOTE: This dependency on rustfs-ecstore is a known architectural limitation.
 # The obs crate imports types from ecstore for metrics collection.
 # Breaking this dependency would require defining traits in obs and
@@ -98,8 +98,8 @@ tracing = { workspace = true, features = ["std", "attributes"] }
 tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["registry", "std", "fmt", "env-filter", "tracing-log", "time", "local-time", "json"] }
-tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "rt", "time", "macros"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "tracing-log", "time", "local-time", "json"] }
+tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread", "time", "macros"] }
 tokio-util = { workspace = true, features = ["io", "compat"] }
 dial9-tokio-telemetry = { workspace = true, optional = true }
 thiserror = { workspace = true }
@@ -115,6 +115,6 @@ libc = { workspace = true }
 
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["full"] }
 tempfile = { workspace = true }
 temp-env = { workspace = true }

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -30,9 +30,9 @@ workspace = true
 
 [dependencies]
 rustfs-credentials = { workspace = true }
-rustfs-config = { workspace = true, features = ["constants", "opa"] }
-tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
-time = { workspace = true, features = ["serde", "parsing", "formatting", "macros", "std"] }
+rustfs-config = { workspace = true, features = ["opa"] }
+tokio = { workspace = true, features = ["full"] }
+time = { workspace = true, features = ["serde", "parsing", "formatting", "macros"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror.workspace = true

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -31,7 +31,7 @@ workspace = true
 [dependencies]
 rustfs-credentials = { workspace = true }
 rustfs-config = { workspace = true, features = ["opa"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 time = { workspace = true, features = ["serde", "parsing", "formatting", "macros"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["raw_value"] }
@@ -42,7 +42,7 @@ ipnetwork = { workspace = true, features = ["serde"] }
 base64-simd = { workspace = true }
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 regex = { workspace = true }
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "http2", "system-proxy", "json"] }
 chrono = { workspace = true, features = ["serde"] }
 tracing.workspace = true
 moka = { workspace = true, features = ["future"] }

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -79,7 +79,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 
 # Utilities
 async-trait = { workspace = true }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 bytes = { workspace = true, features = ["serde"] }
 
 # S3 API dependencies
@@ -131,7 +131,7 @@ socket2 = { workspace = true, optional = true, features = ["all"] }
 tempfile = { workspace = true }
 proptest = "1"
 tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
-tokio = { workspace = true, features = ["test-util", "macros", "rt", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["test-util", "macros", "fs", "rt-multi-thread"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -33,7 +33,7 @@ rmp.workspace = true
 rmp-serde.workspace = true
 s3s = { workspace = true, features = ["minio"] }
 serde = { workspace = true, features = ["derive"] }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread"] }
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }

--- a/crates/rio/Cargo.toml
+++ b/crates/rio/Cargo.toml
@@ -35,7 +35,7 @@ hotpath = ["dep:hotpath", "hotpath/hotpath"]
 [dependencies]
 hotpath = { workspace = true, optional = true }
 arc-swap.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 rand = { workspace = true, features = ["serde"] }
 http.workspace = true
 aes-gcm = { workspace = true, features = ["rand_core"] }
@@ -43,7 +43,7 @@ crc-fast = { workspace = true }
 pin-project-lite.workspace = true
 serde = { workspace = true, features = ["derive"] }
 bytes = { workspace = true, features = ["serde"] }
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "http2", "system-proxy", "stream"] }
 rustls-pki-types.workspace = true
 tokio-util = { workspace = true, features = ["io", "compat"] }
 faster-hex.workspace = true

--- a/crates/rio/Cargo.toml
+++ b/crates/rio/Cargo.toml
@@ -35,7 +35,7 @@ hotpath = ["dep:hotpath", "hotpath/hotpath"]
 [dependencies]
 hotpath = { workspace = true, optional = true }
 arc-swap.workspace = true
-tokio = { workspace = true, features = ["full", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["full"] }
 rand = { workspace = true, features = ["serde"] }
 http.workspace = true
 aes-gcm = { workspace = true, features = ["rand_core"] }

--- a/crates/scanner/Cargo.toml
+++ b/crates/scanner/Cargo.toml
@@ -33,14 +33,14 @@ workspace = true
 rustfs-config = { workspace = true, features = ["server-config-model"] }
 rustfs-common = { workspace = true }
 rustfs-utils = { workspace = true }
-tokio = { workspace = true, features = ["fs", "sync", "rt", "time", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "sync", "time", "macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 chrono = { workspace = true, features = ["serde"] }
 rmp-serde = { workspace = true }
 rustfs-filemeta = { workspace = true }

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -29,7 +29,7 @@ documentation = "https://docs.rs/rustfs-signer/latest/rustfs_signer/"
 tracing.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 http.workspace = true
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 hyper = { workspace = true, features = ["http2", "http1", "server"] }
 serde_urlencoded.workspace = true
 rustfs-utils = { workspace = true, features = ["full"] }

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -33,13 +33,13 @@ async-trait.workspace = true
 # the underlying wire types can move without creating a replication/storage-api cycle.
 rustfs-filemeta.workspace = true
 serde = { workspace = true, features = ["derive"] }
-time = { workspace = true, features = ["std", "parsing", "formatting", "macros", "serde"] }
+time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
 uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml", "json"] }
 serde_json = { workspace = true, features = ["raw_value"] }
-tokio = { workspace = true, features = ["macros", "rt", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "fs", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/targets/Cargo.toml
+++ b/crates/targets/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming", "development-tools", "filesystem"]
 documentation = "https://docs.rs/rustfs-targets/latest/rustfs_targets/"
 
 [dependencies]
-rustfs-config = { workspace = true, features = ["notify", "constants", "audit", "server-config-model"] }
+rustfs-config = { workspace = true, features = ["notify", "audit", "server-config-model"] }
 rustfs-extension-schema = { workspace = true }
 rustfs-tls-runtime = { workspace = true }
 rustfs-s3-types = { workspace = true }

--- a/crates/targets/Cargo.toml
+++ b/crates/targets/Cargo.toml
@@ -26,7 +26,7 @@ lapin = { workspace = true, default-features = false, features = ["tokio", "rust
 libc = { workspace = true }
 pulsar = { workspace = true, default-features = false, features = ["tokio-rustls-runtime", "telemetry"] }
 regex = { workspace = true }
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "http2", "system-proxy"] }
 rumqttc = { workspace = true, features = ["websocket"] }
 redis = { workspace = true, features = ["connection-manager", "tokio-rustls-comp", "tls-rustls-insecure"] }
 rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -28,7 +28,7 @@ documentation = "https://docs.rs/rustfs-test-utils/latest/rustfs_test_utils/"
 [dependencies]
 rustfs-ecstore = { workspace = true }
 rustfs-storage-api = { workspace = true }
-tokio = { workspace = true, features = ["fs", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 tokio-util = { workspace = true, features = ["io", "compat"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
 uuid = { workspace = true, features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/crates/trusted-proxies/Cargo.toml
+++ b/crates/trusted-proxies/Cargo.toml
@@ -37,13 +37,13 @@ rustfs-utils = { workspace = true, features = ["net"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util", "fs"] }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tower = { workspace = true, features = ["timeout"] }
 tracing = { workspace = true }
 regex = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full", "test-util"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 tower = { workspace = true, features = ["util", "timeout"] }
 serial_test = { workspace = true }
 temp-env = { workspace = true }

--- a/crates/trusted-proxies/Cargo.toml
+++ b/crates/trusted-proxies/Cargo.toml
@@ -31,7 +31,7 @@ http = { workspace = true }
 ipnetwork = { workspace = true, features = ["serde"] }
 metrics = { workspace = true }
 moka = { workspace = true, features = ["future", "sync"] }
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "json"] }
 rustfs-config = { workspace = true }
 rustfs-utils = { workspace = true, features = ["net"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/trusted-proxies/Cargo.toml
+++ b/crates/trusted-proxies/Cargo.toml
@@ -37,13 +37,13 @@ rustfs-utils = { workspace = true, features = ["net"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time", "test-util", "fs"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util", "fs"] }
 tower = { workspace = true, features = ["timeout"] }
 tracing = { workspace = true }
 regex = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full", "test-util", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 tower = { workspace = true, features = ["util", "timeout"] }
 serial_test = { workspace = true }
 temp-env = { workspace = true }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -63,7 +63,7 @@ temp-env = { workspace = true }
 proptest = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows = { workspace = true, optional = true, features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
+windows = { workspace = true, optional = true, features = ["Win32_Storage_FileSystem"] }
 
 [lints]
 workspace = true

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -117,7 +117,7 @@ hyper-util = { workspace = true, features = ["tokio", "server-auto", "server-gra
 http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream", "json", "blocking", "query", "form"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "stream"] }
 socket2 = { workspace = true, features = ["all"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "process", "io-util", "fs"] }
 tokio-rustls = { workspace = true, default-features = false, features = ["logging", "tls12", "aws-lc-rs"] }

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -68,7 +68,7 @@ hotpath = { workspace = true, optional = true }
 rustfs-heal = { workspace = true }
 rustfs-audit = { workspace = true }
 rustfs-common = { workspace = true }
-rustfs-config = { workspace = true, features = ["constants", "notify", "server-config-model"] }
+rustfs-config = { workspace = true, features = ["notify", "server-config-model"] }
 rustfs-crypto = { workspace = true }
 rustfs-credentials = { workspace = true }
 rustfs-ecstore = { workspace = true }
@@ -145,7 +145,7 @@ rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", 
 rustls-pki-types = { workspace = true }
 subtle = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
-time = { workspace = true, features = ["parsing", "formatting", "serde", "std", "macros"] }
+time = { workspace = true, features = ["parsing", "formatting", "serde", "macros"] }
 
 # Utilities and Tools
 astral-tokio-tar = { workspace = true }


### PR DESCRIPTION
## Related Issues

- rustfs/backlog#1292
- Follow-up to #4888

## Summary of Changes

- Remove dependency feature entries that are already implied by other requested features in the same dependency declaration.
- Narrow `tokio` away from `full` in `rustfs-kms`, `rustfs-keystone`, `rustfs-obs`, `rustfs-policy`, `rustfs-rio`, and the remaining `rustfs-trusted-proxies` dev-dependency to the APIs each crate actually uses.
- Narrow direct `reqwest` feature declarations per consuming crate, keeping transport behavior features (`rustls`, `http2`, `system-proxy`) local to each crate while retaining API features such as `json`, `stream`, `charset`, and `multipart` only where they are used.
- Keep broad `rustfs-utils/full` declarations unchanged because those require separate code-level narrowing.

## Verification

- `cargo update --verbose`
- `cargo upgrade --exclude ratelimit --verbose`
- `cargo metadata --format-version 1`
- Resolved Cargo feature graph comparison against the pre-cleanup manifest state before the narrowing pass: `resolved feature differences: 0`
- Redundant same-crate feature implication scan after the first cleanup: `remaining implication redundancies: 0`
- `cargo metadata --no-deps --format-version 1`
- Same-crate feature implication scan after the trusted-proxies pass: `same-crate feature implication redundancies: 0`
- `cargo check -p rustfs-kms --all-targets`
- `cargo check -p rustfs-keystone --all-targets`
- `cargo check -p rustfs-trusted-proxies --all-targets`
- `cargo check --workspace --all-targets`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo shear --locked --deny-warnings`
- `make pre-pr`

## Impact

- Dependency manifests are more explicit about each crate's actual async and HTTP client surface.
- TLS, HTTP/2, and system proxy behavior remains enabled for direct reqwest users to avoid changing outbound transport semantics.
- `crates/e2e_test` now declares `reqwest/multipart` directly instead of relying on another dependency to enable that API feature.
- Removing the remaining `tokio/full` use also drops an unnecessary `tokio` lockfile edge on `parking_lot`.

## Additional Notes

- `make pre-pr` passed after the initial cleanup. It reported a macOS linker warning and one nextest leaky marker, but the gate exited successfully with all tests passing.
- After the Tokio and reqwest narrowing passes, focused package checks, `cargo check --workspace --all-targets`, formatting, diff whitespace checks, and cargo-shear all passed.
