### PR TITLE
test(ecstore): cover transition source dedupe

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4339,6 +4339,43 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn queue_transition_task_dedupes_immediate_and_scanner_sources_for_same_version() {
+        let state = TransitionState::new_with_capacity(4);
+        let version_id = Uuid::new_v4();
+        let object = ObjectInfo {
+            bucket: "bucket".to_string(),
+            name: "object".to_string(),
+            version_id: Some(version_id),
+            ..Default::default()
+        };
+        let event = crate::bucket::lifecycle::lifecycle::Event {
+            action: IlmAction::TransitionAction,
+            ..Default::default()
+        };
+
+        let immediate = state.queue_transition_task(&object, &event, &LcEventSrc::S3PutObject).await;
+        let scanner = state.queue_transition_task(&object, &event, &LcEventSrc::Scanner).await;
+
+        assert!(immediate, "immediate transition enqueue must succeed");
+        assert!(scanner, "scanner duplicate is reported handled while already queued");
+        assert_eq!(
+            state.transition_rx.len(),
+            1,
+            "immediate transition plus scanner/backfill duplicate must queue one task"
+        );
+
+        let next_version = ObjectInfo {
+            version_id: Some(Uuid::new_v4()),
+            ..object
+        };
+        let queued_next_version = state.queue_transition_task(&next_version, &event, &LcEventSrc::Scanner).await;
+
+        assert!(queued_next_version, "a different version of the same object must enqueue independently");
+        assert_eq!(state.transition_rx.len(), 2, "deduplication must be scoped to the exact object version");
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn transition_state_init_honors_runtime_configured_worker_count() {
         let (_paths, ecstore) = setup_test_env().await;
         let transition_state = runtime_sources::transition_state_handle();


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1355

## Summary of Changes

Adds a focused regression test for lifecycle transition enqueue deduplication when two different actors target the same object version: an immediate S3 write-source transition enqueue and a scanner/backfill transition enqueue.

The test verifies that the immediate enqueue succeeds, the scanner duplicate is reported as already handled, only one transition task is actually queued for the same bucket/object/version, and a different version of the same object still queues independently so the dedupe key is not too broad.

No production code or public API surface is changed.

## Verification

- `cargo test -p rustfs-ecstore queue_transition_task_dedupes_immediate_and_scanner_sources_for_same_version -- --nocapture`
- `cargo test -p rustfs-ecstore queue_transition_task_dedupes -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

Test-only coverage for lifecycle transition multi-actor enqueue deduplication. No S3 API, on-disk format, wire format, configuration, or deployment compatibility impact.

## Additional Notes

Adversarial validation: correctness attacked duplicate enqueue ordering across immediate and scanner/backfill sources and confirmed the test exercises the shared in-flight claim before source-specific queue handling; simplicity attacked adding production hooks or a larger worker integration test and kept this as the smallest queue-level regression; coverage skeptic confirmed the test fails if duplicate source claims queue more than one task or if the transition key collapses distinct object versions.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
