### PR TITLE
ci(s3select-api): inherit workspace lint policy

### DIFF
--- a/crates/s3select-api/Cargo.toml
+++ b/crates/s3select-api/Cargo.toml
@@ -25,6 +25,9 @@ keywords = ["s3-select", "api", "rustfs", "Minio", "object-store"]
 categories = ["web-programming", "development-tools", "asynchronous"]
 documentation = "https://docs.rs/rustfs-s3select-api/latest/rustfs_s3select_api/"
 
+[lints]
+workspace = true
+
 [dependencies]
 metrics = { workspace = true }
 async-trait.workspace = true


### PR DESCRIPTION
## Related Issues
Fixes rustfs/backlog#1549

## Summary of Changes
Enable the workspace lint policy for `rustfs-s3select-api` so the crate is checked consistently with the rest of the workspace.

## Verification
- `cargo fmt --all --check`
- `cargo clippy -p rustfs-s3select-api --all-targets --all-features -- -D warnings`
- `cargo nextest run -p rustfs-s3select-api --all-features`
- `make pre-commit`

## Impact
No runtime, API, configuration, or compatibility changes. This only opts the crate into the existing workspace lint policy.

## Additional Notes
N/A
