### PR TITLE
chore(deps): sync merged s3s SigV4 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s3s"
 version = "0.14.1"
-source = "git+https://github.com/s3s-project/s3s.git?rev=ce69c3f10824535c7c24b2f71cdb2aaa4dffb5e0#ce69c3f10824535c7c24b2f71cdb2aaa4dffb5e0"
+source = "git+https://github.com/s3s-project/s3s.git?rev=c71128fff3c4271899f87e82704682d74e1a78c6#c71128fff3c4271899f87e82704682d74e1a78c6"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ redis = { version = "1.4.0" }
 rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { git = "https://github.com/s3s-project/s3s.git", rev = "ce69c3f10824535c7c24b2f71cdb2aaa4dffb5e0" }
+s3s = { git = "https://github.com/s3s-project/s3s.git", rev = "c71128fff3c4271899f87e82704682d74e1a78c6" }
 serial_test = "3.5.0"
 shadow-rs = { default-features = false, version = "2.0.0" }
 siphasher = "1.0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -36,8 +36,8 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
-    # Official s3s repository. Temporarily pinned for generic REST SigV4
-    # payload-checksum compatibility while upstream PR 631 is reviewed.
+    # Official s3s repository. Temporarily pinned to the merged generic REST
+    # SigV4 payload-checksum fix until it is available in a crates.io release.
     # owner: marshawcoco  review: 2026-10
     "https://github.com/s3s-project/s3s.git",
     "https://github.com/apache/datafusion.git",


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Pins `s3s` to upstream merge commit `c71128fff3c4271899f87e82704682d74e1a78c6`, which contains the accepted REST SigV4 Base64 payload-checksum fix.
- Refreshes only the `s3s` source entry in `Cargo.lock`.
- Updates the Cargo Deny source rationale to reflect that the upstream fix is merged but not yet available in a crates.io release.

## Verification

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo deny check --hide-inclusion-graph advisories sources bans licenses`
- `cargo test -p s3s base64 -- --nocapture` against the merged upstream checkout: 10 passed
- `cargo build --locked -p rustfs --bin rustfs`
- PyIceberg `0.11.1` live smoke: create, append, reload, scan, catalog probes, and cleanup passed
- Spark `3.5.4` with Iceberg `1.7.1` live smoke without an explicit catalog prefix: create, Base64 SigV4 commit, refresh, `row_count=2`, and cleanup passed

## Impact

No API or configuration changes. RustFS now consumes the final upstream implementation of the Base64 REST SigV4 payload-checksum compatibility used by Java Iceberg REST clients.

## Additional Notes

The Git pin remains temporary until a crates.io `s3s` release includes upstream merge commit `c71128fff3c4271899f87e82704682d74e1a78c6`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
