### PR TITLE
test(ilm): deny manual transition for non-admin

### DIFF
--- a/crates/e2e_test/src/admin_auth_test.rs
+++ b/crates/e2e_test/src/admin_auth_test.rs
@@ -46,6 +46,8 @@ mod tests {
     use std::time::{Duration, Instant};
 
     const ADMIN_INFO_PATH: &str = "/rustfs/admin/v3/info";
+    const ADMIN_MANUAL_TRANSITION_PATH: &str =
+        "/rustfs/admin/v3/ilm/transition/run?bucket=auth-deny-manual-transition&maxObjects=1";
 
     /// Send a SigV4-signed request to `path` (optionally with a JSON `body`) and
     /// return `(status, body)`. Uses the `UNSIGNED_PAYLOAD` content hash so a
@@ -152,6 +154,52 @@ mod tests {
         assert!(
             body.contains("AccessDenied"),
             "admin gate rejection must carry the AccessDenied S3 error code, body: {body}"
+        );
+
+        env.stop_server();
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn non_admin_credential_denied_on_manual_transition_run() -> Result<(), Box<dyn Error + Send + Sync>> {
+        init_logging();
+        let mut env = RustFSTestEnvironment::new().await?;
+        env.start_rustfs_server(vec![]).await?;
+
+        let user_ak = "ilmtransitionlimited";
+        let user_sk = "ilmtransitionlimitedsecret";
+        create_limited_user(&env, user_ak, user_sk).await?;
+
+        let (root_status, root_body) = signed_request(
+            &env.url,
+            http::Method::POST,
+            ADMIN_MANUAL_TRANSITION_PATH,
+            None,
+            &env.access_key,
+            &env.secret_key,
+        )
+        .await?;
+        assert_eq!(
+            root_status,
+            reqwest::StatusCode::OK,
+            "root credential must reach the manual transition handler, body: {root_body}"
+        );
+        assert!(
+            root_body.contains("\"mode\":\"enqueue_only\""),
+            "root response should be the manual transition JSON contract, body: {root_body}"
+        );
+
+        let (status, body) =
+            signed_request(&env.url, http::Method::POST, ADMIN_MANUAL_TRANSITION_PATH, None, user_ak, user_sk).await?;
+        assert_eq!(
+            status,
+            reqwest::StatusCode::FORBIDDEN,
+            "non-admin credential must get 403 on manual transition run, body: {body}"
+        );
+        assert!(
+            body.contains("AccessDenied"),
+            "manual transition rejection must carry the AccessDenied S3 error code, body: {body}"
         );
 
         env.stop_server();


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1481 and rustfs/backlog#1476.

## Summary of Changes
- Add a real-server e2e regression test for the manual ILM transition admin endpoint.
- The test first proves the root credential reaches the `enqueue_only` handler contract, then verifies a limited authenticated user receives `403 AccessDenied` on the same `POST /rustfs/admin/v3/ilm/transition/run` request.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p e2e_test non_admin_credential_denied_on_manual_transition_run -- --nocapture`

## Impact
Test coverage only. No public API, wire format, console behavior, or compatibility change.

## Additional Notes
The e2e test covers the backend permission boundary only; console operations remain out of scope.

Adversarial validation: correctness attacked root handler reachability and limited-user denial with no break found; simplicity found the test reuses the existing signed request and limited-user e2e helpers; security attacked the authenticated-but-unauthorized admin endpoint case and observed `403 AccessDenied`; concurrency/durability found no production lock, IO, or persisted-state change and the e2e is serial like neighboring admin auth tests; compatibility found no endpoint or response contract change beyond assertions; performance found test-only cold build/runtime cost; test-coverage found the new e2e fails if the admin gate allows the limited user or if the root path no longer reaches the enqueue-only handler.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
