### PR TITLE
test(e2e): accept backpressure unknown terminal status

### DIFF
--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -2136,11 +2136,20 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
     assert_eq!(terminal["bucket"].as_str(), Some(bucket.as_str()));
     assert_eq!(terminal["prefix"].as_str(), Some(prefix));
     assert_eq!(terminal["dry_run"].as_bool(), Some(false));
-    assert_eq!(
-        terminal["status"].as_str(),
-        Some("partial"),
+    let terminal_status = terminal["status"].as_str();
+    assert!(
+        matches!(terminal_status, Some("partial" | "unknown")),
         "small transition queue should surface terminal backpressure: {terminal}"
     );
+    if terminal_status == Some("unknown") {
+        let failure_reason = terminal["failure_reason"]
+            .as_str()
+            .ok_or_else(|| format!("unknown terminal status omitted failure_reason: {terminal}"))?;
+        assert!(
+            failure_reason.contains("worker result was not persisted before the transition queue drained"),
+            "unknown terminal status should identify lost worker-result persistence: {terminal}"
+        );
+    }
     let skipped_queue_full = terminal["report"]["skipped_queue_full"]
         .as_u64()
         .ok_or_else(|| format!("terminal status omitted report.skipped_queue_full: {terminal}"))?;


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Update the manual transition distributed admission conflict E2E assertion to accept the existing `unknown` terminal status for the lost worker-result persistence path.
- Keep the test strict by requiring the specific lost worker-result `failure_reason` when the terminal status is `unknown`, while preserving the queue-full backpressure and cold-tier count assertions.

## Verification
- User confirmed local manual verification.
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore manual_transition`
- `git diff --cached --check`

## Impact
Test-only change. No runtime behavior, API, configuration, storage format, or deployment impact.

## Additional Notes
- The failing CI job reported `status: "unknown"` together with queue-full backpressure evidence and the existing lost worker-result persistence failure reason. Product code already models that terminal path, so this PR narrows the E2E expectation to the behavior that can occur under local queue pressure.
- I also attempted the focused E2E locally, but this macOS environment failed during four-node cluster startup before reaching the changed assertion, with `not first disk` and internode connection refused errors.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
