### PR TITLE
docs: add autonomy and approval boundaries to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@ If repo-level instructions conflict, follow the nearest file and keep behavior a
 - Avoid redundant file reads, repeated commands, and unnecessary exploratory work once enough context is available.
 - A good result is a minimal diff with clear assumptions, no over-engineering, and independent verification that survives Adversarial Validation (below).
 
+## Autonomy and Approval Boundaries
+
+- Inquiry tasks (answer, explain, review, diagnose, plan): report findings; do not change files unless a fix is explicitly requested.
+- Action tasks (change, build, fix): make in-scope local changes without asking for approval.
+- Ask for confirmation before destructive or hard-to-reverse operations (force-pushes, history rewrites, deleting data or branches), merging a PR (reviewer approval required), or any material expansion of the requested scope.
+
 ## Communication and Language
 
 - Respond in the same language used by the requester.


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes

This PR originally streamlined the previous 101-line `AGENTS.md` (deduplicating repeated instructions per current prompting best practices for agent instruction files). Since then, `main` replaced that file with a comprehensive rewrite that supersedes the deduplication work, so the branch has been rebased onto the new version and the scope reduced to the one piece still missing from it.

The remaining change adds an "Autonomy and Approval Boundaries" section to the root `AGENTS.md`, following the compact policy template recommended by current prompting guidance: inquiry tasks (answer, explain, review, diagnose, plan) report findings without changing files; action tasks (change, build, fix) proceed with in-scope local changes without approval; confirmation is required before destructive or hard-to-reverse operations, merging a PR, or a material expansion of the requested scope. This absorbs decision-authority rules that the new document does not state explicitly, and complements the ambiguity guidance already present in Execution Discipline.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` — N/A per `AGENTS.md` Verification Before PR: documentation/instruction-only changes are exempt from the verification commands
- [ ] Added/updated necessary tests — N/A (documentation only)
- [x] Documentation updated (if needed)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: none — instruction file for AI agents and contributors only; no runtime surface.

## Additional Notes

Verification: `git diff main -- AGENTS.md` shows a single 6-line section insertion after "Execution Discipline"; no other files change. Per the risk tiers in `AGENTS.md`, this is an exempt (instruction-only) change, so Adversarial Validation does not apply.
