### PR TITLE
test(perf): cover ABBA evidence binding matrix

### DIFF
--- a/scripts/test_hotpath_warp_abba.sh
+++ b/scripts/test_hotpath_warp_abba.sh
@@ -159,33 +159,51 @@ BAD_EVIDENCE_HOOK="${TMP_DIR}/bad-evidence-hook.sh"
 cat >"$BAD_EVIDENCE_HOOK" <<'HOOK'
 #!/usr/bin/env bash
 set -euo pipefail
-cat >"$HOTPATH_ABBA_DEPLOY_EVIDENCE_FILE" <<EOF
-leg=$HOTPATH_ABBA_LEG
-phase=$HOTPATH_ABBA_PHASE
-bucket=wrong-bucket
-binary_sha256=$HOTPATH_ABBA_BINARY_SHA256
+leg="$HOTPATH_ABBA_LEG"
+phase="$HOTPATH_ABBA_PHASE"
+bucket="$HOTPATH_ABBA_BUCKET"
+binary_sha256="$HOTPATH_ABBA_BINARY_SHA256"
 dataset_reset=true
+
+case "${BAD_EVIDENCE_FIELD:?missing BAD_EVIDENCE_FIELD}" in
+  leg) leg=wrong-leg ;;
+  phase) phase=wrong-phase ;;
+  bucket) bucket=wrong-bucket ;;
+  binary_sha256) binary_sha256=wrong-sha256 ;;
+  dataset_reset) dataset_reset=false ;;
+  *) echo "unknown BAD_EVIDENCE_FIELD=$BAD_EVIDENCE_FIELD" >&2; exit 2 ;;
+esac
+
+cat >"$HOTPATH_ABBA_DEPLOY_EVIDENCE_FILE" <<EOF
+leg=$leg
+phase=$phase
+bucket=$bucket
+binary_sha256=$binary_sha256
+dataset_reset=$dataset_reset
 EOF
 HOOK
 chmod +x "$BAD_EVIDENCE_HOOK"
 
-if "$RUNNER" \
-  --baseline-bin /usr/bin/true \
-  --candidate-bin /usr/bin/true \
-  --baseline-revision baseline-test \
-  --candidate-revision candidate-test \
-  --endpoint 127.0.0.1:9000 \
-  --deploy-hook "$BAD_EVIDENCE_HOOK" \
-  --warp-bin /usr/bin/true \
-  --rounds 3 \
-  --out-dir "${TMP_DIR}/bad-deploy-evidence" >/dev/null 2>&1; then
-  echo "expected a formal external deploy hook with wrong evidence to fail" >&2
-  exit 1
-fi
-rg -qx 'external=true' "${TMP_DIR}/bad-deploy-evidence/manifest.env"
-rg -qx 'external_isolation=deploy-hook-attested' "${TMP_DIR}/bad-deploy-evidence/manifest.env"
-rg -qx 'evidence_mode=external-deploy-hook-attested' "${TMP_DIR}/bad-deploy-evidence/manifest.env"
-rg -qx 'formal_evidence=true' "${TMP_DIR}/bad-deploy-evidence/manifest.env"
-rg -qx 'performance_conclusion=not_claimed_gate_and_artifacts_required' "${TMP_DIR}/bad-deploy-evidence/manifest.env"
+for bad_field in leg phase bucket binary_sha256 dataset_reset; do
+  bad_out_dir="${TMP_DIR}/bad-deploy-evidence-${bad_field}"
+  if BAD_EVIDENCE_FIELD="$bad_field" "$RUNNER" \
+    --baseline-bin /usr/bin/true \
+    --candidate-bin /usr/bin/true \
+    --baseline-revision baseline-test \
+    --candidate-revision candidate-test \
+    --endpoint 127.0.0.1:9000 \
+    --deploy-hook "$BAD_EVIDENCE_HOOK" \
+    --warp-bin /usr/bin/true \
+    --rounds 3 \
+    --out-dir "$bad_out_dir" >/dev/null 2>&1; then
+    echo "expected a formal external deploy hook with wrong $bad_field evidence to fail" >&2
+    exit 1
+  fi
+  rg -qx 'external=true' "$bad_out_dir/manifest.env"
+  rg -qx 'external_isolation=deploy-hook-attested' "$bad_out_dir/manifest.env"
+  rg -qx 'evidence_mode=external-deploy-hook-attested' "$bad_out_dir/manifest.env"
+  rg -qx 'formal_evidence=true' "$bad_out_dir/manifest.env"
+  rg -qx 'performance_conclusion=not_claimed_gate_and_artifacts_required' "$bad_out_dir/manifest.env"
+done
 
 echo "hotpath warp ABBA tests passed"


### PR DESCRIPTION
## Related Issues
#1595, #1589

## Summary of Changes
This follow-up strengthens the HotPath Warp ABBA evidence contract tests. The existing mismatched deploy-evidence regression only covered a wrong bucket; this patch turns it into a binding matrix that verifies formal external deploy evidence fails closed when `leg`, `phase`, `bucket`, `binary_sha256`, or `dataset_reset` is wrong.

The runner logic is unchanged. This only ensures future edits cannot weaken the existing deploy-evidence attestation checks while still producing a non-empty evidence file.

## Verification
- `scripts/test_hotpath_warp_abba.sh`
- `bash -n scripts/run_hotpath_warp_abba.sh scripts/test_hotpath_warp_abba.sh`
- `git diff --check`

## Impact
No runtime RustFS behavior, public API, S3 API, metric name, on-disk/on-wire format, quorum, durability, or deployment configuration changes. This is test-only coverage for the performance evidence harness.

## Additional Notes
This PR does not claim measured performance improvement. #1595 remains open until real Linux multi-disk Warp, RSS, throughput, P90/P99, error-rate, A2 drift, and environment provenance artifacts exist.
