### PR TITLE
ci: add nightly GNU build

### DIFF
--- a/.github/workflows/nightly-gnu.yml
+++ b/.github/workflows/nightly-gnu.yml
@@ -1,0 +1,57 @@
+# Copyright 2024 RustFS Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Nightly GNU Build
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+      timezone: "Asia/Shanghai"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-gnu-build-main-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    name: Build x86_64 GNU
+    runs-on: sm-standard-2
+    timeout-minutes: 150
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+          ref: main
+
+      - name: Setup Rust environment
+        uses: ./.github/actions/setup
+        with:
+          cache-shared-key: build-x86_64-unknown-linux-gnu
+          cache-save-if: 'false'
+          install-build-packaging-tools: 'false'
+          install-test-tools: 'false'
+
+      - name: Build RustFS
+        run: cargo build --release --locked --target x86_64-unknown-linux-gnu -p rustfs --bins


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Add a compile-only GitHub Actions workflow that checks out `main` and builds the x86_64 GNU release binary every day at 00:00 Asia/Shanghai. The workflow also supports manual dispatches, reuses the existing Rust setup action and GNU build cache, and keeps scheduled runs from canceling one another.

## Verification

- `cargo fmt --all --check`
- `actionlint .github/workflows/nightly-gnu.yml`
- `scripts/security/check_cache_save_if.sh`
- `scripts/security/check_job_timeouts.sh`
- `scripts/security/check_workflow_pins.sh --enforce`
- `scripts/security/check_persist_credentials.sh`
- `scripts/check_ci_paths_sync.sh`
- `git diff --check`
- Independent correctness, concurrency, security, compatibility, simplicity, and performance reviews

## Impact

Adds one daily `sm-standard-2` runner build. There are no runtime, API, configuration, artifact publishing, or deployment behavior changes.

## Additional Notes

The workflow is compile-only and does not download console assets, package the binary, or upload artifacts.

The repository-wide `--all-features` Clippy command and the default parallel `cargo test` command expose pre-existing failures on the current `main` branch (`dial9`/`Send` compilation constraints and shared global test state, respectively). These failures are unrelated to this workflow-only diff and are not reported as passing here.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
