### PR TITLE
chore(release): prepare 1.0.0-beta.10-preview.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -8805,7 +8805,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8936,7 +8936,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8958,7 +8958,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -8973,7 +8973,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "chrono",
  "metrics",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "insta",
  "rustfs-io-core",
@@ -9000,7 +9000,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "const-str",
  "serde",
@@ -9009,7 +9009,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9022,7 +9022,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9042,7 +9042,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -9053,7 +9053,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "aes-gcm",
  "async-channel",
@@ -9187,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -9196,7 +9196,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9252,7 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "bytes",
  "memmap2",
@@ -9301,7 +9301,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "criterion",
  "metrics",
@@ -9364,7 +9364,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "bytes",
  "futures",
@@ -9390,7 +9390,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9421,7 +9421,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "proptest",
@@ -9441,7 +9441,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9462,7 +9462,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "chrono",
  "humantime",
@@ -9476,7 +9476,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9508,7 +9508,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "criterion",
  "futures",
@@ -9526,7 +9526,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -9542,7 +9542,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9594,7 +9594,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9623,7 +9623,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -9682,7 +9682,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "flatbuffers",
  "prost 0.14.4",
@@ -9700,7 +9700,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "byteorder",
  "bytes",
@@ -9717,7 +9717,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9755,7 +9755,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -9777,14 +9777,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "rustfs-s3-types",
 ]
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -9792,7 +9792,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9819,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9835,7 +9835,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9867,14 +9867,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9890,7 +9890,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "insta",
@@ -9904,7 +9904,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -9954,7 +9954,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "rustfs-ecstore",
  "rustfs-storage-api",
@@ -9966,7 +9966,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "arc-swap",
  "metrics",
@@ -9986,7 +9986,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -10022,7 +10022,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10061,7 +10061,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.96.0"
-version = "1.0.0-beta.9"
+version = "1.0.0-beta.10-preview.1"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -85,51 +85,51 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.9" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.9" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.9" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.9" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.9" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.9" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.9" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.9" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.9" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.9" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.9" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.9" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.9" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.9" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.9" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.9" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.9" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.9" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.9" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.9" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.9" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.9" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.9" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.9" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.9" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.9" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.9" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.9" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.9" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.9" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.9" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.9" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.9" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.9" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.9" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.9" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.9" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.9" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.9" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.9" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.9" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.9" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.9" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.9" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.9" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.10-preview.1" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.10-preview.1" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.10-preview.1" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.10-preview.1" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.10-preview.1" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.10-preview.1" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.10-preview.1" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.10-preview.1" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.10-preview.1" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.10-preview.1" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.10-preview.1" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.10-preview.1" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.10-preview.1" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.10-preview.1" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.10-preview.1" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.10-preview.1" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.10-preview.1" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.10-preview.1" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.10-preview.1" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.10-preview.1" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.10-preview.1" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.10-preview.1" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.10-preview.1" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.10-preview.1" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.10-preview.1" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.10-preview.1" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.10-preview.1" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.10-preview.1" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.10-preview.1" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.10-preview.1" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.10-preview.1" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.10-preview.1" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.10-preview.1" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.10-preview.1" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.10-preview.1" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.10-preview.1" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.10-preview.1" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.10-preview.1" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.10-preview.1" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.10-preview.1" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.10-preview.1" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.10-preview.1" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.10-preview.1" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.10-preview.1" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.10-preview.1" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.9
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10-preview.1
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.9
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10-preview.1
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.9";
+            version = "1.0.0-beta.10-preview.1";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.9.0"
-appVersion: "1.0.0-beta.9"
+version: "0.10.0-preview.1"
+appVersion: "1.0.0-beta.10-preview.1"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,13 +1,14 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
+%global prerelease beta.10-preview.1
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.9
+Release:        beta.10.preview.1
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
 URL:            https://github.com/rustfs/rustfs
-Source0:        https://github.com/rustfs/rustfs/archive/refs/tags/%{version}-%{release}.tar.gz
+Source0:        https://github.com/rustfs/rustfs/archive/refs/tags/%{version}-%{prerelease}.tar.gz
 
 BuildRequires: cargo
 BuildRequires: rust
@@ -26,7 +27,7 @@ BuildRequires: clang-devel
 RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. Along with MinIO, it shares a range of advantages such as simplicity, S3 compatibility, open-source nature, support for data lakes, AI, and big data. Furthermore, it has a better and more user-friendly open-source license in comparison to other storage systems, being constructed under the Apache license. As Rust serves as its foundation, RustFS provides faster speed and safer distributed features for high-performance object storage.
 
 %prep 
-%autosetup -n %{name}-%{version}-%{release}
+%autosetup -n %{name}-%{version}-%{prerelease}
 
 %build
 # Set the target directory according to the schema
@@ -49,7 +50,7 @@ CARGO_TARGET_DIR=$TARGET_DIR RUSTFLAGS="-C link-arg=-fuse-ld=mold -C link-arg=-l
 
 %install
 mkdir -p %buildroot/usr/bin/
-install %_builddir/%{name}-%{version}-%{release}/target/%_arch/%_arch-unknown-linux-gnu/release/rustfs %buildroot/usr/bin/
+install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown-linux-gnu/release/rustfs %buildroot/usr/bin/
 
 %files
 %license LICENSE
@@ -57,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{release}/target/%_arch/%_arch-unknown-li
 %_bindir/rustfs
 
 %changelog
+* Thu Jul 16 2026 houseme <housemecn@gmail.com>
+- Update RPM package to RustFS 1.0.0-beta.10-preview.1
+
 * Tue Jul 14 2026 houseme <housemecn@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.9
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Prepare RustFS `1.0.0-beta.10-preview.1` across the workspace package version and internal workspace dependency versions.
- Update release-facing assets: Docker example tags, Nix package version, Helm chart metadata, and RPM spec metadata/changelog.
- Keep RPM package metadata compatible with the preview prerelease by using `Release: beta.10.preview.1` while preserving the source tag prerelease as `beta.10-preview.1`.

## Verification
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`
- `git diff --check`

## Impact
- Updates release metadata and packaging references for `1.0.0-beta.10-preview.1`.
- No runtime behavior change is intended.

## Additional Notes
Adversarial validation focused on release metadata consistency, old-version leftovers, and package-manager version format compatibility; no blockers found.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
