### PR TITLE
ci(keystone): inherit workspace lint policy

### DIFF
--- a/crates/keystone/Cargo.toml
+++ b/crates/keystone/Cargo.toml
@@ -25,6 +25,9 @@ keywords = ["rustfs", "openstack", "keystone", "authentication", "s3"]
 categories = ["authentication", "web-programming"]
 authors.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tokio = { workspace = true, features = ["rt", "sync"] }
 reqwest = { workspace = true, features = ["json"] }


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1547

## Summary of Changes

- Enable the inherited workspace lint policy for `rustfs-keystone`.
- Keep the change limited to the crate manifest; the inherited policy exposed no warnings requiring source changes.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs-keystone --all-targets --all-features -- -D warnings`
- `cargo test -p rustfs-keystone --all-features`
- `make pre-commit`
- `make pre-pr` (11,079 tests passed, 145 skipped; all workspace doctests passed)

## Impact

No runtime, API, configuration, or compatibility impact. The Keystone crate now participates in the existing workspace Rust and Clippy lint policy.

## Additional Notes

Mechanical adversarial validation completed with no findings. The correctness pass attacked manifest placement, scope drift, and effective lint inheritance; the simplicity pass confirmed that the two-line Cargo opt-in is the smallest repository-consistent change and adds no source edits or lint suppressions.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
