### PR TITLE
chore: self-host contributor wall

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -16,10 +16,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: overtrue/star-history-action@71eb65f6d4798cf9de2549af1205e911555d0511 # v1.1.0
+      - uses: overtrue/star-history-action@276780af00976fb90f2d9f312ce9e25c6eecdcf5 # v1.2.0
         with:
           github-token: ${{ github.token }}
           output-branch: star-history
           output-path: .
           chart-style: gradient
           animate: "true"
+          contributors: "true"

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: overtrue/star-history-action@276780af00976fb90f2d9f312ce9e25c6eecdcf5 # v1.2.0
+      - uses: overtrue/repo-visuals-action@fc2347f1df64da7122b0775b3f20083d7f7294dd # v1.2.1
         with:
           github-token: ${{ github.token }}
           output-branch: star-history

--- a/README.md
+++ b/README.md
@@ -338,7 +338,10 @@ If you have any questions or need assistance:
 RustFS is a community-driven project, and we appreciate all contributions. Check out the [Contributors](https://github.com/rustfs/rustfs/graphs/contributors) page to see the amazing people who have helped make RustFS better.
 
 <a href="https://github.com/rustfs/rustfs/graphs/contributors">
-<img src="https://opencollective.com/rustfs/contributors.svg?width=890&limit=500&button=false" alt="Contributors" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rustfs/rustfs/star-history/contributors-dark.svg">
+  <img src="https://raw.githubusercontent.com/rustfs/rustfs/star-history/contributors-light.svg" alt="RustFS contributors">
+</picture>
 </a>
 
 ## Star History

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -247,7 +247,10 @@ rustfs --help
 RustFS 是一个社区驱动的项目，我们感谢所有的贡献。请查看 [贡献者](https://github.com/rustfs/rustfs/graphs/contributors) 页面，看看那些让 RustFS 变得更好的了不起的人们。
 
 <a href="https://github.com/rustfs/rustfs/graphs/contributors">
-<img src="https://opencollective.com/rustfs/contributors.svg?width=890&limit=500&button=false" alt="Contributors" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rustfs/rustfs/star-history/contributors-dark.svg">
+  <img src="https://raw.githubusercontent.com/rustfs/rustfs/star-history/contributors-light.svg" alt="RustFS 贡献者">
+</picture>
 </a>
 
 ## Star 历史


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- replace the OpenCollective contributor image with self-hosted light and dark SVG files
- enable contributor-wall generation in the existing Star History workflow
- pin `overtrue/repo-visuals-action` to the `v1.2.1` commit

## Verification

- `actionlint .github/workflows/star-history.yml`
- [workflow dispatch using the pinned action](https://github.com/rustfs/rustfs/actions/runs/29639139548)
- verified both raw contributor SVG URLs return HTTP 200

## Impact

The README contributor wall no longer depends on a hosted rendering service. The existing daily workflow now refreshes stars and contributors with `GITHUB_TOKEN` and publishes both SVG variants to the `star-history` branch.

## Additional Notes

Documentation and workflow configuration only; build-based verification is not applicable.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
