### PR TITLE
test(admin): cover manual transition capabilities e2e

### DIFF
--- a/crates/e2e_test/src/storage_class_capability_test.rs
+++ b/crates/e2e_test/src/storage_class_capability_test.rs
@@ -389,6 +389,10 @@ mod tests {
             !unsigned_body.contains("supported_write_classes"),
             "the capability contract must not bypass admin authentication"
         );
+        assert!(
+            !unsigned_body.contains("manual_transition_jobs"),
+            "manual transition job capabilities must not bypass admin authentication"
+        );
 
         let response = signed_admin_get(&env, path).await?;
         assert_eq!(response.status(), StatusCode::OK);
@@ -400,6 +404,25 @@ mod tests {
         );
         assert_eq!(body["storage_classes"]["unsupported_write_error"], "InvalidStorageClass");
         assert_eq!(body["storage_classes"]["legacy_label_behavior"], "normalized_to_effective_class");
+        assert_eq!(body["summary"]["manual_transition_jobs"]["state"], "supported");
+        assert_eq!(body["manual_transition_jobs"]["contract_version"], 1);
+        assert_eq!(body["manual_transition_jobs"]["status"]["state"], "supported");
+        assert_eq!(body["manual_transition_jobs"]["modes"], serde_json::json!(["enqueue_only", "async"]));
+        assert_eq!(body["manual_transition_jobs"]["run_route"], "/rustfs/admin/v3/ilm/transition/run");
+        assert_eq!(
+            body["manual_transition_jobs"]["status_route"],
+            "/rustfs/admin/v3/ilm/transition/jobs/{job_id}"
+        );
+        assert_eq!(
+            body["manual_transition_jobs"]["cancel_route"],
+            "/rustfs/admin/v3/ilm/transition/jobs/{job_id}"
+        );
+        assert_eq!(body["manual_transition_jobs"]["job_id_format"], "uuid");
+        assert_eq!(body["manual_transition_jobs"]["admission_scope"], "bucket");
+        assert_eq!(
+            body["manual_transition_jobs"]["mixed_version_policy"],
+            "fail_closed_when_capability_unknown_or_unsupported"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1479 and rustfs/backlog#1476.

## Summary of Changes
- Extend the authenticated runtime capabilities e2e coverage to assert the manual transition job capability contract exposed by `/rustfs/admin/v4/runtime/capabilities`.
- Verify unauthenticated callers cannot observe the `manual_transition_jobs` capability block.
- Assert the v1 manual transition job contract fields that clients depend on: supported status, `enqueue_only`/`async` modes, run/status/cancel routes, UUID job IDs, bucket-level admission scope, and mixed-version fail-closed policy.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- Rust code quality scan on `crates/e2e_test/src/storage_class_capability_test.rs`
- `NO_PROXY=127.0.0.1,localhost HTTP_PROXY= HTTPS_PROXY= cargo test -p e2e_test authenticated_runtime_capabilities_publish_the_versioned_storage_class_contract -- --nocapture` failed inside the sandbox before assertions with `PermissionDenied: Operation not permitted`.
- The same focused e2e command was retried with elevated local permissions; it started RustFS successfully but did not converge within the local handoff window and was interrupted with exit 130. Draft PR opened for CI validation.

## Impact
Test-only change. No production behavior, API, wire-format, storage-format, deployment, or configuration impact.

## Additional Notes
This follows up on the runtime capability contract introduced by rustfs/rustfs#5306 and pins the same contract through a real signed admin HTTP path.
