### PR TITLE
fix: avoid false stress failure snapshots

### DIFF
--- a/scripts/manual_transition_nightly_stress_runbook.sh
+++ b/scripts/manual_transition_nightly_stress_runbook.sh
@@ -373,13 +373,13 @@ run_entry() {
     return 1
   fi
   printf '%s' "$status_json" >"${RESULT_DIR}/${result_tag}-status.json"
-  if ! status_info="$(printf '%s' "$status_json" | jq -r '[.status // "", .failure_reason // "", (.report.enqueued // 0), (.report.transition_completed // 0), (.report.transition_failed // 0), (.report.tier_failure_by_reason["unknown"] // 0), (.queue_snapshot.queued // 0), (.queue_snapshot.active // 0), (.queue_snapshot.compensation_pending // 0), (.queue_snapshot.compensation_running // 0), (.queue_snapshot.queue_full // 0), (.queue_snapshot.queue_send_timeout // 0)] | map(tostring) | @tsv')"; then
+  if ! status_info="$(printf '%s' "$status_json" | jq -r '[.status // "", .failure_reason // "__none__", (.report.enqueued // 0), (.report.transition_completed // 0), (.report.transition_failed // 0), (.report.tier_failure_by_reason["unknown"] // 0), (.queue_snapshot.queued // 0), (.queue_snapshot.active // 0), (.queue_snapshot.compensation_pending // 0), (.queue_snapshot.compensation_running // 0), (.queue_snapshot.queue_full // 0), (.queue_snapshot.queue_send_timeout // 0)] | map(tostring) | @tsv')"; then
     snapshot_failure "$tag" "invalid_job_status_json" "$job_id"
     return 1
   fi
   IFS=$'\t' read -r status failure_reason report_enqueued report_completed report_failed report_unknown_failure queue_snapshot_queued queue_snapshot_active compensation_pending compensation_running queue_full queue_send_timeout <<< "$status_info"
 
-  if [[ -n "$failure_reason" && "$failure_reason" != "null" ]]; then
+  if [[ "$failure_reason" != "__none__" ]]; then
     snapshot_failure "$tag" "failure_reason=${failure_reason}" "$job_id"
   fi
 

--- a/scripts/test_manual_transition_runbooks.sh
+++ b/scripts/test_manual_transition_runbooks.sh
@@ -110,6 +110,12 @@ rg -q "manual_transition_failure_samples.sh" "$TMP_DIR/stress-runbook/manual_tra
 rg -q "is_terminal_status" "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"
 rg -q "status_json" "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"
 rg -q "@tsv" "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"
+rg -q 'failure_reason // "__none__"' "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"
+rg -q 'failure_reason" != "__none__"' "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"
+if rg -F -q 'failure_reason // ""' "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"; then
+  echo "nightly stress runner must not emit an empty TSV failure_reason field" >&2
+  exit 1
+fi
 rg -q "job_id, status, bucket, prefix, tier" "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"
 if rg -F -q 'join(\"' "$TMP_DIR/stress-runbook/run_nightly_stress_plan.sh"; then
   echo "nightly stress runner must not emit escaped jq quotes" >&2


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1510

## Summary of Changes
- Avoid false manual-transition nightly/stress failure snapshots when terminal job status has no `failure_reason`.
- Use an explicit `__none__` sentinel before TSV parsing so Bash does not collapse an empty field and shift queue/report counters into `failure_reason`.
- Add regression checks to keep the generated runner from emitting an empty TSV `failure_reason` field.

## Verification
- `bash -n scripts/manual_transition_nightly_stress_runbook.sh scripts/test_manual_transition_runbooks.sh`
- `scripts/test_manual_transition_runbooks.sh`
- `git diff --check`
- Docker extended validation continued with a temporary docker-exec curl wrapper because local host port mappings stopped accepting connections while the RustFS containers remained healthy internally.
- Seeded extended run job `63e71185-6866-4a04-b767-a54795ed5694` completed with `lifecycle_config_found=true`, `scanned=1`, `skipped_already_transitioned=1`, clean queue counters, and no false `failure_reason=0` snapshot after this fix.
- Additional eligible-chain probe job `5b98743c-243d-4ec0-a3a4-b67714dd4ae1` completed and final object HEAD showed `x-amz-storage-class: COLDNET5`.

Focused verification was used instead of `make pre-commit` because this PR only changes local operational runbook parsing and its script-level regression test; it does not change Rust runtime behavior, CI workflow behavior, storage formats, or shipped APIs.

## Impact
- Operational runbook behavior only.
- Prevents misleading failure snapshots in successful nightly/stress evidence bundles.
- No Rust runtime, API, storage format, or deployment configuration changes.

## Additional Notes
This is a follow-up to #5337. The continued Docker validation proved the runner can collect seeded transition evidence through Docker internal networking, but the local environment still classified seeded objects as already transitioned before queue enqueue accounting was observable; a longer controlled soak is still required before closing rustfs/backlog#1510.
