### PR TITLE
fix(admin): keep data usage endpoint available

### DIFF
--- a/rustfs/src/app/admin_usecase.rs
+++ b/rustfs/src/app/admin_usecase.rs
@@ -276,10 +276,8 @@ impl DefaultAdminUsecase {
             .await
             .map_err(|_| Self::app_error(S3ErrorCode::InternalError, "list_bucket failed"))?;
         if !Self::data_usage_snapshot_covers_namespace(&info, buckets.into_iter().map(|bucket| bucket.name)) {
-            return Err(Self::app_error(
-                S3ErrorCode::ServiceUnavailable,
-                "authoritative data usage snapshot is not available yet",
-            ));
+            // The default wire shape distinguishes unknown usage from a confirmed zero snapshot.
+            info = DataUsageInfo::default();
         }
 
         let storage_info = StorageAdminApi::storage_info(store.as_ref()).await;

--- a/rustfs/src/app/data_usage_snapshot_gating_test.rs
+++ b/rustfs/src/app/data_usage_snapshot_gating_test.rs
@@ -274,9 +274,20 @@ async fn data_usage_endpoint_treats_legacy_partial_stats_as_unknown_until_covere
     let before_endpoint = live_bucket_usage_computations();
     let unknown = DefaultAdminUsecase::query_data_usage_info_with_store(ecstore.clone())
         .await
-        .expect_err("an uncovered snapshot must be reported as temporarily unavailable");
+        .expect("an uncovered snapshot must be reported as unknown without failing the endpoint");
 
-    assert_eq!(unknown.code, s3s::S3ErrorCode::ServiceUnavailable);
+    assert!(unknown.last_update.is_none());
+    assert!(!unknown.usage_snapshot_complete);
+    assert_eq!(unknown.buckets_count, 0);
+    assert_eq!(unknown.objects_total_count, 0);
+    assert_eq!(unknown.objects_total_size, 0);
+    assert!(unknown.buckets_usage.is_empty());
+    assert!(unknown.bucket_sizes.is_empty());
+    assert!(unknown.total_capacity > 0);
+    assert_eq!(
+        unknown.total_used_capacity,
+        unknown.total_capacity.saturating_sub(unknown.total_free_capacity)
+    );
     assert_eq!(
         live_bucket_usage_computations(),
         before_endpoint,


### PR DESCRIPTION
## Related Issues

Fixes #5476

## Summary of Changes

- Keep `GET /rustfs/admin/v3/datausageinfo` available while the first authoritative scanner snapshot is still pending.
- Return the established unknown-usage wire shape (`last_update: null`, empty usage maps, and `usage_snapshot_complete: false`) instead of a 503 response.
- Preserve real capacity reporting, authoritative snapshot gating, and the prohibition on request-time full object listings.
- Add regression coverage proving incomplete legacy snapshots are sanitized and complete snapshots resume reporting authoritative usage.

## Verification

- `make pre-commit` — passed.
- `cargo nextest run -p rustfs data_usage_endpoint_treats_legacy_partial_stats_as_unknown_until_covered --no-capture` — passed.
- `cargo nextest run -p rustfs object_lambda_client_preserves_hostname_for_tls_sni --no-capture` — passed.
- `make pre-pr` — the default concurrent run was blocked by an unrelated Object Lambda TLS/SNI timeout; the failing test passed in isolation.
- `NEXTEST_TEST_THREADS=1 make pre-pr` — 5,105 tests passed before an unrelated macOS-specific DNS fallback assertion failed in `rustfs-ecstore layout::endpoints::test::create_server_endpoints_bounds_kubernetes_alias_dns_fallback`; the failure reproduces in isolation on the current main branch because macOS reports the unresolvable `.invalid` hosts as non-local instead of returning the expected resolver error.

## Impact

The admin data-usage endpoint now returns HTTP 200 with explicit unknown usage during scanner warm-up, so the console remains operational without presenting stale bucket statistics as authoritative. Once a complete snapshot is available, normal object and bucket counts resume. No configuration, storage-format, or migration changes are required.

## Additional Notes

Adversarial validation covered stale-stat leakage, confirmed-zero ambiguity, request-path full listings, authorization continuity, compatibility of the additive completeness marker, and per-request overhead. No unresolved findings remain in the changed code.