### PR TITLE
chore(build): pin Rust toolchain configs to 1.97.1

### DIFF
--- a/Dockerfile.decommission-local
+++ b/Dockerfile.decommission-local
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.97-trixie
+FROM rust:1.97.1-trixie
 
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -32,7 +32,7 @@ ARG RUSTFS_BUILD_FEATURES=""
 # -----------------------------
 # Build stage
 # -----------------------------
-FROM rust:1.97-trixie AS builder
+FROM rust:1.97.1-trixie AS builder
 
 # Re-declare args after FROM
 ARG TARGETPLATFORM

--- a/crates/ecstore/tests/README.md
+++ b/crates/ecstore/tests/README.md
@@ -20,5 +20,5 @@ Example:
 ```powershell
 $env:RUSTFS_MINIO_FIXTURE_ROOT = '.\rustfs\tmp\minio-fixture-lab-local-key'
 $env:RUSTFS_MINIO_STATIC_KMS_KEY_B64 = '<base64-32-byte-local-minio-kms-key>'
-cargo +1.96.0 test -p rustfs-ecstore --features rio-v2 --test minio_generated_read_test -- --ignored
+cargo +1.97.1 test -p rustfs-ecstore --features rio-v2 --test minio_generated_read_test -- --ignored
 ```

--- a/crates/rio-v2/tests/README.md
+++ b/crates/rio-v2/tests/README.md
@@ -30,7 +30,7 @@ Or point the tests at another generated root:
 
 ```powershell
 $env:RUSTFS_MINIO_FIXTURE_ROOT = '.\rustfs\tmp\minio-fixture-lab-smoke'
-cargo +1.96.0 test -p rustfs-rio-v2 --test minio_generated_fixtures -- --ignored
+cargo +1.97.1 test -p rustfs-rio-v2 --test minio_generated_fixtures -- --ignored
 ```
 
 ## Scope

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Pin the source-build Rust Docker images to `rust:1.97.1-trixie` so local source/decommission builds match the workspace `rust-version`.
- Update the MinIO fixture test README examples from `cargo +1.96.0` to `cargo +1.97.1`.
- Remove `x86_64-darwin` from the Nix flake system matrix while keeping `build-rustfs.sh` support for manual `x86_64-apple-darwin` builds.

## Verification
Not run per request; waiting for CI.

## Impact
Docker source-build paths and fixture documentation now align with Rust 1.97.1. Nix flake outputs no longer include the Intel macOS system, but the manual build script still advertises and detects `x86_64-apple-darwin` for users who compile locally.

## Additional Notes
No `.github/workflows/` files were changed. Base OS images such as `ubuntu:26.04` and `alpine:3.24.1` were intentionally left unchanged because they are separate container baseline choices, not Rust toolchain version pins.
