### PR TITLE
fix(ecstore): accept illumos non-empty rmdir errors

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -103,6 +103,10 @@ fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
     }
 }
 
+fn is_remove_dir_not_empty_error(kind: ErrorKind) -> bool {
+    matches!(kind, ErrorKind::DirectoryNotEmpty | ErrorKind::AlreadyExists)
+}
+
 fn remove_dir_all_if_exists(path: &Path) -> std::io::Result<()> {
     match std::fs::remove_dir_all(path) {
         Ok(()) => Ok(()),
@@ -4361,7 +4365,7 @@ impl LocalDisk {
                 // debug!("remove_dir err {:?} when {:?}", &err, &delete_path);
                 match err.kind() {
                     ErrorKind::NotFound => (),
-                    ErrorKind::DirectoryNotEmpty => (),
+                    kind if is_remove_dir_not_empty_error(kind) => (),
                     kind => {
                         warn!(
                             event = EVENT_DISK_LOCAL_DELETE_FAILED,
@@ -7927,6 +7931,13 @@ mod test {
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn remove_dir_not_empty_accepts_illumos_eexist() {
+        assert!(is_remove_dir_not_empty_error(ErrorKind::DirectoryNotEmpty));
+        assert!(is_remove_dir_not_empty_error(ErrorKind::AlreadyExists));
+        assert!(!is_remove_dir_not_empty_error(ErrorKind::PermissionDenied));
     }
 
     impl<'a> MakeWriter<'a> for CapturedLogs {


### PR DESCRIPTION
## Related Issues
Fixes #4978.

## Summary of Changes
Treat `ErrorKind::AlreadyExists` from non-recursive `remove_dir` the same as `DirectoryNotEmpty` when pruning object directories. illumos/Solaris can return `EEXIST` for a non-empty `rmdir`, which Rust maps to `AlreadyExists`; the previous match surfaced that expected non-empty directory state as `FileAccessDenied`.

Added a focused unit test for the error-kind classifier so the illumos mapping stays covered without needing an illumos runner.

## Verification
- `CARGO_TARGET_DIR=/tmp/rustfs-target-4978 cargo test -p rustfs-ecstore remove_dir_not_empty_accepts_illumos_eexist --lib`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
Single-version object deletes on illumos/Solaris no longer fail with a misleading `InternalError` / `FileAccessDenied` when the object directory is merely non-empty during cleanup. Other permission and I/O errors still propagate.

## Additional Notes
High-risk delete path review: correctness, simplicity, security, concurrency/durability, compatibility, performance, and test coverage were checked against the final diff; no additional break found. A separate shared `make pre-pr` was already running in this checkout, so this PR only claims the focused verification above.
