### PR TITLE
fix(kms): pass attempt timeout in vault kv2 tests

### DIFF
--- a/crates/kms/src/backends/vault.rs
+++ b/crates/kms/src/backends/vault.rs
@@ -938,7 +938,9 @@ mod tests {
     async fn test_vault_kv2_rotate_key_rejected_without_touching_storage() {
         // No Vault instance needed: rotation must be rejected before any storage access,
         // so the call cannot read or overwrite key material.
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let err = client
             .rotate_key("any-key", None)
@@ -950,7 +952,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_vault_kv2_backend_info_reports_at_rest_protection() {
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let info = client.backend_info();
         assert_eq!(info.backend_type, "vault-kv2");
@@ -962,7 +966,9 @@ mod tests {
     #[tokio::test]
     #[ignore] // Requires a running Vault instance (dev mode)
     async fn test_vault_kv2_rotate_rejected_and_material_untouched() {
-        let client = VaultKmsClient::new(integration_vault_config()).await.expect("client");
+        let client = VaultKmsClient::new(integration_vault_config(), Duration::from_secs(30))
+            .await
+            .expect("client");
 
         let key_id = format!("rotate-{}", uuid::Uuid::new_v4());
         client.create_key(&key_id, "AES_256", None).await.expect("create");


### PR DESCRIPTION
## Summary

`cargo test -p rustfs-kms` fails to compile on current main (d4f2efa2ad) with three E0061 errors in `crates/kms/src/backends/vault.rs`.

#5472 changed `VaultKmsClient::new` to require an `attempt_timeout: Duration` parameter, while #5474 (developed in parallel, merged after) added three tests that still call the old single-argument signature at lines 941/953/965.

This PR updates the three call sites to pass `Duration::from_secs(30)`, matching the timeout used by the other integration tests in the same file after #5472.

## Testing

- `cargo test -p rustfs-kms`: 139 passed, 0 failed, 7 ignored
- `make pre-commit`: all checks passed