### PR TITLE
ci: let the CARGO_BUILD_JOBS experiment collect samples on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,18 @@ jobs:
           # the label name "sm-standard-4" had led everyone, including the
           # original mitigation, to assume 4 cores.
           #
-          # Raised to 3 on main pushes only; PRs keep 2 so the merge path is
-          # untouched while the experiment runs. Baseline over 17 samples at 2:
+          # Raised to 3 on main pushes and manual dispatches; PRs keep 2 so the
+          # merge path is untouched while the experiment runs.
+          #
+          # Dispatch is included because push alone cannot supply the samples:
+          # this workflow cancels superseded runs on main, and only 4 of the last
+          # 20 push-triggered Test and Lint jobs reached a terminal state — at
+          # that rate ten samples would take roughly fifty merges. The
+          # concurrency group is scoped by event_name, so a dispatched run has
+          # its own group and is not cancelled by merge traffic, which makes the
+          # sample collectable on demand rather than by waiting.
+          #
+          # Baseline over 17 samples at 2:
           # median nextest/clippy step ratio 1.95, spread 1.85-2.06. The gate-2
           # criterion is that ratio dropping at least 10% (below ~1.76) with no
           # 75m timeout and no run showing three consecutive samples of
@@ -238,7 +248,7 @@ jobs:
           # Must stay step-level: rust-cache hashes CARGO/CC/CFLAGS/CXX/CMAKE/RUST
           # prefixed variables from process.env into the cache key, so promoting
           # this to job level would rotate every key on this lane.
-          CARGO_BUILD_JOBS: ${{ github.event_name == 'push' && '3' || '2' }}
+          CARGO_BUILD_JOBS: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && '3' || '2' }}
         run: |
           mkdir -p artifacts/test-and-lint
           ./scripts/ci/resource_sampler.sh start nextest


### PR DESCRIPTION
Refs rustfs/backlog#1598, #1601 (gate 2 feasibility).

Gate 2 needs ten terminal Test and Lint samples at `CARGO_BUILD_JOBS=3`. Measured just now, **push alone cannot supply them**: this workflow cancels superseded runs on main, and only **4 of the last 20** push-triggered Test and Lint jobs reached a terminal state (15 cancelled, 1 still running). At that rate ten samples take roughly fifty merges — the experiment would sit open for days while the branch it measures keeps moving underneath it.

ci.yml's concurrency group is scoped by `event_name`, so a dispatched run gets its own group and is **not** cancelled by merge traffic. Including `workflow_dispatch` in the raised value turns sample collection from waiting-and-hoping into something deliberate.

PRs still get `2`; the merge path is untouched.

Guards pass.