### PR TITLE
fix(kms): drop stale KmsClient trait import in local_export tests

### DIFF
--- a/crates/kms/src/backup/local_export.rs
+++ b/crates/kms/src/backup/local_export.rs
@@ -560,7 +560,6 @@ async fn fsync_dir(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backends::KmsClient;
     use crate::config::LocalConfig;
     use std::sync::Arc;
     use tempfile::TempDir;


### PR DESCRIPTION
## Related Issues

N/A (main-branch build fix; semantic merge skew between #5499 and #5501)

## Summary of Changes

PR #5499 added a test-module import of the `KmsClient` trait while PR #5501 (merged after) deleted that trait. Both merged cleanly at the text level, leaving `cargo test -p rustfs-kms` unable to compile on main. Remove the stale import.

## Verification

- `cargo check -p rustfs-kms --all-targets` — clean (was: unresolved import on main)

## Impact

Test-only one-line fix; unblocks the rustfs-kms test target for every open PR.

## Additional Notes

Same fix is carried as a standalone commit on #5518; whichever lands first, the other folds cleanly.