### PR TITLE
feat(kms): add master key version to data key envelope contract

### DIFF
--- a/crates/kms/src/backends/local.rs
+++ b/crates/kms/src/backends/local.rs
@@ -942,7 +942,8 @@ impl KmsClient for LocalKmsClient {
         // Encrypt the data key with the master key
         let (encrypted_key, nonce) = self.encrypt_with_master_key(&request.master_key_id, &plaintext_key).await?;
 
-        // Create data key envelope with master key version for rotation support
+        // Local rotation is rejected, so every envelope is wrapped by the key's sole
+        // material and needs no master key version.
         let envelope = DataKeyEnvelope {
             key_id: uuid::Uuid::new_v4().to_string(),
             master_key_id: request.master_key_id.clone(),
@@ -951,6 +952,7 @@ impl KmsClient for LocalKmsClient {
             nonce,
             encryption_context: request.encryption_context.clone(),
             created_at: Zoned::now(),
+            master_key_version: None,
         };
 
         // Serialize the envelope as the ciphertext

--- a/crates/kms/src/backends/static_kms.rs
+++ b/crates/kms/src/backends/static_kms.rs
@@ -137,6 +137,8 @@ impl KmsClient for StaticKmsBackend {
             nonce: nonce_bytes.to_vec(),
             encryption_context: request.encryption_context.clone(),
             created_at: Zoned::now(),
+            // The static backend has a single fixed key with no rotation.
+            master_key_version: None,
         };
         let ciphertext = serde_json::to_vec(&envelope)?;
 
@@ -181,6 +183,8 @@ impl KmsClient for StaticKmsBackend {
             nonce: nonce_bytes.to_vec(),
             encryption_context: request.encryption_context.clone(),
             created_at: Zoned::now(),
+            // The static backend has a single fixed key with no rotation.
+            master_key_version: None,
         };
         let ciphertext = serde_json::to_vec(&envelope)?;
 

--- a/crates/kms/src/backends/vault.rs
+++ b/crates/kms/src/backends/vault.rs
@@ -311,6 +311,7 @@ impl KmsClient for VaultKmsClient {
             nonce,
             encryption_context: request.encryption_context.clone(),
             created_at: Zoned::now(),
+            master_key_version: None,
         };
 
         // Serialize the envelope as the ciphertext

--- a/crates/kms/src/backends/vault.rs
+++ b/crates/kms/src/backends/vault.rs
@@ -938,7 +938,9 @@ mod tests {
     async fn test_vault_kv2_rotate_key_rejected_without_touching_storage() {
         // No Vault instance needed: rotation must be rejected before any storage access,
         // so the call cannot read or overwrite key material.
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let err = client
             .rotate_key("any-key", None)
@@ -950,7 +952,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_vault_kv2_backend_info_reports_at_rest_protection() {
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let info = client.backend_info();
         assert_eq!(info.backend_type, "vault-kv2");
@@ -962,7 +966,9 @@ mod tests {
     #[tokio::test]
     #[ignore] // Requires a running Vault instance (dev mode)
     async fn test_vault_kv2_rotate_rejected_and_material_untouched() {
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let key_id = format!("rotate-{}", uuid::Uuid::new_v4());
         client.create_key(&key_id, "AES_256", None).await.expect("create");

--- a/crates/kms/src/backends/vault_transit.rs
+++ b/crates/kms/src/backends/vault_transit.rs
@@ -406,6 +406,9 @@ impl KmsClient for VaultTransitKmsClient {
             nonce: Vec::new(),
             encryption_context: request.encryption_context.clone(),
             created_at: Zoned::now(),
+            // Transit ciphertext already self-describes its key version
+            // ("vault:vN:..."), so the envelope never carries one.
+            master_key_version: None,
         };
 
         let ciphertext = serde_json::to_vec(&envelope)?;

--- a/crates/kms/src/encryption/dek.rs
+++ b/crates/kms/src/encryption/dek.rs
@@ -32,7 +32,10 @@ use std::collections::HashMap;
 ///
 /// This structure stores the encrypted DEK along with metadata needed for decryption.
 /// The `master_key_version` field records which version of the KEK (Key Encryption Key)
-/// was used to encrypt this DEK, enabling proper key rotation support.
+/// wrapped this DEK so rotation-aware backends can load the matching historical
+/// material. Envelopes written before versioning carry `None`; backends must resolve
+/// `None` to a deterministic baseline version recorded in key metadata, never
+/// implicitly to whatever version is current.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataKeyEnvelope {
     pub key_id: String,
@@ -43,6 +46,12 @@ pub struct DataKeyEnvelope {
     pub encryption_context: HashMap<String, String>,
     #[serde(with = "crate::time_serde::zoned")]
     pub created_at: Zoned,
+    /// KEK version that wrapped `encrypted_key`; `None` on pre-versioning envelopes.
+    ///
+    /// Optional and omitted when `None` so envelopes from non-rotating backends stay
+    /// byte-identical to the historical seven-field JSON shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub master_key_version: Option<u32>,
 }
 
 #[derive(Deserialize)]
@@ -307,6 +316,7 @@ mod tests {
                 map
             },
             created_at: Zoned::now(),
+            master_key_version: None,
         };
 
         // Test serialization
@@ -336,6 +346,8 @@ mod tests {
         let deserialized: DataKeyEnvelope = serde_json::from_str(envelope_json).expect("Should deserialize current format");
         assert_eq!(deserialized.key_id, "test-key-id");
         assert_eq!(deserialized.master_key_id, "master-key-id");
+        // Envelopes persisted before versioning must parse with no master key version.
+        assert_eq!(deserialized.master_key_version, None);
     }
 
     #[tokio::test]
@@ -353,6 +365,50 @@ mod tests {
         let deserialized: DataKeyEnvelope = serde_json::from_str(envelope_json).expect("Should deserialize legacy format");
         assert_eq!(deserialized.key_id, "test-key-id");
         assert_eq!(deserialized.master_key_id, "master-key-id");
+        assert_eq!(deserialized.master_key_version, None);
+    }
+
+    #[test]
+    fn test_data_key_envelope_none_version_serializes_without_field() {
+        // A `None` version must keep the serialized envelope on the historical
+        // seven-field JSON shape so non-rotating backends emit byte-compatible
+        // envelopes that older readers accept unchanged.
+        let envelope = DataKeyEnvelope {
+            key_id: "test-key-id".to_string(),
+            master_key_id: "master-key-id".to_string(),
+            key_spec: "AES_256".to_string(),
+            encrypted_key: vec![1, 2, 3, 4],
+            nonce: vec![5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            encryption_context: HashMap::new(),
+            created_at: Zoned::now(),
+            master_key_version: None,
+        };
+
+        let value = serde_json::to_value(&envelope).expect("serialize envelope");
+        let object = value.as_object().expect("envelope serializes to an object");
+        assert!(!object.contains_key("master_key_version"));
+        assert_eq!(object.len(), 7, "None version must not change the seven-field JSON shape");
+    }
+
+    #[test]
+    fn test_data_key_envelope_version_round_trip() {
+        let envelope = DataKeyEnvelope {
+            key_id: "test-key-id".to_string(),
+            master_key_id: "master-key-id".to_string(),
+            key_spec: "AES_256".to_string(),
+            encrypted_key: vec![1, 2, 3, 4],
+            nonce: vec![5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            encryption_context: HashMap::new(),
+            created_at: Zoned::now(),
+            master_key_version: Some(7),
+        };
+
+        let serialized = serde_json::to_vec(&envelope).expect("serialize envelope");
+        let value: serde_json::Value = serde_json::from_slice(&serialized).expect("parse serialized envelope");
+        assert_eq!(value.get("master_key_version"), Some(&serde_json::json!(7)));
+
+        let deserialized: DataKeyEnvelope = serde_json::from_slice(&serialized).expect("deserialize envelope");
+        assert_eq!(deserialized.master_key_version, Some(7));
     }
 
     #[test]
@@ -368,8 +424,19 @@ mod tests {
         }"#;
         let minio_legacy = br#"{"aead":"AES-256-GCM-HMAC-SHA-256","iv":[1],"nonce":[2],"bytes":[3]}"#;
         let duplicate_key_id = [b"{\"key_id\":\"duplicate\",".as_slice(), &kms_envelope[1..]].concat();
+        // Rotation-aware envelope: the optional master_key_version field must not
+        // change how mixed batches of old and new envelopes are routed.
+        let versioned_envelope = {
+            let mut value: serde_json::Value = serde_json::from_slice(kms_envelope).expect("parse KMS envelope fixture");
+            value
+                .as_object_mut()
+                .expect("KMS envelope fixture is an object")
+                .insert("master_key_version".to_string(), serde_json::json!(2));
+            serde_json::to_vec(&value).expect("serialize versioned envelope")
+        };
 
         assert!(is_data_key_envelope(kms_envelope));
+        assert!(is_data_key_envelope(&versioned_envelope));
         assert!(is_data_key_envelope(&[b" \n".as_slice(), kms_envelope].concat()));
         assert!(!is_data_key_envelope(&duplicate_key_id));
         assert!(!is_data_key_envelope(b"bm9uY2U=:Y2lwaGVydGV4dA=="));

--- a/crates/kms/src/error.rs
+++ b/crates/kms/src/error.rs
@@ -120,6 +120,10 @@ pub enum KmsError {
     /// Persisted key record uses a format version unknown to this build
     #[error("Unsupported key format version {version:?} for key {key_id}")]
     UnsupportedFormatVersion { key_id: String, version: String },
+
+    /// Requested master key version has no persisted material for the key
+    #[error("Key version {version} not found for key {key_id}")]
+    KeyVersionNotFound { key_id: String, version: u32 },
 }
 
 impl KmsError {
@@ -251,6 +255,14 @@ impl KmsError {
         Self::UnsupportedFormatVersion {
             key_id: key_id.into(),
             version: version.into(),
+        }
+    }
+
+    /// Create a key version not found error
+    pub fn key_version_not_found<S: Into<String>>(key_id: S, version: u32) -> Self {
+        Self::KeyVersionNotFound {
+            key_id: key_id.into(),
+            version,
         }
     }
 }


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1565 (part of rustfs/backlog#1562)

## Summary of Changes

First of two stacked PRs restoring safe master key rotation for Vault KV2. This one lands the envelope/version contract with no behavior change:

- `DataKeyEnvelope` gains `#[serde(default, skip_serializing_if = "Option::is_none")] pub master_key_version: Option<u32>`, recording which KEK version wrapped the DEK. The struct doc already claimed this field existed; now it does, with `None` documented as "pre-versioning envelope, resolved by the backend to a deterministic baseline version, never implicitly to current".
- All envelope construction sites (Local, Static, Vault KV2, Vault Transit) explicitly set `None` for now, so every serialized envelope stays byte-identical to the historical seven-field JSON shape. The follow-up PR makes Vault KV2 stamp `Some(current_version)`.
- `KmsError` gains an appended `KeyVersionNotFound { key_id, version: u32 }` variant plus helper, for version-addressed material lookups that must fail closed. No `InvalidKeyVersion` variant was added: malformed version fields already fail typed at envelope parse, unknown record formats have `UnsupportedFormatVersion`, and nonexistent versions get `KeyVersionNotFound` - a fourth variant would have no distinct producer.
- `DataKeyEnvelopeMarker` / `is_data_key_envelope` are untouched: the marker still requires exactly the original seven fields and ignores unknown ones, so SSE mixed-format routing is unchanged in both directions.

Also includes a standalone first commit repairing `cargo test -p rustfs-kms` compilation on main: #5472 added an `attempt_timeout` parameter to `VaultKmsClient::new` while #5474 landed tests still using the one-argument form; the two merged independently and the combination does not compile.

## Verification

- `cargo fmt --all` - clean
- `cargo test -p rustfs-kms` - 141 passed / 0 failed / 7 ignored (139 baseline after the compile repair, +2 new tests)
- `cargo clippy -p rustfs-kms --all-targets -- -D warnings` - clean
- `make pre-commit` - all checks passed

New/extended tests:
- legacy envelope JSON (no field) deserializes to `master_key_version: None` (both timestamp formats)
- `None` serializes without the field and keeps the seven-key JSON object shape
- `Some(7)` round-trips through JSON
- discriminator accepts both legacy and versioned envelopes, still rejects MinIO-legacy/base64/duplicate-key/missing-field payloads

## Impact

No behavior change. Every envelope produced by this build is byte-identical to before; envelopes with the new field are only produced by the follow-up PR. Old binaries reading a versioned envelope ignore the unknown field, which is only safe while no rotation has occurred - the follow-up PR therefore documents "do not rotate until the whole cluster is upgraded" as a hard operational constraint.

## Additional Notes

Stacked series for backlog#1565 (Wave 2): PR-2 (versioned KV2 material storage + rotation reopen) is based on this branch.
