### PR TITLE
fix(tier): narrow mutation proof targets

### DIFF
--- a/crates/ecstore/src/services/tier/tier.rs
+++ b/crates/ecstore/src/services/tier/tier.rs
@@ -506,7 +506,7 @@ fn tier_mutation_proof_targets(
     current: &TierConfigMgr,
     candidate: &TierConfigMgr,
 ) -> HashSet<String> {
-    let mut targets = changed_tier_names(current, candidate);
+    let mut targets = HashSet::new();
     match kind {
         TierMutationIntentKind::Add | TierMutationIntentKind::Edit | TierMutationIntentKind::Remove => {
             if let Some(tier_name) = explicit_tier_name


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1328
Refs rustfs/backlog#1357

## Summary of Changes
This PR keeps the tier config mutation drain scope unchanged, but narrows authoritative mutation target proofs for Add/Edit/Remove to the explicit tier being mutated. The sidecar namespace lock and existing transition/drain path still cover manager-vs-candidate drift, while the identity proof no longer treats unrelated unchanged persisted tiers as if they were part of the current mutation.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore tier_config --features test-util -- --nocapture`
- `cargo test -p rustfs-ecstore add_target_proof_ignores_unchanged_persisted_tiers_when_manager_is_stale --features test-util -- --nocapture`
- `cargo test -p rustfs-ecstore config_write_lock_survives_cancelled_wrapped_update_until_detached_publish_finishes --features test-util -- --nocapture`
- `cargo clippy -p rustfs-ecstore --features test-util --all-targets -- -D warnings`

## Impact
No external API, S3 API, persisted format, or RPC contract change. This only tightens internal tier mutation proof selection so stale local manager state does not make unchanged durable tiers fail an Add/Edit/Remove proof.

## Additional Notes
Adversarial review notes: correctness attacked stale manager plus unrelated persisted tiers and is covered by the add proof regression; simplicity found no smaller safe behavior-equivalent change than narrowing the proof target set; security found no new auth or secret exposure because the change does not alter credentials serialization; concurrency/durability keeps sidecar namespace locking and CAS save behavior unchanged; compatibility found no on-disk or on-wire format change; performance removes unnecessary target proof work for unrelated tiers; test coverage includes both broad tier_config filtering and targeted stale-manager/cancellation-lock regressions. This PR does not claim durable recovery, mixed-version matrix, or peer restart draining completion.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
