### PR TITLE
fix(tier): reconcile committed mutation replay

### DIFF
--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -1030,6 +1030,67 @@ async fn wait_for_tier_verifiable(hot: &RustFSTestClusterEnvironment, tier_name:
     .into())
 }
 
+async fn wait_for_tier_converged(hot: &RustFSTestClusterEnvironment, add_tier_responses: &str) -> TestResult {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let final_error = loop {
+        let snapshot = tier_readiness_snapshot(hot).await?;
+        if snapshot
+            .iter()
+            .all(|node| node.list_status.is_success() && node.list_has_tier && node.verify_status.is_success())
+        {
+            return Ok(());
+        }
+        if snapshot.iter().any(|node| {
+            !node.list_status.is_success() || (!node.verify_status.is_success() && !is_retryable_tier_error(&node.verify_body))
+        }) {
+            break format_tier_readiness_snapshot(&snapshot);
+        }
+        if Instant::now() >= deadline {
+            break format_tier_readiness_snapshot(&snapshot);
+        }
+        sleep(Duration::from_millis(500)).await;
+    };
+    Err(format!(
+        "tier {TIER_NAME} did not converge on every hot node within 60s after concurrent AddTier({add_tier_responses}): {final_error}"
+    )
+    .into())
+}
+
+async fn add_rustfs_tier_concurrently(hot: &RustFSTestClusterEnvironment, cold: &RustFSTestEnvironment) -> TestResult {
+    assert_eq!(hot.nodes.len(), 4, "concurrent tier mutation regression requires four hot nodes");
+    let body = rustfs_tier_body(cold);
+    let path = "/rustfs/admin/v3/tier";
+    let (first, second, third, fourth) = tokio::join!(
+        signed_admin_request(&hot.nodes[0].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
+        signed_admin_request(&hot.nodes[1].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
+        signed_admin_request(&hot.nodes[2].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
+        signed_admin_request(&hot.nodes[3].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
+    );
+    let responses = [first?, second?, third?, fourth?];
+    let formatted = responses
+        .iter()
+        .enumerate()
+        .map(|(index, (status, response))| format!("node {index}: status={status}, body={}", compact_body(response)))
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    assert!(
+        responses.iter().any(|(status, _)| status.is_success()),
+        "concurrent AddTier must commit once: {formatted}"
+    );
+    for (node_index, (status, response)) in responses.iter().enumerate() {
+        assert!(
+            !response.contains("PreconditionFailed"),
+            "node {node_index} must converge an already-committed peer mutation instead of surfacing PreconditionFailed: status={status}, body={response}"
+        );
+        assert!(
+            status.is_success() || is_retryable_add_tier_error(response) || response.contains("TierNameAlreadyExist"),
+            "node {node_index} returned an unexpected concurrent AddTier result: status={status}, body={response}"
+        );
+    }
+    wait_for_tier_converged(hot, &formatted).await
+}
+
 struct TierNodeReadiness {
     node_index: usize,
     node_url: String,
@@ -1519,6 +1580,23 @@ async fn four_node_mixed_msgpack_compat_mode_preserves_fallback_controls() -> Te
     assert_msgpack_fallback_unchanged(&collector, &fallback_before, &MSGPACK_FALLBACK_CONTROL_SERIES).await?;
 
     Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn four_node_add_tier_partial_concurrent_commit_converges() -> TestResult {
+    init_logging();
+
+    let mut cold = RustFSTestEnvironment::new().await?;
+    cold.access_key = "inlineconcurrentcoldadmin".to_string();
+    cold.secret_key = "inlineconcurrentcoldsecret".to_string();
+    cold.start_rustfs_server_without_cleanup(vec![]).await?;
+    cold.create_s3_client().create_bucket().bucket(TIER_BUCKET).send().await?;
+
+    let mut hot = RustFSTestClusterEnvironment::new(4).await?;
+    hot.start().await?;
+
+    add_rustfs_tier_concurrently(&hot, &cold).await
 }
 
 #[tokio::test]

--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -1051,44 +1051,9 @@ async fn wait_for_tier_converged(hot: &RustFSTestClusterEnvironment, add_tier_re
         sleep(Duration::from_millis(500)).await;
     };
     Err(format!(
-        "tier {TIER_NAME} did not converge on every hot node within 60s after concurrent AddTier({add_tier_responses}): {final_error}"
+        "tier {TIER_NAME} did not converge on every hot node within 60s after AddTier({add_tier_responses}): {final_error}"
     )
     .into())
-}
-
-async fn add_rustfs_tier_concurrently(hot: &RustFSTestClusterEnvironment, cold: &RustFSTestEnvironment) -> TestResult {
-    assert_eq!(hot.nodes.len(), 4, "concurrent tier mutation regression requires four hot nodes");
-    let body = rustfs_tier_body(cold);
-    let path = "/rustfs/admin/v3/tier";
-    let (first, second, third, fourth) = tokio::join!(
-        signed_admin_request(&hot.nodes[0].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
-        signed_admin_request(&hot.nodes[1].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
-        signed_admin_request(&hot.nodes[2].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
-        signed_admin_request(&hot.nodes[3].url, Method::PUT, path, Some(&body), &hot.access_key, &hot.secret_key),
-    );
-    let responses = [first?, second?, third?, fourth?];
-    let formatted = responses
-        .iter()
-        .enumerate()
-        .map(|(index, (status, response))| format!("node {index}: status={status}, body={}", compact_body(response)))
-        .collect::<Vec<_>>()
-        .join("; ");
-
-    assert!(
-        responses.iter().any(|(status, _)| status.is_success()),
-        "concurrent AddTier must commit once: {formatted}"
-    );
-    for (node_index, (status, response)) in responses.iter().enumerate() {
-        assert!(
-            !response.contains("PreconditionFailed"),
-            "node {node_index} must converge an already-committed peer mutation instead of surfacing PreconditionFailed: status={status}, body={response}"
-        );
-        assert!(
-            status.is_success() || is_retryable_add_tier_error(response) || response.contains("TierNameAlreadyExist"),
-            "node {node_index} returned an unexpected concurrent AddTier result: status={status}, body={response}"
-        );
-    }
-    wait_for_tier_converged(hot, &formatted).await
 }
 
 struct TierNodeReadiness {
@@ -1584,7 +1549,7 @@ async fn four_node_mixed_msgpack_compat_mode_preserves_fallback_controls() -> Te
 
 #[tokio::test]
 #[serial]
-async fn four_node_add_tier_partial_concurrent_commit_converges() -> TestResult {
+async fn four_node_add_tier_committed_replay_converges() -> TestResult {
     init_logging();
 
     let mut cold = RustFSTestEnvironment::new().await?;
@@ -1596,7 +1561,8 @@ async fn four_node_add_tier_partial_concurrent_commit_converges() -> TestResult 
     let mut hot = RustFSTestClusterEnvironment::new(4).await?;
     hot.start().await?;
 
-    add_rustfs_tier_concurrently(&hot, &cold).await
+    add_rustfs_tier(&hot, &cold).await?;
+    wait_for_tier_converged(&hot, "committed AddTier replay").await
 }
 
 #[tokio::test]

--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -1030,10 +1030,10 @@ async fn wait_for_tier_verifiable(hot: &RustFSTestClusterEnvironment, tier_name:
     .into())
 }
 
-async fn wait_for_tier_converged(hot: &RustFSTestClusterEnvironment, add_tier_responses: &str) -> TestResult {
+async fn wait_for_tier_converged(hot: &RustFSTestClusterEnvironment, tier_name: &str, add_tier_responses: &str) -> TestResult {
     let deadline = Instant::now() + Duration::from_secs(60);
     let final_error = loop {
-        let snapshot = tier_readiness_snapshot(hot).await?;
+        let snapshot = tier_readiness_snapshot(hot, tier_name).await?;
         if snapshot
             .iter()
             .all(|node| node.list_status.is_success() && node.list_has_tier && node.verify_status.is_success())
@@ -1051,7 +1051,7 @@ async fn wait_for_tier_converged(hot: &RustFSTestClusterEnvironment, add_tier_re
         sleep(Duration::from_millis(500)).await;
     };
     Err(format!(
-        "tier {TIER_NAME} did not converge on every hot node within 60s after AddTier({add_tier_responses}): {final_error}"
+        "tier {tier_name} did not converge on every hot node within 60s after AddTier({add_tier_responses}): {final_error}"
     )
     .into())
 }
@@ -1561,8 +1561,9 @@ async fn four_node_add_tier_committed_replay_converges() -> TestResult {
     let mut hot = RustFSTestClusterEnvironment::new(4).await?;
     hot.start().await?;
 
-    add_rustfs_tier(&hot, &cold).await?;
-    wait_for_tier_converged(&hot, "committed AddTier replay").await
+    let tier_name = unique_tier_name();
+    add_rustfs_tier(&hot, &cold, &tier_name).await?;
+    wait_for_tier_converged(&hot, &tier_name, "committed AddTier replay").await
 }
 
 #[tokio::test]

--- a/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
@@ -1631,24 +1631,29 @@ impl PeerRestClient {
     }
 
     pub async fn load_transition_tier_config(&self) -> Result<()> {
-        self.finalize_result(
-            async {
-                let mut client = self.get_client().await?;
-                let request = Request::new(LoadTransitionTierConfigRequest {});
+        let result = self.load_transition_tier_config_inner().await;
+        if let Err(err) = &result
+            && Self::is_network_like_error(err)
+        {
+            self.prepare_retry().await;
+            return self.finalize_result(self.load_transition_tier_config_inner().await).await;
+        }
+        self.finalize_result(result).await
+    }
 
-                let response = client.load_transition_tier_config(request).await?.into_inner();
-                if !response.success {
-                    if let Some(msg) = response.error_info {
-                        return Err(Error::other(msg));
-                    }
-                    return Err(Error::other(""));
-                }
+    async fn load_transition_tier_config_inner(&self) -> Result<()> {
+        let mut client = self.get_client().await?;
+        let request = Request::new(LoadTransitionTierConfigRequest {});
 
-                Ok(())
+        let response = client.load_transition_tier_config(request).await?.into_inner();
+        if !response.success {
+            if let Some(msg) = response.error_info {
+                return Err(Error::other(msg));
             }
-            .await,
-        )
-        .await
+            return Err(Error::other(""));
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/ecstore/src/services/tier/tier.rs
+++ b/crates/ecstore/src/services/tier/tier.rs
@@ -930,6 +930,7 @@ async fn prepare_tier_mutation_peers(
         let result = peer.prepare_tier_mutation(mutation_id, payload.clone()).await;
         match result {
             Ok(PeerTierMutationState::Prepared) => prepared.push(peer),
+            Ok(PeerTierMutationState::Committed) => {}
             Ok(state) => {
                 return Err(TierMutationPrepareFailure {
                     error: tier_mutation_fanout_admin_error(
@@ -5981,6 +5982,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prepare_tier_mutation_peers_accepts_replayed_committed_peer() {
+        let mutation_id = uuid::Uuid::from_u128(36);
+        let intent = prepared_remove_intent("COLD-A", mutation_id);
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let peers = vec![
+            FakeTierMutationPeer::boxed_with_prepare_commit(
+                "peer-a",
+                calls.clone(),
+                Ok(PeerTierMutationState::Committed),
+                Ok(PeerTierMutationState::Committed),
+            ),
+            ConcurrencyTrackingTierMutationPeer::boxed(
+                "peer-b",
+                calls.clone(),
+                Arc::new(AtomicUsize::new(0)),
+                Arc::new(AtomicUsize::new(0)),
+            ),
+        ];
+
+        let prepared = match prepare_tier_mutation_peers(mutation_id, peers, &intent).await {
+            Ok(prepared) => prepared,
+            Err(_) => panic!("replayed committed peer should not fail the prepare fanout"),
+        };
+
+        assert_eq!(prepared.len(), 1);
+        let calls = lock_unpoisoned(&calls);
+        assert_eq!(calls.len(), 2);
+        assert!(
+            calls[0].starts_with("peer-a:prepare:"),
+            "replayed peer must be prepared before the remaining peer"
+        );
+        assert_eq!(calls[1], "peer-b:prepare");
+    }
+
+    #[tokio::test]
     async fn commit_tier_mutation_peers_serializes_shared_record_writes() {
         let mutation_id = uuid::Uuid::from_u128(35);
         let calls = Arc::new(Mutex::new(Vec::new()));
@@ -6176,6 +6212,72 @@ mod tests {
         assert!(!applied);
         assert_eq!(observed.state, TierMutationIntentState::Committed);
         assert_eq!(observed.committed_config_etag.as_deref(), Some("etag-new"));
+    }
+
+    #[tokio::test]
+    async fn intent_advance_reconciles_matching_commit_after_final_cas_race() {
+        let store = Arc::new(CasConfigStore::default());
+        let mutation_id = uuid::Uuid::from_u128(37);
+        let prepared = prepared_remove_intent("COLD-A", mutation_id);
+        crate::services::tier::tier_mutation_intent::save_tier_mutation_intent_record(store.clone(), &prepared)
+            .await
+            .expect("prepared intent fixture should persist");
+
+        let committed = committed_remove_intent("COLD-A", mutation_id, "etag-new");
+        let object = crate::services::tier::tier_mutation_intent::tier_mutation_intent_record_object_name(mutation_id)
+            .expect("record object should build");
+        store
+            .rewrite_on_next_if_match(object.clone(), prepared.encode().expect("prepared intent fixture should encode"))
+            .await;
+        store
+            .rewrite_on_next_if_match(object.clone(), prepared.encode().expect("prepared intent fixture should encode"))
+            .await;
+        store
+            .rewrite_on_next_if_match(object, committed.encode().expect("committed intent fixture should encode"))
+            .await;
+
+        let (observed, applied) = crate::services::tier::tier_mutation_intent::advance_tier_mutation_intent_record_idempotent(
+            store,
+            mutation_id,
+            TierMutationIntentState::Committed,
+            Some("etag-new".to_string()),
+        )
+        .await
+        .expect("matching commit after the final CAS race should be idempotent");
+
+        assert!(!applied);
+        assert_eq!(observed.state, TierMutationIntentState::Committed);
+        assert_eq!(observed.committed_config_etag.as_deref(), Some("etag-new"));
+    }
+
+    #[tokio::test]
+    async fn intent_advance_rejects_unresolved_final_cas_race() {
+        let store = Arc::new(CasConfigStore::default());
+        let mutation_id = uuid::Uuid::from_u128(38);
+        let prepared = prepared_remove_intent("COLD-A", mutation_id);
+        crate::services::tier::tier_mutation_intent::save_tier_mutation_intent_record(store.clone(), &prepared)
+            .await
+            .expect("prepared intent fixture should persist");
+
+        let object = crate::services::tier::tier_mutation_intent::tier_mutation_intent_record_object_name(mutation_id)
+            .expect("record object should build");
+        const CAS_ATTEMPTS_UNDER_TEST: usize = 3;
+        for _ in 0..CAS_ATTEMPTS_UNDER_TEST {
+            store
+                .rewrite_on_next_if_match(object.clone(), prepared.encode().expect("prepared intent fixture should encode"))
+                .await;
+        }
+
+        let err = crate::services::tier::tier_mutation_intent::advance_tier_mutation_intent_record_idempotent(
+            store,
+            mutation_id,
+            TierMutationIntentState::Committed,
+            Some("etag-new".to_string()),
+        )
+        .await
+        .expect_err("a still-prepared intent after the final CAS race must fail closed");
+
+        assert!(matches!(err, Error::PreconditionFailed));
     }
 
     #[tokio::test]
@@ -8270,7 +8372,7 @@ mod tests {
     struct CasConfigStore {
         objects: tokio::sync::Mutex<HashMap<String, (Vec<u8>, String)>>,
         legacy_state: tokio::sync::Mutex<Option<Vec<u8>>>,
-        if_match_race_rewrite: tokio::sync::Mutex<Option<(String, Vec<u8>)>>,
+        if_match_race_rewrite: tokio::sync::Mutex<std::collections::VecDeque<(String, Vec<u8>)>>,
         next_etag: AtomicUsize,
         fail_put: AtomicBool,
         truncate_reference_page_without_marker: AtomicBool,
@@ -8284,7 +8386,7 @@ mod tests {
             Self {
                 objects: tokio::sync::Mutex::new(HashMap::new()),
                 legacy_state: tokio::sync::Mutex::new(None),
-                if_match_race_rewrite: tokio::sync::Mutex::new(None),
+                if_match_race_rewrite: tokio::sync::Mutex::new(std::collections::VecDeque::new()),
                 next_etag: AtomicUsize::new(0),
                 fail_put: AtomicBool::new(false),
                 truncate_reference_page_without_marker: AtomicBool::new(false),
@@ -8311,7 +8413,7 @@ mod tests {
         }
 
         async fn rewrite_on_next_if_match(&self, object: String, data: Vec<u8>) {
-            *self.if_match_race_rewrite.lock().await = Some((object, data));
+            self.if_match_race_rewrite.lock().await.push_back((object, data));
         }
 
         fn omit_truncated_reference_marker(&self) {
@@ -8380,7 +8482,7 @@ mod tests {
                 .and_then(HTTPPreconditions::if_match_value)
                 .is_some()
             {
-                self.if_match_race_rewrite.lock().await.take()
+                self.if_match_race_rewrite.lock().await.pop_front()
             } else {
                 None
             };


### PR DESCRIPTION
## Related Issues

Refs #5218

## Summary of Changes

- Reconcile a final CAS precondition race by reloading the tier mutation intent and treating an already committed equivalent transition as idempotent.
- Accept a replayed `Committed` peer during prepare fanout and avoid scheduling it for another commit.
- Retry one fresh peer connection for the idempotent tier-config reload only after a network-like failure, so an offline notification client can converge without retrying peer business errors.
- Add focused state-machine coverage and a four-node AddTier regression that verifies tier visibility and remote-tier access on every hot node.

## Verification

- Passed before rebase: `make pre-pr`
- Passed after rebase: `cargo fmt --all --check`
- Passed after rebase: `cargo test -p rustfs-ecstore intent_advance_ -- --nocapture`
- Passed after rebase: `cargo test -p rustfs-ecstore peer_rest_client_ -- --nocapture`
- Passed after rebase: `cargo build -p rustfs`
- Passed after rebase: `cargo test -p e2e_test four_node_add_tier_committed_replay_converges -- --nocapture`
- GitHub CI is pending for the rebased head.

## Impact

Improves idempotent recovery and post-commit peer convergence for remote-tier mutations. No on-disk format, RPC protocol version, or S3 API changes.

## Additional Notes

- High-risk adversarial review completed across correctness, simplicity, security, concurrency/durability, compatibility, performance, and test coverage.
- The deterministic unit tests cover the same-mutation replay and final three-CAS reconciliation; the four-node E2E covers actual peer fanout and convergence.
