### PR TITLE
test(internode): pin JSON fallback compatibility

### DIFF
--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -617,6 +617,41 @@ fn records_msgpack_decode_metric_with_codec_label() {
 }
 
 #[test]
+fn records_msgpack_fallback_metric_with_direction_and_message_labels() {
+    let export = ExportMetricsServiceRequest {
+        resource_metrics: vec![ResourceMetrics {
+            scope_metrics: vec![ScopeMetrics {
+                metrics: vec![Metric {
+                    name: MSGPACK_JSON_FALLBACK_COUNTER.to_string(),
+                    data: Some(metric::Data::Sum(Sum {
+                        data_points: vec![NumberDataPoint {
+                            attributes: vec![
+                                metric_attribute(DIRECTION_LABEL, FALLBACK_RESPONSE_DIRECTION),
+                                metric_attribute(MESSAGE_LABEL, "RenameDataResp"),
+                            ],
+                            start_time_unix_nano: 7,
+                            time_unix_nano: 11,
+                            value: Some(number_data_point::Value::AsInt(14)),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+    let mut values = BTreeMap::new();
+
+    record_msgpack_fallback_metrics(&export, &mut values);
+
+    let key = msgpack_fallback_metric_key(FALLBACK_RESPONSE_DIRECTION, "RenameDataResp");
+    assert_eq!(values.get(&key).and_then(|points| points.get(&7)).copied(), Some((11, 14)));
+}
+
+#[test]
 fn records_msgpack_decode_error_metric_with_codec_label() {
     let export = ExportMetricsServiceRequest {
         resource_metrics: vec![ResourceMetrics {

--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -3167,6 +3167,36 @@ mod tests {
     }
 
     #[test]
+    fn rename_data_response_accepts_legacy_json_without_decode_error() {
+        crate::cluster::rpc::runtime_sources::reset_internode_metrics_for_test();
+        let response = RenameDataResp {
+            old_data_dir: Some(Uuid::new_v4()),
+            sign: Some(vec![0x14, 0x35]),
+            old_current_size: Some(crate::disk::OldCurrentSize::Present(64 * 1024)),
+        };
+        let json = serde_json::to_string(&response).expect("legacy rename_data JSON response should encode");
+        let decode_before = rustfs_io_metrics::internode_metrics::global_internode_metrics().msgpack_json_decode_total_for_test();
+        let decode_errors_before = crate::cluster::rpc::runtime_sources::internode_msgpack_json_decode_error_total_for_test();
+
+        let decoded = decode_msgpack_or_json::<RenameDataResp>(&[], &json, "RenameDataResp")
+            .expect("legacy rename_data JSON response should decode");
+        let decode_after = rustfs_io_metrics::internode_metrics::global_internode_metrics().msgpack_json_decode_total_for_test();
+        let decode_errors_after = crate::cluster::rpc::runtime_sources::internode_msgpack_json_decode_error_total_for_test();
+
+        assert_eq!(decoded.old_data_dir, response.old_data_dir);
+        assert_eq!(decoded.sign, response.sign);
+        assert_eq!(decoded.old_current_size, response.old_current_size);
+        assert!(
+            decode_after > decode_before,
+            "legacy JSON response should increment successful decode traffic"
+        );
+        assert_eq!(
+            decode_errors_after, decode_errors_before,
+            "legacy JSON compatibility fallback must stay observable without becoming a decode error"
+        );
+    }
+
+    #[test]
     fn read_multiple_response_payload_len_prefers_msgpack_and_falls_back_to_json() {
         let bin_a = encode_msgpack(&sample_read_multiple_resp("a", b"binary")).expect("msgpack should encode");
         let bin_b = encode_msgpack(&sample_read_multiple_resp("b", b"more")).expect("msgpack should encode");


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1435.

## Summary of Changes
Adds regression coverage for the msgpack rollout compatibility contract confirmed in backlog#1435: mixed-version or rollback traffic may use observable JSON fallback when an old peer lacks the msgpack `_bin` payload, as long as decoding succeeds and decode-error metrics remain unchanged. The runtime behavior is intentionally unchanged.

- Covers legacy JSON-only `RenameDataResp` response decoding in the remote disk client.
- Covers OTLP fallback metric parsing for `direction=response,message=RenameDataResp`, matching the alpha.89 mixed-version evidence shape.
- Keeps all-new fleet-confirmed semantics separate: that path still expects fallback/error to converge to zero under effective msgpack traffic.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore rename_data_response_accepts_legacy_json_without_decode_error`
- `cargo test -p e2e_test records_msgpack_fallback_metric_with_direction_and_message_labels`
- `cargo clippy --all-targets -p rustfs-ecstore -p e2e_test -- -D warnings`
- `make pre-commit`
- `make pre-pr`

## Impact
No public API, storage format, on-wire schema, or runtime configuration changes. This only pins the expected compatibility behavior for old peers and fallback observability.

## Additional Notes
The compatibility boundary remains deliberately fail-open for legacy JSON response payloads that decode successfully. Unsupported or old-peer fallback should be monitored via fallback/decode/decode-error metrics rather than converted into request failure in this PR.
