### PR TITLE
fix(iam): reject cross-identity access key collisions

### DIFF
--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -783,14 +783,10 @@ where
         }
 
         let cache = self.cache.snapshot();
-        let users = Arc::clone(&cache.users);
-        if let Some(x) = users.get(&cred.access_key)
-            && x.credentials.is_service_account()
-        {
+        if cache.users.contains_key(&cred.access_key) || cache.sts_accounts.contains_key(&cred.access_key) {
             return Err(Error::AccessKeyAlreadyExists);
         }
         drop(cache);
-        drop(users);
 
         let u = UserIdentity::new(cred);
 

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -1429,6 +1429,7 @@ mod tests {
         /// When true, parent user has no groups and no mapped policies (empty `policy_db_get`).
         empty_policies: bool,
         saved_sts_users: Arc<Mutex<HashMap<String, UserIdentity>>>,
+        saved_service_account_count: Arc<Mutex<usize>>,
     }
 
     impl StsTestMockStore {
@@ -1436,7 +1437,15 @@ mod tests {
             Self {
                 empty_policies,
                 saved_sts_users: Arc::new(Mutex::new(HashMap::new())),
+                saved_service_account_count: Arc::new(Mutex::new(0)),
             }
+        }
+
+        fn saved_service_account_count(&self) -> usize {
+            *self
+                .saved_service_account_count
+                .lock()
+                .expect("saved_service_account_count mutex poisoned")
         }
     }
 
@@ -1461,10 +1470,16 @@ mod tests {
         async fn save_user_identity(
             &self,
             name: &str,
-            _user_type: UserType,
+            user_type: UserType,
             item: UserIdentity,
             _ttl: Option<usize>,
         ) -> Result<()> {
+            if user_type == UserType::Svc {
+                *self
+                    .saved_service_account_count
+                    .lock()
+                    .expect("saved_service_account_count mutex poisoned") += 1;
+            }
             self.saved_sts_users
                 .lock()
                 .expect("saved_sts_users mutex poisoned")
@@ -1733,6 +1748,72 @@ mod tests {
             .expect_err("duplicate service account should fail");
 
         assert_eq!(err, Error::AccessKeyAlreadyExists);
+    }
+
+    #[tokio::test]
+    async fn service_account_creation_rejects_regular_user_access_key() {
+        ensure_test_global_credentials();
+
+        let iam_sys = test_iam_sys().await;
+        let access_key = "REGULARUSERACCESSKEY1";
+        let user = AddOrUpdateUserReq {
+            secret_key: "regularUserSecret123".to_string(),
+            policy: None,
+            status: rustfs_madmin::AccountStatus::Enabled,
+        };
+
+        iam_sys
+            .store
+            .add_user(access_key, &user)
+            .await
+            .expect("regular user should be created");
+
+        let err = iam_sys
+            .new_service_account("svc-parent-user", None, service_account_opts(access_key, "serviceAccountSecret123"))
+            .await
+            .expect_err("service-account creation must reject a regular-user access key");
+
+        assert_eq!(err, Error::AccessKeyAlreadyExists);
+        assert_eq!(iam_sys.store.api.saved_service_account_count(), 0);
+        let existing = iam_sys.get_user(access_key).await.expect("regular user should remain cached");
+        assert!(!existing.credentials.is_service_account());
+        assert_eq!(existing.credentials.secret_key, user.secret_key);
+    }
+
+    #[tokio::test]
+    async fn service_account_creation_rejects_sts_access_key() {
+        ensure_test_global_credentials();
+
+        let iam_sys = test_iam_sys().await;
+        let access_key = "TEMPORARYSERVICEKEY12";
+        let temp_cred = Credentials {
+            access_key: access_key.to_string(),
+            secret_key: "temporarySecretKey123".to_string(),
+            session_token: "temporary-session-token".to_string(),
+            expiration: Some(OffsetDateTime::now_utc() + time::Duration::hours(1)),
+            status: ACCOUNT_ON.to_string(),
+            parent_user: "sts-parent-user".to_string(),
+            ..Default::default()
+        };
+
+        iam_sys
+            .set_temp_user(access_key, &temp_cred, None)
+            .await
+            .expect("temporary credentials should be created");
+
+        let err = iam_sys
+            .new_service_account("svc-parent-user", None, service_account_opts(access_key, "serviceAccountSecret123"))
+            .await
+            .expect_err("service-account creation must reject a temporary access key");
+
+        assert_eq!(err, Error::AccessKeyAlreadyExists);
+        assert_eq!(iam_sys.store.api.saved_service_account_count(), 0);
+        let existing = iam_sys
+            .get_user(access_key)
+            .await
+            .expect("temporary account should remain cached");
+        assert!(existing.credentials.is_temp());
+        assert_eq!(existing.credentials.secret_key, temp_cred.secret_key);
     }
 
     #[tokio::test]

--- a/rustfs/src/admin/handlers/iam_error.rs
+++ b/rustfs/src/admin/handlers/iam_error.rs
@@ -71,6 +71,7 @@ mod tests {
         let s3_error = iam_error_to_s3_error(IamError::AccessKeyAlreadyExists);
 
         assert_eq!(s3_error.code(), &S3ErrorCode::InvalidArgument);
+        assert_eq!(s3_error.status_code(), Some(http::StatusCode::BAD_REQUEST));
         assert_eq!(s3_error.message(), Some("access key is already in use"));
     }
 


### PR DESCRIPTION
## Related Issues

Fixes #5019

Follow-up to #5066.

## Summary of Changes

- Reject service-account creation when the requested access key already belongs to a regular user, service account, or STS account in the current IAM cache snapshot.
- Preserve the existing identity and avoid persisting a conflicting service-account record.
- Add regression coverage for regular-user and STS collisions, including the error variant, cached identity type, original secret, and absence of service-account persistence.
- Lock the shared duplicate-access-key mapping to HTTP 400, `InvalidArgument`, and `access key is already in use`.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-iam access_key`
- `cargo test -p rustfs duplicate_access_key_maps_to_invalid_argument`
- `cargo clippy --all-targets -p rustfs-iam -- -D warnings`
- `cargo clippy --all-targets -p rustfs -- -D warnings`
- `make pre-commit`
- `make pre-pr`

## Impact

Sequential service-account creation now returns HTTP 400 with `InvalidArgument` instead of overwriting an existing regular-user or STS identity that uses the same access key. Non-conflicting service-account creation and existing regular-user update behavior are unchanged. There are no configuration, storage-format, on-wire-format, or migration changes.

## Additional Notes

This change checks one immutable IAM cache snapshot and does not introduce a distributed atomic access-key reservation. The existing concurrent create/create and stale cross-node cache window is unchanged and should be addressed separately if global linearizable uniqueness is required.

High-risk adversarial validation:

- Correctness: attacked regular-user, service-account, and STS collisions, error variants, cache preservation, and persistence ordering; no break found.
- Simplicity: reduced the production change to the in-place collision guard and reused the shared error mapper; no smaller equivalent found.
- Security: verified authorization remains before collision disclosure and no credential material is logged or returned; no break found.
- Concurrency/durability: attacked snapshot consistency, guard lifetime, lock ordering, cancellation, and existing TOCTOU behavior; no diff-introduced break found.
- Compatibility: verified HTTP 400, `InvalidArgument`, the stable message, fallback behavior, and unchanged formats; no break found.
- Performance: the low-frequency admin path adds at most one allocation-free O(1) lookup and removes one `Arc::clone`; no measurable regression expected.
- Test coverage: mutation-attacked both map lookups, boolean logic, error type, cache overwrite, and persistence-before-guard; every claimed behavior has a failing regression test.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.