### PR TITLE
ci: drop macOS x86_64 release target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,6 @@ jobs:
             {"target_id":"linux-x86_64-gnu","os":"sm-standard-2","target":"x86_64-unknown-linux-gnu","cross":false,"platform":"linux","rustflags":""},
             {"target_id":"linux-aarch64-gnu","os":"sm-standard-2","target":"aarch64-unknown-linux-gnu","cross":true,"platform":"linux","rustflags":""},
             {"target_id":"macos-aarch64","os":"macos-latest","target":"aarch64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
-            {"target_id":"macos-x86_64","os":"macos-26-intel","target":"x86_64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
             {"target_id":"windows-x86_64","os":"windows-latest","target":"x86_64-pc-windows-msvc","cross":false,"platform":"windows","rustflags":""}
           ]}'
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Removed the `macos-x86_64` entry from the Build and Release platform matrix.
- Official release builds now keep macOS Apple Silicon (`macos-aarch64`) while no longer publishing Intel macOS binaries.

## Verification
- `actionlint .github/workflows/build.yml`
- `git diff --check`
- `rg -n "macos-x86_64|macos-26-intel|x86_64-apple-darwin" .github/workflows/build.yml` returned no matches.
- `rg -o '"target_id":"[^"]+"' .github/workflows/build.yml` confirmed the remaining six target IDs: Linux x86_64/aarch64 musl, Linux x86_64/aarch64 gnu, macOS aarch64, and Windows x86_64.

## Impact
Release and manual full-matrix builds will no longer produce `rustfs-macos-x86_64-*` artifacts. macOS Apple Silicon release artifacts are unchanged. Docker image publishing is unaffected because it consumes Linux artifacts only.

## Additional Notes
Focused workflow validation was used because this PR only changes `.github/workflows/build.yml`; the repository workflow guidance requires `actionlint` for workflow changes, and the regular CI workflow explicitly ignores `build.yml` changes.
