### PR TITLE
test(ilm): cover manual transition queue pressure

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -2492,6 +2492,24 @@ impl ManualTransitionRunReport {
     pub fn was_truncated(&self) -> bool {
         self.truncated_by_limit || self.truncated_by_duration
     }
+
+    fn record_enqueue_outcome(&mut self, outcome: TransitionEnqueueOutcome) {
+        match outcome {
+            TransitionEnqueueOutcome::Queued => self.enqueued = self.enqueued.saturating_add(1),
+            TransitionEnqueueOutcome::AlreadyInFlight => {
+                self.skipped_already_in_flight = self.skipped_already_in_flight.saturating_add(1);
+            }
+            TransitionEnqueueOutcome::QueueFull => {
+                self.skipped_queue_full = self.skipped_queue_full.saturating_add(1);
+            }
+            TransitionEnqueueOutcome::QueueClosed => {
+                self.skipped_queue_closed = self.skipped_queue_closed.saturating_add(1);
+            }
+            TransitionEnqueueOutcome::QueueSendTimedOut => {
+                self.skipped_queue_timeout = self.skipped_queue_timeout.saturating_add(1);
+            }
+        }
+    }
 }
 
 pub async fn enqueue_transition_for_existing_objects(api: Arc<ECStore>, bucket: &str) -> Result<(), Error> {
@@ -2818,21 +2836,7 @@ async fn enqueue_transition_with_lifecycle_report(
             let outcome = runtime_sources::transition_state_handle()
                 .queue_transition_task_outcome(oi, &event, src)
                 .await;
-            match outcome {
-                TransitionEnqueueOutcome::Queued => report.enqueued = report.enqueued.saturating_add(1),
-                TransitionEnqueueOutcome::AlreadyInFlight => {
-                    report.skipped_already_in_flight = report.skipped_already_in_flight.saturating_add(1);
-                }
-                TransitionEnqueueOutcome::QueueFull => {
-                    report.skipped_queue_full = report.skipped_queue_full.saturating_add(1);
-                }
-                TransitionEnqueueOutcome::QueueClosed => {
-                    report.skipped_queue_closed = report.skipped_queue_closed.saturating_add(1);
-                }
-                TransitionEnqueueOutcome::QueueSendTimedOut => {
-                    report.skipped_queue_timeout = report.skipped_queue_timeout.saturating_add(1);
-                }
-            }
+            report.record_enqueue_outcome(outcome);
             return outcome.is_handled();
         }
         _ => report.skipped_not_transition = report.skipped_not_transition.saturating_add(1),
@@ -6388,6 +6392,20 @@ mod tests {
         assert_eq!(report.eligible, 0);
         assert_eq!(report.skipped_not_transition, 0);
         assert_eq!(report.skipped_already_transitioned, 1);
+    }
+
+    #[test]
+    fn manual_transition_report_marks_queue_pressure_partial() {
+        let options = ManualTransitionRunOptions::default();
+        let mut report = ManualTransitionRunReport::new("bucket", &options);
+
+        report.record_enqueue_outcome(TransitionEnqueueOutcome::QueueFull);
+
+        assert_eq!(report.enqueued, 0);
+        assert_eq!(report.skipped_queue_full, 1);
+        assert_eq!(report.skipped_queue_closed, 0);
+        assert_eq!(report.skipped_queue_timeout, 0);
+        assert!(report.has_partial_enqueue());
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1481 and rustfs/backlog#1476.

## Summary of Changes
- Move manual transition enqueue outcome accounting onto `ManualTransitionRunReport` so queue pressure outcomes are recorded through the same report state transition used by the production enqueue path.
- Add a focused regression test for `QueueFull` to assert it increments `skipped_queue_full`, leaves `enqueued` unchanged, and marks the report as a partial enqueue.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_report_marks_queue_pressure_partial -- --nocapture`

## Impact
Test coverage and a small internal refactor only. No public API, wire format, console behavior, or compatibility change.

## Additional Notes
The test intentionally avoids mutating the process-global transition queue state; it targets the report accounting path that turns queue pressure into the partial enqueue contract.

Adversarial validation: correctness attacked all enqueue outcome mappings and partial flag behavior with no break found; simplicity attacked the initial one-off helper shape and the final diff keeps the state transition on the report type; security found no auth, secret, deserialization, or logging surface touched; concurrency/durability found no new lock, await, IO, journal, or global queue mutation; compatibility found no API, wire, on-disk, MinIO metadata, or mixed-version contract change; performance found no new hot-path allocation, clone, loop, logging, or blocking work; test-coverage found `manual_transition_report_marks_queue_pressure_partial` fails if `QueueFull` no longer records partial queue pressure, with full queue saturation e2e intentionally deferred to avoid global OnceLock contamination.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
