### PR TITLE
ci(protocols): inherit workspace lint policy

### DIFF
--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -25,6 +25,9 @@ description = "Protocol implementations for RustFS (FTPS, SFTP, etc.)"
 keywords = ["ftp", "sftp", "protocol", "storage", "rustfs"]
 categories = ["network-programming", "filesystem"]
 
+[lints]
+workspace = true
+
 [features]
 default = []
 ftps = ["dep:libunftp", "dep:unftp-core", "dep:rustls", "dep:rustfs-tls-runtime", "dep:subtle"]

--- a/crates/protocols/src/common/dummy_storage.rs
+++ b/crates/protocols/src/common/dummy_storage.rs
@@ -608,7 +608,7 @@ impl StorageBackend for DummyBackend {
             inner.put_object_calls.push(PutObjectCall {
                 bucket: input.bucket.to_string(),
                 key: input.key.to_string(),
-                metadata: input.metadata.clone(),
+                metadata: input.metadata,
             });
             let stall = inner.stall_put_object;
             let entered = inner.put_object_entered.clone();
@@ -731,7 +731,7 @@ impl StorageBackend for DummyBackend {
             inner.create_multipart_calls.push(CreateMultipartCall {
                 bucket: input.bucket.to_string(),
                 key: input.key.to_string(),
-                metadata: input.metadata.clone(),
+                metadata: input.metadata,
             });
         }
         match self.inner.lock().expect("lock").create_multipart_upload.pop_front() {
@@ -749,7 +749,7 @@ impl StorageBackend for DummyBackend {
             inner.upload_part_calls.push(UploadPartCall {
                 bucket: input.bucket.to_string(),
                 key: input.key.to_string(),
-                upload_id: input.upload_id.to_string(),
+                upload_id: input.upload_id,
                 part_number: input.part_number,
                 content_length: input.content_length,
             });
@@ -787,7 +787,7 @@ impl StorageBackend for DummyBackend {
             inner.complete_multipart_calls.push(CompleteCall {
                 bucket: input.bucket.to_string(),
                 key: input.key.to_string(),
-                upload_id: input.upload_id.to_string(),
+                upload_id: input.upload_id,
                 part_count,
             });
         }
@@ -808,7 +808,7 @@ impl StorageBackend for DummyBackend {
             inner.abort_multipart_calls.push(AbortCall {
                 bucket: input.bucket.to_string(),
                 key: input.key.to_string(),
-                upload_id: input.upload_id.to_string(),
+                upload_id: input.upload_id,
             });
         }
         match self.inner.lock().expect("lock").abort_multipart_upload.pop_front() {

--- a/crates/protocols/src/ftps/driver.rs
+++ b/crates/protocols/src/ftps/driver.rs
@@ -379,9 +379,7 @@ where
             .await
             .map_err(|_| Error::new(ErrorKind::PermanentFileNotAvailable, "Access denied"))?;
 
-        let prefix_with_slash = prefix
-            .clone()
-            .map(|p| if p.ends_with('/') { p.to_string() } else { format!("{}/", p) });
+        let prefix_with_slash = prefix.clone().map(|p| if p.ends_with('/') { p } else { format!("{}/", p) });
 
         let list_input = ListObjectsV2Input::builder()
             .bucket(bucket)

--- a/crates/protocols/src/ftps/server.rs
+++ b/crates/protocols/src/ftps/server.rs
@@ -371,7 +371,7 @@ impl UserDetailProvider for FtpsUserDetailProvider {
 
         let ftps_user = FtpsUser {
             username: principal.username.clone(),
-            name: identity.credentials.name.clone(),
+            name: identity.credentials.name,
             session_context,
         };
 

--- a/crates/protocols/src/sftp/write.rs
+++ b/crates/protocols/src/sftp/write.rs
@@ -1495,12 +1495,12 @@ mod tests {
             let buffer_len_u64 = part_buffer_len as u64;
             let phase = match phase_variant {
                 0 => WritePhase::Buffering {
-                    part_buffer: part_buffer.clone(),
+                    part_buffer,
                 },
                 1 => WritePhase::Streaming {
                     upload_id: "UP-proptest".to_string(),
                     abort_authorized: true,
-                    part_buffer: part_buffer.clone(),
+                    part_buffer,
                     uploaded_parts: Vec::new(),
                     next_part_number,
                 },

--- a/crates/protocols/src/swift/bulk.rs
+++ b/crates/protocols/src/swift/bulk.rs
@@ -627,9 +627,7 @@ mod tests {
     #[test]
     fn test_parse_paths_with_empty_lines() {
         let body = "/container1/file1.txt\n\n/container2/file2.txt\n   \n/container1/file3.txt";
-        let paths: Vec<&str> = body.lines().filter(|line| !line.trim().is_empty()).collect();
-
-        assert_eq!(paths.len(), 3);
+        assert_eq!(body.lines().filter(|line| !line.trim().is_empty()).count(), 3);
     }
 
     /// Tests for the `extract_tar_entries` async function.

--- a/crates/protocols/src/swift/object.rs
+++ b/crates/protocols/src/swift/object.rs
@@ -206,10 +206,9 @@ impl ObjectKeyMapper {
     #[allow(dead_code)] // Used in: object operations
     pub fn normalize_path(object: &str) -> String {
         // Split by '/', filter out empty segments (except if it's the end)
-        let segments: Vec<&str> = object.split('/').collect();
         let has_trailing_slash = object.ends_with('/');
 
-        let normalized_segments: Vec<&str> = segments.into_iter().filter(|s| !s.is_empty()).collect();
+        let normalized_segments: Vec<&str> = object.split('/').filter(|s| !s.is_empty()).collect();
 
         let mut result = normalized_segments.join("/");
 

--- a/crates/protocols/src/webdav/driver.rs
+++ b/crates/protocols/src/webdav/driver.rs
@@ -222,7 +222,7 @@ where
                         created: modified,
                         is_dir: false,
                         etag: output.e_tag.as_ref().map(etag_to_string),
-                        content_type: output.content_type.map(|c| c.to_string()),
+                        content_type: output.content_type,
                     }) as Box<dyn DavMetaData>)
                 }
                 Err(e) => {
@@ -1185,7 +1185,7 @@ where
                             created: modified,
                             is_dir: false,
                             etag: output.e_tag.as_ref().map(etag_to_string),
-                            content_type: output.content_type.map(|c| c.to_string()),
+                            content_type: output.content_type,
                         }) as Box<dyn DavMetaData>)
                     }
                     ResolvedPath::Directory { metadata, .. } => {
@@ -1204,7 +1204,7 @@ where
                             created: modified,
                             is_dir: true,
                             etag: metadata.as_ref().and_then(|output| output.e_tag.as_ref().map(etag_to_string)),
-                            content_type: metadata.and_then(|output| output.content_type.map(|c| c.to_string())),
+                            content_type: metadata.and_then(|output| output.content_type),
                         }) as Box<dyn DavMetaData>)
                     }
                 };
@@ -2035,7 +2035,7 @@ mod tests {
             _access_key: &str,
             _secret_key: &str,
         ) -> Result<ListObjectsV2Output, Self::Error> {
-            let prefix = input.prefix.map(|p| p.to_string()).unwrap_or_default();
+            let prefix = input.prefix.unwrap_or_default();
             let mut keys: Vec<String> = self
                 .state
                 .lock()

--- a/crates/protocols/tests/swift_listing_symlink_tests.rs
+++ b/crates/protocols/tests/swift_listing_symlink_tests.rs
@@ -436,12 +436,10 @@ fn test_symlink_to_nested_object() {
 fn test_listing_empty_container() {
     let objects: Vec<&str> = vec![];
 
-    let filtered: Vec<_> = objects.iter().collect();
-    assert_eq!(filtered.len(), 0);
+    assert!(objects.is_empty());
 
     // With prefix
-    let with_prefix: Vec<_> = objects.iter().filter(|o| o.starts_with("prefix/")).collect();
-    assert_eq!(with_prefix.len(), 0);
+    assert!(!objects.iter().any(|o| o.starts_with("prefix/")));
 }
 
 /// Test listing lexicographic ordering


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1548

## Summary of Changes

- Enable the inherited workspace lint policy for `rustfs-protocols`.
- Remove redundant clones and unnecessary collections exposed by the policy across the dummy backend, FTPS, SFTP, Swift, and WebDAV paths.
- Keep ownership and protocol behavior unchanged; no lint suppressions, dependency changes, or unrelated refactors are included.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs-protocols --all-targets --all-features -- -D warnings`
- `cargo nextest run -p rustfs-protocols --all-features` (683/683 passed)
- `make pre-commit`
- `make pre-pr` on the identical protocols diff before rebasing to the latest main (11,079/11,079 nextest tests passed, 145 profile-skipped, and all workspace doctests passed)
- `make pre-commit` after rebasing to `main@91597db9d2`

## Impact

No runtime, API, protocol, configuration, or compatibility behavior is intentionally changed. The protocols crate now participates in the workspace Rust and Clippy lint policy, and values that were already owned are moved instead of cloned.

## Additional Notes

Adversarial review attacked ownership after partial moves, response metadata preservation, test-only collection removal, feature-specific protocol paths, and scope expansion. All focused feature tests and the full workspace gate passed; no concrete behavior break was found. The simpler alternative of adding lint suppressions was rejected because each warning had a direct ownership- or iterator-based fix.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
