### PR TITLE
fix(security): redact OIDC secrets from logs and errors

### DIFF
--- a/crates/iam/src/oidc.rs
+++ b/crates/iam/src/oidc.rs
@@ -172,19 +172,29 @@ pub fn oidc_plugin_authn_metrics_snapshot() -> OidcPluginAuthnMetricsSnapshot {
     OIDC_PLUGIN_AUTHN_METRICS.snapshot()
 }
 
+/// Header names whose values may carry OIDC secrets (client credentials, cookies,
+/// bearer tokens). Their values are never emitted to logs, only their byte length.
+const SENSITIVE_HEADER_NAMES: [&str; 4] = ["authorization", "proxy-authorization", "cookie", "set-cookie"];
+
+fn is_sensitive_header(name: &str) -> bool {
+    SENSITIVE_HEADER_NAMES
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+}
+
 fn format_http_headers(headers: &http::HeaderMap) -> String {
     headers
         .iter()
         .map(|(name, value)| {
-            let value = value.to_str().unwrap_or("<non-utf8>");
-            format!("{}={}", name.as_str(), value)
+            if is_sensitive_header(name.as_str()) {
+                format!("{}=<redacted len={}>", name.as_str(), value.as_bytes().len())
+            } else {
+                let value = value.to_str().unwrap_or("<non-utf8>");
+                format!("{}={}", name.as_str(), value)
+            }
         })
         .collect::<Vec<_>>()
         .join("; ")
-}
-
-fn format_http_body(body: &[u8]) -> String {
-    String::from_utf8_lossy(body).into_owned()
 }
 
 #[derive(Debug, Default)]
@@ -326,7 +336,6 @@ impl<'c> AsyncHttpClient<'c> for ReqwestHttpClient {
             let uri = parts.uri.to_string();
             if tracing::enabled!(tracing::Level::DEBUG) {
                 let request_headers = format_http_headers(&parts.headers);
-                let request_body = format_http_body(&body);
                 debug!(
                     event = EVENT_OIDC_HTTP,
                     component = LOG_COMPONENT_IAM,
@@ -336,7 +345,6 @@ impl<'c> AsyncHttpClient<'c> for ReqwestHttpClient {
                     uri = %uri,
                     request_headers = %request_headers,
                     request_body_len = body.len(),
-                    request_body = %request_body,
                     "oidc outbound http"
                 );
             }
@@ -387,7 +395,6 @@ impl<'c> AsyncHttpClient<'c> for ReqwestHttpClient {
             })?;
             if tracing::enabled!(tracing::Level::DEBUG) {
                 let response_headers = format_http_headers(&headers);
-                let response_body = format_http_body(&body_bytes);
                 debug!(
                     event = EVENT_OIDC_HTTP,
                     component = LOG_COMPONENT_IAM,
@@ -400,7 +407,6 @@ impl<'c> AsyncHttpClient<'c> for ReqwestHttpClient {
                     elapsed_ms,
                     response_headers = %response_headers,
                     response_body_len = body_bytes.len(),
-                    response_body = %response_body,
                     "oidc outbound http"
                 );
             }
@@ -814,7 +820,6 @@ impl OidcSys {
                 }
                 RequestTokenError::Parse(parse_err, body) => {
                     let shape = inspect_token_response_body(body);
-                    let response_body = format_http_body(body);
                     error!(
                         event = EVENT_OIDC_DIAGNOSTICS,
                         component = LOG_COMPONENT_IAM,
@@ -837,12 +842,11 @@ impl OidcSys {
                         response_has_error = shape.has_error,
                         response_has_error_description = shape.has_error_description,
                         response_looks_like_html = shape.looks_like_html,
-                        response_body = %response_body,
                         error = %e,
                         "oidc token exchange failed"
                     );
                     format!(
-                        "token exchange failed: {e}: stage=token_response_parse_failed, provider_id={}, config_url={}, issuer={}, token_endpoint={}, redirect_uri={}, client_id={}, parse_error_path={}, response_body_len={}, response_json_keys={}, response_has_id_token={}, response_has_error={}, response_looks_like_html={}, response_body={}",
+                        "token exchange failed: {e}: stage=token_response_parse_failed, provider_id={}, config_url={}, issuer={}, token_endpoint={}, redirect_uri={}, client_id={}, parse_error_path={}, response_body_len={}, response_json_keys={}, response_has_id_token={}, response_has_error={}, response_looks_like_html={}",
                         session.provider_id,
                         config.config_url,
                         issuer,
@@ -854,8 +858,7 @@ impl OidcSys {
                         shape.json_keys,
                         shape.has_id_token,
                         shape.has_error,
-                        shape.looks_like_html,
-                        response_body
+                        shape.looks_like_html
                     )
                 }
                 RequestTokenError::Other(message) => {
@@ -1847,6 +1850,39 @@ mod tests {
         assert_eq!(extract_string_claim(&claims, "email"), "user@example.com");
         assert_eq!(extract_string_claim(&claims, "sub"), "12345");
         assert_eq!(extract_string_claim(&claims, "missing"), "");
+    }
+
+    #[test]
+    fn format_http_headers_redacts_sensitive_values() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::AUTHORIZATION, "Basic Y2xpZW50OnNlY3JldA==".parse().unwrap());
+        headers.insert(http::header::CONTENT_TYPE, "application/json".parse().unwrap());
+        headers.insert(http::header::COOKIE, "session=super-secret".parse().unwrap());
+
+        let rendered = format_http_headers(&headers);
+
+        // Sensitive header values never appear; only their length is emitted.
+        assert!(!rendered.contains("Y2xpZW50OnNlY3JldA=="), "authorization value leaked: {rendered}");
+        assert!(!rendered.contains("super-secret"), "cookie value leaked: {rendered}");
+        assert!(
+            rendered.contains("authorization=<redacted len="),
+            "expected redacted authorization: {rendered}"
+        );
+        assert!(rendered.contains("cookie=<redacted len="), "expected redacted cookie: {rendered}");
+        // Non-sensitive header values are preserved for diagnostics.
+        assert!(
+            rendered.contains("content-type=application/json"),
+            "content-type should be visible: {rendered}"
+        );
+    }
+
+    #[test]
+    fn is_sensitive_header_is_case_insensitive() {
+        assert!(is_sensitive_header("Authorization"));
+        assert!(is_sensitive_header("PROXY-AUTHORIZATION"));
+        assert!(is_sensitive_header("Set-Cookie"));
+        assert!(!is_sensitive_header("content-type"));
+        assert!(!is_sensitive_header("x-request-id"));
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/oidc.rs
+++ b/rustfs/src/admin/handlers/oidc.rs
@@ -593,8 +593,6 @@ impl Operation for OidcCallbackHandler {
                         result = "code_exchange_failed",
                         requested_provider_id = %provider_id,
                         redirect_uri = %redirect_uri,
-                        code = %code,
-                        state = %state,
                         code_len = code.len(),
                         state_len = state.len(),
                         error = %message,


### PR DESCRIPTION
## Summary

Stop the OIDC subsystem from writing credential-grade secrets into logs. Three sinks currently leak on paths that operators routinely hit:

- The outbound OIDC HTTP client dumps the full request headers and body at `DEBUG`. For the token endpoint that means the `Authorization: Basic <client_id:client_secret>` header and the form body containing the authorization `code` and `client_secret`.
- The same client dumps the full response headers and body at `DEBUG`. The token response body carries `id_token` / `access_token` / `refresh_token`.
- On a token-response parse failure, the raw response body is both logged (`response_body`) and spliced into the error string returned to the caller, which can surface in an HTTP/STS response. The safe `TokenResponseBodyShape` summary and body length are already computed alongside it.
- The admin OIDC callback logs the raw authorization `code` and `state` on the code-exchange error path. The authorization code is a single-use bearer credential.

This is the "OIDC log/error redaction" security pre-work (batch 0B) from the OIDC review in rustfs/backlog#1437. It only changes diagnostic content; HTTP/STS status codes and legitimate request results are unchanged.

## Changes

- `crates/iam/src/oidc.rs`
  - `format_http_headers` now redacts the values of sensitive headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`), emitting only the header name and value length. Non-sensitive header values are preserved for diagnostics.
  - The request/response `DEBUG` events no longer emit the raw body. The byte length (`request_body_len` / `response_body_len`) is retained.
  - The `token_response_parse_failed` diagnostic no longer logs the raw `response_body`, and the returned error string no longer includes it. The `TokenResponseBodyShape` summary (JSON keys, `has_id_token`, `has_error`, `looks_like_html`, …) and `response_body_len` are kept.
  - Removed the now-unused `format_http_body` helper.
- `rustfs/src/admin/handlers/oidc.rs`
  - The `code_exchange_failed` event no longer logs the raw `code` / `state`. The existing `code_len` / `state_len` fields are kept.

## Tests

- `format_http_headers_redacts_sensitive_values` asserts the base64 client secret and cookie value never appear, that sensitive headers render as `<redacted len=...>`, and that non-sensitive headers stay visible.
- `is_sensitive_header_is_case_insensitive` covers the case-insensitive name match.

## Verification

- `cargo test -p rustfs-iam --lib oidc::`
- `cargo fmt --all` + arch guards + clippy before push.
