### PR TITLE
chore(deps): remove redundant obs tracing feature

### DIFF
--- a/crates/obs/Cargo.toml
+++ b/crates/obs/Cargo.toml
@@ -98,7 +98,7 @@ tracing = { workspace = true, features = ["std", "attributes"] }
 tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "tracing-log", "time", "local-time", "json"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "tracing-log", "local-time", "json"] }
 tokio = { workspace = true, features = ["sync", "rt-multi-thread", "time", "macros"] }
 tokio-util = { workspace = true, features = ["io", "compat"] }
 dial9-tokio-telemetry = { workspace = true, optional = true }


### PR DESCRIPTION
## Related Issues

- rustfs/backlog#1292
- Follow-up to #4890

## Summary of Changes

- Remove the redundant `tracing-subscriber/time` feature from `rustfs-obs`.
- Keep `tracing-subscriber/local-time`, which already enables `time` in the same crate feature graph.

## Verification

- `cargo check -p rustfs-obs --all-targets`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo shear --locked --deny-warnings`
- `obs same-crate feature implication redundancies: 0`

## Impact

- No intended runtime behavior change.
- The `rustfs-obs` manifest no longer repeats a feature already implied by `local-time`.

## Additional Notes

- Other `rustfs-obs` feature declarations were checked. `tokio`, `opentelemetry-otlp`, `opentelemetry_sdk`, `rustix`, `zstd`, and `tracing-subscriber` remaining features map to observed API or behavior usage.
