### PR TITLE
perf(protos): cache internode msgpack-only flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9748,6 +9748,7 @@ dependencies = [
  "rustfs-utils",
  "serde",
  "serde_json",
+ "temp-env",
  "tokio",
  "tonic",
  "tonic-prost",

--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -3018,15 +3018,32 @@ mod tests {
 
     #[test]
     fn compat_json_dual_writes_by_default() {
-        let resp = sample_read_multiple_resp("file", b"data");
-        let json = compat_json(&resp).expect("compat_json should encode");
-        assert!(!json.is_empty());
-        assert_eq!(json, serde_json::to_string(&resp).expect("json should encode"));
+        with_internode_msgpack_env(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, None::<&str>),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, None::<&str>),
+            ],
+            || {
+                let resp = sample_read_multiple_resp("file", b"data");
+                let json = compat_json(&resp).expect("compat_json should encode");
+                assert!(!json.is_empty());
+                assert_eq!(json, serde_json::to_string(&resp).expect("json should encode"));
+            },
+        );
+    }
+
+    fn with_internode_msgpack_env<R>(vars: [(&'static str, Option<&'static str>); 2], f: impl FnOnce() -> R) -> R {
+        temp_env::with_vars(vars, || {
+            rustfs_protos::reset_internode_rpc_msgpack_only_cache();
+            let result = f();
+            rustfs_protos::reset_internode_rpc_msgpack_only_cache();
+            result
+        })
     }
 
     #[test]
     fn compat_json_keeps_json_when_msgpack_only_lacks_fleet_confirmation() {
-        temp_env::with_vars(
+        with_internode_msgpack_env(
             [
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, None::<&str>),
@@ -3043,7 +3060,7 @@ mod tests {
 
     #[test]
     fn compat_json_omits_json_only_after_fleet_confirmation() {
-        temp_env::with_vars(
+        with_internode_msgpack_env(
             [
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),

--- a/crates/protos/Cargo.toml
+++ b/crates/protos/Cargo.toml
@@ -54,3 +54,4 @@ doctest = false
 
 [dev-dependencies]
 serde_json = { workspace = true }
+temp-env = { workspace = true }

--- a/crates/protos/src/lib.rs
+++ b/crates/protos/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     collections::HashMap,
     error::Error,
     sync::LazyLock,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicU8, AtomicUsize, Ordering},
     time::{Duration, Instant},
 };
 use tokio::sync::Mutex;
@@ -54,7 +54,11 @@ pub const DEFAULT_GRPC_SERVER_MESSAGE_LEN: usize = 100 * 1024 * 1024;
 /// Default value: https://
 const RUSTFS_HTTPS_PREFIX: &str = "https://";
 const TLS_GENERATION_CACHE_MAX_SIZE: usize = 512;
+const INTERNODE_RPC_MSGPACK_ONLY_CACHE_UNSET: u8 = 0;
+const INTERNODE_RPC_MSGPACK_ONLY_CACHE_FALSE: u8 = 1;
+const INTERNODE_RPC_MSGPACK_ONLY_CACHE_TRUE: u8 = 2;
 static TLS_GENERATION_CACHE: LazyLock<Mutex<HashMap<String, u64>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+static INTERNODE_RPC_MSGPACK_ONLY_CACHE: AtomicU8 = AtomicU8::new(INTERNODE_RPC_MSGPACK_ONLY_CACHE_UNSET);
 
 fn enforce_tls_generation_cache_bound(generation_cache: &mut HashMap<String, u64>, generation: u64, addr: &str) {
     if generation_cache.len() < TLS_GENERATION_CACHE_MAX_SIZE || generation_cache.contains_key(addr) {
@@ -642,13 +646,33 @@ mod tier_mutation_rpc_tests {
 /// decode the compatibility field. Operators must also set the fleet-confirmed guard after the
 /// convergence runbook proves every peer supports `_bin` and rollback.
 pub fn internode_rpc_msgpack_only() -> bool {
-    rustfs_utils::get_env_bool(
+    match INTERNODE_RPC_MSGPACK_ONLY_CACHE.load(Ordering::Acquire) {
+        INTERNODE_RPC_MSGPACK_ONLY_CACHE_FALSE => return false,
+        INTERNODE_RPC_MSGPACK_ONLY_CACHE_TRUE => return true,
+        _ => {}
+    }
+
+    let enabled = rustfs_utils::get_env_bool(
         rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY,
         rustfs_config::DEFAULT_INTERNODE_RPC_MSGPACK_ONLY,
     ) && rustfs_utils::get_env_bool(
         rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED,
         rustfs_config::DEFAULT_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED,
-    )
+    );
+    INTERNODE_RPC_MSGPACK_ONLY_CACHE.store(
+        if enabled {
+            INTERNODE_RPC_MSGPACK_ONLY_CACHE_TRUE
+        } else {
+            INTERNODE_RPC_MSGPACK_ONLY_CACHE_FALSE
+        },
+        Ordering::Release,
+    );
+    enabled
+}
+
+#[doc(hidden)]
+pub fn reset_internode_rpc_msgpack_only_cache() {
+    INTERNODE_RPC_MSGPACK_ONLY_CACHE.store(INTERNODE_RPC_MSGPACK_ONLY_CACHE_UNSET, Ordering::Release);
 }
 
 /// Consecutive-failure threshold after which an internode peer is marked offline (grpc-optimization
@@ -949,6 +973,35 @@ mod tests {
     fn bulk_channel_pool_size_is_at_least_one() {
         // Even without env configuration the pool size is clamped to a usable minimum.
         assert!(bulk_channel_pool_size() >= 1);
+    }
+
+    #[test]
+    fn internode_rpc_msgpack_only_reuses_cached_env_until_reset() {
+        reset_internode_rpc_msgpack_only_cache();
+
+        temp_env::with_vars(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+            || {
+                assert!(internode_rpc_msgpack_only());
+            },
+        );
+
+        temp_env::with_vars(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, None::<&str>),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, None::<&str>),
+            ],
+            || {
+                assert!(internode_rpc_msgpack_only(), "cached value should avoid repeated env reads");
+                reset_internode_rpc_msgpack_only_cache();
+                assert!(!internode_rpc_msgpack_only(), "reset must reload current env values");
+            },
+        );
+
+        reset_internode_rpc_msgpack_only_cache();
     }
 
     #[tokio::test]

--- a/rustfs/src/storage/rpc/node_service/disk.rs
+++ b/rustfs/src/storage/rpc/node_service/disk.rs
@@ -1215,9 +1215,18 @@ mod tests {
         );
     }
 
+    fn with_internode_msgpack_env<R>(vars: [(&'static str, Option<&'static str>); 2], f: impl FnOnce() -> R) -> R {
+        temp_env::with_vars(vars, || {
+            rustfs_protos::reset_internode_rpc_msgpack_only_cache();
+            let result = f();
+            rustfs_protos::reset_internode_rpc_msgpack_only_cache();
+            result
+        })
+    }
+
     #[test]
     fn compat_response_json_keeps_json_when_msgpack_only_lacks_fleet_confirmation() {
-        temp_env::with_vars(
+        with_internode_msgpack_env(
             [
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, None::<&str>),
@@ -1237,7 +1246,7 @@ mod tests {
 
     #[test]
     fn compat_response_json_omits_json_only_after_fleet_confirmation() {
-        temp_env::with_vars(
+        with_internode_msgpack_env(
             [
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
                 (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Cache `rustfs_protos::internode_rpc_msgpack_only()` after the first environment read so the client and server metadata RPC send paths avoid parsing the same rollout flags on every call.

Keep the existing two-flag safety gate unchanged: JSON compatibility fields are omitted only when `RUSTFS_INTERNODE_RPC_MSGPACK_ONLY=true` and `RUSTFS_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED=true` are both set.

Add a test-only cache reset hook and update env-switching compatibility tests so in-process test env changes remain deterministic.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-protos`
- `cargo check -p rustfs-protos --all-targets`
- `cargo clippy -p rustfs-protos --all-targets`
- `cargo test -p rustfs-ecstore compat_json_`
- `cargo test -p rustfs compat_response_json_`
- CI will provide the final validation result.

## Impact
Internode metadata RPC send paths no longer repeatedly read and parse the msgpack-only env flags after the first call in a process. Compatibility behavior is unchanged, and operators can still roll back by restarting with either gate disabled as documented.

## Additional Notes
N/A
