### PR TITLE
fix(s3): allow CopyObject COPY request metadata

### DIFF
--- a/crates/e2e_test/src/copy_object_metadata_test.rs
+++ b/crates/e2e_test/src/copy_object_metadata_test.rs
@@ -117,9 +117,14 @@ mod tests {
             .key("assets/explicit-copy.js")
             .copy_source(format!("{bucket}/{key}"))
             .metadata_directive(MetadataDirective::Copy)
+            .customize()
+            .mutate_request(|request| {
+                request.headers_mut().insert("content-type", "application/octet-stream");
+                request.headers_mut().insert("x-amz-meta-request-only", "ignored");
+            })
             .send()
             .await
-            .expect("explicit COPY directive failed");
+            .expect("explicit COPY directive with request metadata failed");
         let explicit_copy_head = client
             .head_object()
             .bucket(bucket)
@@ -128,6 +133,18 @@ mod tests {
             .await
             .expect("HEAD failed after explicit COPY");
         assert_eq!(explicit_copy_head.cache_control(), Some("max-age=60"));
+        assert_eq!(explicit_copy_head.content_type(), Some("text/javascript; charset=utf-8"));
+        assert_eq!(
+            explicit_copy_head.metadata().and_then(|metadata| metadata.get("mtime")),
+            Some(&"1777992333".to_string())
+        );
+        assert_eq!(
+            explicit_copy_head
+                .metadata()
+                .and_then(|metadata| metadata.get("request-only")),
+            None,
+            "COPY must ignore request metadata"
+        );
         assert_eq!(
             explicit_copy_head.website_redirect_location(),
             None,
@@ -569,20 +586,6 @@ mod tests {
         assert_eq!(
             invalid_directive.as_service_error().and_then(|error| error.code()),
             Some("InvalidArgument")
-        );
-
-        let ignored_replacement = client
-            .copy_object()
-            .bucket(bucket)
-            .key(key)
-            .copy_source(format!("{bucket}/{key}"))
-            .content_type("application/ignored")
-            .send()
-            .await
-            .expect_err("Replacement fields without REPLACE should be rejected");
-        assert_eq!(
-            ignored_replacement.as_service_error().and_then(|error| error.code()),
-            Some("InvalidRequest")
         );
 
         let unchanged = client

--- a/crates/kms/src/backup/local_export.rs
+++ b/crates/kms/src/backup/local_export.rs
@@ -560,7 +560,6 @@ async fn fsync_dir(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backends::KmsClient;
     use crate::config::LocalConfig;
     use std::sync::Arc;
     use tempfile::TempDir;

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -6072,19 +6072,6 @@ impl DefaultObjectUsecase {
                 ));
             }
         };
-        let has_replacement_metadata = metadata.is_some()
-            || cache_control.is_some()
-            || content_disposition.is_some()
-            || content_encoding.is_some()
-            || content_language.is_some()
-            || content_type.is_some()
-            || expires.is_some();
-        if has_replacement_metadata && !replaces_metadata {
-            return Err(S3Error::with_message(
-                S3ErrorCode::InvalidRequest,
-                "Replacement metadata requires the REPLACE metadata directive".to_string(),
-            ));
-        }
         let replacement_metadata = if replaces_metadata {
             validate_archive_content_encoding(&key, content_type.as_deref(), content_encoding.as_deref())?;
             let mut replacement_metadata = metadata.unwrap_or_default();


### PR DESCRIPTION
## Related Issues

Fixes #5511

Related: rustfs/backlog#1580

## Summary of Changes

This fixes the CopyObject regression where requests using the default or explicit `x-amz-metadata-directive: COPY` were rejected when the request also carried metadata-like headers such as `Content-Type` or `x-amz-meta-*`.

The server now keeps replacement metadata construction scoped to the `REPLACE` directive. COPY/default requests preserve source object metadata and ignore replacement-only request fields, while invalid directives and existing REPLACE validation behavior remain unchanged.

The e2e coverage now sends a real explicit COPY request with `Content-Type: application/octet-stream` and `x-amz-meta-request-only: ignored`, then verifies the copied object keeps the source Cache-Control, Content-Type, and user metadata without persisting the request-only metadata.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p e2e_test copy_object_standard_metadata_copy_replace_and_clear -- --nocapture --test-threads=1`
- `cargo test -p e2e_test copy_object_metadata_test -- --test-threads=1`
- `cargo nextest run -p e2e_test -E 'test(copy_object_metadata_test)'`
- `cargo clippy --all-targets -p e2e_test`
- `make pre-commit`
- `make pre-pr` failed in an unrelated ecstore DNS fallback test: `rustfs-ecstore layout::endpoints::test::create_server_endpoints_bounds_kubernetes_alias_dns_fallback`. The same single test also failed when rerun directly with `cargo nextest run -p rustfs-ecstore layout::endpoints::test::create_server_endpoints_bounds_kubernetes_alias_dns_fallback --no-fail-fast`. This PR is intentionally opened as draft so GitHub CI can provide the final signal.

## Impact

S3 CopyObject COPY/default metadata behavior is restored for clients that send metadata-like request headers while asking to copy source metadata. REPLACE semantics, unknown directive handling, website redirect behavior, tags, storage class handling, SSE/SSE-C validation, object lock handling, and self-copy protection are unchanged.

## Additional Notes

High-risk S3 API adversarial validation was run across correctness, simplicity, security, concurrency/durability, compatibility, performance, and test coverage. No P0/P1/P2 findings were identified. The change is intentionally minimal: production code only removes the erroneous non-REPLACE rejection branch, and tests pin the regression through the existing e2e CopyObject metadata suite.
