### PR TITLE
fix: update cluster snapshot test for peer health local node semantics

### DIFF
--- a/rustfs/src/cluster_snapshot.rs
+++ b/rustfs/src/cluster_snapshot.rs
@@ -181,7 +181,8 @@ mod tests {
             snapshot.runtime_status.degraded_reasons,
             vec![ReadinessDegradedReason::StorageAndLockUnavailable]
         );
-        assert_eq!(snapshot.peer_health.peers[0].status.state, CapabilityState::Unknown);
+        // Local node (peers[0]) is supported — no peer health probing needed.
+        assert_eq!(snapshot.peer_health.peers[0].status.state, CapabilityState::Supported);
         if cfg!(target_os = "linux") {
             assert_eq!(snapshot.observability.platform.numa.state, CapabilityState::Unknown);
         } else {


### PR DESCRIPTION
## Problem

Automated hourly verification of `7805cf5ae` found a test regression:

Commit `7805cf5ae` (fix(cluster): clarify peer health and listing timeouts #5086) changed `peer_health_snapshot_from_membership` to report `CapabilityState::Supported` for local nodes — they don't need peer health probing. The `control_plane.rs` tests were updated accordingly, but the integration test `cluster_snapshot_preserves_read_only_sections_and_partial_states` in `rustfs/src/cluster_snapshot.rs` still expected `CapabilityState::Unknown` for the local peer.

## Fix

Updated the assertion in `cluster_snapshot_preserves_read_only_sections_and_partial_states` to expect `CapabilityState::Supported` for `peers[0]` (the local node), with a comment explaining the semantics.

## Verification

- `make pre-commit` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo nextest run --workspace --exclude e2e_test` — **9875/9875 tests passed** (138 skipped)
