### PR TITLE
fix(put): admit bare aws-chunked uploads via wire Content-Length

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -304,15 +304,14 @@ fn range_to_http_range_spec(range: Range) -> S3Result<HTTPRangeSpec> {
 
 /// Resolve the authoritative object length that bucket-quota admission (and downstream sizing) must use.
 ///
-/// For an `aws-chunked` upload the request body is wrapped in chunk framing, so the wire `Content-Length` overcounts the actual object and must never be admitted; the decoded length (`x-amz-decoded-content-length`) is the only authoritative size and is therefore required — a chunked request without it is rejected rather than silently falling back to the framed wire length. For a non-chunked request the raw `Content-Length` is authoritative, with an explicit decoded length as the fallback when the S3 layer only surfaced the latter. A negative or otherwise unknown length is rejected so it can never be reinterpreted as an enormous unsigned size downstream.
+/// When the decoded length (`x-amz-decoded-content-length`) is present it wins: the body of a genuine SigV4 streaming upload is wrapped in chunk framing, so the wire `Content-Length` overcounts the actual object and must never be admitted. An `aws-chunked` content-encoding *without* a decoded length, however, does not mean a framed body: clients legitimately send `Content-Encoding: aws-chunked` on a normal fully-signed upload (see #1857/#2475 — AWS accepts and strips the token), and genuine streaming always carries the decoded length; for those requests the wire `Content-Length` is exactly the object length and remains authoritative (rustfs#4962). A negative or otherwise unknown length is rejected so it can never be reinterpreted as an enormous unsigned size downstream.
 fn resolve_put_object_authoritative_size(headers: &HeaderMap, content_length: Option<i64>) -> S3Result<i64> {
     let decoded_content_length = decoded_content_length_from_headers(headers)?;
-    let size = match (request_uses_aws_chunked(headers), decoded_content_length, content_length) {
-        (true, Some(decoded), _) => decoded,
-        (true, None, _) => return Err(s3_error!(UnexpectedContent)),
-        (false, _, Some(raw)) => raw,
-        (false, Some(decoded), None) => decoded,
-        (false, None, None) => return Err(s3_error!(UnexpectedContent)),
+    let size = match (decoded_content_length, content_length) {
+        (Some(decoded), _) if request_uses_aws_chunked(headers) => decoded,
+        (_, Some(raw)) => raw,
+        (Some(decoded), None) => decoded,
+        (None, None) => return Err(s3_error!(UnexpectedContent)),
     };
 
     if size < 0 {
@@ -10649,11 +10648,22 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_size_rejects_aws_chunked_without_decoded_length() {
-        // A chunked upload without x-amz-decoded-content-length has no authoritative size; the wire length must NOT be a fallback.
+    fn authoritative_size_aws_chunked_without_decoded_length_uses_wire_content_length() {
+        // aws-chunked content-encoding without x-amz-decoded-content-length means the body is
+        // NOT actually chunk-framed (genuine streaming always sends the decoded length; clients
+        // set the bare token on normal uploads — #1857/#2475), so the wire Content-Length is the
+        // object length and the PUT must be admitted, not rejected (rustfs#4962).
         let headers = aws_chunked_headers(None);
-        let err = resolve_put_object_authoritative_size(&headers, Some(1088))
-            .expect_err("chunked upload without decoded length must be rejected");
+        let size = resolve_put_object_authoritative_size(&headers, Some(1088))
+            .expect("bare aws-chunked token with a wire Content-Length must be admitted");
+        assert_eq!(size, 1088);
+    }
+
+    #[test]
+    fn authoritative_size_rejects_aws_chunked_without_any_length() {
+        let headers = aws_chunked_headers(None);
+        let err =
+            resolve_put_object_authoritative_size(&headers, None).expect_err("no length information at all must be rejected");
         assert_eq!(err.code(), &S3ErrorCode::UnexpectedContent);
     }
 


### PR DESCRIPTION
## Related Issues

Fixes #4962.

## Summary of Changes

#4928 made `resolve_put_object_authoritative_size` reject any PUT whose `Content-Encoding` contains `aws-chunked` but lacks `x-amz-decoded-content-length`, on the assumption that the header implies a chunk-framed body whose wire `Content-Length` overcounts. That assumption is wrong for the case #1857/#2475 characterized: clients legitimately send the bare `aws-chunked` token on a normal fully-signed upload whose body is not framed at all — AWS accepts this and strips the token. Genuine SigV4 streaming uploads always carry `x-amz-decoded-content-length`, so for a bare-token request the wire `Content-Length` is exactly the object length. Since fc7d46b6c these requests get `400 UnexpectedContent`, and 5 aws-chunked e2e tests (`content_encoding_test`, `archive_download_integrity_test`) fail deterministically on `main`, turning the E2E check red for every open PR.

This change restores the wire-`Content-Length` fallback for the bare-token case while keeping every protection #4928 introduced: a decoded length still wins whenever it is present (framed wire lengths are still never admitted for quota), negative lengths are still rejected, and a request with no length information at all is still rejected. The previously-rejecting unit test now asserts admission of the bare-token + wire-length case, with a new companion test keeping the "no length at all" rejection covered.

## Verification

- `make pre-commit` — passed.
- `cargo test -p rustfs --lib authoritative_size` — 8/8 passed.
- The 5 regressed e2e tests pass locally against the fixed binary: `cargo test -p e2e_test --lib -- --test-threads=1 --exact content_encoding_test::tests::test_content_encoding_aws_chunked_not_returned_issue_1857 content_encoding_test::tests::test_content_encoding_aws_chunked_with_effective_encoding_roundtrip archive_download_integrity_test::tests::test_archive_put_with_aws_chunked_allowed_when_strict_mode_enabled archive_download_integrity_test::tests::test_archive_put_with_aws_chunked_and_effective_encoding_roundtrips_by_default archive_download_integrity_test::tests::test_archive_put_with_aws_chunked_does_not_persist_content_encoding_by_default` → `5 passed; 0 failed`.

## Impact

Restores S3 compatibility for uploads that send `Content-Encoding: aws-chunked` (alone or in a list) without an `x-amz-decoded-content-length` header — broken on `main` since fc7d46b6c. Quota admission semantics from #4928 are unchanged for genuinely framed streaming uploads. No API or configuration changes.

## Additional Notes

Un-breaks the `End-to-End Tests` CI job and the `e2e-full` merge gate for all open PRs (first observed on #4948, which is unrelated).
