### PR TITLE
fix(iam): separate OIDC role and claim policies

### DIFF
--- a/crates/iam/src/oidc.rs
+++ b/crates/iam/src/oidc.rs
@@ -1139,8 +1139,11 @@ impl OidcSys {
         let mut policies = Vec::new();
         let mut groups = Vec::new();
 
-        // Add default role policy if configured
-        if !config.role_policy.is_empty() {
+        // Role-policy and claim-based authorization are separate OIDC modes. When a
+        // role policy is configured, group claims still provide group context but
+        // must not also become policy names.
+        let has_role_policy = !config.role_policy.trim().is_empty();
+        if has_role_policy {
             for policy in config.role_policy.split(',') {
                 let policy = policy.trim();
                 if !policy.is_empty() {
@@ -1149,21 +1152,20 @@ impl OidcSys {
             }
         }
 
-        // Map groups claim to policies
         for group in &claims.groups {
             groups.push(group.clone());
-            let policy_name = if config.claim_prefix.is_empty() {
-                group.clone()
-            } else {
-                format!("{}{}", config.claim_prefix, group)
-            };
-            policies.push(policy_name);
+            if !has_role_policy {
+                let policy_name = if config.claim_prefix.is_empty() {
+                    group.clone()
+                } else {
+                    format!("{}{}", config.claim_prefix, group)
+                };
+                policies.push(policy_name);
+            }
         }
 
-        // Map primary claim (if different from groups)
-        if config.claim_name != config.groups_claim {
-            let claim_values = extract_groups_claim(&claims.raw, &config.claim_name);
-            for val in claim_values {
+        if !has_role_policy && config.claim_name != config.groups_claim {
+            for val in extract_groups_claim(&claims.raw, &config.claim_name) {
                 let policy_name = if config.claim_prefix.is_empty() {
                     val
                 } else {
@@ -3201,26 +3203,22 @@ mod tests {
     }
 
     #[test]
-    fn test_map_claims_to_policies_with_provider() {
-        let mut config = test_config("okta");
-        config.role_policy = "readwrite".to_string();
-        config.display_name = "Okta".to_string();
+    fn role_policy_does_not_map_groups_as_policies() {
+        let mut config = test_config("authentik");
+        config.role_policy = "consoleAdmin".to_string();
+        config.claim_name = "policy".to_string();
 
         let sys = make_test_sys(vec![config]);
 
         let claims = OidcClaims {
-            sub: "user123".to_string(),
-            email: "user@example.com".to_string(),
-            username: "user".to_string(),
-            groups: vec!["admin".to_string(), "devs".to_string()],
-            raw: HashMap::new(),
+            groups: vec!["authentik Admins".to_string(), "users".to_string()],
+            raw: HashMap::from([("policy".to_string(), serde_json::json!(["readonly"]))]),
+            ..Default::default()
         };
 
-        let (policies, groups) = sys.map_claims_to_policies("okta", &claims);
-        assert_eq!(groups, vec!["admin", "devs"]);
-        assert!(policies.contains(&"readwrite".to_string()));
-        assert!(policies.contains(&"admin".to_string()));
-        assert!(policies.contains(&"devs".to_string()));
+        let (policies, groups) = sys.map_claims_to_policies("authentik", &claims);
+        assert_eq!(groups, vec!["authentik Admins", "users"]);
+        assert_eq!(policies, vec!["consoleAdmin"]);
     }
 
     #[test]
@@ -3243,6 +3241,39 @@ mod tests {
         assert_eq!(groups, vec!["engineers"]);
         assert!(policies.contains(&"oidc-engineers".to_string()));
         assert_eq!(policies.len(), 1);
+    }
+
+    #[test]
+    fn blank_role_policy_uses_claim_mapping() {
+        let mut config = test_config("keycloak");
+        config.role_policy = "   ".to_string();
+
+        let sys = make_test_sys(vec![config]);
+        let claims = OidcClaims {
+            groups: vec!["readonly".to_string()],
+            ..Default::default()
+        };
+
+        let (policies, groups) = sys.map_claims_to_policies("keycloak", &claims);
+        assert_eq!(groups, vec!["readonly"]);
+        assert_eq!(policies, vec!["readonly"]);
+    }
+
+    #[test]
+    fn claim_mapping_keeps_groups_with_distinct_primary_claim() {
+        let mut config = test_config("keycloak");
+        config.claim_name = "policy".to_string();
+
+        let sys = make_test_sys(vec![config]);
+        let claims = OidcClaims {
+            groups: vec!["developers".to_string()],
+            raw: HashMap::from([("policy".to_string(), serde_json::json!(["readonly"]))]),
+            ..Default::default()
+        };
+
+        let (policies, groups) = sys.map_claims_to_policies("keycloak", &claims);
+        assert_eq!(groups, vec!["developers"]);
+        assert_eq!(policies, vec!["developers", "readonly"]);
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Fixes #5477.

## Summary of Changes

- Treat configured OIDC role policies as the exclusive source of direct policy names.
- Preserve OIDC group claims as group authorization context without also interpreting ordinary Authentik group names as RustFS policies in role-policy mode.
- Preserve existing claim-based policy mapping when `role_policy` is unset or blank.
- Add regression coverage for Authentik role-policy logins, blank role policies, and distinct primary policy claims.

## Verification

- `make pre-commit` — passed.
- `cargo nextest run -p rustfs-iam` — 204 tests passed.
- Focused federated identity tests — passed.
- `make pre-pr` — Clippy and guard scripts passed; the test phase stopped after 5,118 passes because `rustfs-ecstore layout::endpoints::test::create_server_endpoints_bounds_kubernetes_alias_dns_fallback` failed in the local VPN/DNS environment. The machine resolves `unrelated-0.example.invalid` to the Fake-IP address `198.18.1.134`, while the unrelated test requires `.invalid` to return NXDOMAIN. No OIDC/IAM test failed; 6,308 tests were not run after nextest fail-fast cancellation.

## Impact

Restores Authentik OIDC login when `role_policy` names a valid RustFS policy but the user's ordinary Authentik groups do not correspond to RustFS policy names. Existing claim-based mapping remains unchanged when no role policy is configured. There are no API, configuration-format, persistence-format, or migration changes.

## Additional Notes

- The existing fail-closed requirement that every selected policy resolve remains unchanged.
- Correctness: attacked role/claim mode selection, whitespace and malformed role values, prefixes, duplicates, and missing providers; no break found.
- Simplicity: attacked control-flow size, helper reuse, branch necessity, comments, and test duplication; no smaller equivalent change found.
- Security: attacked privilege escalation, claim injection/confusion, fail-open paths, policy-resolution bypass, and secret handling; no break found.
- Concurrency/durability: the changed mapping is synchronous and local, with no locks, I/O, cancellation, persistence, or ordering changes; no break found.
- Compatibility: checked MinIO role-policy semantics, Authentik groups, existing RustFS claim configurations, persisted/wire formats, and mixed versions; no break found.
- Performance: compared per-login allocations, cloning, sorting, logging, and blocking work; role mode performs less claim-policy work and no regression was found.
- Test coverage: mutation-mapped every changed behavioral branch to an exact regression assertion; no remaining gap found.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
