### PR TITLE
test(ilm): cover manual transition endpoint contract

### DIFF
--- a/crates/e2e_test/src/reliant/tiering.rs
+++ b/crates/e2e_test/src/reliant/tiering.rs
@@ -354,6 +354,7 @@ struct ManualTransitionRunResponse {
     mode: String,
     job_id: Option<String>,
     status_endpoint: Option<String>,
+    cancel_endpoint: Option<String>,
     report: ManualTransitionRunReport,
 }
 
@@ -394,6 +395,7 @@ struct ManualTransitionRunReport {
 struct ManualTransitionJobStatusResponse {
     job_id: String,
     status_endpoint: String,
+    cancel_endpoint: String,
     status: String,
     cancel_requested: bool,
     failure_reason: Option<String>,
@@ -886,10 +888,16 @@ async fn test_manual_transition_async_job_status_polling() -> TestResult {
         status_endpoint.ends_with(job_id),
         "status endpoint must embed job id: endpoint={status_endpoint}, job_id={job_id}"
     );
+    assert_eq!(
+        accepted.cancel_endpoint.as_deref(),
+        Some(status_endpoint),
+        "async run must return the cancel endpoint used by rc cancel"
+    );
 
     let terminal = wait_for_manual_transition_job_terminal(&hot, status_endpoint, StdDuration::from_secs(30)).await?;
     assert_eq!(terminal.job_id, job_id);
     assert_eq!(terminal.status_endpoint, status_endpoint);
+    assert_eq!(terminal.cancel_endpoint, status_endpoint);
     assert_eq!(terminal.status, "completed", "terminal job response: {terminal:#?}");
     assert!(!terminal.cancel_requested);
     assert_eq!(terminal.failure_reason, None);
@@ -915,6 +923,8 @@ async fn test_manual_transition_async_job_status_polling() -> TestResult {
 
     let after_cancel = manual_transition_job_cancel(&hot, status_endpoint).await?;
     assert_eq!(after_cancel.status, "completed");
+    assert_eq!(after_cancel.status_endpoint, status_endpoint);
+    assert_eq!(after_cancel.cancel_endpoint, status_endpoint);
     assert!(!after_cancel.cancel_requested);
     assert_eq!(
         cold_tier_object_count(&cold_client).await?,
@@ -963,10 +973,16 @@ async fn test_manual_transition_async_limit_reports_terminal_partial() -> TestRe
         .status_endpoint
         .as_deref()
         .ok_or("async response must include status_endpoint")?;
+    assert_eq!(
+        accepted.cancel_endpoint.as_deref(),
+        Some(status_endpoint),
+        "async partial run must return the cancel endpoint used by rc cancel"
+    );
 
     let terminal = wait_for_manual_transition_job_terminal(&hot, status_endpoint, StdDuration::from_secs(30)).await?;
     assert_eq!(terminal.job_id, job_id);
     assert_eq!(terminal.status_endpoint, status_endpoint);
+    assert_eq!(terminal.cancel_endpoint, status_endpoint);
     assert_eq!(terminal.status, "partial", "terminal limit job response: {terminal:#?}");
     assert!(!terminal.cancel_requested);
     assert_eq!(terminal.failure_reason, None);
@@ -990,6 +1006,8 @@ async fn test_manual_transition_async_limit_reports_terminal_partial() -> TestRe
 
     let after_cancel = manual_transition_job_cancel(&hot, status_endpoint).await?;
     assert_eq!(after_cancel.status, "partial");
+    assert_eq!(after_cancel.status_endpoint, status_endpoint);
+    assert_eq!(after_cancel.cancel_endpoint, status_endpoint);
     assert!(!after_cancel.cancel_requested);
     assert_eq!(after_cancel.report.bucket, terminal.report.bucket);
     assert_eq!(after_cancel.report.prefix, terminal.report.prefix);
@@ -1004,6 +1022,8 @@ async fn test_manual_transition_async_limit_reports_terminal_partial() -> TestRe
 
     let second_cancel = manual_transition_job_cancel(&hot, status_endpoint).await?;
     assert_eq!(second_cancel.status, "partial");
+    assert_eq!(second_cancel.status_endpoint, status_endpoint);
+    assert_eq!(second_cancel.cancel_endpoint, status_endpoint);
     assert!(!second_cancel.cancel_requested);
     assert_eq!(second_cancel.report.scanned, terminal.report.scanned);
     assert_eq!(second_cancel.report.transition_completed, terminal.report.transition_completed);
@@ -1462,21 +1482,29 @@ async fn test_manual_transition_async_active_cancel_reports_terminal_cancelled()
         .status_endpoint
         .as_deref()
         .ok_or("async response must include status_endpoint")?;
+    assert_eq!(
+        accepted.cancel_endpoint.as_deref(),
+        Some(status_endpoint),
+        "async active-cancel run must return the cancel endpoint used by rc cancel"
+    );
 
     let active = wait_for_manual_transition_job_running(&hot, status_endpoint, MANUAL_ACTIVE_CANCEL_RUNNING_TIMEOUT).await?;
     assert_eq!(active.job_id, job_id);
     assert_eq!(active.status_endpoint, status_endpoint);
+    assert_eq!(active.cancel_endpoint, status_endpoint);
     assert!(!active.cancel_requested);
 
     let cancel_response = manual_transition_job_cancel(&hot, status_endpoint).await?;
     assert_eq!(cancel_response.job_id, job_id);
     assert_eq!(cancel_response.status_endpoint, status_endpoint);
+    assert_eq!(cancel_response.cancel_endpoint, status_endpoint);
     assert_eq!(cancel_response.status, "running", "active cancel response: {cancel_response:#?}");
     assert!(cancel_response.cancel_requested, "active cancel response: {cancel_response:#?}");
 
     let terminal = wait_for_manual_transition_job_terminal(&hot, status_endpoint, StdDuration::from_secs(30)).await?;
     assert_eq!(terminal.job_id, job_id);
     assert_eq!(terminal.status_endpoint, status_endpoint);
+    assert_eq!(terminal.cancel_endpoint, status_endpoint);
     assert_eq!(terminal.status, "cancelled", "terminal active cancel response: {terminal:#?}");
     assert!(terminal.cancel_requested);
     assert_eq!(terminal.failure_reason, None);


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1479 and rustfs/backlog#1481.

## Summary of Changes
This test-only PR tightens the real backend contract exercised by the manual ILM transition E2E suite.

The async manual transition response model now includes `cancel_endpoint`, and the existing real RustFS backend tests assert that:
- `run?mode=async` returns the same job endpoint for status and cancel, matching the rc status/wait/cancel contract.
- status polling responses keep the endpoint stable while wait-style polling reaches a terminal job state.
- terminal and repeated cancel responses keep the same endpoint contract instead of only returning counters.
- active cancel responses also expose the same durable job endpoint while `cancel_requested` is set.

No production lifecycle, admission, job-store, or wire-format implementation code is changed.

## Verification
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `cargo test -p e2e_test test_manual_transition_async_job_status_polling --no-run` passed.
- `cargo test -p e2e_test test_manual_transition_async_job_status_polling -- --nocapture` compiled and started the real E2E, but the test runtime did not reach a terminal result within the local wait window and was interrupted with exit 130. This is why the PR is Draft.

## Impact
No runtime behavior change. This only strengthens E2E coverage for the durable manual transition status/wait/cancel backend contract consumed by rc/CLI.

## Additional Notes
Adversarial validation: correctness attacked missing or inconsistent `cancel_endpoint` fields across async run, status, terminal wait, terminal cancel, repeated cancel, and active cancel responses; these assertions now fail against that regression. Simplicity attacked helper extraction and production-path edits; the final diff stays inline and test-only to minimize conflict with recently merged lifecycle PRs.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
