### PR TITLE
fix(tier): add mutation RPC auth contract

### DIFF
--- a/crates/ecstore/src/cluster/rpc/http_auth.rs
+++ b/crates/ecstore/src/cluster/rpc/http_auth.rs
@@ -1145,6 +1145,47 @@ mod tests {
     }
 
     #[test]
+    fn tier_mutation_rpc_contract_requires_method_bound_v2_body_digest() {
+        ensure_test_rpc_secret();
+        let mutation_id = uuid::uuid!("12345678-1234-5678-9abc-def012345678");
+        let body = rustfs_protos::canonical_tier_mutation_rpc_body(
+            rustfs_protos::TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            rustfs_protos::TierMutationRpcPhase::Prepare,
+            mutation_id,
+            b"canonical-tier-mutation-prepare",
+        )
+        .expect("small tier mutation body should encode");
+        let mut request = tonic::Request::new(());
+        set_tonic_canonical_body_digest(&mut request, &body).expect("canonical body digest should be attached");
+        let content_sha256 = request
+            .metadata()
+            .get(RPC_CONTENT_SHA256_HEADER)
+            .and_then(|value| value.to_str().ok());
+        let headers =
+            gen_tonic_signature_headers("node-a:9000", "node_service.NodeService", "PrepareTierMutation", content_sha256)
+                .expect("body-bound tier mutation auth headers should build");
+        request.metadata_mut().as_mut().extend(headers.clone());
+
+        assert!(
+            verify_tonic_rpc_signature("node-a:9000", "/node_service.NodeService/PrepareTierMutation", &headers).is_ok(),
+            "tier mutation RPC signature must bind destination, service, method, nonce, and body digest"
+        );
+        let method_replay = verify_tonic_rpc_signature("node-a:9000", "/node_service.NodeService/CommitTierMutation", &headers)
+            .expect_err("prepare auth must not replay to commit");
+        assert_eq!(method_replay.to_string(), "Invalid RPC v2 signature");
+        let tampered_body = rustfs_protos::canonical_tier_mutation_rpc_body(
+            rustfs_protos::TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            rustfs_protos::TierMutationRpcPhase::Commit,
+            mutation_id,
+            b"canonical-tier-mutation-prepare",
+        )
+        .expect("small tier mutation body should encode");
+        let tampered =
+            verify_tonic_canonical_body_digest(&request, &tampered_body).expect_err("commit body must not match prepare digest");
+        assert_eq!(tampered.to_string(), "RPC content SHA-256 mismatch");
+    }
+
+    #[test]
     fn partial_v2_metadata_fails_closed() {
         ensure_test_rpc_secret();
         let mut headers = gen_signature_headers(TONIC_RPC_PREFIX, &Method::GET).expect("legacy auth headers should build");

--- a/crates/protos/src/lib.rs
+++ b/crates/protos/src/lib.rs
@@ -35,6 +35,7 @@ use tonic::{
     transport::{Certificate, Channel, ClientTlsConfig, Endpoint},
 };
 use tracing::{debug, info, warn};
+use uuid::Uuid;
 
 // Type alias for the complex client type
 pub type NodeServiceClientType = NodeServiceClient<
@@ -251,6 +252,47 @@ pub fn canonical_heal_control_response_body(
     Ok(body)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TierMutationRpcPhase {
+    Prepare,
+    Commit,
+    Abort,
+}
+
+impl TierMutationRpcPhase {
+    fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Prepare => "prepare",
+            Self::Commit => "commit",
+            Self::Abort => "abort",
+        }
+    }
+}
+
+pub const TIER_MUTATION_RPC_PROTOCOL_VERSION: u32 = 1;
+
+pub fn canonical_tier_mutation_rpc_body(
+    version: u32,
+    phase: TierMutationRpcPhase,
+    mutation_id: Uuid,
+    canonical_payload: &[u8],
+) -> Result<Vec<u8>, std::num::TryFromIntError> {
+    const DOMAIN: &[u8] = b"rustfs-tier-mutation-rpc-v1\0";
+
+    let phase = phase.as_wire_str().as_bytes();
+    let mutation_id = mutation_id.as_bytes();
+    let mut body = Vec::with_capacity(DOMAIN.len() + 4 + 8 + phase.len() + mutation_id.len() + 8 + canonical_payload.len());
+    body.extend_from_slice(DOMAIN);
+    body.extend_from_slice(&version.to_be_bytes());
+    body.extend_from_slice(&u64::try_from(phase.len())?.to_be_bytes());
+    body.extend_from_slice(phase);
+    body.extend_from_slice(mutation_id);
+    body.extend_from_slice(&u64::try_from(canonical_payload.len())?.to_be_bytes());
+    body.extend_from_slice(canonical_payload);
+    Ok(body)
+}
+
 #[cfg(test)]
 mod heal_control_tests {
     use super::{
@@ -360,6 +402,69 @@ mod heal_control_tests {
             assert!(execution > Duration::ZERO);
             assert!(execution < normalized_transport);
         }
+    }
+}
+
+#[cfg(test)]
+mod tier_mutation_rpc_tests {
+    use super::{TIER_MUTATION_RPC_PROTOCOL_VERSION, TierMutationRpcPhase, canonical_tier_mutation_rpc_body};
+    use uuid::uuid;
+
+    #[test]
+    fn canonical_tier_mutation_body_binds_phase_id_and_payload() {
+        let mutation_id = uuid!("12345678-1234-5678-9abc-def012345678");
+        let payload = b"canonical-intent-record";
+        let baseline = canonical_tier_mutation_rpc_body(
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Prepare,
+            mutation_id,
+            payload,
+        )
+        .expect("small mutation body should encode");
+        let mut golden = b"rustfs-tier-mutation-rpc-v1\0".to_vec();
+        golden.extend_from_slice(&1_u32.to_be_bytes());
+        golden.extend_from_slice(&7_u64.to_be_bytes());
+        golden.extend_from_slice(b"prepare");
+        golden.extend_from_slice(mutation_id.as_bytes());
+        golden.extend_from_slice(&u64::try_from(payload.len()).expect("payload length should fit").to_be_bytes());
+        golden.extend_from_slice(payload);
+        assert_eq!(baseline, golden);
+
+        assert_ne!(
+            baseline,
+            canonical_tier_mutation_rpc_body(2, TierMutationRpcPhase::Prepare, mutation_id, payload)
+                .expect("small mutation body should encode")
+        );
+        assert_ne!(
+            baseline,
+            canonical_tier_mutation_rpc_body(
+                TIER_MUTATION_RPC_PROTOCOL_VERSION,
+                TierMutationRpcPhase::Commit,
+                mutation_id,
+                payload,
+            )
+            .expect("small mutation body should encode")
+        );
+        assert_ne!(
+            baseline,
+            canonical_tier_mutation_rpc_body(
+                TIER_MUTATION_RPC_PROTOCOL_VERSION,
+                TierMutationRpcPhase::Prepare,
+                uuid!("22345678-1234-5678-9abc-def012345678"),
+                payload,
+            )
+            .expect("small mutation body should encode")
+        );
+        assert_ne!(
+            baseline,
+            canonical_tier_mutation_rpc_body(
+                TIER_MUTATION_RPC_PROTOCOL_VERSION,
+                TierMutationRpcPhase::Prepare,
+                mutation_id,
+                b"canonical-intent-record-tampered",
+            )
+            .expect("small mutation body should encode")
+        );
     }
 }
 


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1328 and rustfs/backlog#1357.

Stacked on rustfs/rustfs#5080.

## Summary of Changes
This PR delivers the #1357 B-line RPC/auth contract foundation without adding the peer prepare/commit/abort service handlers yet. It adds a stable `rustfs-protos` canonical tier-mutation RPC body that binds the protocol version, RPC phase (`prepare`, `commit`, or `abort`), mutation UUID, and caller-provided canonical payload bytes without relying on protobuf re-encoding.

The auth regression test then proves that a future tier-mutation RPC must use existing internode v2 authentication with `x-rustfs-content-sha256`: a `PrepareTierMutation` signature cannot replay to `CommitTierMutation`, and changing the canonical phase from prepare to commit changes the body digest. This intentionally reuses the existing tonic v2 signature, nonce, destination audience, method binding, and canonical body digest infrastructure instead of inventing a new auth scheme.

This is a contract-only slice. It does not claim that peer prepare/commit/abort RPC handlers, durable restart draining, coordinator crash recovery, old-peer fail-closed activation, distributed fencing, or the mixed-version deterministic matrix are complete.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-protos tier_mutation_rpc_tests -- --nocapture`
- `cargo test -p rustfs-ecstore cluster::rpc::http_auth::tests::tier_mutation_rpc_contract_requires_method_bound_v2_body_digest -- --nocapture`
- `cargo clippy -p rustfs-protos -p rustfs-ecstore --all-targets -- -D warnings`
- `make pre-commit`

## Impact
No public S3 API, xl.meta, deployment, configuration schema, or generated protobuf service/method changes. The `rustfs-protos` crate gains an additive public helper and a non-exhaustive phase enum for future internode tier-mutation RPC signing. Runtime behavior is unchanged until a later PR wires actual peer prepare/commit/abort handlers to this contract.

## Additional Notes
Adversarial review summary: correctness attacked phase/mutation-id/payload ambiguity and found the canonical body length-prefixes variable fields and includes the raw UUID bytes; security attacked method replay and body tampering and found both covered by the existing v2 signature plus canonical digest test; compatibility attacked generated protobuf and mixed-version surfaces and found this PR does not alter generated service methods or wire schemas; performance attacked hot paths and found this helper is only used by future low-frequency admin tier-mutation RPCs; simplicity attacked adding a new auth scheme and the accepted diff instead reuses existing tonic auth primitives; coverage checked that reverting phase binding, method binding, or body digest binding breaks focused tests.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
