### PR TITLE
test(ilm): cover queue terminal partial reports

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -7361,6 +7361,53 @@ mod tests {
     }
 
     #[test]
+    fn manual_transition_job_record_closed_and_timeout_reports_are_partial() {
+        let options = ManualTransitionRunOptions::default();
+
+        for (bucket, outcome, skipped_queue_closed, skipped_queue_timeout, queue_snapshot) in [
+            (
+                "manual-queue-closed-bucket",
+                TransitionEnqueueOutcome::QueueClosed,
+                1,
+                0,
+                ManualTransitionQueueSnapshot {
+                    queue_capacity: 1,
+                    workers: 1,
+                    ..Default::default()
+                },
+            ),
+            (
+                "manual-queue-timeout-bucket",
+                TransitionEnqueueOutcome::QueueSendTimedOut,
+                0,
+                1,
+                ManualTransitionQueueSnapshot {
+                    queue_capacity: 1,
+                    workers: 1,
+                    queue_send_timeout: 1,
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let mut report = ManualTransitionRunReport::new(bucket, &options);
+            report.record_enqueue_outcome(outcome);
+            assert!(report.has_partial_enqueue());
+
+            let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), bucket, &options, "owner");
+            record.complete(report, queue_snapshot);
+
+            assert_eq!(record.state, ManualTransitionJobState::Partial);
+            assert_eq!(record.report.enqueued, 0);
+            assert_eq!(record.report.skipped_queue_full, 0);
+            assert_eq!(record.report.skipped_queue_closed, skipped_queue_closed);
+            assert_eq!(record.report.skipped_queue_timeout, skipped_queue_timeout);
+            assert_eq!(record.queue_snapshot.queue_send_timeout, queue_snapshot.queue_send_timeout);
+            assert!(record.completed_at_unix_nanos.is_some());
+            assert!(record.error.is_none());
+        }
+    }
+
+    #[test]
     fn manual_transition_version_marker_preserves_null_version_cursor() {
         let null_version = ObjectInfo {
             version_id: None,


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1478, rustfs/backlog#1479, and rustfs/backlog#1481.

## Summary of Changes
- Add a focused manual transition job-record regression test for `QueueClosed` and `QueueSendTimedOut` enqueue outcomes.
- Assert both terminal records become `Partial` and preserve the expected queue counters/snapshot fields.
- Keep the slice test-only with no production behavior changes.

## Verification
- `cargo test -p rustfs-ecstore manual_transition_job_record_closed_and_timeout_reports_are_partial --lib -- --nocapture`
- `git diff --check`

## Impact
No runtime, API, configuration, or compatibility impact. This is test-only coverage for manual transition backpressure reporting.

## Additional Notes
N/A
