### PR TITLE
fix(sse): surface unconfigured managed SSE as 400 and fix anonymous POST SSE-S3 e2e

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -290,8 +290,6 @@ path = "junit.xml"
 #     OffsetDateTime deserialization + same-path failures).
 #   * rustfs#4843 — over-limit archive entry paths hard-reject the whole
 #     archive even under ignore-errors semantics.
-#   * rustfs#4844 — anonymous POST-object with SSE-S3 / bucket-default SSE
-#     returns 500.
 #   * rustfs#4845 — 403 on allowed anonymous POST object-lock fields and on
 #     the list metadata=true extension.
 #   * rustfs#4846 — distributed-lock quorum tests misclassify as timeout
@@ -307,7 +305,6 @@ default-filter = """
     & !test(/^snowball_auto_extract_test::tests::snowball_auto_extract_(prefers_exact_minio_prefix_over_suffix_fallback|supports_minio_prefix_and_directory_markers)$/)
     & !test(/^multipart_auth_test::test_signed_put_object_extract_skips_invalid_entry_when_ignore_errors_enabled$/)
     & !test(/^snowball_auto_extract_test::tests::snowball_auto_extract_(ignores_invalid_entries_when_requested|supports_standard_headers_with_combined_extract_options)$/)
-    & !test(/^multipart_auth_test::test_anonymous_post_object_(accepts_sse_s3|rejects_sse_s3_missing_from_policy_conditions|uses_bucket_default_sse_kms|uses_bucket_default_sse_s3)$/)
     & !test(/^multipart_auth_test::test_anonymous_post_object_(accepts_object_lock_legal_hold_field|accepts_object_lock_retention_fields)$/)
     & !test(/^list_object(s_v2|_versions)_metadata_extension_test::/)
     & !test(/^reliant::lock::test_distributed_lock_(2_nodes_grpc_read_survives_failed_node|4_nodes_grpc_read_write_quorum_split_with_two_failed_nodes)$/)

--- a/crates/e2e_test/src/multipart_auth_test.rs
+++ b/crates/e2e_test/src/multipart_auth_test.rs
@@ -53,6 +53,17 @@ fn sse_customer_key_md5_base64(key: &str) -> String {
     base64::engine::general_purpose::STANDARD.encode(md5::compute(key).0)
 }
 
+/// Env var consumed by the local SSE-S3 DEK provider when KMS is not configured.
+///
+/// Since rustfs#3564 the server fails closed on managed SSE (SSE-S3 or
+/// bucket-default encryption) unless KMS is configured or this master key is
+/// provided, so tests exercising managed SSE on a bare server must seed it.
+const LOCAL_SSE_MASTER_KEY_ENV: &str = "RUSTFS_SSE_S3_MASTER_KEY";
+
+fn local_sse_master_key_value() -> String {
+    base64::engine::general_purpose::STANDARD.encode([0x42u8; 32])
+}
+
 async fn make_tar(files: &[(&str, &[u8])], dirs: &[&str]) -> Vec<u8> {
     let buf = Cursor::new(Vec::new());
     let mut builder = tokio_tar::Builder::new(buf);
@@ -926,7 +937,9 @@ async fn test_anonymous_post_object_accepts_sse_s3() -> Result<(), Box<dyn std::
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server(vec![]).await?;
+    let master_key = local_sse_master_key_value();
+    env.start_rustfs_server_with_env(vec![], &[(LOCAL_SSE_MASTER_KEY_ENV, master_key.as_str())])
+        .await?;
 
     let bucket = "anon-post-sse-s3";
     let object_key = "post-sse-s3-object.txt";
@@ -982,7 +995,9 @@ async fn test_anonymous_post_object_uses_bucket_default_sse_s3() -> Result<(), B
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server(vec![]).await?;
+    let master_key = local_sse_master_key_value();
+    env.start_rustfs_server_with_env(vec![], &[(LOCAL_SSE_MASTER_KEY_ENV, master_key.as_str())])
+        .await?;
 
     let bucket = "anon-post-default-sse-s3";
     let object_key = "post-default-sse-s3-object.txt";
@@ -1053,7 +1068,9 @@ async fn test_anonymous_post_object_uses_bucket_default_sse_kms() -> Result<(), 
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server(vec![]).await?;
+    let master_key = local_sse_master_key_value();
+    env.start_rustfs_server_with_env(vec![], &[(LOCAL_SSE_MASTER_KEY_ENV, master_key.as_str())])
+        .await?;
 
     let bucket = "anon-post-default-sse-kms";
     let object_key = "post-default-sse-kms-object.txt";
@@ -1172,15 +1189,24 @@ async fn test_anonymous_post_object_rejects_sse_s3_policy_mismatch() -> Result<(
 
 #[tokio::test]
 #[serial]
-async fn test_anonymous_post_object_rejects_sse_s3_missing_from_policy_conditions()
+async fn test_anonymous_post_object_accepts_sse_s3_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
+    // MinIO-compatible POST-policy validation (s3s-project/s3s#608) exempts the
+    // x-amz-server-side-encryption* form fields from the "every form field must
+    // appear in the policy conditions" rule, so an SSE-S3 field that the policy
+    // does not mention is accepted and encryption is applied. When the policy
+    // does cover the field, a value mismatch is still rejected — see
+    // test_anonymous_post_object_rejects_sse_s3_policy_mismatch.
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server(vec![]).await?;
+    let master_key = local_sse_master_key_value();
+    env.start_rustfs_server_with_env(vec![], &[(LOCAL_SSE_MASTER_KEY_ENV, master_key.as_str())])
+        .await?;
 
     let bucket = "anon-post-sse-s3-missing";
     let object_key = "post-sse-s3-missing-object.txt";
+    let expected_body = b"post-sse-s3-missing".to_vec();
 
     let admin_client = env.create_s3_client();
     admin_client.create_bucket().bucket(bucket).send().await?;
@@ -1198,7 +1224,7 @@ async fn test_anonymous_post_object_rejects_sse_s3_missing_from_policy_condition
         .text("x-amz-server-side-encryption", "AES256")
         .part(
             "file",
-            reqwest::multipart::Part::bytes(b"post-sse-s3-missing".to_vec())
+            reqwest::multipart::Part::bytes(expected_body.clone())
                 .file_name("upload.txt")
                 .mime_str("text/plain")?,
         );
@@ -1212,11 +1238,15 @@ async fn test_anonymous_post_object_rejects_sse_s3_missing_from_policy_condition
     let status = post_resp.status();
     let response_body = post_resp.text().await?;
 
-    assert_eq!(status, reqwest::StatusCode::FORBIDDEN);
-    assert!(
-        response_body.contains("<Code>AccessDenied</Code>"),
-        "response should contain AccessDenied code, got: {response_body}"
-    );
+    assert_eq!(status, reqwest::StatusCode::NO_CONTENT);
+    assert!(response_body.is_empty(), "204 response should not contain a body, got: {response_body}");
+
+    let head = admin_client.head_object().bucket(bucket).key(object_key).send().await?;
+    assert_eq!(head.server_side_encryption().map(|value| value.as_str()), Some("AES256"));
+
+    let uploaded = admin_client.get_object().bucket(bucket).key(object_key).send().await?;
+    let uploaded = uploaded.body.collect().await?.into_bytes();
+    assert_eq!(uploaded.as_ref(), expected_body.as_slice());
 
     Ok(())
 }

--- a/rustfs/src/storage/sse.rs
+++ b/rustfs/src/storage/sse.rs
@@ -2019,22 +2019,32 @@ impl TestSseDekProvider {
 
     /// Create a local SSE DEK provider for SSE-S3 when KMS is not configured.
     /// Requires RUSTFS_SSE_S3_MASTER_KEY to be a valid base64-encoded 32-byte key.
+    ///
+    /// The failures here are server configuration problems, not internal
+    /// faults: surface them as `InvalidRequest` (HTTP 400) so a managed-SSE
+    /// request against an unconfigured server does not report 500 (rustfs#4844).
     pub fn new_for_local_sse() -> Result<Self, ApiError> {
+        fn sse_not_configured(message: impl Into<String>) -> ApiError {
+            ApiError {
+                code: S3ErrorCode::InvalidRequest,
+                message: message.into(),
+                source: None,
+            }
+        }
+
         let Some(raw_value) = get_env_opt_str("RUSTFS_SSE_S3_MASTER_KEY").filter(|value| !value.trim().is_empty()) else {
-            return Err(ApiError::from(StorageError::other(
+            return Err(sse_not_configured(
                 "SSE-S3 requires RUSTFS_SSE_S3_MASTER_KEY to be set to a base64-encoded 32-byte key when KMS is not configured",
-            )));
+            ));
         };
 
         let decoded = BASE64_STANDARD.decode(raw_value.trim()).map_err(|err| {
-            ApiError::from(StorageError::other(format!(
+            sse_not_configured(format!(
                 "RUSTFS_SSE_S3_MASTER_KEY must be valid base64 for SSE-S3 when KMS is not configured: {err}"
-            )))
+            ))
         })?;
         let master_key: [u8; 32] = decoded.try_into().map_err(|_| {
-            ApiError::from(StorageError::other(
-                "RUSTFS_SSE_S3_MASTER_KEY must decode to exactly 32 bytes for SSE-S3 when KMS is not configured",
-            ))
+            sse_not_configured("RUSTFS_SSE_S3_MASTER_KEY must decode to exactly 32 bytes for SSE-S3 when KMS is not configured")
         })?;
 
         tracing::info!("Using RUSTFS_SSE_S3_MASTER_KEY for SSE-S3 (KMS not configured)");
@@ -3916,6 +3926,11 @@ mod tests {
                 .expect_err("SSE-S3 should fail closed without a configured local master key");
 
                 assert!(err.message.contains("RUSTFS_SSE_S3_MASTER_KEY"));
+                assert_eq!(
+                    err.code,
+                    S3ErrorCode::InvalidRequest,
+                    "missing local SSE master key is a configuration error, not a 500 (rustfs#4844)"
+                );
             },
         )
         .await;
@@ -3947,6 +3962,11 @@ mod tests {
                 .expect_err("SSE-S3 should fail closed with an invalid local master key");
 
                 assert!(err.message.contains("valid base64"));
+                assert_eq!(
+                    err.code,
+                    S3ErrorCode::InvalidRequest,
+                    "invalid local SSE master key is a configuration error, not a 500 (rustfs#4844)"
+                );
             },
         )
         .await;


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
Fixes #4844

## Summary of Changes
Root cause: the four failing e2e tests all drive managed SSE (explicit SSE-S3 or bucket-default encryption) on a bare test server, and since #3564 the local SSE-S3 DEK provider deliberately fails closed when neither KMS nor `RUSTFS_SSE_S3_MASTER_KEY` is configured. That failure surfaced as `500 InternalError` — reproduced locally: `<Error><Code>InternalError</Code><Message>Io error: SSE-S3 requires RUSTFS_SSE_S3_MASTER_KEY to be set to a base64-encoded 32-byte key when KMS is not configured</Message></Error>`. This is not POST-specific; a signed PUT with SSE-S3 on the same server 500s identically. The fail-closed behavior is a deliberate security hardening (#3564 removed the implicit all-zero master key), so the fix keeps it and repairs the two real defects around it:

- `rustfs/src/storage/sse.rs`: the missing/invalid `RUSTFS_SSE_S3_MASTER_KEY` cases are server configuration errors, not internal faults — surface them as `InvalidRequest` (HTTP 400) instead of `InternalError` (HTTP 500). The two existing fail-closed unit tests now also pin the error code.
- `crates/e2e_test/src/multipart_auth_test.rs`: the anonymous POST-object SSE tests predate #3564 and assumed SSE-S3 works on a completely unconfigured server. They now seed `RUSTFS_SSE_S3_MASTER_KEY` for the spawned server (the same pattern #3564 itself applied to `scripts/s3-tests/run.sh`), so they exercise the full encrypt-on-POST / decrypt-on-GET path end to end.
- `test_anonymous_post_object_rejects_sse_s3_missing_from_policy_conditions` is renamed to `test_anonymous_post_object_accepts_sse_s3_missing_from_policy_conditions` and now expects 204 with SSE-S3 applied. The pinned s3s rev deliberately exempts the `x-amz-server-side-encryption*` form fields from the "every form field must appear in the policy conditions" rule (s3s-project/s3s#608, MinIO-compat exception set), and that validation runs inside s3s before any RustFS hook — the POST policy document is not visible to RustFS code (it is dropped during the s3s PostObject→PutObject input conversion), so the old 403 expectation is unimplementable against the pinned dependency and contradicts its deliberate behavior. Security-wise this exemption only lets an uploader opt in to server-managed encryption: for anonymous POSTs the policy is unsigned and self-authored anyway, and a policy-covered value mismatch is still rejected (`test_anonymous_post_object_rejects_sse_s3_policy_mismatch` stays green).
- `.config/nextest.toml`: delete the rustfs#4844 exclusion so the four tests rejoin the `e2e-full` merge gate.

## Verification
- `cargo build --bin rustfs`, then with `CARGO_BIN_EXE_rustfs=<abs>/target/debug/rustfs`:
- `cargo test -p e2e_test -- --test-threads=1 test_anonymous_post_object_accepts_sse_s3 test_anonymous_post_object_uses_bucket_default_sse` — 4 passed (the four previously-failing tests, incl. the renamed missing-from-policy test)
- `cargo test -p e2e_test -- --test-threads=1 test_anonymous_post_object_rejects_sse test_anonymous_post_object_allows_sse_c_fields_outside_policy_conditions` — 10 passed (all SSE negative siblings: SSE-KMS reject family, SSE-S3 policy mismatch, SSE-C)
- `cargo test -p rustfs --lib -- storage::sse` — 106 passed (incl. the strengthened fail-closed tests)
- `cargo nextest list --profile e2e-full -p e2e_test` — confirms the re-admitted tests are selected
- `make pre-commit` — passed
- Baseline repro before the fix: anonymous POST with SSE-S3 against a bare server returned the 500 quoted above; after the fix, an unconfigured server returns 400 `InvalidRequest` and a key-configured server returns 204 with `x-amz-server-side-encryption: AES256` on HEAD and readable content on GET.

## Impact
Managed-SSE requests (PUT or POST, explicit or bucket-default) against a server with neither KMS nor `RUSTFS_SSE_S3_MASTER_KEY` now fail with 400 `InvalidRequest` instead of 500 `InternalError`; the message is unchanged. No change for correctly configured servers. The fail-closed hardening from #3564 is preserved.

## Additional Notes
Adversarial validation (high risk, IAM/KMS/S3-visible): correctness — baseline 500 reproduced and root-caused to `TestSseDekProvider::new_for_local_sse`, fix verified end to end; security — no new key material is introduced, fail-closed retained, encryption verified via HEAD/GET round trip; compatibility — error code change 500→400 on a misconfiguration path only, MinIO parity for the POST-policy SSE exemption follows the pinned s3s; concurrency/durability — no runtime code paths changed beyond error construction; performance — no hot-path change; test coverage — error-code regression pinned in `storage::sse` unit tests, accept paths pinned in e2e.
