### PR TITLE
chore(deps): tighten crate dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5044,7 +5044,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
 ]
 
 [[package]]

--- a/crates/ecstore/Cargo.toml
+++ b/crates/ecstore/Cargo.toml
@@ -103,7 +103,7 @@ hex-simd = { workspace = true }
 tempfile.workspace = true
 hyper = { workspace = true, features = ["http2", "http1", "server"] }
 hyper-util = { workspace = true, features = ["tokio", "server-auto", "server-graceful", "tracing"] }
-hyper-rustls = { workspace = true, default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs", "webpki-roots"] }
+hyper-rustls = { workspace = true, default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs"] }
 rustls = { workspace = true, default-features = false, features = ["aws-lc-rs", "logging", "tls12", "prefer-post-quantum", "std"] }
 rustls-pki-types.workspace = true
 tokio = { workspace = true, features = ["io-util", "sync", "signal", "fs", "rt-multi-thread"] }

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -67,7 +67,7 @@ rustfs-storage-api = { workspace = true }
 rustfs-tls-runtime = { workspace = true, optional = true }
 
 # Async dependencies
-tokio = { workspace = true, features = ["fs", "io-util", "sync", "time", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "io-util", "net", "rt", "sync", "time"] }
 tracing = { workspace = true }
 futures-util = { workspace = true }
 
@@ -131,7 +131,7 @@ socket2 = { workspace = true, optional = true, features = ["all"] }
 tempfile = { workspace = true }
 proptest = "1"
 tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
-tokio = { workspace = true, features = ["test-util", "macros", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["test-util", "macros", "fs"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/replication/Cargo.toml
+++ b/crates/replication/Cargo.toml
@@ -34,7 +34,7 @@ rmp-serde.workspace = true
 s3s = { workspace = true, features = ["minio"] }
 serde = { workspace = true, features = ["derive"] }
 time = { workspace = true, features = ["parsing", "formatting", "macros", "serde"] }
-tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["sync"] }
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }
 

--- a/crates/targets/Cargo.toml
+++ b/crates/targets/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = { workspace = true }
 async-nats = { workspace = true }
 deadpool-postgres = { workspace = true }
 hyper = { workspace = true, features = ["http2", "http1", "server"] }
-hyper-rustls = { workspace = true, default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs", "webpki-roots"] }
+hyper-rustls = { workspace = true, default-features = false, features = ["native-tokio", "tls12", "logging", "aws-lc-rs"] }
 lapin = { workspace = true, default-features = false, features = ["tokio", "rustls", "rustls--aws_lc_rs"] }
 libc = { workspace = true }
 pulsar = { workspace = true, default-features = false, features = ["tokio-rustls-runtime", "telemetry"] }

--- a/crates/targets/Cargo.toml
+++ b/crates/targets/Cargo.toml
@@ -19,7 +19,7 @@ rustfs-s3-types = { workspace = true }
 rustfs-utils = { workspace = true, features = ["egress"] }
 async-trait = { workspace = true }
 async-nats = { workspace = true }
-deadpool-postgres = { workspace = true, features = ["rt_tokio_1"] }
+deadpool-postgres = { workspace = true }
 hyper = { workspace = true, features = ["http2", "http1", "server"] }
 hyper-rustls = { workspace = true, default-features = false, features = ["native-tokio", "http1", "tls12", "logging", "http2", "aws-lc-rs", "webpki-roots"] }
 lapin = { workspace = true, default-features = false, features = ["tokio", "rustls", "rustls--aws_lc_rs"] }

--- a/crates/tls-runtime/Cargo.toml
+++ b/crates/tls-runtime/Cargo.toml
@@ -37,14 +37,14 @@ rustls-pki-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["fs", "rt", "sync", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]
 rcgen.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["macros", "rt", "fs"] }
 
 [lib]
 doctest = false

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -50,7 +50,7 @@ convert_case = { workspace = true, optional = true }
 siphasher = { workspace = true, optional = true }
 snap = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["io-util", "macros", "fs", "rt-multi-thread"] }
+tokio = { workspace = true, optional = true, features = ["io-util", "time"] }
 tracing = { workspace = true }
 transform-stream = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
@@ -58,7 +58,7 @@ zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 temp-env = { workspace = true }
 proptest = "1"
 

--- a/crates/utils/src/compress.rs
+++ b/crates/utils/src/compress.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Write;
+use std::io::{self, Write};
 use std::{fmt, str};
-use tokio::io;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum CompressionAlgorithm {


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1292

## Summary of Changes
- Narrow direct Tokio features in `rustfs-protocols`, `rustfs-tls-runtime`, `rustfs-utils`, and `rustfs-replication` to the features used by their current code paths.
- Move `rustfs-utils` compression helpers from `tokio::io` to `std::io` so the optional `compress` feature no longer pulls Tokio for error/result aliases.
- Remove redundant direct `deadpool-postgres/rt_tokio_1` from `rustfs-targets` because it is already enabled by the dependency default features.
- Trim direct `hyper-rustls` features: `rustfs-targets` now keeps only native roots, TLS 1.2, logging, and the aws-lc-rs provider features needed by MQTT TLS config construction; `rustfs-ecstore` keeps HTTP/1 and HTTP/2 connector support but drops unused `webpki-roots`.

## Verification
- `cargo check -p rustfs-utils --no-default-features --features io,net,compress --all-targets --target-dir /private/tmp/rustfs-check-utils`
- `cargo check -p rustfs-replication --all-targets --target-dir /private/tmp/rustfs-check-replication`
- `cargo check -p rustfs-tls-runtime --all-targets --target-dir /private/tmp/rustfs-check-tls-runtime`
- `cargo check -p rustfs-protocols --all-features --all-targets --target-dir /private/tmp/rustfs-check-protocols`
- `cargo check -p rustfs-targets --all-targets --target-dir /private/tmp/rustfs-check-targets-after`
- `cargo check -p rustfs-ecstore --all-targets --target-dir /private/tmp/rustfs-check-protocols`
- `cargo check -p rustfs-utils --all-features --all-targets --target-dir /private/tmp/rustfs-check-utils`
- `cargo check -p rustfs-targets --all-targets --target-dir /private/tmp/rustfs-check-targets-hyper-rustls`
- `cargo check -p rustfs-ecstore --all-targets --target-dir /private/tmp/rustfs-check-ecstore-hyper-rustls`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo shear --locked --deny-warnings`
- `make pre-pr`

## Impact
Build and dependency feature surface only. No runtime behavior change is expected; TLS provider, TLS 1.2 compatibility, TLS logging, native root loading, and the HTTP protocol support required by existing direct call sites are preserved.

## Additional Notes
The final `make pre-pr` run passed, including 8971 nextest tests and doctests. It emitted only the existing macOS linker `__eh_frame section too large` warning during test builds.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
