### PR TITLE
test(ilm): cover admission scope parallelism

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4627,10 +4627,10 @@ mod tests {
         load_manual_transition_job_record, load_manual_transition_scope_admission,
         load_manual_transition_scope_admission_with_etag, manual_transition_scope_record_object_name,
         manual_transition_worker_result_object_name, manual_transition_worker_result_task_key,
-        persist_manual_transition_job_progress, reconcile_manual_transition_worker_results,
-        record_manual_transition_worker_result, renew_manual_transition_job_lease, request_manual_transition_job_cancel,
-        save_manual_transition_job_record, save_manual_transition_scope_admission_if_absent,
-        save_manual_transition_scope_admission_if_current, save_manual_transition_worker_result_if_absent,
+        reconcile_manual_transition_worker_results, record_manual_transition_worker_result, renew_manual_transition_job_lease,
+        request_manual_transition_job_cancel, save_manual_transition_job_record,
+        save_manual_transition_scope_admission_if_absent, save_manual_transition_scope_admission_if_current,
+        save_manual_transition_worker_result_if_absent,
     };
     use crate::bucket::lifecycle::replication_sink::{
         ReplicateDecision, ReplicateTargetDecision, ReplicationStatusType, VersionPurgeStatusType,

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -8622,11 +8622,30 @@ mod tests {
         assert_eq!(active.scope_key, legacy.scope_key);
         assert!(
             matches!(
-                load_manual_transition_scope_admission(ecstore, &new_record.scope_key).await,
+                load_manual_transition_scope_admission(ecstore.clone(), &new_record.scope_key).await,
                 Err(Error::ConfigNotFound)
             ),
             "conflicted bucket-level admission must be released"
         );
+
+        let other_bucket_record =
+            ManualTransitionJobRecord::new(Uuid::new_v4(), "manual-legacy-scope-other-bucket", &legacy_options, "new-owner");
+        save_manual_transition_job_record(ecstore.clone(), &other_bucket_record)
+            .await
+            .expect("other bucket job record should save");
+
+        let other_bucket_claim = claim_manual_transition_scope_admission(
+            ecstore.clone(),
+            &ManualTransitionScopeAdmission::from_job(&other_bucket_record),
+        )
+        .await
+        .expect("cross-bucket admission claim should resolve");
+
+        assert_eq!(other_bucket_claim, ManualTransitionScopeAdmissionClaim::Claimed);
+        let current = load_manual_transition_scope_admission(ecstore, &other_bucket_record.scope_key)
+            .await
+            .expect("other bucket admission should be saved");
+        assert_eq!(current.job_id, other_bucket_record.job_id);
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
+++ b/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
@@ -1741,10 +1741,19 @@ mod tests {
                 ..Default::default()
             },
         );
+        let other_bucket = manual_transition_scope_key(
+            "bucket-b",
+            &ManualTransitionRunOptions {
+                prefix: "logs/".to_string(),
+                tier: Some("warm".to_string()),
+                ..Default::default()
+            },
+        );
 
         assert_eq!(broad, nested);
         assert_eq!(broad, disjoint);
         assert_ne!(broad, dry_run);
+        assert_ne!(broad, other_bucket);
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1479
Refs rustfs/backlog#1481

## Summary of Changes
Add a focused regression for durable manual transition admission scope boundaries.

This keeps the durable v1 bucket-level contract explicit: jobs in the same bucket remain conservatively serialized across prefix/tier variants, while jobs in different buckets keep distinct scope keys and an active legacy scope admission in one bucket does not block a durable admission claim in another bucket.

The PR is test-only and does not change production behavior.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_scope_key_uses_bucket_level_admission_for_durable_v1 --lib -- --nocapture`
- `cargo test -p rustfs-ecstore manual_transition_admission_blocks_active_legacy_scope_record --lib -- --nocapture`
- `make pre-pr` passed before the final rebase onto main containing rustfs/rustfs#5287; after that rebase and import-conflict fix, the focused checks above passed again on the final head.

## Impact
No user-facing API, wire-format, deployment, or configuration impact. This adds regression coverage for admission parallelism boundaries only.

## Additional Notes
Adversarial validation ran for the test-only change: correctness and simplicity findings were addressed before opening the PR.
