### PR TITLE
ci: install C build tools before compiling s3s-e2e on custom runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,14 @@ jobs:
       - name: Setup Rust toolchain for s3s-e2e installation
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      # The sm-standard-* custom runner images (introduced in #4884) ship no C
+      # toolchain, unlike GitHub-hosted ubuntu-latest. Installing s3s-e2e below
+      # compiles it from source on a cache miss, and build scripts need cc.
+      - name: Install build tools for s3s-e2e compilation
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake pkg-config libssl-dev
+
       - name: Install s3s-e2e test tool
         uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # v2
         with:


### PR DESCRIPTION
## Problem

**End-to-End Tests (rio-v2)** fails on every PR and on main since #4884 switched CI to custom runners:

```
error: linker `cc` not found
error: failed to compile `s3s-e2e v0.14.0-dev (...)`
```

Evidence: [failing job on PR #4876](https://github.com/rustfs/rustfs/actions/runs/29473927763/job/87544336202); the latest completed main run ([29470109187](https://github.com/rustfs/rustfs/actions/runs/29470109187)) fails the same lane.

## Root cause

`e2e-tests-rio-v2` is the only compile-anything job that does **not** go through `.github/actions/setup` (which installs `build-essential`); it uses a bare `dtolnay/rust-toolchain` step. That was fine on GitHub-hosted `ubuntu-latest` images, which preinstall a C toolchain, but the `sm-standard-2` custom runner image ships none — so when `taiki-e/cache-cargo-install-action` misses its cache and compiles `s3s-e2e` from source, every build script fails at the linker.

## Fix

Add one apt step before the s3s-e2e install: `build-essential cmake pkg-config libssl-dev` — the C-toolchain subset of what the shared setup action installs, plus `cmake` which some TLS-stack `-sys` crates require and which was also only present by virtue of the GitHub-hosted image. Deliberately not switching the job to the full setup action: this job only needs to compile one external tool, not the workspace (no protoc/flatc/musl needed).

## Verification

CI on this PR exercises the changed job directly — **End-to-End Tests (rio-v2)** passing here is the end-to-end proof, since the tool cache was never populated on the new runners (the compile failed every time).