### PR TITLE
fix(server): preserve non-S3 trace context

### DIFF
--- a/rustfs/src/server/layer.rs
+++ b/rustfs/src/server/layer.rs
@@ -254,7 +254,7 @@ where
                     req.headers_mut().insert(REQUEST_ID_HEADER, request_id);
                 }
             }
-            RequestContext::from_headers_without_trace_context(req.headers())
+            RequestContext::from_propagated_headers(req.headers())
         };
         let request_id = if is_s3 {
             HeaderValue::from_str(&request_context.request_id).ok()
@@ -2367,6 +2367,39 @@ mod tests {
             let request = Request::builder().uri(path).body(()).expect("build non-S3 request");
             assert_non_s3_request_id_contract(request, path).await;
         }
+    }
+
+    #[tokio::test]
+    async fn non_s3_request_context_preserves_propagated_trace_context() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let capture = HeaderCaptureService::default();
+        let captured_context = capture.request_context();
+        let mut service = ExternalRequestContextLayer::default().layer(capture);
+        let request = Request::builder()
+            .uri("/rustfs/admin/v3/info")
+            .header(REQUEST_ID_HEADER, "client-request-id")
+            .header("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+            .body(())
+            .expect("build admin request");
+
+        let response = service.call(request).await.expect("admin response");
+        let context = captured_context
+            .lock()
+            .expect("captured request context")
+            .clone()
+            .expect("admin request context");
+
+        assert_eq!(
+            response
+                .headers()
+                .get(REQUEST_ID_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("client-request-id")
+        );
+        assert_eq!(context.request_id, "client-request-id");
+        assert_eq!(context.x_amz_request_id, "client-request-id");
+        assert_eq!(context.trace_id.as_deref(), Some("4bf92f3577b34da6a3ce929d0e0e4736"));
+        assert_eq!(context.span_id.as_deref(), Some("00f067aa0ba902b7"));
     }
 
     #[test]

--- a/rustfs/src/storage/request_context.rs
+++ b/rustfs/src/storage/request_context.rs
@@ -100,15 +100,18 @@ impl RequestContext {
         )
     }
 
-    /// Create a context from propagated request headers without copying trace
-    /// state into the request context.
-    pub(crate) fn from_headers_without_trace_context(headers: &HeaderMap) -> Self {
+    /// Create a context for a non-S3 request while mirroring the propagated
+    /// canonical request ID into the compatibility alias.
+    pub(crate) fn from_propagated_headers(headers: &HeaderMap) -> Self {
         let request_id = extract_request_id_from_headers(headers);
+        let (trace_id, span_id) = extract_trace_context_ids_from_headers(headers)
+            .map(|(trace_id, span_id)| (Some(trace_id), Some(span_id)))
+            .unwrap_or((None, None));
         Self {
             x_amz_request_id: request_id.clone(),
             request_id,
-            trace_id: None,
-            span_id: None,
+            trace_id,
+            span_id,
             start_time: Instant::now(),
         }
     }
@@ -329,17 +332,22 @@ mod tests {
     }
 
     #[test]
-    fn test_propagated_request_context_mirrors_canonical_request_id() {
+    fn test_propagated_request_context_mirrors_canonical_id_and_preserves_trace_context() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
         let mut headers = HeaderMap::new();
         headers.insert("x-request-id", HeaderValue::from_static("canonical-request-id"));
         headers.insert("x-amz-request-id", HeaderValue::from_static("untrusted-amz-request-id"));
+        headers.insert(
+            "traceparent",
+            HeaderValue::from_static("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"),
+        );
 
-        let ctx = RequestContext::from_headers_without_trace_context(&headers);
+        let ctx = RequestContext::from_propagated_headers(&headers);
 
         assert_eq!(ctx.request_id, "canonical-request-id");
         assert_eq!(ctx.x_amz_request_id, "canonical-request-id");
-        assert!(ctx.trace_id.is_none());
-        assert!(ctx.span_id.is_none());
+        assert_eq!(ctx.trace_id.as_deref(), Some("4bf92f3577b34da6a3ce929d0e0e4736"));
+        assert_eq!(ctx.span_id.as_deref(), Some("00f067aa0ba902b7"));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Follow-up to #5433.

## Summary of Changes

- Preserve propagated OpenTelemetry trace and span IDs for non-S3 external requests.
- Keep the existing non-S3 canonical request ID and compatibility alias behavior unchanged.
- Add constructor-level and middleware-level regression coverage.

PR #5433 split external request context construction by route type. Its non-S3 branch intentionally skipped trace extraction, so completion logs for Admin, Console, STS, Swift, health, and other control-plane routes lost explicit trace/span correlation even though the tracing layer still joined the upstream trace.

## Verification

- `make pre-pr` with localhost proxy variables cleared: all 11,158 nextest tests, doc tests, formatting, clippy, and repository guard scripts passed.
- `RUSTFLAGS="--cfg tokio_unstable" cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rustfs --lib storage::request_context::tests::test_propagated_request_context_mirrors_canonical_id_and_preserves_trace_context -- --exact --nocapture`
- `cargo test -p rustfs --lib server::layer::tests::non_s3_request_context_preserves_propagated_trace_context -- --exact --nocapture`
- Mutation check: restoring the old non-S3 trace omission makes the middleware regression test fail, and restoring this fix makes it pass.

## Impact

Non-S3 external request logs retain upstream trace correlation. Response request IDs, signed request headers, route classification, and S3 request behavior are unchanged.

## Additional Notes

Standard-tier adversarial validation covered correctness, simplicity, security, concurrency, compatibility, performance, and revert-detecting test coverage; no unresolved findings remain.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.