### PR TITLE
test(ilm): cover queue-full terminal job records

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -7575,13 +7575,27 @@ mod tests {
     }
 
     #[test]
-    fn manual_transition_job_record_closed_and_timeout_reports_are_partial() {
+    fn manual_transition_job_record_queue_pressure_reports_are_partial() {
         let options = ManualTransitionRunOptions::default();
 
-        for (bucket, outcome, skipped_queue_closed, skipped_queue_timeout, queue_snapshot) in [
+        for (bucket, outcome, skipped_queue_full, skipped_queue_closed, skipped_queue_timeout, queue_snapshot) in [
+            (
+                "manual-queue-full-bucket",
+                TransitionEnqueueOutcome::QueueFull,
+                1,
+                0,
+                0,
+                ManualTransitionQueueSnapshot {
+                    queue_capacity: 1,
+                    workers: 1,
+                    queue_full: 1,
+                    ..Default::default()
+                },
+            ),
             (
                 "manual-queue-closed-bucket",
                 TransitionEnqueueOutcome::QueueClosed,
+                0,
                 1,
                 0,
                 ManualTransitionQueueSnapshot {
@@ -7593,6 +7607,7 @@ mod tests {
             (
                 "manual-queue-timeout-bucket",
                 TransitionEnqueueOutcome::QueueSendTimedOut,
+                0,
                 0,
                 1,
                 ManualTransitionQueueSnapshot {
@@ -7612,9 +7627,10 @@ mod tests {
 
             assert_eq!(record.state, ManualTransitionJobState::Partial);
             assert_eq!(record.report.enqueued, 0);
-            assert_eq!(record.report.skipped_queue_full, 0);
+            assert_eq!(record.report.skipped_queue_full, skipped_queue_full);
             assert_eq!(record.report.skipped_queue_closed, skipped_queue_closed);
             assert_eq!(record.report.skipped_queue_timeout, skipped_queue_timeout);
+            assert_eq!(record.queue_snapshot.queue_full, queue_snapshot.queue_full);
             assert_eq!(record.queue_snapshot.queue_send_timeout, queue_snapshot.queue_send_timeout);
             assert!(record.completed_at_unix_nanos.is_some());
             assert!(record.error.is_none());


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1479 and rustfs/backlog#1476.

## Summary of Changes
Extend the durable manual transition queue-pressure terminal record regression matrix to include the `QueueFull` enqueue outcome. The existing test already covered queue-closed and queue-send-timeout terminal records; this adds the missing queue-full poison value and asserts that the terminal job record remains `Partial`, keeps the queue-full counter, and preserves the queue snapshot's queue-full signal.

This is test-only and does not change production logic, API shape, persistence format, or wire format.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_job_record_queue_pressure_reports_are_partial --lib -- --nocapture`

## Impact
No user-facing behavior change. This strengthens regression coverage for durable manual transition job status/read-back under queue pressure.

## Additional Notes
The focused test passed locally with the existing macOS linker `__eh_frame` warning.
