### PR TITLE
chore(docker): update Alpine and Ubuntu base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.23.4 AS build
+FROM alpine:3.24.1 AS build
 
 ARG TARGETARCH
 ARG RELEASE=latest
@@ -70,7 +70,7 @@ RUN set -eux; \
     rm -rf rustfs.zip /build/.tmp || true
 
 
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 
 ARG RELEASE=latest
 ARG BUILD_DATE

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:24.04 AS build
+FROM ubuntu:26.04 AS build
 
 ARG TARGETARCH
 ARG RELEASE=latest
@@ -76,7 +76,7 @@ RUN set -eux; \
     chmod +x /build/rustfs; \
     rm -rf rustfs.zip /build/.tmp || true
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ARG RELEASE=latest
 ARG BUILD_DATE

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -208,7 +208,7 @@ CMD ["cargo", "run", "--bin", "rustfs", "--"]
 # -----------------------------
 # Runtime stage (Ubuntu minimal)
 # -----------------------------
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Upgrade the Alpine build and runtime stages from 3.23.4 to 3.24.1.
- Upgrade the Ubuntu build and runtime stages from 24.04 to 26.04.
- Keep the production and source-build Dockerfiles aligned on the updated runtime base.

## Verification

- `docker buildx imagetools inspect alpine:3.24.1`
- `docker buildx imagetools inspect ubuntu:26.04`
- `docker buildx build --check --platform linux/amd64,linux/arm64 -f Dockerfile .`
- `docker buildx build --check --platform linux/amd64,linux/arm64 -f Dockerfile.glibc .`
- `docker buildx build --check --platform linux/amd64,linux/arm64 -f Dockerfile.source .`
- Full local production image builds for `Dockerfile` and `Dockerfile.glibc`
- RustFS `--version` smoke tests in both built production images
- `bash scripts/test_entrypoint_credentials.sh`

## Impact

Published Alpine images use Alpine 3.24.1, and glibc/source runtime images use Ubuntu 26.04. Container io_uring support still depends on the host kernel and container security policy.

## Additional Notes

Focused Docker validation was used for this Dockerfile-only change.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
