### PR TITLE
fix(iam): add correctly named policy APIs

### DIFF
--- a/crates/iam/src/manager.rs
+++ b/crates/iam/src/manager.rs
@@ -556,7 +556,7 @@ where
         Ok(now)
     }
 
-    pub async fn list_polices(&self, bucket_name: &str) -> Result<HashMap<String, Policy>> {
+    pub async fn list_policies(&self, bucket_name: &str) -> Result<HashMap<String, Policy>> {
         let mut m = HashMap::new();
 
         self.api.load_policy_docs(&mut m).await?;
@@ -586,6 +586,15 @@ where
             .collect();
 
         Ok(filtered)
+    }
+
+    /// Backward-compatible misspelling retained until the next breaking release.
+    #[deprecated(
+        since = "1.0.0",
+        note = "use list_policies instead; this alias will be removed in the next breaking release"
+    )]
+    pub async fn list_polices(&self, bucket_name: &str) -> Result<HashMap<String, Policy>> {
+        self.list_policies(bucket_name).await
     }
 
     pub async fn merge_policies(&self, name: &str) -> (String, Policy) {
@@ -2184,7 +2193,7 @@ where
     }
 }
 
-pub fn get_default_policyes() -> HashMap<String, PolicyDoc> {
+pub fn get_default_policies() -> HashMap<String, PolicyDoc> {
     let default_policies = &DEFAULT_POLICIES;
     default_policies
         .iter()
@@ -2199,6 +2208,15 @@ pub fn get_default_policyes() -> HashMap<String, PolicyDoc> {
             )
         })
         .collect()
+}
+
+/// Backward-compatible misspelling retained until the next breaking release.
+#[deprecated(
+    since = "1.0.0",
+    note = "use get_default_policies instead; this alias will be removed in the next breaking release"
+)]
+pub fn get_default_policyes() -> HashMap<String, PolicyDoc> {
+    get_default_policies()
 }
 
 fn set_default_canned_policies(policies: &mut HashMap<String, PolicyDoc>) {
@@ -2900,7 +2918,7 @@ mod tests {
 
     #[test]
     fn test_get_default_policies() {
-        let policies = get_default_policyes();
+        let policies = get_default_policies();
 
         // Should contain some default policies
         assert!(!policies.is_empty());
@@ -2911,6 +2929,12 @@ mod tests {
             // PolicyDoc.version is i64, not String
             assert!(policy_doc.version >= 0);
         }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_get_default_policyes_matches_current_api() {
+        assert_eq!(get_default_policyes().len(), get_default_policies().len());
     }
 
     #[test]

--- a/crates/iam/src/store/object.rs
+++ b/crates/iam/src/store/object.rs
@@ -22,7 +22,7 @@ use crate::{
     cache::{Cache, CacheEntity},
     error::{is_err_no_such_policy, is_err_no_such_user},
     keyring,
-    manager::{extract_jwt_claims, extract_jwt_claims_allow_missing_exp, get_default_policyes},
+    manager::{extract_jwt_claims, extract_jwt_claims_allow_missing_exp, get_default_policies},
     root_credentials,
 };
 use futures::future::join_all;
@@ -1127,7 +1127,7 @@ impl Store for ObjectStore {
         let cache_snapshot = cache.snapshot();
         let listed_config_items = self.list_all_iamconfig_items().await?;
 
-        let mut policy_docs_cache = CacheEntity::new(get_default_policyes());
+        let mut policy_docs_cache = CacheEntity::new(get_default_policies());
 
         if let Some(policies_list) = listed_config_items.get(POLICIES_LIST_KEY) {
             // Load in fixed-size chunks so each policy is fetched exactly once.

--- a/crates/iam/src/sys.rs
+++ b/crates/iam/src/sys.rs
@@ -18,7 +18,7 @@ use crate::error::is_err_no_such_temp_account;
 use crate::error::{Error, Result};
 use crate::federation::OIDC_VIRTUAL_PARENT_CLAIM;
 use crate::manager::extract_jwt_claims;
-use crate::manager::get_default_policyes;
+use crate::manager::get_default_policies;
 use crate::manager::{IamCache, IamSyncMetricsSnapshot};
 use crate::store::GroupInfo;
 use crate::store::MappedPolicy;
@@ -249,7 +249,7 @@ impl<T: Store> IamSys<T> {
     }
 
     pub async fn delete_policy(&self, name: &str, notify: bool) -> Result<()> {
-        for k in get_default_policyes().keys() {
+        for k in get_default_policies().keys() {
             if k == name {
                 return Err(Error::other("system policy can not be deleted"));
             }
@@ -291,8 +291,17 @@ impl<T: Store> IamSys<T> {
         self.store.api.load_mapped_policies(user_type, is_group, m).await
     }
 
+    pub async fn list_policies(&self, bucket_name: &str) -> Result<HashMap<String, Policy>> {
+        self.store.list_policies(bucket_name).await
+    }
+
+    /// Backward-compatible misspelling retained until the next breaking release.
+    #[deprecated(
+        since = "1.0.0",
+        note = "use list_policies instead; this alias will be removed in the next breaking release"
+    )]
     pub async fn list_polices(&self, bucket_name: &str) -> Result<HashMap<String, Policy>> {
-        self.store.list_polices(bucket_name).await
+        self.list_policies(bucket_name).await
     }
 
     pub async fn list_policy_docs(&self, bucket_name: &str) -> Result<HashMap<String, PolicyDoc>> {
@@ -1683,11 +1692,17 @@ mod tests {
     use super::*;
     use crate::cache::{Cache, CacheEntity};
     use crate::error::Error;
-    use crate::manager::get_default_policyes;
+    use crate::manager::get_default_policies;
     use crate::store::{GroupInfo, MappedPolicy, Store, UserType};
     use rustfs_credentials::{Credentials, init_global_action_credentials};
     use rustfs_policy::auth::{UserIdentity, get_new_credentials_with_metadata};
     use rustfs_policy::policy::Args;
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_list_polices_api_is_available() {
+        let _ = IamSys::<StsTestMockStore>::list_polices;
+    }
     use rustfs_policy::policy::action::{Action, AdminAction, S3Action};
     use rustfs_policy::policy::policy_uses_existing_object_tag_conditions;
     use serde_json::Value;
@@ -1925,7 +1940,7 @@ mod tests {
         }
 
         async fn load_all(&self, cache: &Cache) -> Result<()> {
-            let mut policy_docs = get_default_policyes();
+            let mut policy_docs = get_default_policies();
             let custom_claim_policy =
                 Policy::parse_config(CUSTOM_STS_CLAIM_POLICY_JSON.as_bytes()).expect("custom STS claim policy should parse");
             policy_docs.insert(CUSTOM_STS_CLAIM_POLICY.to_string(), PolicyDoc::new(custom_claim_policy));

--- a/rustfs/src/admin/handlers/policies.rs
+++ b/rustfs/src/admin/handlers/policies.rs
@@ -148,7 +148,7 @@ impl Operation for ListCannedPolicies {
             return Err(s3_error!(InternalError, "iam is not initialized"));
         };
 
-        let policies = iam_store.list_polices(&query.bucket).await.map_err(|e| {
+        let policies = iam_store.list_policies(&query.bucket).await.map_err(|e| {
             warn!(
                 component = LOG_COMPONENT_ADMIN,
                 subsystem = LOG_SUBSYSTEM_POLICY,

--- a/rustfs/src/admin/handlers/user.rs
+++ b/rustfs/src/admin/handlers/user.rs
@@ -724,7 +724,7 @@ impl Operation for ExportIam {
             match file {
                 ALL_POLICIES_FILE => {
                     let policies: HashMap<String, rustfs_policy::policy::Policy> = iam_store
-                        .list_polices("")
+                        .list_policies("")
                         .await
                         .map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, e.to_string()))?;
                     let json_str = serde_json::to_vec(&policies)


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1554.
Parent: rustfs/backlog#1539

## Summary of Changes

- Add correctly named `list_policies` and `get_default_policies` APIs.
- Migrate all in-repository callers and retain the misspelled public APIs as deprecated forwarding shims.
- Add compatibility coverage for the deprecated API surface.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-iam`
- `make pre-commit`

## Impact

Policy loading, filtering, caching, return values, and errors are unchanged. External callers can migrate at their own pace; the deprecated aliases state that they will be removed in the next breaking release.

## Additional Notes

The old spellings remain only in documented deprecated shims and compatibility tests.
