### PR TITLE
fix(docker): upgrade base-image packages in runtime stages to clear Trivy CVE alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,9 @@ LABEL name="RustFS" \
       url="https://rustfs.com" \
       license="Apache-2.0"
 
-RUN apk update && \
+# Upgrade base-image packages so published images pick up security fixes
+# (e.g. openssl/libssl3 CVEs) without waiting for a new Alpine point release.
+RUN apk upgrade --no-cache && \
     apk add --no-cache ca-certificates coreutils curl
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -93,7 +93,10 @@ LABEL name="RustFS" \
       url="https://rustfs.com" \
       license="Apache-2.0"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Upgrade base-image packages so published images pick up security fixes
+# (e.g. tar/gzip/perl CVEs) without waiting for a new Ubuntu point release.
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -223,6 +223,7 @@ LABEL name="RustFS (dev-local)" \
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
+    apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \


### PR DESCRIPTION
## Summary

All 40 open [code scanning alerts](https://github.com/rustfs/rustfs/security/code-scanning) are Trivy findings against the published container images — OS packages frozen at the base-image tag, not Rust code:

- **musl image (`alpine:3.23.4`)**: 30 alerts, all openssl `libssl3`/`libcrypto3` 3.5.6-r0, including HIGH CVE-2026-45447; fix (3.5.7-r0) already in the Alpine 3.23 repo
- **glibc image (`ubuntu:24.04`)**: 10 alerts on `tar`, `gzip`, `perl-base`, `ncurses`; fixes already in the Ubuntu archive

Root cause: the runtime stages only install packages and never upgrade the ones shipped with the base image, so distro security fixes can't reach released images until the base tag itself moves.

## Changes

- `Dockerfile` (musl runtime): replace `apk update` with `apk upgrade --no-cache`
- `Dockerfile.glibc` (glibc runtime): add `apt-get upgrade -y`
- `Dockerfile.source` (ubuntu runtime stage): add `apt-get upgrade -y`

## Verification

Ran the upgrade against the exact base tags in Docker:

- `alpine:3.23.4` + `apk upgrade` → `libssl3`/`libcrypto3` **3.5.7-r0**
- `ubuntu:24.04` + `apt-get upgrade -y` → `tar` **1.35+dfsg-3ubuntu0.2**, `gzip` **1.12-1ubuntu3.2**, `perl-base` **5.38.2-3.2ubuntu0.3**, `ncurses` **6.4+20240113-1ubuntu2.1**

Each matches the "Fixed Version" demanded by the corresponding open alert, so the next published image build closes all 40 alerts.