### PR TITLE
fix(ecstore): stop logging not-found listing quorum miss at error

### DIFF
--- a/crates/ecstore/src/cache_value/metacache_set.rs
+++ b/crates/ecstore/src/cache_value/metacache_set.rs
@@ -124,6 +124,24 @@ fn classify_listing_quorum_failure(errors: &[DiskError]) -> DiskError {
     DiskError::ErasureReadQuorum
 }
 
+/// Returns true when a metacache listing missed quorum purely because the
+/// volume or path is absent on a quorum of drives, i.e. every recorded failure
+/// is [`DiskError::VolumeNotFound`] or [`DiskError::FileNotFound`].
+///
+/// This is a benign, expected outcome: the caller is handed
+/// `VolumeNotFound`/`FileNotFound` and decides how to react. The most common
+/// trigger is a startup race where the system bucket has not yet been created
+/// on every drive when an early reader (e.g. the IAM config loader) lists it.
+/// It must be distinguished from a listing that failed for a real reason (I/O,
+/// timeout, corruption) so the former is not surfaced at `error`. See
+/// rustfs/rustfs#5076.
+fn is_benign_not_found_listing_failure(errors: &[DiskError]) -> bool {
+    !errors.is_empty()
+        && errors
+            .iter()
+            .all(|err| matches!(err, DiskError::VolumeNotFound | DiskError::FileNotFound))
+}
+
 struct PublishedBytesWriter<W> {
     inner: W,
     published: bool,
@@ -840,17 +858,38 @@ async fn list_path_raw_inner(
                     _ => {}
                 });
 
-                error!(
-                    event = EVENT_METACACHE_LISTING,
-                    component = LOG_COMPONENT_ECSTORE,
-                    subsystem = LOG_SUBSYSTEM_METACACHE,
-                    bucket = %opts.bucket,
-                    path = %opts.path,
-                    state = "quorum_failed",
-                    error = %combined_err.join(", "),
-                    "Metacache listing quorum failed"
-                );
                 let failures = errs.iter().flatten().cloned().collect::<Vec<_>>();
+                // A listing that misses quorum purely because the volume/path is
+                // absent on a quorum of drives is benign and expected — the caller
+                // receives VolumeNotFound/FileNotFound and decides how to react.
+                // The common trigger is a startup race where the system bucket is
+                // not yet created on every drive when an early reader (e.g. the IAM
+                // config loader) lists it, so surfacing it at `error` is misleading
+                // noise (rustfs/rustfs#5076). Keep `error` for listings that failed
+                // for a real reason (I/O, timeout, corruption).
+                if is_benign_not_found_listing_failure(&failures) {
+                    debug!(
+                        event = EVENT_METACACHE_LISTING,
+                        component = LOG_COMPONENT_ECSTORE,
+                        subsystem = LOG_SUBSYSTEM_METACACHE,
+                        bucket = %opts.bucket,
+                        path = %opts.path,
+                        state = "quorum_not_found",
+                        error = %combined_err.join(", "),
+                        "Metacache listing quorum not reached (volume/path absent)"
+                    );
+                } else {
+                    error!(
+                        event = EVENT_METACACHE_LISTING,
+                        component = LOG_COMPONENT_ECSTORE,
+                        subsystem = LOG_SUBSYSTEM_METACACHE,
+                        bucket = %opts.bucket,
+                        path = %opts.path,
+                        state = "quorum_failed",
+                        error = %combined_err.join(", "),
+                        "Metacache listing quorum failed"
+                    );
+                }
                 return Err(classify_listing_quorum_failure(&failures));
             }
 
@@ -1036,6 +1075,21 @@ mod tests {
     use std::sync::Mutex;
     use time::OffsetDateTime;
     use uuid::Uuid;
+
+    #[test]
+    fn benign_not_found_listing_failure_detection() {
+        // Pure not-found quorum misses are benign (the volume/path simply does
+        // not exist on a quorum of drives) and must not be logged at ERROR.
+        assert!(is_benign_not_found_listing_failure(&[DiskError::VolumeNotFound]));
+        assert!(is_benign_not_found_listing_failure(
+            &[DiskError::VolumeNotFound, DiskError::FileNotFound,]
+        ));
+        // No recorded failure is not a not-found case.
+        assert!(!is_benign_not_found_listing_failure(&[]));
+        // Any real error must keep the failure at ERROR severity.
+        assert!(!is_benign_not_found_listing_failure(&[DiskError::VolumeNotFound, DiskError::Timeout,]));
+        assert!(!is_benign_not_found_listing_failure(&[DiskError::DiskNotFound]));
+    }
 
     #[tokio::test]
     async fn list_path_raw_empty_disks_returns_read_quorum() {


### PR DESCRIPTION
## Related Issues

Refs rustfs/rustfs#5076

## Summary of Changes

A metacache listing that misses read quorum *purely because the volume or path is absent on a quorum of drives* — every drive reports `VolumeNotFound` / `FileNotFound` — is a benign, expected outcome: `list_path_raw` already hands the caller `VolumeNotFound`/`FileNotFound` and lets it decide how to react. Today that case is logged at `error` as `"Metacache listing quorum failed"`, indistinguishable from a genuine failure.

The most common trigger is a startup race: before the system bucket (`.rustfs.sys`) has been created on every drive, an early reader such as the IAM config loader lists `config/iam/`, and a quorum of drives legitimately report "volume not found". That prints a scary `ERROR` during normal boot which self-heals moments later. In #5076 it led a user to treat this benign startup noise as the cause of unrelated upload failures.

This change:

- adds `is_benign_not_found_listing_failure()`, true only when every recorded drive failure is `VolumeNotFound` or `FileNotFound`;
- demotes that pure not-found quorum miss to `debug` (new `state = "quorum_not_found"`), while keeping the existing `error` + `state = "quorum_failed"` for any listing that failed for a real reason (I/O, timeout, corruption);
- adds a unit test for the classifier.

Control flow and the returned error are unchanged: `classify_listing_quorum_failure` already returns `VolumeNotFound`/`FileNotFound` for the all-not-found case, so only the log severity changes. The result is that a not-found quorum miss no longer logs at `error` regardless of whether the condition surfaced via the peek path (already silent, via the `vnf`/`fnf` counters) or the producer-error path (previously `error`).

## Verification

- `make pre-commit` — fmt + arch checks + logging guardrails + quick-check
- `cargo test -p rustfs-ecstore --lib benign_not_found_listing_failure_detection` — pass
- Reproduced on a fresh single-pool 6-disk instance (the #5076 configuration): the `config/iam` quorum message appears once during init and then uploads of every size and type succeed with correct object sizes. This confirmed the message is benign init-race noise rather than an upload fault.

## Impact

- Log-only change. No API, storage format, wire, or configuration impact; return values and control flow are identical.
- Operators alerting on `state = "quorum_failed"` for `.minio.sys` / `config` paths during startup will no longer see it; the benign case is now `state = "quorum_not_found"` at `debug`. Genuine quorum failures continue to log at `error` unchanged.

## Additional Notes

The broader investigation behind #5076 found no server-side upload defect for single-pool 6-disk erasure sets — direct uploads (all sizes, plain and aws-chunked streaming signatures, concurrent multipart, and slow/stalled bodies) all succeed — so the reported failures point to the reporter's reverse-proxy / client path. This PR only removes the misleading log that made self-diagnosis harder; the reverse-proxy angle is being followed up separately with the reporter.
