### PR TITLE
test(e2e): classify failed lock nodes as quorum loss

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -300,9 +300,6 @@ path = "junit.xml"
 # negative-path siblings of each family stay in as regression guards.
 #   * rustfs#4843 — over-limit archive entry paths hard-reject the whole
 #     archive even under ignore-errors semantics.
-#   * rustfs#4846 — distributed-lock quorum tests misclassify as timeout
-#     under parallel load (multi-node in-process clusters; natural home is
-#     ci-7's nightly cluster lane).
 [profile.e2e-full]
 default-filter = """
     package(e2e_test)
@@ -311,7 +308,6 @@ default-filter = """
     & !test(/^replication_extension_test::/)
     & !test(/^multipart_auth_test::test_signed_put_object_extract_skips_invalid_entry_when_ignore_errors_enabled$/)
     & !test(/^snowball_auto_extract_test::tests::snowball_auto_extract_(ignores_invalid_entries_when_requested|supports_standard_headers_with_combined_extract_options)$/)
-    & !test(/^reliant::lock::test_distributed_lock_(2_nodes_grpc_read_survives_failed_node|4_nodes_grpc_read_write_quorum_split_with_two_failed_nodes)$/)
 """
 fail-fast = false
 

--- a/crates/e2e_test/src/reliant/lock.rs
+++ b/crates/e2e_test/src/reliant/lock.rs
@@ -15,9 +15,7 @@
 
 use super::{grpc_lock_client::GrpcLockClient, grpc_lock_server::spawn_lock_server};
 use rustfs_lock::client::{LockClient, local::LocalClient};
-use rustfs_lock::{
-    GlobalLockManager, LockError, LockInfo, LockRequest, LockResponse, LockStats, LockType, NamespaceLock, ObjectKey,
-};
+use rustfs_lock::{GlobalLockManager, LockInfo, LockRequest, LockResponse, LockStats, LockType, NamespaceLock, ObjectKey};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -35,7 +33,11 @@ struct FailingClient;
 #[async_trait::async_trait]
 impl rustfs_lock::LockClient for FailingClient {
     async fn acquire_lock(&self, _request: &rustfs_lock::LockRequest) -> rustfs_lock::Result<LockResponse> {
-        Err(LockError::internal("simulated gRPC node failure"))
+        // Match RemoteClient's transport-failure response so the coordinator can count this node toward quorum loss.
+        Ok(LockResponse::failure(
+            "Remote lock RPC failed: simulated gRPC node failure",
+            Duration::ZERO,
+        ))
     }
 
     async fn release(&self, _lock_id: &rustfs_lock::LockId) -> rustfs_lock::Result<bool> {


### PR DESCRIPTION
## Related Issues

Fixes #4846.

## Summary of Changes

- Align the in-process failed gRPC lock client with the production `RemoteClient` transport-failure response contract so unavailable nodes count toward quorum loss instead of falling through to a timeout.
- Remove the #4846 exclusions from the `e2e-full` nextest profile, restoring both degraded-node distributed-lock regressions.

## Verification

- `cargo fmt --all --check` — passed.
- `make pre-commit` — passed on the latest `main` base.
- `cargo test -p e2e_test reliant::lock::test_distributed_lock_ -- --nocapture --test-threads=4` — 3 passed.
- `cargo nextest list --profile e2e-full -p e2e_test` — confirmed both #4846 tests are included.
- `make pre-pr` — formatting, repository guards, script checks, and full Clippy passed; the workspace test stage could not complete locally because the host DNS maps `.invalid` names to the local TUN address `198.18.1.134`, causing the unrelated `create_server_endpoints_bounds_kubernetes_alias_dns_fallback` test to fail.

## Impact

Test and CI behavior only. No runtime API, configuration, wire-format, or storage-format changes.

## Additional Notes

The new fixture string intentionally mirrors the production-private `Remote lock RPC failed:` classifier contract; there is no reusable public constant across the crate boundary. CI should validate the full workspace suite in an environment where reserved `.invalid` names do not resolve.