### PR TITLE
test(heal): avoid live disk removal race

### DIFF
--- a/crates/heal/tests/heal_integration_test.rs
+++ b/crates/heal/tests/heal_integration_test.rs
@@ -390,8 +390,10 @@ mod serial_tests {
 
         // ─── 1️⃣ delete format.json on one disk ──────────────
         let format_path = disk_paths[0].join(".rustfs.sys").join("format.json");
-        std::fs::remove_dir_all(&disk_paths[0]).expect("failed to delete all contents under disk_paths[0]");
+        let failed_disk_path = disk_paths[0].with_extension("failed");
+        std::fs::rename(&disk_paths[0], &failed_disk_path).expect("failed to detach disk_paths[0]");
         std::fs::create_dir_all(&disk_paths[0]).expect("failed to recreate disk_paths[0] directory");
+        assert!(!format_path.exists(), "replacement disk already contains format.json before heal");
         println!("✅ Deleted format.json on disk: {:?}", disk_paths[0]);
 
         let (_format_result, format_error) = heal_storage.heal_format(false).await.expect("failed to run heal_format");


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1558

## Summary of Changes

- Replace recursive removal of an active heal-test disk directory with an atomic same-filesystem rename that models detaching the failed disk.
- Recreate the original endpoint path as the replacement disk and assert that it has no `format.json` before healing.
- Preserve the existing assertions that heal restores both the disk format and the previously uploaded object's part file.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs-heal --all-targets -- -D warnings`
- 20 consecutive default-profile nextest runs of `rustfs-heal::heal_integration_test::serial_tests::test_heal_format_with_data`
- `make pre-pr`

## Impact

Test-only change. No runtime, API, storage-format, or deployment impact. The default and CI nextest profiles retain zero retries for this test.

## Additional Notes

Mechanical-tier adversarial validation completed. The correctness pass attacked stale path reuse, replacement-path collisions, concurrent path recreation, and accidental reads from the detached disk; the existing unique test root and path-based `LocalDisk` operations keep the replacement isolated, while the restored part assertion still targets the original endpoint. The simplicity pass found no smaller race-free equivalent and no new helper or retry policy was introduced.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
