### PR TITLE
test(ilm): cover queue pressure job readback

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
+++ b/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
@@ -2077,6 +2077,84 @@ mod tests {
     }
 
     #[test]
+    fn manual_transition_job_record_queue_pressure_reports_persist_readback() {
+        let options = ManualTransitionRunOptions {
+            prefix: "logs/".to_string(),
+            tier: Some("warm".to_string()),
+            max_objects: Some(20),
+            ..Default::default()
+        };
+
+        for (bucket, skipped_queue_full, skipped_queue_timeout, queue_full, queue_send_timeout) in [
+            ("manual-queue-full-status-bucket", 18, 0, 18, 0),
+            ("manual-queue-timeout-status-bucket", 0, 7, 0, 7),
+        ] {
+            let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), bucket, &options, TEST_OWNER);
+            let active_snapshot = ManualTransitionQueueSnapshot {
+                queue_capacity: 1,
+                queued: 1,
+                active: 1,
+                workers: 1,
+                queue_full,
+                queue_send_timeout,
+                ..Default::default()
+            };
+            record.complete(
+                ManualTransitionRunReport {
+                    bucket: bucket.to_string(),
+                    prefix: "logs/".to_string(),
+                    tier: Some("warm".to_string()),
+                    scanned: 20,
+                    eligible: 20,
+                    enqueued: 1,
+                    skipped_queue_full,
+                    skipped_queue_timeout,
+                    continuation_token: Some("opaque-pressure-token".to_string()),
+                    ..Default::default()
+                },
+                active_snapshot,
+            );
+
+            assert_eq!(record.state, ManualTransitionJobState::Running);
+            assert!(record.report.worker_transition_pending());
+            assert_eq!(record.queue_snapshot, active_snapshot);
+            let running_encoded = record.encode().expect("running queue pressure job should encode");
+            let running_decoded = ManualTransitionJobRecord::decode(record.job_id, &running_encoded)
+                .expect("running queue pressure job should decode");
+            assert_eq!(running_decoded.state, ManualTransitionJobState::Running);
+            assert!(running_decoded.report.worker_transition_pending());
+            assert_eq!(running_decoded.report.skipped_queue_full, skipped_queue_full);
+            assert_eq!(running_decoded.report.skipped_queue_timeout, skipped_queue_timeout);
+            assert_eq!(running_decoded.report.continuation_token.as_deref(), Some("opaque-pressure-token"));
+            assert_eq!(running_decoded.queue_snapshot, active_snapshot);
+
+            let terminal_snapshot = ManualTransitionQueueSnapshot {
+                queue_capacity: 1,
+                workers: 1,
+                queue_full,
+                queue_send_timeout,
+                ..Default::default()
+            };
+            record.record_worker_result(ManualTransitionWorkerResult::Completed, terminal_snapshot);
+            let encoded = record.encode().expect("terminal queue pressure job should encode");
+            let decoded =
+                ManualTransitionJobRecord::decode(record.job_id, &encoded).expect("terminal queue pressure job should decode");
+
+            assert_eq!(decoded.state, ManualTransitionJobState::Partial);
+            assert!(decoded.is_terminal());
+            assert_eq!(decoded.report.enqueued, 1);
+            assert_eq!(decoded.report.transition_completed, 1);
+            assert_eq!(decoded.report.skipped_queue_full, skipped_queue_full);
+            assert_eq!(decoded.report.skipped_queue_timeout, skipped_queue_timeout);
+            assert_eq!(decoded.report.continuation_token.as_deref(), Some("opaque-pressure-token"));
+            assert!(decoded.report.has_partial_enqueue());
+            assert_eq!(decoded.queue_snapshot, terminal_snapshot);
+            assert!(decoded.completed_at_unix_nanos.is_some());
+            assert!(decoded.error.is_none());
+        }
+    }
+
+    #[test]
     fn manual_transition_job_record_budget_reports_are_partial_and_resumable() {
         let options = ManualTransitionRunOptions {
             prefix: "logs/".to_string(),


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1479
rustfs/backlog#1476

## Summary of Changes
Adds a focused manual-transition job record regression test for queue-pressure durable readback.

The new test covers both queue-full and queue-send-timeout pressure cases after the scan has completed but before worker results have drained. It encodes and decodes the running job record to assert that the active queue snapshot, worker activity, queue pressure counters, and continuation token remain visible through durable readback. It then records the worker result and verifies the terminal partial record preserves the final pressure counters and queue snapshot after encode/decode.

This is intentionally separate from #5310, which covers the QueueFull terminal path in bucket lifecycle operations.

## Verification
Not run locally per handoff instruction; waiting for GitHub CI.

## Impact
Test-only change. No production behavior, API, persistence format, deployment, or configuration impact expected.

## Additional Notes
Draft PR for CI-backed validation of the remaining backlog#1479 queue-pressure/status readback slice.
