### PR TITLE
feat(kms): Vault Agent token file authentication and credential runbook

### DIFF
--- a/crates/kms/src/api_types.rs
+++ b/crates/kms/src/api_types.rs
@@ -249,6 +249,13 @@ enum StrictVaultAuthMethod {
         #[serde(default)]
         refresh_safety_window_secs: Option<u64>,
     },
+    TokenFile {
+        path: std::path::PathBuf,
+        #[serde(default)]
+        poll_interval_secs: Option<u64>,
+        #[serde(default)]
+        refresh_safety_window_secs: Option<u64>,
+    },
 }
 
 impl From<StrictVaultAuthMethod> for VaultAuthMethod {
@@ -266,6 +273,15 @@ impl From<StrictVaultAuthMethod> for VaultAuthMethod {
                 secret_id,
                 secret_id_file,
                 mount: mount.unwrap_or_else(|| crate::config::DEFAULT_VAULT_APPROLE_MOUNT.to_string()),
+                refresh_safety_window_secs,
+            },
+            StrictVaultAuthMethod::TokenFile {
+                path,
+                poll_interval_secs,
+                refresh_safety_window_secs,
+            } => Self::TokenFile {
+                path,
+                poll_interval_secs,
                 refresh_safety_window_secs,
             },
         }
@@ -427,6 +443,7 @@ impl From<&KmsConfig> for KmsConfigSummary {
                 auth_method_type: match &vault_config.auth_method {
                     VaultAuthMethod::Token { .. } => "token".to_string(),
                     VaultAuthMethod::AppRole { .. } => "approle".to_string(),
+                    VaultAuthMethod::TokenFile { .. } => "token_file".to_string(),
                 },
                 has_stored_credentials: true,
                 namespace: vault_config.namespace.clone(),
@@ -440,6 +457,7 @@ impl From<&KmsConfig> for KmsConfigSummary {
                 auth_method_type: match &vault_config.auth_method {
                     VaultAuthMethod::Token { .. } => "token".to_string(),
                     VaultAuthMethod::AppRole { .. } => "approle".to_string(),
+                    VaultAuthMethod::TokenFile { .. } => "token_file".to_string(),
                 },
                 has_stored_credentials: true,
                 namespace: vault_config.namespace.clone(),

--- a/crates/kms/src/backends/vault_credentials.rs
+++ b/crates/kms/src/backends/vault_credentials.rs
@@ -35,9 +35,10 @@ use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use sha2::Digest;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{info, warn};
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -52,6 +53,9 @@ type AttemptResult<T> = std::result::Result<T, AttemptError>;
 /// Cadence for refresh retries after a failed cycle (on top of the bounded
 /// retries inside one [`policy::execute`] call).
 const DEFAULT_REFRESH_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default seconds between token file re-reads for [`TokenFileSource`].
+const DEFAULT_TOKEN_FILE_POLL_INTERVAL_SECS: u64 = 30;
 
 /// A crate-owned secret value, zeroized on drop and redacted in Debug output.
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
@@ -147,8 +151,8 @@ fn attempt_error(operation: &str, error: vaultrs::error::ClientError) -> Attempt
 ///
 /// Implementations perform one attempt per call; bounded retries and backoff
 /// are owned by the caller through [`policy::execute`] with [`OpClass::Auth`].
-/// Current sources are [`StaticToken`] and [`AppRoleLogin`]; an agent-managed
-/// `TokenFile` source is planned as a follow-up.
+/// Current sources are [`StaticToken`], [`AppRoleLogin`], and the agent-managed
+/// [`TokenFileSource`].
 #[async_trait]
 pub(crate) trait TokenSource: fmt::Debug + Send + Sync {
     /// One login attempt yielding a token for a new client generation.
@@ -286,6 +290,124 @@ impl fmt::Debug for AppRoleLogin {
     }
 }
 
+/// Token source for [`VaultAuthMethod::TokenFile`]: reads an agent-managed
+/// token file (for example a Vault Agent auto-auth sink).
+///
+/// The agent owns the token's lifecycle; this source only tracks the file.
+/// Every read grants the token an observed validity of `validity`, so the
+/// renewal loop re-reads the file at half that interval and installs a new
+/// client generation from whatever the file holds. A file that disappears or
+/// turns empty keeps failing the refresh until the fail-closed window trips,
+/// and heals the provider as soon as it is restored.
+pub(crate) struct TokenFileSource {
+    path: PathBuf,
+    /// Observed validity granted per successful read; the renewal loop
+    /// re-reads at half this value.
+    validity: Duration,
+    /// Digest of the last token read, to tell agent-driven rotations apart
+    /// from plain refreshes in the logs. Never holds the token itself.
+    last_digest: std::sync::Mutex<Option<[u8; 32]>>,
+}
+
+impl TokenFileSource {
+    pub(crate) fn new(path: PathBuf, validity: Duration) -> Self {
+        Self {
+            path,
+            validity,
+            last_digest: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn fatal(error: KmsError) -> AttemptError {
+        AttemptError {
+            class: ErrorClass::Fatal,
+            error,
+        }
+    }
+
+    /// Reject a token file readable by group or other, mirroring the SFTP
+    /// host-key rule: a Vault token grants use of the KMS keys, so a mode
+    /// wider than owner-only is a deployment error, not a warning.
+    #[cfg(unix)]
+    fn check_permissions(&self, metadata: &std::fs::Metadata) -> AttemptResult<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            return Err(Self::fatal(KmsError::configuration_error(format!(
+                "Vault token file {} has insecure permissions {mode:#o} (group and other permission bits must be unset)",
+                self.path.display()
+            ))));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TokenSource for TokenFileSource {
+    async fn acquire(&self) -> AttemptResult<TokenLease> {
+        // Synchronous reads on purpose: the token file is tiny, this runs at
+        // the renewal cadence, and staying off the blocking pool keeps the
+        // paused-clock tests of the renewal timing deterministic.
+        let metadata = std::fs::metadata(&self.path).map_err(|error| {
+            Self::fatal(KmsError::configuration_error(format!(
+                "Failed to read Vault token file {}: {error}",
+                self.path.display()
+            )))
+        })?;
+        #[cfg(unix)]
+        self.check_permissions(&metadata)?;
+
+        let mut raw = std::fs::read_to_string(&self.path).map_err(|error| {
+            Self::fatal(KmsError::configuration_error(format!(
+                "Failed to read Vault token file {}: {error}",
+                self.path.display()
+            )))
+        })?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            raw.zeroize();
+            return Err(Self::fatal(KmsError::configuration_error(format!(
+                "Vault token file {} is empty",
+                self.path.display()
+            ))));
+        }
+
+        let digest: [u8; 32] = sha2::Sha256::digest(trimmed.as_bytes()).into();
+        let previous = self
+            .last_digest
+            .lock()
+            .expect("token file digest mutex poisoned")
+            .replace(digest);
+        if previous.is_some_and(|previous| previous != digest) {
+            info!(
+                path = %self.path.display(),
+                modified = ?metadata.modified().ok(),
+                "Vault token file rotated; installing a new client generation"
+            );
+        }
+
+        let token = trimmed.to_string();
+        raw.zeroize();
+        Ok(TokenLease::new(
+            token,
+            Some(LeaseInfo {
+                ttl: self.validity,
+                renewable: false,
+            }),
+        ))
+    }
+}
+
+impl fmt::Debug for TokenFileSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The token itself is never stored on the source; only its digest is.
+        f.debug_struct("TokenFileSource")
+            .field("path", &self.path)
+            .field("validity", &self.validity)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Map the configured auth method onto a token source.
 pub(crate) fn token_source_for(
     auth_method: &VaultAuthMethod,
@@ -306,6 +428,18 @@ pub(crate) fn token_source_for(
             secret_id.clone(),
             secret_id_file.clone(),
         )?)),
+        VaultAuthMethod::TokenFile {
+            path,
+            poll_interval_secs,
+            ..
+        } => {
+            let poll_interval = Duration::from_secs(poll_interval_secs.unwrap_or(DEFAULT_TOKEN_FILE_POLL_INTERVAL_SECS).max(1));
+            // Validity is twice the poll interval because the renewal loop
+            // fires at half the lease TTL: the file is then re-read once per
+            // poll interval, and a file that stops being readable expires the
+            // token after roughly two missed polls minus the safety window.
+            Ok(Box::new(TokenFileSource::new(path.clone(), poll_interval * 2)))
+        }
     }
 }
 
@@ -370,6 +504,10 @@ impl VaultCredentialPolicy {
         let retry = RetryPolicy::from_config(config);
         let safety_window = match auth_method {
             VaultAuthMethod::AppRole {
+                refresh_safety_window_secs: Some(secs),
+                ..
+            }
+            | VaultAuthMethod::TokenFile {
                 refresh_safety_window_secs: Some(secs),
                 ..
             } => Duration::from_secs(*secs),
@@ -1052,5 +1190,168 @@ mod tests {
         let approle_rendered = format!("{approle_source:?}");
         assert!(approle_rendered.contains("leak-test-role-id"), "role_id is not a secret");
         assert!(approle_rendered.contains(REDACTED_SECRET));
+    }
+
+    /// Write a token file with owner-only permissions, as a Vault Agent sink
+    /// would.
+    fn write_owner_only(path: &std::path::Path, contents: &str) {
+        std::fs::write(path, contents).expect("write token file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).expect("chmod token file");
+        }
+    }
+
+    async fn token_file_provider(path: std::path::PathBuf, policy: VaultCredentialPolicy) -> Arc<VaultCredentialProvider> {
+        Arc::new(
+            VaultCredentialProvider::new(test_settings(), Box::new(TokenFileSource::new(path, Duration::from_secs(60))), policy)
+                .await
+                .expect("token file provider must build without a live Vault"),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_token_file_source_reads_and_trims_token() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vault-token");
+        write_owner_only(&path, &format!("  {TEST_TOKEN}\n"));
+        let source = TokenFileSource::new(path, Duration::from_secs(60));
+
+        let lease = source.acquire().await.expect("readable token file must resolve");
+        assert_eq!(lease.expose(), TEST_TOKEN);
+        let lease_info = lease.lease_info().expect("token file leases carry an observed validity");
+        assert_eq!(lease_info.ttl, Duration::from_secs(60));
+        assert!(!lease_info.renewable, "agent-managed tokens are refreshed by re-reading, not renew-self");
+    }
+
+    #[tokio::test]
+    async fn test_token_file_missing_fails_fatally() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = TokenFileSource::new(dir.path().join("absent-token"), Duration::from_secs(60));
+
+        let failure = source.acquire().await.expect_err("missing token file must fail the attempt");
+        assert_eq!(failure.class, ErrorClass::Fatal);
+        assert!(matches!(failure.error, KmsError::ConfigurationError { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_token_file_empty_fails_fatally() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vault-token");
+        write_owner_only(&path, "  \n\t\n");
+        let source = TokenFileSource::new(path, Duration::from_secs(60));
+
+        let failure = source
+            .acquire()
+            .await
+            .expect_err("effectively empty token file must fail the attempt");
+        assert_eq!(failure.class, ErrorClass::Fatal);
+        assert!(failure.error.to_string().contains("is empty"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_token_file_rejects_group_or_other_permission_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vault-token");
+        write_owner_only(&path, TEST_TOKEN);
+        let source = TokenFileSource::new(path.clone(), Duration::from_secs(60));
+
+        for mode in [0o640u32, 0o604, 0o622, 0o660] {
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).expect("chmod");
+            let failure = source
+                .acquire()
+                .await
+                .expect_err("token file readable or writable beyond the owner must be rejected");
+            assert_eq!(failure.class, ErrorClass::Fatal, "mode {mode:#o}");
+            let rendered = failure.error.to_string();
+            assert!(rendered.contains("insecure permissions"), "mode {mode:#o}: {rendered}");
+            assert!(!rendered.contains(TEST_TOKEN), "permission errors must not echo the token");
+        }
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+        source.acquire().await.expect("owner-only token file must resolve");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_token_file_replacement_installs_new_generation_next_cycle() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vault-token");
+        write_owner_only(&path, "agent-token-v1");
+        let provider = token_file_provider(path.clone(), test_policy(Duration::from_secs(10), Duration::from_secs(5))).await;
+        let task = provider.spawn_renewal_task().expect("token file credentials are lease-bound");
+
+        tokio::time::sleep(Duration::from_secs(29)).await;
+        assert_eq!(provider.snapshot().generation, 0, "no re-read before half the observed validity");
+
+        // Atomic replacement, as a Vault Agent sink writes: temp file + rename.
+        let staged = dir.path().join("vault-token.tmp");
+        write_owner_only(&staged, "agent-token-v2");
+        std::fs::rename(&staged, &path).expect("atomic replace");
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert_eq!(
+            provider.snapshot().generation,
+            1,
+            "the poll after a rotation must install a new generation"
+        );
+
+        // A poll without a rotation still installs a fresh generation: each
+        // successful read re-extends the token's observed validity.
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        assert_eq!(provider.snapshot().generation, 2);
+
+        task.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_token_file_deletion_fails_closed_and_recovers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vault-token");
+        write_owner_only(&path, "agent-token-v1");
+        let provider = token_file_provider(path.clone(), test_policy(Duration::from_secs(10), Duration::from_secs(5))).await;
+        let task = provider.spawn_renewal_task().expect("renewal task");
+
+        std::fs::remove_file(&path).expect("remove token file");
+
+        // Polls at 30s, 35s, ... keep failing; the last read keeps the token
+        // usable until 50s (60s observed validity minus the 10s safety window).
+        tokio::time::sleep(Duration::from_secs(49)).await;
+        provider
+            .current()
+            .expect("token outside the safety window must still be served");
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let error = provider
+            .current()
+            .expect_err("token inside the safety window must be refused");
+        assert!(
+            matches!(error, KmsError::CredentialsUnavailable { .. }),
+            "expected CredentialsUnavailable, got {error:?}"
+        );
+
+        // Restoring the file heals the provider on the next retry cycle.
+        write_owner_only(&path, "agent-token-v2");
+        tokio::time::sleep(Duration::from_secs(6)).await;
+        let handle = provider.current().expect("provider must recover once the token file is back");
+        assert!(handle.generation >= 1);
+
+        task.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_token_file_debug_redacts_token() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vault-token");
+        write_owner_only(&path, TEST_TOKEN);
+        let source = TokenFileSource::new(path.clone(), Duration::from_secs(60));
+        source.acquire().await.expect("token file must resolve");
+
+        let rendered = format!("{source:?}");
+        assert!(!rendered.contains(TEST_TOKEN), "debug output must not leak the vault token: {rendered}");
+        assert!(rendered.contains("vault-token"), "the file path is not a secret");
     }
 }

--- a/crates/kms/src/config.rs
+++ b/crates/kms/src/config.rs
@@ -33,6 +33,7 @@ pub const ENV_KMS_VAULT_APPROLE_ROLE_ID: &str = "RUSTFS_KMS_VAULT_APPROLE_ROLE_I
 pub const ENV_KMS_VAULT_APPROLE_SECRET_ID: &str = "RUSTFS_KMS_VAULT_APPROLE_SECRET_ID";
 pub const ENV_KMS_VAULT_APPROLE_SECRET_ID_FILE: &str = "RUSTFS_KMS_VAULT_APPROLE_SECRET_ID_FILE";
 pub const ENV_KMS_VAULT_APPROLE_MOUNT: &str = "RUSTFS_KMS_VAULT_APPROLE_MOUNT";
+pub const ENV_KMS_VAULT_TOKEN_FILE: &str = "RUSTFS_KMS_VAULT_TOKEN_FILE";
 pub const DEFAULT_VAULT_TRANSIT_METADATA_KV_MOUNT: &str = "secret";
 pub const DEFAULT_VAULT_TRANSIT_METADATA_KEY_PREFIX: &str = "rustfs/kms/transit-metadata";
 pub const DEFAULT_VAULT_APPROLE_MOUNT: &str = "approle";
@@ -418,6 +419,22 @@ pub enum VaultAuthMethod {
         #[serde(default)]
         refresh_safety_window_secs: Option<u64>,
     },
+    /// Agent-managed token file (for example a Vault Agent auto-auth sink):
+    /// the token is read from `path` and re-read periodically so a token
+    /// rotated by the agent is picked up without a restart.
+    TokenFile {
+        path: PathBuf,
+        /// Seconds between token file re-reads. Each successful read also
+        /// extends the token's observed validity to twice this value, so a
+        /// file that stops being readable eventually trips the fail-closed
+        /// window. Defaults to 30 seconds.
+        #[serde(default)]
+        poll_interval_secs: Option<u64>,
+        /// Fail-closed margin in seconds, as on `AppRole`. Defaults to the
+        /// per-attempt timeout.
+        #[serde(default)]
+        refresh_safety_window_secs: Option<u64>,
+    },
 }
 
 impl VaultAuthMethod {
@@ -428,6 +445,15 @@ impl VaultAuthMethod {
             secret_id,
             secret_id_file: None,
             mount: default_vault_approle_mount(),
+            refresh_safety_window_secs: None,
+        }
+    }
+
+    /// Agent-managed token file with the default poll interval.
+    pub fn token_file(path: PathBuf) -> Self {
+        Self::TokenFile {
+            path,
+            poll_interval_secs: None,
             refresh_safety_window_secs: None,
         }
     }
@@ -449,6 +475,16 @@ impl fmt::Debug for VaultAuthMethod {
                 .field("secret_id", &redacted_secret(secret_id))
                 .field("secret_id_file", secret_id_file)
                 .field("mount", mount)
+                .field("refresh_safety_window_secs", refresh_safety_window_secs)
+                .finish(),
+            Self::TokenFile {
+                path,
+                poll_interval_secs,
+                refresh_safety_window_secs,
+            } => f
+                .debug_struct("TokenFile")
+                .field("path", path)
+                .field("poll_interval_secs", poll_interval_secs)
                 .field("refresh_safety_window_secs", refresh_safety_window_secs)
                 .finish(),
         }
@@ -935,6 +971,23 @@ fn is_under_temp_dir(path: &Path) -> bool {
 /// precedent) or inline from `RUSTFS_KMS_VAULT_APPROLE_SECRET_ID`, with the
 /// file taking precedence. Without a role id the legacy token flow applies.
 fn vault_auth_method_from_env() -> Result<VaultAuthMethod> {
+    if let Some(token_file) = get_env_opt_str(ENV_KMS_VAULT_TOKEN_FILE) {
+        // A token file names one authoritative credential source; combining it
+        // with another one would leave the effective identity ambiguous, so
+        // that is a configuration error rather than a precedence rule.
+        if get_env_opt_str(ENV_KMS_VAULT_APPROLE_ROLE_ID).is_some() {
+            return Err(KmsError::configuration_error(format!(
+                "{ENV_KMS_VAULT_TOKEN_FILE} cannot be combined with {ENV_KMS_VAULT_APPROLE_ROLE_ID}; configure exactly one Vault auth method"
+            )));
+        }
+        if get_env_opt_str("RUSTFS_KMS_VAULT_TOKEN").is_some() {
+            return Err(KmsError::configuration_error(format!(
+                "{ENV_KMS_VAULT_TOKEN_FILE} cannot be combined with RUSTFS_KMS_VAULT_TOKEN; configure exactly one Vault auth method"
+            )));
+        }
+        return Ok(VaultAuthMethod::token_file(PathBuf::from(token_file)));
+    }
+
     let Some(role_id) = get_env_opt_str(ENV_KMS_VAULT_APPROLE_ROLE_ID) else {
         return Ok(VaultAuthMethod::Token {
             token: get_env_str("RUSTFS_KMS_VAULT_TOKEN", "dev-token"),
@@ -978,6 +1031,21 @@ fn validate_vault_auth_method(backend_name: &str, auth_method: &VaultAuthMethod)
             }
             if mount.is_empty() {
                 return Err(KmsError::configuration_error(format!("{backend_name} AppRole mount cannot be empty")));
+            }
+            Ok(())
+        }
+        VaultAuthMethod::TokenFile {
+            path,
+            poll_interval_secs,
+            ..
+        } => {
+            if path.as_os_str().is_empty() {
+                return Err(KmsError::configuration_error(format!("{backend_name} token file path cannot be empty")));
+            }
+            if poll_interval_secs == &Some(0) {
+                return Err(KmsError::configuration_error(format!(
+                    "{backend_name} token file poll interval must be greater than 0"
+                )));
             }
             Ok(())
         }
@@ -1486,6 +1554,92 @@ mod tests {
                 assert!(error.to_string().contains(ENV_KMS_VAULT_APPROLE_SECRET_ID));
             },
         );
+    }
+
+    #[test]
+    fn test_from_env_selects_token_file() {
+        with_vars(
+            vec![
+                ("RUSTFS_KMS_BACKEND", Some("vault")),
+                ("RUSTFS_KMS_VAULT_ADDRESS", Some("https://vault.example.com")),
+                (ENV_KMS_VAULT_TOKEN_FILE, Some("/run/vault-agent/token")),
+            ],
+            || {
+                let config = KmsConfig::from_env().expect("kms config should load from env");
+                let vault = config.vault_config().expect("vault backend config");
+                let VaultAuthMethod::TokenFile {
+                    path,
+                    poll_interval_secs,
+                    refresh_safety_window_secs,
+                } = &vault.auth_method
+                else {
+                    panic!("token file in the environment must select TokenFile auth, got {:?}", vault.auth_method);
+                };
+                assert_eq!(path, std::path::Path::new("/run/vault-agent/token"));
+                assert_eq!(poll_interval_secs, &None);
+                assert_eq!(refresh_safety_window_secs, &None);
+            },
+        );
+    }
+
+    #[test]
+    fn test_from_env_token_file_is_mutually_exclusive_with_other_auth() {
+        with_vars(
+            vec![
+                ("RUSTFS_KMS_BACKEND", Some("vault")),
+                (ENV_KMS_VAULT_TOKEN_FILE, Some("/run/vault-agent/token")),
+                (ENV_KMS_VAULT_APPROLE_ROLE_ID, Some("env-role-id")),
+            ],
+            || {
+                let error = KmsConfig::from_env().expect_err("token file combined with approle must be rejected");
+                assert!(error.to_string().contains(ENV_KMS_VAULT_TOKEN_FILE));
+                assert!(error.to_string().contains(ENV_KMS_VAULT_APPROLE_ROLE_ID));
+            },
+        );
+
+        with_vars(
+            vec![
+                ("RUSTFS_KMS_BACKEND", Some("vault-transit")),
+                (ENV_KMS_VAULT_TOKEN_FILE, Some("/run/vault-agent/token")),
+                ("RUSTFS_KMS_VAULT_TOKEN", Some("vault-token")),
+            ],
+            || {
+                let error = KmsConfig::from_env().expect_err("token file combined with a static token must be rejected");
+                assert!(error.to_string().contains(ENV_KMS_VAULT_TOKEN_FILE));
+                assert!(error.to_string().contains("RUSTFS_KMS_VAULT_TOKEN"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_bad_token_file_settings() {
+        let vault_config = |auth_method: VaultAuthMethod| KmsConfig {
+            backend: KmsBackend::VaultKv2,
+            backend_config: BackendConfig::VaultKv2(Box::new(VaultConfig {
+                address: "https://vault.example.com:8200".to_string(),
+                auth_method,
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let error = vault_config(VaultAuthMethod::token_file(PathBuf::new()))
+            .validate()
+            .expect_err("empty token file path must be rejected");
+        assert!(error.to_string().contains("path"));
+
+        let error = vault_config(VaultAuthMethod::TokenFile {
+            path: PathBuf::from("/run/vault-agent/token"),
+            poll_interval_secs: Some(0),
+            refresh_safety_window_secs: None,
+        })
+        .validate()
+        .expect_err("zero poll interval must be rejected");
+        assert!(error.to_string().contains("poll interval"));
+
+        vault_config(VaultAuthMethod::token_file(PathBuf::from("/run/vault-agent/token")))
+            .validate()
+            .expect("well-formed token file auth must validate");
     }
 
     #[test]

--- a/docs/operations/kms-backend-security.md
+++ b/docs/operations/kms-backend-security.md
@@ -2,6 +2,8 @@
 
 RustFS ships several KMS backends. They differ not only in deployment effort but in **where master key material lives and who can read it**. Pick a backend based on the confidentiality boundary you need, not on the name alone.
 
+For how the Vault backends authenticate (static token, AppRole, Vault Agent token file) and how credential refresh and the fail-closed window behave, see the [Vault KMS authentication runbook](vault-kms-authentication.md).
+
 ## Backend comparison
 
 | Backend | Config tag | Master key material location | At-rest protection of key material | Durability | Rotation | Intended use |

--- a/docs/operations/vault-kms-authentication.md
+++ b/docs/operations/vault-kms-authentication.md
@@ -1,0 +1,122 @@
+# Vault KMS authentication runbook
+
+This runbook covers how the RustFS Vault KMS backends (KV2 and Transit) authenticate to Vault, how to deploy AppRole and Vault Agent token-file authentication, and how the fail-closed credential window behaves in production. For what each backend stores in Vault and the KV2/Transit policy scopes, see [KMS backend security properties](kms-backend-security.md).
+
+## Choosing an authentication method
+
+| Method | Config tag | Credential lifetime | Background renewal | Recommended for |
+| --- | --- | --- | --- | --- |
+| Static token | `Token` | Whatever the operator provisioned; RustFS never renews it | None | Development; short-lived experiments |
+| AppRole | `AppRole` | Lease-bound token obtained by login; renewed by RustFS | Renew at half TTL, re-login on failure | Production without a Vault Agent sidecar |
+| Agent token file | `TokenFile` | Owned by Vault Agent; RustFS only re-reads the sink file | File re-read once per poll interval | Production with a Vault Agent (or equivalent) managing auth |
+
+Exactly one method must be configured. Setting `RUSTFS_KMS_VAULT_TOKEN_FILE` together with `RUSTFS_KMS_VAULT_APPROLE_ROLE_ID` or an explicit `RUSTFS_KMS_VAULT_TOKEN` is rejected at startup with a configuration error, because the effective identity would be ambiguous.
+
+The default `dev-token` fallback for `RUSTFS_KMS_VAULT_TOKEN` is rejected outside explicit development mode (`RUSTFS_KMS_ALLOW_INSECURE_DEV_DEFAULTS=true`), as are plain-HTTP Vault addresses and disabled TLS verification.
+
+## AppRole authentication
+
+### Vault-side setup
+
+Create a policy scoped to exactly what the backend needs (see the KV2 and Transit policy examples in [KMS backend security properties](kms-backend-security.md)), then an AppRole that issues tokens carrying it:
+
+```shell
+vault policy write rustfs-kms rustfs-kms-policy.hcl
+
+vault auth enable approle
+
+vault write auth/approle/role/rustfs-kms \
+    token_policies="rustfs-kms" \
+    token_ttl=1h \
+    token_max_ttl=24h \
+    secret_id_ttl=90d \
+    secret_id_num_uses=0
+```
+
+Keep `token_ttl` comfortably above the RustFS per-attempt timeout (default 30s): the fail-closed window defaults to one attempt timeout, so a token TTL close to it leaves almost no usable lifetime.
+
+### RustFS configuration
+
+```shell
+RUSTFS_KMS_BACKEND=vault-transit            # or "vault" for the KV2 backend
+RUSTFS_KMS_VAULT_ADDRESS=https://vault.example.com:8200
+RUSTFS_KMS_VAULT_APPROLE_ROLE_ID=<role-id>
+RUSTFS_KMS_VAULT_APPROLE_SECRET_ID_FILE=/etc/rustfs/approle-secret-id
+# Alternatively, inline (the file takes precedence when both are set):
+# RUSTFS_KMS_VAULT_APPROLE_SECRET_ID=<secret-id>
+# Optional, defaults to "approle":
+# RUSTFS_KMS_VAULT_APPROLE_MOUNT=approle
+```
+
+RustFS logs in at startup, then renews the token at half its TTL in the background. If renewal fails (network, Vault sealed, token revoked), it falls back to a full re-login; if that also fails, it keeps retrying every few seconds until Vault recovers.
+
+### SecretID delivery and rotation
+
+Deliver the SecretID out of band — a secrets-manager-mounted file, an init-container writing `RUSTFS_KMS_VAULT_APPROLE_SECRET_ID_FILE`, or Vault response wrapping unwrapped by your deployment tooling. Treat it like a password: owner-readable file permissions, never in logs or shell history.
+
+The secret_id file is re-read on every login attempt, so rotating the SecretID is a two-step operation with no restart: generate a new SecretID (`vault write -f auth/approle/role/rustfs-kms/secret-id`), atomically replace the file, then revoke the old SecretID accessor. The already-issued token keeps renewing; the new SecretID is only needed at the next full re-login.
+
+An empty or missing secret_id file fails the login attempt immediately (no Vault round trip) and is retried on the normal refresh cadence, so repairing the file heals the backend without a restart.
+
+## Vault Agent token file
+
+In this mode a Vault Agent (or any equivalent process) owns authentication and token renewal, and RustFS only reads the token sink file.
+
+### Vault Agent example
+
+```hcl
+auto_auth {
+  method "approle" {
+    config = {
+      role_id_file_path   = "/etc/vault-agent/role-id"
+      secret_id_file_path = "/etc/vault-agent/secret-id"
+    }
+  }
+
+  sink "file" {
+    config = {
+      path = "/run/vault-agent/token"
+      mode = 0600
+    }
+  }
+}
+```
+
+### RustFS configuration
+
+```shell
+RUSTFS_KMS_BACKEND=vault-transit
+RUSTFS_KMS_VAULT_ADDRESS=https://vault.example.com:8200
+RUSTFS_KMS_VAULT_TOKEN_FILE=/run/vault-agent/token
+```
+
+The poll interval (`poll_interval_secs` in the `TokenFile` auth configuration, default 30 seconds) controls how often the file is re-read. Each successful read grants the token an observed validity of twice the poll interval and installs a fresh client generation, so an agent-rotated token is picked up within one poll interval of the atomic replace.
+
+Requirements enforced at every read, each failing the refresh without contacting Vault:
+
+- The file must exist and be non-empty after trimming whitespace.
+- On Unix, the file must not be readable or writable by group or other (mode `0600` or stricter). Wider permissions are a hard error naming the offending mode, mirroring the SFTP host-key rule. RustFS must run as the file's owner.
+
+If the agent stops refreshing the file that is fine — RustFS re-reads the same token and keeps going as long as the token itself is valid on the Vault side. If the file disappears or turns empty, RustFS keeps serving requests on the last-read token until the fail-closed window trips, and heals automatically once the file is restored.
+
+## Fail-closed window
+
+For lease-bound credentials (AppRole tokens, token files), `current()` refuses to hand out a token that is within the safety window of its expiry and has not been refreshed. Requests then fail with `KMS credentials unavailable: ...` instead of being sent with a token that could lapse mid-flight and fail unpredictably on the Vault side.
+
+- Default window: one per-attempt timeout (`RUSTFS_KMS_TIMEOUT_SECS`, default 30s) — a request issued now can legitimately stay in flight that long, so the token must outlive it.
+- Override: `refresh_safety_window_secs` on the `AppRole` or `TokenFile` auth configuration.
+- Static tokens never trip the window: they carry no lease and are assumed valid until Vault says otherwise.
+
+The window is a symptom threshold, not the fault itself: by the time it trips, refresh has been failing for roughly half the token TTL (AppRole) or two poll intervals (token file).
+
+### Troubleshooting
+
+| Symptom | Log line to look for | Likely cause and fix |
+| --- | --- | --- |
+| Requests fail with `KMS credentials unavailable` | `Vault credential refresh failed; retrying until the credentials recover` (warn, repeated) | Vault unreachable/sealed, or the credential source is broken; the provider recovers on its own once refresh succeeds — fix the cause, no restart needed |
+| Renewal succeeded but re-login later fails | `Vault token renewal failed; falling back to a fresh login` followed by login errors | SecretID expired/revoked or AppRole role changed; rotate the secret_id file |
+| Token file mode error at startup or during polls | `has insecure permissions` in the error | Fix the sink `mode` (0600) and the file owner; the next poll heals the provider |
+| Token file missing/empty errors | `Failed to read Vault token file` / `token file ... is empty` | Vault Agent down or sink misconfigured; restart the agent, the next poll heals the provider |
+| Startup fails immediately with a configuration error naming two env vars | — | Two auth methods configured at once; keep exactly one of token, AppRole, token file |
+
+When diagnosing, confirm three clocks/lifetimes in order: the Vault token TTL (`vault token lookup` with the token's accessor), the RustFS refresh cadence (half TTL or the poll interval), and the fail-closed window. The renewal task logs every failed cycle, so a silent gap in warnings combined with `CredentialsUnavailable` errors points at the process clock or a paused runtime rather than Vault.


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1570 (part of rustfs/backlog#1562). Stacked on #5487 (AppRole login + renewal); this PR's base is `overtrue/kms-1570-approle-renewal` and retargets to `main` automatically once #5487 merges.

## Summary of Changes

Third and final slice of the credential-provider series: Vault Agent token-file authentication plus the operations runbook.

`TokenFileSource` (`backends/vault_credentials.rs`):

- Reads the token from an agent-managed sink file. The agent owns the token's lifecycle; RustFS only tracks the file, reusing the existing renewal loop as the poll driver: each successful read grants an observed validity of twice the poll interval, so the loop re-reads the file once per poll interval (default 30s, `poll_interval_secs`) and installs a fresh client generation from whatever the file holds. An agent-rotated token is therefore picked up within one poll of the atomic replace, with no inotify machinery.
- Strict reads that never contact Vault on failure: whole file into memory then trimmed; empty or whitespace-only content is rejected; on Unix, group/other permission bits are a hard error naming the offending mode (following the SFTP host-key precedent of rejecting rather than warning). A missing/empty/over-permissive file keeps failing the refresh until the fail-closed window trips — same semantics as PR-2 — and the provider heals on the first successful re-read after the file is restored.
- Rotation detection uses a SHA-256 content digest (mtime is logged but not trusted for detection: its granularity is filesystem-dependent, and an atomic rename can carry an older mtime); the token itself is never stored on the source, and the crate-owned copy is zeroized on drop.

Configuration (`config.rs`, `api_types.rs`):

- New `VaultAuthMethod::TokenFile { path, poll_interval_secs, refresh_safety_window_secs }` variant, all optional fields `serde(default)`; accepted by the strict admin-configure deserializer; reported as `token_file` in status summaries.
- New env var `RUSTFS_KMS_VAULT_TOKEN_FILE` (follows the existing `_FILE` naming precedent). Combining it with `RUSTFS_KMS_VAULT_APPROLE_ROLE_ID` or an explicit `RUSTFS_KMS_VAULT_TOKEN` is a configuration error naming both variables — one authoritative credential source only.
- `validate()` rejects an empty path and a zero poll interval.

Runbook (`docs/operations/vault-kms-authentication.md`, linked from `kms-backend-security.md`): choosing between static token / AppRole / Agent token file, AppRole role setup with minimal-policy pointers, SecretID delivery and restart-free rotation, Vault Agent sink deployment with the permission requirements, fail-closed window semantics, and a troubleshooting table keyed on the renewal task's log lines.

## Verification

- `cargo fmt --all` — clean (verified via pre-commit fmt-check)
- `cargo test -p rustfs-kms` — 170 passed / 0 failed / 7 ignored
- `cargo clippy -p rustfs-kms --all-targets -- -D warnings` — clean
- `make pre-commit` — all checks passed (quick-check also compiles the main `rustfs` crate)

New tests (paused clock + temp directories, zero real Vault, zero real sleeps): read-and-trim with lease attributes; missing/empty-file negatives; Unix permission matrix (0640/0604/0622/0660 rejected, 0600 accepted, error never echoes the token); atomic replacement (temp file + rename) installs a new generation on the next poll and a poll without rotation still re-extends validity; deletion fails closed exactly at validity minus safety window and recovers after restore; Debug leak regression for the source. Plus config tests for env selection, mutual exclusion, and validation.

## Impact

- New opt-in auth method; existing token and AppRole configurations are unaffected.
- New failure mode only for token-file deployments: startup or refresh fails on over-permissive/missing/empty token files (previously the variant did not exist). Fail-closed behavior matches the AppRole semantics from #5487.
- The mutual-exclusion check only triggers when `RUSTFS_KMS_VAULT_TOKEN_FILE` is set, so no existing environment combination changes behavior.

## Additional Notes

- Token-file polling deliberately reinstalls a client generation on every successful poll (not only on rotation): each read is what re-extends the token's observed validity, which is what makes deletion eventually trip the fail-closed window. Rebuilding the reqwest client at this cadence is negligible.
- File reads are synchronous (`std::fs`) by design: the file is tiny, reads run at poll cadence off the request path, and staying off the blocking pool keeps the paused-clock timing tests deterministic.
