### PR TITLE
ci(concurrency): inherit workspace lint policy

### DIFF
--- a/crates/concurrency/Cargo.toml
+++ b/crates/concurrency/Cargo.toml
@@ -10,6 +10,9 @@ description = "Shared concurrency contract types for RustFS - workload admission
 keywords = ["rustfs", "concurrency", "admission", "backpressure", "workers"]
 categories = ["concurrency", "filesystem"]
 
+[lints]
+workspace = true
+
 [dependencies]
 # Internal crates
 rustfs-io-core = { workspace = true }


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1545

## Summary of Changes

Make `rustfs-concurrency` inherit the workspace lint policy by adding the standard `[lints] workspace = true` manifest opt-in. The crate already passes the inherited Rust and Clippy lint gates, so no source changes or lint suppressions are needed.

## Verification

- `cargo clippy -p rustfs-concurrency --all-targets --all-features -- -D warnings`
- `cargo test -p rustfs-concurrency` (17 passed)
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 make pre-pr` (11,056 tests passed, 144 skipped; all doctests passed)

## Impact

Build-time policy only. There are no runtime, API, dependency, feature, deployment, configuration, or documentation changes.

## Additional Notes

- Mechanical correctness adversarial pass: challenged Cargo table placement, actual workspace lint activation, all-target/all-feature compilation, and runtime/API/dependency effects; no break was found.
- Simplicity adversarial pass: confirmed the three-line manifest change is the smallest repository-consistent opt-in and introduces no helper, source, suppression, or unrelated change.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
