### PR TITLE
fix(audit): load env-only targets at startup

### DIFF
--- a/rustfs/src/server/audit.rs
+++ b/rustfs/src/server/audit.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use crate::runtime_sources::AppContext;
 use rustfs_audit::{AuditError, AuditResult, audit_system, init_audit_system, system::AuditSystemState};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{info, warn};
 
@@ -44,7 +45,7 @@ pub fn is_audit_module_enabled() -> bool {
     AUDIT_MODULE_ENABLED.load(Ordering::Relaxed)
 }
 
-fn has_any_audit_targets(config: &rustfs_config::server_config::Config) -> bool {
+fn has_any_persisted_audit_targets(config: &rustfs_config::server_config::Config) -> bool {
     for &subsystem in rustfs_config::audit::AUDIT_SUB_SYSTEMS {
         let Some(targets) = config.0.get(subsystem) else {
             continue;
@@ -54,6 +55,29 @@ fn has_any_audit_targets(config: &rustfs_config::server_config::Config) -> bool 
         }
     }
     false
+}
+
+fn has_any_collected_audit_targets(config: &rustfs_config::server_config::Config) -> bool {
+    rustfs_targets::catalog::builtin::builtin_audit_target_admin_descriptors()
+        .into_iter()
+        .any(|descriptor| {
+            let valid_fields = descriptor
+                .valid_fields()
+                .iter()
+                .map(|field| (*field).to_string())
+                .collect::<HashSet<_>>();
+            let (configs, failures) = rustfs_targets::config::collect_target_config_results(
+                config,
+                rustfs_config::audit::AUDIT_ROUTE_PREFIX,
+                descriptor.manifest().target_type,
+                &valid_fields,
+            );
+            !configs.is_empty() || !failures.is_empty()
+        })
+}
+
+fn has_any_audit_targets(config: &rustfs_config::server_config::Config) -> bool {
+    has_any_persisted_audit_targets(config) || has_any_collected_audit_targets(config)
 }
 
 /// Start the audit system.
@@ -193,5 +217,37 @@ pub(crate) async fn apply_audit_module_switch_for_context(context: Option<&AppCo
         }
     } else {
         stop_audit_system().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_any_audit_targets;
+    use rustfs_config::server_config::Config;
+
+    #[test]
+    fn audit_target_detection_includes_env_only_targets() {
+        temp_env::with_vars(
+            [
+                ("RUSTFS_AUDIT_WEBHOOK_ENABLE_PRIMARY", Some("on")),
+                ("RUSTFS_AUDIT_WEBHOOK_ENDPOINT_PRIMARY", Some("https://example.com/hook")),
+            ],
+            || {
+                assert!(has_any_audit_targets(&Config::new()));
+            },
+        );
+    }
+
+    #[test]
+    fn audit_target_detection_ignores_disabled_env_only_targets() {
+        temp_env::with_vars(
+            [
+                ("RUSTFS_AUDIT_WEBHOOK_ENABLE_PRIMARY", Some("off")),
+                ("RUSTFS_AUDIT_WEBHOOK_ENDPOINT_PRIMARY", Some("https://example.com/hook")),
+            ],
+            || {
+                assert!(!has_any_audit_targets(&Config::new()));
+            },
+        );
     }
 }


### PR DESCRIPTION
## Related Issues
Fixes #5183.

## Summary of Changes
Audit startup now detects audit targets resolved from environment variables, not only targets persisted in server config.

The issue reproduced with `rustfs/rustfs:latest` (`1.0.0-beta.11`, commit `1c8088d0b2af0a1afc8df128014b2176037a0622`) when `RUSTFS_AUDIT_ENABLE=true` and `RUSTFS_AUDIT_WEBHOOK_*_PRIMARY` were set only through Docker environment variables. The admin plugin diagnostics reported the audit webhook instance as enabled and env-managed, but runtime state stayed offline with `not_loaded_in_runtime`.

Root cause: the server-side audit startup precheck only inspected persisted audit target sections. With env-only audit targets, the audit module switch was enabled but the audit system initialization was skipped before the target loader had a chance to merge environment configuration.

This change keeps the existing persisted-target check and adds a collected-target check using the existing target config loader. That matches the runtime creation path, so env-only audit targets now start the audit runtime while disabled env-only targets still do not trigger an empty runtime startup.

## Verification
- Reproduced the issue locally with the published `rustfs/rustfs:latest` Docker image and a local webhook sink; audit diagnostics showed `not_loaded_in_runtime` for the env-managed audit webhook target.
- `cargo test -p rustfs audit_target_detection_includes_env_only_targets`
- `cargo test -p rustfs server::audit`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
Env-only audit webhook configurations now become effective at startup when `RUSTFS_AUDIT_ENABLE=true`. Persisted audit target behavior is unchanged. Disabled env-only audit targets remain ignored. No S3 API, on-disk format, or migration impact.

## Additional Notes
Adversarial validation covered correctness, simplicity, test coverage, startup lifecycle/concurrency, compatibility, and performance. No unresolved findings remain.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
