### PR TITLE
fix(ilm): retry transient scope admission races

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
+++ b/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
@@ -659,34 +659,40 @@ pub async fn claim_manual_transition_scope_admission(
     api: Arc<ECStore>,
     admission: &ManualTransitionScopeAdmission,
 ) -> EcstoreResult<ManualTransitionScopeAdmissionClaim> {
-    match save_manual_transition_scope_admission_if_absent(api.clone(), admission).await {
-        Ok(()) => return finish_manual_transition_scope_admission_claim(api, admission).await,
-        Err(Error::PreconditionFailed) => {}
-        Err(err) => return Err(err),
-    }
-
-    let (active, etag) = load_manual_transition_scope_admission_with_etag(api.clone(), &admission.scope_key).await?;
-    let scope_lease_expired = manual_transition_scope_admission_lease_expired(&active);
-    let active_job_reclaimable = if active.job_id == admission.job_id {
-        scope_lease_expired
-    } else {
-        match load_manual_transition_job_record(api.clone(), active.job_id).await {
-            Ok(active_job) => {
-                active_job.is_terminal() || (scope_lease_expired && manual_transition_job_lease_expired(&active_job))
-            }
-            Err(Error::ConfigNotFound) => true,
+    loop {
+        match save_manual_transition_scope_admission_if_absent(api.clone(), admission).await {
+            Ok(()) => return finish_manual_transition_scope_admission_claim(api, admission).await,
+            Err(Error::PreconditionFailed) => {}
             Err(err) => return Err(err),
         }
-    };
-    if active_job_reclaimable {
-        return match save_manual_transition_scope_admission_if_current(api.clone(), admission, &etag).await {
-            Ok(()) => finish_manual_transition_scope_admission_claim(api, admission).await,
-            Err(Error::PreconditionFailed) => Ok(ManualTransitionScopeAdmissionClaim::Conflict(Box::new(active))),
-            Err(err) => Err(err),
-        };
-    }
 
-    Ok(ManualTransitionScopeAdmissionClaim::Conflict(Box::new(active)))
+        let (active, etag) = match load_manual_transition_scope_admission_with_etag(api.clone(), &admission.scope_key).await {
+            Ok(active) => active,
+            Err(Error::ConfigNotFound) => continue,
+            Err(err) => return Err(err),
+        };
+        let scope_lease_expired = manual_transition_scope_admission_lease_expired(&active);
+        let active_job_reclaimable = if active.job_id == admission.job_id {
+            scope_lease_expired
+        } else {
+            match load_manual_transition_job_record(api.clone(), active.job_id).await {
+                Ok(active_job) => {
+                    active_job.is_terminal() || (scope_lease_expired && manual_transition_job_lease_expired(&active_job))
+                }
+                Err(Error::ConfigNotFound) => true,
+                Err(err) => return Err(err),
+            }
+        };
+        if active_job_reclaimable {
+            match save_manual_transition_scope_admission_if_current(api.clone(), admission, &etag).await {
+                Ok(()) => return finish_manual_transition_scope_admission_claim(api, admission).await,
+                Err(Error::PreconditionFailed) => continue,
+                Err(err) => return Err(err),
+            }
+        }
+
+        return Ok(ManualTransitionScopeAdmissionClaim::Conflict(Box::new(active)));
+    }
 }
 
 async fn finish_manual_transition_scope_admission_claim(


### PR DESCRIPTION
## Related Issues
Follow-up to #5276.
Related to #5218 and rustfs/backlog#1479.

## Summary of Changes
- Retry durable manual-transition scope admission when an expected CAS conflict is immediately followed by a missing scope record.
- Retry stale-owner replacement races instead of returning a stale conflict or bubbling `PreconditionFailed` as an internal admission failure.
- Preserve the existing outcomes for stable active owners, empty scopes, terminal owner reclaim, missing owner reclaim, and legacy scope conflict cleanup.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_admission_reclaims_stale_scope_records --lib -- --nocapture`
- `NO_PROXY=127.0.0.1,localhost HTTP_PROXY= HTTPS_PROXY= cargo test -p e2e_test test_manual_transition_async_overlapping_scope_conflict_reports_active_job -- --nocapture`
- `NO_PROXY=127.0.0.1,localhost HTTP_PROXY= HTTPS_PROXY= cargo test -p e2e_test test_manual_transition_async_same_scope_conflict_reports_active_job -- --nocapture`

## Impact
Manual transition async admission no longer turns transient scope-record CAS/delete races into 500-class failures. Stable active conflicts still return `409 Conflict` with the active job response, and no persisted schema or public API shape changes.

## Additional Notes
High-risk adversarial review verdicts:
- Correctness: finite CAS/load and replace races converge; continuous external churn can keep any CAS loop busy, but no self-sustaining livelock was found.
- Simplicity: local loop keeps the existing CAS flow and avoids new status types or handler rewrites.
- Security: no auth, deserialization, or permission surface changed.
- Concurrency/durability: `if-none-match` and `if-match` fences remain authoritative; stale owner overwrite and admission release remain lease/ETag guarded.
- Compatibility: no on-disk/on-wire schema change; legacy scope scan is still enforced before claim success.
- Performance: admission is admin/manual-transition only; added retries occur only under concurrent CAS churn and each iteration awaits storage IO.
- Test coverage: final diff was validated against both CI-failing async conflict E2E scenarios and the stale admission reclaim unit.
