### PR TITLE
feat(hotpath): use mimalloc in inner counting allocator

### DIFF
--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -14,7 +14,8 @@
 
 #[cfg(all(feature = "hotpath", feature = "hotpath-alloc"))]
 #[global_allocator]
-static GLOBAL: hotpath::CountingAllocator = hotpath::CountingAllocator::new();
+static GLOBAL: hotpath::CountingAllocator<mimalloc::MiMalloc> =
+    hotpath::CountingAllocator::new();
 
 #[cfg(not(all(feature = "hotpath", feature = "hotpath-alloc")))]
 #[global_allocator]

--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -13,9 +13,31 @@
 // limitations under the License.
 
 #[cfg(all(feature = "hotpath", feature = "hotpath-alloc"))]
+use std::alloc::{GlobalAlloc, Layout};
+
+#[cfg(all(feature = "hotpath", feature = "hotpath-alloc"))]
+#[derive(Default)]
+struct DefaultMiMalloc;
+
+#[cfg(all(feature = "hotpath", feature = "hotpath-alloc"))]
+// SAFETY: allocation and deallocation are forwarded unchanged to MiMalloc, so
+// MiMalloc's GlobalAlloc guarantees apply to every returned pointer and layout.
+#[allow(unsafe_code)]
+unsafe impl GlobalAlloc for DefaultMiMalloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller upholds GlobalAlloc's contract for layout.
+        unsafe { mimalloc::MiMalloc.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: ptr and layout came from this allocator and are forwarded unchanged.
+        unsafe { mimalloc::MiMalloc.dealloc(ptr, layout) }
+    }
+}
+
+#[cfg(all(feature = "hotpath", feature = "hotpath-alloc"))]
 #[global_allocator]
-static GLOBAL: hotpath::CountingAllocator<mimalloc::MiMalloc> =
-    hotpath::CountingAllocator::new();
+static GLOBAL: hotpath::CountingAllocator<DefaultMiMalloc> = hotpath::CountingAllocator::new();
 
 #[cfg(not(all(feature = "hotpath", feature = "hotpath-alloc")))]
 #[global_allocator]
@@ -25,4 +47,16 @@ fn main() {
     let _hotpath_guard = hotpath::HotpathGuardBuilder::new("main").build();
 
     rustfs::startup_entrypoint::run_process();
+}
+
+#[cfg(all(test, feature = "hotpath", feature = "hotpath-alloc"))]
+mod tests {
+    #[test]
+    #[allow(unsafe_code)]
+    fn hotpath_allocator_uses_mimalloc() {
+        let allocation = Box::new([0_u8; 64]);
+
+        // SAFETY: the live Box pointer is valid to inspect for heap ownership.
+        assert!(unsafe { libmimalloc_sys::mi_is_in_heap_region(allocation.as_ptr().cast()) });
+    }
 }


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Enable `mimalloc::MiMalloc` as the inner allocator for hotpath when both `hotpath` and `hotpath-alloc` features are enabled by changing `rustfs` global allocator from `hotpath::CountingAllocator` default-inner allocator to `hotpath::CountingAllocator<mimalloc::MiMalloc>`. This keeps `mimalloc` as the actual allocator implementation for counted allocations and matches existing mimalloc-based observability/reclaim logic in this codebase.

## Verification
- N/A (no local checks run in this request)

## Impact
Allocations under hotpath+hotpath-alloc builds will be routed through MiMalloc with hotpath counting hooks preserved. Non-hotpath builds remain unchanged using the existing `mimalloc::MiMalloc` global allocator.

## Additional Notes
N/A
