### PR TITLE
fix(runtime): update codec and debug stack headroom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9200,9 +9200,9 @@ dependencies = [
 
 [[package]]
 name = "rustfs-erasure-codec"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39413e8f0ca32be9bc2ca9d29f8d17a2ddf952748284cf0fd148ab11180cf6c"
+checksum = "bb8ba5edcc507013a0a7bcf7424be94f0ef070b38eab8bcbc38206a8148bc70a"
 dependencies = [
  "cc",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,7 @@ pretty_assertions = "1.4.1"
 rand = { version = "0.10.2" }
 ratelimit = "0.10.1"
 rayon = "1.12.0"
-reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.1" }
+reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.2" }
 reed-solomon-simd = "3.1.0"
 regex = { version = "1.13.1" }
 rumqttc = { package = "rumqttc-next", version = "0.33.3" }

--- a/rustfs/src/server/runtime.rs
+++ b/rustfs/src/server/runtime.rs
@@ -19,12 +19,34 @@ use rustfs_obs::dial9::Dial9SessionGuard;
 
 #[inline]
 fn compute_default_thread_stack_size() -> usize {
-    // Baseline: Release 1 MiB，Debug 2 MiB；macOS at least 2 MiB
-    // macOS is more conservative: many system libraries and backtracking are more "stack-eating"
-    if cfg!(debug_assertions) || cfg!(target_os = "macos") {
+    if cfg!(debug_assertions) {
+        // Debug builds keep larger async futures and tracing state on the stack;
+        // scanner e2e paths need more headroom than the release runtime.
+        8 * rustfs_config::DEFAULT_THREAD_STACK_SIZE
+    } else if cfg!(target_os = "macos") {
+        // macOS is more conservative: many system libraries and backtracking are more "stack-eating"
         2 * rustfs_config::DEFAULT_THREAD_STACK_SIZE
     } else {
         rustfs_config::DEFAULT_THREAD_STACK_SIZE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_thread_stack_size_matches_build_profile() {
+        let default_stack = rustfs_config::DEFAULT_THREAD_STACK_SIZE;
+        let expected = if cfg!(debug_assertions) {
+            8 * default_stack
+        } else if cfg!(target_os = "macos") {
+            2 * default_stack
+        } else {
+            default_stack
+        };
+
+        assert_eq!(compute_default_thread_stack_size(), expected);
     }
 }
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Update `rustfs-erasure-codec` from 8.0.1 to the published 8.0.2 release.
- Increase the default Tokio worker thread stack only for debug builds so Linux e2e scanner paths have enough headroom without changing the Linux release default.
- Keep macOS release behavior at the existing 2 MiB stack default and preserve the `RUSTFS_RUNTIME_THREAD_STACK_SIZE` override.

## Verification
- `cargo publish --dry-run --registry crates-io` in `rustfs-erasure-codec`
- `cargo publish --registry crates-io` published `rustfs-erasure-codec` 8.0.2
- `make pre-commit`
- Linux `azure-20780104`: `cargo check -p rustfs-ecstore --locked`
- Linux `azure-20780104`: `cargo check -p e2e_test --locked`
- Linux `azure-20780104`: `cargo build --bin rustfs`
- Linux `azure-20780104`: `cargo test -p e2e_test multipart_auth_test::test_signed_put_object_extract_returns_archive_etag -- --nocapture`

## Impact
Linux release builds keep the existing 1 MiB worker stack default, so production runtime stack defaults and hot paths are unchanged. Debug builds reserve a larger worker stack to avoid scanner/e2e stack overflow. RustFS now consumes the crates.io `rustfs-erasure-codec` 8.0.2 package instead of a temporary git revision.

## Additional Notes
The Linux verification checkout downloaded `rustfs-erasure-codec` 8.0.2 from crates.io and the focused e2e test passed without setting `RUSTFS_RUNTIME_THREAD_STACK_SIZE`.
