### PR TITLE
chore(release): bump version to 1.0.0-beta.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3648,7 +3648,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8959,7 +8959,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8981,7 +8981,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -8996,7 +8996,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "chrono",
  "metrics",
@@ -9011,7 +9011,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "insta",
  "rustfs-io-core",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "const-str",
  "serde",
@@ -9032,7 +9032,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9045,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9065,7 +9065,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -9076,7 +9076,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9211,7 +9211,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9246,7 +9246,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9276,7 +9276,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9313,7 +9313,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "bytes",
  "memmap2",
@@ -9325,7 +9325,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "criterion",
  "metrics",
@@ -9388,7 +9388,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "bytes",
  "futures",
@@ -9414,7 +9414,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9445,7 +9445,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "proptest",
@@ -9465,7 +9465,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "chrono",
  "flate2",
@@ -9504,7 +9504,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "chrono",
  "humantime",
@@ -9518,7 +9518,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9552,7 +9552,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "criterion",
  "futures",
@@ -9570,7 +9570,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "bytes",
  "criterion",
@@ -9586,7 +9586,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9638,7 +9638,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9667,7 +9667,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -9726,7 +9726,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "flatbuffers",
  "prost 0.14.4",
@@ -9748,7 +9748,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "byteorder",
  "bytes",
@@ -9765,7 +9765,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9803,7 +9803,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -9825,14 +9825,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "rustfs-s3-types",
 ]
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -9840,7 +9840,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9868,7 +9868,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9884,7 +9884,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9916,14 +9916,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9939,7 +9939,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "insta",
@@ -9953,7 +9953,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10006,7 +10006,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "rustfs-data-usage",
  "rustfs-ecstore",
@@ -10021,7 +10021,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "arc-swap",
  "metrics",
@@ -10041,7 +10041,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -10077,7 +10077,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10117,7 +10117,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.96.0"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -86,52 +86,52 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.10" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.10" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.10" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.10" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.10" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.10" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.10" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.10" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.10" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.10" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.10" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.10" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.10" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.10" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.10" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.10" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.10" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.10" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.10" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.10" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.10" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.10" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.10" }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-beta.10" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.10" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.10" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.10" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.10" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.10" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.10" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.10" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.10" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.10" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.10" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.10" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.10" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.10" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.10" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.10" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.10" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.10" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.10" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.10" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.10" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.10" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.10" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.11" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.11" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.11" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.11" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.11" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.11" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.11" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.11" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.11" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.11" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.11" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.11" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.11" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.11" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.11" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.11" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.11" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.11" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.11" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.11" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.11" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.11" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.11" }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-beta.11" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.11" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.11" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.11" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.11" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.11" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.11" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.11" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.11" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.11" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.11" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.11" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.11" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.11" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.11" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.11" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.11" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.11" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.11" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.11" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.11" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.11" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.11" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.11
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.10
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.11
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.10";
+            version = "1.0.0-beta.11";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.10.0"
-appVersion: "1.0.0-beta.10"
+version: "0.11.0"
+appVersion: "1.0.0-beta.11"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease beta.10
+%global prerelease beta.11
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.10
+Release:        beta.11
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Thu Jul 23 2026 overtrue <anzhengchao@gmail.com>
+- Update RPM package to RustFS 1.0.0-beta.11
+
 * Fri Jul 17 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.10
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Prepare the `1.0.0-beta.11` release: bump the workspace version and all internal workspace crate dependency versions in `Cargo.toml`/`Cargo.lock`, and align release assets (README Docker examples, `flake.nix`, Helm chart `0.11.0`/`appVersion 1.0.0-beta.11`, `rustfs.spec` release suffix and changelog entry).

Version files are bumped directly to the final target version per the release pipeline; preview identifiers exist only as tag names and never appear in version files.

## Verification

- `cargo fmt --all` / `cargo fmt --all --check`
- `make pre-commit`
- `rg -n "beta\.10"` over release files shows no leftovers outside historical `rustfs.spec` changelog entries

## Impact

Release metadata only; no code behavior changes. Docker docs now reference `rustfs/rustfs:1.0.0-beta.11`, Helm chart version follows the `beta.N -> 0.N.0` mapping.

## Additional Notes

Release will be validated via a `1.0.0-beta.11-preview.1` tag before the final `1.0.0-beta.11` tag is published on the same commit.
