### PR TITLE
chore(deps): update erasure codec and russh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8652,9 +8652,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.3"
+version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059dd24c0fe20721639f7acad7b82cd51ec3dd3254ed8cf7a0b7df6c20eaff1c"
+checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
 dependencies = [
  "aes 0.9.1",
  "aws-lc-rs",
@@ -9194,9 +9194,9 @@ dependencies = [
 
 [[package]]
 name = "rustfs-erasure-codec"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c8af301cb0273d7fb3a1670d74aa9eff015b448f427359658a9ca0f2184b06"
+checksum = "a39413e8f0ca32be9bc2ca9d29f8d17a2ddf952748284cf0fd148ab11180cf6c"
 dependencies = [
  "cc",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,7 @@ pretty_assertions = "1.4.1"
 rand = { version = "0.10.2" }
 ratelimit = "0.10.1"
 rayon = "1.12.0"
-reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.0" }
+reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.1" }
 reed-solomon-simd = "3.1.0"
 regex = { version = "1.13.1" }
 rumqttc = { package = "rumqttc-next", version = "0.33.3" }
@@ -333,7 +333,7 @@ libunftp = { version = "0.23.0" }
 unftp-core = "0.1.0"
 suppaftp = { version = "10.0.1" }
 rcgen = { version = "0.14.8", default-features = false, features = ["aws_lc_rs", "crypto", "pem"] }
-russh = { version = "0.62.3" }
+russh = { version = "0.62.4" }
 russh-sftp = "2.3.0"
 
 # WebDAV


### PR DESCRIPTION
## Related Issues
Refs #5076

## Summary of Changes
- Update `reed-solomon-erasure` (`rustfs-erasure-codec`) from 8.0.0 to 8.0.1.
- Update `russh` from 0.62.3 to 0.62.4 for the security fix requested for this PR.
- Refresh `Cargo.lock` for the two direct dependency bumps only.

## Verification
- `cargo update -p rustfs-erasure-codec --precise 8.0.1`
- `cargo update -p russh --precise 0.62.4`
- `cargo tree -i rustfs-erasure-codec --workspace`
- `cargo tree -i russh --workspace`
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check -p rustfs-ecstore --all-targets`
- `git diff --check`
- `make pre-commit`
- `make pre-pr` completed successfully in an earlier run while the branch included both requested direct dependency updates; a later rerun after lockfile cleanup was interrupted to follow the request to create the PR first.

## Impact
- Updates the erasure codec dependency used by `rustfs-ecstore`.
- Updates the SSH dependency currently pulled by `e2e_test`.
- No configuration, API, or migration changes.

## Additional Notes
N/A
