### PR TITLE
test(ecstore): stabilize late snapshot lease cleanup

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -5849,23 +5849,27 @@ mod tests {
             crate::disk::DataDirDeleteStatus::Deleted
         );
         release_slow_candidate.notify_one();
-        for _ in 0..10 {
-            tokio::task::yield_now().await;
-        }
-        assert_eq!(
-            disk2
-                .delete_data_dir(
-                    bucket,
-                    data_dir,
-                    DeleteOptions {
-                        recursive: true,
-                        ..Default::default()
-                    },
-                )
-                .await
-                .expect("a token acquired after the deadline must be released"),
-            crate::disk::DataDirDeleteStatus::Deleted
-        );
+        timeout(Duration::from_secs(1), async {
+            loop {
+                match disk2
+                    .delete_data_dir(
+                        bucket,
+                        data_dir,
+                        DeleteOptions {
+                            recursive: true,
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .expect("a token acquired after the deadline must be released")
+                {
+                    crate::disk::DataDirDeleteStatus::Deleted => return,
+                    crate::disk::DataDirDeleteStatus::Deferred => tokio::time::sleep(Duration::from_millis(1)).await,
+                }
+            }
+        })
+        .await
+        .expect("late snapshot lease cleanup must finish within the bounded wait");
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Related Issues

Follow-up to rustfs/backlog#1551.
Parent: rustfs/backlog#1539

## Summary of Changes

- Replace the fixed scheduler-yield assumption in the late snapshot-lease cleanup test with a bounded poll of the observable delete result.
- Preserve the assertion that a lease acquired after its deadline is eventually released.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore set_disk::tests::snapshot_lease_acquisition_times_out_one_candidate_and_releases_partial_success --lib -- --exact --quiet` (20 consecutive runs)
- `make pre-commit`

## Impact

Test-only change. Production snapshot-lease and delete behavior are unchanged.

## Additional Notes

This addresses the real CI race observed after #5451. The one-second paused-time bound provides a useful diagnostic if late cleanup regresses.
