### PR TITLE
ci: raise CARGO_BUILD_JOBS to 3 on main pushes as a measured experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,29 @@ jobs:
 
       - name: Run nextest tests
         env:
-          # Three concurrent workspace test links saturate the self-hosted
-          # runner's overlay I/O and can wedge Cargo until the 75m timeout.
-          CARGO_BUILD_JOBS: "2"
+          # #5394 mitigation, now under a measured experiment (backlog#1601).
+          #
+          # 2 was chosen when three concurrent workspace test links were believed
+          # to saturate the runner's overlay I/O and wedge Cargo until the 75m
+          # timeout. cgroup v2 readings from the sampler show the pod actually
+          # has 14 CPUs and 28GB (peak use 2.1GB), so 2 throttles compilation to
+          # a seventh of what is available and memory was never the constraint —
+          # the label name "sm-standard-4" had led everyone, including the
+          # original mitigation, to assume 4 cores.
+          #
+          # Raised to 3 on main pushes only; PRs keep 2 so the merge path is
+          # untouched while the experiment runs. Baseline over 17 samples at 2:
+          # median nextest/clippy step ratio 1.95, spread 1.85-2.06. The gate-2
+          # criterion is that ratio dropping at least 10% (below ~1.76) with no
+          # 75m timeout and no run showing three consecutive samples of
+          # rustc/collect2/rust-lld in D state. If it does not, the conclusion is
+          # "this limit is not the bottleneck" — fix it back at 2 and record the
+          # experiment, which is a result, not a failure.
+          #
+          # Must stay step-level: rust-cache hashes CARGO/CC/CFLAGS/CXX/CMAKE/RUST
+          # prefixed variables from process.env into the cache key, so promoting
+          # this to job level would rotate every key on this lane.
+          CARGO_BUILD_JOBS: ${{ github.event_name == 'push' && '3' || '2' }}
         run: |
           mkdir -p artifacts/test-and-lint
           ./scripts/ci/resource_sampler.sh start nextest


### PR DESCRIPTION
Refs rustfs/backlog#1598, #1601 (gate 2).

## Why now

The #5394 mitigation set `CARGO_BUILD_JOBS: "2"` on the belief that three concurrent workspace test links saturate the runner's overlay I/O. The sampler landed in #5540 now reports cgroup v2 values, and they change the picture:

```
/sys/fs/cgroup/cpu.max:      1400000 100000   ->  14 CPU
/sys/fs/cgroup/memory.max:   30064771072      ->  28 GB
/sys/fs/cgroup/memory.peak:  2264412160       ->  2.1 GB peak
```

**The pod has 14 CPUs, not 4.** `2` throttles compilation to a seventh of what is available, and memory was never close to a constraint. The label name `sm-standard-4` had led everyone — the original mitigation, and every PR description I wrote earlier in this series — to assume four cores. That assumption was wrong and is corrected in the comment.

## What changes

`CARGO_BUILD_JOBS: ${{ github.event_name == 'push' && '3' || '2' }}` — 3 on main pushes, **2 everywhere else**, so the PR merge path is untouched while the experiment runs.

Kept at step level deliberately: rust-cache hashes `CARGO`/`CC`/`CFLAGS`/`CXX`/`CMAKE`/`RUST` prefixed variables from `process.env` into its key, so promoting this to job level would rotate every cache key on this lane.

## Baseline (gate 1, already collected)

17 non-cancelled Test and Lint samples at `2`:

| | median | range |
|---|---|---|
| clippy step | 472s | 463-526s |
| nextest step | 914s | 889-982s |
| **ratio nextest/clippy** | **1.95** | **1.85-2.06** |

Judging by the ratio rather than absolute wall clock is what makes this measurable: clippy runs on the same node at the same time, and `--all-targets` is check-only for workspace members so it never links the ~100 test binaries this limit throttles. It is a control arm, not a second measurement. The ±5% spread means a 10% shift is detectable.

## Acceptance

Collect ≥10 non-cancelled samples at `3` and require **all** of:

- ratio drops ≥10%, below about 1.76;
- zero 75m timeouts (`nextest-diagnostics.txt` `exit_status` never 124/137);
- no run with three consecutive sampler points showing `rustc`/`collect2`/`rust-lld` in D state;
- pod-level `io.pressure` full avg60 max not exceeding the baseline P95.

**If the ratio does not drop, the conclusion is that this limit is not the bottleneck** — fix it back at 2, record the experiment number in the comment, and stop revisiting it. That is a result, not a failure.

Rollback is one expression.

## Caveat on the metric

The nextest figure is step duration, which covers build *and* test execution, while `CARGO_BUILD_JOBS` only affects the build. The ratio is therefore diluted — a given build speedup shows up as a smaller ratio change. Both gate 1 and gate 2 use the same measure so the comparison is valid, but extracting the pure build time from `nextest.log`'s `Finished \`test\` profile ... in Xm Ys` would give a cleaner signal and is worth doing when evaluating.