### PR TITLE
chore(deps): refresh workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,7 +3663,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-http-client",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "clap",
@@ -8838,7 +8844,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.0",
  "base64-simd",
  "bytes",
  "chacha20poly1305",
@@ -9089,7 +9095,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "base64 0.22.1",
+ "base64 0.23.0",
  "base64-simd",
  "byteorder",
  "bytes",
@@ -9249,7 +9255,7 @@ name = "rustfs-heal"
 version = "1.0.0-beta.11"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "futures",
  "http 1.4.2",
  "metrics",
@@ -9420,7 +9426,7 @@ dependencies = [
  "arc-swap",
  "argon2",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "chacha20poly1305",
  "insta",
  "jiff",
@@ -9673,7 +9679,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "dav-server",
  "futures",
@@ -9770,7 +9776,7 @@ dependencies = [
  "aes-gcm",
  "arc-swap",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "crc-fast",
  "faster-hex",
@@ -10229,9 +10235,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ pbkdf2 = "0.13.0"
 rsa = { version = "=0.10.0-rc.18" }
 rustls = { default-features = false, version = "0.23.42" }
 rustls-native-certs = "0.8"
-rustls-pki-types = "1.15.0"
+rustls-pki-types = "1.15.1"
 sha1 = "0.11.0"
 sha2 = "0.11.0"
 subtle = "2.6"
@@ -231,7 +231,7 @@ aws-sdk-s3 = { default-features = false, version = "1.139.0" }
 aws-smithy-http-client = { default-features = false, version = "1.2.0" }
 aws-smithy-runtime-api = { version = "1.13.0" }
 aws-smithy-types = { version = "1.6.1" }
-base64 = "0.22.1"
+base64 = "0.23.0"
 base64-simd = "0.8.0"
 brotli = "8.0.4"
 clap = { version = "4.6.4" }


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Refresh workspace dependency resolution with `cargo update --verbose` and `cargo upgrade --exclude ratelimit --verbose`.
- Update the workspace `base64` dependency requirement from `0.22.1` to `0.23.0`.
- Update `rustls-pki-types` from `1.15.0` to `1.15.1` as selected by the dependency refresh.
- Preserve the explicit `ratelimit` exclusion; `ratelimit` remains at `0.10.1`.

## Verification

Not run locally per maintainer request; validation is deferred to CI.

Commands executed for the dependency refresh:

- `cargo update --verbose`
- `cargo upgrade --exclude ratelimit --verbose`
- `cargo update --verbose` after setting `base64 = "0.23.0"` to refresh the lockfile with the incompatible direct dependency update.

## Impact

RustFS workspace crates that use the shared `base64` dependency now resolve to `base64 0.23.0`. Transitive dependencies that still require `base64 0.22.x`, such as `reqwest`, continue to resolve their compatible version separately. There are no intended RustFS configuration, S3 API, on-wire, or storage-format changes.

## Additional Notes

- CI is expected to provide the validation signal for this dependency refresh.
- The branch was created from the latest `origin/main`.
