### PR TITLE
fix(tier): clear peer mutation runtime blocks

### DIFF
--- a/crates/ecstore/src/services/tier/tier.rs
+++ b/crates/ecstore/src/services/tier/tier.rs
@@ -2629,6 +2629,29 @@ impl TierConfigMgr {
         Ok(())
     }
 
+    pub(crate) async fn apply_prepared_mutation_intent_block(
+        handle: &Arc<RwLock<Self>>,
+        intent: &TierMutationIntent,
+    ) -> std::result::Result<(), AdminError> {
+        let manager = handle.read().await;
+        let runtime = tier_driver_runtime(handle, &manager);
+        let mut runtime = lock_unpoisoned(&runtime);
+        let mut prepared_mutation_blocks = runtime.prepared_mutation_blocks.clone();
+        Self::collect_prepared_mutation_intent_block(&mut prepared_mutation_blocks, intent)?;
+        runtime.prepared_mutation_blocks = prepared_mutation_blocks;
+        Ok(())
+    }
+
+    pub(crate) async fn clear_prepared_mutation_intent_block(handle: &Arc<RwLock<Self>>, mutation_id: uuid::Uuid) {
+        let manager = handle.read().await;
+        let Some(runtime) = registered_tier_driver_runtime(&manager) else {
+            return;
+        };
+        lock_unpoisoned(&runtime)
+            .prepared_mutation_blocks
+            .retain(|_, blocked_mutation_id| *blocked_mutation_id != mutation_id);
+    }
+
     fn collect_prepared_mutation_intent_block(
         prepared_mutation_blocks: &mut HashMap<String, uuid::Uuid>,
         intent: &TierMutationIntent,

--- a/crates/ecstore/src/services/tier/tier_mutation_peer.rs
+++ b/crates/ecstore/src/services/tier/tier_mutation_peer.rs
@@ -17,10 +17,12 @@ use std::sync::Arc;
 use rustfs_protos::{TIER_MUTATION_RPC_PROTOCOL_VERSION, TierMutationRpcPhase};
 use uuid::Uuid;
 
+use super::tier::TierConfigMgr;
 use super::tier_mutation_intent::{
     MAX_TIER_MUTATION_INTENT_SIZE, TierMutationIntent, TierMutationIntentState, advance_tier_mutation_intent_record_idempotent,
     load_tier_mutation_intent_record, save_tier_mutation_intent_record_if_absent,
 };
+use crate::client::admin_handler_utils::AdminError;
 use crate::error::{Error, StorageError};
 use crate::store::ECStore;
 
@@ -51,6 +53,8 @@ pub enum TierMutationPeerError {
     InvalidPayload(String),
     #[error("tier mutation peer intent conflicts with existing record")]
     ConflictingIntent,
+    #[error("tier mutation peer runtime error: {0}")]
+    Runtime(#[source] AdminError),
     #[error("tier mutation peer store error: {0}")]
     Store(#[source] StorageError),
 }
@@ -93,16 +97,32 @@ async fn handle_prepare(
             "prepare intent must be in prepared state".to_string(),
         ));
     }
+    let tier_config_mgr = api.tier_config_mgr();
 
     match save_tier_mutation_intent_record_if_absent(api.clone(), &intent).await {
-        Ok(()) => Ok(TierMutationPeerOutcome {
-            state: TierMutationPeerState::Prepared,
-            applied: true,
-        }),
+        Ok(()) => {
+            TierConfigMgr::apply_prepared_mutation_intent_block(&tier_config_mgr, &intent)
+                .await
+                .map_err(TierMutationPeerError::Runtime)?;
+            Ok(TierMutationPeerOutcome {
+                state: TierMutationPeerState::Prepared,
+                applied: true,
+            })
+        }
         Err(Error::PreconditionFailed) => {
             let existing = load_tier_mutation_intent_record(api, mutation_id).await?;
             if !same_mutation_identity(&existing, &intent) {
                 return Err(TierMutationPeerError::ConflictingIntent);
+            }
+            match existing.state {
+                TierMutationIntentState::Prepared => {
+                    TierConfigMgr::apply_prepared_mutation_intent_block(&tier_config_mgr, &existing)
+                        .await
+                        .map_err(TierMutationPeerError::Runtime)?;
+                }
+                TierMutationIntentState::Committed | TierMutationIntentState::Aborted => {
+                    TierConfigMgr::clear_prepared_mutation_intent_block(&tier_config_mgr, mutation_id).await;
+                }
             }
             Ok(TierMutationPeerOutcome {
                 state: peer_state_from_intent(existing.state),
@@ -119,6 +139,7 @@ async fn handle_commit(
     canonical_payload: &[u8],
 ) -> TierMutationPeerResult<TierMutationPeerOutcome> {
     let committed_config_etag = parse_commit_etag(canonical_payload)?;
+    let tier_config_mgr = api.tier_config_mgr();
     let (intent, applied) = advance_tier_mutation_intent_record_idempotent(
         api,
         mutation_id,
@@ -126,6 +147,9 @@ async fn handle_commit(
         Some(committed_config_etag),
     )
     .await?;
+    if intent.state == TierMutationIntentState::Committed {
+        TierConfigMgr::clear_prepared_mutation_intent_block(&tier_config_mgr, mutation_id).await;
+    }
     Ok(TierMutationPeerOutcome {
         state: peer_state_from_intent(intent.state),
         applied,
@@ -140,8 +164,12 @@ async fn handle_abort(
     if !canonical_payload.is_empty() {
         return Err(TierMutationPeerError::InvalidPayload("abort payload must be empty".to_string()));
     }
+    let tier_config_mgr = api.tier_config_mgr();
     let (intent, applied) =
         advance_tier_mutation_intent_record_idempotent(api, mutation_id, TierMutationIntentState::Aborted, None).await?;
+    if intent.state == TierMutationIntentState::Aborted {
+        TierConfigMgr::clear_prepared_mutation_intent_block(&tier_config_mgr, mutation_id).await;
+    }
     Ok(TierMutationPeerOutcome {
         state: peer_state_from_intent(intent.state),
         applied,

--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -1495,6 +1495,7 @@ mod tests {
         let mutation_id = uuid::Uuid::new_v4();
         let intent = tier_mutation_peer_test_intent(mutation_id, "COLD-A", [3; 32]);
         let prepare_payload = intent.encode().expect("prepare intent should encode");
+        register_mock_tier(&store.tier_config_mgr(), "COLD-A").await;
 
         let prepared = handle_tier_mutation_peer_request(
             store.clone(),
@@ -1507,6 +1508,14 @@ mod tests {
         .expect("first prepare should create the peer intent");
         assert!(prepared.applied);
         assert_eq!(prepared.state, TierMutationPeerState::Prepared);
+        let blocked = match TierConfigMgr::acquire_operation_lease(&store.tier_config_mgr(), "COLD-A").await {
+            Ok(_) => panic!("prepared peer mutation should block new tier operation leases"),
+            Err(err) => err,
+        };
+        assert!(
+            blocked.message.contains("being replaced"),
+            "prepared peer mutation should reuse the existing blocked-tier error: {blocked}"
+        );
 
         let retried_prepare = handle_tier_mutation_peer_request(
             store.clone(),
@@ -1519,6 +1528,14 @@ mod tests {
         .expect("same prepare retry should be idempotent");
         assert!(!retried_prepare.applied);
         assert_eq!(retried_prepare.state, TierMutationPeerState::Prepared);
+        let retried_blocked = match TierConfigMgr::acquire_operation_lease(&store.tier_config_mgr(), "COLD-A").await {
+            Ok(_) => panic!("prepared retry should keep blocking new tier operation leases"),
+            Err(err) => err,
+        };
+        assert!(
+            retried_blocked.message.contains("being replaced"),
+            "prepared retry should keep the existing blocked-tier error: {retried_blocked}"
+        );
 
         let committed = handle_tier_mutation_peer_request(
             store.clone(),
@@ -1531,6 +1548,11 @@ mod tests {
         .expect("commit should advance the prepared peer intent");
         assert!(committed.applied);
         assert_eq!(committed.state, TierMutationPeerState::Committed);
+        drop(
+            TierConfigMgr::acquire_operation_lease(&store.tier_config_mgr(), "COLD-A")
+                .await
+                .expect("committed peer mutation should clear the prepared runtime block"),
+        );
 
         let retried_commit = handle_tier_mutation_peer_request(
             store.clone(),
@@ -1555,6 +1577,11 @@ mod tests {
         .expect("delayed duplicate prepare should report the durable committed state");
         assert!(!delayed_prepare_retry.applied);
         assert_eq!(delayed_prepare_retry.state, TierMutationPeerState::Committed);
+        drop(
+            TierConfigMgr::acquire_operation_lease(&store.tier_config_mgr(), "COLD-A")
+                .await
+                .expect("delayed committed prepare retry must not recreate a runtime block"),
+        );
 
         let loaded = load_tier_mutation_intent_record(store.clone(), mutation_id)
             .await
@@ -1565,6 +1592,7 @@ mod tests {
         let abort_id = uuid::Uuid::new_v4();
         let abort_intent = tier_mutation_peer_test_intent(abort_id, "COLD-B", [4; 32]);
         let abort_prepare_payload = abort_intent.encode().expect("abort prepare intent should encode");
+        register_mock_tier(&store.tier_config_mgr(), "COLD-B").await;
         handle_tier_mutation_peer_request(
             store.clone(),
             TIER_MUTATION_RPC_PROTOCOL_VERSION,
@@ -1574,6 +1602,14 @@ mod tests {
         )
         .await
         .expect("abort target prepare should create the peer intent");
+        let abort_blocked = match TierConfigMgr::acquire_operation_lease(&store.tier_config_mgr(), "COLD-B").await {
+            Ok(_) => panic!("abort target prepare should block new tier operation leases"),
+            Err(err) => err,
+        };
+        assert!(
+            abort_blocked.message.contains("being replaced"),
+            "abort target prepare should reuse the existing blocked-tier error: {abort_blocked}"
+        );
 
         let aborted = handle_tier_mutation_peer_request(
             store.clone(),
@@ -1586,6 +1622,11 @@ mod tests {
         .expect("abort should advance the prepared peer intent");
         assert!(aborted.applied);
         assert_eq!(aborted.state, TierMutationPeerState::Aborted);
+        drop(
+            TierConfigMgr::acquire_operation_lease(&store.tier_config_mgr(), "COLD-B")
+                .await
+                .expect("aborted peer mutation should clear the prepared runtime block"),
+        );
 
         let retried_abort = handle_tier_mutation_peer_request(
             store,


### PR DESCRIPTION
## Related Issues
- Refs rustfs/backlog#1328
- Refs rustfs/backlog#1357
- Stacked on rustfs/rustfs#5080 through base branch `houseme/backlog-1357-coordinator-lock`.

## Summary of Changes
- Install prepared tier mutation runtime blocks on peer prepare requests after the durable intent record is created, so follower peers fail closed immediately instead of waiting for restart recovery.
- Re-apply the runtime block on idempotent duplicate prepare requests when the durable record is still prepared, repairing a missing in-memory block without changing the existing wire contract.
- Clear the in-memory prepared block when peer commit or abort reaches a durable terminal state, and avoid recreating a block when a delayed duplicate prepare observes a committed or aborted record.
- Keep the peer RPC method, payload format, protocol version, and handler signature unchanged; this PR only wires the durable peer state to local runtime guards.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore prepared_mutation_recovery`
- `cargo test -p rustfs-ecstore --features test-util tier_mutation_peer_handler_applies_prepare_commit_and_abort_idempotently`
- `cargo test -p rustfs-ecstore --features test-util tier_mutation_peer_handler`
- `cargo test -p rustfs-ecstore tier_mutation_peer`
- `cargo check -p rustfs-ecstore --all-targets`
- `cargo clippy -p rustfs-ecstore --all-targets`
- `git diff --check`
- `make pre-commit`

## Impact
- No public API, S3 API, config, protobuf, or on-wire compatibility change is intended.
- Peers that receive a prepared tier mutation now block conflicting local tier operations immediately, and terminal commit or abort responses release that local runtime block without requiring restart or full reconcile.
- This is still a focused #1357 slice and does not complete distributed fencing, coordinator crash recovery, peer durable draining, or mixed-version deterministic coverage.

## Additional Notes
- High-risk adversarial review summary: correctness attacked prepare-then-runtime-failure, duplicate prepare after terminal state, and multi-target partial apply; the helper builds the block map on a clone and only publishes after validation, while durable prepared records remain recoverable on retry or restart.
- Security review found no auth or payload-surface expansion; existing RPC authentication and payload validation paths are unchanged.
- Concurrency and durability review found no await while holding the runtime mutex; prepare remains durable-first and terminal commit or abort clears only after durable state advancement.
- Compatibility review found no protobuf, RPC method, body, protocol version, S3 API, or config change.
- Performance review found the new map clone is limited to peer prepare/replay and is not on the per-object S3 hot path.
- Test-coverage review maps the new behavior to `tier_mutation_peer_handler_applies_prepare_commit_and_abort_idempotently`; reverting the peer runtime apply or clear calls makes the lease assertions fail.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
