### PR TITLE
test(ilm): cover restart cancel readback

### DIFF
--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -1813,6 +1813,29 @@ async fn four_node_manual_transition_job_status_survives_node_restart() -> TestR
     assert_eq!(after_restart["bucket"].as_str(), Some(bucket.as_str()));
     assert_eq!(after_restart["dry_run"].as_bool(), Some(true));
 
+    let job_endpoint = format!("/rustfs/admin/v3/ilm/transition/jobs/{job_id}");
+    let (cancel_status, cancel_body) = signed_admin_request(
+        &hot.nodes[3].url,
+        Method::DELETE,
+        &job_endpoint,
+        None,
+        &hot.access_key,
+        &hot.secret_key,
+    )
+    .await?;
+    assert_eq!(
+        cancel_status,
+        StatusCode::OK,
+        "terminal manual transition job cancel after restart failed: {}",
+        compact_body(&cancel_body)
+    );
+    let cancel_value: serde_json::Value = serde_json::from_str(&cancel_body)?;
+    assert_eq!(cancel_value["status"], after_restart["status"], "terminal status changed after restart cancel");
+    assert_eq!(cancel_value["job_id"].as_str(), Some(job_id.as_str()));
+    assert_eq!(cancel_value["bucket"].as_str(), Some(bucket.as_str()));
+    assert_eq!(cancel_value["dry_run"].as_bool(), Some(true));
+    assert_eq!(cancel_value["cancel_requested"].as_bool(), Some(true));
+
     let missing_job_id = Uuid::new_v4();
     let (missing_status, missing_body) = signed_admin_request(
         &hot.nodes[3].url,

--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -1814,15 +1814,8 @@ async fn four_node_manual_transition_job_status_survives_node_restart() -> TestR
     assert_eq!(after_restart["dry_run"].as_bool(), Some(true));
 
     let job_endpoint = format!("/rustfs/admin/v3/ilm/transition/jobs/{job_id}");
-    let (cancel_status, cancel_body) = signed_admin_request(
-        &hot.nodes[3].url,
-        Method::DELETE,
-        &job_endpoint,
-        None,
-        &hot.access_key,
-        &hot.secret_key,
-    )
-    .await?;
+    let (cancel_status, cancel_body) =
+        signed_admin_request(&hot.nodes[3].url, Method::DELETE, &job_endpoint, None, &hot.access_key, &hot.secret_key).await?;
     assert_eq!(
         cancel_status,
         StatusCode::OK,
@@ -1830,7 +1823,10 @@ async fn four_node_manual_transition_job_status_survives_node_restart() -> TestR
         compact_body(&cancel_body)
     );
     let cancel_value: serde_json::Value = serde_json::from_str(&cancel_body)?;
-    assert_eq!(cancel_value["status"], after_restart["status"], "terminal status changed after restart cancel");
+    assert_eq!(
+        cancel_value["status"], after_restart["status"],
+        "terminal status changed after restart cancel"
+    );
     assert_eq!(cancel_value["job_id"].as_str(), Some(job_id.as_str()));
     assert_eq!(cancel_value["bucket"].as_str(), Some(bucket.as_str()));
     assert_eq!(cancel_value["dry_run"].as_bool(), Some(true));


### PR DESCRIPTION
## Summary

Add a focused four-node e2e regression for durable manual transition job cancel readback after a node restart.

The existing cluster e2e already verifies that a terminal async dry-run job can be read from a restarted node. This follow-up extends the same real-process path by issuing `DELETE /rustfs/admin/v3/ilm/transition/jobs/{job_id}` against the restarted node and asserting the terminal job remains stable while `cancel_requested` is persisted in the cancel readback response.

## Changes

- Extend `four_node_manual_transition_job_status_survives_node_restart` with terminal cancel replay after the restarted node is ready.
- Assert the cancel readback preserves `status`, `job_id`, `bucket`, and `dry_run` while setting `cancel_requested`.
- Keep the change test-only; no production logic, API shape, or persistence schema is changed.

## Validation

Not run locally in this handoff. This is published as a Draft PR for GitHub CI validation.

## Issue coverage

Contributes to rustfs/backlog#1479 by covering the real-process restart + cancel replay portion of the remaining manual transition durable job matrix. It does not close #1479 by itself; distributed admission/backpressure stress and the broader queue/rate-limit matrix still remain.
