### PR TITLE
docs(architecture): fix object commit path reference

### DIFF
--- a/docs/architecture/unified-object-generation.md
+++ b/docs/architecture/unified-object-generation.md
@@ -79,8 +79,8 @@ The comparison at the disk commit point is on the full composite; a lower
 
 Comparing the epoch at the `rename` commit point alone is insufficient. The
 authoritative commit sequence is `tmp sync → data-dir rename → xl.meta commit →
-directory sync` in `crates/ecstore/src/set_disk/core/local.rs`, and there are two
-further detachable disk-write points in
+directory sync` in `crates/ecstore/src/disk/local.rs`, and there are two further
+detachable disk-write points in
 `crates/ecstore/src/set_disk/core/io_primitives.rs`:
 
 - **Rollback delete** — on quorum failure each disk runs


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Point the per-disk commit sequence at `crates/ecstore/src/disk/local.rs`.
- Keep coordinator rollback and cleanup references on `crates/ecstore/src/set_disk/core/io_primitives.rs`.

## Verification

- `make doc-paths-check`
- `scripts/check_no_planning_docs.sh`
- `scripts/check_architecture_migration_rules.sh`
- `git diff --check`

## Impact

Documentation-only. This restores the doc-path guard on `main` without changing runtime behavior.

## Additional Notes

N/A
