### PR TITLE
fix(tier): add peer mutation handler core

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -437,6 +437,13 @@ pub mod tier {
         };
     }
 
+    pub mod tier_mutation_peer {
+        pub use crate::services::tier::tier_mutation_peer::{
+            MAX_TIER_MUTATION_PEER_COMMIT_ETAG_SIZE, TierMutationPeerError, TierMutationPeerOutcome, TierMutationPeerResult,
+            TierMutationPeerState, handle_tier_mutation_peer_request,
+        };
+    }
+
     pub mod warm_backend {
         pub use crate::services::tier::warm_backend::{
             WarmBackend, WarmBackendGetOpts, WarmBackendImpl, build_transition_put_options, check_warm_backend, new_warm_backend,

--- a/crates/ecstore/src/services/tier/mod.rs
+++ b/crates/ecstore/src/services/tier/mod.rs
@@ -20,6 +20,7 @@ pub mod tier_config;
 pub mod tier_gen;
 pub mod tier_handlers;
 pub(crate) mod tier_mutation_intent;
+pub mod tier_mutation_peer;
 pub mod warm_backend;
 pub mod warm_backend_aliyun;
 pub mod warm_backend_azure;

--- a/crates/ecstore/src/services/tier/tier_mutation_intent.rs
+++ b/crates/ecstore/src/services/tier/tier_mutation_intent.rs
@@ -346,6 +346,28 @@ pub(crate) async fn save_tier_mutation_intent_record(api: Arc<ECStore>, intent: 
     com::save_config(api, &object, data).await
 }
 
+pub(crate) async fn save_tier_mutation_intent_record_if_absent(
+    api: Arc<ECStore>,
+    intent: &TierMutationIntent,
+) -> EcstoreResult<()> {
+    let object = tier_mutation_intent_record_object_name(intent.mutation_id).map_err(tier_mutation_intent_store_error)?;
+    let data = intent.encode().map_err(tier_mutation_intent_store_error)?;
+    com::save_config_with_opts(
+        api,
+        &object,
+        data,
+        &ObjectOptions {
+            max_parity: true,
+            http_preconditions: Some(HTTPPreconditions {
+                if_none_match: Some("*".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )
+    .await
+}
+
 pub(crate) async fn load_tier_mutation_intent_record(api: Arc<ECStore>, mutation_id: Uuid) -> EcstoreResult<TierMutationIntent> {
     let (intent, _) = load_tier_mutation_intent_record_with_etag(api, mutation_id).await?;
     Ok(intent)

--- a/crates/ecstore/src/services/tier/tier_mutation_peer.rs
+++ b/crates/ecstore/src/services/tier/tier_mutation_peer.rs
@@ -1,0 +1,250 @@
+// Copyright 2024 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use rustfs_protos::{TIER_MUTATION_RPC_PROTOCOL_VERSION, TierMutationRpcPhase};
+use uuid::Uuid;
+
+use super::tier_mutation_intent::{
+    MAX_TIER_MUTATION_INTENT_SIZE, TierMutationIntent, TierMutationIntentState, advance_tier_mutation_intent_record_idempotent,
+    load_tier_mutation_intent_record, save_tier_mutation_intent_record_if_absent,
+};
+use crate::error::{Error, StorageError};
+use crate::store::ECStore;
+
+pub const MAX_TIER_MUTATION_PEER_COMMIT_ETAG_SIZE: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TierMutationPeerState {
+    Prepared,
+    Committed,
+    Aborted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TierMutationPeerOutcome {
+    pub state: TierMutationPeerState,
+    pub applied: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TierMutationPeerError {
+    #[error("unsupported tier mutation peer protocol version: {0}")]
+    UnsupportedProtocolVersion(u32),
+    #[error("tier mutation peer mutation_id is nil")]
+    NilMutationId,
+    #[error("tier mutation peer payload is too large: {len}/{max}")]
+    PayloadTooLarge { len: usize, max: usize },
+    #[error("tier mutation peer payload is invalid: {0}")]
+    InvalidPayload(String),
+    #[error("tier mutation peer intent conflicts with existing record")]
+    ConflictingIntent,
+    #[error("tier mutation peer store error: {0}")]
+    Store(#[source] StorageError),
+}
+
+impl From<Error> for TierMutationPeerError {
+    fn from(error: Error) -> Self {
+        Self::Store(error)
+    }
+}
+
+pub type TierMutationPeerResult<T> = std::result::Result<T, TierMutationPeerError>;
+
+pub async fn handle_tier_mutation_peer_request(
+    api: Arc<ECStore>,
+    protocol_version: u32,
+    phase: TierMutationRpcPhase,
+    mutation_id: Uuid,
+    canonical_payload: &[u8],
+) -> TierMutationPeerResult<TierMutationPeerOutcome> {
+    validate_peer_request_envelope(protocol_version, mutation_id, canonical_payload)?;
+    match phase {
+        TierMutationRpcPhase::Prepare => handle_prepare(api, mutation_id, canonical_payload).await,
+        TierMutationRpcPhase::Commit => handle_commit(api, mutation_id, canonical_payload).await,
+        TierMutationRpcPhase::Abort => handle_abort(api, mutation_id, canonical_payload).await,
+        _ => Err(TierMutationPeerError::InvalidPayload(
+            "tier mutation rpc phase is unsupported".to_string(),
+        )),
+    }
+}
+
+async fn handle_prepare(
+    api: Arc<ECStore>,
+    mutation_id: Uuid,
+    canonical_payload: &[u8],
+) -> TierMutationPeerResult<TierMutationPeerOutcome> {
+    let intent = TierMutationIntent::decode(mutation_id, canonical_payload)
+        .map_err(|err| TierMutationPeerError::InvalidPayload(err.to_string()))?;
+    if intent.state != TierMutationIntentState::Prepared {
+        return Err(TierMutationPeerError::InvalidPayload(
+            "prepare intent must be in prepared state".to_string(),
+        ));
+    }
+
+    match save_tier_mutation_intent_record_if_absent(api.clone(), &intent).await {
+        Ok(()) => Ok(TierMutationPeerOutcome {
+            state: TierMutationPeerState::Prepared,
+            applied: true,
+        }),
+        Err(Error::PreconditionFailed) => {
+            let existing = load_tier_mutation_intent_record(api, mutation_id).await?;
+            if !same_mutation_identity(&existing, &intent) {
+                return Err(TierMutationPeerError::ConflictingIntent);
+            }
+            Ok(TierMutationPeerOutcome {
+                state: peer_state_from_intent(existing.state),
+                applied: false,
+            })
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+async fn handle_commit(
+    api: Arc<ECStore>,
+    mutation_id: Uuid,
+    canonical_payload: &[u8],
+) -> TierMutationPeerResult<TierMutationPeerOutcome> {
+    let committed_config_etag = parse_commit_etag(canonical_payload)?;
+    let (intent, applied) = advance_tier_mutation_intent_record_idempotent(
+        api,
+        mutation_id,
+        TierMutationIntentState::Committed,
+        Some(committed_config_etag),
+    )
+    .await?;
+    Ok(TierMutationPeerOutcome {
+        state: peer_state_from_intent(intent.state),
+        applied,
+    })
+}
+
+async fn handle_abort(
+    api: Arc<ECStore>,
+    mutation_id: Uuid,
+    canonical_payload: &[u8],
+) -> TierMutationPeerResult<TierMutationPeerOutcome> {
+    if !canonical_payload.is_empty() {
+        return Err(TierMutationPeerError::InvalidPayload("abort payload must be empty".to_string()));
+    }
+    let (intent, applied) =
+        advance_tier_mutation_intent_record_idempotent(api, mutation_id, TierMutationIntentState::Aborted, None).await?;
+    Ok(TierMutationPeerOutcome {
+        state: peer_state_from_intent(intent.state),
+        applied,
+    })
+}
+
+fn validate_peer_request_envelope(
+    protocol_version: u32,
+    mutation_id: Uuid,
+    canonical_payload: &[u8],
+) -> TierMutationPeerResult<()> {
+    if protocol_version != TIER_MUTATION_RPC_PROTOCOL_VERSION {
+        return Err(TierMutationPeerError::UnsupportedProtocolVersion(protocol_version));
+    }
+    if mutation_id.is_nil() {
+        return Err(TierMutationPeerError::NilMutationId);
+    }
+    if canonical_payload.len() > MAX_TIER_MUTATION_INTENT_SIZE {
+        return Err(TierMutationPeerError::PayloadTooLarge {
+            len: canonical_payload.len(),
+            max: MAX_TIER_MUTATION_INTENT_SIZE,
+        });
+    }
+    Ok(())
+}
+
+fn parse_commit_etag(canonical_payload: &[u8]) -> TierMutationPeerResult<String> {
+    if canonical_payload.len() > MAX_TIER_MUTATION_PEER_COMMIT_ETAG_SIZE {
+        return Err(TierMutationPeerError::PayloadTooLarge {
+            len: canonical_payload.len(),
+            max: MAX_TIER_MUTATION_PEER_COMMIT_ETAG_SIZE,
+        });
+    }
+    let etag = std::str::from_utf8(canonical_payload)
+        .map_err(|err| TierMutationPeerError::InvalidPayload(err.to_string()))?
+        .trim();
+    if etag.is_empty() {
+        return Err(TierMutationPeerError::InvalidPayload(
+            "commit payload must carry a committed config etag".to_string(),
+        ));
+    }
+    Ok(etag.to_string())
+}
+
+fn peer_state_from_intent(state: TierMutationIntentState) -> TierMutationPeerState {
+    match state {
+        TierMutationIntentState::Prepared => TierMutationPeerState::Prepared,
+        TierMutationIntentState::Committed => TierMutationPeerState::Committed,
+        TierMutationIntentState::Aborted => TierMutationPeerState::Aborted,
+    }
+}
+
+fn same_mutation_identity(existing: &TierMutationIntent, expected: &TierMutationIntent) -> bool {
+    existing.mutation_id == expected.mutation_id
+        && existing.kind == expected.kind
+        && existing.old_config_etag == expected.old_config_etag
+        && existing.candidate_digest == expected.candidate_digest
+        && existing.affected_targets == expected.affected_targets
+        && existing.expires_at_unix_nanos == expected.expires_at_unix_nanos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peer_request_envelope_fails_closed_on_old_version_nil_id_and_large_payload() {
+        let mutation_id = Uuid::new_v4();
+        assert!(matches!(
+            validate_peer_request_envelope(TIER_MUTATION_RPC_PROTOCOL_VERSION + 1, mutation_id, b"payload"),
+            Err(TierMutationPeerError::UnsupportedProtocolVersion(_))
+        ));
+        assert!(matches!(
+            validate_peer_request_envelope(TIER_MUTATION_RPC_PROTOCOL_VERSION, Uuid::nil(), b"payload"),
+            Err(TierMutationPeerError::NilMutationId)
+        ));
+
+        let oversized = vec![0; MAX_TIER_MUTATION_INTENT_SIZE + 1];
+        assert!(matches!(
+            validate_peer_request_envelope(TIER_MUTATION_RPC_PROTOCOL_VERSION, mutation_id, &oversized),
+            Err(TierMutationPeerError::PayloadTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn commit_payload_requires_small_non_empty_utf8_etag() {
+        assert_eq!(
+            parse_commit_etag(b"  committed-etag  ").expect("etag payload should parse"),
+            "committed-etag"
+        );
+        assert!(matches!(
+            parse_commit_etag(b"   "),
+            Err(TierMutationPeerError::InvalidPayload(message)) if message.contains("committed config etag")
+        ));
+        assert!(matches!(
+            parse_commit_etag(&[0xff]),
+            Err(TierMutationPeerError::InvalidPayload(message)) if message.contains("utf-8")
+        ));
+
+        let oversized = vec![b'a'; MAX_TIER_MUTATION_PEER_COMMIT_ETAG_SIZE + 1];
+        assert!(matches!(
+            parse_commit_etag(&oversized),
+            Err(TierMutationPeerError::PayloadTooLarge { .. })
+        ));
+    }
+}

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -553,6 +553,7 @@ mod tests {
                 list_tier_mutation_intent_records, load_tier_mutation_intent_record, load_tier_mutation_intent_record_with_etag,
                 save_tier_mutation_intent_record, save_tier_mutation_intent_record_if_current,
             },
+            tier_mutation_peer::{TierMutationPeerError, TierMutationPeerState, handle_tier_mutation_peer_request},
             warm_backend::WarmBackend,
         },
         storage_api_contracts::{
@@ -572,6 +573,8 @@ mod tests {
     };
     use http::HeaderMap;
     use rustfs_config::server_config::KVS;
+    #[cfg(feature = "test-util")]
+    use rustfs_protos::{TIER_MUTATION_RPC_PROTOCOL_VERSION, TierMutationRpcPhase};
     use std::{
         future::Future,
         io::Cursor,
@@ -1457,6 +1460,184 @@ mod tests {
                 .expect("same abort retry should be idempotent");
         assert!(!retry_abort_advanced);
         assert_eq!(aborted_retry, aborted);
+    }
+
+    #[cfg(feature = "test-util")]
+    fn tier_mutation_peer_test_intent(
+        mutation_id: uuid::Uuid,
+        tier_name: &str,
+        candidate_digest: [u8; 32],
+    ) -> TierMutationIntent {
+        TierMutationIntent {
+            mutation_id,
+            revision: 1,
+            kind: TierMutationIntentKind::Edit,
+            state: TierMutationIntentState::Prepared,
+            old_config_etag: Some("old-etag".to_string()),
+            committed_config_etag: None,
+            candidate_digest,
+            affected_targets: vec![TierMutationIntentTarget {
+                tier_name: tier_name.to_string(),
+                old_backend_identity: Some([1; 32]),
+                new_backend_identity: Some([2; 32]),
+            }],
+            expires_at_unix_nanos: 1_780_000_000_000_000_000,
+        }
+    }
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn tier_mutation_peer_handler_applies_prepare_commit_and_abort_idempotently() {
+        let temp_dir = tempfile::tempdir().expect("create temp store dir");
+        let (_ctx, store, _shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "tier-mutation-peer-handler", &[4])).await;
+        let mutation_id = uuid::Uuid::new_v4();
+        let intent = tier_mutation_peer_test_intent(mutation_id, "COLD-A", [3; 32]);
+        let prepare_payload = intent.encode().expect("prepare intent should encode");
+
+        let prepared = handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Prepare,
+            mutation_id,
+            &prepare_payload,
+        )
+        .await
+        .expect("first prepare should create the peer intent");
+        assert!(prepared.applied);
+        assert_eq!(prepared.state, TierMutationPeerState::Prepared);
+
+        let retried_prepare = handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Prepare,
+            mutation_id,
+            &prepare_payload,
+        )
+        .await
+        .expect("same prepare retry should be idempotent");
+        assert!(!retried_prepare.applied);
+        assert_eq!(retried_prepare.state, TierMutationPeerState::Prepared);
+
+        let committed = handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Commit,
+            mutation_id,
+            b"new-etag",
+        )
+        .await
+        .expect("commit should advance the prepared peer intent");
+        assert!(committed.applied);
+        assert_eq!(committed.state, TierMutationPeerState::Committed);
+
+        let retried_commit = handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Commit,
+            mutation_id,
+            b"new-etag",
+        )
+        .await
+        .expect("same commit retry should be idempotent");
+        assert!(!retried_commit.applied);
+        assert_eq!(retried_commit.state, TierMutationPeerState::Committed);
+
+        let delayed_prepare_retry = handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Prepare,
+            mutation_id,
+            &prepare_payload,
+        )
+        .await
+        .expect("delayed duplicate prepare should report the durable committed state");
+        assert!(!delayed_prepare_retry.applied);
+        assert_eq!(delayed_prepare_retry.state, TierMutationPeerState::Committed);
+
+        let loaded = load_tier_mutation_intent_record(store.clone(), mutation_id)
+            .await
+            .expect("committed peer intent should remain durable");
+        assert_eq!(loaded.state, TierMutationIntentState::Committed);
+        assert_eq!(loaded.committed_config_etag.as_deref(), Some("new-etag"));
+
+        let abort_id = uuid::Uuid::new_v4();
+        let abort_intent = tier_mutation_peer_test_intent(abort_id, "COLD-B", [4; 32]);
+        let abort_prepare_payload = abort_intent.encode().expect("abort prepare intent should encode");
+        handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Prepare,
+            abort_id,
+            &abort_prepare_payload,
+        )
+        .await
+        .expect("abort target prepare should create the peer intent");
+
+        let aborted = handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Abort,
+            abort_id,
+            b"",
+        )
+        .await
+        .expect("abort should advance the prepared peer intent");
+        assert!(aborted.applied);
+        assert_eq!(aborted.state, TierMutationPeerState::Aborted);
+
+        let retried_abort = handle_tier_mutation_peer_request(
+            store,
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Abort,
+            abort_id,
+            b"",
+        )
+        .await
+        .expect("same abort retry should be idempotent");
+        assert!(!retried_abort.applied);
+        assert_eq!(retried_abort.state, TierMutationPeerState::Aborted);
+    }
+
+    #[cfg(feature = "test-util")]
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn tier_mutation_peer_handler_rejects_conflicting_prepare_without_overwrite() {
+        let temp_dir = tempfile::tempdir().expect("create temp store dir");
+        let (_ctx, store, _shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "tier-mutation-peer-conflict", &[4])).await;
+        let mutation_id = uuid::Uuid::new_v4();
+        let intent = tier_mutation_peer_test_intent(mutation_id, "COLD-A", [3; 32]);
+        let prepare_payload = intent.encode().expect("prepare intent should encode");
+        handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Prepare,
+            mutation_id,
+            &prepare_payload,
+        )
+        .await
+        .expect("first prepare should create the peer intent");
+
+        let conflicting = tier_mutation_peer_test_intent(mutation_id, "COLD-A", [4; 32]);
+        let conflicting_payload = conflicting.encode().expect("conflicting intent should encode");
+        let conflict = handle_tier_mutation_peer_request(
+            store.clone(),
+            TIER_MUTATION_RPC_PROTOCOL_VERSION,
+            TierMutationRpcPhase::Prepare,
+            mutation_id,
+            &conflicting_payload,
+        )
+        .await
+        .expect_err("conflicting prepare must fail closed");
+        assert!(matches!(conflict, TierMutationPeerError::ConflictingIntent));
+
+        let loaded = load_tier_mutation_intent_record(store, mutation_id)
+            .await
+            .expect("conflicting prepare must not overwrite the first record");
+        assert_eq!(loaded.candidate_digest, [3; 32]);
+        assert_eq!(loaded.state, TierMutationIntentState::Prepared);
     }
 
     #[cfg(feature = "test-util")]


### PR DESCRIPTION
## Related Issues
Part of rustfs/backlog#1328 and rustfs/backlog#1357.

Stacked on #5080. This PR intentionally does not close the backlog issues because it adds the peer mutation handler core only; production gRPC service wiring, distributed fencing, durable coordinator recovery, peer restart draining, old-peer fail-closed activation, and the mixed-version matrix remain follow-up work.

## Summary of Changes
- Add an ECStore tier mutation peer handler core for prepare, commit, and abort phases using the phase/body contract introduced by the stacked RPC auth work.
- Add atomic prepare persistence through `If-None-Match: *`, so concurrent or repeated prepares cannot overwrite an existing mutation intent.
- Make prepare retries idempotent for the same mutation identity and report the existing durable state, including delayed duplicate prepares after commit.
- Route commit and abort through the existing durable intent ETag state machine, preserving idempotent retries and fail-closed conflicts.
- Expose the handler core through the ECStore public facade for a future thin gRPC adapter without changing S3-facing APIs or protobuf service definitions in this PR.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore tier_mutation_peer --features test-util -- --nocapture`
- `cargo clippy -p rustfs-ecstore --all-targets --features test-util -- -D warnings`
- `make pre-commit`

## Impact
No S3 API or existing internode API compatibility impact is expected. This PR adds a new internal ECStore facade and does not change `node.proto`, request routing, bucket/object metadata formats, or existing RPC method behavior.

## Additional Notes
- Correctness adversary: attacked nil mutation IDs, unsupported protocol versions, oversized payloads, malformed prepare intent payloads, duplicate prepare, delayed prepare after commit, duplicate commit, duplicate abort, and conflicting prepare; no break found after adding the conflict/no-overwrite regression.
- Simplicity adversary: found duplicated test intent construction and resolved it with a two-call-site test helper; no smaller equivalent production diff found.
- Security reviewer: attacked unsigned body confusion and phase confusion at this layer; this core assumes the future transport adapter has already verified the method-bound canonical body digest, and it fail-closes unknown/non-exhaustive phases and malformed payloads.
- Concurrency/durability reviewer: attacked two concurrent prepares with the same mutation ID and different payloads; prepare now uses `If-None-Match: *` and re-loads only for equivalent idempotent retries.
- Compatibility reviewer: confirmed there is no protobuf or existing RPC service mutation in this PR; unknown future phases fail closed through the non-exhaustive match fallback.
- Performance reviewer: this path is control-plane only, adds no object hot-path loop, no new fsync outside existing config-store durability gates, and no logging noise.
- Test-coverage skeptic: the focused test fails if atomic prepare is removed, if duplicate prepare/commit/abort stop being idempotent, if conflicting prepare overwrites, or if envelope validation accepts nil/old/oversized inputs.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
