### PR TITLE
fix(admin): expose effective notify state

### DIFF
--- a/crates/e2e_test/src/notification_webhook_test.rs
+++ b/crates/e2e_test/src/notification_webhook_test.rs
@@ -156,7 +156,43 @@ async fn spawn_event_collector() -> Result<(String, mpsc::UnboundedReceiver<Valu
     Ok((format!("http://{endpoint_ip}.nip.io:{port}/events"), rx, handle))
 }
 
-fn spawn_https_event_collector(ca_path: &Path) -> Result<(String, Arc<AtomicBool>, thread::JoinHandle<()>), BoxError> {
+struct HttpsEventCollector {
+    endpoint: String,
+    running: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+    events: mpsc::UnboundedReceiver<Value>,
+}
+
+impl HttpsEventCollector {
+    fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    fn events_mut(&mut self) -> &mut mpsc::UnboundedReceiver<Value> {
+        &mut self.events
+    }
+
+    fn shutdown(&mut self) -> TestResult {
+        self.running.store(false, Ordering::Relaxed);
+        if let Ok(parsed) = self.endpoint.parse::<reqwest::Url>()
+            && let Some(port) = parsed.port()
+        {
+            let _ = std::net::TcpStream::connect(("127.0.0.1", port));
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.join().map_err(|_| "https event collector thread panicked")?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for HttpsEventCollector {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+fn spawn_https_event_collector(ca_path: &Path) -> Result<HttpsEventCollector, BoxError> {
     use rustls::{
         ServerConfig,
         pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
@@ -188,13 +224,17 @@ fn spawn_https_event_collector(ca_path: &Path) -> Result<(String, Arc<AtomicBool
 
     let running = Arc::new(AtomicBool::new(true));
     let server_running = Arc::clone(&running);
+    let (tx, events) = mpsc::unbounded_channel();
     let handle = thread::spawn(move || {
         let mut connections = Vec::new();
         while server_running.load(Ordering::Relaxed) {
             match listener.accept() {
                 Ok((stream, _)) => {
                     let config = Arc::clone(&server_config);
-                    connections.push(thread::spawn(move || handle_https_probe(stream, config)));
+                    let tx = tx.clone();
+                    connections.push(thread::spawn(move || {
+                        let _ = handle_https_request(stream, config, tx);
+                    }));
                 }
                 Err(err) if err.kind() == ErrorKind::WouldBlock => thread::sleep(Duration::from_millis(20)),
                 Err(_) => break,
@@ -205,44 +245,82 @@ fn spawn_https_event_collector(ca_path: &Path) -> Result<(String, Arc<AtomicBool
         }
     });
 
-    Ok((format!("https://{endpoint_host}:{}/events", addr.port()), running, handle))
+    Ok(HttpsEventCollector {
+        endpoint: format!("https://{endpoint_host}:{}/events", addr.port()),
+        running,
+        handle: Some(handle),
+        events,
+    })
 }
 
-fn handle_https_probe(stream: std::net::TcpStream, server_config: Arc<rustls::ServerConfig>) {
-    use std::io::{Read, Write};
-
-    let _ = stream.set_nonblocking(false);
-    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
-    let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
-    let Ok(connection) = rustls::ServerConnection::new(server_config) else {
-        return;
+fn read_sync_http_message<R: std::io::Read>(stream: &mut R) -> Result<(String, Vec<u8>), BoxError> {
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            return Err("connection closed before request headers were complete".into());
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(pos) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+            break pos;
+        }
     };
-    let mut tls_stream = rustls::StreamOwned::new(connection, stream);
-    let mut buf = [0u8; 1024];
-    if tls_stream.read(&mut buf).is_err() {
-        return;
-    }
-    let response = "HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
-    if tls_stream.write_all(response.as_bytes()).is_err() {
-        return;
-    }
-    tls_stream.conn.send_close_notify();
-    while tls_stream.conn.wants_write() {
-        if tls_stream.conn.write_tls(&mut tls_stream.sock).is_err() {
-            return;
+
+    let header_text = std::str::from_utf8(&buffer[..header_end])?;
+    let mut lines = header_text.split("\r\n");
+    let method = lines
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or("missing request method")?
+        .to_string();
+    let mut content_length = 0usize;
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':')
+            && name.trim().eq_ignore_ascii_case("content-length")
+        {
+            content_length = value.trim().parse()?;
         }
     }
-    let _ = tls_stream.sock.shutdown(std::net::Shutdown::Write);
+
+    let body_offset = header_end + 4;
+    while buffer.len().saturating_sub(body_offset) < content_length {
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            return Err("connection closed before request body was complete".into());
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+    Ok((method, buffer[body_offset..body_offset + content_length].to_vec()))
 }
 
-fn stop_https_event_collector(endpoint: &str, running: Arc<AtomicBool>, handle: thread::JoinHandle<()>) -> TestResult {
-    running.store(false, Ordering::Relaxed);
-    if let Ok(parsed) = endpoint.parse::<reqwest::Url>()
-        && let Some(port) = parsed.port()
-    {
-        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
+fn handle_https_request(
+    stream: std::net::TcpStream,
+    server_config: Arc<rustls::ServerConfig>,
+    tx: mpsc::UnboundedSender<Value>,
+) -> Result<(), BoxError> {
+    use std::io::Write;
+
+    stream.set_nonblocking(false)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    let connection = rustls::ServerConnection::new(server_config)?;
+    let mut tls_stream = rustls::StreamOwned::new(connection, stream);
+    let (method, body) = read_sync_http_message(&mut tls_stream)?;
+    let response = "HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+    tls_stream.write_all(response.as_bytes())?;
+    tls_stream.flush()?;
+    tls_stream.conn.send_close_notify();
+    while tls_stream.conn.wants_write() {
+        tls_stream.conn.write_tls(&mut tls_stream.sock)?;
     }
-    handle.join().map_err(|_| "https event collector thread panicked")?;
+    let _ = tls_stream.sock.shutdown(std::net::Shutdown::Write);
+    if method == "POST"
+        && !body.is_empty()
+        && let Ok(event) = serde_json::from_slice(&body)
+    {
+        let _ = tx.send(event);
+    }
     Ok(())
 }
 
@@ -428,17 +506,20 @@ async fn wait_for_target_registered(env: &RustFSTestEnvironment, target_name: &s
     Err(format!("target {target_name} was not registered in admin ARNs").into())
 }
 
-async fn wait_for_target_listed(env: &RustFSTestEnvironment, target_name: &str) -> TestResult {
+async fn wait_for_target_online(env: &RustFSTestEnvironment, target_name: &str) -> TestResult {
     let url = format!("{}/rustfs/admin/v3/target/list", env.url);
     for _ in 0..40 {
         let response = signed_admin_request(env, http::Method::GET, &url, None).await?;
         if response.status() == StatusCode::OK {
             let body: Value = serde_json::from_slice(&response.bytes().await?)?;
+            if body["notify_enabled"].as_bool() != Some(true) {
+                return Err(format!("admin target list did not report notify_enabled=true: {body}").into());
+            }
             let listed = body["notification_endpoints"].as_array().is_some_and(|endpoints| {
                 endpoints.iter().any(|endpoint| {
                     endpoint["account_id"].as_str() == Some(target_name)
                         && endpoint["service"].as_str() == Some("webhook")
-                        && endpoint["status"].as_str().is_some()
+                        && endpoint["status"].as_str() == Some("online")
                 })
             });
             if listed {
@@ -447,7 +528,7 @@ async fn wait_for_target_listed(env: &RustFSTestEnvironment, target_name: &str) 
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
-    Err(format!("target {target_name} was not listed in admin targets").into())
+    Err(format!("target {target_name} did not become online in admin targets").into())
 }
 
 /// Binds a bucket to a webhook target for ObjectCreated:*/ObjectRemoved:* events,
@@ -497,11 +578,11 @@ fn trimmed_etag(value: Option<&str>) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 /// Regression for rustfs#5052: with the notify module enabled through
-/// RUSTFS_NOTIFY_ENABLE, an HTTPS webhook using a configured CA must be accepted
-/// and remain visible in the admin target list.
+/// RUSTFS_NOTIFY_ENABLE, an HTTPS webhook using a configured CA must become
+/// online and receive a real S3 event POST.
 #[tokio::test]
 #[serial]
-async fn test_https_webhook_target_lists_with_notify_env_enabled() -> TestResult {
+async fn test_https_webhook_target_delivers_event_with_notify_env_enabled() -> TestResult {
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
@@ -509,22 +590,40 @@ async fn test_https_webhook_target_lists_with_notify_env_enabled() -> TestResult
         .await?;
 
     let ca_path = Path::new(&env.temp_dir).join("https-webhook-ca.pem");
-    let (endpoint, running, handle) = spawn_https_event_collector(&ca_path)?;
+    let mut collector = spawn_https_event_collector(&ca_path)?;
     let target = "peri1https";
+    let bucket = "peri1-https-events";
+    let key = "uploads/https.dat";
+    let client = env.create_s3_client();
+    client.create_bucket().bucket(bucket).send().await?;
 
     configure_webhook_target_with_key_values(
         &env,
         target,
         vec![
-            ("endpoint", endpoint.clone()),
+            ("endpoint", collector.endpoint().to_string()),
             ("client_ca", ca_path.to_string_lossy().into_owned()),
         ],
     )
     .await?;
-    wait_for_target_listed(&env, target).await?;
+    wait_for_target_online(&env, target).await?;
+    wait_for_target_registered(&env, target).await?;
+    put_notification_config(&client, bucket, target, "uploads/", ".dat").await?;
+
+    client
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(ByteStream::from_static(b"https webhook event body"))
+        .send()
+        .await?;
+    let event = wait_for_event(collector.events_mut(), key, "s3:ObjectCreated:", Duration::from_secs(20)).await?;
+    assert_eq!(event["EventName"].as_str(), Some("s3:ObjectCreated:Put"));
+    assert_eq!(event["Records"][0]["s3"]["bucket"]["name"].as_str(), Some(bucket));
+    assert_eq!(event_key(&event).as_deref(), Some(key));
 
     env.stop_server();
-    stop_https_event_collector(&endpoint, running, handle)?;
+    collector.shutdown()?;
     Ok(())
 }
 

--- a/crates/targets/src/target/webhook.rs
+++ b/crates/targets/src/target/webhook.rs
@@ -952,7 +952,7 @@ mod tests {
             .expect("https webhook probe should trust configured ca");
 
         assert_eq!(resp.status(), reqwest::StatusCode::OK);
-        assert_eq!(resp.text_with_charset("utf-8").await.expect("read response body"), "");
+        assert!(resp.bytes().await.expect("read response body").is_empty());
         handle.join().expect("tls server thread");
     }
 }

--- a/docs/testing/e2e-suite-inventory.md
+++ b/docs/testing/e2e-suite-inventory.md
@@ -19,19 +19,24 @@
 |---|---|---|
 | admin_auth_test | 3 | ✅ |
 | admin_iam_crud_test | 2 | ✅ |
+| admin_pools_test | 1 | ✅ |
 | admin_timeout_regression_test | 1 |  |
 | anonymous_access_test | 3 | ✅ |
+| api_rate_limit_test | 3 |  |
 | archive_download_integrity_test | 13 |  |
 | bucket_logging_test | 3 |  |
 | bucket_policy_check_test | 1 | ✅ |
 | checksum_upload_test | 7 |  |
 | cluster_concurrency_test | 2 |  |
-| common | 3 |  |
+| cluster_multidrive_pool_test | 2 |  |
+| common | 10 |  |
 | compression_test | 1 |  |
+| connection_cap_test | 2 |  |
 | console_smoke_test | 1 | ✅ |
 | content_encoding_test | 3 | ✅ |
+| copy_object_checksum_test | 3 |  |
 | copy_object_metadata_test | 1 | ✅ |
-| copy_object_version_restore_test | 1 |  |
+| copy_object_version_restore_test | 2 |  |
 | copy_source_invalid_date_test | 1 | ✅ |
 | create_bucket_region_test | 2 | ✅ |
 | degraded_read_eof_regression_test | 3 |  |
@@ -40,6 +45,7 @@
 | delete_objects_versioning_test | 2 | ✅ |
 | existing_object_tag_policy_test | 4 |  |
 | fake_s3_target | 4 | ✅ |
+| fault_proxy | 7 |  |
 | get_codec_streaming_compat_test | 1 |  |
 | head_object_consistency_test | 1 | ✅ |
 | head_object_range_test | 1 | ✅ |
@@ -56,13 +62,13 @@
 | multipart_auth_test | 109 |  |
 | namespace_lock_quorum_test | 2 |  |
 | negative_sigv4_test | 6 | ✅ |
-| notification_webhook_test | 1 | ✅ |
+| notification_webhook_test | 2 | ✅ |
 | object_lambda_test | 16 |  |
 | object_lock | 33 |  |
 | overwrite_cleanup_regression_test | 1 |  |
 | presigned_negative_test | 7 | ✅ |
 | protocols | 16 |  |
-| quota_test | 13 |  |
+| quota_test | 14 |  |
 | reliability_disk_fault_test | 3 |  |
 | reliant | 10 | 4 ✅ |
 | replication_extension_test | 47 | 20 ✅ +27 🌙 |
@@ -75,4 +81,6 @@
 | tls_hot_reload_test | 1 | ✅ |
 | version_id_regression_test | 10 | ✅ |
 
-**Total listed: 439 tests across 57 modules · PR smoke subset: 112 tests / 27 modules** (25 full modules + 4 `reliant` tests + 20 of `replication_extension_test`) **· nightly `e2e-repl-nightly`: 27 tests** · generated 2026-07-16.
+`notification_webhook_test` also has 1 ignored store-and-forward regression tracked by rustfs#4852; ignored tests are excluded from the active counts above.
+
+**Total listed: 467 tests across 63 modules · PR smoke subset: 114 tests / 28 modules** (26 full modules + 4 `reliant` tests + 20 of `replication_extension_test`) **· nightly `e2e-repl-nightly`: 27 tests** · generated 2026-07-21.

--- a/rustfs/src/admin/handlers/event.rs
+++ b/rustfs/src/admin/handlers/event.rs
@@ -245,6 +245,7 @@ struct NotificationEndpoint {
 
 #[derive(Serialize, Debug)]
 struct NotificationEndpointsResponse {
+    notify_enabled: bool,
     notification_endpoints: Vec<NotificationEndpoint>,
 }
 
@@ -399,11 +400,29 @@ impl Operation for ListNotificationTargets {
         let span = Span::current();
         let _enter = span.enter();
         authorize_notification_admin_request(&req, AdminAction::GetBucketTargetAction).await?;
+        refresh_persisted_module_switches_from_store().await.map_err(|err| {
+            warn!(
+                event = EVENT_ADMIN_REQUEST_FAILED,
+                component = LOG_COMPONENT_ADMIN_API,
+                subsystem = LOG_SUBSYSTEM_NOTIFICATION_TARGET,
+                operation = "list_targets",
+                result = "failed",
+                reason = "module_switch_refresh_failed",
+                error = %err,
+                "admin request failed"
+            );
+            s3_error!(InternalError, "failed to refresh notification module state")
+        })?;
+        let notify_enabled = refresh_notify_module_enabled();
         let (ns, config) = load_notification_config_snapshot().await?;
         let runtime_statuses = collect_runtime_statuses(ns.get_target_values().await).await;
         let notification_endpoints = merge_notification_endpoints(&config, runtime_statuses)?;
 
-        let data = serde_json::to_vec(&NotificationEndpointsResponse { notification_endpoints }).map_err(|e| {
+        let data = serde_json::to_vec(&NotificationEndpointsResponse {
+            notify_enabled,
+            notification_endpoints,
+        })
+        .map_err(|e| {
             log_notification_target_request_failed!("list_targets", "serialize_targets_failed", None, None, e);
             s3_error!(InternalError, "failed to serialize targets: {}", e)
         })?;
@@ -536,6 +555,32 @@ mod tests {
             NOTIFY_WEBHOOK_SUB_SYS
         );
         assert!(notification_target_subsystem("webhook").is_err());
+    }
+
+    #[test]
+    fn notification_endpoints_response_includes_required_module_state() {
+        let response = NotificationEndpointsResponse {
+            notify_enabled: true,
+            notification_endpoints: vec![NotificationEndpoint {
+                account_id: "primary".to_string(),
+                service: "webhook".to_string(),
+                status: "online".to_string(),
+                source: TargetEndpointSource::Config,
+            }],
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("notification target response should serialize"),
+            serde_json::json!({
+                "notify_enabled": true,
+                "notification_endpoints": [{
+                    "account_id": "primary",
+                    "service": "webhook",
+                    "status": "online",
+                    "source": "config"
+                }]
+            })
+        );
     }
 
     #[test]
@@ -947,6 +992,22 @@ mod tests {
         assert!(
             list_block.contains("authorize_notification_admin_request(&req, AdminAction::GetBucketTargetAction).await?;"),
             "notification target list should require GetBucketTargetAction"
+        );
+        let authorize_index = list_block
+            .find("authorize_notification_admin_request")
+            .expect("target list should authorize the request");
+        let refresh_index = list_block
+            .find("refresh_persisted_module_switches_from_store().await.map_err")
+            .expect("target list should fail when persisted module state cannot be refreshed");
+        let effective_state_index = list_block
+            .find("let notify_enabled = refresh_notify_module_enabled();")
+            .expect("target list should resolve the effective env and persisted module state");
+        let load_index = list_block
+            .find("load_notification_config_snapshot().await?")
+            .expect("target list should load notification config");
+        assert!(
+            authorize_index < refresh_index && refresh_index < effective_state_index && effective_state_index < load_index,
+            "target list should authorize, refresh persisted state, resolve effective state, then load targets"
         );
         assert!(
             arns_block.contains("authorize_notification_admin_request(&req, AdminAction::GetBucketTargetAction).await?;"),


### PR DESCRIPTION
## Related Issues

- Part of rustfs/backlog#1360.
- Follows #5088 and builds on the notification lifecycle work discussed in #5052 and #5060.

## Summary of Changes

- Add the required top-level `notify_enabled` field to `GET /rustfs/admin/v3/target/list`, computed from the refreshed persisted switch and the environment override.
- Fail closed with an internal error when the persisted module switch cannot be refreshed, while preserving the existing `GetBucketTargetAction` authorization contract.
- Strengthen the HTTPS webhook E2E coverage to require an online target, perform a real object PUT, receive the webhook POST, and validate the event name, bucket, and decoded object key.
- Make the HTTPS test collector clean up listener and connection threads through RAII, validate the custom-CA response as bytes, and refresh the E2E inventory counts.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 make pre-commit`
- `CARGO_INCREMENTAL=0 make pre-pr` (9,951 tests passed; all doctests passed)
- `cargo test -p rustfs notification_endpoints_response_includes_required_module_state`
- `cargo test -p rustfs notification_target_handlers_require_admin_authorization_contract`
- `cargo test -p rustfs-targets test_webhook_client_reaches_https_origin_with_custom_ca`
- `cargo test -p e2e_test test_https_webhook_target_delivers_event_with_notify_env_enabled` with loopback proxy bypass
- `cargo nextest list`

## Impact

The admin target-list response gains one required additive boolean field. Delegated administrators retain the same permission requirement. A failed persisted-switch refresh now returns an internal error instead of reporting potentially stale state. There are no S3 API, on-disk, or inter-node wire-format changes.

## Additional Notes

This is PR 2 of the five-PR backlog plan and is intentionally stacked on #5088. After #5088 merges, this PR can be retargeted to `main`. The console integration PR will consume the new `notify_enabled` field.

High-risk adversarial validation verdicts:

- Correctness: attacked stale persisted state, environment overrides, exact response serialization, and malformed/partial webhook requests; no unresolved failure found.
- Simplicity: attacked the added response flow, synchronous TLS test parser, and cleanup abstraction for redundant code; the retained code is required for the contract and deterministic teardown.
- Security: attacked authorization bypass, diagnostic leakage, and untrusted webhook payload handling; authorization is unchanged and client errors remain generic.
- Concurrency/durability: attacked early returns, panics, blocked accepts/reads, and thread joins; bounded socket timeouts, listener wakeup, join, and `Drop` cover teardown paths.
- Compatibility: attacked delegated-admin access, additive JSON evolution, and lifecycle dependency ordering; the action remains `GetBucketTargetAction` and the response change is additive.
- Performance: attacked request-hot-path work and unbounded test tasks; refresh occurs only on the explicit admin list call and test threads are bounded and joined.
- Test coverage: reverting each behavior breaks the exact JSON/auth-order contract, custom-CA test, or real HTTPS delivery E2E; no uncovered changed behavior remains.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
