### PR TITLE
ci(s3select-query): inherit workspace lint policy

### DIFF
--- a/crates/s3select-query/Cargo.toml
+++ b/crates/s3select-query/Cargo.toml
@@ -25,6 +25,9 @@ keywords = ["s3-select", "query-engine", "rustfs", "Minio", "data-retrieval"]
 categories = ["web-programming", "development-tools", "data-structures"]
 documentation = "https://docs.rs/rustfs-s3select-query/latest/rustfs_s3select_query/"
 
+[lints]
+workspace = true
+
 [dependencies]
 rustfs-s3select-api = { workspace = true }
 async-recursion = { workspace = true }

--- a/crates/s3select-query/src/metadata/mod.rs
+++ b/crates/s3select-query/src/metadata/mod.rs
@@ -76,7 +76,7 @@ impl ContextProviderExtension for MetadataProvider {
 
         let table_handle = self.build_table_handle()?;
 
-        Ok(Arc::new(TableSourceAdapter::try_new(table_ref.clone(), table_name, table_handle)?))
+        Ok(Arc::new(TableSourceAdapter::try_new(table_ref, table_name, table_handle)?))
     }
 }
 


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1550.

## Summary of Changes

- Opt `rustfs-s3select-query` into the workspace lint policy.
- Remove the redundant `TableReference` clone reported after enabling the policy.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p rustfs-s3select-query --all-targets --all-features -- -D warnings`
- `cargo nextest run -p rustfs-s3select-query --all-features` (126 passed, 2 skipped)
- `make pre-commit`

## Impact

No runtime, API, configuration, or compatibility behavior changes. The crate now follows the repository's existing workspace lint policy.

## Additional Notes

The test linker emitted a macOS compact-unwind performance warning; the test command completed successfully and no source warning or test failure was reported.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
