### PR TITLE
test(ilm): cover transition budget partial records

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
+++ b/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
@@ -2077,6 +2077,60 @@ mod tests {
     }
 
     #[test]
+    fn manual_transition_job_record_budget_reports_are_partial_and_resumable() {
+        let options = ManualTransitionRunOptions {
+            prefix: "logs/".to_string(),
+            tier: Some("warm".to_string()),
+            max_objects: Some(1),
+            ..Default::default()
+        };
+
+        for (bucket, truncated_by_limit, truncated_by_duration) in [
+            ("manual-budget-limit-bucket", true, false),
+            ("manual-budget-duration-bucket", false, true),
+        ] {
+            let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), bucket, &options, TEST_OWNER);
+            let queue_snapshot = ManualTransitionQueueSnapshot {
+                queue_capacity: 8,
+                queued: 1,
+                active: 1,
+                workers: 2,
+                ..Default::default()
+            };
+            record.complete(
+                ManualTransitionRunReport {
+                    bucket: bucket.to_string(),
+                    prefix: "logs/".to_string(),
+                    tier: Some("warm".to_string()),
+                    scanned: 1,
+                    eligible: 1,
+                    dry_run_eligible: 1,
+                    truncated_by_limit,
+                    truncated_by_duration,
+                    continuation_token: Some("opaque-budget-token".to_string()),
+                    ..Default::default()
+                },
+                queue_snapshot,
+            );
+
+            assert_eq!(record.state, ManualTransitionJobState::Partial);
+            assert_eq!(record.report.continuation_token.as_deref(), Some("opaque-budget-token"));
+            assert!(record.report.was_truncated());
+            assert_eq!(record.queue_snapshot, queue_snapshot);
+            assert!(record.completed_at_unix_nanos.is_some());
+            assert!(record.error.is_none());
+
+            let encoded = record.encode().expect("budget partial job should encode");
+            let decoded = ManualTransitionJobRecord::decode(record.job_id, &encoded).expect("budget partial job should decode");
+            assert_eq!(decoded.state, ManualTransitionJobState::Partial);
+            assert_eq!(decoded.report.truncated_by_limit, truncated_by_limit);
+            assert_eq!(decoded.report.truncated_by_duration, truncated_by_duration);
+            assert_eq!(decoded.report.continuation_token.as_deref(), Some("opaque-budget-token"));
+            assert_eq!(decoded.queue_snapshot, queue_snapshot);
+        }
+    }
+
+    #[test]
     fn manual_transition_scope_key_is_stable_and_sanitized() {
         let first = manual_transition_scope_key(
             "bucket",


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1478
rustfs/backlog#1476

## Summary of Changes
Adds a focused manual transition durable job record regression test for budget-limited and duration-limited reports. The test verifies both truncation paths are terminal `Partial`, keep the opaque continuation token, preserve the queue snapshot, and survive encode/decode without changing the external API or production logic.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p rustfs-ecstore manual_transition_job_record_budget_reports_are_partial_and_resumable --lib -- --nocapture`
- `make pre-pr`

## Impact
Test-only coverage for manual transition partial/resumable durable job records. No API, wire format, persistence schema, deployment, or configuration changes.

## Additional Notes
This PR does not close #1478 or #1476 by itself. It only covers the budget/duration partial record contract; broader black-box restart, backpressure, and distributed admission coverage remains tracked separately.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
