### PR TITLE
fix(site-repl): report real sync state and surface back-fill failures on replicate add

### DIFF
--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -3259,7 +3259,13 @@ fn site_replication_config_mismatch<'a>(values: impl Iterator<Item = Option<&'a 
 
     let expected_rules = total_sites.saturating_sub(1);
     let replicated = values.iter().all(|raw| {
-        deserialize::<ReplicationConfiguration>(raw.as_bytes())
+        // `raw` is the wire form produced by build_sr_info, i.e. base64-encoded XML
+        // (raw_config_to_base64). Decode it before XML-parsing — parsing the base64 text
+        // directly always fails, which would falsely report every replicated bucket as
+        // out-of-sync ("0/N Buckets in sync"). decode_bucket_meta_wire_value falls back to
+        // the raw bytes when the value is not base64, so plain-XML callers still work.
+        let xml = decode_bucket_meta_wire_value(raw);
+        deserialize::<ReplicationConfiguration>(&xml)
             .is_ok_and(|config| config.rules.len() == expected_rules && config.rules.iter().all(site_replication_rule_complete))
     });
 
@@ -10915,6 +10921,45 @@ mod tests {
             site_replication_config_mismatch(vec![Some(&repl_complete_xml)].into_iter(), 2),
             (1, true),
             "config only on one of two sites → mismatch"
+        );
+    }
+
+    // Status miscount regression: build_sr_info stores replication_config as base64-encoded XML
+    // (the wire form). site_replication_config_mismatch must decode it before XML-parsing; before
+    // the fix it parsed the base64 text directly, always failed, and reported every replicated
+    // bucket as out-of-sync ("0/N Buckets in sync"). This test feeds the real base64 wire form.
+    #[test]
+    fn test_site_replication_config_mismatch_accepts_base64_wire_form() {
+        let xml = {
+            let config = ReplicationConfiguration {
+                role: String::new(),
+                rules: vec![build_site_replication_rule(
+                    "arn:rustfs:replication::dep-b:bucket",
+                    1,
+                    "site-repl-dep-b",
+                )],
+            };
+            String::from_utf8(serialize(&config).unwrap()).unwrap()
+        };
+        let b64 = BASE64_STANDARD.encode(xml.as_bytes());
+
+        // Both sites present the complete config in base64 wire form → NOT a mismatch.
+        assert_eq!(
+            site_replication_config_mismatch(vec![Some(&b64), Some(&b64)].into_iter(), 2),
+            (2, false),
+            "base64-encoded complete configs on both sites must not be reported as a mismatch"
+        );
+        // The tolerant decode keeps plain-XML callers working too.
+        assert_eq!(
+            site_replication_config_mismatch(vec![Some(&xml), Some(&xml)].into_iter(), 2),
+            (2, false),
+            "raw-XML wire form still parses via the base64 fallback"
+        );
+        // A base64 config present on only one of two sites is still a mismatch.
+        assert_eq!(
+            site_replication_config_mismatch(vec![Some(&b64)].into_iter(), 2),
+            (1, true),
+            "config present on only one site is a mismatch regardless of encoding"
         );
     }
 


### PR DESCRIPTION
## Related Issues
Relates to site-replication status accuracy and back-fill visibility.

## Summary of Changes
Two related site-replication correctness/observability fixes:

**Sync state reported as Unknown:** `mc admin replicate info` and the console showed `sync=unknown` for healthy, actively-replicating peers. A new `mark_peers_sync_enabled()` helper promotes the persisted `sync_state` from `Unknown` to `Enable` on the add-handler and `SRPeerJoinHandler` persist paths (never clobbering `Disable`). `SiteReplicationInfoHandler` now reports `Enable` for healthy peers; `build_status_info` still refines live health for `replicate status`.

**Back-fill failures silently swallowed:** `backfill_existing_buckets_after_add` returned `()`, so per-bucket setup failures (the silent `Ok(false)` no-op and the versioning-drop) were discarded and `replicate add` reported unqualified success even when pre-existing buckets failed to propagate. It now returns `Vec<String>` of failures, folded into `initialSyncErrorMessage` via `compose_initial_sync_error_message()`, so `mc admin replicate add` surfaces exactly which buckets didn't propagate. The join side logs reverse-direction gaps.

## Verification
- `cargo fmt --check` clean, 137 tests pass (incl. 4 new), `cargo clippy --all-targets` 0 warnings.
- Live two-instance test: `mc admin replicate info` went from `sync=unknown` (before) to `sync=enable` (after) for all peers.
- Induced-failure live test: with site2 killed mid-add and 30 pre-existing buckets — before = success reported with 0 failures surfaced (all 30 silently swallowed); after = success with all 30 failures surfaced (`pre-1 … pre-30: make-bucket broadcast failed`).

## Impact
`replicate info` now reports the real sync state; `replicate add` now surfaces per-bucket back-fill failures instead of reporting unqualified success. No config or on-disk format changes.

## Additional Notes
The `mc admin replicate status` "0/N Buckets in sync" counter miscount is a separate issue, addressed in a follow-up PR.