### PR TITLE
chore(release): prepare 1.0.0-beta.10-preview.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -8804,7 +8804,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8935,7 +8935,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8957,7 +8957,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -8972,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "chrono",
  "metrics",
@@ -8987,7 +8987,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "insta",
  "rustfs-io-core",
@@ -8999,7 +8999,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "const-str",
  "serde",
@@ -9008,7 +9008,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9021,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9041,7 +9041,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -9052,7 +9052,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "aes-gcm",
  "async-channel",
@@ -9186,7 +9186,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9195,7 +9195,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9251,7 +9251,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9288,7 +9288,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "bytes",
  "memmap2",
@@ -9300,7 +9300,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "criterion",
  "metrics",
@@ -9363,7 +9363,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "bytes",
  "futures",
@@ -9389,7 +9389,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9420,7 +9420,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "proptest",
@@ -9440,7 +9440,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9461,7 +9461,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "chrono",
  "humantime",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9507,7 +9507,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "criterion",
  "futures",
@@ -9525,7 +9525,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -9541,7 +9541,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9593,7 +9593,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9622,7 +9622,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "flatbuffers",
  "prost 0.14.4",
@@ -9699,7 +9699,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "byteorder",
  "bytes",
@@ -9716,7 +9716,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9754,7 +9754,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -9776,14 +9776,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "rustfs-s3-types",
 ]
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9791,7 +9791,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9818,7 +9818,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9834,7 +9834,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9866,14 +9866,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9889,7 +9889,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "insta",
@@ -9903,7 +9903,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -9953,7 +9953,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "rustfs-ecstore",
  "rustfs-storage-api",
@@ -9965,7 +9965,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "arc-swap",
  "metrics",
@@ -9985,7 +9985,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -10021,7 +10021,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10060,7 +10060,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -11592,9 +11592,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.96.0"
-version = "1.0.0-beta.10-preview.1"
+version = "1.0.0-beta.10-preview.4"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -85,51 +85,51 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.10-preview.1" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.10-preview.1" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.10-preview.1" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.10-preview.1" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.10-preview.1" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.10-preview.1" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.10-preview.1" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.10-preview.1" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.10-preview.1" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.10-preview.1" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.10-preview.1" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.10-preview.1" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.10-preview.1" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.10-preview.1" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.10-preview.1" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.10-preview.1" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.10-preview.1" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.10-preview.1" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.10-preview.1" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.10-preview.1" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.10-preview.1" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.10-preview.1" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.10-preview.1" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.10-preview.1" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.10-preview.1" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.10-preview.1" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.10-preview.1" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.10-preview.1" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.10-preview.1" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.10-preview.1" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.10-preview.1" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.10-preview.1" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.10-preview.1" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.10-preview.1" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.10-preview.1" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.10-preview.1" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.10-preview.1" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.10-preview.1" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.10-preview.1" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.10-preview.1" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.10-preview.1" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.10-preview.1" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.10-preview.1" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.10-preview.1" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.10-preview.1" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.10-preview.4" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.10-preview.4" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.10-preview.4" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.10-preview.4" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.10-preview.4" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.10-preview.4" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.10-preview.4" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.10-preview.4" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.10-preview.4" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.10-preview.4" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.10-preview.4" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.10-preview.4" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.10-preview.4" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.10-preview.4" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.10-preview.4" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.10-preview.4" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.10-preview.4" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.10-preview.4" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.10-preview.4" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.10-preview.4" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.10-preview.4" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.10-preview.4" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.10-preview.4" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.10-preview.4" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.10-preview.4" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.10-preview.4" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.10-preview.4" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.10-preview.4" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.10-preview.4" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.10-preview.4" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.10-preview.4" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.10-preview.4" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.10-preview.4" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.10-preview.4" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.10-preview.4" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.10-preview.4" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.10-preview.4" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.10-preview.4" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.10-preview.4" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.10-preview.4" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.10-preview.4" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.10-preview.4" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.10-preview.4" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.10-preview.4" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.10-preview.4" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"
@@ -157,7 +157,7 @@ minlz = "1.2.3"
 reqwest = { default-features = false, version = "0.13.4" }
 rustfs-kafka-async = { version = "1.2.0" }
 socket2 = { version = "0.6.5" }
-tokio = { version = "1.52.3" }
+tokio = { version = "1.52.4" }
 tokio-rustls = { default-features = false, version = "0.26.4" }
 tokio-stream = { version = "0.1.18" }
 tokio-test = "0.4.5"
@@ -277,7 +277,6 @@ rand = { version = "0.10.2" }
 ratelimit = "0.10.1"
 rayon = "1.12.0"
 reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.0" }
-#reed-solomon-erasure = { version = "6.0", features = ["simd-accel"], git = "https://github.com/houseme/reed-solomon-erasure",rev = "main" }
 reed-solomon-simd = "3.1.0"
 regex = { version = "1.13.1" }
 rumqttc = { package = "rumqttc-next", version = "0.33.2" }

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10-preview.1
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10-preview.4
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10-preview.1
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10-preview.4
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.10-preview.1";
+            version = "1.0.0-beta.10-preview.4";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.10.0-preview.1"
-appVersion: "1.0.0-beta.10-preview.1"
+version: "0.10.0-preview.4"
+appVersion: "1.0.0-beta.10-preview.4"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease beta.10-preview.1
+%global prerelease beta.10-preview.4
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.10.preview.1
+Release:        beta.10.preview.4
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Thu Jul 16 2026 houseme <housemecn@gmail.com>
+- Update RPM package to RustFS 1.0.0-beta.10-preview.4
+
 * Thu Jul 16 2026 houseme <housemecn@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.10-preview.1
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Prepare RustFS `1.0.0-beta.10-preview.4` across the workspace package version, internal workspace dependency versions, Docker examples, Nix package metadata, Helm chart metadata, and RPM spec metadata/changelog.
- Remove the stale commented `reed-solomon-erasure` Git dependency line from the workspace dependency list.
- Run release-maintenance dependency commands requested by the maintainer: `cargo update --verbose` and `cargo upgrade --exclude ratelimit --verbose`.
- Keep `ratelimit` pinned at `0.10.1` while allowing the workspace `tokio` requirement to advance to `1.52.4`.

## Verification
- Not run per maintainer instruction to skip validation.
- Executed: `cargo update --verbose`
- Executed: `cargo upgrade --exclude ratelimit --verbose`
- Note: `make pre-commit` was started before the skip-validation instruction and was interrupted; it is not counted as verification for this PR.

## Impact
- Updates release metadata and packaging references for `1.0.0-beta.10-preview.4`.
- Updates dependency metadata after the requested Cargo maintenance commands, excluding `ratelimit`.
- No runtime behavior change is intended beyond dependency metadata updates.

## Additional Notes
This PR intentionally documents skipped local validation because the maintainer requested no additional verification before opening the PR.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
