### PR TITLE
ci: drop cla.yml to least privilege

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,11 +22,18 @@ on:
   issue_comment:
     types: [created, edited]
 
+# Least privilege at the top, widened per job below. This workflow runs on
+# pull_request_target and issue_comment, so it holds full secrets on every fork
+# PR and on any comment anyone writes — the one place in this repository where a
+# compromised action would be handed a repo-write token. It does not check out
+# or execute PR code, so there is no pwn-request path today, but the blast
+# radius should not depend on that staying true.
+#
+# contents: write in particular was never used: the signature records are
+# written to rustfs/cla through the scoped app token created below, and nothing
+# here writes to this repository's contents.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  checks: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
@@ -36,6 +43,9 @@ jobs:
   cancel-closed-pr-runs:
     name: Cancel Closed PR Runs
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    # Echoes one line; the run exists only so the concurrency group cancels the
+    # in-flight run of a closed PR.
+    permissions: {}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -44,6 +54,13 @@ jobs:
 
   cla:
     if: ${{ (github.event_name != 'issue_comment' || github.event.issue.pull_request) && (github.event_name != 'pull_request_target' || github.event.action != 'closed') }}
+    # checks: write reports the merge-queue check run; pull-requests and issues
+    # let cla-bot comment and label. contents stays read — see the note above.
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Refs rustfs/backlog#1598, #1602 (S-2 B1). **Draft on purpose — see the validation gate below.**

## Summary

`cla.yml` triggers on `pull_request_target` and `issue_comment`, so it holds full secrets on **every fork PR and on any comment anyone writes**. That makes it the one place in this repository where a compromised action would be handed a repo-write token. It never checks out or executes PR code, so there is no pwn-request path today — but the blast radius should not depend on that staying true.

`contents: write` was never used. Signature records go to `rustfs/cla` through the app token created inside the job, which is already scoped to `repositories: cla`; nothing here writes to this repository's contents.

- workflow level → `contents: read`
- `cla` job → `contents: read`, `checks: write` (merge-queue check run), `issues: write` + `pull-requests: write` (cla-bot comments and labels)
- `cancel-closed-pr-runs` (one `echo`) → `permissions: {}`

## ⚠️ Validation gate — do not merge before this passes

`CLA Check` is one of three required status checks. Getting a scope wrong blocks merges **repository-wide**, and the failure mode does not show up on our own PRs: the interesting code path is the one for an author who has **not** signed.

So this cannot be validated by opening a normal PR. Required before merge:

1. With an account that has **not** signed the CLA, open a PR against this repository.
2. Confirm the full cycle still works: unsigned → cla-bot comments and the check goes red → comment `I have read and agree to the CLA.` → check goes green.
3. Also exercise the `merge_group` path, which reports through `actions/github-script` and is the only consumer of `checks: write`.
4. Any `403` or `Resource not accessible by integration` → revert immediately; it is a one-commit revert.

Note the distinguishing condition is **author has not signed**, not **PR comes from a fork**: `pull_request_target` hands the same base-repo token to internal and external PRs alike, so a fork PR from someone who already signed exercises none of the interesting branches.

## Verification done here

- `grep` confirms no `git` write, no `gh api` write and no checkout of this repository anywhere in the workflow — the only write path is the scoped app token to `rustfs/cla`.
- Job-level `permissions` replaces rather than merges, so each job lists every scope it needs, including `contents: read`; this is the same trap that would have broken `test-and-lint` in #5529.
- `check_job_timeouts.sh` and `check_persist_credentials.sh` still pass.

Held as a draft until someone with an unsigned-CLA account can run step 1-3.