### PR TITLE
fix(data-usage): make empty checks exhaustive

### DIFF
--- a/crates/data-usage/src/data_usage.rs
+++ b/crates/data-usage/src/data_usage.rs
@@ -507,16 +507,29 @@ pub struct ReplicationStats {
 
 impl ReplicationStats {
     pub fn is_empty(&self) -> bool {
-        self.pending_size == 0
-            && self.replicated_size == 0
-            && self.failed_size == 0
-            && self.failed_count == 0
-            && self.pending_count == 0
-            && self.missed_threshold_size == 0
-            && self.after_threshold_size == 0
-            && self.missed_threshold_count == 0
-            && self.after_threshold_count == 0
-            && self.replicated_count == 0
+        let Self {
+            pending_size,
+            replicated_size,
+            failed_size,
+            failed_count,
+            pending_count,
+            missed_threshold_size,
+            after_threshold_size,
+            missed_threshold_count,
+            after_threshold_count,
+            replicated_count,
+        } = self;
+
+        *pending_size == 0
+            && *replicated_size == 0
+            && *failed_size == 0
+            && *failed_count == 0
+            && *pending_count == 0
+            && *missed_threshold_size == 0
+            && *after_threshold_size == 0
+            && *missed_threshold_count == 0
+            && *after_threshold_count == 0
+            && *replicated_count == 0
     }
 
     #[deprecated(note = "use is_empty instead")]
@@ -535,7 +548,13 @@ pub struct ReplicationAllStats {
 
 impl ReplicationAllStats {
     pub fn is_empty(&self) -> bool {
-        self.replica_size == 0 && self.replica_count == 0 && self.targets.values().all(ReplicationStats::is_empty)
+        let Self {
+            replica_size,
+            replica_count,
+            targets,
+        } = self;
+
+        *replica_size == 0 && *replica_count == 0 && targets.values().all(ReplicationStats::is_empty)
     }
 
     #[deprecated(note = "use is_empty instead")]
@@ -1594,7 +1613,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn replication_stats_empty_checks_every_field() {
         type SetField = fn(&mut ReplicationStats);
 
@@ -1611,16 +1629,15 @@ mod tests {
             ("replicated_count", |stats| stats.replicated_count = 1),
         ];
 
-        assert!(ReplicationStats::default().empty());
+        assert!(ReplicationStats::default().is_empty());
         for (field, set_nonzero) in cases {
             let mut stats = ReplicationStats::default();
             set_nonzero(&mut stats);
-            assert!(!stats.empty(), "{field} must make replication stats non-empty");
+            assert!(!stats.is_empty(), "{field} must make replication stats non-empty");
         }
     }
 
     #[test]
-    #[allow(deprecated)]
     fn replication_all_stats_empty_checks_aggregate_fields_independently() {
         let cases = [
             (
@@ -1639,16 +1656,16 @@ mod tests {
             ),
         ];
 
-        assert!(ReplicationAllStats::default().empty());
+        assert!(ReplicationAllStats::default().is_empty());
         for (field, stats) in cases {
-            assert!(!stats.empty(), "{field} must make aggregate replication stats non-empty");
+            assert!(!stats.is_empty(), "{field} must make aggregate replication stats non-empty");
         }
 
         let empty_targets = ReplicationAllStats {
             targets: HashMap::from([("arn:test:empty".to_string(), ReplicationStats::default())]),
             ..Default::default()
         };
-        assert!(empty_targets.empty(), "all-empty targets must keep aggregate stats empty");
+        assert!(empty_targets.is_empty(), "all-empty targets must keep aggregate stats empty");
 
         let stats = ReplicationAllStats {
             targets: HashMap::from([
@@ -1663,7 +1680,7 @@ mod tests {
             ]),
             ..Default::default()
         };
-        assert!(!stats.empty(), "a non-empty target must make aggregate replication stats non-empty");
+        assert!(!stats.is_empty(), "a non-empty target must make aggregate replication stats non-empty");
     }
 
     #[test]


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->

Fixes rustfs/backlog#1543

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->

Follow up #5422 by making the `ReplicationStats::is_empty` and `ReplicationAllStats::is_empty` implementations exhaustively destructure their structs without `..`. A future field addition now fails compilation until the emptiness predicate is updated. Remove deprecated-API lint suppressions from the regression tests and exercise `is_empty` directly; retain the deprecated `empty` methods as one-line forwarding aliases for compatibility.

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-data-usage` (24 passed)
- `cargo test -p rustfs-scanner size_recursive_prunes_empty_and_preserves_threshold_replication_stats` (1 passed)
- `make pre-pr` on the same final source delta before transplanting it onto the merged #5422 baseline (11,060 nextest tests passed, all doctests passed)

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->

No runtime behavior, Serde layout, persisted format, or public API is changed relative to #5422. The deprecated `empty` methods remain source-compatible forwarding aliases. Future additions to either replication-stat struct must now update its emptiness predicate before the crate can compile.

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->

Standard simplicity and test-coverage adversarial review passed. Simplicity review found the exhaustive local patterns to be the smallest implementation that enforces field completeness, with no helper, allocation, lint suppression, or deprecated test call. The test-coverage skeptic verified one distinct poison value for every current target scalar, independent aggregate size/count projections, empty and mixed target maps, and separate revert-detection coverage for the data-usage and scanner `size_recursive` implementations. Exhaustive patterns without `..` make future struct-field omissions a compile error.

An unrelated load-sensitive multipart test failure discovered during the full local gate is tracked separately in rustfs/backlog#1559. The isolated test and the final full `make pre-pr` run both passed; no ecstore or quarantine changes are included here.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
