### PR TITLE
docs(testing): record GHSA-5354 and GHSA-3ppv regression guards

### DIFF
--- a/docs/testing/security-regressions.md
+++ b/docs/testing/security-regressions.md
@@ -21,6 +21,8 @@ forced to update its pinned test (red -> green).
 | [GHSA-3p3x-734c-h5vx](https://github.com/rustfs/rustfs/security/advisories/GHSA-3p3x-734c-h5vx) | Constant-time secret comparison on WebDAV/FTPS password login | rustfs/rustfs#4403 | `assert_ftps_ghsa_3p3x_wrong_credentials_rejected` (`crates/e2e_test/src/protocols/ftps_core.rs`); `GHSA-3p3x` auth-failure block in `test_webdav_core_operations` (`crates/e2e_test/src/protocols/webdav_core.rs`) | e2e (protocols suite) |
 | [GHSA-r5qv-rc46-hv8q](https://github.com/rustfs/rustfs/security/advisories/GHSA-r5qv-rc46-hv8q) | Internode RPC authentication must fail closed | rustfs/rustfs#4402 | `ghsa_r5qv_resolve_shared_secret_rejects_default_fallback`, `ghsa_r5qv_verify_rpc_signature_fails_closed_on_missing_or_invalid_auth` (`crates/ecstore/src/cluster/rpc/http_auth.rs`) | unit |
 | [GHSA-m77q-r63m-pj89](https://github.com/rustfs/rustfs/security/advisories/GHSA-m77q-r63m-pj89) | STS JWTs signed with shared root secret (intentionally unfixed) | n/a | `test_ghsa_m77q_sts_session_token_signed_with_root_secret` (flow-level pin: signing key == root secret, root-only decode, authorizes) and `test_created_sts_credentials_authorize_with_session_token_claims` (`crates/iam/src/sys.rs`); `token_signing_key` doc (`crates/iam/src/root_credentials.rs`) — pin current by-design behavior; fixing m77q must update red -> green | unit |
+| [GHSA-5354-r3w2-34m8](https://github.com/rustfs/rustfs/security/advisories/GHSA-5354-r3w2-34m8) | Service-account parent must stay within caller scope — a non-owner holding `CreateServiceAccountAdminAction` could parent a service account to the root credential and authenticate as owner | rustfs/rustfs#5141 | `ghsa_5354_non_owner_service_account_parent_confined_to_scope` and the `add_service_account_parent_within_scope` invariant it pins (`rustfs/src/admin/handlers/service_account.rs`) | unit |
+| [GHSA-3ppv-fx5m-m749](https://github.com/rustfs/rustfs/security/advisories/GHSA-3ppv-fx5m-m749) | Versioned object reads must be authorized against `s3:GetObjectVersion`, not `s3:GetObject` (`get_object`, CopyObject source, UploadPartCopy source) | rustfs/rustfs#5142 | `ghsa_3ppv_versioned_read_selects_get_object_version_action` and the `versioned_read_action` helper it pins (`rustfs/src/storage/access.rs`) | unit |
 
 ## Where these run (CI-execution map)
 
@@ -28,11 +30,13 @@ Every security regression must land where CI actually runs it — a named test i
 an unexecuted suite is theater. The suites split across three execution paths by
 topology:
 
-- **Unit tests** — `ghsa_r5qv_*` (`crates/ecstore`) and the GHSA-m77q STS
-  pinning (`crates/iam`) run automatically in the default CI pass
+- **Unit tests** — `ghsa_r5qv_*` (`crates/ecstore`), the GHSA-m77q STS
+  pinning (`crates/iam`), and `ghsa_5354_*` / `ghsa_3ppv_*` (`rustfs` lib) run
+  automatically in the default CI pass
   (`cargo nextest run --profile ci --all --exclude e2e_test`) — no special
-  wiring. This is the CI-executed regression for the RPC fail-closed (r5qv) and
-  STS-signing (m77q) advisories.
+  wiring. This is the CI-executed regression for the RPC fail-closed (r5qv),
+  STS-signing (m77q), service-account parent-scope (5354), and versioned-read
+  authorization (3ppv) advisories.
 - **S3-API negative-auth e2e (e2e-smoke, PR-gated)** — the attacker-facing S3
   auth-rejection suites run on every PR via the `e2e-smoke` nextest profile
   (`.config/nextest.toml`), which each spawns its own server on a random port


### PR DESCRIPTION
## What

PRs #5141 (GHSA-5354, service-account parent-scope enforcement) and #5142 (GHSA-3ppv, versioned object-read authorization) landed the code fixes and named regression tests, but neither added the advisories to `docs/testing/security-regressions.md`. Repo policy is that every fixed GHSA maps to at least one named, discoverable regression test recorded in that inventory; these two were missing.

## Change

- Add two rows to the advisory -> test mapping:
  - **GHSA-5354-r3w2-34m8** -> #5141 -> `ghsa_5354_non_owner_service_account_parent_confined_to_scope` / `add_service_account_parent_within_scope` (`rustfs/src/admin/handlers/service_account.rs`).
  - **GHSA-3ppv-fx5m-m749** -> #5142 -> `ghsa_3ppv_versioned_read_selects_get_object_version_action` / `versioned_read_action` (`rustfs/src/storage/access.rs`).
- Extend the CI-execution map so both `ghsa_5354_*` and `ghsa_3ppv_*` are listed under the default unit-test pass. Both tests live in the `rustfs` lib target and run in `cargo nextest run --profile ci --all --exclude e2e_test`, so no extra CI wiring is needed.

## Verification

- Test names and helper symbols confirmed present in the merged fix commits (9866f68d8, 816656170).
- `bash scripts/check_doc_paths.sh` passes.

Docs-only; no code changes.