### PR TITLE
fix(tier): add mutation peer fanout helpers

### DIFF
--- a/crates/ecstore/src/services/notification_sys.rs
+++ b/crates/ecstore/src/services/notification_sys.rs
@@ -21,6 +21,7 @@ use crate::runtime::sources as runtime_sources;
 use crate::services::metrics_realtime::{CollectMetricsOpts, MetricType};
 use crate::services::rebalance::RebalSaveOpt;
 use crate::storage_api_contracts::admin::StorageAdminApi;
+use bytes::Bytes;
 use futures::future::join_all;
 use lazy_static::lazy_static;
 use rustfs_madmin::health::{Cpus, MemInfo, OsInfo, Partitions, ProcInfo, SysConfig, SysErrors, SysServices};
@@ -35,6 +36,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
 /// After this many consecutive admin-call failures, mark the peer as offline.
 const CONSECUTIVE_FAILURE_THRESHOLD: u32 = 3;
@@ -111,6 +113,17 @@ impl NotificationSys {
 pub struct NotificationPeerErr {
     pub host: String,
     pub err: Option<Error>,
+}
+
+fn notification_peer_result<T>(host: String, result: Result<T>) -> NotificationPeerErr {
+    NotificationPeerErr { host, err: result.err() }
+}
+
+fn unreachable_notification_peer_err() -> NotificationPeerErr {
+    NotificationPeerErr {
+        host: String::new(),
+        err: Some(Error::other("peer is not reachable")),
+    }
 }
 
 impl NotificationSys {
@@ -1070,6 +1083,50 @@ impl NotificationSys {
         }
         join_all(futures).await
     }
+
+    pub async fn prepare_tier_mutation(&self, mutation_id: Uuid, canonical_payload: Bytes) -> Vec<NotificationPeerErr> {
+        let mut futures = Vec::with_capacity(self.peer_clients.len());
+        for client in self.peer_clients.iter().cloned() {
+            let payload = canonical_payload.clone();
+            futures.push(async move {
+                if let Some(client) = client {
+                    notification_peer_result(client.host.to_string(), client.prepare_tier_mutation(mutation_id, payload).await)
+                } else {
+                    unreachable_notification_peer_err()
+                }
+            });
+        }
+        join_all(futures).await
+    }
+
+    pub async fn commit_tier_mutation(&self, mutation_id: Uuid, canonical_payload: Bytes) -> Vec<NotificationPeerErr> {
+        let mut futures = Vec::with_capacity(self.peer_clients.len());
+        for client in self.peer_clients.iter().cloned() {
+            let payload = canonical_payload.clone();
+            futures.push(async move {
+                if let Some(client) = client {
+                    notification_peer_result(client.host.to_string(), client.commit_tier_mutation(mutation_id, payload).await)
+                } else {
+                    unreachable_notification_peer_err()
+                }
+            });
+        }
+        join_all(futures).await
+    }
+
+    pub async fn abort_tier_mutation(&self, mutation_id: Uuid) -> Vec<NotificationPeerErr> {
+        let mut futures = Vec::with_capacity(self.peer_clients.len());
+        for client in self.peer_clients.iter().cloned() {
+            futures.push(async move {
+                if let Some(client) = client {
+                    notification_peer_result(client.host.to_string(), client.abort_tier_mutation(mutation_id).await)
+                } else {
+                    unreachable_notification_peer_err()
+                }
+            });
+        }
+        join_all(futures).await
+    }
 }
 
 async fn scanner_activity_with_timeout<F>(timeout_duration: Duration, host: &str, activity: F) -> Result<ScannerPeerActivity>
@@ -1724,6 +1781,36 @@ mod tests {
         assert!(results[0].host.is_empty());
         assert!(results[0].err.is_some());
         assert!(results[0].err.as_ref().unwrap().to_string().contains("peer is not reachable"));
+    }
+
+    #[tokio::test]
+    async fn tier_mutation_fanout_reports_unreachable_peers_fail_closed() {
+        let sys = NotificationSys {
+            peer_clients: vec![None],
+            all_peer_clients: Vec::new(),
+            peer_admin_caches: vec![Mutex::new(PeerAdminCache::new())],
+        };
+        let mutation_id = Uuid::from_u128(1);
+
+        let prepare = sys.prepare_tier_mutation(mutation_id, Bytes::from_static(b"prepare")).await;
+        assert_eq!(prepare.len(), 1);
+        assert!(prepare[0].host.is_empty());
+        assert!(
+            prepare[0]
+                .err
+                .as_ref()
+                .expect("unreachable prepare peer should carry an error")
+                .to_string()
+                .contains("peer is not reachable")
+        );
+
+        let commit = sys.commit_tier_mutation(mutation_id, Bytes::from_static(b"commit")).await;
+        assert_eq!(commit.len(), 1);
+        assert!(commit[0].err.is_some());
+
+        let abort = sys.abort_tier_mutation(mutation_id).await;
+        assert_eq!(abort.len(), 1);
+        assert!(abort[0].err.is_some());
     }
 
     // --- Tests for handle_peer_failure / handle_server_info_failure caching ---


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1328
Refs rustfs/backlog#1357

## Summary of Changes

Adds `NotificationSys` tier mutation prepare, commit, and abort fanout helpers on top of the peer mutation control client merged in #5096. The helpers concurrently call remote peer clients and report unreachable peers as explicit `NotificationPeerErr` values, giving the future coordinator prepare/commit/abort flow a fail-closed aggregation boundary before config CAS.

This PR intentionally does not wire the helpers into the production tier config mutation coordinator yet. It keeps the boundary narrow so coordinator transaction ordering, crash recovery, old-peer activation gating, and mixed-version behavior can land in later reviewable slices without treating them as already complete.

## Verification

- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `CARGO_TARGET_DIR=/private/tmp/rustfs-1357-recovery-v2-target cargo test -p rustfs-ecstore tier_mutation_fanout_reports_unreachable_peers_fail_closed -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/rustfs-1357-recovery-v2-target cargo check -p rustfs-ecstore --all-targets`
- `CARGO_TARGET_DIR=/private/tmp/rustfs-1357-recovery-v2-target cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`
- `make pre-commit`

## Impact

No public S3 API, public Rust API, protobuf schema, on-wire RPC method, configuration format, or `xl.meta` behavior changes. This is internal control-plane fanout plumbing only, and it remains dormant until a later coordinator integration slice calls it.

## Additional Notes

Adversarial validation summary: correctness attacked unreachable and missing peers and found they fail closed as explicit peer errors; simplicity attacked duplicated result mapping and the repeated branches were factored into local helpers; security attacked RPC auth bypass and found no new auth surface because calls delegate to the signed/proof-verified `PeerRestClient` methods; concurrency/durability attacked lock and await placement and found no new locks or durable state transitions in this helper-only slice; compatibility attacked API and wire changes and found none; performance attacked per-object hot paths and found this is bounded control-plane peer fanout only; coverage attacked the revert case for unreachable peer handling and `tier_mutation_fanout_reports_unreachable_peers_fail_closed` covers it.

Remaining #1357 work: production coordinator prepare/commit/abort orchestration, durable coordinator crash recovery, old-peer fail-closed activation/capability gating, mixed-version deterministic matrix, and live multi-node failure injection are still out of scope for this PR.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
