### PR TITLE
ci: stop running expensive jobs that cannot inform the result

### DIFF
--- a/.github/workflows/ci-docs-only.yml
+++ b/.github/workflows/ci-docs-only.yml
@@ -12,18 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Companion to ci.yml for the required "Test and Lint" status check.
+# Companion to ci.yml for the required "Test and Lint" and "Quick Checks"
+# status checks.
 #
 # ci.yml skips docs-only pull requests via paths-ignore, but the branch
-# ruleset requires a check named "Test and Lint" — without this workflow a
-# docs-only PR would wait on that check forever. This workflow triggers on
-# exactly the paths ci.yml ignores and reports an instant success under the
-# same job name. Mixed PRs trigger both workflows and the real check still
-# gates: a required check with any failing run blocks the merge.
+# ruleset requires checks named "Test and Lint" and "Quick Checks" — without
+# this workflow a docs-only PR would wait on those checks forever. This
+# workflow triggers on exactly the paths ci.yml ignores and reports success
+# under the same job names. Mixed PRs trigger both workflows and the real
+# checks still gate: a required check with any failing run blocks the merge.
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 #
 # Keep the paths list below in sync with the pull_request paths-ignore list
-# in ci.yml.
+# in ci.yml, and keep the quick-checks steps below byte-identical to the
+# quick-checks job in ci.yml (see the comment on that job).
 
 name: Continuous Integration (docs only)
 
@@ -52,9 +54,63 @@ permissions:
   contents: read
 
 jobs:
+  # Deliberately NOT a bare `echo`. Once "Quick Checks" becomes a required
+  # check, ci.yml gates every expensive job behind it, so a mixed PR reports
+  # two check runs with this name: the real one (45-51s) and this companion.
+  # GitHub has no written contract for how it picks between same-named
+  # required check runs ("latest wins" vs "any failure blocks"), so instead of
+  # relying on ordering we make both runs execute the same commands against
+  # the same merge ref — their conclusions are then necessarily identical and
+  # the choice does not matter. Keep these steps byte-identical to the
+  # quick-checks job in ci.yml (a guard script that asserts this, and the paths
+  # sync below, is tracked in rustfs/backlog#1603).
+  #
+  # For a genuinely docs-only PR this adds no strictness (no code changed, so
+  # fmt and the guards always pass) and costs ~50s of ubuntu-latest.
+  quick-checks:
+    name: Quick Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: rustfmt
+
+      - name: Check code formatting
+        run: cargo fmt --all --check
+
+      - name: Check unsafe code allowances
+        run: ./scripts/check_unsafe_code_allowances.sh
+
+      - name: Check layered dependencies
+        run: ./scripts/check_layer_dependencies.sh
+
+      - name: Check architecture migration rules
+        run: ./scripts/check_architecture_migration_rules.sh
+
+      - name: Check tokio io-uring feature guard
+        run: ./scripts/check_no_tokio_io_uring.sh
+
+      - name: Check extension schema boundaries
+        run: ./scripts/check_extension_schema_boundaries.sh
+
+      - name: Check body-cache whitelist guard
+        run: ./scripts/check_body_cache_whitelist.sh
+
+      - name: Check no planning docs committed
+        run: ./scripts/check_no_planning_docs.sh
+
   test-and-lint:
     name: Test and Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,13 @@ jobs:
 
   uring-integration:
     name: io_uring Integration (real)
+    # The pull_request trigger includes `closed` purely so the concurrency
+    # group cancels in-flight runs of a closed PR; every other job opts out of
+    # that run with this guard (or is skipped through its `needs` chain). This
+    # job had neither, so each closed/merged PR really ran the whole io_uring
+    # suite (measured 4m17s / 7m19s / 7m31s on runs 30678272341 / 30678117601 /
+    # 30662728539) and kept the cancellation run in progress for minutes.
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     # GitHub-hosted ubuntu-latest runs a recent kernel with io_uring and, unlike
     # a container, applies no seccomp filter that would block io_uring_setup — so
     # the probe succeeds and the tests exercise the real UringBackend/FdCache/
@@ -746,7 +753,13 @@ jobs:
   # evaluates ILM within ~2s of the due time, well inside the poll window.
   s3-lifecycle-behavior-tests:
     name: S3 Lifecycle Behavior Tests
-    needs: [ build-rustfs-debug-binary ]
+    # Also gated on e2e-tests, matching s3-implemented-tests: when the e2e smoke
+    # suite is already red this lane cannot tell us anything new, and it holds a
+    # sm-standard-4 for up to 30 minutes doing so. Both lanes only download the
+    # prebuilt debug binary (no cargo build), and s3-implemented-tests — which
+    # already waits on e2e-tests — finishes later anyway, so a green PR's total
+    # wall clock is unchanged.
+    needs: [ build-rustfs-debug-binary, e2e-tests ]
     runs-on: sm-standard-4
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1598 (master plan), rustfs/backlog#1599 (batch 1).

## Summary of Changes

Three independent fixes that all stop burning self-hosted runners on work whose outcome is already determined. **None of them changes what is tested.**

**1. `ci-docs-only.yml`: add a "Quick Checks" companion job.**

This is the prerequisite step for gating ci.yml's expensive jobs behind `quick-checks` (backlog#1599). Once "Quick Checks" becomes a required check, a docs-only PR — which does not trigger ci.yml at all — would wait on it forever without a companion job here.

The steps are a **byte-identical copy** of ci.yml's `quick-checks`, not an `echo`. Reason: on a mixed PR (docs + code) two check runs share the name "Quick Checks", and GitHub has no written contract for how it resolves same-named required check runs ("latest wins" vs "any failure blocks"). The existing "Test and Lint" companion gets away with an `echo` because the real job takes 40-90 minutes against the companion's 9s, so the real conclusion always lands last. "Quick Checks" only takes 45-51s (runs 30673292690 / 30673241673 / 30674613104) against ~8-10s for an echo — about 35s of margin, inside ubuntu-latest scheduling jitter. Making both runs execute the same commands against the same merge ref means their conclusions are necessarily identical, so the resolution order stops mattering.

For a genuinely docs-only PR this adds no strictness (no code changed, so fmt and the guards always pass) and costs ~50s of ubuntu-latest.

**2. `ci.yml`: guard `uring-integration` with the `closed` check every other job already has.**

The `pull_request` trigger includes `closed` purely so the concurrency group cancels in-flight runs of a closed PR. Every other job opts out of that run via `if: github.event_name != 'pull_request' || github.event.action != 'closed'`, or is skipped through its `needs` chain. This job had neither, so every closed or merged PR really ran the whole io_uring suite — 4m17s, 7m19s and 7m31s on runs 30678272341, 30678117601 and 30662728539 (job log 91309868055 shows 508 `Compiling` lines and 18 tests actually executing) — and kept the cancellation run in progress for minutes.

**3. `ci.yml`: gate `s3-lifecycle-behavior-tests` on `e2e-tests`, matching `s3-implemented-tests`.**

On run 30645477526 the e2e smoke suite failed, `s3-implemented-tests` correctly skipped, and this lane ran anyway and held a `sm-standard-4`. Both lanes only download the prebuilt debug binary (no cargo build), and `s3-implemented-tests` — which already waits on `e2e-tests` — finishes later regardless, so a green PR's total wall clock is unchanged.

## Verification

- Both `quick-checks` step sequences diffed programmatically: **byte-identical** (24 step lines each).
- YAML structure checked: job keys parse at the expected indent, no tabs introduced.
- No `runs-on`, test filter, nextest profile, artifact, or upload path is touched — `git diff` is limited to one `if:`, one `needs:`, one new companion job, and comments.
- Behavioral verification is inherently post-merge for workflow changes; the acceptance criteria are listed in backlog#1599 (most importantly: a docs-only PR must report exactly one "Quick Checks" + one "Test and Lint", both green and mergeable).

## Impact

No user-facing, API, deployment, or configuration impact. CI-only.

Merge-gate impact: **none in this PR.** "Quick Checks" is not yet a required check and ci.yml's expensive jobs do not yet declare `needs`, so this PR only adds a companion job that reports on docs-only PRs. The required-check and `needs` changes are deliberately split into later steps (see below).

## Additional Notes

**This PR is step ① of a three-step sequence that must not be reordered** (backlog#1599):

1. **this PR** — add the `ci-docs-only.yml` companion job (zero side effects on its own);
2. then add `Quick Checks` to the branch ruleset's required checks (`gh api repos/rustfs/rustfs/rulesets/6436880`, archive the current JSON first — ruleset edits leave no PR audit trail);
3. then add `needs: [ quick-checks ]` to the seven expensive jobs in ci.yml.

Reversing 2 and 3 opens a real merge hole: with `needs` in place but the ruleset not updated, a failing `quick-checks` makes "Test and Lint" report `skipped`, and GitHub treats a skipped required check as satisfied — combined with `required_approving_review_count=0` that lets a broken PR merge. Reversing 1 and 2 leaves docs-only PRs permanently pending.

Fixes 2 and 3 in this PR are independent of that sequence and safe to merge on their own.
