### PR TITLE
test(tier): cover peer mutation fail-closed statuses

### DIFF
--- a/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
@@ -187,6 +187,19 @@ fn validate_tier_mutation_payload_len(phase: TierMutationRpcPhase, payload_len: 
     Ok(())
 }
 
+fn tier_mutation_phase_label(phase: TierMutationRpcPhase) -> &'static str {
+    match phase {
+        TierMutationRpcPhase::Prepare => "prepare",
+        TierMutationRpcPhase::Commit => "commit",
+        TierMutationRpcPhase::Abort => "abort",
+        _ => "unknown",
+    }
+}
+
+fn tier_mutation_control_status_error(phase: TierMutationRpcPhase, status: tonic::Status) -> Error {
+    Error::other(format!("peer tier mutation {} RPC failed: {status}", tier_mutation_phase_label(phase)))
+}
+
 impl PeerRestClient {
     fn recovery_monitor_span(grid_host: &str) -> tracing::Span {
         tracing::info_span!(
@@ -864,7 +877,11 @@ impl PeerRestClient {
                             canonical_payload: canonical_payload.clone(),
                         });
                         set_tonic_canonical_body_digest(&mut request, &canonical_body)?;
-                        client.prepare_tier_mutation(request).await?.into_inner()
+                        client
+                            .prepare_tier_mutation(request)
+                            .await
+                            .map_err(|status| tier_mutation_control_status_error(phase, status))?
+                            .into_inner()
                     }
                     TierMutationRpcPhase::Commit => {
                         let mut request = Request::new(TierMutationCommitRequest {
@@ -873,7 +890,11 @@ impl PeerRestClient {
                             canonical_payload: canonical_payload.clone(),
                         });
                         set_tonic_canonical_body_digest(&mut request, &canonical_body)?;
-                        client.commit_tier_mutation(request).await?.into_inner()
+                        client
+                            .commit_tier_mutation(request)
+                            .await
+                            .map_err(|status| tier_mutation_control_status_error(phase, status))?
+                            .into_inner()
                     }
                     TierMutationRpcPhase::Abort => {
                         let mut request = Request::new(TierMutationAbortRequest {
@@ -882,7 +903,11 @@ impl PeerRestClient {
                             canonical_payload: canonical_payload.clone(),
                         });
                         set_tonic_canonical_body_digest(&mut request, &canonical_body)?;
-                        client.abort_tier_mutation(request).await?.into_inner()
+                        client
+                            .abort_tier_mutation(request)
+                            .await
+                            .map_err(|status| tier_mutation_control_status_error(phase, status))?
+                            .into_inner()
                     }
                     _ => return Err(Error::other("tier mutation rpc phase is unsupported")),
                 };
@@ -1755,6 +1780,32 @@ mod tests {
         );
         validate_tier_mutation_payload_len(TierMutationRpcPhase::Abort, 0).expect("empty abort payload should fit");
         assert!(validate_tier_mutation_payload_len(TierMutationRpcPhase::Abort, 1).is_err());
+    }
+
+    #[test]
+    fn tier_mutation_rpc_status_matrix_fails_closed_for_old_or_unresponsive_peers() {
+        for (phase, label) in [
+            (TierMutationRpcPhase::Prepare, "prepare"),
+            (TierMutationRpcPhase::Commit, "commit"),
+            (TierMutationRpcPhase::Abort, "abort"),
+        ] {
+            for status in [
+                tonic::Status::unimplemented("old peer has no tier mutation control service"),
+                tonic::Status::deadline_exceeded("peer tier mutation control timed out"),
+                tonic::Status::unavailable("peer tier mutation control unavailable"),
+            ] {
+                let err = tier_mutation_control_status_error(phase, status);
+                let rendered = err.to_string();
+                assert!(rendered.contains(&format!("peer tier mutation {label} RPC failed")), "{rendered}");
+                assert!(
+                    rendered.contains("old peer")
+                        || rendered.contains("timed out")
+                        || rendered.contains("unavailable")
+                        || rendered.contains("Unavailable"),
+                    "{rendered}"
+                );
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
Relates to rustfs/backlog#1328 and rustfs/backlog#1357.

## Summary of Changes
This PR rebases the tier mutation old-peer fail-closed status matrix onto main after #5096 merged. It keeps the peer mutation control RPC contract fail-closed by mapping Prepare, Commit, and Abort gRPC status failures into phase-bound errors, and it adds a deterministic matrix for old-peer Unimplemented, timeout, and unavailable responses.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `CARGO_TARGET_DIR=/private/tmp/rustfs-target-1357-mixed-version-v1 cargo test -p rustfs-ecstore cluster::rpc::peer_rest_client::tests::tier_mutation --features test-util -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/rustfs-target-1357-mixed-version-v1 cargo clippy -p rustfs-ecstore --features test-util --all-targets -- -D warnings`
- `make pre-commit`

## Impact
This is a fail-closed compatibility hardening on the peer tier mutation control client error path. It does not change the protobuf wire format, public S3 API, configuration, or durable recovery behavior.

## Additional Notes
Adversarial validation: correctness attacked old-peer Unimplemented, timeout, and unavailable statuses across Prepare, Commit, and Abort; simplicity kept the change to a shared phase-bound status mapper plus the focused matrix instead of refactoring the client; security and compatibility confirmed the change does not weaken body-bound RPC auth or alter wire fields; concurrency and durability confirmed no new lock or persistence path; performance impact is limited to the failure path; coverage is pinned by the new deterministic matrix. This PR does not claim the full distributed fencing, durable recovery, or mixed-version E2E matrix for rustfs/backlog#1357 is complete.
