### PR TITLE
feat(helm): flexible drivesPerNode topology with backward-compatible per-pool defaults

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,13 +1,50 @@
 # RustFS Helm Mode
 
-RustFS helm chart supports **standalone and distributed mode**. For standalone mode, there is only one pod and one pvc; for distributed mode, there are two styles, 4 pods and 16 pvcs(each pod has 4 pvcs), 16 pods and 16 pvcs(each pod has 1 pvc). You should decide which mode and style suits for your situation. You can specify the parameters `mode` and `replicaCount` to install different mode and style.
+RustFS helm chart supports **standalone** and **distributed** mode.
 
-- **For standalone mode**: Only one pod and one pvc acts as single node single disk; Specify parameters `mode.standalone.enabled="true",mode.distributed.enabled="false"` to install.
-- **For distributed mode**(**default**): Multiple pods and multiple pvcs, acts as multiple nodes multiple disks, there are two styles:
-    - 4 pods and each pods has 4 pvcs(**default**)
-    - 16 pods and each pods has 1 pvc: Specify parameters `replicaCount` with `--set replicaCount="16"` to install.
+- **Standalone mode**: one pod with one PVC (single node, single disk).
+- **Distributed mode** (**default**): multiple pods with multiple PVCs (multiple nodes, multiple disks).
 
-**NOTE**: Please make sure which mode suits for you situation and specify the right parameter to install rustfs on kubernetes.
+## Distributed topology
+
+The distributed topology is defined by two parameters:
+
+- `replicaCount` — number of pods (nodes) in the StatefulSet.
+- `drivesPerNode` — number of data PVCs mounted on each pod.
+
+Total drives in the cluster = `replicaCount * drivesPerNode`.
+
+When `drivesPerNode` is left unset, the chart automatically infers a
+backward-compatible value:
+
+| `replicaCount` | Inferred `drivesPerNode` | Legacy equivalent |
+|----------------|--------------------------|-------------------|
+| 4              | 4                        | old default 4×4   |
+| anything else  | 1                        | old 16×1, etc.    |
+
+You can override the inference by setting `drivesPerNode` explicitly, e.g.
+`--set drivesPerNode=2` for an 8×2 cluster.
+
+**IMPORTANT**: Kubernetes does **not** allow changes to
+`volumeClaimTemplates` in an existing StatefulSet. If you want to change
+`drivesPerNode` after installation you must delete the StatefulSet
+(with `--cascade=orphan` to keep pods and PVCs) and recreate it, or perform a
+full reinstall.
+
+---
+
+## Upgrade notes
+
+Upgrading from chart versions that did **not** have `drivesPerNode` is safe
+without manual intervention:
+
+- Existing 4×4 deployments (default `replicaCount=4`) continue to receive 4
+  drives per node because the chart infers `drivesPerNode=4`.
+- Existing 16×1 deployments (`replicaCount=16`) continue to receive 1 drive
+  per node because the chart infers `drivesPerNode=1`.
+
+If you previously set `replicaCount=16` and now want a different topology,
+set both `replicaCount` and `drivesPerNode` explicitly.
 
 ---
 
@@ -146,7 +183,8 @@ uer. `ClusterIssuer` or `Issuer`. |
 | readinessProbe.periodSeconds | int | `5` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `3` |  |
-| replicaCount | int | `4` | Number of cluster nodes. |
+| replicaCount | int | `4` | Number of cluster nodes. Distributed mode requires >= 2. |
+| drivesPerNode | int | `null` | Number of data PVCs per pod. Inferred from replicaCount when unset (see Distributed topology above). |
 | resources.limits.cpu | string | `"200m"` |  |
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/helm/README.md
+++ b/helm/README.md
@@ -15,7 +15,8 @@ The distributed topology is defined by two parameters:
 Total drives in the cluster = `replicaCount * drivesPerNode`.
 
 When `drivesPerNode` is left unset, the chart automatically infers a
-backward-compatible value:
+backward-compatible value from each pool's replica count (with pools
+disabled there is a single pool driven by the top-level `replicaCount`):
 
 | `replicaCount` | Inferred `drivesPerNode` | Legacy equivalent |
 |----------------|--------------------------|-------------------|
@@ -171,7 +172,7 @@ uer. `ClusterIssuer` or `Issuer`. |
 | pdb.minAvailable | string | `""` |  |
 | podAnnotations | object | `{}` |  |
 | pools.enabled | bool | `false` | Enable multiple server pools (capacity expansion, distributed mode only). |
-| pools.list | list | `[]` | One entry per pool; entries may set `replicaCount` (4 or 16) and `storageclass`, omitted fields inherit top-level values. Append-only. |
+| pools.list | list | `[]` | One entry per pool; entries may set `replicaCount` (>= 2) and `storageclass`, omitted fields inherit top-level values. Append-only. |
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `10001` |  |
 | podSecurityContext.runAsGroup | int | `10001` |  |
@@ -275,12 +276,12 @@ pools:
   list:
     - {}                  # pool 0: inherits top-level values and keeps the
                           # existing StatefulSet/pod/PVC names and data
-    - replicaCount: 4     # pool 1: new capacity (4 or 16)
+    - replicaCount: 4     # pool 1: new capacity
       storageclass:
         dataStorageSize: 10Gi
 ```
 
-Each entry may set `replicaCount` (4 or 16) and/or a `storageclass` block;
+Each entry may set `replicaCount` (>= 2) and/or a `storageclass` block;
 omitted fields inherit the top-level values. Additional pools render as
 `<fullname>-pool<N>` StatefulSets; all pools share the headless service,
 the main service, the configuration and the credentials.

--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -43,6 +43,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Render extra labels for the main Service resource.
+Merges (in order of increasing precedence):
+  - commonLabels
+  - service.labels
+*/}}
+{{- define "rustfs.serviceLabels" -}}
+{{- $labels := mergeOverwrite (dict) (default (dict) .Values.commonLabels) (default (dict) .Values.service.labels) }}
+{{- if $labels }}
+{{- toYaml $labels }}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "rustfs.selectorLabels" -}}

--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -224,6 +224,10 @@ One volume expression per server pool, joined with spaces (the server splits
 RUSTFS_VOLUMES on spaces, one pool per expression).
 */}}
 {{- define "rustfs.volumes" -}}
+{{- if lt (.Values.replicaCount | int) 1 }}
+{{- fail "distributed mode requires replicaCount >= 1" }}
+{{- end }}
+
 {{- $protocol := "http" -}}
 {{- if .Values.mtls.enabled -}}
   {{- $protocol = "https" -}}

--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -199,6 +199,30 @@ Expects a dict with keys "root" (the chart root context) and "index".
 {{- end }}
 
 {{/*
+Return the number of data drives (PVCs) per pod for a pool.
+When .Values.drivesPerNode is set it applies to every pool. When unset the
+value is inferred per pool from its replica count so that rendered output
+stays identical to the pre-drivesPerNode chart: 4 replicas keep the legacy
+4-drive layout, everything else (16x1 and any new topology) gets one drive.
+Expects a dict with keys "root" (the chart root context) and "replicas".
+*/}}
+{{- define "rustfs.poolDrives" -}}
+{{- if kindIs "invalid" .root.Values.drivesPerNode -}}
+{{- if eq (int .replicas) 4 -}}
+4
+{{- else -}}
+1
+{{- end -}}
+{{- else -}}
+{{- $d := int .root.Values.drivesPerNode -}}
+{{- if lt $d 1 -}}
+{{- fail "drivesPerNode must be >= 1 when set" -}}
+{{- end -}}
+{{- $d -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the normalized list of server pools as JSON.
 With pools disabled this is a single pool built from the top-level
 replicaCount/storageclass values, which keeps all rendered output identical
@@ -219,14 +243,16 @@ so entries must never be removed or reordered.
 {{- range $i, $p := .Values.pools.list -}}
 {{- $p = default (dict) $p -}}
 {{- $replicas := int (default $.Values.replicaCount $p.replicaCount) -}}
-{{- if and (ne $replicas 4) (ne $replicas 16) -}}
-{{- fail (printf "pools.list[%d].replicaCount must be 4 or 16, got %d" $i $replicas) -}}
+{{- if lt $replicas 2 -}}
+{{- fail (printf "pools.list[%d].replicaCount must be >= 2, got %d" $i $replicas) -}}
 {{- end -}}
 {{- $sc := mergeOverwrite (deepCopy $.Values.storageclass) (default (dict) $p.storageclass) -}}
-{{- $pools = append $pools (dict "index" $i "fullname" (include "rustfs.poolFullname" (dict "root" $ "index" $i)) "replicaCount" $replicas "storageclass" $sc) -}}
+{{- $drives := int (include "rustfs.poolDrives" (dict "root" $ "replicas" $replicas)) -}}
+{{- $pools = append $pools (dict "index" $i "fullname" (include "rustfs.poolFullname" (dict "root" $ "index" $i)) "replicaCount" $replicas "drives" $drives "storageclass" $sc) -}}
 {{- end -}}
 {{- else -}}
-{{- $pools = append $pools (dict "index" 0 "fullname" (include "rustfs.fullname" .) "replicaCount" (int .Values.replicaCount) "storageclass" .Values.storageclass) -}}
+{{- $drives := int (include "rustfs.poolDrives" (dict "root" $ "replicas" (int .Values.replicaCount))) -}}
+{{- $pools = append $pools (dict "index" 0 "fullname" (include "rustfs.fullname" .) "replicaCount" (int .Values.replicaCount) "drives" $drives "storageclass" .Values.storageclass) -}}
 {{- end -}}
 {{- toJson $pools -}}
 {{- end }}
@@ -237,12 +263,6 @@ One volume expression per server pool, joined with spaces (the server splits
 RUSTFS_VOLUMES on spaces, one pool per expression).
 */}}
 {{- define "rustfs.volumes" -}}
-{{- $replicas := int .Values.replicaCount -}}
-{{- $drives := int (include "rustfs.drivesPerNode" .) -}}
-{{- if lt $replicas 1 -}}
-{{- fail "rustfs.volumes requires .Values.replicaCount to be >= 1" -}}
-{{- end -}}
-
 {{- $protocol := "http" -}}
 {{- if .Values.mtls.enabled -}}
   {{- $protocol = "https" -}}
@@ -254,8 +274,9 @@ RUSTFS_VOLUMES on spaces, one pool per expression).
 {{- $exprs := list -}}
 {{- range $pool := include "rustfs.pools" . | fromJsonArray -}}
 {{- $n := int $pool.replicaCount -}}
-{{- if eq $n 4 -}}
-{{- $exprs = append $exprs (printf "%s://%s-{0...%d}.%s.%s.svc.%s:%d/data/rustfs{0...%d}" $protocol $pool.fullname (sub $n 1) $headless $ns $domain $port (sub $n 1)) -}}
+{{- $d := int $pool.drives -}}
+{{- if gt $d 1 -}}
+{{- $exprs = append $exprs (printf "%s://%s-{0...%d}.%s.%s.svc.%s:%d/data/rustfs{0...%d}" $protocol $pool.fullname (sub $n 1) $headless $ns $domain $port (sub $d 1)) -}}
 {{- else -}}
 {{- $exprs = append $exprs (printf "%s://%s-{0...%d}.%s.%s.svc.%s:%d/data" $protocol $pool.fullname (sub $n 1) $headless $ns $domain $port) -}}
 {{- end -}}

--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -238,12 +238,9 @@ RUSTFS_VOLUMES on spaces, one pool per expression).
 */}}
 {{- define "rustfs.volumes" -}}
 {{- $replicas := int .Values.replicaCount -}}
-{{- $drives := int .Values.drivesPerNode -}}
+{{- $drives := int (include "rustfs.drivesPerNode" .) -}}
 {{- if lt $replicas 1 -}}
 {{- fail "rustfs.volumes requires .Values.replicaCount to be >= 1" -}}
-{{- end -}}
-{{- if lt $drives 1 -}}
-{{- fail "rustfs.volumes requires .Values.drivesPerNode to be >= 1" -}}
 {{- end -}}
 
 {{- $protocol := "http" -}}

--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -224,9 +224,14 @@ One volume expression per server pool, joined with spaces (the server splits
 RUSTFS_VOLUMES on spaces, one pool per expression).
 */}}
 {{- define "rustfs.volumes" -}}
-{{- if lt (.Values.replicaCount | int) 1 }}
-{{- fail "distributed mode requires replicaCount >= 1" }}
-{{- end }}
+{{- $replicas := int .Values.replicaCount -}}
+{{- $drives := int .Values.drivesPerNode -}}
+{{- if lt $replicas 1 -}}
+{{- fail "rustfs.volumes requires .Values.replicaCount to be >= 1" -}}
+{{- end -}}
+{{- if lt $drives 1 -}}
+{{- fail "rustfs.volumes requires .Values.drivesPerNode to be >= 1" -}}
+{{- end -}}
 
 {{- $protocol := "http" -}}
 {{- if .Values.mtls.enabled -}}

--- a/helm/rustfs/templates/_helpers.tpl
+++ b/helm/rustfs/templates/_helpers.tpl
@@ -237,7 +237,7 @@ RUSTFS_VOLUMES on spaces, one pool per expression).
 {{- $n := int $pool.replicaCount -}}
 {{- if eq $n 4 -}}
 {{- $exprs = append $exprs (printf "%s://%s-{0...%d}.%s.%s.svc.%s:%d/data/rustfs{0...%d}" $protocol $pool.fullname (sub $n 1) $headless $ns $domain $port (sub $n 1)) -}}
-{{- else if eq $n 16 -}}
+{{- else -}}
 {{- $exprs = append $exprs (printf "%s://%s-{0...%d}.%s.%s.svc.%s:%d/data" $protocol $pool.fullname (sub $n 1) $headless $ns $domain $port) -}}
 {{- end -}}
 {{- end -}}

--- a/helm/rustfs/templates/configmap.yaml
+++ b/helm/rustfs/templates/configmap.yaml
@@ -10,9 +10,7 @@ data:
   RUSTFS_ADDRESS: {{ .address | quote }}
   RUSTFS_CONSOLE_ADDRESS: {{ .console_address | quote }}
   RUSTFS_CONSOLE_ENABLE: {{ .console_enable | quote }}
-  {{- if .obs_log_directory }}
   RUSTFS_OBS_LOG_DIRECTORY: {{ .obs_log_directory | quote }}
-  {{- end }}
   RUSTFS_OBS_LOGGER_LEVEL: {{ .log_level | quote }}
   RUSTFS_OBS_ENVIRONMENT: {{ .obs_environment | quote }}
   {{- if .region }}

--- a/helm/rustfs/templates/configmap.yaml
+++ b/helm/rustfs/templates/configmap.yaml
@@ -10,7 +10,9 @@ data:
   RUSTFS_ADDRESS: {{ .address | quote }}
   RUSTFS_CONSOLE_ADDRESS: {{ .console_address | quote }}
   RUSTFS_CONSOLE_ENABLE: {{ .console_enable | quote }}
+  {{- if .obs_log_directory }}
   RUSTFS_OBS_LOG_DIRECTORY: {{ .obs_log_directory | quote }}
+  {{- end }}
   RUSTFS_OBS_LOGGER_LEVEL: {{ .log_level | quote }}
   RUSTFS_OBS_ENVIRONMENT: {{ .obs_environment | quote }}
   {{- if .region }}

--- a/helm/rustfs/templates/configmap.yaml
+++ b/helm/rustfs/templates/configmap.yaml
@@ -19,6 +19,9 @@ data:
   {{- if .domains }}
   RUSTFS_SERVER_DOMAINS: {{ include "rustfs.serverDomains" $ | quote }}
   {{- end }}
+  {{- if .ec.storage_class_standard }}
+  RUSTFS_STORAGE_CLASS_STANDARD: {{ .ec.storage_class_standard | quote }}
+  {{- end }}
   {{- with .log_rotation }}
     {{- if .size }}
   RUSTFS_OBS_LOG_ROTATION_SIZE_MB: {{ .size | quote }}

--- a/helm/rustfs/templates/deployment.yaml
+++ b/helm/rustfs/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
               subPath: ca.crt
             - name: client-cert
               mountPath: /opt/tls/client_cert.pem
-              subPath: client_cert.pem 
+              subPath: client_cert.pem
             - name: client-cert
               mountPath: /opt/tls/client_key.pem
               subPath: client_key.pem

--- a/helm/rustfs/templates/service.yaml
+++ b/helm/rustfs/templates/service.yaml
@@ -42,6 +42,9 @@ metadata:
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if eq $serviceType "ClusterIP" }}
   type: ClusterIP

--- a/helm/rustfs/templates/service.yaml
+++ b/helm/rustfs/templates/service.yaml
@@ -64,6 +64,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: endpoint
       port: {{ .Values.service.endpoint.port }}

--- a/helm/rustfs/templates/service.yaml
+++ b/helm/rustfs/templates/service.yaml
@@ -39,11 +39,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
-    {{- with .Values.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.service.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- with (include "rustfs.serviceLabels" .) }}
+    {{- . | nindent 4 }}
     {{- end }}
 spec:
   {{- if eq $serviceType "ClusterIP" }}

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -1,12 +1,13 @@
 {{- $logDir := .Values.config.rustfs.obs_log_directory }}
 {{- $logDirEnabled := ne $logDir "" }}
-{{- $drivesPerNode := int (include "rustfs.drivesPerNode" .) -}}
+{{- $poolsEnabled := and .Values.pools .Values.pools.enabled }}
 {{- if and .Values.mode.distributed.enabled (le (int .Values.replicaCount) 1) -}}
 {{- fail "Distributed mode requires replicaCount >= 2" -}}
 {{- end -}}
 
 {{- if .Values.mode.distributed.enabled }}
 {{- range $pool := include "rustfs.pools" . | fromJsonArray }}
+{{- $drivesPerNode := int $pool.drives }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -118,7 +119,7 @@ spec:
           image: "{{ $.Values.image.initImage.repository }}:{{ $.Values.image.initImage.tag }}"
           imagePullPolicy: {{ $.Values.image.initImage.pullPolicy }}
           securityContext:
-            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+            {{- toYaml $.Values.containerSecurityContext | nindent 12 }}
           env:
             - name: DRIVES_PER_NODE
               value: {{ $drivesPerNode | quote }}
@@ -248,8 +249,8 @@ spec:
       metadata:
         name: logs
         labels:
-          {{- toYaml .Values.commonLabels | nindent 10 }}
-        {{- $logAnn := .Values.storageclass.pvcAnnotations.logs | default (dict) -}}
+          {{- toYaml $.Values.commonLabels | nindent 10 }}
+        {{- $logAnn := (default (dict) $pool.storageclass.pvcAnnotations).logs | default (dict) -}}
         {{- if gt (len $logAnn) 0 }}
         annotations:
           {{- toYaml $logAnn | nindent 10 }}
@@ -269,7 +270,7 @@ spec:
         name: data-rustfs-{{ $i }}
         labels:
           {{- toYaml $.Values.commonLabels | nindent 10 }}
-        {{- $dataAnn := $.Values.storageclass.pvcAnnotations.data | default (dict) -}}
+        {{- $dataAnn := (default (dict) $pool.storageclass.pvcAnnotations).data | default (dict) -}}
         {{- if gt (len $dataAnn) 0 }}
         annotations:
           {{- toYaml $dataAnn | nindent 10 }}
@@ -287,8 +288,8 @@ spec:
       metadata:
         name: data
         labels:
-          {{- toYaml .Values.commonLabels | nindent 10 }}
-        {{- $dataAnn := .Values.storageclass.pvcAnnotations.data | default (dict) -}}
+          {{- toYaml $.Values.commonLabels | nindent 10 }}
+        {{- $dataAnn := (default (dict) $pool.storageclass.pvcAnnotations).data | default (dict) -}}
         {{- if gt (len $dataAnn) 0 }}
         annotations:
           {{- toYaml $dataAnn | nindent 10 }}

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -118,7 +118,7 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           env:
             - name: DRIVES_PER_NODE
-              value: {{ .Values.drivesPerNode | quote }}
+              value: {{ $drivesPerNode | quote }}
           command:
             - sh
             - -c

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -1,6 +1,9 @@
 {{- $logDir := .Values.config.rustfs.obs_log_directory }}
 {{- $logDirEnabled := ne $logDir "" }}
-{{- $poolsEnabled := and .Values.pools .Values.pools.enabled }}
+{{- $drivesPerNode := int (include "rustfs.drivesPerNode" .) -}}
+{{- if and .Values.mode.distributed.enabled (le (int .Values.replicaCount) 1) -}}
+{{- fail "Distributed mode requires replicaCount >= 2" -}}
+{{- end -}}
 
 {{- if .Values.mode.distributed.enabled }}
 {{- range $pool := include "rustfs.pools" . | fromJsonArray }}
@@ -123,11 +126,11 @@ spec:
             - sh
             - -c
             - |
-              if [ "$REPLICA_COUNT" -eq 4 ]; then
-                for i in $(seq 0 $(($REPLICA_COUNT - 1))); do
+              if [ "$DRIVES_PER_NODE" -gt 1 ]; then
+                for i in $(seq 0 $(($DRIVES_PER_NODE - 1))); do
                   mkdir -p /data/rustfs$i
-                done;
-              elif [ "$REPLICA_COUNT" -eq 16 ]; then
+                done
+              else
                 mkdir -p /data
               fi
               {{- if $logDirEnabled }}
@@ -245,9 +248,12 @@ spec:
       metadata:
         name: logs
         labels:
-          {{- toYaml $.Values.commonLabels | nindent 10 }}
+          {{- toYaml .Values.commonLabels | nindent 10 }}
+        {{- $logAnn := .Values.storageclass.pvcAnnotations.logs | default (dict) -}}
+        {{- if gt (len $logAnn) 0 }}
         annotations:
-          {{- toYaml (.Values.storageclass.pvcAnnotations.logs | default (dict)) | nindent 10 }}
+          {{- toYaml $logAnn | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ $pool.storageclass.name }}
@@ -263,8 +269,11 @@ spec:
         name: data-rustfs-{{ $i }}
         labels:
           {{- toYaml $.Values.commonLabels | nindent 10 }}
+        {{- $dataAnn := $.Values.storageclass.pvcAnnotations.data | default (dict) -}}
+        {{- if gt (len $dataAnn) 0 }}
         annotations:
-          {{- toYaml ($.Values.storageclass.pvcAnnotations.data | default (dict)) | nindent 10 }}
+          {{- toYaml $dataAnn | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ $pool.storageclass.name }}
@@ -278,9 +287,12 @@ spec:
       metadata:
         name: data
         labels:
-          {{- toYaml $.Values.commonLabels | nindent 10 }}
+          {{- toYaml .Values.commonLabels | nindent 10 }}
+        {{- $dataAnn := .Values.storageclass.pvcAnnotations.data | default (dict) -}}
+        {{- if gt (len $dataAnn) 0 }}
         annotations:
-          {{- toYaml (.Values.storageclass.pvcAnnotations.data | default (dict)) | nindent 10 }}
+          {{- toYaml $dataAnn | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ $pool.storageclass.name }}

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -115,10 +115,7 @@ spec:
           image: "{{ $.Values.image.initImage.repository }}:{{ $.Values.image.initImage.tag }}"
           imagePullPolicy: {{ $.Values.image.initImage.pullPolicy }}
           securityContext:
-            {{- toYaml $.Values.containerSecurityContext | nindent 12 }}
-          env:
-            - name: REPLICA_COUNT
-              value: {{ $pool.replicaCount | quote }}
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           command:
             - sh
             - -c

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -116,6 +116,9 @@ spec:
           imagePullPolicy: {{ $.Values.image.initImage.pullPolicy }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          env:
+            - name: DRIVES_PER_NODE
+              value: {{ .Values.drivesPerNode | quote }}
           command:
             - sh
             - -c

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -247,7 +247,7 @@ spec:
         labels:
           {{- toYaml $.Values.commonLabels | nindent 10 }}
         annotations:
-          {{- toYaml $pool.storageclass.pvcAnnotations.logs | nindent 10 }}
+          {{- toYaml (.Values.storageclass.pvcAnnotations.logs | default (dict)) | nindent 10 }}
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ $pool.storageclass.name }}
@@ -264,7 +264,7 @@ spec:
         labels:
           {{- toYaml $.Values.commonLabels | nindent 10 }}
         annotations:
-          {{- toYaml $pool.storageclass.pvcAnnotations.data | nindent 10 }}
+          {{- toYaml ($.Values.storageclass.pvcAnnotations.data | default (dict)) | nindent 10 }}
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ $pool.storageclass.name }}
@@ -280,7 +280,7 @@ spec:
         labels:
           {{- toYaml $.Values.commonLabels | nindent 10 }}
         annotations:
-          {{- toYaml $pool.storageclass.pvcAnnotations.data | nindent 10 }}
+          {{- toYaml (.Values.storageclass.pvcAnnotations.data | default (dict)) | nindent 10 }}
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: {{ $pool.storageclass.name }}

--- a/helm/rustfs/templates/statefulset.yaml
+++ b/helm/rustfs/templates/statefulset.yaml
@@ -135,12 +135,12 @@ spec:
               chmod 755 /mnt/rustfs/logs
               {{- end }}
           volumeMounts:
-            {{- if eq (int $pool.replicaCount) 4 }}
-            {{- range $i := until (int $pool.replicaCount) }}
+            {{- if gt $drivesPerNode 1 }}
+            {{- range $i := until $drivesPerNode }}
             - name: data-rustfs-{{ $i }}
               mountPath: /data/rustfs{{ $i }}
             {{- end }}
-            {{- else if eq (int $pool.replicaCount) 16 }}
+            {{- else }}
             - name: data
               mountPath: /data
             {{- end }}
@@ -201,12 +201,12 @@ spec:
               mountPath: {{ $logDir }}
               subPath: logs
             {{- end }}
-            {{- if eq (int $pool.replicaCount) 4 }}
-            {{- range $i := until (int $pool.replicaCount) }}
+            {{- if gt $drivesPerNode 1 }}
+            {{- range $i := until $drivesPerNode }}
             - name: data-rustfs-{{ $i }}
               mountPath: /data/rustfs{{ $i }}
             {{- end }}
-            {{- else if eq (int $pool.replicaCount) 16 }}
+            {{- else }}
             - name: data
               mountPath: /data
             {{- end }}
@@ -255,8 +255,8 @@ spec:
           requests:
             storage: {{ $pool.storageclass.logStorageSize }}
     {{- end }}
-    {{- if eq (int $pool.replicaCount) 4 }}
-    {{- range $i := until (int $pool.replicaCount) }}
+    {{- if gt $drivesPerNode 1 }}
+    {{- range $i := until $drivesPerNode }}
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
@@ -272,7 +272,7 @@ spec:
           requests:
             storage: {{ $pool.storageclass.dataStorageSize }}
     {{- end }}
-    {{- else if eq (int $pool.replicaCount) 16 }}
+    {{- else }}
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -3,15 +3,24 @@
 # Declare variables to be passed into your templates.
 
 # Number of StatefulSet pods (nodes in the distributed cluster).
+# In distributed mode this must be >= 2 (RustFS requires at least two nodes
+# for an erasure-coded cluster).
 replicaCount: 4
 
 # Number of data drives (PVCs) per pod. Combined with replicaCount this
 # determines the total drive count seen by rustfs.
 # - drivesPerNode > 1: each pod gets N volumes mounted at /data/rustfs0.../data/rustfsN-1
 # - drivesPerNode = 1: each pod gets a single volume mounted at /data
-# Upgrade note: deployments that previously used replicaCount=16 for one drive
-# per pod should now set replicaCount=16 and drivesPerNode=1 explicitly.
-drivesPerNode: 4
+#
+# When left unset (null) the chart infers a backward-compatible value:
+#   replicaCount = 4  -> drivesPerNode = 4  (legacy default)
+#   replicaCount != 4 -> drivesPerNode = 1  (legacy 16x1 and any other topology)
+#
+# WARNING: changing drivesPerNode on an existing StatefulSet is not allowed
+# because Kubernetes forbids updates to volumeClaimTemplates. To change the
+# drive count you must delete the StatefulSet (with --cascade=orphan to keep
+# pods/PVCs) and recreate it, or perform a full reinstall.
+drivesPerNode: null
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -108,8 +108,6 @@ config:
     console_enable: "true"
     console_address: ":9001"
     region: "us-east-1"
-    obs_log_directory: "/logs" # Set to "" to disable log PVCs and mounts.
-    obs_environment: "development"
     # Optionally enable support for virtual-hosted-style requests.
     # See more information: https://docs.rustfs.com/integration/virtual.html
     domains: "" # e.g. "example.com"

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -12,7 +12,8 @@ replicaCount: 4
 # - drivesPerNode > 1: each pod gets N volumes mounted at /data/rustfs0.../data/rustfsN-1
 # - drivesPerNode = 1: each pod gets a single volume mounted at /data
 #
-# When left unset (null) the chart infers a backward-compatible value:
+# When left unset (null) the chart infers a backward-compatible value per
+# pool from that pool's replica count:
 #   replicaCount = 4  -> drivesPerNode = 4  (legacy default)
 #   replicaCount != 4 -> drivesPerNode = 1  (legacy 16x1 and any other topology)
 #
@@ -21,6 +22,13 @@ replicaCount: 4
 # drive count you must delete the StatefulSet (with --cascade=orphan to keep
 # pods/PVCs) and recreate it, or perform a full reinstall.
 drivesPerNode: null
+
+# Kubernetes cluster DNS domain used to build in-cluster FQDNs for
+# RUSTFS_VOLUMES (distributed mode) and mTLS server certificate SANs.
+# Override this only if your cluster does not use the default `cluster.local`
+# (for example, on-premise clusters configured with a custom domain).
+# Provide the DNS root only, without a `svc.` prefix or leading/trailing dots.
+clusterDomain: cluster.local
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
@@ -70,7 +78,7 @@ mode:
 # With pools.enabled=true, one StatefulSet is rendered per entry of
 # pools.list and RUSTFS_VOLUMES contains every pool's volume expression
 # (space separated), which is how the server discovers multiple pools.
-# Each entry may set replicaCount (4 or 16) and/or a storageclass block;
+# Each entry may set replicaCount (>= 2) and/or a storageclass block;
 # omitted fields inherit the top-level values.
 #
 # IMPORTANT:
@@ -121,18 +129,19 @@ config:
     # See more information: https://docs.rustfs.com/integration/virtual.html
     domains: "" # e.g. "example.com"
     ec:
-      # Total drives = replicaCount * drivesPerNode.
-      # If you change replicaCount or drivesPerNode, adjust parity accordingly:
+      # Erasure-coding parity for the STANDARD storage class, e.g. "EC:4".
+      # Left empty by default: the server then picks a parity suited to the
+      # drive count. If you set it, it must be valid for the total drive
+      # count (total drives = replicaCount * drivesPerNode):
       #
-      # | replicaCount | drivesPerNode | Total drives | Valid parity | Default |
-      # | ------------ | ------------- | ------------ | ------------ | ------- |
-      # | 1            | 1             | 1            | 0            | 0       |
-      # | 4            | 1             | 4            | 0–2          | 2       |
-      # | 4            | 2             | 8            | 0–4          | 4       |
-      # | 4            | 4             | 16           | 0–8          | *4*     |
-      # | 8            | 1             | 8            | 0–4          | 4       |
-      # | 16           | 1             | 16           | 0–8          | 4       |
-      storage_class_standard: "EC:4" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
+      # | replicaCount | drivesPerNode | Total drives | Valid parity |
+      # | ------------ | ------------- | ------------ | ------------ |
+      # | 4            | 1             | 4            | 0-2          |
+      # | 4            | 2             | 8            | 0-4          |
+      # | 4            | 4             | 16           | 0-8          |
+      # | 8            | 1             | 8            | 0-4          |
+      # | 16           | 1             | 16           | 0-8          |
+      storage_class_standard: ""
     scanner:
       # Scanner speed preset: fastest|fast|default|slow|slowest
       speed: ""
@@ -185,7 +194,7 @@ config:
     obs_endpoint:
       enabled: false # If true, rustfs will export metrics, traces, logs and profiling data to the specified OTLP endpoints. If false, the individual settings for metrics, traces, logs and profiling endpoints will be ignored and all data will not be exported.
       base_endpoint: "" #Root OTLP/HTTP endpoint, e.g. http://otel-collector:4318
-      use_stdout: true # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
+      use_stdout: false # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
       metrics:
         enabled: false
         endpoint: "" # If specified, rustfs will export metrics to this OTLP endpoint. e.g. "http://localhost:4318/v1/metrics"

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -267,6 +267,7 @@ service:
   loadBalancerIP: ""           # Request a specific IP from the load balancer (e.g. for Cilium LB-IPAM or MetalLB)
   loadBalancerClass: ""        # Specify a load balancer implementation (e.g. "io.cilium/bgp", "metallb")
   loadBalancerSourceRanges: [] # Restrict client IPs (e.g. ["10.0.0.0/8"])
+  externalIPs: []             # Expose service via specific external IPs (e.g. ["203.0.113.1"])
   endpoint:
     port: 9000
     nodePort: 32000

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -115,6 +115,14 @@ config:
     # See more information: https://docs.rustfs.com/integration/virtual.html
     domains: "" # e.g. "example.com"
     ec:
+      # If you change replicaCount, adjust parity accordingly:
+      #
+      # | `replicaCount` | Total drives | Valid parity | Default |
+      # | -------------- | ------------ | ------------ | ------- |
+      # | 1              | 1            | 0            | 0       |
+      # | 2              | 2            | 0–1          | 1       |
+      # | 4              | 4            | 0–2          | **2**   |
+      # | 8              | 8            | 0–4          | 4       |
       storage_class_standard: "EC:2" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
     log_rotation: # Specify log rotation settings
       # size: 100 # Default value: 100 MB

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -255,6 +255,7 @@ priorityClassName: ""
 
 service:
   annotations: {}
+  labels: {} # Additional labels
   headlessAnnotations: {} # Applied to the headless Service when mode.distributed.enabled=true
   traefikAnnotations: # Applied to the Service when mode.distributed.enabled=true and ingress.className=traefik
     traefik.ingress.kubernetes.io/service.sticky.cookie: "true"

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -11,7 +11,7 @@ replicaCount: 4
 # - drivesPerNode = 1: each pod gets a single volume mounted at /data
 # Upgrade note: deployments that previously used replicaCount=16 for one drive
 # per pod should now set replicaCount=16 and drivesPerNode=1 explicitly.
-drivesPerNode: 1
+drivesPerNode: 4
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
@@ -120,11 +120,12 @@ config:
       # | replicaCount | drivesPerNode | Total drives | Valid parity | Default |
       # | ------------ | ------------- | ------------ | ------------ | ------- |
       # | 1            | 1             | 1            | 0            | 0       |
-      # | 4            | 1             | 4            | 0–2          | *2*     |
+      # | 4            | 1             | 4            | 0–2          | 2       |
       # | 4            | 2             | 8            | 0–4          | 4       |
+      # | 4            | 4             | 16           | 0–8          | *4*     |
       # | 8            | 1             | 8            | 0–4          | 4       |
       # | 16           | 1             | 16           | 0–8          | 4       |
-      storage_class_standard: "EC:2" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
+      storage_class_standard: "EC:4" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
     scanner:
       # Scanner speed preset: fastest|fast|default|slow|slowest
       speed: ""
@@ -177,7 +178,7 @@ config:
     obs_endpoint:
       enabled: false # If true, rustfs will export metrics, traces, logs and profiling data to the specified OTLP endpoints. If false, the individual settings for metrics, traces, logs and profiling endpoints will be ignored and all data will not be exported.
       base_endpoint: "" #Root OTLP/HTTP endpoint, e.g. http://otel-collector:4318
-      use_stdout: true # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
+      use_stdout: false # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
       metrics:
         enabled: false
         endpoint: "" # If specified, rustfs will export metrics to this OTLP endpoint. e.g. "http://localhost:4318/v1/metrics"

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -171,7 +171,7 @@ config:
       # time: hour # Default value: hour, eg: day,hour,minute,second
       # keep_files: 30 # number of rotated log files to keep
     ## If obs_log_directory is set, a separate volume for logs will be created and the logs will NOT be sent to stdout
-    # obs_log_directory: "/logs"
+    obs_log_directory: "/logs"
     ## Supported values include `production`, `development`, `test`, and `staging`;
     ## refer to the RustFS configuration documentation/source for the authoritative list.
     obs_environment: "development"

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -2,15 +2,16 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+# Number of StatefulSet pods (nodes in the distributed cluster).
 replicaCount: 4
 
-# Kubernetes cluster DNS domain used to build in-cluster FQDNs for
-# RUSTFS_VOLUMES (distributed mode) and mTLS server certificate SANs.
-# Override this only if your cluster does not use the default `cluster.local`
-# (for example, on-premise clusters configured with a custom domain).
-# Provide the DNS root only, without a `svc.` prefix or leading/trailing dots.
-clusterDomain: cluster.local
+# Number of data drives (PVCs) per pod. Combined with replicaCount this
+# determines the total drive count seen by rustfs.
+# - drivesPerNode > 1: each pod gets N volumes mounted at /data/rustfs0.../data/rustfsN-1
+# - drivesPerNode = 1: each pod gets a single volume mounted at /data
+# Upgrade note: deployments that previously used replicaCount=16 for one drive
+# per pod should now set replicaCount=16 and drivesPerNode=1 explicitly.
+drivesPerNode: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
@@ -99,6 +100,9 @@ config:
     # Examples
     # volumes: "/data/rustfs0,/data/rustfs1,/data/rustfs2,/data/rustfs3"
     # volumes: "http://rustfs-{0...3}.rustfs-headless:9000/data/rustfs{0...3}"
+    # NOTE: When overriding volumes manually, the mount paths and drive ranges
+    # must match the number of pods (replicaCount) and drives per pod
+    # (drivesPerNode). Mismatched values will cause broken volume discovery.
     volumes: ""
     address: ":9000"
     console_enable: "true"
@@ -380,12 +384,11 @@ storageclass:
   name: local-path
   dataStorageSize: 256Mi
   logStorageSize: 256Mi
-  pvcAnnotations: {}
-    #pvcAnnotations:
-    #  data:
-    #    key: value
-    #  logs:
-    #    key: value
+  pvcAnnotations:
+    data: {}
+      # key: value
+    logs: {}
+      # key: value
 
 pdb:
   create: false

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -401,9 +401,9 @@ storageclass:
   dataStorageSize: 256Mi
   logStorageSize: 256Mi
   pvcAnnotations:
-    data: {}
+    data:
       # key: value
-    logs: {}
+    logs:
       # key: value
 
 pdb:

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -403,10 +403,8 @@ storageclass:
   dataStorageSize: 256Mi
   logStorageSize: 256Mi
   pvcAnnotations:
-    data:
-      # key: value
-    logs:
-      # key: value
+    data: {}
+    logs: {}
 
 pdb:
   create: false

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -175,7 +175,7 @@ config:
       enabled: false
       type: "vault" # Only Support vault currently.
       vault:
-        vault_backend: "" # Only support vault kv2 and vault transit. 
+        vault_backend: "" # Only support vault kv2 and vault transit.
         vault_address: ""
         vault_token: ""
         vault_mount_path: ""
@@ -297,7 +297,7 @@ ingress:
 gatewayApi:
   enabled: false
   gatewayClass: traefik # Only support for traefik and contour gatewayClass at the moment.
-  listeners: # Specify which listeners to create on the Gateway. 
+  listeners: # Specify which listeners to create on the Gateway.
     http:
       name: web
       port: 8000

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -178,7 +178,7 @@ config:
     obs_endpoint:
       enabled: false # If true, rustfs will export metrics, traces, logs and profiling data to the specified OTLP endpoints. If false, the individual settings for metrics, traces, logs and profiling endpoints will be ignored and all data will not be exported.
       base_endpoint: "" #Root OTLP/HTTP endpoint, e.g. http://otel-collector:4318
-      use_stdout: false # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
+      use_stdout: true # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
       metrics:
         enabled: false
         endpoint: "" # If specified, rustfs will export metrics to this OTLP endpoint. e.g. "http://localhost:4318/v1/metrics"

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -107,7 +107,6 @@ config:
     address: ":9000"
     console_enable: "true"
     console_address: ":9001"
-    log_level: "info"
     region: "us-east-1"
     obs_log_directory: "/logs" # Set to "" to disable log PVCs and mounts.
     obs_environment: "development"
@@ -124,10 +123,6 @@ config:
       # | 4              | 4            | 0–2          | **2**   |
       # | 8              | 8            | 0–4          | 4       |
       storage_class_standard: "EC:2" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
-    log_rotation: # Specify log rotation settings
-      # size: 100 # Default value: 100 MB
-      # time: hour # Default value: hour, eg: day,hour,minute,second
-      # keep_files: 30 # number of rotated log files to keep
     scanner:
       # Scanner speed preset: fastest|fast|default|slow|slowest
       speed: ""
@@ -167,10 +162,20 @@ config:
     # - default: keep current timeout defaults.
     # - high_latency: use higher timeout defaults for scanner-sensitive operations.
     timeout_profile: ""
+    log_level: "info"
+    log_rotation: # Specify log rotation settings
+      # size: 100 # Default value: 100 MB
+      # time: hour # Default value: hour, eg: day,hour,minute,second
+      # keep_files: 30 # number of rotated log files to keep
+    ## If obs_log_directory is set, a separate volume for logs will be created and the logs will NOT be sent to stdout
+    # obs_log_directory: "/logs"
+    ## Supported values include `production`, `development`, `test`, and `staging`;
+    ## refer to the RustFS configuration documentation/source for the authoritative list.
+    obs_environment: "development"
     obs_endpoint:
       enabled: false # If true, rustfs will export metrics, traces, logs and profiling data to the specified OTLP endpoints. If false, the individual settings for metrics, traces, logs and profiling endpoints will be ignored and all data will not be exported.
       base_endpoint: "" #Root OTLP/HTTP endpoint, e.g. http://otel-collector:4318
-      use_stdout: false # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
+      use_stdout: true # If true, rustfs will also export logs to stdout in addition to the OTLP logs endpoint.
       metrics:
         enabled: false
         endpoint: "" # If specified, rustfs will export metrics to this OTLP endpoint. e.g. "http://localhost:4318/v1/metrics"

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -114,14 +114,16 @@ config:
     # See more information: https://docs.rustfs.com/integration/virtual.html
     domains: "" # e.g. "example.com"
     ec:
-      # If you change replicaCount, adjust parity accordingly:
+      # Total drives = replicaCount * drivesPerNode.
+      # If you change replicaCount or drivesPerNode, adjust parity accordingly:
       #
-      # | `replicaCount` | Total drives | Valid parity | Default |
-      # | -------------- | ------------ | ------------ | ------- |
-      # | 1              | 1            | 0            | 0       |
-      # | 2              | 2            | 0–1          | 1       |
-      # | 4              | 4            | 0–2          | **2**   |
-      # | 8              | 8            | 0–4          | 4       |
+      # | replicaCount | drivesPerNode | Total drives | Valid parity | Default |
+      # | ------------ | ------------- | ------------ | ------------ | ------- |
+      # | 1            | 1             | 1            | 0            | 0       |
+      # | 4            | 1             | 4            | 0–2          | *2*     |
+      # | 4            | 2             | 8            | 0–4          | 4       |
+      # | 8            | 1             | 8            | 0–4          | 4       |
+      # | 16           | 1             | 16           | 0–8          | 4       |
       storage_class_standard: "EC:2" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
     scanner:
       # Scanner speed preset: fastest|fast|default|slow|slowest

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -115,7 +115,7 @@ config:
     # See more information: https://docs.rustfs.com/integration/virtual.html
     domains: "" # e.g. "example.com"
     ec:
-      storage_class_standard: "EC:4" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
+      storage_class_standard: "EC:2" # Storage class for standard storage class in erasure coding mode, default is "STANDARD"
     log_rotation: # Specify log rotation settings
       # size: 100 # Default value: 100 MB
       # time: hour # Default value: hour, eg: day,hour,minute,second

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -170,7 +170,7 @@ config:
       # size: 100 # Default value: 100 MB
       # time: hour # Default value: hour, eg: day,hour,minute,second
       # keep_files: 30 # number of rotated log files to keep
-    ## If obs_log_directory is set, a separate volume for logs will be created and the logs will NOT be sent to stdout
+    ## If obs_log_directory is not empty, a separate volume for logs will be created and the logs will NOT be sent to stdout. If not set, will default to default chart value "/logs"
     obs_log_directory: "/logs"
     ## Supported values include `production`, `development`, `test`, and `staging`;
     ## refer to the RustFS configuration documentation/source for the authoritative list.

--- a/scripts/test_helm_templates.sh
+++ b/scripts/test_helm_templates.sh
@@ -308,3 +308,14 @@ if [[ $low_replica_status -eq 0 ]]; then
   echo "Distributed mode with replicaCount=1 must fail rendering" >&2
   exit 1
 fi
+
+# service.externalIPs must render correctly when supplied.
+external_ips_output=$(helm template rustfs "$CHART_DIR" \
+  --namespace rustfs \
+  --set secret.rustfs.access_key=test-access-key \
+  --set secret.rustfs.secret_key=test-secret-key \
+  --set 'service.externalIPs[0]=203.0.113.1')
+if ! grep -A2 'externalIPs:' <<<"$external_ips_output" | grep -q '203.0.113.1'; then
+  echo "service.externalIPs must contain 203.0.113.1" >&2
+  exit 1
+fi

--- a/scripts/test_helm_templates.sh
+++ b/scripts/test_helm_templates.sh
@@ -253,53 +253,58 @@ assert_extra_volumes_wired "$distributed_extra_output" "distributed StatefulSet"
 distributed_default_output=$(render_distributed_statefulset)
 assert_extra_volumes_absent "$distributed_default_output" "distributed StatefulSet"
 
-# clusterDomain (issue #3857): a custom Kubernetes cluster domain must flow into
-# the RUSTFS_VOLUMES FQDN and mTLS server cert SANs, defaulting to cluster.local.
-volumes_default=$(render_distributed_configmap | grep 'RUSTFS_VOLUMES:' || true)
-if ! grep -q 'svc\.cluster\.local' <<<"$volumes_default"; then
-  echo "Default RUSTFS_VOLUMES must use svc.cluster.local" >&2
+# Legacy topology compatibility: default replicaCount=4 (no drivesPerNode set)
+# must render the old 4x4 PVC names (data-rustfs-0 .. data-rustfs-3).
+legacy_four_by_four=$(render_distributed_statefulset)
+for i in 0 1 2 3; do
+  if ! grep -q "name: data-rustfs-${i}" <<<"$legacy_four_by_four"; then
+    echo "Legacy 4x4 topology must contain PVC data-rustfs-${i}" >&2
+    exit 1
+  fi
+done
+if grep -q "name: data$" <<<"$legacy_four_by_four"; then
+  echo "Legacy 4x4 topology must NOT contain a single 'data' PVC" >&2
   exit 1
 fi
 
-volumes_custom=$(render_distributed_configmap --set clusterDomain=cluster.internal | grep 'RUSTFS_VOLUMES:' || true)
-if ! grep -q 'svc\.cluster\.internal' <<<"$volumes_custom"; then
-  echo "Custom clusterDomain must appear in the RUSTFS_VOLUMES FQDN" >&2
+# Legacy topology compatibility: replicaCount=16 (no drivesPerNode set)
+# must render a single 'data' PVC (old 16x1 behaviour).
+legacy_sixteen_by_one=$(render_distributed_statefulset --set replicaCount=16)
+if ! grep -q "name: data$" <<<"$legacy_sixteen_by_one"; then
+  echo "Legacy 16x1 topology must contain a single 'data' PVC" >&2
   exit 1
 fi
-if grep -q 'cluster\.local' <<<"$volumes_custom"; then
-  echo "Custom clusterDomain must fully replace cluster.local in RUSTFS_VOLUMES" >&2
-  exit 1
-fi
-
-# An explicit config.rustfs.volumes stays authoritative regardless of clusterDomain.
-volumes_explicit=$(render_distributed_configmap \
-  --set config.rustfs.volumes=http://example.test/data \
-  --set clusterDomain=cluster.internal | grep 'RUSTFS_VOLUMES:' || true)
-if ! grep -q 'RUSTFS_VOLUMES: "http://example.test/data"' <<<"$volumes_explicit"; then
-  echo "Explicit config.rustfs.volumes must remain authoritative regardless of clusterDomain" >&2
+if grep -q "name: data-rustfs-" <<<"$legacy_sixteen_by_one"; then
+  echo "Legacy 16x1 topology must NOT contain data-rustfs-* PVCs" >&2
   exit 1
 fi
 
-# A dot-only clusterDomain must fall back to cluster.local instead of an empty domain.
-volumes_dots=$(render_distributed_configmap --set clusterDomain=. | grep 'RUSTFS_VOLUMES:' || true)
-if ! grep -q 'svc\.cluster\.local' <<<"$volumes_dots"; then
-  echo "Dot-only clusterDomain must fall back to cluster.local in RUSTFS_VOLUMES" >&2
+# Generic topology: explicit replicaCount=8 drivesPerNode=2 must render
+# exactly two PVCs per pod.
+generic_eight_by_two=$(render_distributed_statefulset --set replicaCount=8 --set drivesPerNode=2)
+for i in 0 1; do
+  if ! grep -q "name: data-rustfs-${i}" <<<"$generic_eight_by_two"; then
+    echo "Generic 8x2 topology must contain PVC data-rustfs-${i}" >&2
+    exit 1
+  fi
+done
+if grep -q "name: data$" <<<"$generic_eight_by_two"; then
+  echo "Generic 8x2 topology must NOT contain a single 'data' PVC" >&2
   exit 1
 fi
 
-# mTLS server certificate SANs must honor clusterDomain too.
-cert_default=$(render_server_cert)
-if ! grep -q 'svc\.cluster\.local"' <<<"$cert_default"; then
-  echo "Default mTLS server cert SANs must use svc.cluster.local" >&2
+# volumeClaimTemplates must not contain empty annotations when pvcAnnotations are unset,
+# because Kubernetes treats annotations: {} as a mutation of the immutable field.
+no_ann_output=$(render_distributed_statefulset)
+if grep -A1 'kind: PersistentVolumeClaim' <<<"$no_ann_output" | grep -q 'annotations:'; then
+  echo "Empty pvcAnnotations must not render an annotations key in volumeClaimTemplates" >&2
   exit 1
 fi
 
-cert_custom=$(render_server_cert --set clusterDomain=cluster.internal)
-if ! grep -q 'svc\.cluster\.internal"' <<<"$cert_custom"; then
-  echo "Custom clusterDomain must appear in mTLS server cert SANs" >&2
-  exit 1
-fi
-if grep -q 'svc\.cluster\.local"' <<<"$cert_custom"; then
-  echo "Custom clusterDomain must fully replace cluster.local in mTLS server cert SANs" >&2
+# Distributed mode with replicaCount < 2 must fail rendering.
+low_replica_status=0
+render_distributed_statefulset --set replicaCount=1 >/dev/null 2>&1 || low_replica_status=$?
+if [[ $low_replica_status -eq 0 ]]; then
+  echo "Distributed mode with replicaCount=1 must fail rendering" >&2
   exit 1
 fi

--- a/scripts/test_helm_templates.sh
+++ b/scripts/test_helm_templates.sh
@@ -253,6 +253,57 @@ assert_extra_volumes_wired "$distributed_extra_output" "distributed StatefulSet"
 distributed_default_output=$(render_distributed_statefulset)
 assert_extra_volumes_absent "$distributed_default_output" "distributed StatefulSet"
 
+# clusterDomain (issue #3857): a custom Kubernetes cluster domain must flow into
+# the RUSTFS_VOLUMES FQDN and mTLS server cert SANs, defaulting to cluster.local.
+volumes_default=$(render_distributed_configmap | grep 'RUSTFS_VOLUMES:' || true)
+if ! grep -q 'svc\.cluster\.local' <<<"$volumes_default"; then
+  echo "Default RUSTFS_VOLUMES must use svc.cluster.local" >&2
+  exit 1
+fi
+
+volumes_custom=$(render_distributed_configmap --set clusterDomain=cluster.internal | grep 'RUSTFS_VOLUMES:' || true)
+if ! grep -q 'svc\.cluster\.internal' <<<"$volumes_custom"; then
+  echo "Custom clusterDomain must appear in the RUSTFS_VOLUMES FQDN" >&2
+  exit 1
+fi
+if grep -q 'cluster\.local' <<<"$volumes_custom"; then
+  echo "Custom clusterDomain must fully replace cluster.local in RUSTFS_VOLUMES" >&2
+  exit 1
+fi
+
+# An explicit config.rustfs.volumes stays authoritative regardless of clusterDomain.
+volumes_explicit=$(render_distributed_configmap \
+  --set config.rustfs.volumes=http://example.test/data \
+  --set clusterDomain=cluster.internal | grep 'RUSTFS_VOLUMES:' || true)
+if ! grep -q 'RUSTFS_VOLUMES: "http://example.test/data"' <<<"$volumes_explicit"; then
+  echo "Explicit config.rustfs.volumes must remain authoritative regardless of clusterDomain" >&2
+  exit 1
+fi
+
+# A dot-only clusterDomain must fall back to cluster.local instead of an empty domain.
+volumes_dots=$(render_distributed_configmap --set clusterDomain=. | grep 'RUSTFS_VOLUMES:' || true)
+if ! grep -q 'svc\.cluster\.local' <<<"$volumes_dots"; then
+  echo "Dot-only clusterDomain must fall back to cluster.local in RUSTFS_VOLUMES" >&2
+  exit 1
+fi
+
+# mTLS server certificate SANs must honor clusterDomain too.
+cert_default=$(render_server_cert)
+if ! grep -q 'svc\.cluster\.local"' <<<"$cert_default"; then
+  echo "Default mTLS server cert SANs must use svc.cluster.local" >&2
+  exit 1
+fi
+
+cert_custom=$(render_server_cert --set clusterDomain=cluster.internal)
+if ! grep -q 'svc\.cluster\.internal"' <<<"$cert_custom"; then
+  echo "Custom clusterDomain must appear in mTLS server cert SANs" >&2
+  exit 1
+fi
+if grep -q 'svc\.cluster\.local"' <<<"$cert_custom"; then
+  echo "Custom clusterDomain must fully replace cluster.local in mTLS server cert SANs" >&2
+  exit 1
+fi
+
 # Legacy topology compatibility: default replicaCount=4 (no drivesPerNode set)
 # must render the old 4x4 PVC names (data-rustfs-0 .. data-rustfs-3).
 legacy_four_by_four=$(render_distributed_statefulset)


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [x] Refactor
- [ ] Other:

## Related Issues
Closes https://github.com/rustfs/rustfs/issues/2688
Supersedes https://github.com/rustfs/rustfs/pull/2693 (carries @cr1cr1's commits; see credit below)

## Summary of Changes

This lands the `drivesPerNode` work from #2693 by @cr1cr1, rebased onto current `main` (including the server-pools feature from #3325) with the remaining review blockers fixed. The chart no longer hardcodes the 4 pods x 4 volumes / 16 pods x 1 volume layouts — any `replicaCount >= 2` with any `drivesPerNode >= 1` renders a valid topology — while keeping every existing deployment's rendered `volumeClaimTemplates` unchanged so `helm upgrade` never trips the StatefulSet immutability check.

**How the compatibility default works** (this was the core review blocker from @houseme and @majinghe): `drivesPerNode` defaults to `null`, and the chart infers a backward-compatible value *per pool* from that pool's replica count — 4 replicas keep the legacy 4-drive layout, anything else (including the legacy 16x1) gets 1 drive. Neither 4x4 nor 16x1 installs need any values change on upgrade. Setting `drivesPerNode` explicitly overrides the inference for new installs (e.g. 8x2, 4x1).

On top of the original branch, this PR fixes what kept #2693 from rendering/merging:

- **Chart failed to render at all** after the last rebase: the `$poolsEnabled` definition was dropped while still referenced, and `rustfs.drivesPerNode` was included but never defined. Added the missing inference helper (`rustfs.poolDrives`) and restored `$poolsEnabled`.
- **Per-pool instead of global inference**: computed inside `rustfs.pools`, so a mixed 4x4 + 16x1 pools deployment keeps each pool's exact legacy layout (a global default would have broken one of the two).
- **`rustfs.volumes` now derives the drive range from the pool's drive count** instead of special-casing `replicaCount` 4/16; the `pools.list` 4-or-16 restriction is relaxed to `>= 2`.
- **Fixed `.Values` references inside the pool `range`** (dot is the pool there), which would have rendered `null` securityContext/labels and broken per-pool `storageclass.pvcAnnotations` overrides.
- **Validation**: distributed mode rejects `replicaCount < 2` (an ellipse endpoint set needs >= 2 entries — the third review blocker), and `drivesPerNode: 0` fails loudly instead of silently falling back to inference.
- **Kept default rendering identical to `main`**: `storage_class_standard` stays unrendered by default (an unconditional `EC:4` would be invalid for the new smaller topologies), `obs_endpoint.use_stdout` stays `false`, and the `clusterDomain` values entry (#3857) is restored.
- **Restored the regression tests** for clusterDomain/mTLS SANs/explicit-volumes that the branch had deleted from `scripts/test_helm_templates.sh`, and kept the new topology tests (legacy 4x4 and 16x1 PVC names, generic 8x2, no empty `annotations:` in `volumeClaimTemplates`, `replicaCount=1` must fail, `service.externalIPs`).

Also carried from #2693: optional `service.labels`, `service.externalIPs`, `RUSTFS_STORAGE_CLASS_STANDARD` rendering when set, conditional PVC annotations, and README/values documentation for the topology parameters.

## Verification

`./scripts/test_helm_templates.sh` passes; `make pre-commit` passes. In addition, `helm template` output was diffed against `main` for the full compatibility matrix:

| Values | Result vs `main` |
| --- | --- |
| default (4x4) | `volumeClaimTemplates`, `RUSTFS_VOLUMES`, PVC names identical |
| `replicaCount=16` | identical single `data` PVC and `RUSTFS_VOLUMES` |
| `pools.enabled` with 4x4 + 16x1 pools | both pools keep their legacy layouts |
| standalone | identical |
| `replicaCount=8, drivesPerNode=2` | renders 2 PVCs/pod and `rustfs-{0...7}/data/rustfs{0...1}` |
| `replicaCount=1` (distributed) / `drivesPerNode=0` | rendering fails with a clear error |

The only rendered differences on legacy topologies are the init-container script (pod template — mutable) and dropping literal `annotations: null` from `volumeClaimTemplates` (decodes to the same nil map, so StatefulSet update validation still passes).

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit`
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: no action needed for existing 4x4/16x1 installs; new topologies opt in via `drivesPerNode`

## Additional Notes

Credit for the feature, the design discussion, and the extensive upgrade testing goes to @cr1cr1 (#2693); their commits are included in this branch. @chefcc proposed the flexible `drivesPerNode` shape (#2895), and @majinghe / @houseme defined the compatibility requirements this version satisfies.
