### PR TITLE
test(ilm): cover manual transition queue pressure status

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
+++ b/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
@@ -1116,6 +1116,31 @@ mod tests {
     }
 
     #[test]
+    fn manual_transition_job_record_queue_pressure_report_is_partial() {
+        let options = ManualTransitionRunOptions::default();
+        let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), "bucket", &options, TEST_OWNER);
+        let queue_snapshot = ManualTransitionQueueSnapshot {
+            queue_capacity: 1,
+            queue_full: 1,
+            ..Default::default()
+        };
+
+        record.complete(
+            ManualTransitionRunReport {
+                skipped_queue_full: 1,
+                ..Default::default()
+            },
+            queue_snapshot,
+        );
+
+        assert_eq!(record.state, ManualTransitionJobState::Partial);
+        assert_eq!(record.report.skipped_queue_full, 1);
+        assert_eq!(record.queue_snapshot.queue_capacity, 1);
+        assert_eq!(record.queue_snapshot.queue_full, 1);
+        assert!(record.error.is_none());
+    }
+
+    #[test]
     fn manual_transition_scope_key_is_stable_and_sanitized() {
         let first = manual_transition_scope_key(
             "bucket",


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1479.

## Summary of Changes
Adds focused durable manual transition job coverage for queue-pressure terminal status.

The new unit test drives `ManualTransitionJobRecord::complete` with a scan report that includes `skipped_queue_full` and verifies the durable job state becomes `partial`, preserves the queue-full counter, keeps the queue snapshot, and does not mark the job as failed.

This is intentionally a narrow test-only slice. It does not change runtime behavior, admission scope, durable job storage, status/cancel routes, or worker execution.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_job_record_queue_pressure_report_is_partial -- --nocapture`

## Impact
No runtime or API impact. This only strengthens regression coverage for manual transition durable job status semantics under queue pressure.

## Additional Notes
Adversarial validation: correctness attacked queue-full reports being reported as completed; simplicity rejected a heavier e2e slice in favor of this smaller state-machine test; test coverage confirms the assertion hits the durable job record terminal-state path directly.
