### PR TITLE
fix(oidc): warn on request-header redirect fallback

### DIFF
--- a/rustfs/src/runtime_sources.rs
+++ b/rustfs/src/runtime_sources.rs
@@ -13,7 +13,14 @@
 // limitations under the License.
 
 use crate::app::context;
+use rustfs_config::ENV_RUSTFS_BROWSER_REDIRECT_URL;
+use rustfs_iam::federation::FederatedIdentityService;
 use std::sync::Arc;
+use tracing::warn;
+
+const LOG_COMPONENT_MAIN: &str = "main";
+const LOG_SUBSYSTEM_AUTH: &str = "auth";
+const EVENT_OIDC_BROWSER_REDIRECT_FALLBACK: &str = "oidc_browser_redirect_fallback";
 
 pub(crate) use context::{
     AppContext, NotifyInterface, ServerContextSlot, default_notify_interface as fallback_notify_interface,
@@ -22,9 +29,9 @@ pub(crate) use context::{
     default_s3select_db_interface as fallback_s3select_db_interface,
     default_scanner_metrics_interface as fallback_scanner_metrics_interface,
     default_server_config_interface as fallback_server_config_interface,
-    default_storage_class_interface as fallback_storage_class_interface, publish_federated_identity_service,
-    publish_server_config, publish_storage_class_config, resolve_action_credentials as current_action_credentials,
-    resolve_boot_time as current_boot_time, resolve_bucket_metadata_handle as current_bucket_metadata_handle,
+    default_storage_class_interface as fallback_storage_class_interface, publish_server_config, publish_storage_class_config,
+    resolve_action_credentials as current_action_credentials, resolve_boot_time as current_boot_time,
+    resolve_bucket_metadata_handle as current_bucket_metadata_handle,
     resolve_bucket_monitor_handle as current_bucket_monitor_handle, resolve_buffer_config as current_buffer_config,
     resolve_daily_tier_stats as current_daily_tier_stats, resolve_deployment_id as current_deployment_id,
     resolve_encryption_service as current_encryption_service, resolve_endpoints_handle as current_endpoints_handle,
@@ -52,6 +59,24 @@ pub(crate) use context::{
     resolve_tier_config_handle as current_tier_config_handle, resolve_token_signing_key as current_token_signing_key,
 };
 
+pub(crate) fn publish_federated_identity_service(service: Arc<FederatedIdentityService>) -> bool {
+    let browser_redirect_url = rustfs_utils::get_env_opt_str(ENV_RUSTFS_BROWSER_REDIRECT_URL);
+    if service.has_providers() && browser_redirect_url.as_deref().is_none_or(|value| value.trim().is_empty()) {
+        warn!(
+            event = EVENT_OIDC_BROWSER_REDIRECT_FALLBACK,
+            component = LOG_COMPONENT_MAIN,
+            subsystem = LOG_SUBSYSTEM_AUTH,
+            state = "fallback_enabled",
+            configuration = ENV_RUSTFS_BROWSER_REDIRECT_URL,
+            fallback_source = "request_host_and_forwarded_proto",
+            reason = "trusted_console_origin_not_configured",
+            "OIDC browser redirect fallback enabled"
+        );
+    }
+
+    context::publish_federated_identity_service(service)
+}
+
 #[cfg(test)]
 pub(crate) fn set_test_outbound_tls_generation(generation: u64) {
     context::set_test_outbound_tls_generation(generation);
@@ -67,4 +92,137 @@ pub(crate) use context::{IamInterface, KmsInterface, NotificationSystemInterface
 
 pub(crate) fn current_app_context() -> Option<Arc<AppContext>> {
     context::get_global_app_context()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustfs_iam::{
+        federation::{
+            FederatedAuthorization, FederatedCodeExchange, FederatedIdentityProvider, FederatedIdentityRegistry,
+            Result as FederationResult,
+        },
+        oidc::{OidcProviderConfig, OidcProviderSummary},
+    };
+    use std::{
+        io::{self, Write},
+        sync::Mutex,
+    };
+    use tracing_subscriber::{Registry, fmt::MakeWriter, layer::SubscriberExt};
+
+    struct TestProvider {
+        has_providers: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl FederatedIdentityProvider for TestProvider {
+        fn has_providers(&self) -> bool {
+            self.has_providers
+        }
+
+        fn list_providers(&self) -> Vec<OidcProviderSummary> {
+            Vec::new()
+        }
+
+        fn list_visible_providers(&self) -> Vec<OidcProviderSummary> {
+            Vec::new()
+        }
+
+        fn provider_config(&self, _id: &str) -> Option<&OidcProviderConfig> {
+            None
+        }
+
+        async fn authorize_url(
+            &self,
+            _provider_id: &str,
+            _redirect_uri: &str,
+            _redirect_after: Option<String>,
+        ) -> FederationResult<String> {
+            unreachable!("startup publication test does not authorize")
+        }
+
+        async fn exchange_code(&self, _state: &str, _code: &str, _redirect_uri: &str) -> FederationResult<FederatedCodeExchange> {
+            unreachable!("startup publication test does not exchange codes")
+        }
+
+        async fn verify_web_identity_token(&self, _jwt: &str) -> FederationResult<FederatedAuthorization> {
+            unreachable!("startup publication test does not verify tokens")
+        }
+
+        async fn create_logout_token(&self, _provider_id: &str, _id_token: &str) -> FederationResult<String> {
+            unreachable!("startup publication test does not create logout tokens")
+        }
+
+        async fn build_logout_url(
+            &self,
+            _logout_token: &str,
+            _post_logout_redirect_uri: &str,
+        ) -> FederationResult<Option<String>> {
+            unreachable!("startup publication test does not build logout URLs")
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    struct CapturedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("captured log lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for CapturedLogs {
+        type Writer = CapturedLogWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            CapturedLogWriter(self.0.clone())
+        }
+    }
+
+    fn test_service(has_providers: bool) -> Arc<FederatedIdentityService> {
+        let provider = Arc::new(TestProvider { has_providers });
+        Arc::new(FederatedIdentityService::new(FederatedIdentityRegistry::new(provider)))
+    }
+
+    fn capture_startup_publication(has_providers: bool, browser_redirect_url: Option<&str>) -> String {
+        temp_env::with_var(ENV_RUSTFS_BROWSER_REDIRECT_URL, browser_redirect_url, || {
+            let logs = CapturedLogs::default();
+            let captured = logs.0.clone();
+            let subscriber = Registry::default().with(
+                tracing_subscriber::fmt::layer()
+                    .without_time()
+                    .with_target(false)
+                    .with_level(true)
+                    .with_ansi(false)
+                    .with_writer(logs),
+            );
+
+            tracing::subscriber::with_default(subscriber, || {
+                assert!(publish_federated_identity_service(test_service(has_providers)));
+            });
+
+            String::from_utf8(captured.lock().expect("captured log lock").clone()).expect("captured logs must be UTF-8")
+        })
+    }
+
+    #[test]
+    fn oidc_startup_publication_warns_only_for_request_header_fallback() {
+        let output = capture_startup_publication(true, None);
+
+        assert!(output.contains("WARN"), "{output}");
+        assert!(output.contains(EVENT_OIDC_BROWSER_REDIRECT_FALLBACK), "{output}");
+        assert!(output.contains(ENV_RUSTFS_BROWSER_REDIRECT_URL), "{output}");
+        assert!(output.contains("request_host_and_forwarded_proto"), "{output}");
+        assert!(output.contains("trusted_console_origin_not_configured"), "{output}");
+        assert!(capture_startup_publication(false, None).is_empty());
+        assert!(capture_startup_publication(true, Some("https://console.example.com")).is_empty());
+        assert!(!capture_startup_publication(true, Some("  ")).is_empty());
+    }
 }

--- a/rustfs/src/startup_auth.rs
+++ b/rustfs/src/startup_auth.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rustfs_config::ENV_RUSTFS_BROWSER_REDIRECT_URL;
 use rustfs_iam::{
     federation::{FederatedIdentityRegistry, FederatedIdentityService, oidc::StandardOidcAdapter},
     get_oidc, init_oidc_sys,
@@ -28,24 +27,6 @@ const LOG_SUBSYSTEM_AUTH: &str = "auth";
 const EVENT_KEYSTONE_AUTH_INITIALIZED: &str = "keystone_auth_initialized";
 const EVENT_KEYSTONE_AUTH_INITIALIZATION_FAILED: &str = "keystone_auth_initialization_failed";
 const EVENT_OIDC_INITIALIZATION_FAILED: &str = "oidc_initialization_failed";
-const EVENT_OIDC_BROWSER_REDIRECT_FALLBACK: &str = "oidc_browser_redirect_fallback";
-
-fn warn_if_oidc_browser_redirect_fallback(has_oidc_providers: bool, browser_redirect_url: Option<&str>) {
-    if !has_oidc_providers || browser_redirect_url.is_some_and(|value| !value.trim().is_empty()) {
-        return;
-    }
-
-    warn!(
-        event = EVENT_OIDC_BROWSER_REDIRECT_FALLBACK,
-        component = LOG_COMPONENT_MAIN,
-        subsystem = LOG_SUBSYSTEM_AUTH,
-        state = "fallback_enabled",
-        configuration = ENV_RUSTFS_BROWSER_REDIRECT_URL,
-        fallback_source = "request_host_and_forwarded_proto",
-        reason = "trusted_console_origin_not_configured",
-        "OIDC browser redirect fallback enabled"
-    );
-}
 
 pub(crate) async fn init_auth_integrations() -> Result<()> {
     let keystone_config = rustfs_keystone::KeystoneConfig::from_env().map_err(Error::other)?;
@@ -72,9 +53,6 @@ pub(crate) async fn init_auth_integrations() -> Result<()> {
     match init_oidc_sys().await {
         Ok(()) => {
             if let Some(oidc) = get_oidc() {
-                let browser_redirect_url = rustfs_utils::get_env_opt_str(ENV_RUSTFS_BROWSER_REDIRECT_URL);
-                warn_if_oidc_browser_redirect_fallback(oidc.has_providers(), browser_redirect_url.as_deref());
-
                 let adapter = Arc::new(StandardOidcAdapter::new(oidc));
                 let registry = FederatedIdentityRegistry::new(adapter);
                 let service = Arc::new(FederatedIdentityService::new(registry));
@@ -93,72 +71,4 @@ pub(crate) async fn init_auth_integrations() -> Result<()> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::{self, Write};
-    use std::sync::{Arc, Mutex};
-    use tracing_subscriber::{Registry, fmt::MakeWriter, layer::SubscriberExt};
-
-    #[derive(Clone, Default)]
-    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
-
-    struct CapturedLogWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl Write for CapturedLogWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0.lock().expect("captured log lock").extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'writer> MakeWriter<'writer> for CapturedLogs {
-        type Writer = CapturedLogWriter;
-
-        fn make_writer(&'writer self) -> Self::Writer {
-            CapturedLogWriter(self.0.clone())
-        }
-    }
-
-    fn capture_browser_redirect_warning(has_oidc_providers: bool, browser_redirect_url: Option<&str>) -> String {
-        let logs = CapturedLogs::default();
-        let captured = logs.0.clone();
-        let subscriber = Registry::default().with(
-            tracing_subscriber::fmt::layer()
-                .without_time()
-                .with_target(false)
-                .with_level(false)
-                .with_ansi(false)
-                .with_writer(logs),
-        );
-
-        tracing::subscriber::with_default(subscriber, || {
-            warn_if_oidc_browser_redirect_fallback(has_oidc_providers, browser_redirect_url);
-        });
-
-        String::from_utf8(captured.lock().expect("captured log lock").clone()).expect("captured logs must be UTF-8")
-    }
-
-    #[test]
-    fn warns_when_oidc_uses_request_header_redirect_fallback() {
-        let output = capture_browser_redirect_warning(true, None);
-
-        assert!(output.contains(EVENT_OIDC_BROWSER_REDIRECT_FALLBACK), "{output}");
-        assert!(output.contains(ENV_RUSTFS_BROWSER_REDIRECT_URL), "{output}");
-        assert!(output.contains("request_host_and_forwarded_proto"), "{output}");
-        assert!(output.contains("trusted_console_origin_not_configured"), "{output}");
-    }
-
-    #[test]
-    fn skips_redirect_fallback_warning_when_not_applicable() {
-        assert!(capture_browser_redirect_warning(false, None).is_empty());
-        assert!(capture_browser_redirect_warning(true, Some("https://console.example.com")).is_empty());
-        assert!(!capture_browser_redirect_warning(true, Some("  ")).is_empty());
-    }
 }

--- a/rustfs/src/startup_auth.rs
+++ b/rustfs/src/startup_auth.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rustfs_config::ENV_RUSTFS_BROWSER_REDIRECT_URL;
 use rustfs_iam::{
     federation::{FederatedIdentityRegistry, FederatedIdentityService, oidc::StandardOidcAdapter},
     get_oidc, init_oidc_sys,
@@ -27,6 +28,24 @@ const LOG_SUBSYSTEM_AUTH: &str = "auth";
 const EVENT_KEYSTONE_AUTH_INITIALIZED: &str = "keystone_auth_initialized";
 const EVENT_KEYSTONE_AUTH_INITIALIZATION_FAILED: &str = "keystone_auth_initialization_failed";
 const EVENT_OIDC_INITIALIZATION_FAILED: &str = "oidc_initialization_failed";
+const EVENT_OIDC_BROWSER_REDIRECT_FALLBACK: &str = "oidc_browser_redirect_fallback";
+
+fn warn_if_oidc_browser_redirect_fallback(has_oidc_providers: bool, browser_redirect_url: Option<&str>) {
+    if !has_oidc_providers || browser_redirect_url.is_some_and(|value| !value.trim().is_empty()) {
+        return;
+    }
+
+    warn!(
+        event = EVENT_OIDC_BROWSER_REDIRECT_FALLBACK,
+        component = LOG_COMPONENT_MAIN,
+        subsystem = LOG_SUBSYSTEM_AUTH,
+        state = "fallback_enabled",
+        configuration = ENV_RUSTFS_BROWSER_REDIRECT_URL,
+        fallback_source = "request_host_and_forwarded_proto",
+        reason = "trusted_console_origin_not_configured",
+        "OIDC browser redirect fallback enabled"
+    );
+}
 
 pub(crate) async fn init_auth_integrations() -> Result<()> {
     let keystone_config = rustfs_keystone::KeystoneConfig::from_env().map_err(Error::other)?;
@@ -53,6 +72,9 @@ pub(crate) async fn init_auth_integrations() -> Result<()> {
     match init_oidc_sys().await {
         Ok(()) => {
             if let Some(oidc) = get_oidc() {
+                let browser_redirect_url = rustfs_utils::get_env_opt_str(ENV_RUSTFS_BROWSER_REDIRECT_URL);
+                warn_if_oidc_browser_redirect_fallback(oidc.has_providers(), browser_redirect_url.as_deref());
+
                 let adapter = Arc::new(StandardOidcAdapter::new(oidc));
                 let registry = FederatedIdentityRegistry::new(adapter);
                 let service = Arc::new(FederatedIdentityService::new(registry));
@@ -71,4 +93,72 @@ pub(crate) async fn init_auth_integrations() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::{Registry, fmt::MakeWriter, layer::SubscriberExt};
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    struct CapturedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("captured log lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'writer> MakeWriter<'writer> for CapturedLogs {
+        type Writer = CapturedLogWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            CapturedLogWriter(self.0.clone())
+        }
+    }
+
+    fn capture_browser_redirect_warning(has_oidc_providers: bool, browser_redirect_url: Option<&str>) -> String {
+        let logs = CapturedLogs::default();
+        let captured = logs.0.clone();
+        let subscriber = Registry::default().with(
+            tracing_subscriber::fmt::layer()
+                .without_time()
+                .with_target(false)
+                .with_level(false)
+                .with_ansi(false)
+                .with_writer(logs),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            warn_if_oidc_browser_redirect_fallback(has_oidc_providers, browser_redirect_url);
+        });
+
+        String::from_utf8(captured.lock().expect("captured log lock").clone()).expect("captured logs must be UTF-8")
+    }
+
+    #[test]
+    fn warns_when_oidc_uses_request_header_redirect_fallback() {
+        let output = capture_browser_redirect_warning(true, None);
+
+        assert!(output.contains(EVENT_OIDC_BROWSER_REDIRECT_FALLBACK), "{output}");
+        assert!(output.contains(ENV_RUSTFS_BROWSER_REDIRECT_URL), "{output}");
+        assert!(output.contains("request_host_and_forwarded_proto"), "{output}");
+        assert!(output.contains("trusted_console_origin_not_configured"), "{output}");
+    }
+
+    #[test]
+    fn skips_redirect_fallback_warning_when_not_applicable() {
+        assert!(capture_browser_redirect_warning(false, None).is_empty());
+        assert!(capture_browser_redirect_warning(true, Some("https://console.example.com")).is_empty());
+        assert!(!capture_browser_redirect_warning(true, Some("  ")).is_empty());
+    }
 }


### PR DESCRIPTION
## Related Issues

Related to rustfs/backlog#1437.

## Summary of Changes

- Emit a structured startup warning when at least one OIDC provider is available but `RUSTFS_BROWSER_REDIRECT_URL` is unset or blank.
- Bind the warning to the production federated identity service publication path so startup wiring and provider state are covered together.
- Identify the request Host and forwarded-protocol fallback, the missing trusted Console origin, and the existing configuration key without logging request-controlled values.
- Cover warning level, configured-origin suppression, no-provider suppression, and blank-value behavior through the production publication entry point.

## Verification

- `make pre-commit`
- `cargo test -p rustfs --lib runtime_sources::tests::oidc_startup_publication_warns_only_for_request_header_fallback --no-default-features`
- `cargo clippy -p rustfs --lib --tests --no-deps -- -D warnings`
- `cargo fmt --all --check`
- `./scripts/check_logging_guardrails.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_unsafe_code_allowances.sh`

## Adversarial Validation

- Correctness: exercised the production publication entry with provider present/absent and redirect origin missing/configured/blank; no incorrect branch found.
- Simplicity: attached the warning to the existing service publication boundary without adding a public abstraction or configuration surface.
- Security: confirmed the warning logs only fixed diagnostic fields and no request-controlled Host, forwarded header, token, or credential values.
- Concurrency/durability: the startup-only environment read and warning add no await, lock-order, persistence, or publication-order change.
- Compatibility: preserved the publication function signature, return value, OIDC fallback, API behavior, and optional configuration contract.
- Performance: added one startup environment lookup and provider-state check, with no request-path or hot-path work.
- Test coverage: the focused test calls the production publication function and fails if the warning condition or WARN level is removed or inverted.

## Impact

No configuration becomes mandatory and the existing OIDC browser redirect fallback remains unchanged. Deployments with OIDC providers and no `RUSTFS_BROWSER_REDIRECT_URL` now receive one actionable startup warning during authentication integration initialization.

## Additional Notes

This PR is warning-only for compatibility. It does not make request Host or forwarded-protocol headers a trusted redirect source and does not remove the underlying security risk; operators should configure `RUSTFS_BROWSER_REDIRECT_URL` with the trusted Console origin.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
