### PR TITLE
fix(ilm): report manual transition tier failures

### DIFF
--- a/crates/e2e_test/src/reliant/tiering.rs
+++ b/crates/e2e_test/src/reliant/tiering.rs
@@ -74,16 +74,19 @@ const MANUAL_ASYNC_STATUS_BUCKET: &str = "ilm7-manual-async-status";
 const MANUAL_CONTINUATION_BUCKET: &str = "ilm7-manual-continuation";
 const MANUAL_ASYNC_LIMIT_BUCKET: &str = "ilm7-manual-async-limit";
 const MANUAL_ASYNC_CONFLICT_BUCKET: &str = "ilm7-manual-async-conflict";
+const MANUAL_TIER_FAILURE_BUCKET: &str = "ilm7-manual-tier-failure";
 const MANUAL_QUEUE_PRESSURE_PREFIX: &str = "manual-queue-pressure/";
 const MANUAL_CONTINUATION_PREFIX: &str = "manual-continuation/";
 const MANUAL_ASYNC_LIMIT_PREFIX: &str = "manual-async-limit/";
 const MANUAL_ASYNC_CONFLICT_PREFIX: &str = "manual-async-conflict/";
 const MANUAL_ASYNC_CONFLICT_NESTED_PREFIX: &str = "manual-async-conflict/nested/";
+const MANUAL_TIER_FAILURE_PREFIX: &str = "manual-tier-failure/";
 const OBJECT_KEY: &str = "tier/鲁A12345/report.bin";
 const MANUAL_DUE_KEY: &str = "manual-due/report.bin";
 const MANUAL_DRY_RUN_KEY: &str = "manual-dry-run/report.bin";
 const MANUAL_NOT_DUE_KEY: &str = "manual-not-due/report.bin";
 const MANUAL_ASYNC_STATUS_KEY: &str = "manual-async-status/report.bin";
+const MANUAL_TIER_FAILURE_KEY: &str = "manual-tier-failure/report.bin";
 const CONTENT_TYPE: &str = "application/x-ilm7";
 const USER_META_KEY: &str = "ilm7-origin";
 const USER_META_VAL: &str = "hermetic-transition";
@@ -173,6 +176,15 @@ async fn add_rustfs_tier(hot: &RustFSTestEnvironment, cold: &RustFSTestEnvironme
     .await?;
     if !status.is_success() {
         return Err(format!("AddTier(RustFS) failed: status={status}, body={resp}").into());
+    }
+    Ok(())
+}
+
+async fn remove_rustfs_tier_force(hot: &RustFSTestEnvironment) -> TestResult {
+    let path = format!("/rustfs/admin/v3/tier/{TIER_NAME}?force=true");
+    let (status, resp) = signed_admin_request(&hot.url, Method::DELETE, &path, None, &hot.access_key, &hot.secret_key).await?;
+    if !status.is_success() {
+        return Err(format!("RemoveTier(RustFS) failed: status={status}, body={resp}").into());
     }
     Ok(())
 }
@@ -355,6 +367,10 @@ struct ManualTransitionRunReport {
     skipped_queue_full: u64,
     skipped_queue_closed: u64,
     skipped_queue_timeout: u64,
+    #[serde(default)]
+    tier_failure: u64,
+    #[serde(default)]
+    cancelled: bool,
     truncated_by_limit: bool,
     truncated_by_duration: bool,
     continuation_token: Option<String>,
@@ -718,6 +734,8 @@ async fn test_manual_transition_run_black_box_semantics() -> TestResult {
     assert_eq!(due.report.skipped_delete_marker, 0);
     assert_eq!(due.report.skipped_directory, 0);
     assert_eq!(due.report.skipped_replication, 0);
+    assert_eq!(due.report.tier_failure, 0);
+    assert!(!due.report.cancelled);
     assert!(!due.report.truncated_by_limit);
     assert!(!due.report.truncated_by_duration);
     wait_for_transition(&hot_client, MANUAL_DUE_BUCKET, MANUAL_DUE_KEY, StdDuration::from_secs(90)).await?;
@@ -745,6 +763,8 @@ async fn test_manual_transition_run_black_box_semantics() -> TestResult {
     assert_eq!(dry.report.dry_run_eligible, 1, "dry-run report: {:#?}", dry.report);
     assert_eq!(dry.report.enqueued, 0, "dry-run report: {:#?}", dry.report);
     assert_eq!(dry.report.skipped_not_transition, 1, "dry-run report: {:#?}", dry.report);
+    assert_eq!(dry.report.tier_failure, 0);
+    assert!(!dry.report.cancelled);
     assert!(!dry.report.truncated_by_duration);
     assert_eq!(
         cold_tier_object_count(&cold_client).await?,
@@ -767,6 +787,8 @@ async fn test_manual_transition_run_black_box_semantics() -> TestResult {
     assert_eq!(not_due.report.eligible, 0, "not-due report: {:#?}", not_due.report);
     assert_eq!(not_due.report.enqueued, 0, "not-due report: {:#?}", not_due.report);
     assert_eq!(not_due.report.skipped_not_transition, 1, "not-due report: {:#?}", not_due.report);
+    assert_eq!(not_due.report.tier_failure, 0);
+    assert!(!not_due.report.cancelled);
     assert_eq!(not_due.report.skipped_queue_full, 0);
     assert_eq!(not_due.report.skipped_queue_closed, 0);
     assert_eq!(not_due.report.skipped_queue_timeout, 0);
@@ -840,6 +862,8 @@ async fn test_manual_transition_async_job_status_polling() -> TestResult {
     assert_eq!(terminal.report.skipped_queue_full, 0);
     assert_eq!(terminal.report.skipped_queue_closed, 0);
     assert_eq!(terminal.report.skipped_queue_timeout, 0);
+    assert_eq!(terminal.report.tier_failure, 0);
+    assert!(!terminal.report.cancelled);
     assert!(!terminal.report.truncated_by_limit);
     assert!(!terminal.report.truncated_by_duration);
 
@@ -909,6 +933,8 @@ async fn test_manual_transition_async_limit_reports_terminal_partial() -> TestRe
     assert_eq!(terminal.report.skipped_queue_full, 0);
     assert_eq!(terminal.report.skipped_queue_closed, 0);
     assert_eq!(terminal.report.skipped_queue_timeout, 0);
+    assert_eq!(terminal.report.tier_failure, 0);
+    assert!(!terminal.report.cancelled);
     assert!(terminal.report.truncated_by_limit);
     assert!(!terminal.report.truncated_by_duration);
 
@@ -920,12 +946,16 @@ async fn test_manual_transition_async_limit_reports_terminal_partial() -> TestRe
     assert_eq!(after_cancel.report.tier, terminal.report.tier);
     assert_eq!(after_cancel.report.scanned, terminal.report.scanned);
     assert_eq!(after_cancel.report.skipped_not_transition, terminal.report.skipped_not_transition);
+    assert_eq!(after_cancel.report.tier_failure, terminal.report.tier_failure);
+    assert_eq!(after_cancel.report.cancelled, terminal.report.cancelled);
     assert_eq!(after_cancel.report.truncated_by_limit, terminal.report.truncated_by_limit);
 
     let second_cancel = manual_transition_job_cancel(&hot, status_endpoint).await?;
     assert_eq!(second_cancel.status, "partial");
     assert!(!second_cancel.cancel_requested);
     assert_eq!(second_cancel.report.scanned, terminal.report.scanned);
+    assert_eq!(second_cancel.report.tier_failure, terminal.report.tier_failure);
+    assert_eq!(second_cancel.report.cancelled, terminal.report.cancelled);
     assert_eq!(second_cancel.report.truncated_by_limit, terminal.report.truncated_by_limit);
     assert_eq!(cold_tier_object_count(&cold_client).await?, before_remote_count);
     Ok(())
@@ -1017,6 +1047,87 @@ async fn test_manual_transition_async_overlapping_scope_conflict_reports_active_
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_manual_transition_async_tier_failure_reports_terminal_partial() -> TestResult {
+    let mut cold = RustFSTestEnvironment::new().await?;
+    cold.access_key = "manualtierfailurecoldadmin".to_string();
+    cold.secret_key = "manualtierfailurecoldsecret".to_string();
+    cold.start_rustfs_server_without_cleanup(vec![]).await?;
+    let cold_client = cold.create_s3_client();
+    cold_client.create_bucket().bucket(TIER_BUCKET).send().await?;
+
+    let mut hot = RustFSTestEnvironment::new().await?;
+    hot.start_rustfs_server_with_env(vec![], &[("RUSTFS_SCANNER_ENABLED", "false"), ("RUSTFS_SCANNER_CYCLE", "3600")])
+        .await?;
+    let hot_client = hot.create_s3_client();
+    add_rustfs_tier(&hot, &cold).await?;
+
+    hot_client.create_bucket().bucket(MANUAL_TIER_FAILURE_BUCKET).send().await?;
+    let due_mtime = OffsetDateTime::now_utc() - time::Duration::hours(25);
+    put_backdated_single_part_object(
+        &hot_client,
+        MANUAL_TIER_FAILURE_BUCKET,
+        MANUAL_TIER_FAILURE_KEY,
+        b"manual tier failure object",
+        due_mtime,
+    )
+    .await?;
+    put_lifecycle_transition_rule(
+        &hot_client,
+        MANUAL_TIER_FAILURE_BUCKET,
+        "manual-tier-failure",
+        MANUAL_TIER_FAILURE_PREFIX,
+        0,
+    )
+    .await?;
+    remove_rustfs_tier_force(&hot).await?;
+
+    let before_remote_count = cold_tier_object_count(&cold_client).await?;
+    let accepted = manual_transition_async_run(&hot, MANUAL_TIER_FAILURE_BUCKET, MANUAL_TIER_FAILURE_PREFIX, false, 10).await?;
+    assert_eq!(accepted.state, "accepted");
+    assert_eq!(accepted.mode, "durable_job");
+    let job_id = accepted.job_id.as_deref().ok_or("async response must include job_id")?;
+    let status_endpoint = accepted
+        .status_endpoint
+        .as_deref()
+        .ok_or("async response must include status_endpoint")?;
+
+    let terminal = wait_for_manual_transition_job_terminal(&hot, status_endpoint, StdDuration::from_secs(30)).await?;
+    assert_eq!(terminal.job_id, job_id);
+    assert_eq!(terminal.status, "partial", "terminal tier failure job response: {terminal:#?}");
+    assert!(!terminal.cancel_requested);
+    assert_eq!(terminal.failure_reason, None);
+    assert_eq!(terminal.report.bucket, MANUAL_TIER_FAILURE_BUCKET);
+    assert_eq!(terminal.report.prefix, MANUAL_TIER_FAILURE_PREFIX);
+    assert_eq!(terminal.report.tier.as_deref(), Some(TIER_NAME));
+    assert!(!terminal.report.dry_run);
+    assert!(terminal.report.lifecycle_config_found);
+    assert_eq!(terminal.report.scanned, 1, "terminal tier failure job response: {terminal:#?}");
+    assert_eq!(terminal.report.eligible, 0, "terminal tier failure job response: {terminal:#?}");
+    assert_eq!(terminal.report.enqueued, 0, "terminal tier failure job response: {terminal:#?}");
+    assert_eq!(terminal.report.tier_failure, 1, "terminal tier failure job response: {terminal:#?}");
+    assert_eq!(terminal.report.skipped_queue_full, 0);
+    assert_eq!(terminal.report.skipped_queue_closed, 0);
+    assert_eq!(terminal.report.skipped_queue_timeout, 0);
+    assert!(!terminal.report.cancelled);
+    assert!(!terminal.report.truncated_by_limit);
+    assert!(!terminal.report.truncated_by_duration);
+    assert_eq!(
+        cold_tier_object_count(&cold_client).await?,
+        before_remote_count,
+        "tier failure must not create a remote object"
+    );
+    assert_remains_not_transitioned(
+        &hot_client,
+        MANUAL_TIER_FAILURE_BUCKET,
+        MANUAL_TIER_FAILURE_KEY,
+        StdDuration::from_secs(2),
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_manual_transition_run_contract_no_status_cancel_fields() -> TestResult {
     let mut cold = RustFSTestEnvironment::new().await?;
     cold.access_key = "manualcontractcoldtieradmin".to_string();
@@ -1092,6 +1203,8 @@ async fn test_manual_transition_run_continuation_token_resumes_without_raw_marke
     assert_eq!(first.report.scanned, 1, "first continuation page: {first:#?}");
     assert_eq!(first.report.eligible, 1, "first continuation page: {first:#?}");
     assert_eq!(first.report.dry_run_eligible, 1, "first continuation page: {first:#?}");
+    assert_eq!(first.report.tier_failure, 0);
+    assert!(!first.report.cancelled);
     assert!(first.report.truncated_by_limit);
     let continuation = first
         .report
@@ -1119,6 +1232,8 @@ async fn test_manual_transition_run_continuation_token_resumes_without_raw_marke
     assert_eq!(second.report.scanned, 1, "second continuation page: {second:#?}");
     assert_eq!(second.report.eligible, 1, "second continuation page: {second:#?}");
     assert_eq!(second.report.dry_run_eligible, 1, "second continuation page: {second:#?}");
+    assert_eq!(second.report.tier_failure, 0);
+    assert!(!second.report.cancelled);
     assert!(!second.report.truncated_by_limit);
     assert!(second.report.continuation_token.is_none());
 
@@ -1173,6 +1288,8 @@ async fn test_manual_transition_run_queue_pressure_partial() -> TestResult {
         "expected queue-pressure path to skip at least one object: {:#?}",
         response.report
     );
+    assert_eq!(response.report.tier_failure, 0);
+    assert!(!response.report.cancelled);
     assert!(!response.report.truncated_by_duration);
     assert!(response.report.enqueued < 20, "partial run should not enqueue all items in this setup");
 

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -1605,7 +1605,7 @@ fn spawn_manual_transition_job_recovery_once(api: Arc<ECStore>) -> Option<JoinHa
         let cancel_token = runtime_sources::background_services_cancel_token().unwrap_or_default();
         select! {
             _ = cancel_token.cancelled() => {}
-            result = recover_manual_transition_jobs_once(api, DEFAULT_MANUAL_TRANSITION_JOB_RECOVERY_LIMIT, None) => {
+            result = recover_manual_transition_jobs(api, DEFAULT_MANUAL_TRANSITION_JOB_RECOVERY_LIMIT) => {
                 match result {
                     Ok(stats) => {
                         debug!(
@@ -1655,6 +1655,32 @@ enum ManualTransitionJobRecoveryOutcome {
     Resumed,
     Cancelled,
     Skipped,
+}
+
+async fn recover_manual_transition_jobs(api: Arc<ECStore>, limit: usize) -> Result<ManualTransitionJobRecoveryStats, Error> {
+    let mut marker = None;
+    let mut total = ManualTransitionJobRecoveryStats::default();
+
+    loop {
+        let stats = recover_manual_transition_jobs_once(api.clone(), limit, marker).await?;
+        total.scanned = total.scanned.saturating_add(stats.scanned);
+        total.resumed = total.resumed.saturating_add(stats.resumed);
+        total.cancelled = total.cancelled.saturating_add(stats.cancelled);
+        total.skipped = total.skipped.saturating_add(stats.skipped);
+        total.failed = total.failed.saturating_add(stats.failed);
+
+        if !stats.truncated {
+            total.truncated = false;
+            total.next_marker = None;
+            return Ok(total);
+        }
+        let Some(next_marker) = stats.next_marker else {
+            return Err(Error::other("manual transition job recovery page is truncated without a next marker"));
+        };
+        total.truncated = true;
+        total.next_marker = Some(next_marker.clone());
+        marker = Some(next_marker);
+    }
 }
 
 pub async fn recover_manual_transition_jobs_once(
@@ -3299,6 +3325,15 @@ async fn enqueue_transition_with_lifecycle_report(
                 report.skipped_tier = report.skipped_tier.saturating_add(1);
                 return false;
             }
+            if !options.dry_run
+                && !runtime_sources::tier_config_mgr_handle()
+                    .read()
+                    .await
+                    .is_tier_valid(&event.storage_class)
+            {
+                report.tier_failure = report.tier_failure.saturating_add(1);
+                return false;
+            }
             report.eligible = report.eligible.saturating_add(1);
             if options.dry_run {
                 report.dry_run_eligible = report.dry_run_eligible.saturating_add(1);
@@ -4169,12 +4204,12 @@ mod tests {
         lifecycle_rule_has_date_expiration, lifecycle_version_purge_state_from_completed_targets,
         manual_transition_duration_elapsed, manual_transition_has_more_after_limit, manual_transition_version_marker,
         mark_delete_opts_skip_decommissioned_on_remote_success, merge_stale_multipart_candidate,
-        persist_manual_transition_page_checkpoint, recover_manual_transition_jobs_once, replication_state_for_delete,
-        resolve_transition_queue_capacity, resolve_transition_queue_send_timeout, resolve_transition_worker_count,
-        resolve_transition_workers_absolute_max, run_tier_free_version_recovery_loop, select_restore_s3_location,
-        set_recovered_free_version_enqueue_observer, should_defer_date_expiry_for_recent_config_update,
-        should_reuse_lifecycle_delete_replication_state, transitioned_cleanup_tuple, transitioned_object_delete_opts,
-        wait_for_tier_free_version_recovery,
+        persist_manual_transition_page_checkpoint, recover_manual_transition_jobs, recover_manual_transition_jobs_once,
+        replication_state_for_delete, resolve_transition_queue_capacity, resolve_transition_queue_send_timeout,
+        resolve_transition_worker_count, resolve_transition_workers_absolute_max, run_tier_free_version_recovery_loop,
+        select_restore_s3_location, set_recovered_free_version_enqueue_observer,
+        should_defer_date_expiry_for_recent_config_update, should_reuse_lifecycle_delete_replication_state,
+        transitioned_cleanup_tuple, transitioned_object_delete_opts, wait_for_tier_free_version_recovery,
     };
     #[cfg(feature = "test-util")]
     use super::{delete_free_version_remote_object_then, encode_dir_object, get_transitioned_object_reader_with_tier_manager};
@@ -6857,6 +6892,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manual_transition_reports_runtime_tier_failure_before_enqueue() {
+        let lc = latest_transition_lifecycle();
+        let object = current_object(ReplicationStatusType::Completed);
+        let options = ManualTransitionRunOptions::default();
+        let mut report = ManualTransitionRunReport::new(&object.bucket, &options);
+
+        let handled = enqueue_transition_with_lifecycle_report(&object, &lc, &LcEventSrc::Scanner, &options, &mut report).await;
+
+        assert!(!handled);
+        assert_eq!(report.eligible, 0);
+        assert_eq!(report.enqueued, 0);
+        assert_eq!(report.tier_failure, 1);
+        assert!(!report.has_partial_enqueue());
+    }
+
+    #[tokio::test]
     async fn manual_transition_counts_already_transitioned_object() {
         let lc = latest_transition_lifecycle();
         let mut object = current_object(ReplicationStatusType::Completed);
@@ -7051,6 +7102,93 @@ mod tests {
                 Err(Error::ConfigNotFound)
             ),
             "completed recovery must release the scope admission"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn manual_transition_recovery_drains_multiple_record_pages() {
+        let (_paths, ecstore) = setup_test_env().await;
+        let mut job_ids = Vec::new();
+
+        for bucket in ["manual-recovery-page-a", "manual-recovery-page-b"] {
+            let job_id = Uuid::new_v4();
+            let options = ManualTransitionRunOptions {
+                prefix: "logs/".to_string(),
+                ..Default::default()
+            };
+            let mut record = ManualTransitionJobRecord::new(job_id, bucket, &options, "old-owner");
+            record.lease_expires_at_unix_nanos = 0;
+            save_manual_transition_job_record(ecstore.clone(), &record)
+                .await
+                .expect("expired job record should save");
+            save_manual_transition_scope_admission_if_absent(ecstore.clone(), &ManualTransitionScopeAdmission::from_job(&record))
+                .await
+                .expect("expired scope admission should save");
+            job_ids.push((job_id, record.scope_key.clone()));
+        }
+
+        let stats = recover_manual_transition_jobs(ecstore.clone(), 1)
+            .await
+            .expect("manual transition recovery should drain all pages");
+
+        assert_eq!(stats.resumed, 2);
+        assert_eq!(stats.failed, 0);
+        assert!(!stats.truncated);
+        assert!(stats.next_marker.is_none());
+        for (job_id, scope_key) in job_ids {
+            let recovered = load_manual_transition_job_record(ecstore.clone(), job_id)
+                .await
+                .expect("recovered job should load");
+            assert_eq!(recovered.state, ManualTransitionJobState::Completed);
+            assert!(
+                matches!(
+                    load_manual_transition_scope_admission(ecstore.clone(), &scope_key).await,
+                    Err(Error::ConfigNotFound)
+                ),
+                "completed recovery must release every scope admission"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn manual_transition_recovery_completes_expired_cancelled_record() {
+        let (_paths, ecstore) = setup_test_env().await;
+        let job_id = Uuid::new_v4();
+        let options = ManualTransitionRunOptions {
+            prefix: "logs/".to_string(),
+            ..Default::default()
+        };
+        let mut record = ManualTransitionJobRecord::new(job_id, "manual-recovery-cancel-bucket", &options, "old-owner");
+        record.lease_expires_at_unix_nanos = 0;
+        record.mark_cancel_requested();
+        save_manual_transition_job_record(ecstore.clone(), &record)
+            .await
+            .expect("expired cancelled job record should save");
+        save_manual_transition_scope_admission_if_absent(ecstore.clone(), &ManualTransitionScopeAdmission::from_job(&record))
+            .await
+            .expect("expired cancelled scope admission should save");
+
+        let stats = recover_manual_transition_jobs(ecstore.clone(), 10)
+            .await
+            .expect("manual transition recovery should process cancelled jobs");
+
+        assert_eq!(stats.cancelled, 1);
+        assert_eq!(stats.resumed, 0);
+        assert_eq!(stats.failed, 0);
+        let recovered = load_manual_transition_job_record(ecstore.clone(), job_id)
+            .await
+            .expect("cancelled job should load");
+        assert_eq!(recovered.state, ManualTransitionJobState::Cancelled);
+        assert!(recovered.cancel_requested);
+        assert!(recovered.report.cancelled);
+        assert!(
+            matches!(
+                load_manual_transition_scope_admission(ecstore, &record.scope_key).await,
+                Err(Error::ConfigNotFound)
+            ),
+            "cancelled recovery must release the scope admission"
         );
     }
 

--- a/rustfs/src/admin/handlers/ilm_transition.rs
+++ b/rustfs/src/admin/handlers/ilm_transition.rs
@@ -412,7 +412,7 @@ async fn authorize_manual_transition_request(req: &S3Request<Body>) -> S3Result<
 }
 
 fn response_state(report: &ManualTransitionRunReport) -> &'static str {
-    if report.was_truncated() || report.has_partial_enqueue() {
+    if report.was_truncated() || report.has_partial_enqueue() || report.tier_failure > 0 {
         "partial"
     } else {
         "completed"
@@ -1133,6 +1133,16 @@ mod tests {
     fn manual_transition_response_reports_partial_for_duration_budget() {
         let report = ManualTransitionRunReport {
             truncated_by_duration: true,
+            ..Default::default()
+        };
+
+        assert_eq!(response_state(&report), "partial");
+    }
+
+    #[test]
+    fn manual_transition_response_reports_partial_for_tier_failure() {
+        let report = ManualTransitionRunReport {
+            tier_failure: 1,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1481
rustfs/backlog#1431

## Summary of Changes
This PR hardens async manual transition accounting when the lifecycle rule still references a tier that is no longer present in the runtime tier manager. Instead of counting the object as eligible or enqueueing work that cannot run, the manual transition scan records `tier_failure`, leaves the object on the hot tier, and reports the terminal job state as `partial`.

It also drains all manual transition recovery pages during startup recovery instead of processing only one page, and adds regression coverage for both multi-page recovery and expired cancelled job recovery releasing the persisted scope admission.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo build -p rustfs`
- `cargo test -p rustfs-ecstore manual_transition_reports_runtime_tier_failure_before_enqueue --lib -- --nocapture`
- `cargo test -p rustfs manual_transition_response_reports_partial_for_tier_failure --lib -- --nocapture`
- `cargo test -p rustfs-ecstore manual_transition_recovery_drains_multiple_record_pages --lib -- --nocapture`
- `cargo test -p rustfs-ecstore manual_transition_recovery_completes_expired_cancelled_record --lib -- --nocapture`
- `cargo test -p e2e_test --lib reliant::tiering::test_manual_transition_async_tier_failure_reports_terminal_partial -- --exact --nocapture`
- `cargo clippy -p e2e_test --lib -- -D warnings`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `cargo clippy -p rustfs --lib -- -D warnings`

## Impact
No S3 API, admin route, persisted metadata, proto schema, or configuration compatibility change is introduced. Existing response fields are used; the visible behavior change is that a real manual transition run with a missing runtime tier is reported as terminal `partial` with `tier_failure > 0` instead of looking completed or eligible.

The recovery loop can now process more than one persisted job page per startup pass. The added per-object runtime tier check is limited to non-dry-run manual transition candidates after lifecycle matching and tier filtering, not the regular scanner worker hot path.

## Additional Notes
This PR is opened as draft because the focused validation above passed but the full `make pre-commit` gate has not been rerun for this high-risk ILM/tiering slice.

Adversarial validation summary: correctness attacked stale lifecycle tier configuration, multi-page recovery truncation, and cancelled expired jobs; no unresolved break found after the new tests. Simplicity attacked the new recovery entrypoint visibility and it was kept private to avoid expanding the crate API. Security attacked admin/API and serialization surface; no new endpoint, auth path, schema, or untrusted parser was added. Concurrency/durability attacked persisted scope admission leaks and startup recovery pagination; the tests now assert every recovered/cancelled job releases its scope admission. Compatibility attacked S3/admin response and persisted format drift; the PR reuses existing report fields and changes no schema. Performance attacked extra locking on object paths; the new tier-manager read lock is limited to manual transition candidates and avoids enqueueing work that would fail later. Test coverage attacked revertability; reverting the tier failure check, response-state mapping, recovery page drain, or cancelled recovery release should fail the new focused or e2e tests.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
