### PR TITLE
test(ilm): re-enable test_transition_and_restore_flows; fix test-util disk-open and restore error-path lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # test_transition_and_restore_flows was re-enabled by rustfs/backlog#1303:
+      # its "missing xl.meta on disk2" was a test-util bug (open_disk hardcoded
+      # disk_index 0), not an EC metadata-distribution issue.
       # restore_object_usecase_reports_ongoing_conflict_and_completion was
       # re-enabled by backlog#1304 (restore accepts serialize on a short CAS
       # guard; the copy-back no longer holds the #4877 whole-copy-back lock,
@@ -230,9 +233,6 @@ jobs:
       # they keep #[ignore] with a backlog reference):
       #   - test_noncurrent_{expiry,transition}_still_works_after_immediate_compensation_transition:
       #     noncurrent transition/expiry after an immediate compensation transition.
-      #   - test_transition_and_restore_flows: transition metadata is missing on
-      #     one drive (assert_transition_meta_consistent: "missing xl.meta ... on
-      #     disk2") - an EC metadata-distribution issue, not the restore lock.
       #   - test_restore_chain_local_read_expiry_keeps_remote_and_allows_re_restore:
       #     DeleteRestoredAction sets opts.transition.expire_restored, but no
       #     delete path reads that flag, so cleanup deletes the whole object
@@ -242,7 +242,7 @@ jobs:
         run: |
           cargo nextest run -j1 --run-ignored ignored-only \
             -p rustfs-scanner -p rustfs \
-            -E '(binary(lifecycle_integration_test) or (package(rustfs) and test(lifecycle_transition_api_test))) and not (test(test_transition_and_restore_flows) or test(test_noncurrent_expiry_still_works_after_immediate_compensation_transition) or test(test_noncurrent_transition_still_works_after_immediate_compensation_transition) or test(test_restore_chain_local_read_expiry_keeps_remote_and_allows_re_restore))'
+            -E '(binary(lifecycle_integration_test) or (package(rustfs) and test(lifecycle_transition_api_test))) and not (test(test_noncurrent_expiry_still_works_after_immediate_compensation_transition) or test(test_noncurrent_transition_still_works_after_immediate_compensation_transition) or test(test_restore_chain_local_read_expiry_keeps_remote_and_allows_re_restore))'
 
   test-and-lint-rio-v2:
     name: Test and Lint (rio-v2)

--- a/crates/ecstore/src/services/tier/test_util.rs
+++ b/crates/ecstore/src/services/tier/test_util.rs
@@ -67,7 +67,8 @@ use uuid::Uuid;
 
 use crate::client::transition_api::{ReadCloser, ReaderImpl};
 use crate::disk::endpoint::Endpoint;
-use crate::disk::{DiskAPI, DiskOption, STORAGE_FORMAT_FILE, new_disk};
+use crate::disk::format::FormatV3;
+use crate::disk::{DiskAPI, DiskOption, FORMAT_CONFIG_FILE, RUSTFS_META_BUCKET, STORAGE_FORMAT_FILE, new_disk};
 use crate::services::tier::tier::TierConfigMgr;
 use crate::services::tier::tier_config::{TierConfig, TierMinIO, TierType};
 use crate::services::tier::warm_backend::{WarmBackend, WarmBackendGetOpts, build_transition_put_options};
@@ -498,10 +499,19 @@ pub struct TransitionMeta {
 }
 
 async fn open_disk(disk_path: &Path) -> Option<crate::disk::DiskStore> {
+    // `LocalDisk::new` rejects an endpoint whose (set_idx, disk_idx) disagrees
+    // with the position recorded in the disk's own format.json, so derive the
+    // real indices instead of assuming slot 0 (rustfs/backlog#1303).
+    let format_data = tokio::fs::read(disk_path.join(RUSTFS_META_BUCKET).join(FORMAT_CONFIG_FILE))
+        .await
+        .ok()?;
+    let format = FormatV3::try_from(format_data.as_slice()).ok()?;
+    let (set_idx, disk_idx) = format.find_disk_index_by_disk_id(format.erasure.this).ok()?;
+
     let mut endpoint = Endpoint::try_from(disk_path.to_str()?).ok()?;
     endpoint.set_pool_index(0);
-    endpoint.set_set_index(0);
-    endpoint.set_disk_index(0);
+    endpoint.set_set_index(set_idx);
+    endpoint.set_disk_index(disk_idx);
     new_disk(
         &endpoint,
         &DiskOption {

--- a/crates/scanner/tests/lifecycle_integration_test.rs
+++ b/crates/scanner/tests/lifecycle_integration_test.rs
@@ -734,7 +734,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial]
-    #[ignore = "FAILING on main: excluded from the serial ILM lane pending a fix, see rustfs/backlog#1148 (ilm-1 partial)"]
+    #[ignore = "global-state ILM integration test: runs serialized in the CI ILM Integration (serial) lane, see ci.yml test-ilm-integration-serial and rustfs/backlog#1148 (ilm-1)"]
     async fn test_transition_and_restore_flows() {
         let (disk_paths, ecstore) = setup_test_env().await;
 


### PR DESCRIPTION
## Related Issues

Closes rustfs/backlog#1303. Related: rustfs/backlog#1148 (serial-lane exclusions), #4956 / backlog#1304 (restore accept-path CAS, which fixed the restore self-deadlock at its source).

## Summary of Changes

Re-enables `test_transition_and_restore_flows` in the ILM Integration (serial) lane by fixing the test-util bug that was masking it. **Test-only change** after rebasing onto current main.

**The reported "missing xl.meta on disk2" was a test-util bug, not an EC metadata-distribution issue.** After a transition, all four shard disks hold a fully consistent xl.meta — verified by decoding every shard with `dump_fileinfo` (identical `(status, tier, remote key, remote version id)` tuple on all four disks). The panic came from `open_disk` in `crates/ecstore/src/services/tier/test_util.rs`, which hardcoded `disk_index = 0` for every disk path. `LocalDisk::new` validates the endpoint's `(set_idx, disk_idx)` against the position recorded in the disk's own `format.json` and rejects mismatches with `InconsistentDisk`, so every disk except the real slot-0 disk failed to open, and `read_transition_meta` collapsed that into `None` → "missing xl.meta". Nobody hit this before because all other callers of the shard-reading helpers only ever read `disk_paths[0]`. `open_disk` now derives the real `(set_idx, disk_idx)` from the disk's `format.json`. This also un-breaks `free_version_count` / `wait_for_free_version_absence` for non-first disks, which silently returned 0 before. (This corrects the ci.yml comment inherited from #4886 that attributed the failure to "EC metadata distribution".)

**Note on scope:** an earlier revision of this PR also propagated `no_lock` into the restore copy-back's `update_restore_metadata` path to fix a restore self-deadlock. That deadlock was fixed at its source by #4956 (backlog#1304), which replaced #4877's whole-copy-back object write lock with an accept-path CAS guard that is dropped before the copy-back runs. With no outer lock held, the copy-back's `opts.no_lock` is `false` and the metadata rewrite acquires the lock normally, so that propagation is now a no-op with a misleading comment — dropped on the merge. The remaining diff is purely the test-util fix plus re-enabling the test.

## Verification

- `cargo nextest run -p rustfs-scanner -E 'test(test_transition_and_restore_flows)' --run-ignored all` — passes on the merged tree (test-util fix + #4956's deadlock fix; was fast-failing at ~2.2s on the bogus "missing xl.meta" before this change).
- Full ILM Integration (serial) lane command from ci.yml run locally — the re-enabled test passes alongside the rest of the lane.
- `make pre-commit`

## Impact

Test-only. The tier test-util helpers now work on every shard disk (not just slot 0), and `test_transition_and_restore_flows` rejoins the serial lane. No product-code change. The remaining lane exclusions (`test_noncurrent_*` ×2, `test_restore_chain_*`) are unrelated known issues and stay excluded; `restore_object_usecase_*` was already re-enabled by #4956.

## Additional Notes

The ci.yml comment block is updated to record that the disk2 "missing xl.meta" symptom was a test-util indexing bug (open_disk hardcoding disk_index 0), superseding the earlier "EC metadata-distribution" attribution.
