### PR TITLE
feat(log-analyzer): Phase 2 — causal folding, timeline anomalies, external rules (LA-9)

### DIFF
--- a/crates/log-analyzer/src/analyze.rs
+++ b/crates/log-analyzer/src/analyze.rs
@@ -94,6 +94,23 @@ pub struct TimeBucket {
     pub other: u64,
 }
 
+/// One deterministic timeline heuristic hit (rustfs/backlog#1290 sub-item
+/// B). All three kinds are hints, not verdicts.
+#[derive(Debug, Clone, Serialize)]
+pub struct TimelineAnomaly {
+    /// "mixed_offsets" | "node_ranges_disjoint" | "log_gap".
+    pub kind: String,
+    /// Operator-facing description.
+    pub message: String,
+    /// Involved node labels (node_ranges_disjoint); empty otherwise.
+    pub nodes: Vec<String>,
+    /// Gap boundaries in UTC (log_gap); null otherwise.
+    pub gap_start: Option<DateTime<Utc>>,
+    pub gap_end: Option<DateTime<Utc>>,
+    /// log_gap only: a startup-class finding begins within 5min after the gap.
+    pub restart_evidence: bool,
+}
+
 #[derive(Debug, Serialize)]
 pub struct AnalysisReport {
     /// Stability contract for JSON consumers.
@@ -105,6 +122,8 @@ pub struct AnalysisReport {
     pub low_confidence: Vec<Finding>,
     pub unmatched_top: Vec<UnmatchedCluster>,
     pub timeline: Vec<TimeBucket>,
+    /// Timeline/clock heuristics (schema v2, rustfs/backlog#1290).
+    pub timeline_anomalies: Vec<TimelineAnomaly>,
     /// Pass-through of every skipped input (no silent caps).
     pub skipped_inputs: Vec<(String, SkipReason)>,
 }
@@ -135,6 +154,9 @@ pub struct Analyzer {
     time_range: Option<(DateTime<FixedOffset>, DateTime<FixedOffset>)>,
     nodes: BTreeSet<String>,
     offsets: BTreeSet<String>,
+    /// node label -> (min ts, max ts, timestamped event count); feeds the
+    /// disjoint-node-ranges heuristic.
+    node_ranges: BTreeMap<String, (DateTime<FixedOffset>, DateTime<FixedOffset>, u64)>,
     /// unix-minute -> counts.
     minute_buckets: BTreeMap<i64, BucketCounts>,
     unmatched: HashMap<String, ClusterAcc>,
@@ -153,6 +175,7 @@ impl Analyzer {
             time_range: None,
             nodes: BTreeSet::new(),
             offsets: BTreeSet::new(),
+            node_ranges: BTreeMap::new(),
             minute_buckets: BTreeMap::new(),
             unmatched: HashMap::new(),
             unmatched_overflow: 0,
@@ -188,6 +211,16 @@ impl Analyzer {
                 Some((first, last)) => (first.min(ts), last.max(ts)),
             });
             self.offsets.insert(format_offset(&ts));
+            if let Some(node) = event.node.as_deref() {
+                self.node_ranges
+                    .entry(node.to_string())
+                    .and_modify(|(min, max, count)| {
+                        *min = (*min).min(ts);
+                        *max = (*max).max(ts);
+                        *count += 1;
+                    })
+                    .or_insert((ts, ts, 1));
+            }
             let bucket = self.minute_buckets.entry(ts.timestamp().div_euclid(60)).or_default();
             match event.level {
                 Some(LogLevel::Error) => bucket.error += 1,
@@ -246,10 +279,18 @@ impl Analyzer {
         unmatched_top.sort_by(|a, b| b.count.cmp(&a.count).then(a.template.cmp(&b.template)));
         unmatched_top.truncate(self.opts.top_unmatched);
 
-        let timeline = merge_timeline(&self.minute_buckets);
+        let (timeline, bucket_width_min) = merge_timeline(&self.minute_buckets);
+        let timeline_anomalies = detect_timeline_anomalies(
+            &self.offsets,
+            &self.node_ranges,
+            &self.minute_buckets,
+            bucket_width_min,
+            &findings,
+            &low_confidence,
+        );
 
         let mut report = AnalysisReport {
-            schema_version: 1,
+            schema_version: 2,
             summary: Summary {
                 events_total: self.events_total,
                 events_after_filter: self.events_after_filter,
@@ -265,6 +306,7 @@ impl Analyzer {
             low_confidence,
             unmatched_top,
             timeline,
+            timeline_anomalies,
             skipped_inputs: ingest.skipped,
         };
 
@@ -312,9 +354,11 @@ fn format_offset(ts: &DateTime<FixedOffset>) -> String {
     format!("{sign}{:02}:{:02}", abs / 3600, (abs % 3600) / 60)
 }
 
-fn merge_timeline(minute_buckets: &BTreeMap<i64, BucketCounts>) -> Vec<TimeBucket> {
+/// Returns the merged display buckets and the chosen bucket width (minutes);
+/// the width also parameterizes the log-gap heuristic threshold.
+fn merge_timeline(minute_buckets: &BTreeMap<i64, BucketCounts>) -> (Vec<TimeBucket>, i64) {
     let (Some((&first, _)), Some((&last, _))) = (minute_buckets.first_key_value(), minute_buckets.last_key_value()) else {
-        return Vec::new();
+        return (Vec::new(), 1);
     };
     let span = last - first + 1;
     let width = BUCKET_WIDTHS_MIN
@@ -331,7 +375,7 @@ fn merge_timeline(minute_buckets: &BTreeMap<i64, BucketCounts>) -> Vec<TimeBucke
         slot.warn += counts.warn;
         slot.other += counts.other;
     }
-    merged
+    let buckets = merged
         .into_iter()
         .map(|(slot, counts)| TimeBucket {
             start: DateTime::<Utc>::from_timestamp(slot * width * 60, 0).expect("valid timestamp"),
@@ -339,7 +383,134 @@ fn merge_timeline(minute_buckets: &BTreeMap<i64, BucketCounts>) -> Vec<TimeBucke
             warn: counts.warn,
             other: counts.other,
         })
-        .collect()
+        .collect();
+    (buckets, width)
+}
+
+/// Finding ids whose presence right after a log gap upgrades it to restart
+/// evidence, and ids that make mixed offsets a likely signature root cause.
+const STARTUP_RULE_IDS: [&str; 3] = ["startup-fatal", "runtime-failed", "endpoint-resolve-failed"];
+const SIGNATURE_RULE_IDS: [&str; 2] = ["client-signature-mismatch", "internode-signature-mismatch"];
+
+/// Timeline/clock heuristics (rustfs/backlog#1290 sub-item B). Three
+/// deterministic hints — mixed UTC offsets, disjoint per-node time ranges,
+/// and gaps in an otherwise continuous timeline — each phrased as a hint,
+/// never a verdict.
+fn detect_timeline_anomalies(
+    offsets: &BTreeSet<String>,
+    node_ranges: &BTreeMap<String, (DateTime<FixedOffset>, DateTime<FixedOffset>, u64)>,
+    minute_buckets: &BTreeMap<i64, BucketCounts>,
+    bucket_width_min: i64,
+    findings: &[Finding],
+    low_confidence: &[Finding],
+) -> Vec<TimelineAnomaly> {
+    let mut anomalies = Vec::new();
+    let has_finding =
+        |ids: &[&str]| findings.iter().chain(low_confidence).any(|f| ids.contains(&f.rule_id.as_str()));
+
+    // 1. Mixed UTC offsets: nodes disagree on timezone or clock source.
+    if offsets.len() > 1 {
+        let mut message = format!(
+            "日志包含多个 UTC 偏移({}):节点时区/时钟源可能不一致,跨节点排序前先归一到 UTC。",
+            offsets.iter().cloned().collect::<Vec<_>>().join(" / ")
+        );
+        if has_finding(&SIGNATURE_RULE_IDS) {
+            message.push_str("同时检测到签名不匹配类 finding,时钟偏移是其高概率根因。");
+        }
+        anomalies.push(TimelineAnomaly {
+            kind: "mixed_offsets".to_string(),
+            message,
+            nodes: Vec::new(),
+            gap_start: None,
+            gap_end: None,
+            restart_evidence: false,
+        });
+    }
+
+    // 2. Per-node time ranges that do not overlap at all (both sides with a
+    // meaningful sample size): clocks are wrong or collection windows differ.
+    let sizable: Vec<(&String, &(DateTime<FixedOffset>, DateTime<FixedOffset>, u64))> =
+        node_ranges.iter().filter(|(_, (_, _, count))| *count > 100).collect();
+    for (i, (node_a, (min_a, max_a, _))) in sizable.iter().enumerate() {
+        for (node_b, (min_b, max_b, _)) in sizable.iter().skip(i + 1) {
+            if max_a < min_b || max_b < min_a {
+                anomalies.push(TimelineAnomaly {
+                    kind: "node_ranges_disjoint".to_string(),
+                    message: format!(
+                        "节点 {node_a} 与 {node_b} 的日志时间范围完全不重叠({node_a}: {} → {},{node_b}: {} → {}):时钟错乱或采集不同期。",
+                        min_a.to_rfc3339(),
+                        max_a.to_rfc3339(),
+                        min_b.to_rfc3339(),
+                        max_b.to_rfc3339(),
+                    ),
+                    nodes: vec![(*node_a).clone(), (*node_b).clone()],
+                    gap_start: None,
+                    gap_end: None,
+                    restart_evidence: false,
+                });
+            }
+        }
+    }
+
+    // 3. Log gaps: >= 3 consecutive non-empty minutes, then a zero-event
+    // span of at least max(15min, 3x display bucket width), then activity
+    // again — the shape of a process restart or hang.
+    let threshold = (3 * bucket_width_min).max(15);
+    let startup_after_gap = |gap_end: DateTime<Utc>| {
+        findings.iter().chain(low_confidence).find_map(|f| {
+            if !STARTUP_RULE_IDS.contains(&f.rule_id.as_str()) {
+                return None;
+            }
+            let first = f.first_seen?.with_timezone(&Utc);
+            (first >= gap_end && first <= gap_end + Duration::minutes(5)).then(|| f.rule_id.clone())
+        })
+    };
+    let minutes: Vec<i64> = minute_buckets.keys().copied().collect();
+    let mut run_len = 1i64;
+    for window in minutes.windows(2) {
+        let (prev, next) = (window[0], window[1]);
+        let delta = next - prev;
+        if delta == 1 {
+            run_len += 1;
+            continue;
+        }
+        if run_len >= 3 && delta - 1 >= threshold {
+            let gap_start = DateTime::<Utc>::from_timestamp((prev + 1) * 60, 0).expect("valid timestamp");
+            let gap_end = DateTime::<Utc>::from_timestamp(next * 60, 0).expect("valid timestamp");
+            let restart = startup_after_gap(gap_end);
+            let span = human_duration_minutes(delta - 1);
+            let message = match &restart {
+                Some(rule_id) => format!(
+                    "时间线断档 {} → {}(约 {span}),断档后 5 分钟内出现 {rule_id}:重启证据。",
+                    gap_start.to_rfc3339(),
+                    gap_end.to_rfc3339(),
+                ),
+                None => format!(
+                    "时间线断档 {} → {}(约 {span}),此前有连续活动:疑似进程重启或挂起区间。",
+                    gap_start.to_rfc3339(),
+                    gap_end.to_rfc3339(),
+                ),
+            };
+            anomalies.push(TimelineAnomaly {
+                kind: "log_gap".to_string(),
+                message,
+                nodes: Vec::new(),
+                gap_start: Some(gap_start),
+                gap_end: Some(gap_end),
+                restart_evidence: restart.is_some(),
+            });
+        }
+        run_len = 1;
+    }
+    anomalies
+}
+
+fn human_duration_minutes(minutes: i64) -> String {
+    if minutes >= 60 {
+        format!("{:.1}h", minutes as f64 / 60.0)
+    } else {
+        format!("{minutes}min")
+    }
 }
 
 /// Causal folding (rustfs/backlog#1290 sub-item A): a symptom finding
@@ -555,6 +726,103 @@ mod tests {
         assert_eq!(report.unmatched_top[0].count, 2);
         assert_eq!(report.unmatched_top[0].template, "failed to sync <path> after <n> retries");
         assert_eq!(report.summary.distinct_offsets, vec!["+08:00"]);
+    }
+
+    #[test]
+    fn disjoint_node_ranges_are_flagged() {
+        let mut a = analyzer(AnalyzeOptions::default());
+        // node1: 101 events across 00:00-01:40; node2: 101 events across
+        // 03:00-04:40 — completely disjoint windows, both sizable.
+        for (node, base_hour) in [("node1", 0), ("node2", 3)] {
+            for i in 0..101 {
+                let mut ev = event(
+                    "request ok",
+                    Some(LogLevel::Info),
+                    Some(&format!("2026-07-15T{:02}:{:02}:00Z", base_hour + i / 60, i % 60)),
+                );
+                ev.node = Some(Arc::from(node));
+                a.observe(ev);
+            }
+        }
+        let report = a.finalize(IngestReport::default());
+        let disjoint: Vec<_> = report.timeline_anomalies.iter().filter(|a| a.kind == "node_ranges_disjoint").collect();
+        assert_eq!(disjoint.len(), 1, "{:?}", report.timeline_anomalies);
+        assert_eq!(disjoint[0].nodes, vec!["node1".to_string(), "node2".to_string()]);
+        assert!(disjoint[0].message.contains("完全不重叠"));
+
+        // Below the >100-events bar the heuristic stays quiet.
+        let mut a = analyzer(AnalyzeOptions::default());
+        for (node, hour) in [("node1", 0), ("node2", 3)] {
+            for i in 0..5 {
+                let mut ev = event("request ok", Some(LogLevel::Info), Some(&format!("2026-07-15T0{hour}:0{i}:00Z")));
+                ev.node = Some(Arc::from(node));
+                a.observe(ev);
+            }
+        }
+        let report = a.finalize(IngestReport::default());
+        assert!(report.timeline_anomalies.iter().all(|a| a.kind != "node_ranges_disjoint"));
+    }
+
+    #[test]
+    fn log_gap_is_flagged_and_upgrades_on_startup_finding() {
+        let mut a = analyzer(AnalyzeOptions::default());
+        // 4 consecutive active minutes, a 40min hole, then activity again.
+        for minute in 0..4 {
+            a.observe(event("x", Some(LogLevel::Error), Some(&format!("2026-07-15T03:0{minute}:00Z"))));
+        }
+        a.observe(event(
+            "[FATAL] Observability initialization failed: collector unavailable",
+            Some(LogLevel::Error),
+            Some("2026-07-15T03:44:30Z"),
+        ));
+        let report = a.finalize(IngestReport::default());
+        let gaps: Vec<_> = report.timeline_anomalies.iter().filter(|a| a.kind == "log_gap").collect();
+        assert_eq!(gaps.len(), 1, "{:?}", report.timeline_anomalies);
+        assert!(gaps[0].restart_evidence, "startup-fatal right after the gap: {:?}", gaps[0]);
+        assert!(gaps[0].message.contains("重启证据"));
+        assert_eq!(gaps[0].gap_start.expect("start").to_rfc3339(), "2026-07-15T03:04:00+00:00");
+        assert_eq!(gaps[0].gap_end.expect("end").to_rfc3339(), "2026-07-15T03:44:00+00:00");
+
+        // Same hole but no startup finding afterwards: still a gap, no upgrade.
+        let mut a = analyzer(AnalyzeOptions::default());
+        for minute in 0..4 {
+            a.observe(event("x", Some(LogLevel::Error), Some(&format!("2026-07-15T03:0{minute}:00Z"))));
+        }
+        a.observe(event("x", Some(LogLevel::Error), Some("2026-07-15T03:44:30Z")));
+        let report = a.finalize(IngestReport::default());
+        let gaps: Vec<_> = report.timeline_anomalies.iter().filter(|a| a.kind == "log_gap").collect();
+        assert_eq!(gaps.len(), 1);
+        assert!(!gaps[0].restart_evidence);
+        assert!(gaps[0].message.contains("疑似进程重启或挂起"));
+
+        // A short 3-minute lull is not a gap.
+        let mut a = analyzer(AnalyzeOptions::default());
+        for minute in 0..4 {
+            a.observe(event("x", Some(LogLevel::Error), Some(&format!("2026-07-15T03:0{minute}:00Z"))));
+        }
+        a.observe(event("x", Some(LogLevel::Error), Some("2026-07-15T03:07:00Z")));
+        let report = a.finalize(IngestReport::default());
+        assert!(report.timeline_anomalies.iter().all(|a| a.kind != "log_gap"));
+    }
+
+    #[test]
+    fn mixed_offsets_anomaly_requires_multiple_offsets() {
+        // Single offset: quiet.
+        let mut a = analyzer(AnalyzeOptions::default());
+        a.observe(event("x", Some(LogLevel::Error), Some("2026-07-15T03:00:00+08:00")));
+        a.observe(event("x", Some(LogLevel::Error), Some("2026-07-15T04:00:00+08:00")));
+        let report = a.finalize(IngestReport::default());
+        assert!(report.timeline_anomalies.iter().all(|a| a.kind != "mixed_offsets"));
+
+        // Mixed offsets plus a signature finding: flagged with the clock note.
+        let mut a = analyzer(AnalyzeOptions::default());
+        a.observe(event("x", Some(LogLevel::Error), Some("2026-07-15T03:00:00+08:00")));
+        a.observe(event("SignatureDoesNotMatch", Some(LogLevel::Error), Some("2026-07-15T03:00:00Z")));
+        let report = a.finalize(IngestReport::default());
+        let mixed: Vec<_> = report.timeline_anomalies.iter().filter(|a| a.kind == "mixed_offsets").collect();
+        assert_eq!(mixed.len(), 1);
+        assert!(mixed[0].message.contains("+08:00"));
+        assert!(mixed[0].message.contains("签名不匹配"), "signature note missing: {}", mixed[0].message);
     }
 
     #[test]

--- a/crates/log-analyzer/src/analyze.rs
+++ b/crates/log-analyzer/src/analyze.rs
@@ -128,6 +128,9 @@ pub struct AnalysisReport {
     pub skipped_inputs: Vec<(String, SkipReason)>,
 }
 
+/// (min ts, max ts, timestamped event count) for one node label.
+type NodeRange = (DateTime<FixedOffset>, DateTime<FixedOffset>, u64);
+
 #[derive(Default)]
 struct BucketCounts {
     error: u64,
@@ -156,7 +159,7 @@ pub struct Analyzer {
     offsets: BTreeSet<String>,
     /// node label -> (min ts, max ts, timestamped event count); feeds the
     /// disjoint-node-ranges heuristic.
-    node_ranges: BTreeMap<String, (DateTime<FixedOffset>, DateTime<FixedOffset>, u64)>,
+    node_ranges: BTreeMap<String, NodeRange>,
     /// unix-minute -> counts.
     minute_buckets: BTreeMap<i64, BucketCounts>,
     unmatched: HashMap<String, ClusterAcc>,
@@ -398,15 +401,19 @@ const SIGNATURE_RULE_IDS: [&str; 2] = ["client-signature-mismatch", "internode-s
 /// never a verdict.
 fn detect_timeline_anomalies(
     offsets: &BTreeSet<String>,
-    node_ranges: &BTreeMap<String, (DateTime<FixedOffset>, DateTime<FixedOffset>, u64)>,
+    node_ranges: &BTreeMap<String, NodeRange>,
     minute_buckets: &BTreeMap<i64, BucketCounts>,
     bucket_width_min: i64,
     findings: &[Finding],
     low_confidence: &[Finding],
 ) -> Vec<TimelineAnomaly> {
     let mut anomalies = Vec::new();
-    let has_finding =
-        |ids: &[&str]| findings.iter().chain(low_confidence).any(|f| ids.contains(&f.rule_id.as_str()));
+    let has_finding = |ids: &[&str]| {
+        findings
+            .iter()
+            .chain(low_confidence)
+            .any(|f| ids.contains(&f.rule_id.as_str()))
+    };
 
     // 1. Mixed UTC offsets: nodes disagree on timezone or clock source.
     if offsets.len() > 1 {
@@ -429,8 +436,7 @@ fn detect_timeline_anomalies(
 
     // 2. Per-node time ranges that do not overlap at all (both sides with a
     // meaningful sample size): clocks are wrong or collection windows differ.
-    let sizable: Vec<(&String, &(DateTime<FixedOffset>, DateTime<FixedOffset>, u64))> =
-        node_ranges.iter().filter(|(_, (_, _, count))| *count > 100).collect();
+    let sizable: Vec<(&String, &NodeRange)> = node_ranges.iter().filter(|(_, (_, _, count))| *count > 100).collect();
     for (i, (node_a, (min_a, max_a, _))) in sizable.iter().enumerate() {
         for (node_b, (min_b, max_b, _)) in sizable.iter().skip(i + 1) {
             if max_a < min_b || max_b < min_a {
@@ -474,7 +480,7 @@ fn detect_timeline_anomalies(
             run_len += 1;
             continue;
         }
-        if run_len >= 3 && delta - 1 >= threshold {
+        if run_len >= 3 && delta > threshold {
             let gap_start = DateTime::<Utc>::from_timestamp((prev + 1) * 60, 0).expect("valid timestamp");
             let gap_end = DateTime::<Utc>::from_timestamp(next * 60, 0).expect("valid timestamp");
             let restart = startup_after_gap(gap_end);
@@ -745,7 +751,11 @@ mod tests {
             }
         }
         let report = a.finalize(IngestReport::default());
-        let disjoint: Vec<_> = report.timeline_anomalies.iter().filter(|a| a.kind == "node_ranges_disjoint").collect();
+        let disjoint: Vec<_> = report
+            .timeline_anomalies
+            .iter()
+            .filter(|a| a.kind == "node_ranges_disjoint")
+            .collect();
         assert_eq!(disjoint.len(), 1, "{:?}", report.timeline_anomalies);
         assert_eq!(disjoint[0].nodes, vec!["node1".to_string(), "node2".to_string()]);
         assert!(disjoint[0].message.contains("完全不重叠"));
@@ -819,7 +829,11 @@ mod tests {
         a.observe(event("x", Some(LogLevel::Error), Some("2026-07-15T03:00:00+08:00")));
         a.observe(event("SignatureDoesNotMatch", Some(LogLevel::Error), Some("2026-07-15T03:00:00Z")));
         let report = a.finalize(IngestReport::default());
-        let mixed: Vec<_> = report.timeline_anomalies.iter().filter(|a| a.kind == "mixed_offsets").collect();
+        let mixed: Vec<_> = report
+            .timeline_anomalies
+            .iter()
+            .filter(|a| a.kind == "mixed_offsets")
+            .collect();
         assert_eq!(mixed.len(), 1);
         assert!(mixed[0].message.contains("+08:00"));
         assert!(mixed[0].message.contains("签名不匹配"), "signature note missing: {}", mixed[0].message);
@@ -845,9 +859,17 @@ mod tests {
         }
         let report = a.finalize(IngestReport::default());
 
-        let quorum = report.findings.iter().find(|f| f.rule_id == "ec-write-quorum").expect("quorum");
+        let quorum = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "ec-write-quorum")
+            .expect("quorum");
         assert_eq!(quorum.collapsed_into.as_deref(), Some("disk-marked-faulty"));
-        let disk = report.findings.iter().find(|f| f.rule_id == "disk-marked-faulty").expect("disk");
+        let disk = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "disk-marked-faulty")
+            .expect("disk");
         assert_eq!(disk.caused, vec!["ec-write-quorum".to_string()]);
         // The P2 root is promoted to the collapsed P1 symptom's position.
         assert_eq!(report.findings[0].rule_id, "disk-marked-faulty");
@@ -877,7 +899,11 @@ mod tests {
             Some("2026-07-15T05:00:00+08:00"),
         ));
         let report = a.finalize(IngestReport::default());
-        let quorum = report.findings.iter().find(|f| f.rule_id == "ec-write-quorum").expect("quorum");
+        let quorum = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "ec-write-quorum")
+            .expect("quorum");
         assert_eq!(quorum.collapsed_into, None);
         assert!(report.findings.iter().all(|f| f.caused.is_empty()));
     }
@@ -895,7 +921,11 @@ mod tests {
         a.observe(panic_ev);
 
         let report = a.finalize(IngestReport::default());
-        let poisoned = report.findings.iter().find(|f| f.rule_id == "rwlock-poisoned").expect("poisoned");
+        let poisoned = report
+            .findings
+            .iter()
+            .find(|f| f.rule_id == "rwlock-poisoned")
+            .expect("poisoned");
         assert_eq!(poisoned.collapsed_into.as_deref(), Some("process-panic"));
         let panic = report.findings.iter().find(|f| f.rule_id == "process-panic").expect("panic");
         assert_eq!(panic.caused, vec!["rwlock-poisoned".to_string()]);

--- a/crates/log-analyzer/src/analyze.rs
+++ b/crates/log-analyzer/src/analyze.rs
@@ -19,8 +19,8 @@
 use crate::ingest::{IngestReport, SkipReason};
 use crate::model::{EventKind, LogEvent, LogLevel, ParseStats};
 use crate::redact;
-use crate::rules::{Finding, FindingsCollector, RuleEngine};
-use chrono::{DateTime, FixedOffset, Utc};
+use crate::rules::{Finding, FindingsCollector, RuleEngine, Severity};
+use chrono::{DateTime, Duration, FixedOffset, Utc};
 use regex::Regex;
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -221,6 +221,7 @@ impl Analyzer {
                 findings.push(finding);
             }
         }
+        collapse_findings(&mut findings);
 
         let mut unmatched_top: Vec<UnmatchedCluster> = self
             .unmatched
@@ -341,6 +342,103 @@ fn merge_timeline(minute_buckets: &BTreeMap<i64, BucketCounts>) -> Vec<TimeBucke
         .collect()
 }
 
+/// Causal folding (rustfs/backlog#1290 sub-item A): a symptom finding
+/// collapses under a root-cause finding named by its rule's
+/// `implies_root_cause` edges when the root plausibly precedes it
+/// (`root.first_seen <= symptom.first_seen + 5min`) and is not a
+/// long-finished historical episode (`root.last_seen >= symptom.first_seen -
+/// 30min`). A timestamp-less side (pure stderr panics) associates by
+/// existence. Only confirmed findings participate — folding real symptoms
+/// under a low-confidence root would hide them behind shaky evidence.
+///
+/// Findings are then re-sorted so a root block is promoted to the most
+/// severe position among itself and its collapsed symptoms, weighted by the
+/// block's combined count: the report top keeps answering "the most likely
+/// cause" even when the root itself is a lower-severity finding.
+fn collapse_findings(findings: &mut [Finding]) {
+    let index_of: HashMap<String, usize> = findings.iter().enumerate().map(|(i, f)| (f.rule_id.clone(), i)).collect();
+    // Among several qualifying roots pick the earliest first_seen;
+    // timestamp-less roots come last, rule id breaks remaining ties.
+    let root_key = |f: &Finding| (f.first_seen.is_none(), f.first_seen, f.rule_id.clone());
+
+    let mut chosen: Vec<Option<usize>> = vec![None; findings.len()];
+    for (i, symptom) in findings.iter().enumerate() {
+        for root_id in &symptom.implies_root_cause {
+            let Some(&r) = index_of.get(root_id) else { continue };
+            if r == i {
+                continue;
+            }
+            let root = &findings[r];
+            let qualifies = match (root.first_seen, symptom.first_seen) {
+                (Some(root_first), Some(symptom_first)) => {
+                    root_first <= symptom_first + Duration::minutes(5)
+                        && root.last_seen.unwrap_or(root_first) >= symptom_first - Duration::minutes(30)
+                }
+                _ => true,
+            };
+            if qualifies && chosen[i].is_none_or(|cur| root_key(&findings[r]) < root_key(&findings[cur])) {
+                chosen[i] = Some(r);
+            }
+        }
+    }
+
+    // Follow chains so a symptom never points at a root that is itself
+    // collapsed (external rules may build A -> B -> C edges); the visited
+    // guard stops on adversarial cycles.
+    let resolve = |mut r: usize| {
+        let mut seen = vec![false; chosen.len()];
+        while let Some(next) = chosen[r] {
+            if seen[r] {
+                break;
+            }
+            seen[r] = true;
+            r = next;
+        }
+        r
+    };
+
+    let mut caused: Vec<Vec<String>> = vec![Vec::new(); findings.len()];
+    for i in 0..findings.len() {
+        let Some(first) = chosen[i] else { continue };
+        let root = resolve(first);
+        if root == i {
+            continue;
+        }
+        let root_id = findings[root].rule_id.clone();
+        findings[i].collapsed_into = Some(root_id);
+        caused[root].push(findings[i].rule_id.clone());
+    }
+    for (i, mut list) in caused.into_iter().enumerate() {
+        list.sort();
+        findings[i].caused = list;
+    }
+    // A cycle can leave a "root" both collapsed and carrying symptoms; keep
+    // it visible rather than folding every participant out of the report.
+    for finding in findings.iter_mut() {
+        if !finding.caused.is_empty() {
+            finding.collapsed_into = None;
+        }
+    }
+
+    let mut effective: HashMap<String, (Severity, u64)> =
+        findings.iter().map(|f| (f.rule_id.clone(), (f.severity, f.count))).collect();
+    for finding in findings.iter() {
+        if let Some(root) = &finding.collapsed_into {
+            let entry = effective.get_mut(root).expect("collapse target exists");
+            entry.0 = entry.0.min(finding.severity);
+            entry.1 += finding.count;
+        }
+    }
+    findings.sort_by(|a, b| {
+        let (severity_a, count_a) = effective[&a.rule_id];
+        let (severity_b, count_b) = effective[&b.rule_id];
+        severity_a
+            .cmp(&severity_b)
+            .then(count_b.cmp(&count_a))
+            .then(a.rule_id.cmp(&b.rule_id))
+    });
+}
+
 fn redact_report(report: &mut AnalysisReport) {
     for finding in report.findings.iter_mut().chain(report.low_confidence.iter_mut()) {
         for sample in &mut finding.samples {
@@ -457,6 +555,106 @@ mod tests {
         assert_eq!(report.unmatched_top[0].count, 2);
         assert_eq!(report.unmatched_top[0].template, "failed to sync <path> after <n> retries");
         assert_eq!(report.summary.distinct_offsets, vec!["+08:00"]);
+    }
+
+    #[test]
+    fn causal_collapse_folds_quorum_under_disk_faulty() {
+        let mut a = analyzer(AnalyzeOptions::default());
+        // Root: disk faulty at t0 (P2). Symptom: write quorum at t0+2min (P1).
+        for minute in [0, 1] {
+            a.observe(event(
+                "Disk health check marked disk faulty",
+                Some(LogLevel::Error),
+                Some(&format!("2026-07-15T03:0{minute}:00+08:00")),
+            ));
+        }
+        for second in 0..3 {
+            a.observe(event(
+                "erasure write quorum (required=8, achieved=5)",
+                Some(LogLevel::Error),
+                Some(&format!("2026-07-15T03:02:0{second}+08:00")),
+            ));
+        }
+        let report = a.finalize(IngestReport::default());
+
+        let quorum = report.findings.iter().find(|f| f.rule_id == "ec-write-quorum").expect("quorum");
+        assert_eq!(quorum.collapsed_into.as_deref(), Some("disk-marked-faulty"));
+        let disk = report.findings.iter().find(|f| f.rule_id == "disk-marked-faulty").expect("disk");
+        assert_eq!(disk.caused, vec!["ec-write-quorum".to_string()]);
+        // The P2 root is promoted to the collapsed P1 symptom's position.
+        assert_eq!(report.findings[0].rule_id, "disk-marked-faulty");
+
+        let mut out = Vec::new();
+        crate::report::render(&report, crate::report::ReportFormat::Text, &mut out).expect("render");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(text.contains("级联症状: ec-write-quorum ×3"), "missing cascade line:\n{text}");
+        assert!(
+            !text.contains("[P1 服务不可用] ec-write-quorum"),
+            "collapsed symptom must not render flat:\n{text}"
+        );
+    }
+
+    #[test]
+    fn causal_collapse_respects_the_time_window() {
+        let mut a = analyzer(AnalyzeOptions::default());
+        // Root appears 2h AFTER the symptom: outside the 5min precedence window.
+        a.observe(event(
+            "erasure write quorum (required=8, achieved=5)",
+            Some(LogLevel::Error),
+            Some("2026-07-15T03:00:00+08:00"),
+        ));
+        a.observe(event(
+            "Disk health check marked disk faulty",
+            Some(LogLevel::Error),
+            Some("2026-07-15T05:00:00+08:00"),
+        ));
+        let report = a.finalize(IngestReport::default());
+        let quorum = report.findings.iter().find(|f| f.rule_id == "ec-write-quorum").expect("quorum");
+        assert_eq!(quorum.collapsed_into, None);
+        assert!(report.findings.iter().all(|f| f.caused.is_empty()));
+    }
+
+    #[test]
+    fn causal_collapse_uses_existence_for_timestamp_less_roots() {
+        let mut a = analyzer(AnalyzeOptions::default());
+        a.observe(event(
+            "rwlock IAM cache poisoned, recovering",
+            Some(LogLevel::Error),
+            Some("2026-07-15T03:00:00+08:00"),
+        ));
+        let mut panic_ev = event("thread 'main' panicked at src/main.rs:1:1: boom", Some(LogLevel::Error), None);
+        panic_ev.kind = EventKind::Panic;
+        a.observe(panic_ev);
+
+        let report = a.finalize(IngestReport::default());
+        let poisoned = report.findings.iter().find(|f| f.rule_id == "rwlock-poisoned").expect("poisoned");
+        assert_eq!(poisoned.collapsed_into.as_deref(), Some("process-panic"));
+        let panic = report.findings.iter().find(|f| f.rule_id == "process-panic").expect("panic");
+        assert_eq!(panic.caused, vec!["rwlock-poisoned".to_string()]);
+    }
+
+    #[test]
+    fn json_keeps_collapsed_findings_with_relation_fields() {
+        let mut a = analyzer(AnalyzeOptions::default());
+        a.observe(event(
+            "Disk health check marked disk faulty",
+            Some(LogLevel::Error),
+            Some("2026-07-15T03:00:00+08:00"),
+        ));
+        a.observe(event(
+            "erasure write quorum (required=8, achieved=5)",
+            Some(LogLevel::Error),
+            Some("2026-07-15T03:02:00+08:00"),
+        ));
+        let report = a.finalize(IngestReport::default());
+        let value = serde_json::to_value(&report).expect("json");
+        let findings = value["findings"].as_array().expect("array");
+        let ids: Vec<&str> = findings.iter().map(|f| f["rule_id"].as_str().expect("id")).collect();
+        assert!(ids.contains(&"ec-write-quorum"), "collapsed finding stays in JSON: {ids:?}");
+        let quorum = findings.iter().find(|f| f["rule_id"] == "ec-write-quorum").expect("quorum");
+        assert_eq!(quorum["collapsed_into"], "disk-marked-faulty");
+        let disk = findings.iter().find(|f| f["rule_id"] == "disk-marked-faulty").expect("disk");
+        assert_eq!(disk["caused"][0], "ec-write-quorum");
     }
 
     #[test]

--- a/crates/log-analyzer/src/lib.rs
+++ b/crates/log-analyzer/src/lib.rs
@@ -28,11 +28,12 @@ mod redact;
 pub mod report;
 pub mod rules;
 
-pub use analyze::{AnalysisReport, AnalyzeOptions, Analyzer, Summary, TimeBucket, UnmatchedCluster};
+pub use analyze::{AnalysisReport, AnalyzeOptions, Analyzer, Summary, TimeBucket, TimelineAnomaly, UnmatchedCluster};
 pub use ingest::{IngestOptions, IngestReport, SkipReason, ingest_path, ingest_reader};
 pub use model::{EventKind, LogEvent, LogLevel, ParseStats, SourceRef};
 pub use parse::LineParser;
 pub use report::{ReportFormat, render};
 pub use rules::{
-    Finding, FindingsCollector, Matcher, Rule, RuleEngine, RuleSet, RuleSetError, Severity, seed_rule_set, seed_rules,
+    EXTERNAL_RULES_SCHEMA_VERSION, ExternalRulesError, Finding, FindingsCollector, Matcher, Rule, RuleEngine, RuleSet,
+    RuleSetError, Severity, seed_rule_set, seed_rules, seed_rules_with_external,
 };

--- a/crates/log-analyzer/src/report/markdown.rs
+++ b/crates/log-analyzer/src/report/markdown.rs
@@ -76,7 +76,10 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
         writeln!(w, "未发现已知故障模式;请查看下方「未识别的高频错误」是否有线索。")?;
         writeln!(w)?;
     }
-    for finding in &report.findings {
+    // Collapsed symptoms render inside their root's block, not flat.
+    let counts: std::collections::HashMap<&str, u64> =
+        report.findings.iter().map(|f| (f.rule_id.as_str(), f.count)).collect();
+    for finding in report.findings.iter().filter(|f| f.collapsed_into.is_none()) {
         writeln!(
             w,
             "### [{}] {} — {} (×{})",
@@ -88,6 +91,14 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
         writeln!(w)?;
         if let (Some(first), Some(last)) = (finding.first_seen, finding.last_seen) {
             writeln!(w, "- 首次: {} · 末次: {}", first.to_rfc3339(), last.to_rfc3339())?;
+        }
+        if !finding.caused.is_empty() {
+            let items: Vec<String> = finding
+                .caused
+                .iter()
+                .map(|id| format!("`{id}` ×{}", counts.get(id.as_str()).copied().unwrap_or(0)))
+                .collect();
+            writeln!(w, "- 级联症状: {}", items.join(", "))?;
         }
         writeln!(w, "- 节点: {}", finding.nodes.iter().cloned().collect::<Vec<_>>().join(", "))?;
         writeln!(w, "- 诊断: {}", finding.diagnosis)?;

--- a/crates/log-analyzer/src/report/markdown.rs
+++ b/crates/log-analyzer/src/report/markdown.rs
@@ -70,6 +70,15 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
     }
     writeln!(w)?;
 
+    if !report.timeline_anomalies.is_empty() {
+        writeln!(w, "## 时间线异常(提示)")?;
+        writeln!(w)?;
+        for anomaly in &report.timeline_anomalies {
+            writeln!(w, "- ⚠ {}", anomaly.message)?;
+        }
+        writeln!(w)?;
+    }
+
     writeln!(w, "## 发现(按严重度)")?;
     writeln!(w)?;
     if report.findings.is_empty() {

--- a/crates/log-analyzer/src/report/markdown.rs
+++ b/crates/log-analyzer/src/report/markdown.rs
@@ -86,8 +86,7 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
         writeln!(w)?;
     }
     // Collapsed symptoms render inside their root's block, not flat.
-    let counts: std::collections::HashMap<&str, u64> =
-        report.findings.iter().map(|f| (f.rule_id.as_str(), f.count)).collect();
+    let counts: std::collections::HashMap<&str, u64> = report.findings.iter().map(|f| (f.rule_id.as_str(), f.count)).collect();
     for finding in report.findings.iter().filter(|f| f.collapsed_into.is_none()) {
         writeln!(
             w,

--- a/crates/log-analyzer/src/report/mod.rs
+++ b/crates/log-analyzer/src/report/mod.rs
@@ -159,7 +159,8 @@ mod tests {
         let mut out = Vec::new();
         render(&report, ReportFormat::Json, &mut out).expect("render");
         let value: serde_json::Value = serde_json::from_slice(&out).expect("parse");
-        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema_version"], 2);
+        assert!(value["timeline_anomalies"].is_array());
         assert_eq!(value["findings"][0]["rule_id"], "ec-write-quorum");
         assert_eq!(value["findings"][0]["count"], 2);
         assert_eq!(value["summary"]["files_parsed"], 2);

--- a/crates/log-analyzer/src/report/text.rs
+++ b/crates/log-analyzer/src/report/text.rs
@@ -82,6 +82,15 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
     }
     writeln!(w)?;
 
+    if !report.timeline_anomalies.is_empty() {
+        writeln!(w, "时间线异常(提示)")?;
+        writeln!(w, "{LIGHT_RULE}")?;
+        for anomaly in &report.timeline_anomalies {
+            writeln!(w, "[!] {}", anomaly.message)?;
+        }
+        writeln!(w)?;
+    }
+
     writeln!(w, "发现(按严重度)")?;
     writeln!(w, "{LIGHT_RULE}")?;
     if report.findings.is_empty() {

--- a/crates/log-analyzer/src/report/text.rs
+++ b/crates/log-analyzer/src/report/text.rs
@@ -97,8 +97,7 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
         writeln!(w, "未发现已知故障模式;请查看下方「未识别的高频错误」是否有线索。")?;
     }
     // Collapsed symptoms render inside their root's block, not flat.
-    let counts: std::collections::HashMap<&str, u64> =
-        report.findings.iter().map(|f| (f.rule_id.as_str(), f.count)).collect();
+    let counts: std::collections::HashMap<&str, u64> = report.findings.iter().map(|f| (f.rule_id.as_str(), f.count)).collect();
     for finding in report.findings.iter().filter(|f| f.collapsed_into.is_none()) {
         render_finding(finding, &counts, w)?;
     }

--- a/crates/log-analyzer/src/report/text.rs
+++ b/crates/log-analyzer/src/report/text.rs
@@ -87,8 +87,11 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
     if report.findings.is_empty() {
         writeln!(w, "未发现已知故障模式;请查看下方「未识别的高频错误」是否有线索。")?;
     }
-    for finding in &report.findings {
-        render_finding(finding, w)?;
+    // Collapsed symptoms render inside their root's block, not flat.
+    let counts: std::collections::HashMap<&str, u64> =
+        report.findings.iter().map(|f| (f.rule_id.as_str(), f.count)).collect();
+    for finding in report.findings.iter().filter(|f| f.collapsed_into.is_none()) {
+        render_finding(finding, &counts, w)?;
     }
 
     if !report.low_confidence.is_empty() {
@@ -135,7 +138,7 @@ pub(super) fn render(report: &AnalysisReport, w: &mut dyn io::Write) -> io::Resu
     Ok(())
 }
 
-fn render_finding(finding: &Finding, w: &mut dyn io::Write) -> io::Result<()> {
+fn render_finding(finding: &Finding, counts: &std::collections::HashMap<&str, u64>, w: &mut dyn io::Write) -> io::Result<()> {
     let nodes = finding.nodes.iter().cloned().collect::<Vec<_>>().join(", ");
     writeln!(
         w,
@@ -148,6 +151,14 @@ fn render_finding(finding: &Finding, w: &mut dyn io::Write) -> io::Result<()> {
     )?;
     if let (Some(first), Some(last)) = (finding.first_seen, finding.last_seen) {
         writeln!(w, "    首次 {}   末次 {}", first.to_rfc3339(), last.to_rfc3339())?;
+    }
+    if !finding.caused.is_empty() {
+        let items: Vec<String> = finding
+            .caused
+            .iter()
+            .map(|id| format!("{id} ×{}", counts.get(id.as_str()).copied().unwrap_or(0)))
+            .collect();
+        writeln!(w, "    级联症状: {}", items.join("、"))?;
     }
     writeln!(w, "    诊断: {}", finding.diagnosis)?;
     writeln!(w, "    建议: {}", finding.suggestion)?;

--- a/crates/log-analyzer/src/rules/external.rs
+++ b/crates/log-analyzer/src/rules/external.rs
@@ -1,0 +1,190 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! External rule file loading (`--rules`, rustfs/backlog#1290 sub-item C):
+//! the support team ships new rules — or hotfixes a misfiring built-in one —
+//! without waiting for a release. External rules deserialize into the exact
+//! same [`Rule`] type as the seed library (design decision 3 of
+//! rustfs/backlog#1281); their anchors are NOT covered by the CI anchor
+//! guard, so their quality is on the file author.
+
+use super::model::Rule;
+use super::rule_set::{RuleSet, RuleSetError};
+use super::seed::seed_rules;
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Supported `schema_version` of the external rules file.
+pub const EXTERNAL_RULES_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Deserialize)]
+struct ExternalRuleFile {
+    schema_version: u32,
+    rules: Vec<Rule>,
+}
+
+#[derive(Debug, Error)]
+pub enum ExternalRulesError {
+    #[error("cannot parse rules file: {0}")]
+    Parse(#[from] serde_json::Error),
+    #[error("unsupported rules schema_version {found} (supported: {EXTERNAL_RULES_SCHEMA_VERSION})")]
+    SchemaVersion { found: u32 },
+    #[error("duplicate rule id '{0}' within the external rules file")]
+    DuplicateInFile(String),
+    #[error(transparent)]
+    Invalid(#[from] RuleSetError),
+}
+
+/// Parses an external rule file and merges it over the built-in seed rules.
+/// An external rule with the same id REPLACES the built-in one; the merged
+/// set is validated as a whole and any problem fails the load — analysis
+/// never runs with a half-broken rule set.
+pub fn seed_rules_with_external(json: &str) -> Result<RuleSet, ExternalRulesError> {
+    let file: ExternalRuleFile = serde_json::from_str(json)?;
+    if file.schema_version != EXTERNAL_RULES_SCHEMA_VERSION {
+        return Err(ExternalRulesError::SchemaVersion {
+            found: file.schema_version,
+        });
+    }
+    // Same-id merging would silently swallow duplicates inside the file
+    // itself, so reject those before merging.
+    let mut seen = std::collections::BTreeSet::new();
+    for rule in &file.rules {
+        if !seen.insert(rule.id.clone()) {
+            return Err(ExternalRulesError::DuplicateInFile(rule.id.clone()));
+        }
+    }
+
+    let mut rules = seed_rules();
+    for external in file.rules {
+        match rules.iter_mut().find(|rule| rule.id == external.id) {
+            Some(existing) => *existing = external,
+            None => rules.push(external),
+        }
+    }
+    Ok(RuleSet::new(rules)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{EventKind, LogEvent, LogLevel, SourceRef};
+    use crate::rules::RuleEngine;
+    use std::sync::Arc;
+
+    fn event(message: &str) -> LogEvent {
+        LogEvent {
+            timestamp: None,
+            level: Some(LogLevel::Error),
+            target: None,
+            message: message.to_string(),
+            fields: serde_json::Map::new(),
+            source: SourceRef {
+                file: Arc::from("rustfs.log"),
+                line: 1,
+            },
+            node: None,
+            kind: EventKind::Json,
+        }
+    }
+
+    /// The canonical external-file shape; also documents the on-disk format
+    /// (kept in sync with docs/operations/log-diagnose.md).
+    const EXTERNAL_FILE: &str = r#"{
+      "schema_version": 1,
+      "rules": [
+        {
+          "id": "custom-oom-killer",
+          "severity": "p1_unavailable",
+          "category": "process",
+          "title": "内核 OOM killer 终止了进程",
+          "matcher": { "message_contains": "Out of memory: Killed process" },
+          "diagnosis": "内核因内存不足杀掉了 rustfs 进程。",
+          "suggestion": "检查内存限制与其他驻留进程;考虑调大内存或加节点。"
+        }
+      ]
+    }"#;
+
+    #[test]
+    fn external_rule_is_added_and_matches() {
+        let set = seed_rules_with_external(EXTERNAL_FILE).expect("load");
+        let seed_len = seed_rules().len();
+        assert_eq!(set.rules().len(), seed_len + 1);
+        let engine = RuleEngine::new(set);
+        let hits = engine.matches(&event("Out of memory: Killed process 1234 (rustfs)"));
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn same_id_overrides_the_builtin_rule() {
+        let file = r#"{
+          "schema_version": 1,
+          "rules": [
+            {
+              "id": "ec-write-quorum",
+              "severity": "p4_info",
+              "category": "erasure",
+              "title": "覆盖后的写仲裁规则",
+              "matcher": { "message_contains": "OVERRIDDEN-ANCHOR-TEXT" },
+              "diagnosis": "外部覆盖。",
+              "suggestion": "外部覆盖。"
+            }
+          ]
+        }"#;
+        let set = seed_rules_with_external(file).expect("load");
+        assert_eq!(set.rules().len(), seed_rules().len(), "override must not grow the set");
+        let engine = RuleEngine::new(set);
+        // The built-in matcher no longer fires; the external one does.
+        assert!(
+            engine
+                .matches(&event("erasure write quorum (required=8, achieved=5)"))
+                .is_empty()
+        );
+        assert_eq!(engine.matches(&event("OVERRIDDEN-ANCHOR-TEXT hit")).len(), 1);
+    }
+
+    #[test]
+    fn bad_files_fail_fast_with_actionable_errors() {
+        // Not JSON at all.
+        assert!(matches!(seed_rules_with_external("nope"), Err(ExternalRulesError::Parse(_))));
+
+        // Wrong schema version.
+        let err = seed_rules_with_external(r#"{"schema_version": 9, "rules": []}"#).expect_err("schema");
+        assert!(err.to_string().contains("schema_version 9"), "{err}");
+
+        // Duplicate id inside the file.
+        let dup = r#"{
+          "schema_version": 1,
+          "rules": [
+            {"id": "x-dup", "severity": "p4_info", "category": "ops", "title": "a",
+             "matcher": {"message_contains": "aaaaaaaaaa"}, "diagnosis": "d", "suggestion": "s"},
+            {"id": "x-dup", "severity": "p4_info", "category": "ops", "title": "b",
+             "matcher": {"message_contains": "bbbbbbbbbb"}, "diagnosis": "d", "suggestion": "s"}
+          ]
+        }"#;
+        let err = seed_rules_with_external(dup).expect_err("dup");
+        assert!(err.to_string().contains("x-dup"), "{err}");
+
+        // Bad regex: the merged-set validation names the offending rule.
+        let bad_regex = r#"{
+          "schema_version": 1,
+          "rules": [
+            {"id": "x-bad-regex", "severity": "p4_info", "category": "ops", "title": "a",
+             "matcher": {"message_regex": "[unclosed"}, "diagnosis": "d", "suggestion": "s"}
+          ]
+        }"#;
+        let err = seed_rules_with_external(bad_regex).expect_err("regex");
+        assert!(err.to_string().contains("x-bad-regex"), "{err}");
+    }
+}

--- a/crates/log-analyzer/src/rules/findings.rs
+++ b/crates/log-analyzer/src/rules/findings.rs
@@ -54,6 +54,15 @@ pub struct Finding {
     pub evidence: BTreeMap<String, EvidenceValues>,
     /// `count < rule.min_count`: the report demotes this to low-confidence.
     pub below_min_count: bool,
+    /// Causal folding (rustfs/backlog#1290): the root-cause finding this one
+    /// collapsed into. Renderers fold it under that root instead of listing
+    /// it flat; JSON keeps the full finding either way.
+    pub collapsed_into: Option<String>,
+    /// The symptom finding ids collapsed under this root (other direction).
+    pub caused: Vec<String>,
+    /// The rule's causal edges, carried for `finalize` — not report data.
+    #[serde(skip)]
+    pub implies_root_cause: Vec<String>,
 }
 
 struct FindingAcc {
@@ -98,6 +107,9 @@ impl FindingsCollector {
                 samples: Vec::new(),
                 evidence: BTreeMap::new(),
                 below_min_count: false,
+                collapsed_into: None,
+                caused: Vec::new(),
+                implies_root_cause: rule.implies_root_cause.clone(),
             },
             min_count: rule.min_count,
             evidence_fields: rule.evidence_fields.clone(),

--- a/crates/log-analyzer/src/rules/mod.rs
+++ b/crates/log-analyzer/src/rules/mod.rs
@@ -17,12 +17,14 @@
 //! (rustfs/backlog#1286).
 
 mod engine;
+mod external;
 mod findings;
 mod model;
 mod rule_set;
 mod seed;
 
 pub use engine::RuleEngine;
+pub use external::{EXTERNAL_RULES_SCHEMA_VERSION, ExternalRulesError, seed_rules_with_external};
 pub use findings::{EvidenceValues, Finding, FindingsCollector};
 pub use model::{Matcher, Rule, Severity};
 pub use rule_set::{RuleSet, RuleSetError};

--- a/docs/operations/log-diagnose.md
+++ b/docs/operations/log-diagnose.md
@@ -30,8 +30,14 @@ rustfs diagnose logs.tar.gz --since 24h --format md > report.md
 ## 报告解读
 
 - **发现(按严重度)**:P0 数据风险 → P1 服务不可用 → P2 降级 → P3 客户端侧
-  → P4 提示。每条带诊断结论、建议动作、证据字段与样本行。quorum 类发现
-  通常是级联症状,优先处理同时段的 disk/peer 类 P2 发现。
+  → P4 提示。每条带诊断结论、建议动作、证据字段与样本行。
+- **因果折叠**:当症状类发现(如 quorum 刷屏)在时间上跟随其已知根因
+  (如盘 faulty)出现时,报告把症状折叠进根因块的"级联症状"行,根因块
+  提升到两者中更高的严重度位置——报告首块直接回答"最可能的原因"。
+  JSON 输出保留全部 findings(`collapsed_into` / `caused` 字段标注关系)。
+- **时间线异常(提示)**:三个确定性启发,均为提示不定罪——混合 UTC 偏移
+  (伴签名错误时点名时钟偏移)、节点时间范围完全不重叠、时间线断档
+  (断档后紧跟 startup 类发现时升级为"重启证据")。
 - **低频提示**:命中数低于规则阈值的匹配(如零星的签名错误),仅供参考。
 - **未识别的高频错误**:规则库未覆盖的 WARN/ERROR 消息模板聚类。这一节是
   规则库迭代的输入——反复出现的新模板请提给维护者补规则
@@ -44,6 +50,44 @@ rustfs diagnose logs.tar.gz --since 24h --format md > report.md
 
 把 bucket/object/AK/IP 等客户标识替换为稳定哈希(同值同哈希,保持可关联),
 规则 id、诊断文本与 panic 源码位置保留。适合把报告转发到工单系统或群聊。
+
+## 自定义规则(`--rules <file.json>`)
+
+支持团队可以在不等发版的情况下补规则,或热修一条误报的内置规则:
+
+```bash
+rustfs diagnose customer.zip --rules extra-rules.json
+```
+
+文件格式(`Rule` 的 JSON 表示与内置规则完全一致):
+
+```json
+{
+  "schema_version": 1,
+  "rules": [
+    {
+      "id": "custom-oom-killer",
+      "severity": "p1_unavailable",
+      "category": "process",
+      "title": "内核 OOM killer 终止了进程",
+      "matcher": { "message_contains": "Out of memory: Killed process" },
+      "diagnosis": "内核因内存不足杀掉了 rustfs 进程。",
+      "suggestion": "检查内存限制与其他驻留进程;考虑调大内存或加节点。"
+    }
+  ]
+}
+```
+
+- `severity`:`p0_data_risk | p1_unavailable | p2_degraded | p3_client_side | p4_info`;
+- `matcher`:`message_prefix` / `message_contains` / `message_regex` /
+  `field_equals {name, value}` / `target_prefix` / `is_panic` / `min_level` /
+  `all [..]` / `any [..]`,与内置规则同一套类型;
+- 可选字段:`evidence_fields`、`min_count`(默认 1)、`implies_root_cause`
+  (参与因果折叠)、`anchors`;
+- **同 id 覆盖内置规则**(用于热修误报);合并后的规则集整体校验,任何错误
+  (坏 regex、重复 id、空 matcher 组)会逐条打印并以退出码 2 失败——不会
+  带着半坏的规则集分析;
+- 外部规则的 `anchors` 不受 CI 锚点守卫约束,质量由文件作者自担。
 
 ## 已知边界
 

--- a/rustfs/src/config/cli.rs
+++ b/rustfs/src/config/cli.rs
@@ -156,6 +156,10 @@ pub struct DiagnoseOpts {
     #[arg(long)]
     pub redact: bool,
 
+    /// Extra rules file (JSON; same-id rules override built-ins)
+    #[arg(long)]
+    pub rules: Option<std::path::PathBuf>,
+
     /// Max unmatched error patterns to list
     #[arg(long, default_value_t = 20)]
     pub top: usize,

--- a/rustfs/src/diagnose.rs
+++ b/rustfs/src/diagnose.rs
@@ -25,8 +25,8 @@
 use crate::config::{DiagnoseFormat, DiagnoseOpts};
 use chrono::{DateTime, FixedOffset, Local};
 use rustfs_log_analyzer::{
-    AnalyzeOptions, Analyzer, IngestOptions, IngestReport, LogLevel, ReportFormat, RuleEngine, ingest_path, ingest_reader,
-    render, seed_rule_set,
+    AnalyzeOptions, Analyzer, IngestOptions, IngestReport, LogLevel, ReportFormat, RuleEngine, RuleSet, ingest_path,
+    ingest_reader, render, seed_rule_set, seed_rules_with_external,
 };
 use std::io::Result;
 use std::path::Path;
@@ -39,8 +39,17 @@ pub fn execute_diagnose(opts: &DiagnoseOpts) -> Result<()> {
             std::process::exit(2);
         }
     };
+    let rule_set = match load_rule_set(opts) {
+        Ok(set) => set,
+        Err(message) => {
+            // Fail fast: never analyze with a half-broken rule set. The
+            // message lists every problem at once (RuleSetError::Multiple).
+            eprintln!("diagnose: {message}");
+            std::process::exit(2);
+        }
+    };
 
-    let mut analyzer = Analyzer::new(RuleEngine::new(seed_rule_set()), analyze_opts);
+    let mut analyzer = Analyzer::new(RuleEngine::new(rule_set), analyze_opts);
     let ingest_opts = IngestOptions::default();
     let mut merged = IngestReport::default();
     let mut readable_inputs = 0usize;
@@ -69,6 +78,17 @@ pub fn execute_diagnose(opts: &DiagnoseOpts) -> Result<()> {
     let report = analyzer.finalize(merged);
     let stdout = std::io::stdout();
     render(&report, report_format(opts.format), &mut stdout.lock())
+}
+
+/// Built-in seed rules, optionally merged with `--rules <file.json>`
+/// (rustfs/backlog#1290 sub-item C): same-id external rules override
+/// built-ins; the merged set validates as a whole.
+fn load_rule_set(opts: &DiagnoseOpts) -> std::result::Result<RuleSet, String> {
+    let Some(path) = &opts.rules else {
+        return Ok(seed_rule_set());
+    };
+    let json = std::fs::read_to_string(path).map_err(|err| format!("cannot read rules file '{}': {err}", path.display()))?;
+    seed_rules_with_external(&json).map_err(|err| format!("invalid rules file '{}': {err}", path.display()))
 }
 
 fn report_format(format: DiagnoseFormat) -> ReportFormat {

--- a/rustfs/tests/diagnose_e2e.rs
+++ b/rustfs/tests/diagnose_e2e.rs
@@ -198,6 +198,8 @@ fn cli_parses_diagnose_and_keeps_legacy_server_routing() {
         "--since".to_string(),
         "24h".to_string(),
         "--redact".to_string(),
+        "--rules".to_string(),
+        "/tmp/extra-rules.json".to_string(),
     ])
     .expect("parse");
     let CommandResult::Diagnose(opts) = parsed else {
@@ -206,6 +208,7 @@ fn cli_parses_diagnose_and_keeps_legacy_server_routing() {
     assert_eq!(opts.paths, vec!["/tmp/customer-logs"]);
     assert!(opts.redact);
     assert_eq!(opts.since.as_deref(), Some("24h"));
+    assert_eq!(opts.rules.as_deref(), Some(std::path::Path::new("/tmp/extra-rules.json")));
 
     // Legacy preprocessor regression: a bare volume still means `server`.
     let legacy = Opt::parse_command(vec!["rustfs".to_string(), "/data".to_string()]);

--- a/rustfs/tests/diagnose_e2e.rs
+++ b/rustfs/tests/diagnose_e2e.rs
@@ -176,7 +176,7 @@ fn json_format_has_a_stable_schema() {
     let mut out = Vec::new();
     render(&report, ReportFormat::Json, &mut out).expect("render");
     let value: serde_json::Value = serde_json::from_slice(&out).expect("parse");
-    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["schema_version"], 2);
     assert!(value["findings"].as_array().expect("findings").len() >= 2);
     assert!(value["summary"]["parse"]["json_ok"].as_u64().expect("json_ok") > 0);
 
@@ -229,5 +229,5 @@ fn binary_smoke_diagnose_json() {
         .expect("run rustfs diagnose");
     assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("stdout JSON");
-    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["schema_version"], 2);
 }


### PR DESCRIPTION
## What

Phase 2 of the offline log fault-analysis system (rustfs/backlog#1290, master plan rustfs/backlog#1281), stacked on the MVP PR #4876. Three independent sub-items, one commit each:

### A. Causal folding (root-cause collapsing)

A symptom finding whose rule declares `implies_root_cause` edges (seeded in the MVP: quorum-class → disk/peer roots, `rwlock-poisoned` → `process-panic`) now collapses under a qualifying root: `root.first_seen <= symptom.first_seen + 5min` and `root.last_seen >= symptom.first_seen - 30min`; a timestamp-less side (pure stderr panics) associates by existence. `Finding` gains `collapsed_into` / `caused`; text/markdown render the root block with an indented "级联症状: ec-write-quorum ×3412" line and stop listing collapsed symptoms flat, while JSON keeps every finding. The root block is promoted to the most severe position among itself and its symptoms, so the report top still answers "the most likely cause" — a P2 disk-faulty root with a P1 quorum cascade renders first. Chains from external rules resolve transitively with a cycle guard; only confirmed findings participate (a low-confidence root never swallows real symptoms).

### B. Timeline/clock anomaly detection (JSON schema v2)

Three deterministic hints rendered between the summary and findings, phrased as hints, never verdicts:

1. **Mixed UTC offsets** — nodes disagree on timezone/clock source; when a signature-mismatch finding coexists, the message names clock skew as the likely root cause.
2. **Disjoint per-node time ranges** — two nodes with >100 timestamped events each whose ranges do not overlap at all: wrong clocks or different collection windows.
3. **Log gaps** — a zero-event span of at least max(15min, 3× display bucket width) after ≥3 consecutive active minutes, with activity resuming after; upgraded to "restart evidence" when a startup-class finding (`startup-fatal` / `runtime-failed` / `endpoint-resolve-failed`) begins within 5 minutes after the gap.

JSON output gains `timeline_anomalies` and `schema_version` bumps 1 → 2.

### C. External rule loading (`--rules <file.json>`)

`rustfs diagnose ... --rules extra.json` merges an external rule file (`{"schema_version": 1, "rules": [<Rule>...]}` — the exact serde shape of the built-in rules) over the seed library. Same-id rules replace built-ins so support can hotfix a misfiring rule without a release. The merged set validates as a whole; any problem (bad regex, duplicate id, empty matcher group, wrong schema version) prints every error at once and exits 2 — analysis never runs on a half-broken set. External anchors are exempt from the CI anchor guard (documented as author-owned quality). `docs/operations/log-diagnose.md` gains a custom-rules section with a complete example.

## Verification

- `cargo test -p rustfs-log-analyzer`: 80 passed (10 new: 4 folding, 3 timeline, 3 external-rules).
- `cargo test -p rustfs --test diagnose_e2e`: 6 passed, 1 ignored (binary smoke, opt-in by design).
- `cargo clippy -p rustfs -p rustfs-log-analyzer --all-targets -- -D warnings` clean; `make pre-commit` green; `scripts/check_log_analyzer_rules.sh` OK.
- Real-binary smoke on a synthetic multi-fault sample (disk-faulty → quorum spam, mixed offsets + signature mismatch, [FATAL] after a gap, kernel OOM line + external rule): the report opens with the promoted `disk-marked-faulty` root block carrying `级联症状: ec-write-quorum ×4`, the mixed-offsets hint names clock skew, and the external `custom-oom-killer` rule fires; a bad rules file exits 2 listing the offending rule id.

## Notes for reviewers

- Stacked on #4876; base is the MVP branch and will be retargeted to `main` once #4876 merges. Only the top three commits are new here.
- The collapse window/thresholds (5min / 30min / >100 events / max(15min, 3× bucket width)) come verbatim from the spec in rustfs/backlog#1290 and are deliberately conservative; all three heuristics are presentation-level and fully disclosed in JSON.
