### PR TITLE
ci: bump repo-visuals-action to v1.3.0

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: overtrue/repo-visuals-action@fc2347f1df64da7122b0775b3f20083d7f7294dd # v1.2.1
+      - uses: overtrue/repo-visuals-action@72f34d24769ff5d341956da2f23952594ef2f1e2 # v1.3.0
         with:
           github-token: ${{ github.token }}
           output-branch: star-history


### PR DESCRIPTION
Bumps the pinned `overtrue/repo-visuals-action` in the Star History workflow from `v1.2.1` (`fc2347f`) to `v1.3.0` (`72f34d24769ff5d341956da2f23952594ef2f1e2`).

v1.3.0 is a backward-compatible feature release: output filenames and existing `chart-style` values are unchanged, so the current `chart-style: gradient` / `animate` / `contributors` configuration continues to work with no other changes. The gradient theme automatically picks up the redesigned chart look on the next scheduled run.

The SHA is pinned per repo convention, with the version as a trailing comment.

Full changelog: https://github.com/overtrue/repo-visuals-action/compare/v1.2.1...v1.3.0