### PR TITLE
test(ecstore): give the read-version quorum fixture a valid part

### DIFF
--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -1971,6 +1971,17 @@ mod metadata_cache_tests {
                 let mut fi = valid_test_fileinfo(object);
                 fi.mod_time = Some(OffsetDateTime::now_utc());
                 fi.erasure.index = fi.erasure.distribution[disk_index];
+                // `valid_test_fileinfo` carries a positive size with no parts —
+                // the shape `validate_collection_contents` rejects as
+                // `FileCorrupt` — so it can drive
+                // `get_object_with_fileinfo_rejects_positive_size_without_parts`.
+                // Metadata that has to survive a write needs the matching part.
+                fi.parts.push(ObjectPartInfo {
+                    number: 1,
+                    size: 1,
+                    actual_size: 1,
+                    ..Default::default()
+                });
                 disk.write_metadata(bucket, bucket, object, fi)
                     .await
                     .expect("metadata should be written before quorum read");


### PR DESCRIPTION
## Related Issues

N/A — fixes a break introduced on `main` by the interaction of #5354 and #5365.

## Summary of Changes

`Test and Lint` currently fails on `main` for every PR: `set_disk::read::metadata_cache_tests::read_version_optimized_counts_only_valid_metadata_toward_quorum` and `read_version_optimized_uses_current_set_drive_quorum_not_pool_set_count` both panic with `metadata should be written before quorum read: FileCorrupt`.

The two changes are individually correct and neither could observe the break on its own:

- #5365 added the `read_version_quorum_test_set` helper, which writes `valid_test_fileinfo` to disk with `write_metadata` before exercising the optimized version read.
- #5354 then taught `FileInfo::validate_collection_contents` to reject a positive size with no parts as `FileCorrupt`. `valid_test_fileinfo` is deliberately that shape — it exists to drive `get_object_with_fileinfo_rejects_positive_size_without_parts` — so #5354 fixed up the on-disk fixtures that existed when it landed, including the analogous one in `disk/local.rs`. #5365 was in flight at the time and its new fixture was never adjusted.

Once both are on `main` the helper's `write_metadata` fails, and the failure is deterministic rather than flaky.

The fix pushes a part matching the fixture's size inside `read_version_quorum_test_set`, mirroring what #5354 did for its own on-disk fixture. `valid_test_fileinfo` itself is left part-less on purpose: `get_object_with_fileinfo_rejects_positive_size_without_parts` asserts that exact shape is rejected, so adding parts there would silently gut that test. Only this one call site writes the fixture to disk; the other ~26 uses pass it to in-memory helpers and are unaffected.

## Verification

- `cargo test -p rustfs-ecstore --lib set_disk::read::metadata_cache_tests` — previously 31 passed / 2 failed, now 33 passed / 0 failed
- `cargo fmt --all --check` — clean
- `cargo clippy -p rustfs-ecstore --lib --tests` — clean

Reproduction before the fix, on unmodified `main` at eb755e2b97:

```bash
cargo test -p rustfs-ecstore --lib set_disk::read::metadata_cache_tests
```

## Impact

Test-only. No production code paths, APIs, configuration, or behavior change. Unblocks the `Test and Lint` lane for all open PRs.

## Additional Notes

`main` has two further red lanes that this PR does not address. Both reproduce on this PR too — which contains nothing but a test-fixture change — so neither is caused by the PR under review:

- **`Test and Lint (rio-v2)`** — `set_disk::ops::object::transition_source_identity_matrix_tests::transition_source_identity_field_matrix_rejects_single_field_drift`. This one is deterministic, not flaky: it fails in ~0.4s because `transition_object` returns `Ok(())` where the test expects the post-upload source-identity re-check (`object.rs:3841`) to reject the drift. It reproduces locally only with the `rio-v2` feature enabled — without it the same test passes in ~17s:

  ```bash
  cargo test -p rustfs-ecstore --features rio-v2,test-util --lib -- --exact set_disk::ops::object::transition_source_identity_matrix_tests::transition_source_identity_field_matrix_rejects_single_field_drift
  ```

  `git bisect run` over `882e1a71b1..eb755e2b97` (3 steps, no skips) points at **5426237a49 `fix(filemeta): preserve canonical version order` (#5353)** as the first bad commit.

- **`ILM Integration (serial)`** — the restore copy-back tests in `rustfs/src/app/lifecycle_transition_api_test.rs`, which poll for 20s (40 x 500ms) against a mock tier armed with 1.5s of injected latency. Different tests in that family fail on different runs (`restore_object_usecase_accepts_exactly_one_of_two_concurrent_restores` at line 2259, `restore_object_usecase_reports_ongoing_conflict_and_completion` at line 2133), always with the copy-back never completing inside the window. The lane passed 9 of the 10 `main` runs before `eb755e2b97` and has failed every run at or after it, so this is most likely a regression in the same window rather than runner noise — but it is not bisected yet.

Both deserve their own PRs.
