### PR TITLE
test(ecstore): fix read version rio fixture

### DIFF
--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -1969,6 +1969,12 @@ mod metadata_cache_tests {
             let (dir, disk) = new_read_version_test_disk(bucket).await;
             if disk_index < readable_disks {
                 let mut fi = valid_test_fileinfo(object);
+                fi.parts.push(ObjectPartInfo {
+                    number: 1,
+                    size: 1,
+                    actual_size: 1,
+                    ..Default::default()
+                });
                 fi.mod_time = Some(OffsetDateTime::now_utc());
                 fi.erasure.index = fi.erasure.distribution[disk_index];
                 disk.write_metadata(bucket, bucket, object, fi)


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Add a valid single-part descriptor to the persisted `read_version_quorum_test_set` fixture.
- Keep the shared positive-size/no-parts fixture unchanged so the corruption regression test continues to exercise `FileCorrupt`.
- Restore the read-version quorum tests under the `rio-v2` feature without changing production behavior.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore --features rio-v2 read_version_optimized_uses_current_set_drive_quorum_not_pool_set_count --lib -- --nocapture`
- `cargo test -p rustfs-ecstore --features rio-v2 read_version_optimized_counts_only_valid_metadata_toward_quorum --lib -- --nocapture`
- `cargo test -p rustfs-ecstore --features rio-v2 get_object_with_fileinfo_rejects_positive_size_without_parts --lib -- --nocapture`
- `cargo clippy -p rustfs-ecstore --all-targets --features rio-v2 -- -D warnings`
- Mechanical correctness and simplicity adversarial reviews: no findings.
- `make pre-commit`: formatting and all guard scripts passed; the workspace-wide quick compilation check was stopped after the focused rio-v2 build and clippy checks passed so the draft PR could hand the remaining broad verification to CI.

## Impact

Test-only change. No runtime, API, configuration, compatibility, or storage-format impact.

## Additional Notes

The shared `valid_test_fileinfo` intentionally remains a positive-size/no-parts poison fixture for `get_object_with_fileinfo_rejects_positive_size_without_parts`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
