### PR TITLE
ci: stop a PR run once Test and Lint has failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,11 +143,23 @@ jobs:
     needs: [ quick-checks ]
     runs-on: sm-standard-4
     timeout-minutes: 90
+    # Both lines are required. Job-level `permissions` replaces the workflow
+    # block rather than merging with it, so declaring only `actions: write`
+    # would drop `contents: read` and break this job's checkout and the
+    # repo-token the setup action hands to setup-protoc.
+    permissions:
+      contents: read
+      actions: write
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # This job's token can cancel runs and delete Actions caches. Checkout
+          # otherwise writes it into .git/config, where a PR's own build.rs or
+          # proc-macro could read it back out.
+          persist-credentials: false
 
       - name: Setup Rust environment
         uses: ./.github/actions/setup
@@ -278,6 +290,48 @@ jobs:
       - name: Run rebalance/decommission migration proofs
         run: ./scripts/check_migration_gate_count.sh
 
+      # Early stop. Once this job has failed the PR cannot merge, so the sibling
+      # lanes are burning runners on a result nobody can act on: on run
+      # 30674613104 three lanes had already failed while Test and Lint and the
+      # rio-v2 variant kept going past 70 minutes.
+      #
+      # Only this job may cancel. The lanes that are NOT required checks
+      # (protocols, ILM, e2e, s3-tests) must never hold that power: a flake in
+      # one of them would turn the required "Test and Lint" into `cancelled`,
+      # which blocks the merge. Today a maintainer can merge with sftp red, and
+      # that has to stay true.
+      #
+      # These steps run last so the `if: always()` artifact upload above still
+      # captures logs and diagnostics before the run goes away.
+      - name: Annotate early-stop reason
+        if: failure() && github.event_name == 'pull_request'
+        run: |
+          echo "## CI early-stop" >> "$GITHUB_STEP_SUMMARY"
+          echo "Job \`${GITHUB_JOB}\` (Test and Lint) failed; cancelling run ${GITHUB_RUN_ID} to free runners." >> "$GITHUB_STEP_SUMMARY"
+          echo "Sibling jobs showing **cancelled** were stopped by this job, not by their own failure." >> "$GITHUB_STEP_SUMMARY"
+
+      # curl rather than `gh`: every existing `gh` call in this repo runs on
+      # ubuntu-latest, and the sm-standard-* images are custom and trimmed (they
+      # ship no C toolchain, see the e2e job below), so `gh` is not known to
+      # exist here.
+      #
+      # Fork PRs are excluded explicitly instead of relying on the error path:
+      # their GITHUB_TOKEN is forced read-only and job-level permissions cannot
+      # raise it, so the call would always 403. Skipping keeps their logs clean.
+      - name: Cancel run on failure (same-repo PR only)
+        if: >-
+          failure() && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel" || true
+
   # Dedicated serial lane for the ILM / lifecycle integration tests. These tests
   # drive the object layer through process-global singletons (the GLOBAL_ENV
   # ECStore, the global tier-config manager, background-expiry workers) and bind
@@ -361,7 +415,13 @@ jobs:
     runs-on: sm-standard-4
     timeout-minutes: 60
     strategy:
-      fail-fast: false
+      # On a PR, one failing protocol leg is enough to know the PR is not ready,
+      # so stop the sibling leg instead of paying another ~40 minutes for it.
+      # Everywhere else (main pushes, the merge queue, the weekly schedule) keep
+      # the full signal: there we want to know whether swift AND sftp are broken,
+      # not just whichever failed first. This is the only part of the early-stop
+      # work that also covers fork PRs, since it needs no token.
+      fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         features:
           - name: swift


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1598 (master plan), rustfs/backlog#1599 (batch 1). Stacked on #5529.

## Summary of Changes

Stops a PR run once its verdict is already settled. On run 30674613104 the e2e (21m), ILM (36m) and sftp (38m) lanes had all failed while Test and Lint and the rio-v2 variant kept running past 70 minutes. With one full PR run needing roughly seven `sm-standard-4` out of a 15-21 runner pool, that time comes straight out of other PRs' queue time — six runs in a 20-run window sat queued 72-488 minutes.

Two mechanisms, both scoped to `pull_request` so main pushes, the merge queue and the weekly schedule keep the full failure signal:

**1. `test-and-lint-protocols`: `fail-fast: ${{ github.event_name == 'pull_request' }}`.** One failing protocol leg stops its sibling. This is the only part of the early-stop work that **also covers fork PRs**, since it needs no token.

**2. `test-and-lint`: on failure, cancel the run** via `POST /actions/runs/{id}/cancel`, plus a step-summary note so a contributor seeing grey `cancelled` siblings knows they were stopped by this job rather than failing on their own.

**Only `test-and-lint` may cancel.** The lanes that are *not* required checks (protocols, ILM, e2e, s3-tests) must never hold that power: a flake in one of them would turn the required "Test and Lint" into `cancelled`, which blocks the merge. A maintainer can merge today with sftp red, and that has to stay true — otherwise this "optimization" would quietly tighten the merge gate.

## Verification

- `permissions` appears at job level exactly once, on `test-and-lint`, and lists **both** `contents: read` and `actions: write`. Job-level permissions replace the workflow block rather than merging with it, so omitting `contents` would break this job's checkout and the repo-token the setup action passes to `setup-protoc`.
- `persist-credentials: false` added to that job's checkout only (1 occurrence). Verified safe: the job performs no `git fetch/push/pull/clone/ls-remote`, and the repo has no `.gitmodules`. Cargo's git dependencies (datafusion, s3s) clone into `~/.cargo/git` anonymously and do not use the checked-out repo's `.git/config`.
- Cancel step appears exactly once; `GH_TOKEN` is scoped to that single step's `env`, never the job's.
- The two new steps sit after the `if: always()` artifact upload, so logs and diagnostics are captured before the run disappears.
- YAML structure re-validated (15 jobs parse, no tabs).
- **One check to run before merging**: confirm `curl` exists on `sm-standard-4` (temporarily add `command -v curl && curl --version` to any job on that label). If it is absent, switch this step to a SHA-pinned `actions/github-script` and re-run `scripts/security/check_workflow_pins.sh --enforce`.
- Remaining acceptance criteria are post-merge, in backlog#1599: early stop within 3 minutes of Test and Lint completing with the four sibling lanes `cancelled` and run billable < 120 minutes; checkout and Setup Rust environment still green (proves `contents: read` survived); on a fork PR the cancel step must be **skipped**, not failed; and after a cancel, "Test and Lint" shows `CANCELLED` with the merge still blocked.

## Impact

CI-only; no user-facing, API, deployment, or configuration impact.

Merge-gate strictness is deliberately unchanged: cancellation is triggered only by a job whose failure already blocks the merge.

Contributor-visible change: sibling lanes now show `cancelled` instead of running to completion. The step summary explains why, and `fail-fast` on the protocols matrix means a PR sees one protocol failure at a time rather than both.

Known trade-off: a flaky `test-and-lint` will now cancel the siblings, losing the "would the others have passed?" signal for that run. Scoped to `pull_request` to contain it. Rollback is a single-commit revert of the two steps plus the `permissions` block; backlog#1599 sets a two-week review point — if the re-run rate rises versus the pre-change baseline, revert.

## Additional Notes

**Blocked: merge only after #5528 and #5529, in that order**, and only after `Quick Checks` has been added to the branch ruleset's required checks. Without that, a cancelled run leaves downstream jobs reporting `skipped`, and GitHub treats a skipped required check as satisfied.

Stacked on #5529 — if that is squash-merged first, rebase this branch onto the new `main` rather than force-pushing over it.
