### PR TITLE
test(ilm): cover manual transition e2e stress

### DIFF
--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -1906,13 +1906,14 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
     let prefix = "transition/distributed-admission/";
     hot_client.create_bucket().bucket(&bucket).send().await?;
     put_lifecycle_with_transition_retry(&hot_client, &bucket, &tier_name).await?;
-    for index in 0u8..64 {
+    for index in 0..64 {
         let key = format!("{prefix}object-{index:02}.bin");
+        let seed = u8::try_from(index)?;
         hot_client
             .put_object()
             .bucket(&bucket)
             .key(key)
-            .body(ByteStream::from(payload(64 * KIB, index)))
+            .body(ByteStream::from(payload(64 * KIB, seed)))
             .send()
             .await?;
     }
@@ -1985,11 +1986,11 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
         Some("partial"),
         "small transition queue should surface terminal backpressure: {terminal}"
     );
-    let skipped_queue_full = terminal["report"]["skipped_queue_full"]
-        .as_u64()
-        .ok_or_else(|| format!("terminal status omitted report.skipped_queue_full: {terminal}"))?;
     assert!(
-        skipped_queue_full > 0,
+        terminal["report"]["skipped_queue_full"]
+            .as_u64()
+            .ok_or_else(|| format!("terminal status omitted report.skipped_queue_full: {terminal}"))?
+            > 0,
         "terminal status should include queue-full backpressure counters: {terminal}"
     );
     let queue_snapshot = terminal["queue_snapshot"]

--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -1309,6 +1309,47 @@ async fn start_manual_transition_job(hot: &RustFSTestClusterEnvironment, bucket:
         .ok_or_else(|| format!("manual transition run response omitted job_id: {response}").into())
 }
 
+async fn start_manual_transition_job_on_node(
+    hot: &RustFSTestClusterEnvironment,
+    node_index: usize,
+    bucket: &str,
+    prefix: &str,
+    tier_name: &str,
+    dry_run: bool,
+    max_objects: u64,
+) -> TestResult<(StatusCode, String)> {
+    let bucket = urlencoding::encode(bucket);
+    let prefix = urlencoding::encode(prefix);
+    let tier = urlencoding::encode(tier_name);
+    let path = format!(
+        "/rustfs/admin/v3/ilm/transition/run?bucket={bucket}&prefix={prefix}&tier={tier}&dryRun={dry_run}&maxObjects={max_objects}&mode=async"
+    );
+    signed_admin_request(&hot.nodes[node_index].url, Method::POST, &path, None, &hot.access_key, &hot.secret_key).await
+}
+
+async fn read_manual_transition_job_status_endpoint(
+    hot: &RustFSTestClusterEnvironment,
+    node_index: usize,
+    status_endpoint: &str,
+) -> TestResult<serde_json::Value> {
+    let (status, response) = signed_admin_request(
+        &hot.nodes[node_index].url,
+        Method::GET,
+        status_endpoint,
+        None,
+        &hot.access_key,
+        &hot.secret_key,
+    )
+    .await?;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "manual transition job status endpoint was not readable on node {node_index}: {}",
+        compact_body(&response)
+    );
+    Ok(serde_json::from_str(&response)?)
+}
+
 async fn wait_for_manual_transition_job_terminal(
     hot: &RustFSTestClusterEnvironment,
     node_index: usize,
@@ -1833,6 +1874,143 @@ async fn four_node_manual_transition_job_status_survives_node_restart() -> TestR
         missing_body.contains("<Code>NoSuchKey</Code>") || missing_body.contains("NoSuchKey"),
         "unknown manual transition job should return NoSuchKey, body: {}",
         compact_body(&missing_body)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn four_node_manual_transition_distributed_admission_conflict_reports_status_and_backpressure() -> TestResult {
+    init_logging();
+
+    let mut cold = RustFSTestEnvironment::new().await?;
+    cold.access_key = "inlinedistadmissioncoldadmin".to_string();
+    cold.secret_key = "inlinedistadmissioncoldsecret".to_string();
+    cold.start_rustfs_server_without_cleanup(vec![]).await?;
+    let cold_client = cold.create_s3_client();
+    cold_client.create_bucket().bucket(TIER_BUCKET).send().await?;
+
+    let mut hot = RustFSTestClusterEnvironment::new(4).await?;
+    hot.set_env("RUSTFS_SCANNER_ENABLED", "false");
+    hot.set_env("RUSTFS_SCANNER_CYCLE", "3600");
+    hot.set_env("RUSTFS_MAX_TRANSITION_WORKERS", "1");
+    hot.set_env("RUSTFS_TRANSITION_QUEUE_CAPACITY", "1");
+    hot.start().await?;
+
+    let hot_client = hot.create_s3_client(0)?;
+    let tier_name = unique_tier_name();
+    add_rustfs_tier(&hot, &cold, &tier_name).await?;
+
+    let bucket = format!("distributed-admission-{}", Uuid::new_v4().simple());
+    let prefix = "transition/distributed-admission/";
+    hot_client.create_bucket().bucket(&bucket).send().await?;
+    put_lifecycle_with_transition_retry(&hot_client, &bucket, &tier_name).await?;
+    for index in 0u8..64 {
+        let key = format!("{prefix}object-{index:02}.bin");
+        hot_client
+            .put_object()
+            .bucket(&bucket)
+            .key(key)
+            .body(ByteStream::from(payload(64 * KIB, index)))
+            .send()
+            .await?;
+    }
+
+    let (node0, node1) = tokio::join!(
+        start_manual_transition_job_on_node(&hot, 0, &bucket, prefix, &tier_name, false, 64),
+        start_manual_transition_job_on_node(&hot, 1, &bucket, prefix, &tier_name, false, 64)
+    );
+    let responses = [(0usize, node0?), (1usize, node1?)];
+    let accepted = responses
+        .iter()
+        .find(|(_, (status, _))| *status == StatusCode::ACCEPTED)
+        .ok_or_else(|| format!("one distributed async run must be accepted: {responses:#?}"))?;
+    let conflict = responses
+        .iter()
+        .find(|(_, (status, _))| *status == StatusCode::CONFLICT)
+        .ok_or_else(|| format!("one distributed async run must report conflict: {responses:#?}"))?;
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|(_, (status, _))| *status == StatusCode::ACCEPTED)
+            .count(),
+        1,
+        "distributed admission must allow exactly one winner: {responses:#?}"
+    );
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|(_, (status, _))| *status == StatusCode::CONFLICT)
+            .count(),
+        1,
+        "distributed admission must reject exactly one overlapping contender: {responses:#?}"
+    );
+
+    let accepted_body: serde_json::Value = serde_json::from_str(&accepted.1.1)?;
+    let conflict_body: serde_json::Value = serde_json::from_str(&conflict.1.1)?;
+    let job_id = accepted_body["job_id"]
+        .as_str()
+        .ok_or_else(|| format!("accepted response omitted job_id: {}", accepted.1.1))?;
+    let status_endpoint = accepted_body["status_endpoint"]
+        .as_str()
+        .ok_or_else(|| format!("accepted response omitted status_endpoint: {}", accepted.1.1))?;
+    assert_eq!(accepted_body["state"].as_str(), Some("accepted"));
+    assert_eq!(accepted_body["mode"].as_str(), Some("durable_job"));
+    assert_eq!(accepted_body["cancel_endpoint"].as_str(), Some(status_endpoint));
+    assert_eq!(conflict_body["state"].as_str(), Some("conflict"));
+    assert_eq!(conflict_body["mode"].as_str(), Some("durable_job"));
+    assert_eq!(conflict_body["active_job_id"].as_str(), Some(job_id));
+    assert_eq!(conflict_body["status_endpoint"].as_str(), Some(status_endpoint));
+    assert_eq!(conflict_body["cancel_endpoint"].as_str(), Some(status_endpoint));
+    assert!(
+        conflict_body["scope_key"]
+            .as_str()
+            .is_some_and(|scope_key| !scope_key.is_empty()),
+        "conflict response must expose a readable active scope key: {}",
+        conflict.1.1
+    );
+
+    let status = read_manual_transition_job_status_endpoint(&hot, conflict.0, status_endpoint).await?;
+    assert_eq!(status["job_id"].as_str(), Some(job_id));
+    assert_eq!(status["status_endpoint"].as_str(), Some(status_endpoint));
+
+    let terminal = wait_for_manual_transition_job_terminal(&hot, conflict.0, job_id, false).await?;
+    assert_eq!(terminal["job_id"].as_str(), Some(job_id));
+    assert_eq!(terminal["bucket"].as_str(), Some(bucket.as_str()));
+    assert_eq!(terminal["prefix"].as_str(), Some(prefix));
+    assert_eq!(terminal["dry_run"].as_bool(), Some(false));
+    assert_eq!(
+        terminal["status"].as_str(),
+        Some("partial"),
+        "small transition queue should surface terminal backpressure: {terminal}"
+    );
+    let skipped_queue_full = terminal["report"]["skipped_queue_full"]
+        .as_u64()
+        .ok_or_else(|| format!("terminal status omitted report.skipped_queue_full: {terminal}"))?;
+    assert!(
+        skipped_queue_full > 0,
+        "terminal status should include queue-full backpressure counters: {terminal}"
+    );
+    let queue_snapshot = terminal["queue_snapshot"]
+        .as_object()
+        .ok_or_else(|| format!("terminal status omitted queue_snapshot: {terminal}"))?;
+    for field in [
+        "queue_capacity",
+        "queued",
+        "active",
+        "workers",
+        "queue_full",
+        "queue_send_timeout",
+    ] {
+        assert!(
+            queue_snapshot.get(field).and_then(serde_json::Value::as_u64).is_some(),
+            "queue_snapshot.{field} must be readable in terminal status: {terminal}"
+        );
+    }
+    assert!(
+        cold_tier_object_count(&cold_client).await? < 64,
+        "queue pressure should leave at least one object untransitioned"
     );
 
     Ok(())

--- a/crates/e2e_test/src/reliant/tiering.rs
+++ b/crates/e2e_test/src/reliant/tiering.rs
@@ -505,11 +505,17 @@ async fn manual_transition_job_status(
     hot: &RustFSTestEnvironment,
     status_endpoint: &str,
 ) -> Result<ManualTransitionJobStatusResponse, Box<dyn std::error::Error + Send + Sync>> {
-    let (status, body) =
-        signed_admin_request(&hot.url, Method::GET, status_endpoint, None, &hot.access_key, &hot.secret_key).await?;
+    let (status, body) = manual_transition_job_status_raw(hot, status_endpoint).await?;
     assert_eq!(status, reqwest::StatusCode::OK, "manual transition job status response: {body}");
     assert_manual_transition_job_response_contract(&body, "manual transition job status response")?;
     Ok(serde_json::from_str(&body)?)
+}
+
+async fn manual_transition_job_status_raw(
+    hot: &RustFSTestEnvironment,
+    status_endpoint: &str,
+) -> Result<(reqwest::StatusCode, String), Box<dyn std::error::Error + Send + Sync>> {
+    signed_admin_request(&hot.url, Method::GET, status_endpoint, None, &hot.access_key, &hot.secret_key).await
 }
 
 async fn manual_transition_job_cancel(
@@ -554,7 +560,7 @@ fn assert_manual_transition_job_response_contract(
         "versionMarker",
     ] {
         assert!(
-            !body.contains(&format!("\"{incompatible}\"")),
+            value.get(incompatible).is_none(),
             "{context} must not expose incompatible field {incompatible}: {body}"
         );
     }
@@ -1683,7 +1689,12 @@ async fn test_manual_transition_async_cancel_after_process_restart_recovers_term
     let cold_client = cold.create_s3_client();
     cold_client.create_bucket().bucket(TIER_BUCKET).send().await?;
 
-    let restart_env = [("RUSTFS_SCANNER_ENABLED", "false"), ("RUSTFS_SCANNER_CYCLE", "3600")];
+    let restart_env = [
+        ("RUSTFS_SCANNER_ENABLED", "false"),
+        ("RUSTFS_SCANNER_CYCLE", "3600"),
+        ("RUSTFS_MAX_TRANSITION_WORKERS", "1"),
+        ("RUSTFS_TRANSITION_QUEUE_CAPACITY", "512"),
+    ];
     let mut hot = RustFSTestEnvironment::new().await?;
     hot.start_rustfs_server_with_env(vec![], &restart_env).await?;
     let hot_client = hot.create_s3_client();
@@ -1703,9 +1714,9 @@ async fn test_manual_transition_async_cancel_after_process_restart_recovers_term
         put_single_part_object(&hot_client, MANUAL_RESTART_CANCEL_BUCKET, &key, b"manual restart cancel payload").await?;
     }
 
-    let before_remote_count = cold_tier_object_count(&cold_client).await?;
+    cold.stop_server();
     let accepted =
-        manual_transition_async_run(&hot, MANUAL_RESTART_CANCEL_BUCKET, MANUAL_RESTART_CANCEL_PREFIX, true, 10_000).await?;
+        manual_transition_async_run(&hot, MANUAL_RESTART_CANCEL_BUCKET, MANUAL_RESTART_CANCEL_PREFIX, false, 10_000).await?;
     let job_id = accepted.job_id.as_deref().ok_or("async response must include job_id")?;
     let status_endpoint = accepted
         .status_endpoint
@@ -1713,57 +1724,87 @@ async fn test_manual_transition_async_cancel_after_process_restart_recovers_term
         .ok_or("async response must include status_endpoint")?;
     assert_eq!(accepted.cancel_endpoint.as_deref(), Some(status_endpoint));
 
-    let active = wait_for_manual_transition_job_running(&hot, status_endpoint, MANUAL_ACTIVE_CANCEL_RUNNING_TIMEOUT).await?;
-    assert_eq!(active.job_id, job_id);
-    assert!(!active.cancel_requested);
-
     hot.restart_server_preserving_data(vec![], &restart_env).await?;
 
     let restarted = manual_transition_job_status(&hot, status_endpoint).await?;
     assert_eq!(restarted.job_id, job_id);
     assert_eq!(restarted.status_endpoint, status_endpoint);
     assert_eq!(restarted.cancel_endpoint, status_endpoint);
-    assert!(
-        matches!(restarted.status.as_str(), "running" | "completed" | "partial" | "cancelled" | "unknown"),
-        "restart status response must be running or terminal: {restarted:#?}"
-    );
 
-    let cancel_after_restart = manual_transition_job_cancel(&hot, status_endpoint).await?;
-    assert_eq!(cancel_after_restart.job_id, job_id);
-    assert_eq!(cancel_after_restart.status_endpoint, status_endpoint);
-    assert_eq!(cancel_after_restart.cancel_endpoint, status_endpoint);
-    if cancel_after_restart.status == "running" {
-        assert!(
-            cancel_after_restart.cancel_requested,
-            "cancel after restart must durably mark a still-running job: {cancel_after_restart:#?}"
-        );
-    }
+    let terminal = match restarted.status.as_str() {
+        "running" => {
+            let cancel_after_restart = manual_transition_job_cancel(&hot, status_endpoint).await?;
+            assert_eq!(cancel_after_restart.job_id, job_id);
+            assert_eq!(cancel_after_restart.status_endpoint, status_endpoint);
+            assert_eq!(cancel_after_restart.cancel_endpoint, status_endpoint);
+            assert_eq!(
+                cancel_after_restart.status, "running",
+                "cancel after restart response: {cancel_after_restart:#?}"
+            );
+            assert!(
+                cancel_after_restart.cancel_requested,
+                "cancel after restart must durably mark a still-running job: {cancel_after_restart:#?}"
+            );
+            wait_for_manual_transition_job_terminal(&hot, status_endpoint, MANUAL_RESTART_RECOVERY_TIMEOUT).await?
+        }
+        "unknown" | "cancelled" | "completed" | "partial" => {
+            let cancel_after_restart = manual_transition_job_cancel(&hot, status_endpoint).await?;
+            assert_eq!(cancel_after_restart.job_id, job_id);
+            assert_eq!(cancel_after_restart.status_endpoint, status_endpoint);
+            assert_eq!(cancel_after_restart.cancel_endpoint, status_endpoint);
+            assert_eq!(cancel_after_restart.status, restarted.status);
+            assert_eq!(cancel_after_restart.report.bucket, MANUAL_RESTART_CANCEL_BUCKET);
+            assert_eq!(cancel_after_restart.report.prefix, MANUAL_RESTART_CANCEL_PREFIX);
+            assert!(!cancel_after_restart.report.dry_run);
+            cancel_after_restart
+        }
+        _ => {
+            return Err(format!("unexpected manual transition job status after restart: {restarted:#?}").into());
+        }
+    };
 
-    let terminal = wait_for_manual_transition_job_terminal(&hot, status_endpoint, MANUAL_RESTART_RECOVERY_TIMEOUT).await?;
     assert_eq!(terminal.job_id, job_id);
     assert_eq!(terminal.status_endpoint, status_endpoint);
     assert_eq!(terminal.cancel_endpoint, status_endpoint);
     assert!(
         matches!(terminal.status.as_str(), "unknown" | "cancelled" | "completed" | "partial"),
-        "post-restart manual transition job must fail closed or recover terminal: {terminal:#?}"
+        "post-restart manual transition job must remain readable through the durable endpoint: {terminal:#?}"
     );
-    if terminal.status == "unknown" {
-        assert!(
-            terminal
-                .failure_reason
-                .as_deref()
-                .is_some_and(|reason| reason.contains("restart") || reason.contains("owner loss")),
-            "unknown terminal status must explain the restart/owner-loss boundary: {terminal:#?}"
-        );
+    match terminal.status.as_str() {
+        "unknown" => {
+            assert!(
+                terminal
+                    .failure_reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("unknown after restart") || reason.contains("owner loss")),
+                "unknown terminal status must explain the restart/owner-loss boundary: {terminal:#?}"
+            );
+        }
+        "cancelled" => {
+            assert!(
+                terminal.cancel_requested,
+                "cancelled terminal response must retain the cancel request: {terminal:#?}"
+            );
+            assert!(
+                terminal.report.cancelled,
+                "cancelled terminal response must report cancellation: {terminal:#?}"
+            );
+            assert_eq!(terminal.failure_reason, None);
+        }
+        "partial" => {
+            assert!(
+                terminal.report.transition_failed > 0 || terminal.report.tier_failure > 0,
+                "partial terminal response must report a worker or tier failure after cold-tier stop: {terminal:#?}"
+            );
+        }
+        "completed" => {
+            assert_eq!(terminal.failure_reason, None);
+        }
+        _ => unreachable!("terminal status was validated above"),
     }
     assert_eq!(terminal.report.bucket, MANUAL_RESTART_CANCEL_BUCKET);
     assert_eq!(terminal.report.prefix, MANUAL_RESTART_CANCEL_PREFIX);
-    assert!(terminal.report.dry_run);
-    assert_eq!(
-        cold_tier_object_count(&cold_client).await?,
-        before_remote_count,
-        "dry-run restart recovery must not create remote tier objects"
-    );
+    assert!(!terminal.report.dry_run);
 
     Ok(())
 }

--- a/crates/e2e_test/src/reliant/tiering.rs
+++ b/crates/e2e_test/src/reliant/tiering.rs
@@ -396,6 +396,18 @@ struct ManualTransitionRunReport {
 }
 
 #[derive(Debug, Deserialize)]
+struct ManualTransitionQueueSnapshot {
+    queue_capacity: u64,
+    queued: u64,
+    active: u64,
+    workers: u64,
+    queue_full: u64,
+    queue_send_timeout: u64,
+    compensation_pending: u64,
+    compensation_running: u64,
+}
+
+#[derive(Debug, Deserialize)]
 struct ManualTransitionJobStatusResponse {
     job_id: String,
     status_endpoint: String,
@@ -404,6 +416,7 @@ struct ManualTransitionJobStatusResponse {
     cancel_requested: bool,
     failure_reason: Option<String>,
     report: ManualTransitionRunReport,
+    queue_snapshot: ManualTransitionQueueSnapshot,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1052,6 +1065,14 @@ async fn test_manual_transition_async_limit_reports_terminal_partial() -> TestRe
     assert!(!terminal.report.cancelled);
     assert!(terminal.report.truncated_by_limit);
     assert!(!terminal.report.truncated_by_duration);
+    assert!(terminal.queue_snapshot.queue_capacity >= terminal.queue_snapshot.queued);
+    assert_eq!(terminal.queue_snapshot.queued, 0);
+    assert!(terminal.queue_snapshot.workers >= terminal.queue_snapshot.active);
+    assert_eq!(terminal.queue_snapshot.active, 0);
+    assert_eq!(terminal.queue_snapshot.queue_full, 0);
+    assert_eq!(terminal.queue_snapshot.queue_send_timeout, 0);
+    assert_eq!(terminal.queue_snapshot.compensation_pending, 0);
+    assert_eq!(terminal.queue_snapshot.compensation_running, 0);
     let continuation = terminal
         .report
         .continuation_token

--- a/crates/e2e_test/src/reliant/tiering.rs
+++ b/crates/e2e_test/src/reliant/tiering.rs
@@ -78,6 +78,7 @@ const MANUAL_ASYNC_SAME_SCOPE_CONFLICT_BUCKET: &str = "ilm7-manual-async-same-sc
 const MANUAL_TIER_FAILURE_BUCKET: &str = "ilm7-manual-tier-failure";
 const MANUAL_WORKER_FAILURE_BUCKET: &str = "ilm7-manual-worker-failure";
 const MANUAL_ACTIVE_CANCEL_BUCKET: &str = "ilm7-manual-active-cancel";
+const MANUAL_RESTART_CANCEL_BUCKET: &str = "ilm7-manual-restart-cancel";
 const MANUAL_QUEUE_PRESSURE_PREFIX: &str = "manual-queue-pressure/";
 const MANUAL_CONTINUATION_PREFIX: &str = "manual-continuation/";
 const MANUAL_ASYNC_LIMIT_PREFIX: &str = "manual-async-limit/";
@@ -87,9 +88,12 @@ const MANUAL_ASYNC_SAME_SCOPE_CONFLICT_PREFIX: &str = "manual-async-same-scope-c
 const MANUAL_TIER_FAILURE_PREFIX: &str = "manual-tier-failure/";
 const MANUAL_WORKER_FAILURE_PREFIX: &str = "manual-worker-failure/";
 const MANUAL_ACTIVE_CANCEL_PREFIX: &str = "manual-active-cancel/";
+const MANUAL_RESTART_CANCEL_PREFIX: &str = "manual-restart-cancel/";
 const MANUAL_ASYNC_CONFLICT_OBJECTS: usize = 512;
 const MANUAL_ACTIVE_CANCEL_OBJECTS: usize = 512;
+const MANUAL_RESTART_CANCEL_OBJECTS: usize = 512;
 const MANUAL_ACTIVE_CANCEL_RUNNING_TIMEOUT: StdDuration = StdDuration::from_secs(15);
+const MANUAL_RESTART_RECOVERY_TIMEOUT: StdDuration = StdDuration::from_secs(80);
 const OBJECT_KEY: &str = "tier/鲁A12345/report.bin";
 const MANUAL_DUE_KEY: &str = "manual-due/report.bin";
 const MANUAL_DRY_RUN_KEY: &str = "manual-dry-run/report.bin";
@@ -491,6 +495,7 @@ async fn manual_transition_job_status(
     let (status, body) =
         signed_admin_request(&hot.url, Method::GET, status_endpoint, None, &hot.access_key, &hot.secret_key).await?;
     assert_eq!(status, reqwest::StatusCode::OK, "manual transition job status response: {body}");
+    assert_manual_transition_job_response_contract(&body, "manual transition job status response")?;
     Ok(serde_json::from_str(&body)?)
 }
 
@@ -501,7 +506,46 @@ async fn manual_transition_job_cancel(
     let (status, body) =
         signed_admin_request(&hot.url, Method::DELETE, status_endpoint, None, &hot.access_key, &hot.secret_key).await?;
     assert_eq!(status, reqwest::StatusCode::OK, "manual transition job cancel response: {body}");
+    assert_manual_transition_job_response_contract(&body, "manual transition job cancel response")?;
     Ok(serde_json::from_str(&body)?)
+}
+
+fn assert_manual_transition_job_response_contract(
+    body: &str,
+    context: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let value: serde_json::Value = serde_json::from_str(body)?;
+    assert_eq!(
+        value.get("mode").and_then(serde_json::Value::as_str),
+        Some("durable_job"),
+        "{context} must keep the durable job mode: {body}"
+    );
+    assert!(
+        value.get("job_id").and_then(serde_json::Value::as_str).is_some(),
+        "{context} must include job_id: {body}"
+    );
+    assert!(
+        value.get("status_endpoint").and_then(serde_json::Value::as_str).is_some(),
+        "{context} must include status_endpoint: {body}"
+    );
+    assert!(
+        value.get("cancel_endpoint").and_then(serde_json::Value::as_str).is_some(),
+        "{context} must include cancel_endpoint: {body}"
+    );
+    for incompatible in [
+        "scope_key",
+        "next_marker",
+        "next_version_idmarker",
+        "marker",
+        "version_marker",
+        "versionMarker",
+    ] {
+        assert!(
+            !body.contains(&format!("\"{incompatible}\"")),
+            "{context} must not expose incompatible field {incompatible}: {body}"
+        );
+    }
+    Ok(())
 }
 
 async fn wait_for_manual_transition_job_terminal(
@@ -1604,6 +1648,100 @@ async fn test_manual_transition_async_active_cancel_reports_terminal_cancelled()
         cold_tier_object_count(&cold_client).await?,
         before_remote_count,
         "active dry-run cancel must not create a remote tier object"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_manual_transition_async_cancel_after_process_restart_recovers_terminal() -> TestResult {
+    let mut cold = RustFSTestEnvironment::new().await?;
+    cold.access_key = "manualrestartcancelcoldadmin".to_string();
+    cold.secret_key = "manualrestartcancelcoldsecret".to_string();
+    cold.start_rustfs_server_without_cleanup(vec![]).await?;
+    let cold_client = cold.create_s3_client();
+    cold_client.create_bucket().bucket(TIER_BUCKET).send().await?;
+
+    let restart_env = [("RUSTFS_SCANNER_ENABLED", "false"), ("RUSTFS_SCANNER_CYCLE", "3600")];
+    let mut hot = RustFSTestEnvironment::new().await?;
+    hot.start_rustfs_server_with_env(vec![], &restart_env).await?;
+    let hot_client = hot.create_s3_client();
+    add_rustfs_tier(&hot, &cold).await?;
+
+    hot_client.create_bucket().bucket(MANUAL_RESTART_CANCEL_BUCKET).send().await?;
+    put_lifecycle_transition_rule(
+        &hot_client,
+        MANUAL_RESTART_CANCEL_BUCKET,
+        "manual-restart-cancel",
+        MANUAL_RESTART_CANCEL_PREFIX,
+        1,
+    )
+    .await?;
+    for idx in 0..MANUAL_RESTART_CANCEL_OBJECTS {
+        let key = format!("{MANUAL_RESTART_CANCEL_PREFIX}obj-{idx:03}");
+        put_single_part_object(&hot_client, MANUAL_RESTART_CANCEL_BUCKET, &key, b"manual restart cancel payload").await?;
+    }
+
+    let before_remote_count = cold_tier_object_count(&cold_client).await?;
+    let accepted =
+        manual_transition_async_run(&hot, MANUAL_RESTART_CANCEL_BUCKET, MANUAL_RESTART_CANCEL_PREFIX, true, 10_000).await?;
+    let job_id = accepted.job_id.as_deref().ok_or("async response must include job_id")?;
+    let status_endpoint = accepted
+        .status_endpoint
+        .as_deref()
+        .ok_or("async response must include status_endpoint")?;
+    assert_eq!(accepted.cancel_endpoint.as_deref(), Some(status_endpoint));
+
+    let active = wait_for_manual_transition_job_running(&hot, status_endpoint, MANUAL_ACTIVE_CANCEL_RUNNING_TIMEOUT).await?;
+    assert_eq!(active.job_id, job_id);
+    assert!(!active.cancel_requested);
+
+    hot.restart_server_preserving_data(vec![], &restart_env).await?;
+
+    let restarted = manual_transition_job_status(&hot, status_endpoint).await?;
+    assert_eq!(restarted.job_id, job_id);
+    assert_eq!(restarted.status_endpoint, status_endpoint);
+    assert_eq!(restarted.cancel_endpoint, status_endpoint);
+    assert!(
+        matches!(restarted.status.as_str(), "running" | "completed" | "partial" | "cancelled" | "unknown"),
+        "restart status response must be running or terminal: {restarted:#?}"
+    );
+
+    let cancel_after_restart = manual_transition_job_cancel(&hot, status_endpoint).await?;
+    assert_eq!(cancel_after_restart.job_id, job_id);
+    assert_eq!(cancel_after_restart.status_endpoint, status_endpoint);
+    assert_eq!(cancel_after_restart.cancel_endpoint, status_endpoint);
+    if cancel_after_restart.status == "running" {
+        assert!(
+            cancel_after_restart.cancel_requested,
+            "cancel after restart must durably mark a still-running job: {cancel_after_restart:#?}"
+        );
+    }
+
+    let terminal = wait_for_manual_transition_job_terminal(&hot, status_endpoint, MANUAL_RESTART_RECOVERY_TIMEOUT).await?;
+    assert_eq!(terminal.job_id, job_id);
+    assert_eq!(terminal.status_endpoint, status_endpoint);
+    assert_eq!(terminal.cancel_endpoint, status_endpoint);
+    assert!(
+        matches!(terminal.status.as_str(), "unknown" | "cancelled" | "completed" | "partial"),
+        "post-restart manual transition job must fail closed or recover terminal: {terminal:#?}"
+    );
+    if terminal.status == "unknown" {
+        assert!(
+            terminal
+                .failure_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("restart") || reason.contains("owner loss")),
+            "unknown terminal status must explain the restart/owner-loss boundary: {terminal:#?}"
+        );
+    }
+    assert_eq!(terminal.report.bucket, MANUAL_RESTART_CANCEL_BUCKET);
+    assert_eq!(terminal.report.prefix, MANUAL_RESTART_CANCEL_PREFIX);
+    assert!(terminal.report.dry_run);
+    assert_eq!(
+        cold_tier_object_count(&cold_client).await?,
+        before_remote_count,
+        "dry-run restart recovery must not create remote tier objects"
     );
 
     Ok(())

--- a/rustfs/src/admin/handlers/ilm_transition.rs
+++ b/rustfs/src/admin/handlers/ilm_transition.rs
@@ -1237,6 +1237,47 @@ mod tests {
     }
 
     #[test]
+    fn manual_transition_job_response_reads_back_terminal_queue_pressure_snapshot() {
+        let options = ManualTransitionRunOptions {
+            prefix: "logs/".to_string(),
+            tier: Some("WARM".to_string()),
+            ..Default::default()
+        };
+        let mut record = ManualTransitionJobRecord::new(Uuid::new_v4(), "bucket", &options, "owner-a");
+        let queue_snapshot = ManualTransitionQueueSnapshot {
+            queue_capacity: 4,
+            queued: 2,
+            active: 1,
+            workers: 2,
+            queue_full: 3,
+            queue_send_timeout: 5,
+            compensation_pending: 7,
+            compensation_running: 1,
+        };
+
+        record.complete(
+            ManualTransitionRunReport {
+                bucket: "bucket".to_string(),
+                prefix: options.prefix.clone(),
+                tier: options.tier.clone(),
+                skipped_queue_full: 3,
+                skipped_queue_timeout: 5,
+                ..Default::default()
+            },
+            queue_snapshot,
+        );
+
+        let response = manual_transition_job_response(record);
+
+        assert_eq!(response.status, ManualTransitionJobState::Partial);
+        assert_eq!(response.report.skipped_queue_full, 3);
+        assert_eq!(response.report.skipped_queue_timeout, 5);
+        assert_eq!(response.queue_snapshot, queue_snapshot);
+        assert!(response.completed_at_unix_nanos.is_some());
+        assert_eq!(response.failure_reason, None);
+    }
+
+    #[test]
     fn manual_transition_active_job_cancel_token_round_trips() {
         let job_id = Uuid::new_v4();
         let cancel_token = CancellationToken::new();


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1479 and rustfs/backlog#1476.

## Summary of Changes
Adds test-focused coverage for the remaining #1479 manual transition durable-job stress matrix that is not already on current main. This PR adds queue pressure status readback coverage for terminal durable job responses, including queue snapshot fields and a handler-level queue snapshot readback assertion.

Adds a process-level restart E2E for accepted async manual transition jobs. The test restarts the RustFS process while preserving data, verifies durable status/cancel endpoint compatibility after restart, and accepts the race-safe terminal/status outcomes that can occur around process loss: running followed by cancel, unknown, cancelled, completed, or partial with failure counters.

Stabilizes the existing different-bucket async dry-run admission test so it verifies bucket-scope admission concurrency without racing lifecycle background transitions. The real four-node distributed admission/backpressure E2E is already present on current main after merging the related slice, and it was re-run locally on this branch as part of the verification below.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `git diff --cached --check`
- `cargo test -p e2e_test test_manual_transition_async_different_buckets_admit_concurrently -- --nocapture`
- `cargo test -p e2e_test four_node_manual_transition_distributed_admission_conflict_reports_status_and_backpressure -- --nocapture`
- `cargo test -p e2e_test test_manual_transition_async_limit_reports_terminal_partial -- --nocapture`
- `cargo test -p e2e_test test_manual_transition_async_cancel_after_process_restart_recovers_terminal -- --nocapture`
- `cargo test -p rustfs --lib manual_transition_job_response_reads_back_terminal_queue_pressure_snapshot`
- `cargo clippy --all-targets -p rustfs --lib`

## Impact
Test-focused PR with one handler unit-test assertion and no production API, wire format, persistence format, or CLI behavior changes.

## Additional Notes
Mixed-version capability fail-closed was re-audited against current main and does not require new code in this PR: the runtime capabilities contract exposes `mixed_version_policy = fail_closed_when_capability_unknown_or_unsupported`, the authenticated capabilities E2E asserts that field, and the route-inventory unit tests keep the manual transition run/status/cancel contract tied to registered admin routes.

Adversarial review summary: correctness attacked the restart terminal-state branches and 202/status/cancel contract; simplicity attacked helper duplication and commit hygiene; concurrency/durability attacked process restart and owner-loss semantics; compatibility attacked API fields and confirmed this PR does not add or remove response fields; performance attacked hot paths and found no production code changes; test coverage maps each new claim to a failing E2E or handler assertion.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
