### PR TITLE
fix(auth): stop 403 on POST object-lock fields and signed list metadata=true

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -292,8 +292,6 @@ path = "junit.xml"
 #     archive even under ignore-errors semantics.
 #   * rustfs#4844 — anonymous POST-object with SSE-S3 / bucket-default SSE
 #     returns 500.
-#   * rustfs#4845 — 403 on allowed anonymous POST object-lock fields and on
-#     the list metadata=true extension.
 #   * rustfs#4846 — distributed-lock quorum tests misclassify as timeout
 #     under parallel load (multi-node in-process clusters; natural home is
 #     ci-7's nightly cluster lane).
@@ -308,8 +306,6 @@ default-filter = """
     & !test(/^multipart_auth_test::test_signed_put_object_extract_skips_invalid_entry_when_ignore_errors_enabled$/)
     & !test(/^snowball_auto_extract_test::tests::snowball_auto_extract_(ignores_invalid_entries_when_requested|supports_standard_headers_with_combined_extract_options)$/)
     & !test(/^multipart_auth_test::test_anonymous_post_object_(accepts_sse_s3|rejects_sse_s3_missing_from_policy_conditions|uses_bucket_default_sse_kms|uses_bucket_default_sse_s3)$/)
-    & !test(/^multipart_auth_test::test_anonymous_post_object_(accepts_object_lock_legal_hold_field|accepts_object_lock_retention_fields)$/)
-    & !test(/^list_object(s_v2|_versions)_metadata_extension_test::/)
     & !test(/^reliant::lock::test_distributed_lock_(2_nodes_grpc_read_survives_failed_node|4_nodes_grpc_read_write_quorum_split_with_two_failed_nodes)$/)
 """
 fail-fast = false

--- a/rustfs/src/app/metadata_route.rs
+++ b/rustfs/src/app/metadata_route.rs
@@ -15,6 +15,7 @@
 //! MinIO-compatible metadata listing extension routes.
 
 use super::bucket_usecase::DefaultBucketUsecase;
+use crate::auth::{check_key_valid, get_session_token};
 use crate::storage::access::{ReqInfo, authorize_request, req_info_mut};
 use async_trait::async_trait;
 use http::header::CONTENT_TYPE;
@@ -104,8 +105,25 @@ fn metadata_operation(method: &Method, uri: &Uri, headers: &HeaderMap, host: Opt
 
 async fn check_metadata_access(req: &mut S3Request<Body>, target: BucketTarget) -> S3Result<()> {
     {
+        // s3s dispatches custom routes before the `S3Access::check` hook runs,
+        // so the signature credentials it verified have not been resolved into
+        // a `ReqInfo` yet. Resolve them here; otherwise a signed request is
+        // authorized as anonymous and denied (rustfs#4845).
         if req_info_mut(req).is_err() {
-            req.extensions.insert(ReqInfo::default());
+            let (cred, is_owner) = match req.credentials.as_ref() {
+                Some(input_cred) => {
+                    let (cred, is_owner) =
+                        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key)
+                            .await?;
+                    (Some(cred), is_owner)
+                }
+                None => (None, false),
+            };
+            req.extensions.insert(ReqInfo {
+                cred,
+                is_owner,
+                ..Default::default()
+            });
         }
         let req_info = req_info_mut(req)?;
         req_info.bucket = Some(target.bucket);

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -24,6 +24,7 @@ use crate::server::RemoteAddr;
 use crate::storage::request_context::RequestContext;
 use crate::storage::storage_api::access_consumer::contract::bucket::BucketOperations;
 use crate::storage::storage_api::runtime_sources_consumer::runtime_sources;
+use http::Method;
 use metrics::counter;
 use rustfs_iam::error::Error as IamError;
 use rustfs_policy::policy::action::{Action, AdminAction, S3Action};
@@ -1901,12 +1902,20 @@ impl S3Access for FS {
 
         authorize_request(req, Action::S3Action(S3Action::PutObjectAction)).await?;
 
-        if legal_hold_write_requested(req.input.object_lock_legal_hold_status.as_ref()) {
-            authorize_request(req, Action::S3Action(S3Action::PutObjectLegalHoldAction)).await?;
-        }
+        // s3s routes browser POST uploads (PostObject) through this hook after
+        // converting the form into a PutObjectInput. MinIO's PostPolicy handler
+        // gates POST solely on s3:PutObject — object-lock form fields are
+        // constrained by the POST policy conditions instead (s3s rejects any
+        // form field not covered by the policy) — so the object-lock action
+        // checks below apply to real PUT requests only (rustfs#4845).
+        if req.method != Method::POST {
+            if legal_hold_write_requested(req.input.object_lock_legal_hold_status.as_ref()) {
+                authorize_request(req, Action::S3Action(S3Action::PutObjectLegalHoldAction)).await?;
+            }
 
-        if retention_write_requested(req.input.object_lock_mode.as_ref(), req.input.object_lock_retain_until_date.as_ref()) {
-            authorize_request(req, Action::S3Action(S3Action::PutObjectRetentionAction)).await?;
+            if retention_write_requested(req.input.object_lock_mode.as_ref(), req.input.object_lock_retain_until_date.as_ref()) {
+                authorize_request(req, Action::S3Action(S3Action::PutObjectRetentionAction)).await?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Related Issues

Fixes #4845.

## Summary of Changes

Two independent authorization surfaces returned 403 where the e2e suites expect success (surfaced by the first automated full-e2e run, backlog#1149 ci-5):

**a) Anonymous POST-object with object-lock form fields.** s3s converts a browser POST form into a `PutObjectInput` and gates it through the `S3Access::put_object` hook. That hook's object-lock hardening demanded `s3:PutObjectLegalHold` / `s3:PutObjectRetention` on top of `s3:PutObject`, so an anonymous POST whose bucket policy grants only `s3:PutObject` was denied even though the signed/validated POST policy explicitly covered the `x-amz-object-lock-*` fields. MinIO's `PostPolicyBucketHandler` gates POST solely on `s3:PutObject` — object-lock form fields are constrained by the POST policy conditions instead, and s3s already rejects any form field not covered by the policy (the passing `rejects_*_missing_from_policy_conditions` / `_policy_mismatch` twins are exactly that path). The fix skips the two extra action checks only when `req.method == POST`; real PUT, CopyObject, and CreateMultipartUpload keep the hardening unchanged.

**b) ListObjectsV2 / ListObjectVersions `metadata=true` extension.** s3s dispatches custom routes (`MetadataRoute`) before the `S3Access::check` hook ever runs, so the signature credentials s3s verified were never resolved into a `ReqInfo`. `check_metadata_access` inserted a default `ReqInfo` (cred = None), which made `authorize_request` evaluate every signed request as anonymous → `AccessDenied`. The fix resolves `req.credentials` via `check_key_valid` (mirroring the replication extension route in `admin/router.rs`); anonymous requests still take the bucket-policy path as before.

The four tests are re-admitted to the `e2e-full` nextest merge-gate profile and the #4845 exclusion entry is deleted, per the quarantine discipline in `.config/nextest.toml`.

## Verification

- `cargo test -p e2e_test --lib -- --test-threads=1 test_anonymous_post_object_accepts_object_lock_legal_hold_field test_anonymous_post_object_accepts_object_lock_retention_fields test_list_objects_v2_metadata_extension_returns_metadata_tags_and_internal test_list_object_versions_metadata_extension_returns_metadata_tags_and_internal` — the four previously excluded tests now pass (they fail without this change).
- `cargo test -p e2e_test --lib -- --test-threads=1 test_anonymous_post_object_rejects_object_lock test_write_paths_require_put_object` — the 5 negative POST-policy siblings and the 2 PUT/copy/multipart object-lock permission-enforcement tests still pass (11 passed total in the combined post-rebase run).
- `cargo test -p e2e_test --lib -- --test-threads=1 test_anonymous_post_object --skip sse` — all 67 anonymous POST-object tests pass (SSE family skipped: known-failing #4844, tracked separately).
- `cargo test -p rustfs --lib metadata_route` (4 passed) and `cargo test -p rustfs --lib storage::access` (30 passed, 1 ignored).
- `make pre-commit` — passed.
- `cargo clippy -p rustfs --all-targets -- -D warnings` — passed.

## Impact

Anonymous browser POST uploads that declare `x-amz-object-lock-*` fields in their POST policy now succeed with a bucket policy granting only `s3:PutObject`, matching MinIO. PUT/CopyObject/CreateMultipartUpload continue to require `s3:PutObjectRetention` / `s3:PutObjectLegalHold` for object-lock writes. Signed requests to the MinIO-compatible `metadata=true` listing extension are now authorized as the signing identity instead of being treated as anonymous. No API surface, configuration, or deployment changes.

## Additional Notes

MinIO parity for (a) was verified against `minio/minio` master `cmd/bucket-handlers.go`: `PostPolicyBucketHandler` performs no `PutObjectRetentionAction` / `PutObjectLegalHoldAction` checks. If a stricter stance is wanted later (e.g. enforcing the actions for policy-less anonymous POSTs), it needs s3s to plumb the validated policy through to the access hooks — the `PostObjectInput` → `PutObjectInput` conversion currently drops it.
