### PR TITLE
test(ilm): cover pending worker budget status

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
+++ b/crates/ecstore/src/bucket/lifecycle/manual_transition_job.rs
@@ -2131,6 +2131,60 @@ mod tests {
     }
 
     #[test]
+    fn manual_transition_job_budget_report_waits_for_pending_workers() {
+        let options = ManualTransitionRunOptions {
+            prefix: "logs/".to_string(),
+            tier: Some("warm".to_string()),
+            max_objects: Some(1),
+            ..Default::default()
+        };
+        let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), "manual-budget-pending-bucket", &options, TEST_OWNER);
+        let active_snapshot = ManualTransitionQueueSnapshot {
+            queue_capacity: 4,
+            queued: 1,
+            active: 1,
+            workers: 2,
+            ..Default::default()
+        };
+
+        record.complete(
+            ManualTransitionRunReport {
+                bucket: "manual-budget-pending-bucket".to_string(),
+                prefix: "logs/".to_string(),
+                tier: Some("warm".to_string()),
+                scanned: 1,
+                eligible: 1,
+                enqueued: 1,
+                truncated_by_limit: true,
+                continuation_token: Some("opaque-budget-token".to_string()),
+                ..Default::default()
+            },
+            active_snapshot,
+        );
+
+        assert_eq!(record.state, ManualTransitionJobState::Running);
+        assert!(record.scan_completed);
+        assert!(record.completed_at_unix_nanos.is_none());
+        assert!(record.report.was_truncated());
+        assert!(record.report.worker_transition_pending());
+        assert_eq!(record.report.continuation_token.as_deref(), Some("opaque-budget-token"));
+        assert_eq!(record.queue_snapshot, active_snapshot);
+
+        let drained_snapshot = ManualTransitionQueueSnapshot {
+            queue_capacity: 4,
+            workers: 2,
+            ..Default::default()
+        };
+        record.record_worker_result(ManualTransitionWorkerResult::Completed, drained_snapshot);
+
+        assert_eq!(record.state, ManualTransitionJobState::Partial);
+        assert_eq!(record.report.transition_completed, 1);
+        assert_eq!(record.queue_snapshot, drained_snapshot);
+        assert!(record.completed_at_unix_nanos.is_some());
+        assert!(record.error.is_none());
+    }
+
+    #[test]
     fn manual_transition_scope_key_is_stable_and_sanitized() {
         let first = manual_transition_scope_key(
             "bucket",


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1479 and rustfs/backlog#1476.

## Summary of Changes
Add focused manual transition job record coverage for a budget-truncated scan while worker tasks are still pending.

The new test verifies that a scan stopped by the object budget with one enqueued worker task remains `Running`, preserves the opaque continuation token, and keeps the active queue snapshot until the worker result drains. It then records the worker result and verifies the job transitions to terminal `Partial` because the budget truncation is still resumable.

This is intentionally test-only and avoids the existing queue-pressure terminal/readback matrix covered by rustfs/rustfs#5310 and rustfs/rustfs#5313.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore manual_transition_job_budget_report_waits_for_pending_workers --lib -- --nocapture`

## Impact
No runtime behavior, API, wire-format, storage-format, deployment, or configuration impact. This only strengthens regression coverage for manual transition running status under budget pressure with pending workers.

## Additional Notes
Opened as draft because the full `make pre-commit` gate was not run locally for this small test-only slice. The focused test passed locally with the existing macOS linker `__eh_frame section too large` warning.
