### PR TITLE
fix(filemeta): canonicalize version order after insert

### DIFF
--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -356,6 +356,14 @@ impl FileMeta {
             .versions
             .partition_point(|existing| existing.header.sorts_before(&new_shallow.header));
         self.versions.insert(insert_pos, new_shallow);
+        // `partition_point` only returns the canonical slot when `versions` is
+        // already canonically ordered, and nothing establishes that: `FileMeta::load`
+        // replays the on-disk order verbatim, and metadata written before the
+        // canonical-order fix ordered equal-`mod_time` ties by insertion rather than
+        // by `sorts_before`. Re-sort so an insert leaves the list canonical either
+        // way, matching what `set_idx` already does on the replace path. Cheap: after
+        // a correctly placed insert the slice is a single sorted run.
+        self.sort_by_mod_time();
         Ok(())
 
         // if !ver.valid() {
@@ -1213,6 +1221,57 @@ mod test {
         assert_eq!(fm.versions[0].header.version_type, VersionType::Object);
         assert_eq!(fm.versions[1].header.version_type, VersionType::Delete);
         assert!(fm.versions[0].header.sorts_before(&fm.versions[1].header));
+    }
+
+    /// `add_version_filemata` positions an inserted version with
+    /// `partition_point(sorts_before)`, which only yields the canonical slot when
+    /// `versions` is already canonically ordered. Nothing establishes that
+    /// precondition on load: `FileMeta::unmarshal_msg` pushes versions in file
+    /// order, and metadata written before the canonical-order fix ordered
+    /// equal-`mod_time` ties by insertion instead of by `sorts_before`. An insert
+    /// into such a list must still leave it canonical, the same way `set_idx`
+    /// already re-sorts on the replace path.
+    #[test]
+    fn add_version_filemata_canonicalizes_versions_loaded_out_of_order() {
+        let mod_time = OffsetDateTime::from_unix_timestamp(1_700_000_000).expect("valid test timestamp");
+        let first = version_for_ordering(VersionType::Object, Uuid::from_u128(70), mod_time, 70);
+        let second = version_for_ordering(VersionType::Object, Uuid::from_u128(80), mod_time, 80);
+        let (early, late) = if first.header().sorts_before(&second.header()) {
+            (first, second)
+        } else {
+            (second, first)
+        };
+
+        // Persist the pair the wrong way round to emulate a pre-canonical-order
+        // xl.meta, bypassing add_version_filemata so the bad order really lands on
+        // the wire.
+        let mut legacy = FileMeta::new();
+        legacy
+            .versions
+            .push(FileMetaShallowVersion::try_from(late).expect("shallow later version"));
+        legacy
+            .versions
+            .push(FileMetaShallowVersion::try_from(early).expect("shallow earlier version"));
+
+        let mut loaded =
+            FileMeta::load(&legacy.marshal_msg().expect("serialize legacy metadata")).expect("reload legacy metadata");
+        assert!(
+            !loaded.versions[0].header.sorts_before(&loaded.versions[1].header),
+            "fixture must reach add_version_filemata non-canonically ordered"
+        );
+
+        loaded
+            .add_version_filemata(version_for_ordering(VersionType::Delete, Uuid::from_u128(90), mod_time, 90))
+            .expect("insert equal-time delete marker");
+
+        assert_eq!(loaded.versions.len(), 3);
+        assert!(
+            loaded
+                .versions
+                .windows(2)
+                .all(|pair| pair[0].header.sorts_before(&pair[1].header)),
+            "insert must leave the version list canonically ordered"
+        );
     }
 
     /// Regression for backlog#799 B16: replication reset state must be


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

`FileMeta::add_version_filemata` positions a newly inserted version with
`partition_point(|existing| existing.header.sorts_before(&new.header))`. That
returns the canonical slot only when `versions` is *already* ordered by
`sorts_before`, and nothing establishes that precondition:

- `FileMeta::unmarshal_msg` pushes versions in file order, so `FileMeta::load`
  replays whatever order is on disk verbatim — it never canonicalizes.
- Metadata written before the canonical-order fix (#5353) ordered
  equal-`mod_time` ties by *insertion* (`partition_point` on `mod_time` alone
  inserted ahead of every equal-time entry), not by `sorts_before`.

So a list can reach `add_version_filemata` non-canonically ordered, and the
insert then trusts a precondition that does not hold.

The blast radius is bounded: `partition_point`'s binary search never advances
`left` past an index where the predicate is guaranteed true, nor lowers `right`
below one where it is guaranteed false, so the returned index always lands
inside the equal-`mod_time` run and the `mod_time` ordering — the primary sort
key — cannot be broken. What can stay wrong is the tie order *within* such a
run. The one tie that carries meaning is an object version versus a delete
marker sharing a timestamp, where canonical order resolves the object as latest.

This re-sorts after the insert so the list ends up canonical regardless of the
order it was loaded in, mirroring what `set_idx` already does unconditionally on
the replace path since #5353 — that path was made self-healing and the insert
path was left asymmetric. Cost is negligible: after a correctly placed insert
the slice is a single sorted run, so the adaptive sort is O(n), the same class
as the `insert` memmove already performed.

Scope note: the read path is deliberately left alone. Canonicalizing legacy
metadata on load would also fix pure reads of pre-#5353 data, but it changes
read results for existing on-disk data and adds work to a hot path — that is a
migration decision, not a drive-by. This fix is self-healing on the next
metadata write.

## Verification

- `cargo test -p rustfs-filemeta --lib` — 210 passed, including the three
  ordering tests added by #5353.
- The new test `add_version_filemata_canonicalizes_versions_loaded_out_of_order`
  fails before the change (`insert must leave the version list canonically
  ordered`) and passes after. Its precondition assertion passing against the
  unfixed build is what demonstrates the non-canonical order genuinely survives
  a marshal/load round-trip rather than being only theoretical.
- `cargo fmt --all -- --check`
- `scripts/check_architecture_migration_rules.sh`,
  `scripts/check_logging_guardrails.sh`
- `cargo clippy -p rustfs -p rustfs-ecstore --all-targets --features rio-v2 -- -D warnings`
  and `cargo nextest run -p rustfs -p rustfs-ecstore --features rio-v2` running
  locally; CI covers both lanes.

## Impact

No on-disk format change and no API change. Version lists that were already
canonical are unaffected (sorting an ordered slice is a no-op). Lists loaded
non-canonically now converge to canonical order on the next metadata write,
which also makes replicas across an erasure set agree on the same `latest`.

## Additional Notes

`sorts_before` is a lexicographic comparison over
(`mod_time` desc, `version_type` asc, `signature` desc, `version_id` desc,
`flags` desc) and is therefore a valid strict weak ordering, so
`sort_by(cmp_shallow_versions_for_order)` cannot trip Rust's total-order check.
`set_idx` has already relied on that same comparator unconditionally since
#5353.