### PR TITLE
fix(ecstore): cap mmap-copy shard reads to stop large single-part GET OOM

### DIFF
--- a/crates/config/src/constants/zero_copy.rs
+++ b/crates/config/src/constants/zero_copy.rs
@@ -56,3 +56,33 @@ pub const DEFAULT_OBJECT_MMAP_READ_ENABLE: bool = true;
 ///
 /// Prefer [`DEFAULT_OBJECT_MMAP_READ_ENABLE`].
 pub const DEFAULT_OBJECT_ZERO_COPY_ENABLE: bool = DEFAULT_OBJECT_MMAP_READ_ENABLE;
+
+/// Environment variable capping the byte length a single mmap-copy read may
+/// materialize in memory.
+///
+/// The mmap-copy read path returns the whole requested range as one owned
+/// allocation before the first byte is served. GET/heal shard reads request
+/// the entire part span in one call, so for a large single-part object
+/// (e.g. a multi-gigabyte non-multipart upload) an uncapped mmap-copy read
+/// allocates the whole shard in memory — stalling first-byte latency past the
+/// disk-read timeout and OOM-killing memory-limited deployments
+/// (<https://github.com/rustfs/rustfs/issues/5123>). Reads longer than this
+/// cap fall back to the bounded streaming reader instead.
+///
+/// - Purpose: Bound per-shard-read memory for mmap-based reads
+/// - Acceptable values: byte count as an unsigned integer; `0` disables
+///   mmap-copy for all non-empty reads (every read streams)
+/// - Example: `export RUSTFS_OBJECT_MMAP_READ_MAX_LENGTH=8388608`
+pub const ENV_OBJECT_MMAP_READ_MAX_LENGTH: &str = "RUSTFS_OBJECT_MMAP_READ_MAX_LENGTH";
+
+/// Default mmap-copy read length cap: 32 MiB per shard read.
+///
+/// Large enough that typical multipart part shards (parts up to a few hundred
+/// megabytes across the erasure set) keep the mmap fast path, small enough
+/// that whole-part reads of huge single-part objects stream instead of
+/// materializing gigabytes per shard.
+///
+/// The cap bounds memory per shard reader, so a single part read can still
+/// materialize up to `data_shards x cap` bytes; raising the cap raises that
+/// per-request bound proportionally.
+pub const DEFAULT_OBJECT_MMAP_READ_MAX_LENGTH: usize = 32 * 1024 * 1024;

--- a/crates/ecstore/src/io_support/bitrot.rs
+++ b/crates/ecstore/src/io_support/bitrot.rs
@@ -22,7 +22,10 @@ use crate::diagnostics::get::{
 use crate::disk::{self, DiskAPI as _, DiskStore, FileReader, MmapCopyStageMetrics, error::DiskError};
 use crate::erasure::coding::{BitrotReader, BitrotWriterWrapper, CustomWriter};
 use bytes::Bytes;
-use rustfs_config::{DEFAULT_OBJECT_MMAP_READ_ENABLE, ENV_OBJECT_MMAP_READ_ENABLE, ENV_OBJECT_ZERO_COPY_ENABLE};
+use rustfs_config::{
+    DEFAULT_OBJECT_MMAP_READ_ENABLE, DEFAULT_OBJECT_MMAP_READ_MAX_LENGTH, ENV_OBJECT_MMAP_READ_ENABLE,
+    ENV_OBJECT_MMAP_READ_MAX_LENGTH, ENV_OBJECT_ZERO_COPY_ENABLE,
+};
 use rustfs_utils::HashAlgorithm;
 use std::future::Future;
 use std::io::{self, Cursor};
@@ -79,6 +82,21 @@ pub(crate) fn object_mmap_read_enabled() -> bool {
         &[ENV_OBJECT_ZERO_COPY_ENABLE],
         DEFAULT_OBJECT_MMAP_READ_ENABLE,
     )
+}
+
+/// Mmap-copy read length cap. Cached: this is consulted on every shard open
+/// and `std::env::var` takes a process-global lock. In test builds the env
+/// var is read directly so `temp_env` overrides take effect.
+pub(crate) fn object_mmap_read_max_length() -> usize {
+    #[cfg(test)]
+    {
+        rustfs_utils::get_env_usize(ENV_OBJECT_MMAP_READ_MAX_LENGTH, DEFAULT_OBJECT_MMAP_READ_MAX_LENGTH)
+    }
+    #[cfg(not(test))]
+    {
+        static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        *CACHED.get_or_init(|| rustfs_utils::get_env_usize(ENV_OBJECT_MMAP_READ_MAX_LENGTH, DEFAULT_OBJECT_MMAP_READ_MAX_LENGTH))
+    }
 }
 
 #[derive(Clone)]
@@ -305,7 +323,28 @@ async fn open_disk_reader(
     let metrics_path = metrics_path.filter(|_| rustfs_io_metrics::get_stage_metrics_enabled());
     let stage_metrics_enabled = metrics_path.is_some();
 
-    if use_mmap_read && disk.is_local() {
+    // Mmap-copy materializes the whole `offset..offset+length` range as one
+    // owned allocation before any byte is served, and GET/heal shard reads
+    // request the entire part span in one call. Over-cap reads (e.g. a huge
+    // single-part object, rustfs#5123) take the bounded streaming path below.
+    let use_mmap_copy = if use_mmap_read && disk.is_local() {
+        let mmap_read_cap = object_mmap_read_max_length();
+        let within_cap = length <= mmap_read_cap;
+        if !within_cap {
+            rustfs_io_metrics::record_zero_copy_fallback("read_length_exceeds_cap");
+            debug!(
+                length,
+                mmap_read_cap,
+                path = %path,
+                "zero_copy_read_skipped_over_cap"
+            );
+        }
+        within_cap
+    } else {
+        false
+    };
+
+    if use_mmap_copy {
         let start = stage_metrics_enabled.then(Instant::now);
         let zero_copy_start = Instant::now();
         let mmap_metrics = metrics_path.map(|metrics_path| MmapCopyStageMetrics {
@@ -683,6 +722,96 @@ mod tests {
                 assert!(object_mmap_read_enabled());
             },
         );
+    }
+
+    #[test]
+    fn object_mmap_read_max_length_defaults_and_env_override() {
+        temp_env::with_var(ENV_OBJECT_MMAP_READ_MAX_LENGTH, None::<&str>, || {
+            assert_eq!(object_mmap_read_max_length(), DEFAULT_OBJECT_MMAP_READ_MAX_LENGTH);
+        });
+        temp_env::with_var(ENV_OBJECT_MMAP_READ_MAX_LENGTH, Some("1024"), || {
+            assert_eq!(object_mmap_read_max_length(), 1024);
+        });
+        temp_env::with_var(ENV_OBJECT_MMAP_READ_MAX_LENGTH, Some("0"), || {
+            assert_eq!(object_mmap_read_max_length(), 0);
+        });
+    }
+
+    // rustfs#5123: whole-part shard reads of large single-part objects must not
+    // be materialized in memory by the mmap-copy path; over-cap reads stream.
+    #[tokio::test]
+    async fn open_disk_reader_streams_when_length_exceeds_mmap_cap() {
+        use crate::disk::endpoint::Endpoint;
+        use crate::disk::{DiskOption, new_disk};
+        use tokio::io::AsyncReadExt;
+
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let mut endpoint =
+            Endpoint::try_from(dir.path().to_str().expect("tempdir path should be utf8")).expect("endpoint should parse");
+        endpoint.set_pool_index(0);
+        endpoint.set_set_index(0);
+        endpoint.set_disk_index(0);
+        let disk = new_disk(
+            &endpoint,
+            &DiskOption {
+                cleanup: false,
+                health_check: false,
+            },
+        )
+        .await
+        .expect("local disk should be created");
+
+        let payload = vec![7u8; 4096];
+        disk.make_volume("test-bucket").await.expect("volume should be created");
+        disk.write_all("test-bucket", "obj/part.1", Bytes::from(payload.clone()))
+            .await
+            .expect("shard file should be written");
+
+        temp_env::async_with_vars([(ENV_OBJECT_MMAP_READ_MAX_LENGTH, Some("1024"))], async {
+            let over_cap = open_disk_reader(&disk, "test-bucket", "obj/part.1", 0, payload.len(), true, None)
+                .await
+                .expect("over-cap read should open");
+            assert!(
+                matches!(over_cap, ShardReader::Stream(_)),
+                "read longer than the mmap cap must take the streaming path"
+            );
+            let mut over_cap = over_cap;
+            let mut streamed = Vec::new();
+            over_cap
+                .read_to_end(&mut streamed)
+                .await
+                .expect("streaming fallback should read the range");
+            assert_eq!(streamed, payload, "streaming fallback must return the same bytes");
+
+            let under_cap = open_disk_reader(&disk, "test-bucket", "obj/part.1", 0, 512, true, None)
+                .await
+                .expect("under-cap read should open");
+            assert!(
+                matches!(under_cap, ShardReader::InMemory(_)),
+                "read within the mmap cap keeps the mmap-copy fast path"
+            );
+
+            let at_cap = open_disk_reader(&disk, "test-bucket", "obj/part.1", 0, 1024, true, None)
+                .await
+                .expect("at-cap read should open");
+            assert!(
+                matches!(at_cap, ShardReader::InMemory(_)),
+                "read of exactly the mmap cap keeps the mmap-copy fast path"
+            );
+        })
+        .await;
+
+        // Cap of 0 disables mmap-copy for every non-empty read.
+        temp_env::async_with_vars([(ENV_OBJECT_MMAP_READ_MAX_LENGTH, Some("0"))], async {
+            let disabled = open_disk_reader(&disk, "test-bucket", "obj/part.1", 0, 512, true, None)
+                .await
+                .expect("read with cap 0 should open");
+            assert!(
+                matches!(disabled, ShardReader::Stream(_)),
+                "cap 0 must route every non-empty read to the streaming path"
+            );
+        })
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Fixes #5123.

Downloading a large single-part object (e.g. a 70GB non-multipart upload) blows up memory and OOM-kills the process. Two symptoms from the report, one root cause:

- GET/heal shard reads request the **entire part span** in a single `open_disk_reader` call, and on local disks with mmap reads enabled (`RUSTFS_OBJECT_MMAP_READ_ENABLE`, default `true`) that call materializes the whole `(offset, length)` range as one owned `Bytes` via `read_file_mmap_copy` before the first byte is served.
- The whole-range materialization runs inside the first stripe read's disk-read timeout window, which is why the reporter hit the 10s `RUSTFS_OBJECT_DISK_READ_TIMEOUT` default and saw a ~20s first-byte stall after raising it — and then OOM on a 4GB-limit pod.

`v1.0.0-beta.10` and `main` share this behavior.

## Fix

Cap the mmap-copy path at a new `RUSTFS_OBJECT_MMAP_READ_MAX_LENGTH` (default **32MiB per shard read**; `0` disables mmap-copy for all non-empty reads). Over-cap reads fall back to `read_file_stream` — the bounded streaming reader that remote disks, mmap error fallbacks, and deferred parity readers already use — so decode pulls block-by-block under duplex backpressure and per-block disk-read timeouts, keeping memory bounded regardless of object size and fixing time-to-first-byte.

Default rationale: mainstream multipart clients (aws cli 8MB, boto3 8MB, mc 16MiB+, s3cmd 15MB parts) never cross the cap on any EC layout, so the mmap fast path is preserved for the common case; the main population that crosses it is exactly the pathological one (huge single-part objects on small erasure sets). Worst-case per-part materialized memory becomes `data_shards × cap`. The cap is `OnceLock`-cached on non-test builds (consulted per shard open; matches the GET flag caching convention), read directly in test builds so `temp_env` overrides apply.

The single choke point covers GET (legacy duplex and codec streaming), heal, and deferred parity readers — all shard opens flow through `open_disk_reader`.

## Verification

- `cargo test -p rustfs-ecstore --lib io_support::bitrot` — 15 pass, including new tests: cap default/override/zero wiring, and a real-local-disk test asserting over-cap → `ShardReader::Stream` with byte-identical content, under-cap and exactly-at-cap → `InMemory`, cap=0 → `Stream`.
- `cargo test -p rustfs-ecstore --lib set_disk::read` — 131 pass.
- `cargo clippy -p rustfs-config -p rustfs-ecstore --all-targets` clean; `make pre-commit` (fmt + arch checks + workspace quick-check) passes.
- Adversarial validation (all seven roles, high-risk tier) run over the final diff:
  - **Correctness**: empirical byte-equivalence of Stream vs InMemory through full bitrot decode at non-zero offsets; `try_take_block` returning `None` for `Stream` falls through to the verified scratch path; no whole-stream timeout exists (per-block budgets only). No break.
  - **Concurrency/durability**: streaming fd path bypasses the cached-fd pool, so `invalidate_cached_fd` contracts are unaffected; per-stripe timeouts and duplex backpressure confirmed — memory stays bounded under a slow client (the reporter's Traefik case). No break.
  - **Compatibility**: legacy whole-file bitrot verification never routes through `open_disk_reader`; streaming shard sources are the long-exercised remote-disk norm; no wire/on-disk format change. No break.
  - **Security**: cap gates the only `read_file_mmap_copy` call site (remote-disk impl unreachable from it); heal covered by the same choke point; garbage env values fall back to the default. No break.
  - **Performance**: env read cached per review; over-cap streaming penalty quantified as bounded (~2× CPU warm-cache for reads just over the cap, disk-time dominated when cold, strictly better first-byte latency); logging/metrics added at established frequency and label cardinality.
  - **Simplicity / test-coverage**: findings (exact-boundary and cap=0 tests) folded into the diff.