### PR TITLE
test(ilm): cover cancelled continuation resume

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -7870,7 +7870,7 @@ mod tests {
             ..Default::default()
         };
 
-        let report = enqueue_transition_for_existing_objects_scoped(ecstore, &bucket, options)
+        let report = enqueue_transition_for_existing_objects_scoped(ecstore.clone(), &bucket, options)
             .await
             .expect("manual transition dry-run scan should stop on active cancel");
 
@@ -7894,6 +7894,29 @@ mod tests {
         assert_eq!(marker.as_deref(), Some(keys[0].as_str()));
         assert_eq!(version_marker.as_deref(), Some("null"));
         assert_eq!(cancel_polls.load(Ordering::SeqCst), 2);
+
+        let resumed = enqueue_transition_for_existing_objects_scoped(
+            ecstore,
+            &bucket,
+            ManualTransitionRunOptions {
+                prefix: prefix.to_string(),
+                continuation_token: Some(token.to_string()),
+                tier: Some("WARM".to_string()),
+                dry_run: true,
+                max_objects: Some(10),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("manual transition dry-run scan should resume after active cancel");
+
+        assert!(!resumed.cancelled);
+        assert!(!resumed.was_truncated());
+        assert_eq!(resumed.scanned, 1);
+        assert_eq!(resumed.eligible, 1);
+        assert_eq!(resumed.dry_run_eligible, 1);
+        assert_eq!(resumed.enqueued, 0);
+        assert!(resumed.continuation_token.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1478, rustfs/backlog#1479, and rustfs/backlog#1481.

## Summary of Changes
Extends the existing manual lifecycle transition active-cancel regression so the same production scanner path now proves the opaque continuation token returned after cancellation can resume the run and scan only the remaining object.

This is test-only. It keeps the existing cancel behavior assertions, then reuses the returned continuation token in a second dry-run manual transition call and checks that the resumed report is not cancelled, is not truncated, scans one remaining object, and returns no further continuation token.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_active_cancel_returns_resume_cursor_after_progress --lib -- --nocapture`

## Impact
No production behavior, API, storage format, or compatibility impact. This only strengthens regression coverage for manual transition cancel + continuation resume semantics.

## Additional Notes
Draft because full `make pre-pr` was not run in this slice. Focused validation passed with the existing macOS linker warning: `ld: __eh_frame section too large`.

Adversarial validation: correctness attacked the cancel checkpoint/resume boundary and confirmed the second call consumes only the remaining object; simplicity attacked adding a new helper or new test file and kept the diff inside the existing regression; test-coverage attacked revert-detection, where removing the continuation-resume block would leave this behavior unpinned.
