### PR TITLE
test(replication): distinguish backlog from failed counters

### DIFF
--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -117,6 +117,7 @@ const REPLICATION_FAILED_EVENT: &str = "s3:Replication:OperationFailedReplicatio
 const REPLICATION_EVENT_MAX_BUFFER_BYTES: usize = 1024 * 1024;
 const OTLP_METRICS_BODY_LIMIT: u64 = 4 * 1024 * 1024;
 const BUCKET_LABEL: &str = "bucket";
+const TOTAL_FAILED_COUNT_METRIC: &str = "rustfs_bucket_replication_total_failed_count";
 const CURRENT_BACKLOG_COUNT_METRIC: &str = "rustfs_bucket_replication_current_backlog_count";
 const CURRENT_BACKLOG_BYTES_METRIC: &str = "rustfs_bucket_replication_current_backlog_bytes";
 const MRF_PENDING_COUNT_METRIC: &str = "rustfs_bucket_replication_mrf_pending_count";
@@ -262,6 +263,7 @@ fn record_backlog_metrics(export: &ExportMetricsServiceRequest, values: &mut BTr
 
 fn record_backlog_metric(metric: &Metric, values: &mut BTreeMap<String, BTreeMap<String, (u64, f64)>>) {
     if ![
+        TOTAL_FAILED_COUNT_METRIC,
         CURRENT_BACKLOG_COUNT_METRIC,
         CURRENT_BACKLOG_BYTES_METRIC,
         MRF_PENDING_COUNT_METRIC,
@@ -3917,7 +3919,8 @@ async fn test_bucket_replication_recovers_after_target_outage() -> TestResult {
 /// loopback target keeps replication workers occupied long enough for the metrics
 /// runtime to publish non-zero bucket backlog gauges; after the real target
 /// returns, replication must converge and the exported current/MRF pending gauges
-/// must settle back to zero.
+/// must settle back to zero even though the historical failed counter remains
+/// non-zero.
 #[tokio::test]
 #[serial]
 async fn test_bucket_replication_backlog_metrics_observe_outage_and_recovery() -> TestResult {
@@ -4003,6 +4006,14 @@ async fn test_bucket_replication_backlog_metrics_observe_outage_and_recovery() -
         current_bytes >= current_backlog,
         "backlog bytes should be at least the object count while queued; count={current_backlog}, bytes={current_bytes}"
     );
+    let failed_count = collector
+        .wait_for_bucket_metric(
+            TOTAL_FAILED_COUNT_METRIC,
+            source_bucket,
+            |value| value >= 1.0,
+            "record at least one failed replication attempt during outage",
+        )
+        .await?;
 
     slow_target.stop().await;
     target_env.restart_server_preserving_data(vec![], &[]).await?;
@@ -4018,6 +4029,11 @@ async fn test_bucket_replication_backlog_metrics_observe_outage_and_recovery() -
             .wait_for_bucket_metric(metric, source_bucket, |value| value == 0.0, "settle back to zero after recovery")
             .await?;
     }
+    let final_failed_count = collector.bucket_metric_value(TOTAL_FAILED_COUNT_METRIC, source_bucket).await;
+    assert!(
+        final_failed_count >= failed_count,
+        "historical failed counter should remain non-zero after recovery while current backlog is zero; before={failed_count}, after={final_failed_count}"
+    );
 
     let target_state = list_replication_state(&target_client, target_bucket).await?;
     for key in ["before-outage.txt"].into_iter().chain(outage_keys) {


### PR DESCRIPTION
## Related Issues
Refs rustfs/backlog#1604
Refs rustfs/backlog#1610
Refs rustfs/rustfs#5526

## Summary of Changes
This PR extends the replication backlog e2e coverage added by rustfs/rustfs#5564 so the outage/recovery path also proves that historical failed counters are not the source of truth for current backlog.

The OTLP test collector now records `rustfs_bucket_replication_total_failed_count` in addition to the current backlog and MRF pending gauges. During the controlled target outage, the test waits for at least one failed replication attempt to be exported. After the real target is restored and replication converges, it still requires current backlog and MRF pending gauges to settle to zero while the failed counter remains non-zero.

This keeps the test focused on the #1610 matrix item that current backlog must not be confused with historical failure counters, without changing production metrics, public APIs, metric labels, or durable MRF format.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p e2e_test test_bucket_replication_backlog_metrics_observe_outage_and_recovery -- --nocapture`
- `cargo clippy --all-targets -p e2e_test`

## Impact
Test-only change. No user-facing API, S3 behavior, Prometheus metric name, label set, configuration, wire format, or on-disk format changes.

## Additional Notes
Adversarial validation summary: correctness attacked the regression where `current_backlog_count` is accidentally wired to failed counters; the enhanced e2e now fails that regression by requiring current backlog to be zero after recovery while `total_failed_count` remains non-zero. Simplicity attacked adding a new separate e2e, but extending the existing outage/recovery test provides the same signal with fewer services and less runtime. Compatibility/security/performance found no production-surface change; the test collector still binds to loopback and keeps the existing OTLP body cap.

Remaining rustfs/backlog#1610 gaps are multi-node PromQL aggregation, source restart durable MRF replay, provider unavailable/corrupt durable MRF e2e, and target/bucket churn series retirement. Per-target backlog remains rustfs/backlog#1608.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
