### PR TITLE
fix(ecstore): fail fast on missing RPC secret in distributed startup

### DIFF
--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -19,6 +19,7 @@ use crate::runtime::instance::InstanceContext;
 use crate::runtime::sources as runtime_sources;
 use crate::storage_api_contracts::object::EcstoreObjectIO;
 use rustfs_config::server_config::KVS;
+use rustfs_credentials::{RPC_SECRET_REQUIRED_OPERATOR_MESSAGE, try_get_rpc_token};
 use tracing::{debug, error, info, warn};
 
 const LOG_COMPONENT_ECSTORE: &str = "ecstore";
@@ -27,6 +28,7 @@ const EVENT_DECOMMISSION_RESUME_RETRY: &str = "decommission_resume_retry";
 const EVENT_DECOMMISSION_RESUME_FAILED: &str = "decommission_resume_failed";
 const EVENT_STORE_FORMAT_RETRY: &str = "store_format_retry";
 const EVENT_ECSTORE_INIT_STATUS: &str = "ecstore_init_status";
+const EVENT_STORE_RPC_SECRET_PREFLIGHT_FAILED: &str = "store_rpc_secret_preflight_failed";
 
 fn pool_first_endpoint_is_local(pool: &crate::layout::endpoints::PoolEndpoints) -> bool {
     pool.endpoints.as_ref().first().is_some_and(|endpoint| endpoint.is_local)
@@ -47,6 +49,48 @@ fn resolve_startup_pool_defaults_with(
     validate(endpoint_pools)?;
     let drive_counts = startup_pool_drive_counts(endpoint_pools);
     drive_counts.into_iter().map(ec_drives_no_config).collect()
+}
+
+/// Fail fast when the topology spans remote nodes but no internode RPC secret
+/// resolves. Every remote format read would otherwise fail client-side with
+/// "No valid auth token" and startup would retry for minutes before dying with
+/// a misleading "erasure read quorum" error (issues #4939, #5153).
+fn preflight_startup_rpc_secret(endpoint_pools: &EndpointServerPools) -> Result<()> {
+    preflight_startup_rpc_secret_with(endpoint_pools, try_get_rpc_token)
+}
+
+fn preflight_startup_rpc_secret_with(
+    endpoint_pools: &EndpointServerPools,
+    resolve_rpc_token: impl FnOnce() -> std::io::Result<String>,
+) -> Result<()> {
+    let has_remote_endpoint = endpoint_pools
+        .as_ref()
+        .iter()
+        .flat_map(|pool| pool.endpoints.as_ref().iter())
+        .any(|endpoint| !endpoint.is_local);
+
+    if !has_remote_endpoint {
+        return Ok(());
+    }
+
+    match resolve_rpc_token() {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            // The message prefix must stay aligned with the runtime log in
+            // cluster/rpc/http_auth.rs: the log-analyzer `rpc-secret-resolution`
+            // rule anchors on it, and this preflight aborts before that log
+            // would ever be emitted.
+            error!(
+                event = EVENT_STORE_RPC_SECRET_PREFLIGHT_FAILED,
+                component = LOG_COMPONENT_ECSTORE,
+                subsystem = LOG_SUBSYSTEM_STORE_INIT,
+                "RPC auth secret resolution failed: {err}; {RPC_SECRET_REQUIRED_OPERATOR_MESSAGE}"
+            );
+            Err(Error::other(format!(
+                "store init aborted: endpoints include remote nodes but {err}; {RPC_SECRET_REQUIRED_OPERATOR_MESSAGE}"
+            )))
+        }
+    }
 }
 
 fn should_resume_local_decommission(endpoints: &EndpointServerPools, idx: usize) -> Result<bool> {
@@ -217,6 +261,8 @@ impl ECStore {
         // payload writes use the runtime storage-class snapshot published later
         // from config before the store is marked ready.
         let default_pool_parities = resolve_startup_pool_defaults(&endpoint_pools)?;
+
+        preflight_startup_rpc_secret(&endpoint_pools)?;
 
         let mut deployment_id = None;
 
@@ -522,9 +568,10 @@ impl ECStore {
 mod tests {
     use super::{
         LOCAL_DECOMMISSION_RESUME_MAX_CONFIG_RETRIES, load_pool_meta_for_startup, pool_first_endpoint_is_local,
-        resolve_startup_pool_defaults_with, resolve_store_init_stage_result, save_validated_pool_meta_for_startup,
-        should_auto_start_rebalance_after_init, should_auto_start_rebalance_after_recovered_meta,
-        should_resume_local_decommission, should_retry_local_decommission_resume, wait_for_local_decommission_resume_delay,
+        preflight_startup_rpc_secret_with, resolve_startup_pool_defaults_with, resolve_store_init_stage_result,
+        save_validated_pool_meta_for_startup, should_auto_start_rebalance_after_init,
+        should_auto_start_rebalance_after_recovered_meta, should_resume_local_decommission,
+        should_retry_local_decommission_resume, wait_for_local_decommission_resume_delay,
     };
     #[cfg(feature = "test-util")]
     use crate::{
@@ -851,6 +898,123 @@ mod tests {
         assert!(
             pool_first_endpoint_is_local(endpoints.as_ref().get(1).expect("second pool should exist")),
             "the expanded pool should be initialized by its own first local endpoint"
+        );
+    }
+
+    fn rpc_preflight_pools(pools: Vec<Vec<Endpoint>>) -> EndpointServerPools {
+        EndpointServerPools::from(
+            pools
+                .into_iter()
+                .enumerate()
+                .map(|(pool_index, endpoints)| PoolEndpoints {
+                    legacy: false,
+                    set_count: 1,
+                    drives_per_set: endpoints.len(),
+                    endpoints: Endpoints::from(endpoints),
+                    cmd_line: format!("pool-{pool_index}"),
+                    platform: String::new(),
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn parsed_local_endpoint() -> Endpoint {
+        let mut endpoint = Endpoint::try_from("http://127.0.0.1:9000/data").expect("local endpoint should parse");
+        endpoint.is_local = true;
+        endpoint
+    }
+
+    fn parsed_remote_endpoint() -> Endpoint {
+        let mut endpoint = Endpoint::try_from("http://10.0.0.2:9000/data").expect("remote endpoint should parse");
+        endpoint.is_local = false;
+        endpoint
+    }
+
+    #[test]
+    fn test_rpc_secret_preflight_aborts_for_remote_endpoints_without_secret() {
+        // The remote endpoint intentionally sits behind a local one: the
+        // preflight must scan every endpoint, not just the first.
+        let pools = rpc_preflight_pools(vec![vec![parsed_local_endpoint(), parsed_remote_endpoint()]]);
+
+        let err = preflight_startup_rpc_secret_with(&pools, || {
+            Err(std::io::Error::other(rustfs_credentials::RPC_SECRET_REQUIRED_MESSAGE))
+        })
+        .expect_err("remote endpoints without an RPC secret must abort startup before the format retry loop");
+
+        let message = err.to_string();
+        assert!(message.contains("store init aborted"), "unexpected error: {message}");
+        assert!(
+            message.contains(rustfs_credentials::RPC_SECRET_REQUIRED_MESSAGE),
+            "error must state the resolution failure: {message}"
+        );
+        assert!(
+            message.contains(rustfs_credentials::RPC_SECRET_REQUIRED_OPERATOR_MESSAGE),
+            "error must carry the operator remediation guidance: {message}"
+        );
+    }
+
+    #[test]
+    fn test_rpc_secret_preflight_aborts_for_remote_endpoint_in_later_pool() {
+        // The remote endpoint hides in a later, otherwise-local pool: a
+        // first-pool shortcut (the `first_local` shape) must not pass.
+        let pools = rpc_preflight_pools(vec![vec![parsed_local_endpoint()], vec![parsed_remote_endpoint()]]);
+
+        let err = preflight_startup_rpc_secret_with(&pools, || {
+            Err(std::io::Error::other(rustfs_credentials::RPC_SECRET_REQUIRED_MESSAGE))
+        })
+        .expect_err("a remote endpoint in a later pool must abort startup without an RPC secret");
+
+        let message = err.to_string();
+        assert!(message.contains("store init aborted"), "unexpected error: {message}");
+    }
+
+    #[test]
+    fn test_rpc_secret_preflight_skips_resolution_for_local_only_endpoints() {
+        preflight_startup_rpc_secret_with(&rpc_preflight_pools(vec![vec![parsed_local_endpoint()]]), || {
+            panic!("single-node topology must not resolve an RPC secret")
+        })
+        .expect("local-only topology must start without an RPC secret");
+    }
+
+    #[test]
+    fn test_rpc_secret_preflight_accepts_remote_endpoints_with_resolved_secret() {
+        preflight_startup_rpc_secret_with(&rpc_preflight_pools(vec![vec![parsed_remote_endpoint()]]), || {
+            Ok("resolved-secret".to_string())
+        })
+        .expect("a resolvable RPC secret must not block startup");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn test_new_with_instance_ctx_aborts_before_format_retry_loop_without_rpc_secret() {
+        // Guard: under a shared-process `cargo test` run another test may have
+        // already pinned the process-global RPC secret (ensure_test_rpc_secret),
+        // which would let init proceed past the preflight into remote disk
+        // init. A failing probe pins nothing, so it cannot poison later tests;
+        // under nextest's process-per-test model (CI) the guard never fires.
+        if rustfs_credentials::try_get_rpc_token().is_ok() {
+            return;
+        }
+
+        let mut remote_endpoint = parsed_remote_endpoint();
+        remote_endpoint.set_pool_index(0);
+        remote_endpoint.set_set_index(0);
+        remote_endpoint.set_disk_index(0);
+
+        let err = crate::store::ECStore::new_with_instance_ctx(
+            "127.0.0.1:0".parse().expect("test address"),
+            rpc_preflight_pools(vec![vec![remote_endpoint]]),
+            CancellationToken::new(),
+            Arc::new(crate::runtime::instance::InstanceContext::new()),
+        )
+        .await
+        .expect_err("distributed init without an RPC secret must abort before the format retry loop");
+
+        let message = err.to_string();
+        assert!(message.contains("store init aborted"), "unexpected error: {message}");
+        assert!(
+            message.contains(rustfs_credentials::RPC_SECRET_REQUIRED_OPERATOR_MESSAGE),
+            "abort must carry the operator remediation guidance: {message}"
         );
     }
 

--- a/docs/operations/internode-grpc-benchmark-runbook.md
+++ b/docs/operations/internode-grpc-benchmark-runbook.md
@@ -123,8 +123,10 @@ target/bench/internode-transport/
 Captured while running the first real A/B on a 4-node ansible cluster; needed before any live run:
 
 - **RPC secret is mandatory on current `main`.** Internode RPC fails closed: default creds
-  (`RUSTFS_SECRET_KEY=rustfsadmin`) with no `RUSTFS_RPC_SECRET` → `No valid auth token` → the cluster
-  never reaches `storage_quorum`. Set a **non-default** `RUSTFS_RPC_SECRET`, identical on every node.
+  (`RUSTFS_SECRET_KEY=rustfsadmin`) with no `RUSTFS_RPC_SECRET` → the node aborts startup immediately
+  with `store init aborted: endpoints include remote nodes but RPC authentication secret is not
+  configured` (builds before the preflight instead showed `No valid auth token` and never reached
+  `storage_quorum`). Set a **non-default** `RUSTFS_RPC_SECRET`, identical on every node.
 - **systemd start timeout.** The install unit is `Type=notify`; READY only fires after quorum, which on
   freshly-purged disks exceeds a 30 s `TimeoutStartSec` → crash loop. Use a drop-in `TimeoutStartSec=infinity`.
 - **Server-side metrics need OTLP.** RustFS has no Prometheus pull endpoint (`/admin/v3/metrics` is NDJSON,


### PR DESCRIPTION
## Related Issues

Related to #4939 and #5153 — both are this failure mode reported through its misleading symptom.

## Summary of Changes

Distributed startup currently buries a missing internode RPC secret under a misleading error: every remote `format.json` read fails client-side with `No valid auth token`, and after 10 retries (~2 minutes) startup dies with `store init failed to load formats after 10 retries: erasure read quorum`. The only hint is a Once-logged `RPC auth secret resolution failed` from the RPC auth layer.

- Add `preflight_startup_rpc_secret` to `ECStore::new_with_instance_ctx` (`crates/ecstore/src/store/init.rs`): before any disk opens or the format-load retry loop starts, if any endpoint across all pools is non-local, resolve the RPC secret once via `rustfs_credentials::try_get_rpc_token()`. On failure, abort startup immediately with `store init aborted: endpoints include remote nodes but <cause>; <RPC_SECRET_REQUIRED_OPERATOR_MESSAGE>`.
- The preflight emits the `RPC auth secret resolution failed` log line with the same message prefix as the runtime log in `cluster/rpc/http_auth.rs` (see the code comment), so the log-analyzer `rpc-secret-resolution` rule keeps classifying this scenario — the runtime log is no longer reachable once startup aborts first. This intentional literal duplication is documented at both call sites' shared anchor in the rule seed.
- Single-node (all-local) topologies are unaffected: the resolver is never invoked, pinned by a panicking-resolver test.
- Placing the check in ECStore init covers both the main server and embedded startup paths; both initialize credentials before storage init.
- Updated the internode gRPC benchmark runbook bullet that documented the old failure signature.

## Verification

- `make pre-pr` (fmt-check, guard scripts, log-analyzer rules check, clippy `-D warnings`, full workspace `cargo nextest run --all --exclude e2e_test`) — pass.
- Focused: `cargo test -p rustfs-ecstore --lib store::init` (29 tests), `cargo test -p rustfs-log-analyzer` (87), `cargo test -p rustfs-credentials` (24) — pass.
- Mutation check: with the preflight call site removed, the new constructor-level test fails (deterministic red through the old retry loop); with it wired, it passes in milliseconds. The wiring needs its own test because the module-wide `#![allow(dead_code)]` in `store/mod.rs` defeats any dead-code lint backstop.
- New regression tests: abort when a remote endpoint hides behind a local one in the same pool; abort when the remote endpoint appears only in a later pool; local-only topology never resolves the secret; remote endpoint plus resolvable secret proceeds; constructor-level abort before the format retry loop.

## Impact

- Operator-facing: a distributed deployment with an unresolvable RPC secret now fails startup in milliseconds with an actionable message instead of ~2 minutes of retries ending in `erasure read quorum`. Tooling that greps for the old symptom in this scenario should switch to the new message; the `RPC auth secret resolution failed` log signature is preserved.
- No wire, on-disk, or API changes; no behavior change for correctly configured clusters or single-node deployments.

## Additional Notes

Adversarial validation (high-risk tier, all seven roles), one-line verdicts:

- Correctness: credential-init ordering verified on every production path; preflight and runtime auth share `try_get_rpc_token` over immutable inputs, so their verdicts cannot diverge — no break found.
- Simplicity: no existing "any remote endpoint" helper; the `SetupType`/instance-ctx alternative was rejected because direct constructors leave it `Unknown`; the injection seam mirrors `resolve_startup_pool_defaults_with` — no break found.
- Security: no secret material can reach the new error/log strings (static message chain only); fail-closed posture unchanged — no break found.
- Concurrency/durability: no locks, no I/O, no await points; the OnceLock set race resolves to one agreed value — no break found.
- Compatibility: nothing on the wire changes for mixed-version clusters; every topology the preflight refuses already failed on main, only slower and misleadingly — no break found.
- Performance: startup-only cost that pre-warms the RPC-secret cache read by later RPC calls — no break found.
- Test coverage: two findings (unpinned call-site wiring; missing multi-pool boundary case) — both fixed via the constructor-level and later-pool tests.
