### PR TITLE
fix(tier): add mutation intent scan helper

### DIFF
--- a/crates/ecstore/src/services/tier/tier_mutation_intent.rs
+++ b/crates/ecstore/src/services/tier/tier_mutation_intent.rs
@@ -19,8 +19,10 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::config::com;
+use crate::disk::RUSTFS_META_BUCKET;
 use crate::error::{Error, Result as EcstoreResult};
 use crate::services::tier::tier::TierDestinationId;
+use crate::storage_api_contracts::list::ListOperations as _;
 use crate::store::ECStore;
 
 pub(crate) const TIER_MUTATION_INTENT_SCHEMA: &str = "rustfs-tier-mutation-intent-v1";
@@ -106,6 +108,15 @@ pub(crate) struct TierMutationIntent {
     pub candidate_digest: TierMutationDigest,
     pub affected_targets: Vec<TierMutationIntentTarget>,
     pub expires_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TierMutationIntentRecordScan {
+    pub intents: Vec<TierMutationIntent>,
+    pub scanned: usize,
+    pub failed: usize,
+    pub next_marker: Option<String>,
+    pub truncated: bool,
 }
 
 impl TierMutationIntent {
@@ -310,6 +321,55 @@ pub(crate) async fn delete_tier_mutation_intent_record(api: Arc<ECStore>, mutati
         Ok(()) | Err(Error::ConfigNotFound) => Ok(()),
         Err(err) => Err(err),
     }
+}
+
+pub(crate) async fn list_tier_mutation_intent_records(
+    api: Arc<ECStore>,
+    limit: usize,
+    marker: Option<String>,
+) -> EcstoreResult<TierMutationIntentRecordScan> {
+    if limit == 0 {
+        return Err(Error::other("tier mutation intent scan limit must be greater than zero"));
+    }
+
+    let list = api
+        .clone()
+        .list_objects_v2(
+            RUSTFS_META_BUCKET,
+            TIER_MUTATION_INTENT_RECORD_PREFIX,
+            marker,
+            None,
+            i32::try_from(limit).map_or(i32::MAX, |value| value),
+            false,
+            None,
+            false,
+        )
+        .await?;
+    let mut scan = TierMutationIntentRecordScan {
+        intents: Vec::with_capacity(list.objects.len()),
+        scanned: 0,
+        failed: 0,
+        next_marker: list.next_continuation_token,
+        truncated: list.is_truncated,
+    };
+
+    for object in list.objects {
+        scan.scanned += 1;
+        let mutation_id = match tier_mutation_intent_id_from_record_object_name(&object.name) {
+            Ok(mutation_id) => mutation_id,
+            Err(_) => {
+                scan.failed += 1;
+                continue;
+            }
+        };
+        match load_tier_mutation_intent_record(api.clone(), mutation_id).await {
+            Ok(intent) => scan.intents.push(intent),
+            Err(Error::ConfigNotFound) => {}
+            Err(_) => scan.failed += 1,
+        }
+    }
+
+    Ok(scan)
 }
 
 fn tier_mutation_intent_store_error(err: TierMutationIntentError) -> Error {

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -541,14 +541,16 @@ mod tests {
             },
         },
         client::transition_api::ReaderImpl,
+        config::com,
         disk::RUSTFS_META_BUCKET,
         runtime::{global::set_object_store_resolver, sources as runtime_sources},
         services::tier::{
             test_util::{MockWarmBackend, TransitionCleanupStoreBarrier, register_mock_tier},
             tier::TierConfigMgr,
             tier_mutation_intent::{
-                TierMutationIntent, TierMutationIntentKind, TierMutationIntentState, TierMutationIntentTarget,
-                delete_tier_mutation_intent_record, load_tier_mutation_intent_record, save_tier_mutation_intent_record,
+                TIER_MUTATION_INTENT_RECORD_PREFIX, TierMutationIntent, TierMutationIntentKind, TierMutationIntentState,
+                TierMutationIntentTarget, delete_tier_mutation_intent_record, list_tier_mutation_intent_records,
+                load_tier_mutation_intent_record, save_tier_mutation_intent_record,
             },
             warm_backend::WarmBackend,
         },
@@ -1276,6 +1278,66 @@ mod tests {
             .await
             .expect_err("deleted tier mutation intent record should not load");
         assert!(matches!(err, Error::ConfigNotFound));
+    }
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn tier_mutation_intent_record_scan_retains_good_records_and_counts_bad_records() {
+        let temp_dir = tempfile::tempdir().expect("create temp store dir");
+        let (_ctx, store, _shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "tier-mutation-intent-scan", &[4])).await;
+        let build_intent = |mutation_id: uuid::Uuid, tier_name: &str| TierMutationIntent {
+            mutation_id,
+            revision: 1,
+            kind: TierMutationIntentKind::Edit,
+            state: TierMutationIntentState::Prepared,
+            old_config_etag: Some("old-etag".to_string()),
+            committed_config_etag: None,
+            candidate_digest: [3; 32],
+            affected_targets: vec![TierMutationIntentTarget {
+                tier_name: tier_name.to_string(),
+                old_backend_identity: Some([1; 32]),
+                new_backend_identity: Some([2; 32]),
+            }],
+            expires_at_unix_nanos: 1_780_000_000_000_000_000,
+        };
+        let first_id = uuid::Uuid::parse_str("12345678-1234-5678-9abc-def012345678").expect("first uuid should parse");
+        let second_id = uuid::Uuid::parse_str("22345678-1234-5678-9abc-def012345678").expect("second uuid should parse");
+        let first = build_intent(first_id, "COLD-A");
+        let second = build_intent(second_id, "COLD-B");
+        save_tier_mutation_intent_record(store.clone(), &first)
+            .await
+            .expect("first tier mutation intent record should persist");
+        save_tier_mutation_intent_record(store.clone(), &second)
+            .await
+            .expect("second tier mutation intent record should persist");
+        com::save_config(
+            store.clone(),
+            &format!("{TIER_MUTATION_INTENT_RECORD_PREFIX}/00/00/33345678123456789abcdef012345678.json"),
+            b"{}".to_vec(),
+        )
+        .await
+        .expect("malformed-shard intent record should persist");
+        com::save_config(
+            store.clone(),
+            &format!("{TIER_MUTATION_INTENT_RECORD_PREFIX}/44/44/44445678123456789abcdef012345678.json"),
+            b"{".to_vec(),
+        )
+        .await
+        .expect("corrupt-json intent record should persist");
+
+        let scan = list_tier_mutation_intent_records(store, 100, None)
+            .await
+            .expect("tier mutation intent records should scan");
+        let mut loaded_ids: Vec<_> = scan.intents.into_iter().map(|intent| intent.mutation_id).collect();
+        loaded_ids.sort();
+
+        assert_eq!(scan.scanned, 4);
+        assert_eq!(scan.failed, 2);
+        assert_eq!(loaded_ids, vec![first_id, second_id]);
+        assert!(!scan.truncated);
+        assert_eq!(scan.next_marker, None);
     }
 
     #[cfg(feature = "test-util")]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1328 and rustfs/backlog#1357.

Stacked on rustfs/rustfs#5075.

## Summary of Changes
This PR adds the next crate-private foundation slice for #1357 durable tier-config mutation fencing: a paginated scan helper for tier mutation intent records. The helper lists the canonical intent record prefix from the RustFS meta bucket, derives mutation IDs from canonical record keys, loads and validates each record through the checksum-protected decoder, keeps valid records available for later recovery/drain logic, treats concurrently deleted records as benign, and counts malformed keys or corrupt payloads as failed entries without blocking the rest of the page.

This does not wire the scan into production startup or mutation coordination yet. That is intentional: the later coordinator recovery loop can now build on a tested primitive without changing current tier-config mutation behavior in this slice.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore tier_mutation_intent --features test-util -- --nocapture`
- `cargo clippy -p rustfs-ecstore --features test-util --all-targets -- -D warnings`
- `make pre-commit`

## Impact
No public S3 API, public Rust API, WarmBackend trait, xl.meta, RPC/on-wire, deployment, or configuration behavior changes. The new helper is crate-private and currently test-covered only; production behavior remains unchanged until a later coordinator/recovery PR explicitly wires it in.

## Additional Notes
Adversarial review summary: correctness checked that malformed keys and corrupt payloads cannot poison good records in the same scan page; simplicity checked that the helper reuses existing config-object save/load/list primitives and avoids a new storage abstraction; security/compatibility checked that no untrusted sidecar data is trusted without existing checksum/schema/key validation and no external format is changed; concurrency/durability checked that missing records are tolerated as concurrent deletion while real list failures still fail the scan; performance checked that allocation is bounded by the returned page; coverage checked that reverting the scan helper or bad-record accounting breaks `tier_mutation_intent_record_scan_retains_good_records_and_counts_bad_records`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
