### PR TITLE
test(perf): reject zero-byte paired warp sizes

### DIFF
--- a/scripts/run_pinned_paired_abba_bench.sh
+++ b/scripts/run_pinned_paired_abba_bench.sh
@@ -243,21 +243,18 @@ build_runner_cmd_for_product() {
   local bucket="$3"
   local leg_out_dir="$4"
   local endpoint image_ref image_digest revision_or_release ack_contract
-  local -a node_args
   if [[ "$product" == "rustfs" ]]; then
     endpoint="$RUSTFS_ENDPOINT"
     image_ref="$RUSTFS_IMAGE_REF"
     image_digest="$RUSTFS_IMAGE_DIGEST"
     revision_or_release="$RUSTFS_REVISION"
     ack_contract="$RUSTFS_ACK_CONTRACT"
-    node_args=("${RUSTFS_NODE_ARGS[@]}")
   else
     endpoint="$MINIO_ENDPOINT"
     image_ref="$MINIO_IMAGE_REF"
     image_digest="$MINIO_IMAGE_DIGEST"
     revision_or_release="$MINIO_RELEASE"
     ack_contract="$MINIO_ACK_CONTRACT"
-    node_args=("${MINIO_NODE_ARGS[@]}")
   fi
 
   RUNNER_CMD=(
@@ -286,7 +283,14 @@ build_runner_cmd_for_product() {
     --bucket "$bucket" \
     --out-dir "$leg_out_dir"
   )
-  RUNNER_CMD+=("${COMMON_LABELS[@]}" "${node_args[@]}")
+  if ((${#COMMON_LABELS[@]} > 0)); then
+    RUNNER_CMD+=("${COMMON_LABELS[@]}")
+  fi
+  if [[ "$product" == "rustfs" && ${#RUSTFS_NODE_ARGS[@]} -gt 0 ]]; then
+    RUNNER_CMD+=("${RUSTFS_NODE_ARGS[@]}")
+  elif [[ "$product" == "minio" && ${#MINIO_NODE_ARGS[@]} -gt 0 ]]; then
+    RUNNER_CMD+=("${MINIO_NODE_ARGS[@]}")
+  fi
   if [[ "$DRY_RUN" == "true" ]]; then
     RUNNER_CMD+=(--dry-run)
   fi

--- a/scripts/run_pinned_paired_abba_bench.sh
+++ b/scripts/run_pinned_paired_abba_bench.sh
@@ -14,7 +14,7 @@ WARP_BIN="warp"
 WARP_MODE="get"
 DURATION="60s"
 CONCURRENCIES="1,64"
-SIZES="0B,16383B,16384B,16385B,32767B,32768B,32769B,131071B,131072B,131073B,262143B,262144B,262145B,1048575B,1048576B,1048577B,4194304B"
+SIZES="1B,16383B,16384B,16385B,32767B,32768B,32769B,131071B,131072B,131073B,262143B,262144B,262145B,1048575B,1048576B,1048577B,4194304B"
 ROUNDS_PER_LEG=5
 COOLDOWN_SECS=20
 BUCKET_PREFIX="rustfs-1432-paired"
@@ -50,7 +50,7 @@ Options:
   --warp-mode <get|put|mixed>             Default: get
   --duration <dur>                        Default: 60s
   --concurrencies <csv>                   Default: 1,64
-  --sizes <csv>                           Default: #1432 boundary matrix
+  --sizes <csv>                           Default: #1432 positive-size boundary matrix
   --rounds-per-leg <n>                    Default: 5
   --cooldown-secs <n>                     Default: 20
   --bucket-prefix <prefix>                Default: rustfs-1432-paired
@@ -108,6 +108,19 @@ validate_ack_contract() {
     strict|relaxed) ;;
     *) die "$name must be strict or relaxed" ;;
   esac
+}
+
+validate_warp_sizes_supported() {
+  local raw
+  local -a raw_sizes
+  IFS=',' read -r -a raw_sizes <<< "$SIZES"
+  for raw in "${raw_sizes[@]}"; do
+    case "$raw" in
+      0|0B|0b|0K|0KB|0KiB|0k|0kb|0kib|0M|0MB|0MiB|0m|0mb|0mib|0G|0GB|0GiB|0g|0gb|0gib)
+        die "--sizes contains $raw, but warp requires object size > 0; run zero-byte compatibility as a separate functional probe"
+        ;;
+    esac
+  done
 }
 
 validate_label() {
@@ -185,6 +198,9 @@ validate_args() {
   validate_ack_contract "$MINIO_ACK_CONTRACT" "--minio-ack-contract"
   validate_csv_nonempty "$CONCURRENCIES" "--concurrencies"
   validate_csv_nonempty "$SIZES" "--sizes"
+  if [[ "$TOOL" == "warp" ]]; then
+    validate_warp_sizes_supported
+  fi
   validate_positive_int "$ROUNDS_PER_LEG" "--rounds-per-leg"
   validate_nonnegative_int "$COOLDOWN_SECS" "--cooldown-secs"
   [[ "$TOOL" == "warp" || "$TOOL" == "s3bench" ]] || die "--tool must be warp or s3bench"

--- a/scripts/test_pinned_paired_abba_bench.sh
+++ b/scripts/test_pinned_paired_abba_bench.sh
@@ -34,6 +34,27 @@ if "$RUNNER" \
   exit 1
 fi
 
+if "$RUNNER" \
+  --access-key minioadmin \
+  --secret-key minioadmin \
+  --rustfs-endpoint http://127.0.0.1:9000 \
+  --rustfs-image-ref rustfs/rustfs:bench \
+  --rustfs-image-digest sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --rustfs-revision 42fc84063 \
+  --rustfs-ack-contract relaxed \
+  --minio-endpoint http://127.0.0.1:9100 \
+  --minio-image-ref quay.io/minio/minio:RELEASE.2025-07-18T21-56-31Z \
+  --minio-image-digest sha256:1111222233334444111122223333444411112222333344441111222233334444 \
+  --minio-release RELEASE.2025-07-18T21-56-31Z \
+  --minio-ack-contract strict \
+  --sizes 0B \
+  --out-dir "$TMP_DIR/bad-zero-size" \
+  --dry-run >"$TMP_DIR/bad-zero-size.log" 2>&1; then
+  echo "expected warp zero-byte benchmark size to fail" >&2
+  exit 1
+fi
+rg -q "warp requires object size > 0" "$TMP_DIR/bad-zero-size.log"
+
 "$RUNNER" \
   --access-key minioadmin \
   --secret-key minioadmin \

--- a/scripts/test_pinned_paired_abba_bench.sh
+++ b/scripts/test_pinned_paired_abba_bench.sh
@@ -47,6 +47,26 @@ fi
   --minio-image-digest sha256:1111222233334444111122223333444411112222333344441111222233334444 \
   --minio-release RELEASE.2025-07-18T21-56-31Z \
   --minio-ack-contract strict \
+  --concurrencies 1 \
+  --sizes 1048576B \
+  --rounds-per-leg 1 \
+  --cooldown-secs 0 \
+  --out-dir "$TMP_DIR/good-no-optional-arrays" \
+  --dry-run >"$TMP_DIR/dry-run-no-optional-arrays.log"
+
+"$RUNNER" \
+  --access-key minioadmin \
+  --secret-key minioadmin \
+  --rustfs-endpoint http://127.0.0.1:9000 \
+  --rustfs-image-ref rustfs/rustfs:bench \
+  --rustfs-image-digest sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --rustfs-revision 42fc84063 \
+  --rustfs-ack-contract relaxed \
+  --minio-endpoint http://127.0.0.1:9100 \
+  --minio-image-ref quay.io/minio/minio:RELEASE.2025-07-18T21-56-31Z \
+  --minio-image-digest sha256:1111222233334444111122223333444411112222333344441111222233334444 \
+  --minio-release RELEASE.2025-07-18T21-56-31Z \
+  --minio-ack-contract strict \
   --concurrencies 1,64 \
   --sizes 1048575B,1048576B,1048577B \
   --rounds-per-leg 5 \


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1432

## Summary of Changes
The pinned RustFS/MinIO paired ABBA benchmark runner now uses a positive-size default boundary matrix. This removes the invalid zero-byte warp cell that fails before any comparable paired data can be collected.

The runner also validates explicit zero-byte warp sizes up front and returns an actionable error telling operators to keep zero-byte compatibility as a separate functional probe. This preserves the benchmark contract without weakening provenance, labels, node metrics, or the ABBA schedule.

## Verification
- `bash -n scripts/run_pinned_paired_abba_bench.sh scripts/test_pinned_paired_abba_bench.sh && scripts/test_pinned_paired_abba_bench.sh`
- `git diff --check`
- Local pinned Docker paired matrix is running separately with the fixed positive-size matrix; this PR does not claim final performance results from that in-progress run.

## Impact
No public API, wire format, storage format, or runtime behavior changes. The change only affects the local benchmark runner defaults and validation for warp-based #1432 performance evidence collection.

## Additional Notes
`warp` rejects zero-byte object generation with `WithSize: size must be > 0`, so zero-byte coverage should remain a functional compatibility probe rather than a throughput benchmark cell.
