### PR TITLE
fix(kms): pass attempt timeout to Vault test clients

### DIFF
--- a/crates/kms/src/backends/vault.rs
+++ b/crates/kms/src/backends/vault.rs
@@ -938,7 +938,9 @@ mod tests {
     async fn test_vault_kv2_rotate_key_rejected_without_touching_storage() {
         // No Vault instance needed: rotation must be rejected before any storage access,
         // so the call cannot read or overwrite key material.
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let err = client
             .rotate_key("any-key", None)
@@ -950,7 +952,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_vault_kv2_backend_info_reports_at_rest_protection() {
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let info = client.backend_info();
         assert_eq!(info.backend_type, "vault-kv2");
@@ -962,7 +966,9 @@ mod tests {
     #[tokio::test]
     #[ignore] // Requires a running Vault instance (dev mode)
     async fn test_vault_kv2_rotate_rejected_and_material_untouched() {
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let key_id = format!("rotate-{}", uuid::Uuid::new_v4());
         client.create_key(&key_id, "AES_256", None).await.expect("create");


### PR DESCRIPTION
## Related Issues

N/A (main-branch build fix; fallout from the merge sequence of #5472 and #5474)

## Summary of Changes

PR #5472 added an `attempt_timeout` parameter to `VaultKmsClient::new`. PR #5474 was developed in parallel and introduced three tests calling the old single-argument signature. Both PRs merged cleanly at the text level, but the combination cannot compile: `cargo test -p rustfs-kms` fails on main with three E0061 errors at `crates/kms/src/backends/vault.rs`.

This PR updates the three test call sites to pass `Duration::from_secs(30)`, matching the other integration-test call sites introduced by #5472.

## Verification

- `cargo test -p rustfs-kms` — 139 passed / 0 failed / 7 ignored (was: compile error on main)
- `cargo clippy -p rustfs-kms --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Impact

Test-only change; unblocks CI for every PR that compiles the rustfs-kms test target. No runtime behavior change.

## Additional Notes

N/A
