### PR TITLE
ci: restore latest.json updates for prerelease tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -848,12 +848,14 @@ jobs:
 
           echo "✅ All assets uploaded successfully"
 
-  # Update latest.json for stable releases only: prerelease tags (alpha/beta/
-  # rc) must never overwrite the stable version pointer.
+  # Update latest.json for every release tag (stable and prerelease): the
+  # project currently ships prerelease tags only, so gating this to stable
+  # left the version pointer permanently stale. release_type records whether
+  # the pointed-to version is a prerelease.
   update-latest-version:
     name: Update Latest Version
     needs: [ build-check, upload-release-assets ]
-    if: startsWith(github.ref, 'refs/tags/') && needs.build-check.outputs.build_type == 'release'
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Update latest.json
@@ -871,6 +873,12 @@ jobs:
 
           VERSION="${{ needs.build-check.outputs.version }}"
           TAG="${{ needs.build-check.outputs.version }}"
+
+          if [[ "${{ needs.build-check.outputs.build_type }}" == "prerelease" ]]; then
+            RELEASE_TYPE="prerelease"
+          else
+            RELEASE_TYPE="stable"
+          fi
 
           # Install ossutil
           OSSUTIL_VERSION="2.1.1"
@@ -892,7 +900,7 @@ jobs:
             "version": "${VERSION}",
             "tag": "${TAG}",
             "release_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "release_type": "stable",
+            "release_type": "${RELEASE_TYPE}",
             "download_url": "https://github.com/${{ github.repository }}/releases/tag/${TAG}"
           }
           EOF
@@ -900,7 +908,7 @@ jobs:
           # Upload to OSS
           "$OSSUTIL_BIN" cp latest.json oss://rustfs-version/latest.json --force
 
-          echo "✅ Updated latest.json for stable release $VERSION"
+          echo "✅ Updated latest.json for ${RELEASE_TYPE} release $VERSION"
 
   # Publish release (remove draft status)
   publish-release:


### PR DESCRIPTION
## Problem

[#4582](https://github.com/rustfs/rustfs/pull/4582) gated the `update-latest-version` job in `build.yml` to `build_type == 'release'` so that prerelease tags could not overwrite the stable version pointer with `release_type: "stable"`.

In practice the project currently ships prerelease tags only (e.g. `1.0.0-beta.10-preview.1`), so the job is skipped on every release and the `latest.json` pointer on OSS has been permanently stale ever since. Example skipped run: [Update Latest Version](https://github.com/rustfs/rustfs/actions/runs/29479886347/job/87583403218).

## Change

- Run `update-latest-version` for every release tag again (`startsWith(github.ref, 'refs/tags/')`), matching the pre-#4582 behavior and the Docker workflow's policy of tagging `latest` for alpha/beta prereleases.
- Keep the honest half of the #4582 fix: write `release_type` from the actual build type (`prerelease` / `stable`) instead of hardcoding `"stable"`, so a beta pointer is no longer mislabeled.

The in-repo consumer (`rustfs/src/update.rs` `VersionInfo`) does not deserialize `release_type`, so the value change is safe for the built-in version checker.

## Verification

- `actionlint .github/workflows/build.yml` — no findings
- YAML parses cleanly