### PR TITLE
test(rpc): cover tonic auth service binding

### DIFF
--- a/crates/ecstore/src/cluster/rpc/http_auth.rs
+++ b/crates/ecstore/src/cluster/rpc/http_auth.rs
@@ -1049,6 +1049,17 @@ mod tests {
     }
 
     #[test]
+    fn tonic_v2_signature_is_bound_to_exact_service() {
+        ensure_test_rpc_secret();
+        let headers = gen_tonic_signature_headers("node-a:9000", "node_service.NodeService", "Ping", None)
+            .expect("tonic auth headers should build");
+
+        let error = verify_tonic_rpc_signature("node-a:9000", "/other.NodeService/Ping", &headers)
+            .expect_err("signature replayed to a different service must fail");
+        assert_eq!(error.to_string(), "Invalid RPC v2 signature");
+    }
+
+    #[test]
     fn tonic_v2_signature_is_bound_to_destination_audience() {
         ensure_test_rpc_secret();
         let headers = gen_tonic_signature_headers("node-a:9000", "node_service.NodeService", "Ping", None)


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds one regression test for the recent internode RPC v2 auth change. The new test verifies a signature for `/node_service.NodeService/Ping` cannot be replayed to `/other.NodeService/Ping`, so the service name stays part of the exact HMAC target.

## Verification
- `CARGO_TARGET_DIR=/tmp/rustfs-target-test-gap-rpc-service cargo test -p rustfs-ecstore tonic_v2_signature_is_bound_to_exact_service`
- Mutation check: temporarily removed `scope.service` from the v2 HMAC payload and the new focused test failed with `signature replayed to a different service must fail`.
- `cargo fmt --all --check`
- `make pre-commit`

## Impact
Test-only. No runtime behavior change.

## Additional Notes
N/A
