### PR TITLE
fix(ilm): honor explicit object lock metadata

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4079,20 +4079,27 @@ pub async fn eval_action_from_lifecycle(
     );
 
     let lock_enabled = if let Some(lr) = lr { lr.mode.is_some() } else { false };
+    let object_locked = object_lock_boundary::is_object_locked_by_metadata(&oi.user_defined, oi.delete_marker);
 
     match event.action {
-        IlmAction::DeleteAllVersionsAction | IlmAction::DelMarkerDeleteAllVersionsAction if lock_enabled => {
+        IlmAction::DeleteAllVersionsAction | IlmAction::DelMarkerDeleteAllVersionsAction if lock_enabled || object_locked => {
             return lifecycle::Event::default();
         }
-        IlmAction::DeleteVersionAction | IlmAction::DeleteRestoredVersionAction => {
-            if oi.version_id.is_none() {
+        IlmAction::DeleteAction
+        | IlmAction::DeleteRestoredAction
+        | IlmAction::DeleteVersionAction
+        | IlmAction::DeleteRestoredVersionAction => {
+            if matches!(event.action, IlmAction::DeleteVersionAction | IlmAction::DeleteRestoredVersionAction)
+                && oi.version_id.is_none()
+            {
                 return lifecycle::Event::default();
             }
             // Lifecycle operations should never bypass governance retention
-            if lock_enabled
-                && object_lock_boundary::check_object_lock_for_deletion(&oi.bucket, oi, false)
-                    .await
-                    .is_some()
+            if object_locked
+                || (lock_enabled
+                    && object_lock_boundary::check_object_lock_for_deletion(&oi.bucket, oi, false)
+                        .await
+                        .is_some())
             {
                 //if serverDebugLog {
                 if oi.version_id.is_some() {
@@ -4540,6 +4547,7 @@ mod tests {
         BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule, MetadataEntry, OutputLocation,
         RestoreRequest, RestoreRequestType, S3Location, Timestamp, Transition, TransitionStorageClass,
     };
+    use s3s::header::{X_AMZ_OBJECT_LOCK_LEGAL_HOLD, X_AMZ_OBJECT_LOCK_MODE, X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE};
     use serial_test::serial;
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
@@ -7053,6 +7061,16 @@ mod tests {
         }
     }
 
+    fn current_object_with_metadata(
+        replication_status: ReplicationStatusType,
+        user_defined: HashMap<String, String>,
+    ) -> ObjectInfo {
+        ObjectInfo {
+            user_defined: Arc::new(user_defined),
+            ..current_object(replication_status)
+        }
+    }
+
     #[test]
     fn lifecycle_replication_blocks_only_pending_failed_or_pending_purge() {
         assert!(lifecycle_replication_blocks_action(&delete_marker_object(
@@ -7652,6 +7670,41 @@ mod tests {
         let event = eval_action_from_lifecycle(&lc, None, &object).await;
 
         assert_eq!(event.action, IlmAction::DeleteAction);
+    }
+
+    #[tokio::test]
+    async fn existing_object_lifecycle_skips_current_expiration_for_explicit_legal_hold() {
+        let lc = latest_expiration_lifecycle();
+        let object = current_object_with_metadata(
+            ReplicationStatusType::Completed,
+            HashMap::from([(X_AMZ_OBJECT_LOCK_LEGAL_HOLD.as_str().to_string(), "ON".to_string())]),
+        );
+
+        let event = eval_action_from_lifecycle(&lc, None, &object).await;
+
+        assert_eq!(event.action, IlmAction::NoneAction);
+    }
+
+    #[tokio::test]
+    async fn existing_object_lifecycle_skips_current_expiration_for_explicit_retention() {
+        let lc = latest_expiration_lifecycle();
+        let retain_until = (OffsetDateTime::now_utc() + time::Duration::days(30))
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("future retain-until date should format");
+        let object = current_object_with_metadata(
+            ReplicationStatusType::Completed,
+            HashMap::from([
+                (
+                    X_AMZ_OBJECT_LOCK_MODE.as_str().to_string(),
+                    s3s::dto::ObjectLockRetentionMode::COMPLIANCE.to_string(),
+                ),
+                (X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE.as_str().to_string(), retain_until),
+            ]),
+        );
+
+        let event = eval_action_from_lifecycle(&lc, None, &object).await;
+
+        assert_eq!(event.action, IlmAction::NoneAction);
     }
 
     #[tokio::test]

--- a/crates/lifecycle/src/evaluator.rs
+++ b/crates/lifecycle/src/evaluator.rs
@@ -66,19 +66,8 @@ impl Evaluator {
     }
 
     /// IsObjectLocked checks if it is appropriate to remove an
-    /// object according to locking configuration when this is lifecycle/bucket quota asking.
-    /// Uses the common `is_object_locked_by_metadata` function for consistency.
+    /// object according to its persisted object-lock metadata.
     pub fn is_object_locked(&self, obj: &ObjectOpts) -> bool {
-        // First check if object lock is enabled for this bucket
-        if self.lock_retention.as_ref().is_none_or(|v| {
-            v.object_lock_enabled
-                .as_ref()
-                .is_none_or(|v| v.as_str() != ObjectLockEnabled::ENABLED)
-        }) {
-            return false;
-        }
-
-        // Use the common function to check if the object is locked
         object_lock::is_object_locked_by_metadata(&obj.user_defined, obj.delete_marker)
     }
 
@@ -102,7 +91,8 @@ impl Evaluator {
                             v.object_lock_enabled
                                 .as_ref()
                                 .is_some_and(|v| v.as_str() == ObjectLockEnabled::ENABLED)
-                        }) || self.any_version_has_pending_replication(objs)
+                        }) || objs.iter().any(|obj| self.is_object_locked(obj))
+                            || self.any_version_has_pending_replication(objs)
                         {
                             event = Event::default();
                         } else {
@@ -122,9 +112,14 @@ impl Evaluator {
                             break 'top_loop;
                         }
                     }
-                    IlmAction::DeleteVersionAction | IlmAction::DeleteRestoredVersionAction => {
+                    IlmAction::DeleteAction
+                    | IlmAction::DeleteRestoredAction
+                    | IlmAction::DeleteVersionAction
+                    | IlmAction::DeleteRestoredVersionAction => {
                         // Defensive code, should never happen
-                        if obj.version_id.is_none_or(|v| v.is_nil()) {
+                        if matches!(event.action, IlmAction::DeleteVersionAction | IlmAction::DeleteRestoredVersionAction)
+                            && obj.version_id.is_none_or(|v| v.is_nil())
+                        {
                             event.action = IlmAction::NoneAction;
                         }
                         if self.is_object_locked(obj) {
@@ -198,12 +193,15 @@ fn lifecycle_action_waits_for_replication(action: IlmAction) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use rustfs_common::metrics::IlmAction;
     use s3s::dto::{
-        BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule, Transition, TransitionStorageClass,
+        BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule, ObjectLockConfiguration,
+        ObjectLockEnabled, Transition, TransitionStorageClass,
     };
+    use s3s::header::{X_AMZ_OBJECT_LOCK_LEGAL_HOLD, X_AMZ_OBJECT_LOCK_MODE, X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE};
     use time::OffsetDateTime;
     use uuid::Uuid;
 
@@ -295,6 +293,13 @@ mod tests {
         })
     }
 
+    fn lock_enabled_without_default_retention() -> Arc<ObjectLockConfiguration> {
+        Arc::new(ObjectLockConfiguration {
+            object_lock_enabled: Some(ObjectLockEnabled::from_static(ObjectLockEnabled::ENABLED)),
+            rule: None,
+        })
+    }
+
     fn object_opts(replication_status: ReplicationStatusType, version_purge_status: VersionPurgeStatusType) -> ObjectOpts {
         ObjectOpts {
             name: "logs/object".to_string(),
@@ -321,11 +326,38 @@ mod tests {
         }
     }
 
+    fn locked_current_object_opts(replication_status: ReplicationStatusType) -> ObjectOpts {
+        let mut user_defined = HashMap::new();
+        user_defined.insert(X_AMZ_OBJECT_LOCK_LEGAL_HOLD.as_str().to_string(), "ON".to_string());
+
+        ObjectOpts {
+            user_defined,
+            ..current_object_opts(replication_status)
+        }
+    }
+
     fn versioned_object_opts(replication_status: ReplicationStatusType, is_latest: bool) -> ObjectOpts {
         ObjectOpts {
             num_versions: 2,
             is_latest,
             ..current_object_opts(replication_status)
+        }
+    }
+
+    fn locked_versioned_object_opts(replication_status: ReplicationStatusType, is_latest: bool) -> ObjectOpts {
+        let retain_until = (OffsetDateTime::now_utc() + time::Duration::days(30))
+            .format(&time::format_description::well_known::Rfc3339)
+            .expect("future retain-until date should format");
+        let mut user_defined = HashMap::new();
+        user_defined.insert(
+            X_AMZ_OBJECT_LOCK_MODE.as_str().to_string(),
+            s3s::dto::ObjectLockRetentionMode::COMPLIANCE.to_string(),
+        );
+        user_defined.insert(X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE.as_str().to_string(), retain_until);
+
+        ObjectOpts {
+            user_defined,
+            ..versioned_object_opts(replication_status, is_latest)
         }
     }
 
@@ -415,6 +447,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn evaluator_skips_latest_expiration_for_explicit_legal_hold_without_default_retention() {
+        let evaluator =
+            Evaluator::new(latest_expiration_lifecycle()).with_lock_retention(Some(lock_enabled_without_default_retention()));
+
+        let events = evaluator
+            .eval(&[locked_current_object_opts(ReplicationStatusType::Completed)])
+            .await
+            .expect("explicit legal hold should still produce a lifecycle decision");
+
+        assert_eq!(events[0].action, IlmAction::NoneAction);
+    }
+
+    #[tokio::test]
     async fn evaluator_skips_transition_while_replication_pending() {
         let evaluator = Evaluator::new(latest_transition_lifecycle());
 
@@ -465,6 +510,22 @@ mod tests {
             .expect("completed replication should allow delete-all lifecycle decision");
 
         assert_eq!(events[0].action, IlmAction::DeleteAllVersionsAction);
+        assert_eq!(events[1].action, IlmAction::NoneAction);
+    }
+
+    #[tokio::test]
+    async fn evaluator_skips_delete_all_versions_for_explicit_retention_without_default_retention() {
+        let evaluator = Evaluator::new(all_versions_expiration_lifecycle())
+            .with_lock_retention(Some(lock_enabled_without_default_retention()));
+        let latest = versioned_object_opts(ReplicationStatusType::Completed, true);
+        let noncurrent = locked_versioned_object_opts(ReplicationStatusType::Completed, false);
+
+        let events = evaluator
+            .eval(&[latest, noncurrent])
+            .await
+            .expect("explicit retention should still produce lifecycle decisions");
+
+        assert_eq!(events[0].action, IlmAction::NoneAction);
         assert_eq!(events[1].action, IlmAction::NoneAction);
     }
 }


### PR DESCRIPTION
## Related Issues
- Follow-up for rustfs/backlog#1501
- Parent: rustfs/backlog#1499
- Source: rustfs/rustfs#5167

## Summary of Changes
This PR makes ILM deletion decisions honor explicit Object Lock metadata on the object itself. Lifecycle evaluation now blocks current expiration, restored expiration, version expiration, and delete-all-version actions when the candidate object metadata carries an active legal hold or active explicit retention, even when the bucket has Object Lock enabled without a default retention rule available to the lifecycle path.

The ECStore secondary lifecycle scan now applies the same explicit metadata check before returning a delete action. Existing default-retention behavior is preserved: when default retention is available, lifecycle still uses the existing object-lock deletion check and never bypasses governance retention.

This does not add Console/Admin operation functionality, does not add or change any public S3/API endpoint, and does not change on-disk, wire, RPC, or config formats.

## Verification
- `cargo fmt --all`
- `cargo test -p rustfs-lifecycle evaluator_skips_latest_expiration_for_explicit_legal_hold_without_default_retention -- --nocapture`
- `cargo test -p rustfs-lifecycle evaluator_skips_delete_all_versions_for_explicit_retention_without_default_retention -- --nocapture`
- `cargo test -p rustfs-ecstore existing_object_lifecycle_skips_current_expiration_for_explicit_legal_hold -- --nocapture`
- `cargo test -p rustfs-ecstore existing_object_lifecycle_skips_current_expiration_for_explicit_retention -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy -p rustfs-lifecycle -p rustfs-ecstore --all-targets -- -D warnings`

`make pre-commit` and `make pre-pr` were not run locally; this PR is opened as draft for GitHub Actions validation first.

## Impact
Objects carrying active explicit Object Lock legal hold or retention metadata are now fail-closed against lifecycle deletion in the evaluator and secondary scan paths. This is a safety-preserving compatibility fix and only reduces lifecycle deletion eligibility for locked objects that already advertise Object Lock metadata.

No Console/Admin behavior is introduced. No external API shape changes are introduced.

## Additional Notes
High-risk adversarial validation was performed for lifecycle/Object Lock behavior: correctness attacked current, version, restored, and delete-all deletion paths; simplicity attacked helper and smaller-diff alternatives; security attacked deletion-protection weakening and API exposure; concurrency/durability attacked new locks, awaits, and durable writes; compatibility attacked public S3/API, on-disk, wire, RPC, config, and Console/Admin surfaces; performance attacked hot-path IO, logging, and allocation changes; test coverage attacked revert-detection for each behavior claim. No blocking finding remained.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
