### PR TITLE
test(ilm): cover heartbeat backpressure status

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -8972,6 +8972,61 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn manual_transition_heartbeat_persists_backpressure_status_snapshot() {
+        let (_paths, ecstore) = setup_test_env().await;
+        let job_id = Uuid::new_v4();
+        let options = ManualTransitionRunOptions {
+            prefix: "logs/".to_string(),
+            tier: Some("WARM".to_string()),
+            max_objects: Some(25),
+            ..Default::default()
+        };
+        let mut record = ManualTransitionJobRecord::new(job_id, "manual-heartbeat-backpressure-bucket", &options, "owner-a");
+        record.report.scanned = 17;
+        record.report.eligible = 11;
+        record.report.enqueued = 3;
+        let old_lease_id = record.lease_id;
+        save_manual_transition_job_record(ecstore.clone(), &record)
+            .await
+            .expect("running job record should save");
+        save_manual_transition_scope_admission_if_absent(ecstore.clone(), &ManualTransitionScopeAdmission::from_job(&record))
+            .await
+            .expect("running scope admission should save");
+        let queue_snapshot = ManualTransitionQueueSnapshot {
+            queue_capacity: 4,
+            queued: 2,
+            active: 1,
+            workers: 2,
+            queue_full: 5,
+            queue_send_timeout: 7,
+            compensation_pending: 3,
+            compensation_running: 1,
+        };
+
+        let renewed = renew_manual_transition_job_lease(ecstore.clone(), job_id, queue_snapshot)
+            .await
+            .expect("running job heartbeat should persist queue pressure status");
+
+        assert_eq!(renewed.state, ManualTransitionJobState::Running);
+        assert_eq!(renewed.lease_id, old_lease_id);
+        assert_eq!(renewed.queue_snapshot, queue_snapshot);
+        assert_eq!(renewed.report.scanned, 17);
+        assert_eq!(renewed.report.eligible, 11);
+        assert_eq!(renewed.report.enqueued, 3);
+        let loaded = load_manual_transition_job_record(ecstore.clone(), job_id)
+            .await
+            .expect("renewed heartbeat should reload");
+        assert_eq!(loaded.queue_snapshot, queue_snapshot);
+        let admission = load_manual_transition_scope_admission(ecstore, &record.scope_key)
+            .await
+            .expect("heartbeat must keep scope admission aligned with the renewed job");
+        assert_eq!(admission.job_id, job_id);
+        assert_eq!(admission.lease_id, renewed.lease_id);
+        assert_eq!(admission.lease_expires_at_unix_nanos, renewed.lease_expires_at_unix_nanos);
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn manual_transition_job_lost_worker_results_mark_unknown_and_release_admission() {
         let (_paths, ecstore) = setup_test_env().await;
         let job_id = Uuid::new_v4();


### PR DESCRIPTION
## Related Issues
- Relates to rustfs/backlog#1479

## Summary of Changes
- Add a focused regression for durable manual transition job heartbeats preserving queue/backpressure status snapshots.
- Verify `renew_manual_transition_job_lease` persists queue capacity, queued/active workers, queue full, queue send timeout, and compensation counters into the job record.
- Verify the scope admission remains aligned with the renewed job lease so status readers see the current backpressure snapshot without releasing active admission.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_heartbeat_persists_backpressure_status_snapshot --lib -- --nocapture`
- Rust code quality scan on the changed Rust file for production unwrap/expect, numeric casts, string errors, boxed public errors, println/eprintln, relaxed atomics, and default substitution patterns.

## Impact
- Test-only coverage for ILM manual transition durable job status visibility.
- No API, storage format, wire format, runtime behavior, or configuration change.

## Additional Notes
- Focused test completed with the existing macOS linker `__eh_frame section too large` warning.
- Adversarial validation: correctness attacked heartbeat/read-back and admission alignment; simplicity attacked duplicate coverage against existing checkpoint/lost-worker tests; coverage skeptic confirms reverting the heartbeat queue snapshot persistence would fail this test while existing checkpoint/recovery tests do not pin the same trigger.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
