### PR TITLE
fix(bench): parse final warp report metrics

### DIFF
--- a/scripts/run_object_batch_bench_enhanced.sh
+++ b/scripts/run_object_batch_bench_enhanced.sh
@@ -664,6 +664,21 @@ extract_first() {
   rg -o "$regex" "$file" | head -n1 || true
 }
 
+extract_report_line() {
+  local regex="$1"
+  local file="$2"
+  awk -v regex="$regex" '
+    /^Report:/ {
+      in_report = 1
+      next
+    }
+    in_report && $0 ~ regex {
+      print
+      exit
+    }
+  ' "$file"
+}
+
 normalize_duration_metric() {
   local value="$1"
   value="$(trim "${value:-N/A}")"
@@ -684,12 +699,27 @@ normalize_duration_metric() {
 extract_metrics() {
   local log_file="$1"
 
-  local throughput reqps latency req_p90 req_p99
-  throughput="$(extract_first '[0-9]+(\.[0-9]+)?[[:space:]]*(GiB/s|MiB/s|KiB/s|GB/s|MB/s|KB/s|B/s)' "$log_file")"
-  reqps="$(extract_first '[0-9]+(\.[0-9]+)?[[:space:]]*(obj/s|req/s|ops/s|requests/s)' "$log_file")"
-  latency="$(rg -o 'Reqs:[[:space:]]+Avg:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' "$log_file" | head -n1 | sed -E 's/^Reqs:[[:space:]]+Avg:[[:space:]]+//')"
-  req_p90="$(rg -o '90%:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' "$log_file" | head -n1 | sed -E 's/^90%:[[:space:]]+//')"
-  req_p99="$(rg -o '99%:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' "$log_file" | head -n1 | sed -E 's/^99%:[[:space:]]+//')"
+  local average_line reqs_line throughput reqps latency req_p90 req_p99 reqps_num
+  average_line="$(extract_report_line '^[[:space:]]*[*][[:space:]]+Average:' "$log_file")"
+  reqs_line="$(extract_report_line '^[[:space:]]*[*][[:space:]]+Reqs:' "$log_file")"
+
+  if [[ -n "$average_line" ]]; then
+    throughput="$(echo "$average_line" | sed -E 's/^.*Average:[[:space:]]*//; s/,[[:space:]]*.*$//')"
+    reqps="$(echo "$average_line" | sed -E 's/^.*Average:[[:space:]]*[^,]+,[[:space:]]*//; s/[[:space:]]*$//')"
+  else
+    throughput="$(extract_first '[0-9]+(\.[0-9]+)?[[:space:]]*(GiB/s|MiB/s|KiB/s|GB/s|MB/s|KB/s|B/s)' "$log_file")"
+    reqps="$(extract_first '[0-9]+(\.[0-9]+)?[[:space:]]*(obj/s|req/s|ops/s|requests/s)' "$log_file")"
+  fi
+
+  if [[ -n "$reqs_line" ]]; then
+    latency="$(echo "$reqs_line" | rg -o 'Avg:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' | sed -E 's/^Avg:[[:space:]]+//')"
+    req_p90="$(echo "$reqs_line" | rg -o '90%:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' | sed -E 's/^90%:[[:space:]]+//')"
+    req_p99="$(echo "$reqs_line" | rg -o '99%:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' | sed -E 's/^99%:[[:space:]]+//')"
+  else
+    latency="$(rg -o 'Reqs:[[:space:]]+Avg:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' "$log_file" | head -n1 | sed -E 's/^Reqs:[[:space:]]+Avg:[[:space:]]+//')"
+    req_p90="$(rg -o '90%:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' "$log_file" | head -n1 | sed -E 's/^90%:[[:space:]]+//')"
+    req_p99="$(rg -o '99%:[[:space:]]+[0-9]+(\.[0-9]+)?(ms|us|µs|s)' "$log_file" | head -n1 | sed -E 's/^99%:[[:space:]]+//')"
+  fi
 
   if [[ -z "$latency" ]]; then
     latency="$(extract_first '[0-9]+(\.[0-9]+)?[[:space:]]*(ms|us|µs|s)' "$log_file")"

--- a/scripts/test_object_batch_bench_enhanced.sh
+++ b/scripts/test_object_batch_bench_enhanced.sh
@@ -69,3 +69,36 @@ fi
   --dry-run >/dev/null
 
 rg -qx 'run_label_count=0' "${TMP_DIR}/default/run_manifest.env"
+
+FAKE_WARP="${TMP_DIR}/fake-warp"
+cat >"$FAKE_WARP" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'LOG'
+ -       PUT Average: 161 Obj/s, 5.0MiB/s; Current 161 Obj/s, 5.0MiB/s.
+Report: GET. Concurrency: 64. Ran: 7s
+ * Average: 653.90 MiB/s, 20925.58 obj/s
+ * Reqs: Avg: 3.5ms, 50%: 2.0ms, 90%: 3.6ms, 99%: 24.1ms, Fastest: 0.2ms, Slowest: 607.7ms, StdDev: 20.6ms
+Throughput, split into 7 x 1s:
+LOG
+EOF
+chmod +x "$FAKE_WARP"
+
+"$RUNNER" \
+  --tool warp \
+  --endpoint http://127.0.0.1:9000 \
+  --access-key test-access \
+  --secret-key test-secret \
+  --sizes 32767B \
+  --rounds 1 \
+  --retry-per-round 1 \
+  --cooldown-secs 0 \
+  --duration 1s \
+  --out-dir "${TMP_DIR}/fake-warp-run" \
+  --warp-bin "$FAKE_WARP" \
+  --server-image-ref rustfs/rustfs:bench \
+  --server-image-digest sha256:0123456789abcdef \
+  --server-revision 9f61bad94 \
+  --require-server-provenance >/dev/null 2>&1
+
+rg -q '^32767B,warp,1,1,128,ok,0,[^,]+,[^,]+,653.90 MiB/s,685663846.400000,20925.58,3.5 ms,3.500000,[^,]+,3.6 ms,3.600000,24.1 ms,24.100000$' "${TMP_DIR}/fake-warp-run/round_results.csv"


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1432 and rustfs/backlog#1431. This PR does not close either issue.

## Summary of Changes
Fix the enhanced object batch benchmark parser so warp runs read throughput, request rate, and latency from the final `Report: <mode>` block instead of the first matching metric anywhere in the log. A GET run can contain PUT preparation progress lines before the final GET report, and the previous first-match parser could record the PUT progress throughput in `round_results.csv`.

Add a script regression test with a fake warp log that contains a misleading PUT `Average` line followed by the final GET report. The test asserts that `round_results.csv` records the final GET values.

## Verification
- `scripts/test_object_batch_bench_enhanced.sh`
- `bash -n scripts/run_object_batch_bench_enhanced.sh scripts/test_object_batch_bench_enhanced.sh`
- `git diff --check origin/main...HEAD`
- `make script-tests`

## Impact
This is benchmark tooling only. It does not change RustFS runtime behavior, S3 API semantics, wire format, on-disk format, defaults, or compatibility behavior.

## Additional Notes
This fixes a parser issue found while analyzing the completed rustfs/backlog#1432 pinned RustFS/MinIO ABBA matrix. Existing raw warp logs can still be re-parsed with the corrected logic, but existing CSV summaries generated by the old parser should not be used for performance conclusions without correction.
