### PR TITLE
fix(credentials): enforce RPC fallback credential policy

### DIFF
--- a/crates/credentials/src/credentials.rs
+++ b/crates/credentials/src/credentials.rs
@@ -260,13 +260,10 @@ fn resolve_rpc_secret(env_secret: Option<&str>, global_access: Option<&str>, glo
 
     match (global_access, global_secret) {
         (Some(access_key), Some(secret_key)) => {
-            // Fail closed: never derive the RPC secret while the default secret
-            // key is in effect. The derivation uses `secret_key` as the HMAC key,
-            // so a public default secret yields a publicly computable RPC secret
-            // that any network peer can use to forge internode RPC signatures.
-            // Operators running with default credentials must configure
-            // RUSTFS_RPC_SECRET (or set a non-default RUSTFS_SECRET_KEY) instead.
-            if secret_key.trim() == DEFAULT_SECRET_KEY {
+            // Fail closed when either half of the active credential pair still
+            // uses the public default. Operators must configure both custom
+            // credentials or provide RUSTFS_RPC_SECRET explicitly.
+            if access_key.trim() == DEFAULT_ACCESS_KEY || secret_key.trim() == DEFAULT_SECRET_KEY {
                 return None;
             }
             derive_rpc_secret(access_key, secret_key)
@@ -589,18 +586,11 @@ mod tests {
     fn test_resolve_rpc_secret_rejects_default_credentials_for_derivation() {
         assert!(resolve_rpc_secret(None, None, None).is_none());
 
-        // Fail closed: the default secret key must not yield a derivable RPC
-        // secret, otherwise the derived value is publicly computable and any
-        // network peer can forge internode RPC signatures.
+        // Fail closed when either half of the credential pair uses the public
+        // default.
         assert!(resolve_rpc_secret(None, Some(DEFAULT_ACCESS_KEY), Some(DEFAULT_SECRET_KEY)).is_none());
-
-        // A default access key paired with a non-default secret key is still
-        // safe to derive: the HMAC key (the secret key) is not public.
-        let expected = derive_rpc_secret(DEFAULT_ACCESS_KEY, "custom-global-secret").expect("secret should derive");
-        assert_eq!(
-            resolve_rpc_secret(None, Some(DEFAULT_ACCESS_KEY), Some("custom-global-secret")).as_deref(),
-            Some(expected.as_str())
-        );
+        assert!(resolve_rpc_secret(None, Some(DEFAULT_ACCESS_KEY), Some("custom-global-secret")).is_none());
+        assert!(resolve_rpc_secret(None, Some("custom-access"), Some(DEFAULT_SECRET_KEY)).is_none());
 
         assert!(resolve_rpc_secret(Some(DEFAULT_SECRET_KEY), Some("custom-access"), Some("custom-global-secret")).is_none());
     }
@@ -633,6 +623,10 @@ mod tests {
     fn test_resolve_rpc_secret_accepts_non_default_secret() {
         assert_eq!(
             resolve_rpc_secret(Some("custom-rpc-secret"), None, None).as_deref(),
+            Some("custom-rpc-secret")
+        );
+        assert_eq!(
+            resolve_rpc_secret(Some("custom-rpc-secret"), Some(DEFAULT_ACCESS_KEY), Some(DEFAULT_SECRET_KEY)).as_deref(),
             Some("custom-rpc-secret")
         );
         let expected = derive_rpc_secret("custom-access", "custom-global-secret").expect("secret should derive");

--- a/crates/e2e_test/src/cluster_multidrive_pool_test.rs
+++ b/crates/e2e_test/src/cluster_multidrive_pool_test.rs
@@ -87,6 +87,12 @@ async fn cluster_two_pool_smoke() -> TestResult {
 
     let mut cluster =
         RustFSTestClusterEnvironment::with_topology(ClusterTopology::per_node_pools(2, vec![vec![0], vec![1]])).await?;
+    cluster.access_key = "custom-two-pool-access".to_string();
+    cluster.secret_key = "custom-two-pool-secret".to_string();
+    // Override any inherited test-runner value with an explicit blank. The
+    // credentials getter treats blank as absent and must derive one stable RPC
+    // secret from the shared non-default credential pair on every node.
+    cluster.set_env("RUSTFS_RPC_SECRET", "");
 
     // The two-pool layout must emit one ellipses argument per pool.
     let volumes = cluster.rustfs_volumes_arg();


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Reject RPC secret derivation when either the active access key or secret key still uses the public `rustfsadmin` default.
- Preserve the existing source priority: an initialized global RPC secret first, then a non-empty `RUSTFS_RPC_SECRET`, then deterministic derivation from a fully custom AK/SK pair.
- Extend the two-pool end-to-end smoke test to boot with custom AK/SK and no explicit RPC secret, then verify an S3 PUT/GET round trip.
- Add regression coverage proving an explicit RPC secret still takes priority when the S3 credential pair uses defaults.

## Verification

- `cargo fmt --all --check` — passed.
- `cargo test -p rustfs-credentials` — passed (24 unit tests and 2 doc tests).
- `cargo clippy -p rustfs-credentials --all-targets -- -D warnings` — passed.
- `cargo check -p e2e_test --all-targets` — passed.
- `cargo test -p e2e_test cluster_two_pool_smoke -- --nocapture` — passed; both pools started without an explicit RPC secret and PUT/GET completed successfully.
- `make pre-commit` — passed before rebasing onto the latest `main`; a latest-base rerun passed all guard scripts and was stopped during the clean workspace compilation to prioritize the requested PR creation.
- `make pre-pr` — formatting, guard scripts, and workspace Clippy passed; the nextest build was interrupted after more than 50 minutes because test-binary linking was blocked on local network-volume I/O.

## Impact

Deployments using the default access key with a custom secret key can no longer derive an internode RPC secret implicitly. They must configure a fully custom AK/SK pair or set `RUSTFS_RPC_SECRET` explicitly. Fully custom, identical AK/SK values across nodes continue to support multi-pool startup without an explicit RPC secret.

No API, wire-format, or on-disk format changes are introduced.

## Additional Notes

- Correctness: attacked blank RPC configuration, either default credential half, and explicit-secret priority; regression tests cover each branch.
- Security: default credential material fails closed and no secret values are logged or persisted by this change.
- Concurrency/durability: the existing `OnceLock` initialization and race handling are unchanged; no storage or durability paths change.
- Compatibility: the intentional behavior change is limited to default-AK/custom-SK fallback; explicit RPC configuration remains compatible.
- Performance: only one startup-time string comparison is added; request hot paths are unchanged.
- Test coverage: reverting the access-key guard fails the credential regression test, while reverting the E2E setup removes coverage for two-pool derived RPC startup.

Rollback is a normal commit revert. Mixed-version or rolling expansion should continue to use one explicit, stable `RUSTFS_RPC_SECRET` across all nodes.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
