### PR TITLE
fix(auth): enforce presigned URL expiry limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,7 +3941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5361,7 +5361,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8097,7 +8097,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10221,7 +10221,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10294,7 +10294,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10351,7 +10351,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s3s"
 version = "0.14.1"
-source = "git+https://github.com/s3s-project/s3s.git?rev=8136db4ac8253c0ccfd86f8216e00e0235747757#8136db4ac8253c0ccfd86f8216e00e0235747757"
+source = "git+https://github.com/cxymds/s3s.git?rev=b0c2d740d4277d05de17bf5932a99f7cfe8ebe22#b0c2d740d4277d05de17bf5932a99f7cfe8ebe22"
 dependencies = [
  "arc-swap",
  "arrayvec",
@@ -11494,10 +11494,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12598,7 +12598,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10351,7 +10351,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s3s"
 version = "0.14.1"
-source = "git+https://github.com/cxymds/s3s.git?rev=b0c2d740d4277d05de17bf5932a99f7cfe8ebe22#b0c2d740d4277d05de17bf5932a99f7cfe8ebe22"
+source = "git+https://github.com/cxymds/s3s.git?rev=afa1796ec64cd1e1c78dfee46c4b4b72bbc7b39d#afa1796ec64cd1e1c78dfee46c4b4b72bbc7b39d"
 dependencies = [
  "arc-swap",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ redis = { version = "1.4.1" }
 rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { git = "https://github.com/cxymds/s3s.git", rev = "b0c2d740d4277d05de17bf5932a99f7cfe8ebe22" }
+s3s = { git = "https://github.com/cxymds/s3s.git", rev = "afa1796ec64cd1e1c78dfee46c4b4b72bbc7b39d" }
 serial_test = "4.0.1"
 shadow-rs = { default-features = false, version = "2.0.0" }
 siphasher = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ redis = { version = "1.4.1" }
 rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }
 rustc-hash = { version = "2.1.3" }
-s3s = { git = "https://github.com/s3s-project/s3s.git", rev = "8136db4ac8253c0ccfd86f8216e00e0235747757" }
+s3s = { git = "https://github.com/cxymds/s3s.git", rev = "b0c2d740d4277d05de17bf5932a99f7cfe8ebe22" }
 serial_test = "4.0.1"
 shadow-rs = { default-features = false, version = "2.0.0" }
 siphasher = "1.0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,9 @@ allow-git = [
     # SigV4 payload-checksum fix until it is available in a crates.io release.
     # owner: marshawcoco  review: 2026-10
     "https://github.com/s3s-project/s3s.git",
+    # Presigned URL expiry validation pending upstream submission.
+    # owner: cxymds  review: 2026-10
+    "https://github.com/cxymds/s3s.git",
     "https://github.com/apache/datafusion.git",
 ]
 


### PR DESCRIPTION
## Description

Fixes rustfs/backlog#1529.

Update the pinned s3s revision to include the SigV4 presigned URL expiry limit from s3s-project/s3s#645. Values above 604800 seconds, malformed values, negative values, and duplicate parameters are rejected with `AuthorizationQueryParametersError`; values from 0 through 604800 retain their existing semantics.

This draft temporarily pins the reviewed commit from the contributor fork so RustFS CI can validate the integration. Before marking it ready, the dependency URL and revision must be updated to the merged commit in `s3s-project/s3s`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- Upstream parser tests cover 0, 1, 604800, 604801, `u32::MAX`, malformed, negative, and duplicate values.
- Upstream operation test verifies `AuthorizationQueryParametersError`.
- Existing zero-expiry behavior remains covered.
- `cargo fmt --all --check` and `git diff --check` pass in RustFS.
- RustFS CI and final `make pre-pr` remain required.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Dependencies

- Depends on s3s-project/s3s#645.
- Replace the temporary contributor-fork pin with the upstream merged commit before ready-for-review.
