### PR TITLE
ci: make the cache size report readable from the API

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -166,11 +166,19 @@ jobs:
       - name: Report cache input sizes
         if: always()
         run: |
+          # tee, not a plain redirect: sent only to $GITHUB_STEP_SUMMARY these
+          # numbers are readable in the UI but absent from the job log, and the
+          # REST API exposes the log, not the summary — which made the figures
+          # unreachable for exactly the scripted comparison they exist for.
+          sizes="$(du -sh ~/.cargo/registry/src ~/.cargo/registry/cache \
+                          ~/.cargo/registry/index ~/.cargo/git target 2>/dev/null || true)"
+          echo "cache-input-sizes-begin"
+          printf '%s\n' "$sizes"
+          echo "cache-input-sizes-end"
           {
             echo "### Cache input sizes (ci-dev)"
             echo '```'
-            du -sh ~/.cargo/registry/src ~/.cargo/registry/cache ~/.cargo/registry/index \
-                   ~/.cargo/git target 2>/dev/null || true
+            printf '%s\n' "$sizes"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
Refs rustfs/backlog#1598, #1600.

The `Report cache input sizes` step added in #5566 sent its output only to `$GITHUB_STEP_SUMMARY`. That renders in the UI but never appears in the job log, and the REST API exposes the log, not the summary — so the one number the `cache-all-crates` decision rests on could not be fetched by the script that needed it.

Now printed to stdout between `cache-input-sizes-begin`/`-end` markers as well, with the summary rendering kept.

Verified: extracted the step body, `bash -n` clean, and ran it locally — degrades gracefully when a path is absent.