### PR TITLE
fix(admin): serve bucket usage from snapshot without a blocking version walk

### DIFF
--- a/rustfs/src/admin/handlers/account_info.rs
+++ b/rustfs/src/admin/handlers/account_info.rs
@@ -19,8 +19,7 @@ use crate::admin::storage_api::bucket::versioning_sys::BucketVersioningSys;
 use crate::admin::storage_api::contract::admin::StorageAdminApi;
 use crate::admin::storage_api::contract::bucket::{BucketOperations, BucketOptions};
 use crate::admin::storage_api::data_usage::{
-    apply_bucket_usage_memory_overlay, load_data_usage_from_backend, refresh_bucket_usage_from_object_layer,
-    replace_bucket_usage_memory_from_info,
+    apply_bucket_usage_memory_overlay, load_data_usage_from_backend, replace_bucket_usage_memory_from_info,
 };
 use crate::admin::storage_api::metadata_sys;
 use crate::auth::get_condition_values;
@@ -38,7 +37,6 @@ use s3s::{Body, S3Error, S3ErrorCode, S3Request, S3Response, S3Result, s3_error}
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::debug;
 
 #[allow(dead_code)]
 #[derive(Debug, Serialize, Default)]
@@ -277,15 +275,9 @@ impl Operation for AccountInfoHandler {
                     access: rustfs_madmin::AccountAccess { read: rd, write: wr },
                     ..Default::default()
                 };
-                // AccountInfo backs Console bucket stats, so prefer object-layer usage over potentially cold scanner snapshots.
-                if let Err(err) = refresh_bucket_usage_from_object_layer(store.clone(), &mut data_usage_info, &bucket.name).await
-                {
-                    debug!(
-                        bucket = %bucket.name,
-                        error = %err,
-                        "failed to refresh account info bucket usage from object layer"
-                    );
-                }
+                // Serve the scanner snapshot plus the in-memory write overlay applied above.
+                // Awaiting a live version walk per bucket made this endpoint scale with
+                // bucket size (rustfs/rustfs#4902).
                 apply_usage_to_bucket_access_info(&mut bucket_info, data_usage_info.buckets_usage.get(&bucket.name));
                 account_info.buckets.push(bucket_info);
             }

--- a/rustfs/src/admin/storage_api.rs
+++ b/rustfs/src/admin/storage_api.rs
@@ -456,19 +456,6 @@ pub(crate) mod data_usage {
         crate::storage::storage_api::ecstore_data_usage::apply_bucket_usage_memory_overlay(data_usage_info).await;
     }
 
-    pub(crate) async fn refresh_bucket_usage_from_object_layer(
-        store: Arc<crate::storage::storage_api::ECStore>,
-        data_usage_info: &mut rustfs_data_usage::DataUsageInfo,
-        bucket_name: &str,
-    ) -> Result<rustfs_data_usage::BucketUsageInfo, crate::storage::storage_api::StorageError> {
-        crate::storage::storage_api::ecstore_data_usage::refresh_bucket_usage_from_object_layer(
-            store,
-            data_usage_info,
-            bucket_name,
-        )
-        .await
-    }
-
     pub(crate) async fn load_data_usage_from_backend(
         store: Arc<crate::storage::storage_api::ECStore>,
     ) -> Result<rustfs_data_usage::DataUsageInfo, crate::storage::storage_api::StorageError> {

--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -19,10 +19,8 @@ use super::storage_api::admin_usecase::capacity::{
     PoolDecommissionInfo, PoolStatus, RebalStatus, get_total_usable_capacity, get_total_usable_capacity_free,
 };
 use super::storage_api::admin_usecase::contract::StorageAdminApi;
-use super::storage_api::admin_usecase::contract::bucket::{BucketOperations, BucketOptions};
 use super::storage_api::admin_usecase::data_usage::{
-    apply_bucket_usage_memory_overlay, load_data_usage_from_backend, refresh_bucket_usage_from_object_layer,
-    replace_bucket_usage_memory_from_info,
+    apply_bucket_usage_memory_overlay, load_data_usage_from_backend, replace_bucket_usage_memory_from_info,
 };
 use super::storage_api::admin_usecase::{ECStore, EndpointServerPools};
 use crate::app::runtime_sources::{
@@ -250,8 +248,10 @@ impl DefaultAdminUsecase {
             Self::app_error(S3ErrorCode::InternalError, "load_data_usage_from_backend failed")
         })?;
         replace_bucket_usage_memory_from_info(&info).await;
+        // Serve the scanner snapshot plus the in-memory write overlay. Awaiting a live
+        // per-bucket version walk here made this endpoint scale with bucket size
+        // (rustfs/rustfs#4902).
         apply_bucket_usage_memory_overlay(&mut info).await;
-        Self::refresh_live_bucket_usage_for_data_usage_info(store.clone(), &mut info).await;
 
         let storage_info = StorageAdminApi::storage_info(store.as_ref()).await;
 
@@ -319,32 +319,6 @@ impl DefaultAdminUsecase {
         );
 
         Ok(info)
-    }
-
-    async fn refresh_live_bucket_usage_for_data_usage_info(store: Arc<ECStore>, data_usage_info: &mut DataUsageInfo) {
-        let buckets = match store
-            .list_bucket(&BucketOptions {
-                no_metadata: true,
-                ..Default::default()
-            })
-            .await
-        {
-            Ok(buckets) => buckets,
-            Err(err) => {
-                debug!(error = %err, "failed to list buckets while refreshing data usage info");
-                return;
-            }
-        };
-
-        for bucket in buckets {
-            if let Err(err) = refresh_bucket_usage_from_object_layer(store.clone(), data_usage_info, &bucket.name).await {
-                debug!(
-                    bucket = %bucket.name,
-                    error = %err,
-                    "failed to refresh data usage info bucket usage from object layer"
-                );
-            }
-        }
     }
 
     pub async fn execute_list_pool_statuses(&self) -> AdminUsecaseResult<Vec<PoolStatus>> {

--- a/rustfs/src/app/storage_api.rs
+++ b/rustfs/src/app/storage_api.rs
@@ -57,19 +57,6 @@ pub(crate) mod data_usage {
         crate::storage::storage_api::ecstore_data_usage::load_data_usage_from_backend(store).await
     }
 
-    pub(crate) async fn refresh_bucket_usage_from_object_layer(
-        store: Arc<crate::storage::storage_api::ECStore>,
-        data_usage_info: &mut rustfs_data_usage::DataUsageInfo,
-        bucket_name: &str,
-    ) -> Result<rustfs_data_usage::BucketUsageInfo, crate::storage::storage_api::StorageError> {
-        crate::storage::storage_api::ecstore_data_usage::refresh_bucket_usage_from_object_layer(
-            store,
-            data_usage_info,
-            bucket_name,
-        )
-        .await
-    }
-
     pub(crate) async fn replace_bucket_usage_memory_from_info(data_usage_info: &rustfs_data_usage::DataUsageInfo) {
         crate::storage::storage_api::ecstore_data_usage::replace_bucket_usage_memory_from_info(data_usage_info).await;
     }
@@ -936,10 +923,6 @@ pub(crate) mod s3_api {
 
 pub(crate) mod admin_usecase {
     pub(crate) mod contract {
-        pub(crate) mod bucket {
-            pub(crate) use super::super::super::storage_contracts::{BucketOperations, BucketOptions};
-        }
-
         pub(crate) use super::super::storage_contracts::StorageAdminApi;
     }
 

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -384,9 +384,8 @@ pub(crate) mod ecstore_data_usage {
     pub(crate) use rustfs_ecstore::api::data_usage::{
         apply_bucket_usage_memory_overlay, init_compression_total_memory_from_backend, load_data_usage_from_backend,
         record_bucket_delete_marker_memory, record_bucket_object_delete_memory, record_bucket_object_version_write_memory,
-        record_bucket_object_write_memory, record_bucket_object_write_unknown_previous_memory,
-        refresh_bucket_usage_from_object_layer, remove_bucket_usage_from_backend, replace_bucket_usage_memory_from_info,
-        store_compression_total_in_backend,
+        record_bucket_object_write_memory, record_bucket_object_write_unknown_previous_memory, remove_bucket_usage_from_backend,
+        replace_bucket_usage_memory_from_info, store_compression_total_in_backend,
     };
 }
 


### PR DESCRIPTION
## Summary

Draft PR for #4902, scoped to the first-PR boundary agreed in the issue: return the scanner snapshot plus the existing memory overlay immediately, and do not await a live version walk on the admin request path.

`AccountInfo` and `DataUsageInfo` both awaited `refresh_bucket_usage_from_object_layer` once per bucket, so both endpoints scaled with bucket size. On the ~440k-object bucket from the issue the walk takes ~6m55s, which is what the Console shows as a stalled bucket overview.

Both handlers already load the scanner snapshot and apply the in-memory write overlay *before* the per-bucket loop. The walk then overwrote those values. This PR drops the walk and serves what is already computed.

**This is deliberately snapshot-only.** Per point 6 of the review, the response contract stays as-is rather than gaining freshness states.

## Scope

Following the review, everything that lives in the background-recount coordinator is out of scope here. This PR contains no scheduler, no in-flight map, no epoch fencing, no semaphore, and no TTL cache consumption — so blocking issues 1, 2, 4 and 5 do not arise in this diff. The coordinator is deferred to a follow-up.

`ecstore` is not modified. `refresh_bucket_usage_from_object_layer` and its existing tests are left in place: it is now unused (`pub`, so no dead-code warning), which is intentional groundwork for the bounded coordinator follow-up rather than an oversight. Happy to delete it here instead if you would rather it not sit unused.

## Withdrawing an earlier claim

I claimed in the issue that this work removes the `list_path worker failed: channel closed` errors. **That was wrong and I withdraw it.** You are correct: this branch does not touch `gather_results`, and the 300s bound I had proposed was below the ~415s walk anyway. The consumer-gone behavior is a separate fix and I am not claiming anything about it here.

## Verification

- `make pre-commit` — passes
- `cargo clippy -p rustfs --all-targets` — clean
- `cargo test -p rustfs-ecstore --lib data_usage` — 32 passed; the overlay/snapshot semantics this PR now relies on are already covered there and are unchanged
- Rebased onto current `main` (`1.0.0-beta.10`)

## Known gap — guidance welcome

The one item from your required-coverage list that applies to this reduced scope is *"both admin endpoints returning without entering a live version walk"* as a regression guard. **It is not in this PR**, and I did not want to hand-wave it.

The obstacle is a boundary question I would rather you decide than guess at. A deterministic guard is straightforward in principle — writing objects via `ECStore` directly bypasses the usage overlay, so object layer non-empty / snapshot+overlay empty is a clean divergence state, and the assertion is that the response reports nothing for that bucket. But driving `execute_query_data_usage_info` needs `set_object_layer` exported through the `storage_api` boundary (it currently is not) plus coordination on the `GLOBAL_OBJECT_API` `OnceLock`.

Would you prefer:
1. exporting `set_object_layer` through the test boundary module, or
2. this guard living at a different layer, or
3. deferring it to the coordinator PR, where the harness is needed anyway?

Happy to add it in whichever shape fits your architecture rules.

Refs #4902
