### PR TITLE
test(ilm): cover restart unknown readback

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
+++ b/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
@@ -1625,6 +1625,26 @@ mod tests {
     }
 
     #[test]
+    fn manual_transition_job_record_persists_restart_unknown_state() {
+        let options = ManualTransitionRunOptions::default();
+        let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), "bucket", &options, TEST_OWNER);
+        record.mark_unknown_if_unowned();
+
+        let encoded = record.encode().expect("unknown restart job should encode");
+        let decoded = ManualTransitionJobRecord::decode(record.job_id, &encoded).expect("unknown restart job should decode");
+
+        assert_eq!(decoded.state, ManualTransitionJobState::Unknown);
+        assert!(decoded.is_terminal());
+        assert!(decoded.completed_at_unix_nanos.is_some());
+        assert!(
+            decoded
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("unknown after restart"))
+        );
+    }
+
+    #[test]
     fn manual_transition_job_record_failure_counts_tier_failure() {
         let options = ManualTransitionRunOptions::default();
         let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), "bucket", &options, TEST_OWNER);


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1481.

## Summary of Changes
- Add a deterministic persisted read-back test for manual transition jobs that are marked `Unknown` after restart or owner loss.
- Verify the encoded/decoded record stays terminal, keeps `completed_at_unix_nanos`, and preserves the restart/owner-loss error context.
- Keep this as test-only coverage; there are no API, wire, disk-format, or runtime behavior changes.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p rustfs-ecstore manual_transition_job_record_persists_restart_unknown_state --lib -- --nocapture`
- `cargo test -p rustfs-ecstore manual_transition_job_record_marks_restart_unknown_terminal --lib -- --nocapture`
- `make pre-pr`

## Impact
Test-only. This improves #1481 persisted restart/owner-loss status coverage without changing production behavior.

## Additional Notes
This PR does not close rustfs/backlog#1481 by itself. The remaining black-box work still includes true in-flight restart/cancel validation on an independent runner, CLI status/wait/cancel e2e if that CLI surface is in scope, and distributed duplicate/same-scope coverage.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
