### PR TITLE
test(ilm): cover manual transition worker failure summary

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4571,9 +4571,10 @@ mod tests {
     };
     use crate::bucket::lifecycle::manual_transition_job::{
         ManualTransitionJobRecord, ManualTransitionJobState, ManualTransitionScopeAdmission, ManualTransitionScopeAdmissionClaim,
-        claim_manual_transition_scope_admission, legacy_manual_transition_scope_key, load_manual_transition_job_record,
-        load_manual_transition_scope_admission, renew_manual_transition_job_lease, request_manual_transition_job_cancel,
-        save_manual_transition_job_record, save_manual_transition_scope_admission_if_absent,
+        ManualTransitionWorkerResult, claim_manual_transition_scope_admission, legacy_manual_transition_scope_key,
+        load_manual_transition_job_record, load_manual_transition_scope_admission, renew_manual_transition_job_lease,
+        request_manual_transition_job_cancel, save_manual_transition_job_record,
+        save_manual_transition_scope_admission_if_absent,
     };
     use crate::bucket::lifecycle::replication_sink::{
         ReplicateDecision, ReplicateTargetDecision, ReplicationStatusType, VersionPurgeStatusType,
@@ -7324,6 +7325,36 @@ mod tests {
         assert_eq!(report.enqueued, 0);
         assert_eq!(report.tier_failure, 1);
         assert!(!report.has_partial_enqueue());
+    }
+
+    #[test]
+    fn manual_transition_complete_preserves_worker_failure_summary() {
+        let options = ManualTransitionRunOptions::default();
+        let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), "manual-worker-summary-bucket", &options, "owner-a");
+
+        record.record_worker_result(ManualTransitionWorkerResult::Completed, ManualTransitionQueueSnapshot::default());
+        record.record_worker_result(ManualTransitionWorkerResult::TierFailure, ManualTransitionQueueSnapshot::default());
+        record.complete(
+            ManualTransitionRunReport {
+                bucket: "manual-worker-summary-bucket".to_string(),
+                scanned: 3,
+                eligible: 2,
+                enqueued: 2,
+                tier_failure: 1,
+                ..Default::default()
+            },
+            ManualTransitionQueueSnapshot::default(),
+        );
+
+        assert_eq!(record.state, ManualTransitionJobState::Partial);
+        assert!(record.scan_completed);
+        assert_eq!(record.report.scanned, 3);
+        assert_eq!(record.report.eligible, 2);
+        assert_eq!(record.report.enqueued, 2);
+        assert_eq!(record.report.transition_completed, 1);
+        assert_eq!(record.report.transition_failed, 1);
+        assert_eq!(record.report.tier_failure, 2);
+        assert!(record.completed_at_unix_nanos.is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1478, rustfs/backlog#1479, and rustfs/backlog#1481.

## Summary of Changes
Adds a focused manual transition regression test for the terminal worker failure summary. The test pins that `ManualTransitionJobRecord::complete` preserves worker-side `transition_completed` and `transition_failed` counters while folding scan-time tier failures and worker tier failures into the final `tier_failure` summary, so terminal `Partial` reports do not undercount failed tier work after scan progress is merged.

## Verification
- `cargo test -p rustfs-ecstore manual_transition_complete_preserves_worker_failure_summary --lib -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
Test-only change. No runtime behavior, API, wire format, storage format, configuration, or deployment impact.

## Additional Notes
Kept as draft because the full `make pre-commit` gate was not run locally for this small test-only slice.
