### PR TITLE
chore(release): prepare 1.0.0-beta.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,7 +3654,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -8845,7 +8845,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8981,7 +8981,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9003,7 +9003,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9018,7 +9018,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "chrono",
  "metrics",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "insta",
  "rustfs-io-core",
@@ -9045,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "const-str",
  "serde",
@@ -9054,7 +9054,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9067,7 +9067,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9087,7 +9087,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "rmp-serde",
@@ -9097,7 +9097,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9235,7 +9235,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -9300,7 +9300,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9337,7 +9337,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "bytes",
  "memmap2",
@@ -9349,7 +9349,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "criterion",
  "metrics",
@@ -9412,7 +9412,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "bytes",
  "futures",
@@ -9438,7 +9438,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9472,7 +9472,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "metrics",
@@ -9494,7 +9494,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "chrono",
  "flate2",
@@ -9534,7 +9534,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "chrono",
  "humantime",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9582,7 +9582,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "criterion",
  "futures",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "bytes",
  "criterion",
@@ -9616,7 +9616,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9668,7 +9668,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9697,7 +9697,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -9759,7 +9759,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "flatbuffers",
  "prost 0.14.4",
@@ -9782,7 +9782,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "byteorder",
  "bytes",
@@ -9799,7 +9799,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -9837,7 +9837,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -9859,14 +9859,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "rustfs-s3-types",
 ]
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -9874,7 +9874,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9903,7 +9903,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9919,7 +9919,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9957,14 +9957,14 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9981,7 +9981,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "insta",
@@ -9995,7 +9995,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10048,7 +10048,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "rustfs-data-usage",
  "rustfs-ecstore",
@@ -10063,7 +10063,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "arc-swap",
  "metrics",
@@ -10083,7 +10083,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "axum",
@@ -10119,7 +10119,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10160,7 +10160,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -870,7 +870,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "sha1 0.10.7",
  "time",
  "tokio",
@@ -934,7 +934,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "percent-encoding",
@@ -970,7 +970,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "lru 0.16.4",
  "percent-encoding",
@@ -1001,7 +1001,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -1027,7 +1027,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -1054,7 +1054,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -1076,7 +1076,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "p256 0.13.2",
  "percent-encoding",
  "sha2 0.11.0",
@@ -1108,7 +1108,7 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "md-5 0.11.0",
@@ -1142,7 +1142,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
@@ -1161,7 +1161,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -1224,7 +1224,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -1245,7 +1245,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1271,7 +1271,7 @@ checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -1285,7 +1285,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -1337,7 +1337,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -1368,7 +1368,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -3229,7 +3229,7 @@ dependencies = [
  "futures-util",
  "headers",
  "htmlescape",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "libc",
@@ -3672,7 +3672,7 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4384,7 +4384,7 @@ dependencies = [
  "google-cloud-gax",
  "hex",
  "hmac 0.13.0",
- "http 1.4.2",
+ "http 1.5.0",
  "jsonwebtoken 10.4.0",
  "reqwest",
  "rustc_version",
@@ -4409,7 +4409,7 @@ dependencies = [
  "futures",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project",
  "rand 0.10.2",
  "serde",
@@ -4431,7 +4431,7 @@ dependencies = [
  "google-cloud-rpc",
  "google-cloud-wkt",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -4544,7 +4544,7 @@ dependencies = [
  "google-cloud-type",
  "google-cloud-wkt",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "md5",
  "percent-encoding",
@@ -4624,7 +4624,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4727,7 +4727,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.2",
+ "http 1.5.0",
  "httpdate",
  "mime",
  "sha1 0.10.7",
@@ -4739,7 +4739,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -4961,9 +4961,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4987,7 +4987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -4998,7 +4998,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
 ]
@@ -5044,7 +5044,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
  "httpdate",
@@ -5061,7 +5061,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "log",
@@ -5095,7 +5095,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "hyper",
  "ipnet",
@@ -6704,10 +6704,10 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
- "http 1.4.2",
+ "http 1.5.0",
  "rand 0.8.7",
  "serde",
  "serde_json",
@@ -6815,7 +6815,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "humantime",
  "itertools 0.14.0",
  "parking_lot",
@@ -6871,7 +6871,7 @@ dependencies = [
  "dyn-clone",
  "ed25519-dalek 2.2.0",
  "hmac 0.12.1",
- "http 1.4.2",
+ "http 1.5.0",
  "itertools 0.10.5",
  "log",
  "oauth2",
@@ -6932,7 +6932,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "opentelemetry",
  "reqwest",
 ]
@@ -6944,7 +6944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "flate2",
- "http 1.4.2",
+ "http 1.5.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -7820,7 +7820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -7840,7 +7840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7861,7 +7861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -7874,7 +7874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8329,9 +8329,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b9503711b03773e43b31668c7b5bd279ee7cd9b7d18cff7c23a42cc1d08e5a"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -8481,7 +8481,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -8627,7 +8627,7 @@ dependencies = [
  "async-tungstenite",
  "futures-io",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "rustls-native-certs",
  "rustls-pki-types",
  "rustls-webpki",
@@ -8657,7 +8657,7 @@ dependencies = [
  "flume",
  "futures-io",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "log",
  "mqttbytes-core-next",
  "rumqttc-core-next",
@@ -8874,7 +8874,7 @@ dependencies = [
  "hex-simd",
  "hmac 0.13.0",
  "hotpath",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -9008,7 +9008,7 @@ dependencies = [
  "base64-simd",
  "bytes",
  "crc-fast",
- "http 1.4.2",
+ "http 1.5.0",
  "md-5 0.11.0",
  "pretty_assertions",
  "sha1 0.11.0",
@@ -9129,7 +9129,7 @@ dependencies = [
  "hex-simd",
  "hmac 0.13.0",
  "hotpath",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -9275,7 +9275,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.0",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "metrics",
  "rustfs-common",
  "rustfs-concurrency",
@@ -9306,7 +9306,7 @@ dependencies = [
  "async-trait",
  "base64-simd",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "jsonwebtoken 11.0.0",
  "moka",
  "openidconnect",
@@ -9416,7 +9416,7 @@ version = "1.0.0-beta.12"
 dependencies = [
  "bytes",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -9710,7 +9710,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac 0.13.0",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -9811,7 +9811,7 @@ dependencies = [
  "futures",
  "hex-simd",
  "hotpath",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "md-5 0.11.0",
  "pin-project-lite",
@@ -9882,7 +9882,7 @@ dependencies = [
  "datafusion",
  "futures",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "metrics",
  "parking_lot",
  "rustfs-common",
@@ -9927,7 +9927,7 @@ dependencies = [
  "futures",
  "hex-simd",
  "hmac 0.13.0",
- "http 1.4.2",
+ "http 1.5.0",
  "metrics",
  "rand 0.10.2",
  "rmp-serde",
@@ -9968,7 +9968,7 @@ version = "1.0.0-beta.12"
 dependencies = [
  "base64-simd",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "rustfs-utils",
  "s3s",
@@ -10087,7 +10087,7 @@ version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
  "axum",
- "http 1.4.2",
+ "http 1.5.0",
  "ipnetwork",
  "metrics",
  "moka",
@@ -10133,7 +10133,7 @@ dependencies = [
  "hex-simd",
  "highway",
  "hmac 0.13.0",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "local-ip-address",
  "lz4",
@@ -10190,7 +10190,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest",
  "rustify_derive",
  "serde",
@@ -10230,9 +10230,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -10370,7 +10370,7 @@ dependencies = [
  "futures",
  "hex-simd",
  "hmac 0.13.0",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "httparse",
@@ -11498,7 +11498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -11734,13 +11734,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -11844,7 +11844,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "rand 0.8.7",
  "rustls-pki-types",
@@ -11896,7 +11896,7 @@ dependencies = [
  "bytes",
  "flate2",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -11983,7 +11983,7 @@ dependencies = [
  "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
  "tower",
@@ -12003,7 +12003,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
@@ -12176,7 +12176,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.5",
@@ -12363,7 +12363,7 @@ checksum = "30ffcc0e81025065dda612ec1e26a3d81bb16ef3062354873d17a35965d68522"
 dependencies = [
  "async-trait",
  "derive_builder",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest",
  "rustify",
  "rustify_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.12" }
 async-channel = "2.5.0"
 async_zip = { default-features = false, version = "0.0.18" }
 mysql_async = { default-features = false, version = "0.37" }
-async-compression = { version = "0.4.42" }
+async-compression = { version = "0.4.43" }
 async-recursion = "1.1.1"
 async-trait = "0.1.91"
 async-nats = { version = "0.50.0", default-features = false }
@@ -152,7 +152,7 @@ lapin = { default-features = false, version = "4.10.0" }
 hyper = { version = "1.11.0" }
 hyper-rustls = { default-features = false, version = "0.27.9" }
 hyper-util = { version = "0.1.20" }
-http = "1.4.2"
+http = "1.5.0"
 http-body = "1.1.0"
 http-body-util = "0.1.4"
 minlz = "1.2.3"
@@ -200,7 +200,7 @@ jsonwebtoken = { version = "11.0.0" }
 openidconnect = { default-features = false, version = "4.0" }
 pbkdf2 = "0.13.0"
 rsa = { version = "=0.10.0-rc.18" }
-rustls = { default-features = false, version = "0.23.42" }
+rustls = { default-features = false, version = "0.23.43" }
 rustls-native-certs = "0.8"
 rustls-pki-types = "1.15.1"
 sha1 = "0.11.0"
@@ -283,7 +283,7 @@ reed-solomon-erasure = { package = "rustfs-erasure-codec", version = "8.0.2" }
 reed-solomon-simd = "3.1.0"
 regex = { version = "1.13.1" }
 rumqttc = { package = "rumqttc-next", version = "0.33.3" }
-redis = { version = "1.4.1" }
+redis = { version = "1.5.0" }
 rustix = { version = "1.1.4" }
 rust-embed = { version = "8.12.0" }
 rustc-hash = { version = "2.1.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.97.1"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -86,52 +86,52 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.11" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.11" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.11" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.11" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.11" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.11" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.11" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.11" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.11" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.11" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.11" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.11" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.11" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.11" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.11" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.11" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.11" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.11" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.11" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.11" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.11" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.11" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.11" }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-beta.11" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.11" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.11" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.11" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.11" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.11" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.11" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.11" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.11" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.11" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.11" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.11" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.11" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.11" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.11" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.11" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.11" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.11" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.11" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.11" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.11" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.11" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.11" }
+rustfs = { path = "./rustfs", version = "1.0.0-beta.12" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.12" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.12" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.12" }
+rustfs-common = { path = "crates/common", version = "1.0.0-beta.12" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.12" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-beta.12" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.12" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.12" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.12" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.12" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.12" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.12" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.12" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.12" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.12" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.12" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.12" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.12" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.12" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.12" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.12" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.12" }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-beta.12" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.12" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.12" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.12" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.12" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.12" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.12" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.12" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.12" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.12" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.12" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.12" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.12" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.12" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.12" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.12" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.12" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.12" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.12" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.12" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.12" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.12" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.12" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.11
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.12
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.11
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.12
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.11";
+            version = "1.0.0-beta.12";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.11.0"
-appVersion: "1.0.0-beta.11"
+version: "0.12.0"
+appVersion: "1.0.0-beta.12"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease beta.11
+%global prerelease beta.12
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.11
+Release:        beta.12
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Thu Jul 30 2026 overtrue <anzhengchao@gmail.com>
+- Update RPM package to RustFS 1.0.0-beta.12
+
 * Thu Jul 23 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.11
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Bump all RustFS workspace packages and lockfile entries to `1.0.0-beta.12`.
- Align Docker examples, Nix package metadata, Helm chart metadata, and RPM packaging metadata with beta.12.
- Add the beta.12 RPM changelog entry.

## Verification

- `cargo metadata --locked --no-deps --format-version 1`
- `bash scripts/test_helm_chart_version.sh`
- `helm lint helm/rustfs`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 make pre-commit`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 make pre-pr`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 RUSTFLAGS="--cfg tokio_unstable" cargo clippy --all-targets --all-features -- -D warnings`

## Impact

Release metadata only. No runtime behavior changes.

## Additional Notes

The final release tag will be created only after preview artifacts and images are validated from the exact merged commit.

---

- [x] I have read and followed the contributing guidelines.
- [x] I have added or updated tests where appropriate.
- [x] All existing tests pass locally.