### PR TITLE
test(perf): tolerate empty paired runner node args

### DIFF
--- a/scripts/run_pinned_paired_abba_bench.sh
+++ b/scripts/run_pinned_paired_abba_bench.sh
@@ -243,21 +243,18 @@ build_runner_cmd_for_product() {
   local bucket="$3"
   local leg_out_dir="$4"
   local endpoint image_ref image_digest revision_or_release ack_contract
-  local -a node_args
   if [[ "$product" == "rustfs" ]]; then
     endpoint="$RUSTFS_ENDPOINT"
     image_ref="$RUSTFS_IMAGE_REF"
     image_digest="$RUSTFS_IMAGE_DIGEST"
     revision_or_release="$RUSTFS_REVISION"
     ack_contract="$RUSTFS_ACK_CONTRACT"
-    node_args=("${RUSTFS_NODE_ARGS[@]}")
   else
     endpoint="$MINIO_ENDPOINT"
     image_ref="$MINIO_IMAGE_REF"
     image_digest="$MINIO_IMAGE_DIGEST"
     revision_or_release="$MINIO_RELEASE"
     ack_contract="$MINIO_ACK_CONTRACT"
-    node_args=("${MINIO_NODE_ARGS[@]}")
   fi
 
   RUNNER_CMD=(
@@ -286,7 +283,14 @@ build_runner_cmd_for_product() {
     --bucket "$bucket" \
     --out-dir "$leg_out_dir"
   )
-  RUNNER_CMD+=("${COMMON_LABELS[@]}" "${node_args[@]}")
+  if ((${#COMMON_LABELS[@]} > 0)); then
+    RUNNER_CMD+=("${COMMON_LABELS[@]}")
+  fi
+  if [[ "$product" == "rustfs" && ${#RUSTFS_NODE_ARGS[@]} -gt 0 ]]; then
+    RUNNER_CMD+=("${RUSTFS_NODE_ARGS[@]}")
+  elif [[ "$product" == "minio" && ${#MINIO_NODE_ARGS[@]} -gt 0 ]]; then
+    RUNNER_CMD+=("${MINIO_NODE_ARGS[@]}")
+  fi
   if [[ "$DRY_RUN" == "true" ]]; then
     RUNNER_CMD+=(--dry-run)
   fi

--- a/scripts/test_pinned_paired_abba_bench.sh
+++ b/scripts/test_pinned_paired_abba_bench.sh
@@ -47,6 +47,26 @@ fi
   --minio-image-digest sha256:1111222233334444111122223333444411112222333344441111222233334444 \
   --minio-release RELEASE.2025-07-18T21-56-31Z \
   --minio-ack-contract strict \
+  --concurrencies 1 \
+  --sizes 1048576B \
+  --rounds-per-leg 1 \
+  --cooldown-secs 0 \
+  --out-dir "$TMP_DIR/good-no-optional-arrays" \
+  --dry-run >"$TMP_DIR/dry-run-no-optional-arrays.log"
+
+"$RUNNER" \
+  --access-key minioadmin \
+  --secret-key minioadmin \
+  --rustfs-endpoint http://127.0.0.1:9000 \
+  --rustfs-image-ref rustfs/rustfs:bench \
+  --rustfs-image-digest sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --rustfs-revision 42fc84063 \
+  --rustfs-ack-contract relaxed \
+  --minio-endpoint http://127.0.0.1:9100 \
+  --minio-image-ref quay.io/minio/minio:RELEASE.2025-07-18T21-56-31Z \
+  --minio-image-digest sha256:1111222233334444111122223333444411112222333344441111222233334444 \
+  --minio-release RELEASE.2025-07-18T21-56-31Z \
+  --minio-ack-contract strict \
   --concurrencies 1,64 \
   --sizes 1048575B,1048576B,1048577B \
   --rounds-per-leg 5 \


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1432

## Summary of Changes
- Guard optional common label and node metric/container argument arrays before appending them to the pinned paired ABBA runner command, so the runner works under `set -u` when callers omit `--label`, `--rustfs-node-*`, or `--minio-node-*`.
- Add a dry-run regression case that exercises the no-optional-array path.

## Verification
- `git diff --check`
- `bash -n scripts/run_pinned_paired_abba_bench.sh scripts/test_pinned_paired_abba_bench.sh`
- `bash scripts/test_pinned_paired_abba_bench.sh`
- Local Docker smoke: ran `scripts/run_pinned_paired_abba_bench.sh` against pinned `rustfs/rustfs:latest@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c` and `minio/minio:latest@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e` with `sizes=1MiB`, `concurrencies=1`, `rounds_per_leg=1`, `duration=5s`; all A1/B1/B2/A2 legs completed successfully.

## Impact
Developer tooling only. No runtime API, on-disk format, on-wire format, or deployment configuration changes.

## Additional Notes
The local Docker smoke is intentionally a short runner validation, not a complete #1432 performance conclusion. It proves the pinned paired runner can execute an ABBA schedule without optional node metrics arguments; the broader benchmark matrix still needs a dedicated longer run.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
