### PR TITLE
ci(cla): upgrade CLA to v2

### DIFF
--- a/.github/cla.yml
+++ b/.github/cla.yml
@@ -15,8 +15,8 @@
 enabled: true
 
 document:
-  version: v1
-  url: https://github.com/rustfs/cla/blob/main/cla/v1.md
+  version: v2
+  url: https://github.com/rustfs/cla/blob/main/cla/v2.md
 
 signing:
   mode: comment

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,4 +33,4 @@ documentation impact. Use N/A when there is no expected impact.
 
 ---
 
-Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v1.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
+Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.


### PR DESCRIPTION
## What

Upgrade the Contributor License Agreement from v1 to v2.

- `.github/cla.yml`: bump `document.version` `v1` -> `v2` and point `url` at `https://github.com/rustfs/cla/blob/main/cla/v2.md`.
- `.github/pull_request_template.md`: update the CLA document link new contributors are asked to review to `cla/v2.md`.

The `cla/v2.md` document already exists in `rustfs/cla`. No workflow changes are needed — `overtrue/cla-bot@v0.0.9` reads `.github/cla.yml`, so bumping `document.version`/`url` is enough. The `signing.comment_pattern` (`I have read and agree to the CLA.`) is unchanged since it is a signing mechanism independent of the document version.

## Note on existing signatures

Bumping `document.version` means the bot treats the current version as `v2`. Contributors who previously signed `v1` may be prompted to re-sign against `v2`. If we want to grandfather existing signers, that would be handled in the `rustfs/cla` registry, not here.

## Verification

- Grep confirms no remaining `cla/v1` / `version: v1` references in the repo.
- Config-only change; no code paths affected.
