### PR TITLE
test(internode): pin msgpack gate rollback coverage

### DIFF
--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -3075,6 +3075,41 @@ mod tests {
     }
 
     #[test]
+    fn compat_json_restores_json_when_either_msgpack_only_gate_is_removed() {
+        with_internode_msgpack_env(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+            || {
+                let resp = sample_read_multiple_resp("file", b"data");
+                let json = compat_json(&resp).expect("compat_json should encode");
+
+                assert!(json.is_empty(), "both gates should enter msgpack-only send mode");
+            },
+        );
+
+        for vars in [
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("false")),
+            ],
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("false")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+        ] {
+            with_internode_msgpack_env(vars, || {
+                let resp = sample_read_multiple_resp("file", b"data");
+                let json = compat_json(&resp).expect("compat_json should encode");
+
+                assert!(!json.is_empty(), "removing either gate should restore old-peer JSON compatibility");
+                assert_eq!(json, serde_json::to_string(&resp).expect("json should encode"));
+            });
+        }
+    }
+
+    #[test]
     fn read_multiple_response_decode_reports_corrupt_msgpack_item() {
         let endpoint = sample_remote_endpoint();
         let response = ReadMultipleResponse {

--- a/crates/protos/src/lib.rs
+++ b/crates/protos/src/lib.rs
@@ -1194,6 +1194,36 @@ mod tests {
     }
 
     #[test]
+    fn request_compat_send_site_manifest_pins_exact_json_policies() {
+        let mut policies = REQUEST_COMPAT_SEND_SITES
+            .iter()
+            .map(|send_site| (send_site.field.message, send_site.field.json_field, send_site.policy))
+            .collect::<Vec<_>>();
+        policies.sort_by_key(|(message, json_field, _)| (*message, *json_field));
+
+        assert_eq!(
+            policies,
+            [
+                (
+                    "BatchReadVersionRequest",
+                    "batch_read_version_req",
+                    RequestJsonPolicy::MsgpackOnlyEligible
+                ),
+                ("DeleteVersionRequest", "file_info", RequestJsonPolicy::AlwaysDualWriteUntilFallbackZero,),
+                ("DeleteVersionRequest", "opts", RequestJsonPolicy::AlwaysDualWriteUntilFallbackZero),
+                ("DeleteVersionsRequest", "opts", RequestJsonPolicy::AlwaysDualWriteUntilFallbackZero,),
+                ("DeleteVersionsRequest", "versions", RequestJsonPolicy::AlwaysDualWriteUntilFallbackZero,),
+                ("ReadMultipleRequest", "read_multiple_req", RequestJsonPolicy::MsgpackOnlyEligible),
+                ("ReadVersionRequest", "opts", RequestJsonPolicy::MsgpackOnlyEligible),
+                ("RenameDataRequest", "file_info", RequestJsonPolicy::MsgpackOnlyEligible),
+                ("UpdateMetadataRequest", "file_info", RequestJsonPolicy::MsgpackOnlyEligible),
+                ("UpdateMetadataRequest", "opts", RequestJsonPolicy::MsgpackOnlyEligible),
+                ("WriteMetadataRequest", "file_info", RequestJsonPolicy::MsgpackOnlyEligible),
+            ]
+        );
+    }
+
+    #[test]
     fn response_compat_send_site_manifest_covers_node_proto_bin_fields() {
         let mut manifest_fields = RESPONSE_COMPAT_SEND_SITES
             .iter()
@@ -1290,6 +1320,31 @@ mod tests {
                 assert!(!internode_rpc_msgpack_only(), "reset must reload current env values");
             },
         );
+
+        reset_internode_rpc_msgpack_only_cache();
+    }
+
+    #[test]
+    fn internode_rpc_msgpack_only_requires_request_and_fleet_confirmation() {
+        for (requested, fleet_confirmed, expected) in [
+            (None, None, false),
+            (Some("true"), None, false),
+            (None, Some("true"), false),
+            (Some("true"), Some("false"), false),
+            (Some("false"), Some("true"), false),
+            (Some("true"), Some("true"), true),
+        ] {
+            reset_internode_rpc_msgpack_only_cache();
+            temp_env::with_vars(
+                [
+                    (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, requested),
+                    (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, fleet_confirmed),
+                ],
+                || {
+                    assert_eq!(internode_rpc_msgpack_only(), expected);
+                },
+            );
+        }
 
         reset_internode_rpc_msgpack_only_cache();
     }

--- a/rustfs/src/storage/rpc/node_service/disk.rs
+++ b/rustfs/src/storage/rpc/node_service/disk.rs
@@ -1264,6 +1264,44 @@ mod tests {
     }
 
     #[test]
+    fn compat_response_json_restores_json_when_either_msgpack_only_gate_is_removed() {
+        let payload = SamplePayload {
+            name: "rollback".to_string(),
+            count: 12,
+        };
+
+        with_internode_msgpack_env(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+            || {
+                let json = compat_response_json(&payload).expect("compat response json should encode");
+
+                assert!(json.is_empty(), "both gates should enter msgpack-only response mode");
+            },
+        );
+
+        for vars in [
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("false")),
+            ],
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("false")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+        ] {
+            with_internode_msgpack_env(vars, || {
+                let json = compat_response_json(&payload).expect("compat response json should encode");
+
+                assert!(!json.is_empty(), "removing either gate should restore old-peer JSON compatibility");
+                assert_eq!(json, serde_json::to_string(&payload).expect("json should encode"));
+            });
+        }
+    }
+
+    #[test]
     fn decode_msgpack_or_json_fails_closed_on_corrupt_non_empty_msgpack() {
         let err = decode_msgpack_or_json::<SamplePayload>(b"not-msgpack", r#"{"name":"json","count":1}"#, "SamplePayload")
             .expect_err("corrupt non-empty msgpack must not fall back to JSON");
@@ -1331,6 +1369,52 @@ mod tests {
     }
 
     #[test]
+    fn encode_read_multiple_response_payloads_respects_msgpack_only_gate_and_rollback() {
+        let responses = vec![ReadMultipleResp {
+            bucket: "bucket".to_string(),
+            prefix: "prefix".to_string(),
+            file: "gate".to_string(),
+            exists: true,
+            data: b"payload".to_vec(),
+            ..Default::default()
+        }];
+
+        with_internode_msgpack_env(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+            || {
+                let (json_payloads, msgpack_payloads) =
+                    encode_read_multiple_response_payloads(&responses).expect("read multiple responses should encode");
+
+                assert_eq!(json_payloads, vec![String::new()]);
+                assert_eq!(msgpack_payloads.len(), responses.len());
+                let decoded = decode_msgpack_or_json::<ReadMultipleResp>(&msgpack_payloads[0], "", "ReadMultipleResp")
+                    .expect("msgpack read multiple response should decode");
+                assert_eq!(decoded.file, responses[0].file);
+            },
+        );
+
+        with_internode_msgpack_env(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("false")),
+            ],
+            || {
+                let (json_payloads, msgpack_payloads) =
+                    encode_read_multiple_response_payloads(&responses).expect("read multiple responses should encode");
+
+                assert!(!json_payloads[0].is_empty(), "rollback should restore response JSON");
+                assert_eq!(msgpack_payloads.len(), responses.len());
+                let json_decoded: ReadMultipleResp =
+                    serde_json::from_str(&json_payloads[0]).expect("json read multiple response should decode");
+                assert_eq!(json_decoded.file, responses[0].file);
+            },
+        );
+    }
+
+    #[test]
     fn encode_batch_read_version_response_payloads_keeps_json_and_msgpack_in_sync() {
         let responses = vec![BatchReadVersionResp {
             index: 3,
@@ -1355,5 +1439,50 @@ mod tests {
         assert_eq!(json_decoded.index, responses[0].index);
         assert_eq!(msgpack_decoded.path, responses[0].path);
         assert_eq!(msgpack_decoded.error, responses[0].error);
+    }
+
+    #[test]
+    fn encode_batch_read_version_response_payloads_respects_msgpack_only_gate_and_rollback() {
+        let responses = vec![BatchReadVersionResp {
+            index: 4,
+            path: "object-b".to_string(),
+            version_id: "version-b".to_string(),
+            success: true,
+            ..Default::default()
+        }];
+
+        with_internode_msgpack_env(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("true")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+            || {
+                let (json_payloads, msgpack_payloads) =
+                    encode_batch_read_version_response_payloads(&responses).expect("batch read version responses should encode");
+
+                assert_eq!(json_payloads, vec![String::new()]);
+                assert_eq!(msgpack_payloads.len(), responses.len());
+                let decoded = decode_msgpack_or_json::<BatchReadVersionResp>(&msgpack_payloads[0], "", "BatchReadVersionResp")
+                    .expect("msgpack batch read version response should decode");
+                assert_eq!(decoded.path, responses[0].path);
+            },
+        );
+
+        with_internode_msgpack_env(
+            [
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY, Some("false")),
+                (rustfs_config::ENV_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED, Some("true")),
+            ],
+            || {
+                let (json_payloads, msgpack_payloads) =
+                    encode_batch_read_version_response_payloads(&responses).expect("batch read version responses should encode");
+
+                assert!(!json_payloads[0].is_empty(), "rollback should restore response JSON");
+                assert_eq!(msgpack_payloads.len(), responses.len());
+                let json_decoded: BatchReadVersionResp =
+                    serde_json::from_str(&json_payloads[0]).expect("json batch read version response should decode");
+                assert_eq!(json_decoded.path, responses[0].path);
+            },
+        );
     }
 }


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1435 and rustfs/backlog#1431.

## Summary of Changes
Adds focused test-only coverage for the internode msgpack-only rollout gates and rollback behavior across request compatibility and response payload encoding.

Pins the send-site compatibility manifest to exact JSON policies so future proto send-site changes cannot accidentally move DeleteVersion/DeleteVersions into msgpack-only before fallback-zero evidence is verified.

Adds request-side and response-side tests proving that both `RUSTFS_INTERNODE_RPC_MSGPACK_ONLY=true` and `RUSTFS_INTERNODE_RPC_MSGPACK_ONLY_FLEET_CONFIRMED=true` are required before eligible payloads clear JSON compatibility fields, and that removing either gate restores JSON compatibility alongside `_bin` dual-write.

## Verification
- `cargo test -p rustfs-protos request_compat_send_site_manifest_pins_exact_json_policies`
- `cargo test -p rustfs-protos internode_rpc_msgpack_only_requires_request_and_fleet_confirmation`
- `cargo test -p rustfs-ecstore compat_json_restores_json_when_either_msgpack_only_gate_is_removed`
- `cargo test -p rustfs compat_response_json_restores_json_when_either_msgpack_only_gate_is_removed`
- `cargo test -p rustfs encode_read_multiple_response_payloads_respects_msgpack_only_gate_and_rollback`
- `cargo test -p rustfs encode_batch_read_version_response_payloads_respects_msgpack_only_gate_and_rollback`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-pr`

## Impact
No runtime API, S3 API, proto field number, wire-format, or persisted-format change. This PR only strengthens regression coverage for the msgpack-only compatibility gates and rollback behavior.

## Additional Notes
Adversarial validation for this test-only patch attacked single-flag and fleet-only rollout states plus rollback removal of either gate in correctness and test coverage; no behavior regression was found in that review.

## N/A
