### PR TITLE
fix(kms): remove dead import of removed KmsClient in local_export tests

### DIFF
--- a/crates/kms/src/backup/local_export.rs
+++ b/crates/kms/src/backup/local_export.rs
@@ -560,7 +560,6 @@ async fn fsync_dir(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backends::KmsClient;
     use crate::config::LocalConfig;
     use std::sync::Arc;
     use tempfile::TempDir;


### PR DESCRIPTION
## Problem

Commit `db8039dec` (`feat(kms): export local backend key material as sealed backup bundles (#5499)`) introduced `crates/kms/src/backup/local_export.rs` with a test module that imports `crate::backends::KmsClient`.

However, `KmsClient` was removed in an earlier commit `76b3c085b` (`refactor(kms): fold the KmsClient layer into KmsBackend (#5501)`). This causes a compilation error:

```
error[E0432]: unresolved import `crate::backends::KmsClient`
   --> crates/kms/src/backup/local_export.rs:563:9
```

## Fix

Remove the dead import `use crate::backends::KmsClient;` from the test module. `LocalKmsClient` is already available via `use super::*;` (imported at line 51), and all test functions use `LocalKmsClient` exclusively.

## Verification

- `cargo fmt --all --check` — passed
- `cargo check -p rustfs-kms` — passed
- `cargo clippy -p rustfs-kms --all-targets -- -D warnings` — passed (in-progress full workspace clippy confirmed kms crate clean)
- All guard scripts passed (fmt-check, unsafe-code-check, architecture-migration-check, logging-guardrails-check, tokio-io-uring-check, extension-schema-check, body-cache-whitelist-check, doc-paths-check, planning-docs-check, log-analyzer-rules-check)
- Full workspace `make pre-pr` could not complete in time due to cold `rustfs-ecstore` compilation (~15 min); CI will cover the rest.

Baseline: `db8039dece301279226ea7b035af7d8890321cc6`
