### PR TITLE
fix(ecstore): reload bucket metadata under one write guard

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -127,8 +127,8 @@ pub mod bucket {
             get_global_bucket_metadata_sys, get_lifecycle_config, get_logging_config, get_notification_config,
             get_object_lock_config, get_public_access_block_config, get_quota_config, get_replication_config,
             get_request_payment_config, get_sse_config, get_tagging_config, get_versioning_config, get_website_config,
-            init_bucket_metadata_sys, list_bucket_targets, remove_bucket_metadata, set_bucket_metadata, update,
-            update_bucket_targets_under_transaction_lock, update_config_with,
+            init_bucket_metadata_sys, list_bucket_targets, reload_bucket_metadata, remove_bucket_metadata, set_bucket_metadata,
+            update, update_bucket_targets_under_transaction_lock, update_config_with,
         };
     }
 

--- a/crates/ecstore/src/bucket/metadata_sys.rs
+++ b/crates/ecstore/src/bucket/metadata_sys.rs
@@ -85,6 +85,20 @@ pub async fn set_bucket_metadata(bucket: String, bm: BucketMetadata) -> Result<(
     Ok(())
 }
 
+/// Re-read a bucket's metadata from disk into this instance's cache under the
+/// metadata-system write guard.
+///
+/// This is the entry point for peer reload notifications (the
+/// `LoadBucketMetadata` RPC). Prefer it over loading separately and then
+/// calling [`set_bucket_metadata`]: the guard must cover the disk read as
+/// well as the install, or concurrent reloads can install their snapshots out
+/// of order. See [`BucketMetadataSys::reload_bucket_metadata`].
+pub async fn reload_bucket_metadata(bucket: &str) -> Result<()> {
+    let sys = get_bucket_metadata_sys()?;
+    let mut lock = sys.write().await;
+    lock.reload_bucket_metadata(bucket).await
+}
+
 /// Drop a bucket's cached metadata from the in-memory map.
 ///
 /// This is the counterpart to [`set_bucket_metadata`] and is invoked when a
@@ -619,6 +633,35 @@ impl BucketMetadataSys {
         map.clear();
     }
 
+    /// Re-read a bucket's metadata from disk and install it in the cache.
+    ///
+    /// Takes `&mut self` so the read and the install are necessarily covered
+    /// by the *same* `BucketMetadataSys` write guard — a read guard cannot
+    /// call this. That exclusion is the point, not an implementation detail:
+    /// a load performed outside the guard lets two overlapping reload
+    /// notifications both read before either writes, so the one holding the
+    /// OLDER snapshot can install last and resurrect superseded
+    /// configuration. Holding the guard across both steps makes the last
+    /// writer also the last reader, so the cache converges on the newest
+    /// state on disk. It equally excludes [`Self::update`], which would
+    /// otherwise be able to persist a new config in that same window only to
+    /// have a concurrent reload overwrite its cache entry.
+    ///
+    /// This matters beyond freshness: consumers that resolve secrets from
+    /// this cache with no disk fallback — Swift TempURL signing keys go
+    /// through the map-only [`get`] — would otherwise keep honoring a
+    /// revoked key for unauthenticated pre-signed access until the
+    /// 15-minute refresh loop repaired the entry (and that loop only runs
+    /// under dist-erasure).
+    ///
+    /// Reads through `self.api` rather than the ambient store handle so the
+    /// snapshot comes from the same instance whose cache receives it.
+    pub async fn reload_bucket_metadata(&mut self, bucket: &str) -> Result<()> {
+        let bm = load_bucket_metadata(self.api.clone(), bucket).await?;
+        self.set(bucket.to_owned(), Arc::new(bm)).await;
+        Ok(())
+    }
+
     pub async fn update(&mut self, bucket: &str, config_file: &str, data: Vec<u8>) -> Result<OffsetDateTime> {
         self.update_and_parse(bucket, config_file, data, true).await
     }
@@ -1105,6 +1148,61 @@ mod tests {
             kept.policy_config_json,
             b"kept-marker".to_vec(),
             "a fabricated refresh default must not replace real metadata"
+        );
+    }
+
+    /// A peer reload notification must re-read disk and install the fresh
+    /// snapshot, and it must do so under the metadata-system write guard.
+    ///
+    /// The guard placement is what keeps overlapping reloads from installing
+    /// their snapshots out of order, and it is enforced by the `&mut self`
+    /// receiver — the `sys.write()` below is the only way to call this.
+    /// Holding that guard across disk I/O also means nothing in the load path
+    /// may re-enter the metadata system, so the reload is wrapped in a
+    /// timeout: a re-entrant read would deadlock rather than fail visibly.
+    #[tokio::test]
+    #[serial]
+    async fn reload_bucket_metadata_installs_the_current_on_disk_snapshot() {
+        let (_dirs, ecstore) = isolated_store_over_temp_disks().await;
+        let sys = Arc::new(RwLock::new(BucketMetadataSys::new(ecstore.clone())));
+
+        // V1 is installed through the cache, so map and disk agree.
+        let mut v1 = BucketMetadata::new("reloaded-bucket");
+        v1.policy_config_json = b"v1-marker".to_vec();
+        sys.read().await.persist_and_set(v1).await.expect("v1 should persist");
+
+        // V2 lands on disk only — the cache still holds V1. This is exactly
+        // the state a peer is in when a reload notification arrives.
+        let mut v2 = BucketMetadata::new("reloaded-bucket");
+        v2.policy_config_json = b"v2-marker".to_vec();
+        v2.save_with_store(ecstore.clone()).await.expect("v2 should persist");
+        assert_eq!(
+            sys.read()
+                .await
+                .get("reloaded-bucket")
+                .await
+                .expect("v1 cached")
+                .policy_config_json,
+            b"v1-marker".to_vec(),
+            "writing straight to disk must leave the cache untouched"
+        );
+
+        timeout(Duration::from_secs(30), async {
+            sys.write().await.reload_bucket_metadata("reloaded-bucket").await
+        })
+        .await
+        .expect("reload must not deadlock while holding the write guard across the disk read")
+        .expect("reload should succeed");
+
+        assert_eq!(
+            sys.read()
+                .await
+                .get("reloaded-bucket")
+                .await
+                .expect("v2 cached")
+                .policy_config_json,
+            b"v2-marker".to_vec(),
+            "reload must install the snapshot it read from disk"
         );
     }
 

--- a/rustfs/src/storage/mod.rs
+++ b/rustfs/src/storage/mod.rs
@@ -69,9 +69,9 @@ pub(crate) use storage_api::{
     get_lock_acquire_timeout, get_public_access_block_config, head_prefix_consumer, helper_consumer, init_background_replication,
     init_bucket_metadata_sys, init_ecstore_config, init_local_disks_with_instance_ctx, init_lock_clients,
     is_all_buckets_not_found, is_err_bucket_not_found, is_err_object_not_found, is_err_version_not_found, is_valid_storage_class,
-    load_bucket_metadata, options_consumer, prewarm_local_disk_id_map_with_instance_ctx, read_config, record_replication_proxy,
-    rpc_consumer, runtime_sources_consumer, s3_api_consumer, serialize, set_bucket_metadata, table_catalog_path_hash,
-    to_s3s_etag, topology_snapshot_from_endpoint_pools_with_capabilities, try_migrate_bucket_metadata, try_migrate_iam_config,
+    options_consumer, prewarm_local_disk_id_map_with_instance_ctx, read_config, record_replication_proxy, rpc_consumer,
+    runtime_sources_consumer, s3_api_consumer, serialize, table_catalog_path_hash, to_s3s_etag,
+    topology_snapshot_from_endpoint_pools_with_capabilities, try_migrate_bucket_metadata, try_migrate_iam_config,
     try_migrate_server_config, update_bucket_metadata_config, verify_rpc_signature, wrap_reader,
 };
 

--- a/rustfs/src/storage/rpc/node_service/bucket.rs
+++ b/rustfs/src/storage/rpc/node_service/bucket.rs
@@ -17,7 +17,7 @@ use crate::storage::storage_api::rpc_consumer::node_service::contract::bucket::{
     BucketOptions, DeleteBucketOptions, MakeBucketOptions,
 };
 use crate::storage::storage_api::rpc_consumer::node_service::{
-    DiskError, StoragePeerS3ClientExt as _, load_bucket_metadata, remove_bucket_metadata, set_bucket_metadata,
+    DiskError, StoragePeerS3ClientExt as _, reload_bucket_metadata, remove_bucket_metadata,
 };
 use rustfs_common::heal_channel::HealOpts;
 use rustfs_protos::proto_gen::node_service::*;
@@ -66,21 +66,23 @@ impl NodeService {
             }));
         }
 
-        let Some(store) = self.resolve_object_store() else {
+        // The reload below resolves the metadata system's own store; this
+        // check only preserves the RPC's "server not initialized" contract.
+        if self.resolve_object_store().is_none() {
             return Ok(Response::new(LoadBucketMetadataResponse {
                 success: false,
                 error_info: Some("errServerNotInitialized".to_string()),
             }));
-        };
+        }
 
-        match load_bucket_metadata(store, &bucket).await {
-            Ok(meta) => {
-                if let Err(err) = set_bucket_metadata(bucket.clone(), meta).await {
-                    return Ok(Response::new(LoadBucketMetadataResponse {
-                        success: false,
-                        error_info: Some(err.to_string()),
-                    }));
-                };
+        // Reload under a single write guard rather than loading here and
+        // calling `set_bucket_metadata` after: a load outside the guard lets
+        // two overlapping notifications install their snapshots out of order,
+        // leaving the cache on the older one until the 15-minute refresh loop
+        // repairs it. Cache-only consumers (Swift TempURL signing keys) would
+        // keep honoring revoked configuration for that whole window.
+        match reload_bucket_metadata(&bucket).await {
+            Ok(()) => {
                 if scanner_maintenance_change {
                     rustfs_scanner::record_scanner_maintenance_change(&bucket);
                 }

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -236,8 +236,8 @@ pub(crate) mod rpc_consumer {
             ECStore, Error, FileInfoVersions, LocalPeerS3Client, MetricType, PEER_RESTDRY_RUN, PEER_RESTSIGNAL, PEER_RESTSUB_SYS,
             ReadMultipleReq, ReadMultipleResp, ReadOptions, SERVICE_SIGNAL_REFRESH_CONFIG, SERVICE_SIGNAL_RELOAD_DYNAMIC,
             StorageDiskRpcExt, StoragePeerS3ClientExt, UpdateMetadataOpts, all_local_disk_path, collect_local_metrics,
-            find_local_disk_by_ref, get_local_server_property, load_bucket_metadata, reload_transition_tier_config,
-            remove_bucket_metadata, set_bucket_metadata, validate_batch_read_version_item_count,
+            find_local_disk_by_ref, get_local_server_property, reload_bucket_metadata, reload_transition_tier_config,
+            remove_bucket_metadata, validate_batch_read_version_item_count,
         };
         pub(crate) type StorageResult<T> = super::super::Result<T>;
 
@@ -1349,10 +1349,6 @@ impl StoragePeerS3ClientExt for LocalPeerS3Client {
     }
 }
 
-pub(crate) async fn load_bucket_metadata(api: Arc<ECStore>, bucket: &str) -> Result<BucketMetadata> {
-    ecstore_bucket::metadata::load_bucket_metadata(api, bucket).await
-}
-
 #[cfg(test)]
 pub(crate) fn bucket_metadata_sys_initialized() -> bool {
     ecstore_bucket::metadata_sys::get_global_bucket_metadata_sys().is_some()
@@ -1425,12 +1421,26 @@ pub(crate) async fn get_bucket_website_config(bucket: &str) -> Result<(s3s::dto:
     ecstore_bucket::metadata_sys::get_website_config(bucket).await
 }
 
+/// Install a bucket's metadata in the cache without reading disk.
+///
+/// Test-only: production reload paths must go through
+/// [`reload_bucket_metadata`], which holds one guard across the disk read and
+/// the install. Loading separately and calling this afterwards reintroduces
+/// the window where concurrent reloads install snapshots out of order.
+#[cfg(test)]
 pub(crate) async fn set_bucket_metadata(bucket: String, bm: BucketMetadata) -> Result<()> {
     ecstore_bucket::metadata_sys::set_bucket_metadata(bucket, bm).await
 }
 
 pub(crate) async fn remove_bucket_metadata(bucket: &str) -> Result<bool> {
     ecstore_bucket::metadata_sys::remove_bucket_metadata(bucket).await
+}
+
+/// Reload a bucket's metadata from disk into the cache under a single write
+/// guard, so overlapping peer reload notifications cannot install snapshots
+/// out of order.
+pub(crate) async fn reload_bucket_metadata(bucket: &str) -> Result<()> {
+    ecstore_bucket::metadata_sys::reload_bucket_metadata(bucket).await
 }
 
 pub(crate) async fn update_bucket_metadata_config(


### PR DESCRIPTION
## Problem

`handle_load_bucket_metadata` — the peer `LoadBucketMetadata` RPC handler — loaded a bucket's metadata from disk and *then* called `set_bucket_metadata` to install it. The metadata-system write guard covered only the install, not the read.

Two overlapping reload notifications could therefore both read before either wrote:

```
peer A: load(v1) ............... set(v1)   <- older snapshot installs last
peer B:      load(v2) .. set(v2)
```

The cache ends up on `v1` and keeps serving superseded configuration until the 15-minute refresh loop repairs it — and that loop only runs under dist-erasure, so a non-dist deployment never self-heals.

## Why the load has to be inside the guard

Serializing only the install is not enough: the ordering bug is between the *reads*. Whoever reads last must also write last, and the only way to guarantee that is to hold one guard across both steps. The same guard additionally excludes `update()`, which could otherwise persist a new config and then have a concurrent reload overwrite its cache entry with a pre-update snapshot.

## Change

Add `metadata_sys::reload_bucket_metadata`. The `BucketMetadataSys` method takes `&mut self`, so the read and the install are *necessarily* covered by the same write guard — a read guard cannot call it. That is compile-time enforcement, not a convention a future caller can drift from.

It reads through `self.api` rather than the ambient store handle, so the snapshot comes from the same instance whose cache receives it.

This lands on the same shape as `update_config_with` from #5398 (free fn takes `sys.write()`, `&mut self` method does load + install under that guard, reads via `self.api`), so the two paths agree rather than each inventing their own discipline.

The `rustfs`-side `set_bucket_metadata` facade is now `#[cfg(test)]`: no production path can reconstruct the load-then-set shape.

## Security relevance

Consumers that resolve secrets from this cache with no disk fallback go through the map-only `get()`. Swift TempURL signing keys are such a consumer, and since #5398 Swift account metadata writes persist *and* notify peers — so a TempURL key rotation reaches this exact handler. A lost reload left peers honoring a revoked signing key for unauthenticated pre-signed access for the whole refresh window.

## Not addressed here

A reload still loads via `load_bucket_metadata`, which degrades a missing metadata file to a fabricated in-memory default and installs it over a real cached entry. That is a separate fail-closed defect; this PR deliberately preserves the existing load semantics so the two are not conflated. `load_bucket_metadata_for_update` (added in #5398, which refuses to fabricate under erasure setups) is the natural model for closing it.

## Verification

Rebased onto current `main` (`2423ba8e3f`) after #5398 landed mid-work; one export-list conflict resolved and everything re-run.

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p rustfs -p rustfs-ecstore --all-targets -- -D warnings` — exit 0, no warnings
- `cargo test -p rustfs-ecstore --lib bucket::metadata_sys::` — 9 passed
- `cargo test -p rustfs --lib storage::rpc::node_service::` — 146 passed, 9 ignored
- `cargo test -p rustfs-protocols --features swift --test swift_metadata_persistence` — 2 passed
- architecture guard scripts (layer deps, migration rules, logging, doc paths, migration gate count, security smoke count) — all pass

New test `reload_bucket_metadata_installs_the_current_on_disk_snapshot` writes `v2` straight to disk behind a cache holding `v1` — the state a peer is in when a notification arrives — and asserts the reload installs `v2`. It is wrapped in a timeout because holding the guard across disk I/O means nothing in the load path may re-enter the metadata system; a re-entrant read would deadlock rather than fail visibly.
