### PR TITLE
test(ecstore): cover transition upload cancellation

### DIFF
--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -4653,6 +4653,55 @@ mod transition_upload_integrity_tests {
 
     #[tokio::test]
     #[serial_test::serial]
+    async fn cancelled_after_remote_upload_cleans_candidate_and_preserves_source() {
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
+        let bucket = "transition-cancel-after-upload-bucket";
+        let object = "object.bin";
+        let payload = b"cancelled transition after upload must clean remote candidate".repeat(1024);
+        let original = write_source(&set_disks, &disk_stores, bucket, object, &payload).await;
+        let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();
+        let backend = register_mock_tier(&runtime_sources::global_tier_config_mgr(), &tier_name).await;
+        let barrier = TransitionCommitBarrier::install(bucket, object);
+
+        let transition_set = Arc::clone(&set_disks);
+        let transition = tokio::spawn(async move {
+            transition_set
+                .transition_object(bucket, object, &transition_options(&original, tier_name))
+                .await
+        });
+        barrier.wait_until_paused().await;
+        assert_eq!(
+            backend.put_count().await,
+            1,
+            "transition must upload a remote candidate before the cancellation point"
+        );
+        let put_versions = backend.put_versions().await;
+        assert_eq!(put_versions.len(), 1, "transition should expose one remote candidate/version");
+        assert_eq!(backend.object_count().await, 1, "remote candidate should be visible before cancellation");
+
+        transition.abort();
+        let join = transition
+            .await
+            .expect_err("aborted transition task should report cancellation");
+        assert!(join.is_cancelled(), "transition task should be cancelled, not panic");
+        drop(barrier);
+
+        assert!(
+            backend
+                .wait_for_remote_absence(&put_versions[0].0, Duration::from_secs(5))
+                .await,
+            "cancellation cleanup must remove the uploaded remote candidate"
+        );
+        assert_eq!(
+            backend.remove_versions().await,
+            put_versions,
+            "cancellation cleanup must target the exact remote version returned by PUT"
+        );
+        assert_local_source_intact(&set_disks, bucket, object, &payload).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
     async fn real_bitrot_producer_failures_do_not_commit_transition() {
         let (temp_dirs, disk_stores, set_disks) = hermetic_set_disks(4).await;
         let tier_name = format!("COLDTIER{}", &Uuid::new_v4().simple().to_string()[..8]).to_uppercase();


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1353

## Summary of Changes

Adds a focused regression test for cancelling an ILM transition after the remote tier candidate has been uploaded and before the local metadata commit proceeds. The test uses the real `transition_object` path, the existing transition commit barrier, and `MockWarmBackend` to prove that cancellation removes the exact remote candidate/version returned by PUT and leaves the source object readable and un-transitioned.

## Verification

- `cargo test -p rustfs-ecstore --features test-util cancelled_after_remote_upload_cleans_candidate_and_preserves_source -- --nocapture`
- `cargo test -p rustfs-ecstore --features test-util transition_upload_integrity_tests -- --nocapture`
- `cargo clippy -p rustfs-ecstore --features test-util --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Impact

Test-only change. No production code, external API, S3 behavior, on-disk format, wire format, configuration, or deployment impact.

## Additional Notes

Adversarial review covered correctness, simplicity, concurrency/durability scope, compatibility, performance, security, and test coverage. This PR only closes the in-process future-cancellation regression gap for #1353; it does not claim crash-safe durable recovery (#1352), operation-id/protocol safeguards (#1356), or distributed tier mutation coordination (#1357).

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
