### PR TITLE
test(tier): fix uring test build fake peer

### DIFF
--- a/crates/ecstore/src/services/tier/tier.rs
+++ b/crates/ecstore/src/services/tier/tier.rs
@@ -5811,8 +5811,8 @@ mod tests {
             let calls = Arc::new(Mutex::new(Vec::new()));
             let handle = TierConfigMgr::new();
 
-            let err = TIER_MUTATION_TEST_COMMIT_PEERS
-                .scope(vec![FakeTierMutationCommitPeer::boxed("peer-a", calls.clone(), Err(peer_error))], async {
+            let err = TIER_MUTATION_TEST_PEERS
+                .scope(vec![FakeTierMutationPeer::boxed("peer-a", calls.clone(), Err(peer_error))], async {
                     TierConfigMgr::reload_handle_with(&handle, store.clone()).await
                 })
                 .await


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1357

Follow-up to #5122.

## Summary of Changes
This PR fixes the post-merge `io_uring Integration (real)` test-build failure on #5122 by pointing the mixed-version replay regression test back at the existing `TierMutationPeer` test task-local and fake peer helper.

The change is test-only and does not alter production tier mutation, peer fanout, RPC, fencing, or recovery behavior.

## Verification
- `cargo test -p rustfs-ecstore uring_ --no-run`
- `cargo test -p rustfs-ecstore committed_replay_mixed_version_peer_matrix_fails_before_local_publish`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
No user-facing API, wire-format, on-disk-format, deployment, or configuration impact. This only restores the ecstore lib test build for the io_uring CI leg.

## Additional Notes
Adversarial validation: correctness checked that the selected fake peer preserves the same commit-recording behavior asserted by the test; simplicity checked that the two-name replacement is the minimal fix; coverage checked that reverting this hunk reproduces the `E0425`/`E0433` build failure under `cargo test -p rustfs-ecstore uring_ --no-run`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
