### PR TITLE
test(ecstore): cover transition cleanup failure

### DIFF
--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -4307,6 +4307,97 @@ mod transition_upload_integrity_tests {
         assert_eq!(backend.object_count().await, 0);
         assert_local_source_intact(&set_disks, bucket, object, &payload).await;
     }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn authoritative_read_failure_after_upload_cleans_exact_candidate_and_preserves_source() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "transition-authoritative-read-failure-bucket";
+        let object = "object.bin";
+        let payload = b"authoritative metadata read failure must clean remote candidate".repeat(1024);
+        let original = write_source(&set_disks, &disk_stores, bucket, object, &payload).await;
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&runtime_sources::global_tier_config_mgr(), &tier_name).await;
+        let put_barrier = backend.arm_put_barrier().await;
+
+        let transition_set = Arc::clone(&set_disks);
+        let transition = tokio::spawn(async move {
+            transition_set
+                .transition_object(bucket, object, &transition_options(&original, tier_name))
+                .await
+        });
+        put_barrier.wait_until_paused().await;
+        let saved_disks = {
+            let mut disks = set_disks.disks.write().await;
+            let saved = std::mem::take(&mut *disks);
+            *disks = vec![None; saved.len()];
+            saved
+        };
+        put_barrier.release();
+
+        let err = transition
+            .await
+            .expect("transition task should not panic")
+            .expect_err("authoritative metadata read failure must fail the transition");
+        *set_disks.disks.write().await = saved_disks;
+        assert!(
+            matches!(
+                err,
+                StorageError::ErasureReadQuorum | StorageError::InsufficientReadQuorum(_, _) | StorageError::Io(_)
+            ),
+            "unexpected authoritative read failure: {err:?}"
+        );
+        assert_eq!(backend.put_count().await, 1);
+        assert_eq!(backend.remove_count().await, 1);
+        assert_eq!(
+            backend.remove_versions().await,
+            backend.put_versions().await,
+            "authoritative read failure must remove the exact uploaded remote version"
+        );
+        assert_eq!(backend.object_count().await, 0);
+        assert_local_source_intact(&set_disks, bucket, object, &payload).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn remote_cleanup_failure_after_version_rejection_preserves_source_and_candidate() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "transition-cleanup-failure-bucket";
+        let object = "object.bin";
+        let payload = b"cleanup failure must keep source and orphan evidence".repeat(1024);
+        let original = write_source(&set_disks, &disk_stores, bucket, object, &payload).await;
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&runtime_sources::global_tier_config_mgr(), &tier_name).await;
+        backend.set_put_remote_version(Some("opaque-version-token".to_string())).await;
+        let put_barrier = backend.arm_put_barrier().await;
+
+        let transition_set = Arc::clone(&set_disks);
+        let transition = tokio::spawn(async move {
+            transition_set
+                .transition_object(bucket, object, &transition_options(&original, tier_name))
+                .await
+        });
+        put_barrier.wait_until_paused().await;
+        backend.set_server_error(true).await;
+        put_barrier.release();
+
+        transition
+            .await
+            .expect("transition task should not panic")
+            .expect_err("opaque remote version must fail closed even if cleanup also fails");
+        assert_eq!(backend.put_count().await, 1);
+        assert_eq!(
+            backend.remove_count().await,
+            0,
+            "cleanup failure before backend remove must not be reported as a successful exact delete"
+        );
+        assert_eq!(
+            backend.object_count().await,
+            1,
+            "failed cleanup must leave the remote candidate visible for durable reconciliation"
+        );
+        assert_local_source_intact(&set_disks, bucket, object, &payload).await;
+    }
 }
 
 #[cfg(all(test, feature = "test-util"))]


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1355.

## Summary of Changes
Adds two deterministic regression tests for transition fault-matrix cleanup boundaries.

- `remote_cleanup_failure_after_version_rejection_preserves_source_and_candidate`: the remote PUT succeeds and returns an opaque version token that must be rejected locally, then the cleanup DELETE itself fails before the backend records a successful remove. The test asserts the transition still fails closed, the failed cleanup is not reported as a successful exact delete, the remote candidate remains visible for durable reconciliation, and the local source object remains readable.
- `authoritative_read_failure_after_upload_cleans_exact_candidate_and_preserves_source`: the remote PUT fully stores a candidate and pauses before returning, then the local disk set is made unavailable so the authoritative pre-commit metadata re-read fails. The test asserts the transition returns an error, removes the exact uploaded remote version, leaves no remote candidate, and keeps the local source readable after disks return.

This is a test-only matrix slice and does not change production behavior, public APIs, S3 semantics, on-disk metadata, or RPC/on-wire formats.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore authoritative_read_failure_after_upload_cleans_exact_candidate_and_preserves_source --features test-util`
- `cargo test -p rustfs-ecstore remote_cleanup_failure_after_version_rejection_preserves_source_and_candidate --features test-util`
- `cargo test -p rustfs-ecstore transition_upload_integrity_tests --features test-util`
- `cargo clippy -p rustfs-ecstore --features test-util --all-targets -- -D warnings`

Full `make pre-pr` was not started for this branch because the Linux validation server was already saturated by parallel full gates and this PR is a focused test-only matrix slice. GitHub CI is expected to provide the full authoritative gate for this PR.

## Impact
No user-facing behavior change. No compatibility impact. This only strengthens regression coverage for remote cleanup failure and authoritative local metadata read failure side-effect boundaries.

## Additional Notes
Adversarial review outcome: correctness attacked PUT-success plus local-version-rejection plus cleanup-delete-failure, and PUT-success plus authoritative re-read failure after local disk unavailability; no break found in the expected fail-closed/local-source-preserving outcomes. Simplicity found no production helper, broader refactor, or duplicate helper; the smaller equivalent is the added in-module tests only. Test-coverage confirmed the tests fail if cleanup is skipped for the authoritative read failure, if failed cleanup is counted as successful remove, if an opaque remote version is committed, or if the local source becomes unreadable.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
