### PR TITLE
fix(heal): return canonical tokens for duplicate starts

### DIFF
--- a/crates/common/src/heal_channel.rs
+++ b/crates/common/src/heal_channel.rs
@@ -243,6 +243,19 @@ pub enum HealAdmissionResult {
     Dropped(HealAdmissionDropReason),
 }
 
+/// Admission decision together with the canonical task identifier.
+///
+/// A merged request must return the identifier of the task that already owns
+/// the work instead of exposing the discarded request identifier as a new
+/// client token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealAdmissionReceipt {
+    /// Admission decision for the submitted request.
+    pub result: HealAdmissionResult,
+    /// Canonical identifier of the accepted or merged task.
+    pub task_id: String,
+}
+
 impl HealAdmissionResult {
     pub fn result_label(self) -> &'static str {
         match self {
@@ -382,8 +395,25 @@ pub type HealChannelSender = mpsc::UnboundedSender<HealChannelCommand>;
 /// Heal channel receiver
 pub type HealChannelReceiver = mpsc::UnboundedReceiver<HealChannelCommand>;
 
+/// Canonical-receipt start command kept separate from the legacy public enum.
+#[derive(Debug)]
+pub struct HealReceiptCommand {
+    /// Heal request to admit.
+    pub request: HealChannelRequest,
+    /// Completion channel for the admission receipt.
+    pub response_tx: oneshot::Sender<Result<HealAdmissionReceipt, String>>,
+}
+
+/// Canonical-receipt command receiver.
+pub type HealReceiptReceiver = mpsc::UnboundedReceiver<HealReceiptCommand>;
+
+struct HealChannelSenders {
+    command: HealChannelSender,
+    receipt: mpsc::UnboundedSender<HealReceiptCommand>,
+}
+
 /// Global heal channel sender
-static GLOBAL_HEAL_CHANNEL_SENDER: OnceLock<HealChannelSender> = OnceLock::new();
+static GLOBAL_HEAL_CHANNEL_SENDERS: OnceLock<HealChannelSenders> = OnceLock::new();
 
 type HealResponseSender = broadcast::Sender<HealChannelResponse>;
 
@@ -392,17 +422,24 @@ static GLOBAL_HEAL_RESPONSE_SENDER: OnceLock<HealResponseSender> = OnceLock::new
 
 /// Initialize global heal channel
 pub fn init_heal_channel() -> Result<HealChannelReceiver, &'static str> {
-    let (tx, rx) = mpsc::unbounded_channel();
-    if GLOBAL_HEAL_CHANNEL_SENDER.set(tx).is_ok() {
-        Ok(rx)
-    } else {
-        Err("Heal channel sender already initialized")
-    }
+    let (receiver, receipt_receiver) = init_heal_channels()?;
+    drop(receipt_receiver);
+    Ok(receiver)
+}
+
+/// Initialize the legacy command and canonical-receipt channels atomically.
+pub fn init_heal_channels() -> Result<(HealChannelReceiver, HealReceiptReceiver), &'static str> {
+    let (command, command_receiver) = mpsc::unbounded_channel();
+    let (receipt, receipt_receiver) = mpsc::unbounded_channel();
+    GLOBAL_HEAL_CHANNEL_SENDERS
+        .set(HealChannelSenders { command, receipt })
+        .map_err(|_| "Heal channel sender already initialized")?;
+    Ok((command_receiver, receipt_receiver))
 }
 
 /// Get global heal channel sender
 pub fn get_heal_channel_sender() -> Option<&'static HealChannelSender> {
-    GLOBAL_HEAL_CHANNEL_SENDER.get()
+    GLOBAL_HEAL_CHANNEL_SENDERS.get().map(|senders| &senders.command)
 }
 
 /// Send heal command through global channel
@@ -434,6 +471,21 @@ pub fn publish_heal_response(response: HealChannelResponse) -> Result<(), broadc
 /// Subscribe to heal responses.
 pub fn subscribe_heal_responses() -> broadcast::Receiver<HealChannelResponse> {
     heal_response_sender().subscribe()
+}
+
+/// Send heal start request and wait for structured admission feedback.
+pub async fn send_heal_request_with_receipt(request: HealChannelRequest) -> Result<HealAdmissionReceipt, String> {
+    let (response_tx, response_rx) = oneshot::channel();
+    let senders = GLOBAL_HEAL_CHANNEL_SENDERS
+        .get()
+        .ok_or_else(|| "Heal channel not initialized".to_string())?;
+    senders
+        .receipt
+        .send(HealReceiptCommand { request, response_tx })
+        .map_err(|err| format!("Failed to send heal receipt command: {err}"))?;
+    response_rx
+        .await
+        .map_err(|e| format!("Failed to receive heal admission response: {e}"))?
 }
 
 /// Send heal start request and wait for structured admission feedback.

--- a/crates/heal/src/heal/channel.rs
+++ b/crates/heal/src/heal/channel.rs
@@ -20,8 +20,8 @@ use crate::heal::{
 };
 use crate::{Error, Result};
 use rustfs_common::heal_channel::{
-    HealAdmissionResult, HealChannelCommand, HealChannelPriority, HealChannelReceiver, HealChannelRequest, HealChannelResponse,
-    HealRequestSource, HealScanMode, publish_heal_response,
+    HealAdmissionReceipt, HealAdmissionResult, HealChannelCommand, HealChannelPriority, HealChannelReceiver, HealChannelRequest,
+    HealChannelResponse, HealReceiptCommand, HealReceiptReceiver, HealRequestSource, HealScanMode, publish_heal_response,
 };
 use rustfs_madmin::heal_commands::HealResultItem;
 use serde::Serialize;
@@ -79,8 +79,19 @@ impl HealChannelProcessor {
         }
     }
 
-    /// Start processing heal channel requests
-    pub async fn start(&mut self, mut receiver: HealChannelReceiver) -> Result<()> {
+    /// Start processing legacy heal channel requests.
+    pub async fn start(&mut self, receiver: HealChannelReceiver) -> Result<()> {
+        let (receipt_sender, receipt_receiver) = mpsc::unbounded_channel();
+        drop(receipt_sender);
+        self.start_with_receipts(receiver, receipt_receiver).await
+    }
+
+    /// Start processing legacy and canonical-receipt heal channel requests.
+    pub async fn start_with_receipts(
+        &mut self,
+        mut receiver: HealChannelReceiver,
+        mut receipt_receiver: HealReceiptReceiver,
+    ) -> Result<()> {
         info!(
             target: "rustfs::heal::channel",
             event = EVENT_HEAL_CHANNEL_STATE,
@@ -90,6 +101,7 @@ impl HealChannelProcessor {
             "Heal channel started"
         );
 
+        let mut receipt_channel_open = true;
         loop {
             tokio::select! {
                 command = receiver.recv() => {
@@ -118,6 +130,23 @@ impl HealChannelProcessor {
                             );
                             break;
                         }
+                    }
+                }
+                command = receipt_receiver.recv(), if receipt_channel_open => {
+                    let Some(HealReceiptCommand { request, response_tx }) = command else {
+                        receipt_channel_open = false;
+                        continue;
+                    };
+                    if let Err(e) = self.process_start_request(request, false, true, response_tx).await {
+                        error!(
+                            target: "rustfs::heal::channel",
+                            event = EVENT_HEAL_CHANNEL_REQUEST,
+                            component = LOG_COMPONENT_HEAL,
+                            subsystem = LOG_SUBSYSTEM_CHANNEL,
+                            state = "receipt_process_failed",
+                            error = %e,
+                            "Heal receipt request processing failed"
+                        );
                     }
                 }
                 response = self.response_receiver.recv() => {
@@ -152,7 +181,7 @@ impl HealChannelProcessor {
     /// Process heal command
     async fn process_command(&self, command: HealChannelCommand) -> Result<()> {
         match command {
-            HealChannelCommand::Start { request, response_tx } => self.process_start_request(request, response_tx).await,
+            HealChannelCommand::Start { request, response_tx } => self.process_legacy_start_request(request, response_tx).await,
             HealChannelCommand::Query {
                 heal_path,
                 client_token,
@@ -166,11 +195,28 @@ impl HealChannelProcessor {
         }
     }
 
+    async fn process_legacy_start_request(
+        &self,
+        request: HealChannelRequest,
+        response_tx: oneshot::Sender<std::result::Result<HealAdmissionResult, String>>,
+    ) -> Result<()> {
+        let (receipt_tx, receipt_rx) = oneshot::channel();
+        self.process_start_request(request, true, false, receipt_tx).await?;
+        let result = receipt_rx
+            .await
+            .map_err(|err| Error::other(format!("heal receipt channel closed: {err}")))?
+            .map(|receipt| receipt.result);
+        let _ = response_tx.send(result);
+        Ok(())
+    }
+
     /// Process start request
     async fn process_start_request(
         &self,
         request: HealChannelRequest,
-        response_tx: oneshot::Sender<std::result::Result<HealAdmissionResult, String>>,
+        preserve_alias: bool,
+        publish_canonical_id: bool,
+        response_tx: oneshot::Sender<std::result::Result<HealAdmissionReceipt, String>>,
     ) -> Result<()> {
         debug!(
             target: "rustfs::heal::channel",
@@ -201,8 +247,13 @@ impl HealChannelProcessor {
         };
 
         // Submit to heal manager
-        match self.heal_manager.submit_heal_request(heal_request).await {
-            Ok(admission) => {
+        match self
+            .heal_manager
+            .submit_heal_request_with_receipt_and_alias(heal_request, preserve_alias)
+            .await
+        {
+            Ok(receipt) => {
+                let admission = receipt.result;
                 debug!(
                     target: "rustfs::heal::channel",
                     event = EVENT_HEAL_CHANNEL_REQUEST,
@@ -214,9 +265,13 @@ impl HealChannelProcessor {
                     "Heal admission decided"
                 );
 
-                let _ = response_tx.send(Ok(admission));
-
-                self.publish_response(admission_response(request.id, admission));
+                let response_id = if publish_canonical_id {
+                    receipt.task_id.clone()
+                } else {
+                    request.id.clone()
+                };
+                self.publish_response(admission_response(response_id, receipt.result));
+                let _ = response_tx.send(Ok(receipt));
             }
             Err(e) => {
                 let error_text = e.to_string();
@@ -537,6 +592,7 @@ mod tests {
         HealAdmissionDropReason, HealAdmissionResult, HealChannelPriority, HealChannelRequest, HealRequestSource, HealScanMode,
     };
     use std::sync::Arc;
+    use std::time::Duration;
 
     // Mock storage for testing
     struct MockStorage;
@@ -1097,27 +1153,190 @@ mod tests {
 
         let (tx, rx) = oneshot::channel();
         processor
-            .process_start_request(request.clone(), tx)
+            .process_start_request(request.clone(), false, true, tx)
             .await
             .expect("first admission should succeed");
-        assert_eq!(
-            rx.await
-                .expect("oneshot should resolve")
-                .expect("admission should be returned"),
-            HealAdmissionResult::Accepted
-        );
+        let first = rx
+            .await
+            .expect("oneshot should resolve")
+            .expect("admission should be returned");
+        assert_eq!(first.result, HealAdmissionResult::Accepted);
+        assert_eq!(first.task_id, "admission-id");
+
+        let mut duplicate = request;
+        duplicate.id = "duplicate-id".to_string();
+        let (tx, rx) = oneshot::channel();
+        processor
+            .process_start_request(duplicate, false, true, tx)
+            .await
+            .expect("duplicate admission should succeed");
+        let merged = rx
+            .await
+            .expect("oneshot should resolve")
+            .expect("admission should be returned");
+        assert_eq!(merged.result, HealAdmissionResult::Merged);
+        assert_eq!(merged.task_id, "admission-id");
+    }
+
+    #[tokio::test]
+    async fn test_legacy_start_preserves_duplicate_alias_and_submitted_response_id() {
+        let manager = create_test_heal_manager();
+        let processor = HealChannelProcessor::new(manager.clone());
+        let request = HealChannelRequest {
+            id: "legacy-original-id".to_string(),
+            bucket: "bucket".to_string(),
+            object_prefix: Some("object".to_string()),
+            priority: HealChannelPriority::Low,
+            source: HealRequestSource::Admin,
+            ..Default::default()
+        };
+        let mut responses = rustfs_common::heal_channel::subscribe_heal_responses();
 
         let (tx, rx) = oneshot::channel();
         processor
-            .process_start_request(request, tx)
+            .process_command(HealChannelCommand::Start {
+                request: request.clone(),
+                response_tx: tx,
+            })
             .await
-            .expect("duplicate admission should succeed");
+            .expect("legacy start should be processed");
         assert_eq!(
             rx.await
-                .expect("oneshot should resolve")
-                .expect("admission should be returned"),
+                .expect("legacy response should arrive")
+                .expect("legacy start should succeed"),
+            HealAdmissionResult::Accepted
+        );
+
+        let mut duplicate = request;
+        duplicate.id = "legacy-duplicate-id".to_string();
+        let (tx, rx) = oneshot::channel();
+        processor
+            .process_command(HealChannelCommand::Start {
+                request: duplicate,
+                response_tx: tx,
+            })
+            .await
+            .expect("legacy duplicate should be processed");
+        assert_eq!(
+            rx.await
+                .expect("legacy duplicate response should arrive")
+                .expect("legacy duplicate should succeed"),
             HealAdmissionResult::Merged
         );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let response = responses.recv().await.expect("legacy broadcast should stay open");
+                if response.request_id == "legacy-duplicate-id" {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("legacy broadcast must retain the submitted request id");
+        assert_eq!(
+            manager
+                .get_task_status_for_path("bucket/object", "legacy-duplicate-id")
+                .await
+                .expect("legacy alias should resolve"),
+            HealTaskStatus::Pending
+        );
+        manager
+            .cancel_task("legacy-duplicate-id")
+            .await
+            .expect("legacy alias should cancel the canonical task");
+    }
+
+    #[tokio::test]
+    async fn test_public_legacy_start_processes_commands_with_receipt_channel_closed() {
+        let manager = create_test_heal_manager();
+        let mut processor = HealChannelProcessor::new(manager);
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let processor_task = tokio::spawn(async move { processor.start(command_rx).await });
+        let (response_tx, response_rx) = oneshot::channel();
+        command_tx
+            .send(HealChannelCommand::Start {
+                request: HealChannelRequest {
+                    id: "legacy-start-loop-id".to_string(),
+                    bucket: "bucket".to_string(),
+                    object_prefix: Some("object".to_string()),
+                    source: HealRequestSource::Admin,
+                    ..Default::default()
+                },
+                response_tx,
+            })
+            .expect("legacy command should send");
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), response_rx)
+                .await
+                .expect("legacy processor should not starve")
+                .expect("legacy response should arrive")
+                .expect("legacy start should succeed"),
+            HealAdmissionResult::Accepted
+        );
+        drop(command_tx);
+        tokio::time::timeout(Duration::from_secs(1), processor_task)
+            .await
+            .expect("legacy processor should stop when command channel closes")
+            .expect("legacy processor task should join")
+            .expect("legacy processor should stop cleanly");
+    }
+
+    #[tokio::test]
+    async fn test_receipt_channel_returns_canonical_id_end_to_end() {
+        let manager = create_test_heal_manager();
+        let mut processor = HealChannelProcessor::new(manager);
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let (receipt_tx, receipt_rx) = mpsc::unbounded_channel();
+        let processor_task = tokio::spawn(async move { processor.start_with_receipts(command_rx, receipt_rx).await });
+        let request = HealChannelRequest {
+            id: "receipt-original-id".to_string(),
+            bucket: "bucket".to_string(),
+            object_prefix: Some("object".to_string()),
+            source: HealRequestSource::Admin,
+            ..Default::default()
+        };
+
+        let (response_tx, response_rx) = oneshot::channel();
+        receipt_tx
+            .send(HealReceiptCommand {
+                request: request.clone(),
+                response_tx,
+            })
+            .expect("receipt command should send");
+        let accepted = tokio::time::timeout(Duration::from_secs(1), response_rx)
+            .await
+            .expect("receipt processor should not starve")
+            .expect("receipt response should arrive")
+            .expect("receipt start should succeed");
+        assert_eq!(accepted.result, HealAdmissionResult::Accepted);
+        assert_eq!(accepted.task_id, "receipt-original-id");
+
+        let mut duplicate = request;
+        duplicate.id = "receipt-duplicate-id".to_string();
+        let (response_tx, response_rx) = oneshot::channel();
+        receipt_tx
+            .send(HealReceiptCommand {
+                request: duplicate,
+                response_tx,
+            })
+            .expect("duplicate receipt command should send");
+        let merged = tokio::time::timeout(Duration::from_secs(1), response_rx)
+            .await
+            .expect("duplicate receipt should not starve")
+            .expect("duplicate receipt response should arrive")
+            .expect("duplicate receipt should succeed");
+        assert_eq!(merged.result, HealAdmissionResult::Merged);
+        assert_eq!(merged.task_id, "receipt-original-id");
+
+        drop(receipt_tx);
+        drop(command_tx);
+        tokio::time::timeout(Duration::from_secs(1), processor_task)
+            .await
+            .expect("receipt processor should stop when channels close")
+            .expect("receipt processor task should join")
+            .expect("receipt processor should stop cleanly");
     }
 
     #[tokio::test]
@@ -1147,7 +1366,7 @@ mod tests {
 
         let (tx, rx) = oneshot::channel();
         processor
-            .process_start_request(request, tx)
+            .process_start_request(request, false, true, tx)
             .await
             .expect("processor should surface invalid request through response channel");
         assert!(rx.await.expect("oneshot should resolve").is_err());

--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -19,7 +19,7 @@ use crate::heal::{
 };
 use crate::{Error, Result};
 use metrics::{counter, gauge};
-use rustfs_common::heal_channel::{HealAdmissionDropReason, HealAdmissionResult, HealRequestSource};
+use rustfs_common::heal_channel::{HealAdmissionDropReason, HealAdmissionReceipt, HealAdmissionResult, HealRequestSource};
 use rustfs_concurrency::{AdmissionState, WorkloadAdmissionSnapshotProvider, WorkloadClass};
 use rustfs_madmin::heal_commands::HealResultItem;
 #[cfg(test)]
@@ -67,6 +67,17 @@ struct RetryOwnershipTestHook {
 static RETRY_OWNERSHIP_TEST_HOOK: LazyLock<Mutex<Option<Arc<RetryOwnershipTestHook>>>> = LazyLock::new(|| Mutex::new(None));
 
 #[cfg(test)]
+struct DuplicateAdmissionTestHook {
+    request_id: String,
+    active_lock_reached: Notify,
+    active_lock_release: Notify,
+}
+
+#[cfg(test)]
+static DUPLICATE_ADMISSION_TEST_HOOK: LazyLock<Mutex<Option<Arc<DuplicateAdmissionTestHook>>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+#[cfg(test)]
 async fn pause_retry_ownership_transition(task_id: &str, to_queue: bool) {
     let hook = RETRY_OWNERSHIP_TEST_HOOK.lock().await.clone();
     let Some(hook) = hook.filter(|hook| hook.task_id == task_id) else {
@@ -79,6 +90,16 @@ async fn pause_retry_ownership_transition(task_id: &str, to_queue: bool) {
         hook.active_to_retrying_reached.notify_one();
         hook.active_to_retrying_release.notified().await;
     }
+}
+
+#[cfg(test)]
+async fn pause_duplicate_admission_after_active_lock(request_id: &str) {
+    let hook = DUPLICATE_ADMISSION_TEST_HOOK.lock().await.clone();
+    let Some(hook) = hook.filter(|hook| hook.request_id == request_id) else {
+        return;
+    };
+    hook.active_lock_reached.notify_one();
+    hook.active_lock_release.notified().await;
 }
 
 type WorkloadSnapshotProviderRef = Arc<dyn WorkloadAdmissionSnapshotProvider + Send + Sync>;
@@ -1423,110 +1444,47 @@ impl HealManager {
     }
 
     /// Submit heal request
-    pub async fn submit_heal_request(&self, request: HealRequest) -> Result<HealAdmissionResult> {
+    pub async fn submit_heal_request_with_receipt(&self, request: HealRequest) -> Result<HealAdmissionReceipt> {
+        self.submit_heal_request_with_receipt_and_alias(request, false).await
+    }
+
+    pub(crate) async fn submit_heal_request_with_receipt_and_alias(
+        &self,
+        request: HealRequest,
+        preserve_alias: bool,
+    ) -> Result<HealAdmissionReceipt> {
         let config = self.config.read().await;
         let dedup_key = PriorityHealQueue::make_dedup_key(&request);
 
-        // Keep this lock order aligned with the scheduler so a request cannot
-        // slip between queued and active states while duplicate admission runs.
-        let active_duplicate = {
-            let active_heals = self.active_heals.lock().await;
-            (!request.force_start)
-                .then(|| active_heal_for_dedup_key(&active_heals, &dedup_key))
-                .flatten()
-        };
-        if let Some((merged_task_id, _)) = active_duplicate {
-            let admission = Self::duplicate_admission_for_request(&request, &config);
-
-            match admission {
-                HealAdmissionResult::Merged => {
-                    self.insert_task_alias(&request.id, &merged_task_id).await;
-                    info!(
-                        target: "rustfs::heal::manager",
-                        event = EVENT_HEAL_QUEUE_ADMISSION,
-                        component = LOG_COMPONENT_HEAL,
-                        subsystem = LOG_SUBSYSTEM_MANAGER,
-                        request_id = %request.id,
-                        merged_task_id = %merged_task_id,
-                        priority = ?request.priority,
-                        result = "merged_active_duplicate",
-                        "Heal queue admission decided"
-                    );
-                }
-                HealAdmissionResult::Dropped(reason) => {
-                    warn!(
-                        target: "rustfs::heal::manager",
-                        event = EVENT_HEAL_QUEUE_ADMISSION,
-                        component = LOG_COMPONENT_HEAL,
-                        subsystem = LOG_SUBSYSTEM_MANAGER,
-                        request_id = %request.id,
-                        priority = ?request.priority,
-                        reason = reason.as_str(),
-                        result = "dropped_active_duplicate",
-                        "Heal queue admission decided"
-                    );
-                }
-                HealAdmissionResult::Accepted | HealAdmissionResult::Full => {}
-            }
-
-            return Ok(admission);
-        }
-
-        let retrying_duplicate = {
-            let retrying_heals = self.retrying_heals.lock().await;
-            (!request.force_start)
-                .then(|| retrying_heal_for_dedup_key(&retrying_heals, &dedup_key))
-                .flatten()
-        };
-        if let Some((merged_task_id, _)) = retrying_duplicate {
-            let admission = Self::duplicate_admission_for_request(&request, &config);
-
-            match admission {
-                HealAdmissionResult::Merged => {
-                    self.insert_task_alias(&request.id, &merged_task_id).await;
-                    info!(
-                        target: "rustfs::heal::manager",
-                        event = EVENT_HEAL_QUEUE_ADMISSION,
-                        component = LOG_COMPONENT_HEAL,
-                        subsystem = LOG_SUBSYSTEM_MANAGER,
-                        request_id = %request.id,
-                        merged_task_id = %merged_task_id,
-                        priority = ?request.priority,
-                        result = "merged_retrying_duplicate",
-                        "Heal queue admission decided"
-                    );
-                }
-                HealAdmissionResult::Dropped(reason) => {
-                    warn!(
-                        target: "rustfs::heal::manager",
-                        event = EVENT_HEAL_QUEUE_ADMISSION,
-                        component = LOG_COMPONENT_HEAL,
-                        subsystem = LOG_SUBSYSTEM_MANAGER,
-                        request_id = %request.id,
-                        priority = ?request.priority,
-                        reason = reason.as_str(),
-                        result = "dropped_retrying_duplicate",
-                        "Heal queue admission decided"
-                    );
-                }
-                HealAdmissionResult::Accepted | HealAdmissionResult::Full => {}
-            }
-
-            return Ok(admission);
-        }
-
+        // Match the scheduler's active -> queue order and keep retry ownership
+        // in the same atomic view. Otherwise queue -> active and
+        // active -> retrying transitions can slip between duplicate checks.
+        let active_heals = self.active_heals.lock().await;
+        #[cfg(test)]
+        pause_duplicate_admission_after_active_lock(&request.id).await;
         let mut queue = self.heal_queue.lock().await;
-
-        let queued_duplicate = (!request.force_start)
-            .then(|| queue.request_for_dedup_key(&dedup_key).map(|queued| queued.id.clone()))
-            .flatten();
-        if let Some(merged_task_id) = queued_duplicate {
+        let retrying_heals = self.retrying_heals.lock().await;
+        let duplicate = (!request.force_start).then(|| {
+            active_heal_for_dedup_key(&active_heals, &dedup_key)
+                .map(|(task_id, _)| (task_id, "active"))
+                .or_else(|| {
+                    queue
+                        .request_for_dedup_key(&dedup_key)
+                        .map(|queued| (queued.id.clone(), "queued"))
+                })
+                .or_else(|| retrying_heal_for_dedup_key(&retrying_heals, &dedup_key).map(|(task_id, _)| (task_id, "retrying")))
+        });
+        if let Some((merged_task_id, duplicate_state)) = duplicate.flatten() {
             let admission = Self::duplicate_admission_for_request(&request, &config);
+            drop(retrying_heals);
             drop(queue);
+            drop(active_heals);
 
             match admission {
                 HealAdmissionResult::Merged => {
-                    self.insert_task_alias(&request.id, &merged_task_id).await;
+                    if preserve_alias {
+                        self.insert_task_alias(&request.id, &merged_task_id).await;
+                    }
                     debug!(
                         target: "rustfs::heal::manager",
                         event = EVENT_HEAL_QUEUE_ADMISSION,
@@ -1535,8 +1493,9 @@ impl HealManager {
                         request_id = %request.id,
                         merged_task_id = %merged_task_id,
                         priority = ?request.priority,
+                        duplicate_state,
                         result = "merged_duplicate",
-                        "Heal queue request merged"
+                        "Heal queue admission decided"
                     );
                 }
                 HealAdmissionResult::Dropped(reason) => {
@@ -1548,25 +1507,45 @@ impl HealManager {
                         request_id = %request.id,
                         priority = ?request.priority,
                         reason = reason.as_str(),
+                        duplicate_state,
                         result = "dropped_duplicate",
-                        "Heal queue request dropped"
+                        "Heal queue admission decided"
                     );
                 }
                 HealAdmissionResult::Accepted | HealAdmissionResult::Full => {}
             }
 
-            return Ok(admission);
+            return Ok(HealAdmissionReceipt {
+                result: admission,
+                task_id: merged_task_id,
+            });
         }
 
+        let mut task_id = request.id.clone();
         let admission = Self::admit_request_to_queue(&mut queue, request, &config, "submit");
+        if admission == HealAdmissionResult::Merged
+            && let Some(queued) = queue.request_for_dedup_key(&dedup_key)
+        {
+            task_id.clone_from(&queued.id);
+        }
         let should_notify = matches!(admission, HealAdmissionResult::Accepted) && config.event_driven_scheduler_enable;
+        drop(retrying_heals);
         drop(queue);
+        drop(active_heals);
 
         if should_notify {
             self.notify.notify_one();
         }
 
-        Ok(admission)
+        Ok(HealAdmissionReceipt {
+            result: admission,
+            task_id,
+        })
+    }
+
+    /// Submit heal request.
+    pub async fn submit_heal_request(&self, request: HealRequest) -> Result<HealAdmissionResult> {
+        Ok(self.submit_heal_request_with_receipt_and_alias(request, true).await?.result)
     }
 
     /// Get task status
@@ -3552,6 +3531,103 @@ mod tests {
                 .expect("duplicate request should produce admission result"),
             HealAdmissionResult::Merged
         );
+    }
+
+    #[tokio::test]
+    async fn test_admin_duplicate_receipt_returns_canonical_task_without_alias() {
+        let storage: Arc<dyn HealStorageAPI> = Arc::new(MockStorage);
+        let manager = HealManager::new(storage, None);
+        let mut original = HealRequest::object("bucket".to_string(), "object".to_string(), None);
+        original.source = HealRequestSource::Admin;
+        let original_id = original.id.clone();
+        let mut duplicate = HealRequest::object("bucket".to_string(), "object".to_string(), None);
+        duplicate.source = HealRequestSource::Admin;
+        let duplicate_id = duplicate.id.clone();
+
+        let accepted = manager
+            .submit_heal_request_with_receipt(original)
+            .await
+            .expect("first request should be accepted");
+        let merged = manager
+            .submit_heal_request_with_receipt(duplicate)
+            .await
+            .expect("duplicate request should merge");
+
+        assert_eq!(accepted.result, HealAdmissionResult::Accepted);
+        assert_eq!(accepted.task_id, original_id);
+        assert_eq!(merged.result, HealAdmissionResult::Merged);
+        assert_eq!(merged.task_id, original_id);
+        assert_eq!(manager.canonical_task_id(&duplicate_id).await, duplicate_id);
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_admission_is_atomic_with_queue_to_active_transition() {
+        let storage: Arc<dyn HealStorageAPI> = Arc::new(MockStorage);
+        let manager = Arc::new(HealManager::new(storage.clone(), None));
+        let mut original = HealRequest::object("bucket".to_string(), "object".to_string(), None);
+        original.source = HealRequestSource::Admin;
+        let original_id = original.id.clone();
+        assert_eq!(
+            manager
+                .submit_heal_request(original)
+                .await
+                .expect("original request should be accepted"),
+            HealAdmissionResult::Accepted
+        );
+
+        let mut duplicate = HealRequest::object("bucket".to_string(), "object".to_string(), None);
+        duplicate.source = HealRequestSource::Admin;
+        let hook = Arc::new(DuplicateAdmissionTestHook {
+            request_id: duplicate.id.clone(),
+            active_lock_reached: Notify::new(),
+            active_lock_release: Notify::new(),
+        });
+        *DUPLICATE_ADMISSION_TEST_HOOK.lock().await = Some(hook.clone());
+
+        let duplicate_manager = manager.clone();
+        let duplicate_task = tokio::spawn(async move { duplicate_manager.submit_heal_request_with_receipt(duplicate).await });
+        tokio::time::timeout(Duration::from_secs(1), hook.active_lock_reached.notified())
+            .await
+            .expect("duplicate admission should reach the active lock hook");
+
+        let transition_manager = manager.clone();
+        let transition_storage = storage.clone();
+        let (attempting_active_tx, attempting_active_rx) = tokio::sync::oneshot::channel();
+        let (active_acquired_tx, mut active_acquired_rx) = tokio::sync::oneshot::channel();
+        let transition = tokio::spawn(async move {
+            let _ = attempting_active_tx.send(());
+            let mut active = transition_manager.active_heals.lock().await;
+            let _ = active_acquired_tx.send(());
+            let mut queue = transition_manager.heal_queue.lock().await;
+            let request = queue.pop_next().expect("original request should remain queued");
+            let task = Arc::new(HealTask::from_request(request, transition_storage));
+            active.insert(task.id.clone(), task);
+        });
+        tokio::time::timeout(Duration::from_secs(1), attempting_active_rx)
+            .await
+            .expect("transition should attempt the active lock")
+            .expect("transition attempt signal should be delivered");
+        assert!(matches!(
+            active_acquired_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+
+        hook.active_lock_release.notify_one();
+        let receipt = tokio::time::timeout(Duration::from_secs(1), duplicate_task)
+            .await
+            .expect("duplicate admission should not hang")
+            .expect("duplicate task should join")
+            .expect("duplicate admission should succeed");
+        tokio::time::timeout(Duration::from_secs(1), transition)
+            .await
+            .expect("queue to active transition should not hang")
+            .expect("queue to active transition should join");
+        *DUPLICATE_ADMISSION_TEST_HOOK.lock().await = None;
+
+        assert_eq!(receipt.result, HealAdmissionResult::Merged);
+        assert_eq!(receipt.task_id, original_id);
+        assert_eq!(manager.get_queue_length().await, 0);
+        assert_eq!(manager.get_active_task_count().await, 1);
     }
 
     #[tokio::test]

--- a/crates/heal/src/lib.rs
+++ b/crates/heal/src/lib.rs
@@ -156,10 +156,10 @@ pub async fn init_heal_manager_with_workload_provider(
         let channel_receiver = if force_channel_failure {
             Err("forced heal channel initialization failure")
         } else {
-            rustfs_common::heal_channel::init_heal_channel()
+            rustfs_common::heal_channel::init_heal_channels()
         };
-        let receiver = match channel_receiver {
-            Ok(receiver) => receiver,
+        let (receiver, receipt_receiver) = match channel_receiver {
+            Ok(receivers) => receivers,
             Err(err) => {
                 stop_initializing_manager(&heal_manager).await?;
                 return Err(Error::Config(err.to_string()));
@@ -175,7 +175,7 @@ pub async fn init_heal_manager_with_workload_provider(
 
         tokio::spawn(async move {
             let mut processor = channel_processor.lock().await;
-            if let Err(e) = processor.start(receiver).await {
+            if let Err(e) = processor.start_with_receipts(receiver, receipt_receiver).await {
                 error!(
                     target: "rustfs::heal",
                     event = EVENT_HEAL_RUNTIME_STATE,

--- a/rustfs/src/admin/handlers/heal.rs
+++ b/rustfs/src/admin/handlers/heal.rs
@@ -919,11 +919,9 @@ impl Operation for HealHandler {
             spawn_traced(async move {
                 // Create heal request through channel
                 let heal_request = build_heal_channel_request(&hip);
-                let client_token = heal_request.id.clone();
-
-                match rustfs_common::heal_channel::send_heal_request_with_admission(heal_request).await {
-                    Ok(admission) if admission.is_admitted() => {
-                        let resp_bytes = encode_heal_start_success(client_token, client_address);
+                match rustfs_common::heal_channel::send_heal_request_with_receipt(heal_request).await {
+                    Ok(receipt) if receipt.result.is_admitted() => {
+                        let resp_bytes = encode_heal_start_success(receipt.task_id, client_address);
                         match resp_bytes {
                             Ok(resp_bytes) => {
                                 let _ = tx_clone
@@ -943,13 +941,13 @@ impl Operation for HealHandler {
                             }
                         }
                     }
-                    Ok(admission) => {
+                    Ok(receipt) => {
                         let _ = tx_clone
                             .send(HealResp {
                                 api_err: Some(format!(
                                     "heal request not admitted: admission={}, reason={}",
-                                    admission.result_label(),
-                                    admission.reason_label()
+                                    receipt.result.result_label(),
+                                    receipt.result.reason_label()
                                 )),
                                 ..Default::default()
                             })


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Return the canonical heal task identifier when an admin start request is merged with queued, active, or retrying work.
- Make duplicate detection and queue admission atomic across queue-to-active ownership transitions.
- Preserve the existing public `HealChannelCommand::Start` behavior, legacy aliases, and submitted-ID broadcasts while adding a separate receipt channel for canonical tokens.
- Prevent a closed receipt channel from causing a busy select loop.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/rustfs-heal-target cargo test -p rustfs-common --lib heal_channel --no-fail-fast`
- `CARGO_TARGET_DIR=/tmp/rustfs-heal-target cargo test -p rustfs-heal --lib --no-fail-fast`
- `CARGO_TARGET_DIR=/tmp/rustfs-heal-target cargo test -p rustfs-heal --lib receipt_channel_returns_canonical_id_end_to_end --no-fail-fast`
- `CARGO_TARGET_DIR=/tmp/rustfs-heal-target cargo test -p rustfs --lib admin::handlers::heal::tests --no-fail-fast`
- `CARGO_TARGET_DIR=/tmp/rustfs-heal-target cargo clippy -p rustfs-common -p rustfs-heal -p rustfs --lib --all-targets -- -D warnings`
- `scripts/check_logging_guardrails.sh`
- `scripts/check_layer_dependencies.sh`
- `scripts/check_architecture_migration_rules.sh`
- `scripts/check_unsafe_code_allowances.sh`
- `scripts/check_doc_paths.sh`

Full `make pre-pr` is intentionally deferred to the final stacked heal-control PR so each intermediate PR runs focused verification only.

## Impact

Repeated admin heal starts for the same local work now return the existing canonical client token instead of an unusable newly generated token. Public legacy channel APIs remain source-compatible. Cluster-wide routing and mutual exclusion are intentionally handled by the next stacked PR.

## Additional Notes

High-risk adversarial validation:

- Correctness: attacked duplicate admission across queued, active, and retrying transitions; the admission lock set and canonical ownership remained consistent.
- Security: attacked forged identifiers and privilege-boundary changes; this PR adds no wire endpoint or authorization change.
- Concurrency/durability: attacked queue-to-active TOCTOU, lock ordering, channel closure, and cancellation; deterministic regression tests pass with one continuous owner.
- Compatibility: attacked the public command enum, processor start API, legacy aliases, and broadcast identifiers; legacy behavior remains covered.
- Performance: attacked hot-path locking and closed-channel spinning; no spin remains, with the existing linear duplicate lookup retained.
- Test coverage: reverting canonical receipt handling, atomic admission, alias compatibility, or closed-channel handling causes a focused regression test to fail.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
