### PR TITLE
docs: fix dead TLS configuration doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ nix run
 2. **Create a Bucket**: Use the console to create a new bucket for your objects.
 3. **Upload Objects**: You can upload files directly through the console or use S3-compatible APIs/clients to interact with your RustFS instance.
 
-**NOTE**: To access the RustFS instance via `https`, please refer to the [TLS Configuration Docs](https://docs.rustfs.com/integration/tls-configured.html).
+**NOTE**: To access the RustFS instance via `https`, please refer to the [TLS Configuration Docs](https://docs.rustfs.com/integration/tls-configured).
 
 ## Documentation
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -172,7 +172,7 @@ make help-docker                      # 显示所有 Docker 相关命令
 2. **创建存储桶**: 使用控制台为您​​的对象创建一个新的存储桶 (Bucket)。
 3. **上传对象**: 您可以直接通过控制台上传文件，或使用 S3 兼容的 API/客户端与您的 RustFS 实例进行交互。
 
-**注意**: 如果您希望通过 `https` 访问 RustFS 实例，请参考 [TLS 配置文档](https://docs.rustfs.com/integration/tls-configured.html)。
+**注意**: 如果您希望通过 `https` 访问 RustFS 实例，请参考 [TLS 配置文档](https://docs.rustfs.com/integration/tls-configured)。
 
 ## 文档
 


### PR DESCRIPTION
## What

The TLS configuration doc link in `README.md` and `README_ZH.md` returns 404: docs.rustfs.com dropped the `.html` suffix from page URLs during a site restructure.

- Before: `https://docs.rustfs.com/integration/tls-configured.html` (404)
- After: `https://docs.rustfs.com/integration/tls-configured` (200, listed in the site's sitemap, page title "TLS Configuration")

## Why not #5154

Supersedes #5154, which pointed the links at Wayback Machine snapshots on the claim that the host is dead. The docs site is alive — only the URL format changed — so linking to the live canonical page is the correct fix. All other `docs.rustfs.com` links in the repo were checked and are valid.