### PR TITLE
fix(kms): do not include secret value in static KMS format error

### DIFF
--- a/rustfs/src/init.rs
+++ b/rustfs/src/init.rs
@@ -394,11 +394,11 @@ fn build_static_kms_config(cfg: &config::Config) -> std::io::Result<rustfs_kms::
         )));
     }
 
-    let colon_pos = secret_str.find(':').ok_or_else(|| {
-        Error::other(format!(
-            "Static KMS secret key must be in format <key-name>:<base64-key>, got: {secret_str}"
-        ))
-    })?;
+    // Do not include the value in the error: a malformed value is likely the raw
+    // secret key itself, and this message ends up in startup logs.
+    let colon_pos = secret_str
+        .find(':')
+        .ok_or_else(|| Error::other("Static KMS secret key must be in format <key-name>:<base64-key>"))?;
     let key_id = secret_str[..colon_pos].to_string();
     let secret_key = secret_str[colon_pos + 1..].to_string();
 


### PR DESCRIPTION
## Related Issues

Follow-up to #5222 (review finding).

## Summary of Changes

`build_static_kms_config()` in `rustfs/src/init.rs` included the raw env var value in the malformed-format error:

```rust
"Static KMS secret key must be in format <key-name>:<base64-key>, got: {secret_str}"
```

The most likely misconfiguration is setting `RUSTFS_KMS_STATIC_SECRET_KEY` to the bare base64 key without the `<key-name>:` prefix — exactly the case that triggers this error — so the full secret key material would be written to startup logs. This PR drops the value from the message, matching the equivalent parsing error in `KmsConfig::from_env()` which already omits it.

## Verification

- `cargo check -p rustfs` — zero errors
- `cargo fmt` — clean

## Impact

- Error-message-only change; no functional behavior change. Startup still fails with a clear format hint, just without echoing the secret.