### PR TITLE
test(s3): cover delete marker list visibility

### DIFF
--- a/crates/e2e_test/src/delete_marker_migration_semantics_test.rs
+++ b/crates/e2e_test/src/delete_marker_migration_semantics_test.rs
@@ -56,6 +56,21 @@ mod tests {
         );
     }
 
+    async fn assert_current_list_hides_delete_marker(client: &Client, bucket: &str, key: &str) {
+        let listed = client
+            .list_objects_v2()
+            .bucket(bucket)
+            .prefix(key)
+            .send()
+            .await
+            .expect("list current objects after delete marker");
+
+        assert!(
+            listed.contents().iter().all(|object| object.key() != Some(key)),
+            "ListObjectsV2 must hide an object whose latest version is a delete marker"
+        );
+    }
+
     #[tokio::test]
     #[serial]
     async fn test_versioning_only_delete_marker_has_minio_compatible_visibility_for_migration_proof() {
@@ -94,6 +109,7 @@ mod tests {
         assert_eq!(markers[0].version_id(), Some(delete_marker_version_id));
         assert_eq!(markers[0].is_latest(), Some(true));
         assert_current_get_is_delete_marker_not_found(&client, bucket, key).await;
+        assert_current_list_hides_delete_marker(&client, bucket, key).await;
     }
 
     #[tokio::test]
@@ -118,6 +134,17 @@ mod tests {
             .await
             .expect("put historical version");
         let data_version_id = put.version_id().expect("put should return data version id");
+        let listed_before_delete = client
+            .list_objects_v2()
+            .bucket(bucket)
+            .prefix(key)
+            .send()
+            .await
+            .expect("list current object before creating delete marker");
+        assert!(
+            listed_before_delete.contents().iter().any(|object| object.key() == Some(key)),
+            "ListObjectsV2 must include the current object before it is deleted"
+        );
 
         let delete_marker = client
             .delete_object()
@@ -145,6 +172,7 @@ mod tests {
         assert_eq!(markers[0].version_id(), Some(delete_marker_version_id));
         assert_eq!(markers[0].is_latest(), Some(true));
         assert_current_get_is_delete_marker_not_found(&client, bucket, key).await;
+        assert_current_list_hides_delete_marker(&client, bucket, key).await;
 
         let historical = client
             .get_object()


### PR DESCRIPTION
## Related Issues

Refs #5375

## Summary of Changes

- Extend the existing versioning migration E2E coverage to verify that `ListObjectsV2` hides a key when its latest version is a delete marker.
- Warm and verify the current-object listing before deletion, then assert that the key is hidden while its historical version and delete-marker evidence remain available.
- Keep the change test-only; no production behavior is modified.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p e2e_test --all-targets -- -D warnings`
- `cargo test -p e2e_test delete_marker_migration_semantics_test -- --nocapture --test-threads=1` (2 passed)
- `cargo test --all --doc`
- Full `make pre-pr` was attempted. Static checks and Clippy passed, but the workspace Nextest run is currently blocked on macOS by the pre-existing `rustfs-ecstore layout::endpoints::test::create_server_endpoints_bounds_kubernetes_alias_dns_fallback` failure; an isolated rerun fails the same way. This branch does not modify that test or its implementation. A separate load-sensitive cold-fill test passed on isolated rerun.

## Impact

Test-only change. No runtime, API, configuration, deployment, or compatibility impact.

## Additional Notes

This regression coverage validates the existing single-node `ListObjectsV2` semantics. It does not claim to reproduce the two-node remote `walk_dir` transport path reported in #5375.