### PR TITLE
ci(checksums): inherit workspace lint policy

### DIFF
--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -25,6 +25,9 @@ keywords = ["checksum-calculation", "verification", "integrity", "authenticity",
 categories = ["web-programming", "development-tools", "network-programming"]
 documentation = "https://docs.rs/rustfs-checksums/latest/rustfs_checksum/"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes = { workspace = true, features = ["serde"] }
 crc-fast = { workspace = true }


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1544

## Summary of Changes

Opt `rustfs-checksums` into the workspace lint policy by adding `[lints] workspace = true` to its package manifest.

The final change is intentionally limited to the manifest opt-in. No runtime code, public API, dependency, or feature behavior changes.

## Verification

- `cargo clippy -p rustfs-checksums --all-targets --all-features -- -D warnings`
- `cargo test -p rustfs-checksums --all-features` (25 passed)
- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit`
- `make pre-pr` (11,045 nextest tests passed, 144 skipped; all doctests passed)

## Impact

No runtime, API, compatibility, deployment, or configuration impact. Future builds of `rustfs-checksums` now enforce the same workspace Rust and Clippy lint policy as other opted-in workspace crates.

## Additional Notes

Mechanical adversarial validation completed. The correctness pass attacked production compilation, dependency and API boundaries, and the crate test path; no break was found. The simplicity pass demonstrated that earlier Rust-source cleanup and dependency movement were unnecessary, so those edits were removed and the final diff was reduced to the three-line manifest opt-in.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
