### PR TITLE
feat(replication): expose runtime target backlog

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -184,13 +184,13 @@ pub mod bucket {
             ReplicationDeleteStateSource, ReplicationHealQueueResult, ReplicationObjectBridge, ReplicationObjectIO,
             ReplicationOperation, ReplicationPoolTrait, ReplicationPriority, ReplicationQueueAdmission, ReplicationScannerBridge,
             ReplicationState, ReplicationStats, ReplicationStatusType, ReplicationStorage, ReplicationTargetValidationError,
-            ReplicationType, ResyncOpts, ResyncStatusType, TargetReplicationResyncStatus, VersionPurgeStatusType,
-            delete_replication_state_from_config, delete_replication_version_id, get_global_replication_pool,
-            get_global_replication_stats, init_background_replication, read_durable_mrf_backlog, replication_state_to_filemeta,
-            replication_status_to_filemeta, replication_statuses_map, replication_target_arns, resync_start_conflict_id,
-            should_remove_replication_target, should_schedule_delete_replication, should_use_existing_delete_replication_info,
-            should_use_existing_delete_replication_source, validate_replication_config_target_arns,
-            version_purge_status_to_filemeta,
+            ReplicationType, ResyncOpts, ResyncStatusType, RuntimeReplicationTargetBacklog, TargetReplicationResyncStatus,
+            VersionPurgeStatusType, delete_replication_state_from_config, delete_replication_version_id,
+            get_global_replication_pool, get_global_replication_stats, init_background_replication, read_durable_mrf_backlog,
+            replication_state_to_filemeta, replication_status_to_filemeta, replication_statuses_map, replication_target_arns,
+            resync_start_conflict_id, should_remove_replication_target, should_schedule_delete_replication,
+            should_use_existing_delete_replication_info, should_use_existing_delete_replication_source,
+            validate_replication_config_target_arns, version_purge_status_to_filemeta,
         };
     }
 

--- a/crates/ecstore/src/bucket/replication/mod.rs
+++ b/crates/ecstore/src/bucket/replication/mod.rs
@@ -78,7 +78,7 @@ pub use replication_queue_boundary::{
 };
 pub use replication_resync_boundary::{BucketReplicationResyncStatus, ResyncOpts, TargetReplicationResyncStatus};
 pub use replication_scanner_bridge::ReplicationScannerBridge;
-pub use replication_state::ReplicationStats;
+pub use replication_state::{ReplicationStats, RuntimeReplicationTargetBacklog};
 pub use replication_stats_boundary::BucketStats;
 pub use replication_storage_boundary::{ReplicationObjectIO, ReplicationStorage};
 pub(crate) use replication_target_config_bridge::ReplicationTargetConfigBridge;

--- a/crates/ecstore/src/bucket/replication/replication_pool.rs
+++ b/crates/ecstore/src/bucket/replication/replication_pool.rs
@@ -760,6 +760,7 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
 
     /// Queues a replica task
     pub async fn queue_replica_task(&self, ri: ReplicateObjectInfo) -> ReplicationQueueAdmission {
+        let target_arns = ri.dsc.replicate_target_arns();
         // If object is large, queue it to a static set of large workers
         if should_queue_large_object(ri.size) {
             use std::collections::hash_map::DefaultHasher;
@@ -776,10 +777,12 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
 
                 if let Some(worker) = lrg_workers.get(index) {
                     self.stats.inc_q(&ri.bucket, ri.size, ri.delete_marker, ri.op_type);
+                    self.stats.inc_target_q(&ri.bucket, &target_arns, ri.size);
                     if worker.try_send(ReplicationOperation::Object(Box::new(ri.clone()))).is_ok() {
                         return ReplicationQueueAdmission::Queued;
                     }
                     self.stats.dec_q(&ri.bucket, ri.size, ri.delete_marker, ri.op_type);
+                    self.stats.dec_target_q(&ri.bucket, &target_arns, ri.size);
 
                     // Try to add more workers if possible
                     let max_l_workers = *self.max_l_workers.read().await;
@@ -808,10 +811,12 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
         };
 
         self.stats.inc_q(&ri.bucket, ri.size, ri.delete_marker, ri.op_type);
+        self.stats.inc_target_q(&ri.bucket, &target_arns, ri.size);
         if channel.try_send(ReplicationOperation::Object(Box::new(ri.clone()))).is_ok() {
             return ReplicationQueueAdmission::Queued;
         }
         self.stats.dec_q(&ri.bucket, ri.size, ri.delete_marker, ri.op_type);
+        self.stats.dec_target_q(&ri.bucket, &target_arns, ri.size);
 
         // Queue to MRF if all workers are busy.
         let admission = self.queue_mrf_save_admission(ri.to_mrf_entry(), "object").await;
@@ -825,6 +830,11 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
 
     /// Queues a replica delete task
     pub async fn queue_replica_delete_task(&self, doi: DeletedObjectReplicationInfo) -> ReplicationQueueAdmission {
+        let target_arns = if doi.target_arn.is_empty() {
+            Vec::new()
+        } else {
+            vec![doi.target_arn.clone()]
+        };
         let ch = self
             .worker_queue_channel(&doi.op_type, &doi.bucket, &doi.delete_object.object_name, 0)
             .await;
@@ -834,10 +844,12 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
         };
 
         self.stats.inc_q(&doi.bucket, 0, true, doi.op_type);
+        self.stats.inc_target_q(&doi.bucket, &target_arns, 0);
         if channel.try_send(ReplicationOperation::Delete(Box::new(doi.clone()))).is_ok() {
             return ReplicationQueueAdmission::Queued;
         }
         self.stats.dec_q(&doi.bucket, 0, true, doi.op_type);
+        self.stats.dec_target_q(&doi.bucket, &target_arns, 0);
 
         let admission = self.queue_mrf_save_admission(doi.to_mrf_entry(), "delete").await;
 
@@ -856,9 +868,11 @@ impl<S: ReplicationStorage> ReplicationPool<S> {
         let bucket = entry.bucket.clone();
         let size = entry.size;
         let is_delete = matches!(entry.op, MrfOpKind::Delete);
+        let target_arns = entry.target_arns.clone();
         let admission = queue_mrf_save_entry(&self.mrf_save_tx, entry, queue_type).await;
         if admission == ReplicationQueueAdmission::Queued {
             self.stats.inc_q(&bucket, size, is_delete, ReplicationType::Heal);
+            self.stats.inc_target_q(&bucket, &target_arns, size);
         }
         admission
     }
@@ -1534,6 +1548,7 @@ struct ReplicationBacklogGuard {
     size: i64,
     is_delete_marker: bool,
     op_type: ReplicationType,
+    target_arns: Vec<String>,
 }
 
 impl ReplicationBacklogGuard {
@@ -1544,16 +1559,23 @@ impl ReplicationBacklogGuard {
             size: object.size,
             is_delete_marker: object.delete_marker,
             op_type: object.op_type,
+            target_arns: object.dsc.replicate_target_arns(),
         }
     }
 
     fn for_delete(stats: Arc<ReplicationStats>, delete: &DeletedObjectReplicationInfo) -> Self {
+        let target_arns = if delete.target_arn.is_empty() {
+            Vec::new()
+        } else {
+            vec![delete.target_arn.clone()]
+        };
         Self {
             stats,
             bucket: delete.bucket.clone(),
             size: 0,
             is_delete_marker: true,
             op_type: delete.op_type,
+            target_arns,
         }
     }
 }
@@ -1561,6 +1583,7 @@ impl ReplicationBacklogGuard {
 impl Drop for ReplicationBacklogGuard {
     fn drop(&mut self) {
         self.stats.dec_q(&self.bucket, self.size, self.is_delete_marker, self.op_type);
+        self.stats.dec_target_q(&self.bucket, &self.target_arns, self.size);
     }
 }
 
@@ -1607,6 +1630,7 @@ async fn queue_mrf_save_entry(
 fn dec_mrf_entries(stats: &ReplicationStats, entries: &[MrfReplicateEntry]) {
     for entry in entries {
         stats.dec_q(&entry.bucket, entry.size, matches!(entry.op, MrfOpKind::Delete), ReplicationType::Heal);
+        stats.dec_target_q(&entry.bucket, &entry.target_arns, entry.size);
     }
 }
 
@@ -1998,6 +2022,7 @@ async fn queue_replicate_deletes(batch: ReplicationHealResyncDeletes) -> Replica
 
 #[cfg(test)]
 mod tests {
+    use super::super::replication_filemeta_boundary::ReplicateTargetDecision;
     use super::super::replication_resync_boundary::{decode_mrf_file, encode_mrf_file, encode_resync_file};
     use super::super::replication_storage_boundary::{
         DeletedObject, FileInfo, GetObjectReader, HTTPRangeSpec, ListOperations, ObjectIO, ObjectOperations, PutObjReader,
@@ -2343,6 +2368,22 @@ mod tests {
         (stats.replication_stats.q_stat.curr.count, stats.replication_stats.q_stat.curr.bytes)
     }
 
+    fn current_target_queue(pool: &ReplicationPool<LoadResyncNodeStore>, bucket: &str, target_arn: &str) -> Option<(u64, u64)> {
+        pool.stats
+            .runtime_target_backlog_snapshot()
+            .into_iter()
+            .find(|target| target.bucket == bucket && target.target_arn == target_arn)
+            .map(|target| (target.count, target.bytes))
+    }
+
+    fn test_replicate_decision(target_arns: &[&str]) -> ReplicateDecision {
+        let mut decision = ReplicateDecision::default();
+        for target_arn in target_arns {
+            decision.set(ReplicateTargetDecision::new((*target_arn).to_string(), true, false));
+        }
+        decision
+    }
+
     async fn wait_for_current_queue(pool: &ReplicationPool<LoadResyncNodeStore>, bucket: &str, expected: (i64, i64)) {
         tokio::time::timeout(Duration::from_secs(10), async {
             loop {
@@ -2374,6 +2415,35 @@ mod tests {
 
         assert_eq!(admission, ReplicationQueueAdmission::Queued);
         assert_eq!(current_queue(&pool, "admission-bucket").await, (1, 4096));
+    }
+
+    #[tokio::test]
+    async fn regular_worker_admission_counts_target_backlog_before_receive() {
+        let pool = new_test_replication_pool(Arc::new(LoadResyncNodeStore::new("node-a", empty_resync_shared_state()))).await;
+        let (tx, _rx) = mpsc::channel(1);
+        pool.workers.write().await.push(tx);
+
+        let admission = pool
+            .queue_replica_task(ReplicateObjectInfo {
+                bucket: "target-admission-bucket".to_string(),
+                name: "object".to_string(),
+                size: 4096,
+                op_type: ReplicationType::Object,
+                dsc: test_replicate_decision(&["arn:rustfs:replication:target-b", "arn:rustfs:replication:target-a"]),
+                ..Default::default()
+            })
+            .await;
+
+        assert_eq!(admission, ReplicationQueueAdmission::Queued);
+        assert_eq!(current_queue(&pool, "target-admission-bucket").await, (1, 4096));
+        assert_eq!(
+            current_target_queue(&pool, "target-admission-bucket", "arn:rustfs:replication:target-a"),
+            Some((1, 4096))
+        );
+        assert_eq!(
+            current_target_queue(&pool, "target-admission-bucket", "arn:rustfs:replication:target-b"),
+            Some((1, 4096))
+        );
     }
 
     #[tokio::test]
@@ -2417,6 +2487,33 @@ mod tests {
 
         assert_eq!(admission, ReplicationQueueAdmission::Queued);
         assert_eq!(current_queue(&pool, "delete-admission-bucket").await, (1, 0));
+    }
+
+    #[tokio::test]
+    async fn delete_admission_counts_target_backlog_before_receive() {
+        let pool = new_test_replication_pool(Arc::new(LoadResyncNodeStore::new("node-a", empty_resync_shared_state()))).await;
+        let (tx, _rx) = mpsc::channel(1);
+        pool.workers.write().await.push(tx);
+
+        let admission = pool
+            .queue_replica_delete_task(DeletedObjectReplicationInfo {
+                bucket: "delete-target-admission-bucket".to_string(),
+                target_arn: "arn:rustfs:replication:target-a".to_string(),
+                delete_object: ReplicationDeletedObject {
+                    object_name: "deleted-object".to_string(),
+                    ..Default::default()
+                },
+                op_type: ReplicationType::Delete,
+                ..Default::default()
+            })
+            .await;
+
+        assert_eq!(admission, ReplicationQueueAdmission::Queued);
+        assert_eq!(current_queue(&pool, "delete-target-admission-bucket").await, (1, 0));
+        assert_eq!(
+            current_target_queue(&pool, "delete-target-admission-bucket", "arn:rustfs:replication:target-a"),
+            Some((1, 0))
+        );
     }
 
     #[tokio::test]
@@ -2785,6 +2882,7 @@ mod tests {
                 name: "fallback-object".to_string(),
                 size: 2048,
                 op_type: ReplicationType::Object,
+                dsc: test_replicate_decision(&["arn:rustfs:replication:target-a"]),
                 ..Default::default()
             })
             .await;
@@ -2793,6 +2891,10 @@ mod tests {
         let queued = pool.stats.get_latest_replication_stats("runtime-backlog").await;
         assert_eq!(queued.replication_stats.q_stat.curr.count, 1);
         assert_eq!(queued.replication_stats.q_stat.curr.bytes, 2048);
+        assert_eq!(
+            current_target_queue(&pool, "runtime-backlog", "arn:rustfs:replication:target-a"),
+            Some((1, 2048))
+        );
     }
 
     #[test]
@@ -2931,12 +3033,14 @@ mod tests {
     async fn replication_backlog_guard_decrements_on_drop() {
         let stats = Arc::new(ReplicationStats::new());
         stats.inc_q("guard-bucket", 256, false, ReplicationType::Object);
+        stats.inc_target_q("guard-bucket", &["arn:rustfs:replication:target-a".to_string()], 256);
 
         {
             let object = ReplicateObjectInfo {
                 bucket: "guard-bucket".to_string(),
                 size: 256,
                 op_type: ReplicationType::Object,
+                dsc: test_replicate_decision(&["arn:rustfs:replication:target-a"]),
                 ..Default::default()
             };
             let _guard = ReplicationBacklogGuard::for_object(stats.clone(), &object);
@@ -2945,6 +3049,30 @@ mod tests {
         let queued = stats.get_latest_replication_stats("guard-bucket").await;
         assert_eq!(queued.replication_stats.q_stat.curr.count, 0);
         assert_eq!(queued.replication_stats.q_stat.curr.bytes, 0);
+        assert!(stats.runtime_target_backlog_snapshot().is_empty());
+    }
+
+    #[test]
+    fn dec_mrf_entries_decrements_target_backlog() {
+        let stats = ReplicationStats::new();
+        let entry = MrfReplicateEntry {
+            bucket: "mrf-target-drain-bucket".to_string(),
+            object: "object".to_string(),
+            version_id: None,
+            retry_count: 1,
+            size: 1024,
+            op: MrfOpKind::Object,
+            delete_marker_version_id: None,
+            delete_marker: false,
+            delete_marker_mtime: None,
+            target_arns: vec!["arn:rustfs:replication:target-a".to_string()],
+        };
+
+        stats.inc_q(&entry.bucket, entry.size, false, ReplicationType::Heal);
+        stats.inc_target_q(&entry.bucket, &entry.target_arns, entry.size);
+        dec_mrf_entries(&stats, std::slice::from_ref(&entry));
+
+        assert!(stats.runtime_target_backlog_snapshot().is_empty());
     }
 
     #[test]

--- a/crates/ecstore/src/bucket/replication/replication_state.rs
+++ b/crates/ecstore/src/bucket/replication/replication_state.rs
@@ -22,9 +22,9 @@ use super::replication_stats_boundary::{
     QueueCache, ReplicationMetricScope, SRMetricsSummary, XferStats,
 };
 use super::runtime_boundary as runtime_sources;
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 use std::sync::atomic::{AtomicI64, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex, Weak};
 use std::time::{Duration, SystemTime};
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::interval;
@@ -151,6 +151,83 @@ pub struct ReplicationStats {
     // Bucket replication cache
     pub cache: Arc<RwLock<HashMap<String, BucketReplicationStats>>>,
     pub most_recent_stats: Arc<Mutex<HashMap<String, BucketStats>>>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeReplicationTargetBacklog {
+    pub bucket: String,
+    pub target_arn: String,
+    pub count: u64,
+    pub bytes: u64,
+}
+
+type TargetQueueKey = (String, String);
+type TargetQueueCache = HashMap<TargetQueueKey, InQueueMetric>;
+
+struct TargetQueueCacheSlot {
+    owner: Weak<StdMutex<QueueCache>>,
+    metrics: TargetQueueCache,
+}
+
+impl TargetQueueCacheSlot {
+    fn new(owner: &Arc<StdMutex<QueueCache>>) -> Self {
+        Self {
+            owner: Arc::downgrade(owner),
+            metrics: TargetQueueCache::default(),
+        }
+    }
+
+    fn belongs_to(&self, owner: &Arc<StdMutex<QueueCache>>) -> bool {
+        self.owner.upgrade().is_some_and(|current| Arc::ptr_eq(&current, owner))
+    }
+}
+
+// Keep runtime target counters outside ReplicationStats to preserve its public struct shape.
+static TARGET_QUEUE_CACHES: LazyLock<StdMutex<Vec<TargetQueueCacheSlot>>> = LazyLock::new(|| StdMutex::new(Vec::new()));
+
+fn i64_to_u64_floor_zero(value: i64) -> u64 {
+    u64::try_from(value.max(0)).unwrap_or(0)
+}
+
+fn normalized_target_arns(target_arns: &[String]) -> Vec<&str> {
+    let mut target_arns = target_arns
+        .iter()
+        .map(String::as_str)
+        .filter(|target_arn| !target_arn.is_empty())
+        .collect::<Vec<_>>();
+    target_arns.sort_unstable();
+    target_arns.dedup();
+    target_arns
+}
+
+fn target_queue_cache_snapshot(cache: &TargetQueueCache) -> Vec<RuntimeReplicationTargetBacklog> {
+    cache
+        .iter()
+        .filter_map(|((bucket, target_arn), metric)| {
+            let count = i64_to_u64_floor_zero(metric.curr.get_current_count());
+            let bytes = i64_to_u64_floor_zero(metric.curr.get_current_bytes());
+            (count > 0 || bytes > 0).then(|| RuntimeReplicationTargetBacklog {
+                bucket: bucket.clone(),
+                target_arn: target_arn.clone(),
+                count,
+                bytes,
+            })
+        })
+        .collect()
+}
+
+fn prune_stale_target_queue_caches(caches: &mut Vec<TargetQueueCacheSlot>) {
+    caches.retain(|slot| slot.owner.strong_count() > 0);
+}
+
+fn with_target_queue_caches<T>(f: impl FnOnce(&mut Vec<TargetQueueCacheSlot>) -> T) -> T {
+    match TARGET_QUEUE_CACHES.lock() {
+        Ok(mut caches) => f(&mut caches),
+        Err(poisoned) => {
+            let mut caches = poisoned.into_inner();
+            f(&mut caches)
+        }
+    }
 }
 
 impl ReplicationStats {
@@ -684,6 +761,68 @@ impl ReplicationStats {
         }
     }
 
+    pub(crate) fn inc_target_q(&self, bucket: &str, target_arns: &[String], size: i64) {
+        let target_arns = normalized_target_arns(target_arns);
+        if target_arns.is_empty() {
+            return;
+        }
+        with_target_queue_caches(|caches| {
+            prune_stale_target_queue_caches(caches);
+            let slot_index = match caches.iter().position(|slot| slot.belongs_to(&self.q_cache)) {
+                Some(index) => index,
+                None => {
+                    caches.push(TargetQueueCacheSlot::new(&self.q_cache));
+                    caches.len() - 1
+                }
+            };
+            let slot = &mut caches[slot_index];
+            let bucket = bucket.to_string();
+            for target_arn in target_arns {
+                let metric = match slot.metrics.entry((bucket.clone(), target_arn.to_string())) {
+                    Entry::Occupied(entry) => entry.into_mut(),
+                    Entry::Vacant(entry) => entry.insert(InQueueMetric::default()),
+                };
+                metric.curr.add_current(size, 1);
+            }
+        });
+    }
+
+    pub(crate) fn dec_target_q(&self, bucket: &str, target_arns: &[String], size: i64) {
+        let target_arns = normalized_target_arns(target_arns);
+        if target_arns.is_empty() {
+            return;
+        }
+        with_target_queue_caches(|caches| {
+            prune_stale_target_queue_caches(caches);
+            if let Some(slot) = caches.iter_mut().find(|slot| slot.belongs_to(&self.q_cache)) {
+                let bucket = bucket.to_string();
+                for target_arn in target_arns {
+                    if let Some(metric) = slot.metrics.get_mut(&(bucket.clone(), target_arn.to_string())) {
+                        metric.curr.subtract_current(size, 1);
+                    }
+                }
+                slot.metrics
+                    .retain(|_, metric| metric.curr.get_current_count() > 0 || metric.curr.get_current_bytes() > 0);
+            }
+        });
+    }
+
+    pub fn runtime_target_backlog_snapshot(&self) -> Vec<RuntimeReplicationTargetBacklog> {
+        let mut snapshot = with_target_queue_caches(|caches| {
+            caches
+                .iter()
+                .find(|slot| slot.belongs_to(&self.q_cache))
+                .map(|slot| target_queue_cache_snapshot(&slot.metrics))
+                .unwrap_or_default()
+        });
+        snapshot.sort_by(|left, right| {
+            left.bucket
+                .cmp(&right.bucket)
+                .then_with(|| left.target_arn.cmp(&right.target_arn))
+        });
+        snapshot
+    }
+
     /// Increase proxy metrics
     pub async fn inc_proxy(&self, bucket: &str, api: &str, is_err: bool) {
         let mut p_cache = self.p_cache.lock().await;
@@ -706,6 +845,94 @@ impl Default for ReplicationStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_target_backlog_snapshot_tracks_targets() {
+        let stats = ReplicationStats::new();
+        stats.inc_target_q(
+            "photos",
+            &[
+                "arn:rustfs:replication:target-b".to_string(),
+                "arn:rustfs:replication:target-a".to_string(),
+                "arn:rustfs:replication:target-a".to_string(),
+            ],
+            1024,
+        );
+
+        let snapshot = stats.runtime_target_backlog_snapshot();
+
+        assert_eq!(
+            snapshot,
+            vec![
+                RuntimeReplicationTargetBacklog {
+                    bucket: "photos".to_string(),
+                    target_arn: "arn:rustfs:replication:target-a".to_string(),
+                    count: 1,
+                    bytes: 1024,
+                },
+                RuntimeReplicationTargetBacklog {
+                    bucket: "photos".to_string(),
+                    target_arn: "arn:rustfs:replication:target-b".to_string(),
+                    count: 1,
+                    bytes: 1024,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_target_backlog_ignores_empty_targets() {
+        let stats = ReplicationStats::new();
+        stats.inc_target_q("photos", &["".to_string()], 1024);
+
+        assert!(stats.runtime_target_backlog_snapshot().is_empty());
+    }
+
+    #[test]
+    fn runtime_target_backlog_is_scoped_to_stats_instance() {
+        let first = ReplicationStats::new();
+        let second = ReplicationStats::new();
+        first.inc_target_q("photos", &["arn:rustfs:replication:target-a".to_string()], 1024);
+
+        assert!(second.runtime_target_backlog_snapshot().is_empty());
+        assert_eq!(first.runtime_target_backlog_snapshot()[0].count, 1);
+    }
+
+    #[test]
+    fn runtime_target_backlog_decrements_with_saturation() {
+        let stats = ReplicationStats::new();
+        let target_arns = ["arn:rustfs:replication:target-a".to_string()];
+        stats.inc_target_q("photos", &target_arns, 1024);
+        stats.dec_target_q("photos", &target_arns, 2048);
+
+        assert!(stats.runtime_target_backlog_snapshot().is_empty());
+    }
+
+    #[test]
+    fn runtime_target_backlog_prunes_stale_sidecar_on_next_access() {
+        {
+            let stats = ReplicationStats::new();
+            stats.inc_target_q("photos", &["arn:rustfs:replication:target-a".to_string()], 1024);
+            assert!(
+                TARGET_QUEUE_CACHES
+                    .lock()
+                    .expect("target queue cache mutex")
+                    .iter()
+                    .any(|slot| slot.owner.strong_count() > 0)
+            );
+        }
+
+        let stats = ReplicationStats::new();
+        stats.inc_target_q("photos", &["arn:rustfs:replication:target-b".to_string()], 1024);
+
+        assert!(
+            TARGET_QUEUE_CACHES
+                .lock()
+                .expect("target queue cache mutex")
+                .iter()
+                .all(|slot| slot.owner.strong_count() > 0)
+        );
+    }
 
     #[tokio::test]
     async fn test_replication_stats_new() {

--- a/crates/obs/src/metrics/collectors/bucket_replication.rs
+++ b/crates/obs/src/metrics/collectors/bucket_replication.rs
@@ -17,7 +17,8 @@
 use crate::metrics::report::PrometheusMetric;
 use crate::metrics::schema::bucket_replication::{
     BUCKET_L, BUCKET_REPL_BANDWIDTH_CURRENT_MD, BUCKET_REPL_BANDWIDTH_LIMIT_MD, BUCKET_REPL_CURRENT_BACKLOG_BYTES_MD,
-    BUCKET_REPL_CURRENT_BACKLOG_COUNT_MD, BUCKET_REPL_DURABLE_MRF_AVAILABLE_MD, BUCKET_REPL_DURABLE_MRF_BACKLOG_BYTES_MD,
+    BUCKET_REPL_CURRENT_BACKLOG_COUNT_MD, BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD,
+    BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD, BUCKET_REPL_DURABLE_MRF_AVAILABLE_MD, BUCKET_REPL_DURABLE_MRF_BACKLOG_BYTES_MD,
     BUCKET_REPL_DURABLE_MRF_BACKLOG_COUNT_MD, BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_BYTES_MD,
     BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD, BUCKET_REPL_LAST_HR_FAILED_BYTES_MD, BUCKET_REPL_LAST_HR_FAILED_COUNT_MD,
     BUCKET_REPL_LAST_MIN_FAILED_BYTES_MD, BUCKET_REPL_LAST_MIN_FAILED_COUNT_MD, BUCKET_REPL_LATENCY_MS_MD,
@@ -38,7 +39,7 @@ use std::borrow::Cow;
 
 const BASE_BUCKET_REPLICATION_METRICS_PER_BUCKET: usize = 25;
 const BASE_BUCKET_REPLICATION_BACKLOG_METRICS_PER_BUCKET: usize = 11;
-const BUCKET_REPLICATION_DURABLE_MRF_METRICS_PER_TARGET: usize = 2;
+const BUCKET_REPLICATION_BACKLOG_METRICS_PER_TARGET: usize = 4;
 
 #[derive(Debug, Clone, Default)]
 pub struct BucketReplicationTargetStats {
@@ -101,12 +102,14 @@ pub(crate) struct BucketReplicationBacklogStats {
     pub(crate) mrf_missed_count: u64,
     pub(crate) mrf_flush_failures: u64,
     pub(crate) mrf_last_flush_duration_millis: u64,
-    pub(crate) durable_mrf_targets: Vec<BucketReplicationTargetBacklogStats>,
+    pub(crate) target_backlogs: Vec<BucketReplicationTargetBacklogStats>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BucketReplicationTargetBacklogStats {
     pub(crate) target_arn: String,
+    pub(crate) current_backlog_count: u64,
+    pub(crate) current_backlog_bytes: u64,
     pub(crate) durable_mrf_backlog_count: u64,
     pub(crate) durable_mrf_backlog_bytes: u64,
 }
@@ -304,7 +307,7 @@ pub(crate) fn collect_bucket_replication_backlog_metrics(stats: &[BucketReplicat
         .iter()
         .map(|stat| {
             BASE_BUCKET_REPLICATION_BACKLOG_METRICS_PER_BUCKET
-                + stat.durable_mrf_targets.len() * BUCKET_REPLICATION_DURABLE_MRF_METRICS_PER_TARGET
+                + stat.target_backlogs.len() * BUCKET_REPLICATION_BACKLOG_METRICS_PER_TARGET
         })
         .sum();
     let mut metrics = Vec::with_capacity(metric_count);
@@ -362,9 +365,25 @@ pub(crate) fn collect_bucket_replication_backlog_metrics(stats: &[BucketReplicat
             )
             .with_label(BUCKET_L, bucket_label),
         );
-        for target in &stat.durable_mrf_targets {
+        for target in &stat.target_backlogs {
             let bucket_label: Cow<'static, str> = Cow::Owned(stat.bucket.clone());
             let target_label: Cow<'static, str> = Cow::Owned(target.target_arn.clone());
+            metrics.push(
+                PrometheusMetric::from_descriptor(
+                    &BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD,
+                    target.current_backlog_count as f64,
+                )
+                .with_label(BUCKET_L, bucket_label.clone())
+                .with_label(TARGET_ARN_L, target_label.clone()),
+            );
+            metrics.push(
+                PrometheusMetric::from_descriptor(
+                    &BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD,
+                    target.current_backlog_bytes as f64,
+                )
+                .with_label(BUCKET_L, bucket_label.clone())
+                .with_label(TARGET_ARN_L, target_label.clone()),
+            );
             metrics.push(
                 PrometheusMetric::from_descriptor(
                     &BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD,
@@ -506,15 +525,17 @@ mod tests {
             mrf_missed_count: 4,
             mrf_flush_failures: 5,
             mrf_last_flush_duration_millis: 6,
-            durable_mrf_targets: vec![BucketReplicationTargetBacklogStats {
+            target_backlogs: vec![BucketReplicationTargetBacklogStats {
                 target_arn: "arn:rustfs:replication:target-a".to_string(),
+                current_backlog_count: 3,
+                current_backlog_bytes: 4096,
                 durable_mrf_backlog_count: 2,
                 durable_mrf_backlog_bytes: 2048,
             }],
         }];
 
         let metrics = collect_bucket_replication_backlog_metrics(&stats);
-        assert_eq!(metrics.len(), 13);
+        assert_eq!(metrics.len(), 15);
 
         let backlog_count_name = BUCKET_REPL_CURRENT_BACKLOG_COUNT_MD.get_full_metric_name();
         assert!(metrics.iter().any(|metric| {
@@ -549,6 +570,28 @@ mod tests {
             metric.name == durable_bytes_name
                 && metric.value == 2048.0
                 && metric.labels.iter().any(|(key, value)| *key == BUCKET_L && value == "b1")
+        }));
+
+        let target_count_name = BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD.get_full_metric_name();
+        assert!(metrics.iter().any(|metric| {
+            metric.name == target_count_name
+                && metric.value == 3.0
+                && metric.labels.iter().any(|(key, value)| *key == BUCKET_L && value == "b1")
+                && metric
+                    .labels
+                    .iter()
+                    .any(|(key, value)| *key == TARGET_ARN_L && value == "arn:rustfs:replication:target-a")
+        }));
+
+        let target_bytes_name = BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD.get_full_metric_name();
+        assert!(metrics.iter().any(|metric| {
+            metric.name == target_bytes_name
+                && metric.value == 4096.0
+                && metric.labels.iter().any(|(key, value)| *key == BUCKET_L && value == "b1")
+                && metric
+                    .labels
+                    .iter()
+                    .any(|(key, value)| *key == TARGET_ARN_L && value == "arn:rustfs:replication:target-a")
         }));
 
         let durable_target_count_name = BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD.get_full_metric_name();
@@ -638,7 +681,7 @@ mod tests {
             mrf_missed_count: 4,
             mrf_flush_failures: 5,
             mrf_last_flush_duration_millis: 6,
-            durable_mrf_targets: Vec::new(),
+            target_backlogs: Vec::new(),
         }];
 
         let metrics = collect_bucket_replication_backlog_metrics(&stats);

--- a/crates/obs/src/metrics/scheduler.rs
+++ b/crates/obs/src/metrics/scheduler.rs
@@ -80,7 +80,8 @@ use crate::metrics::runtime_sources::bucket_monitor_available;
 use crate::metrics::schema::audit::{AUDIT_FAILED_MESSAGES_MD, AUDIT_TARGET_QUEUE_LENGTH_MD, AUDIT_TOTAL_MESSAGES_MD};
 use crate::metrics::schema::bucket_replication::{
     BUCKET_L, BUCKET_REPL_BANDWIDTH_CURRENT_MD, BUCKET_REPL_BANDWIDTH_LIMIT_MD, BUCKET_REPL_CURRENT_BACKLOG_BYTES_MD,
-    BUCKET_REPL_CURRENT_BACKLOG_COUNT_MD, BUCKET_REPL_DURABLE_MRF_AVAILABLE_MD, BUCKET_REPL_DURABLE_MRF_BACKLOG_BYTES_MD,
+    BUCKET_REPL_CURRENT_BACKLOG_COUNT_MD, BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD,
+    BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD, BUCKET_REPL_DURABLE_MRF_AVAILABLE_MD, BUCKET_REPL_DURABLE_MRF_BACKLOG_BYTES_MD,
     BUCKET_REPL_DURABLE_MRF_BACKLOG_COUNT_MD, BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_BYTES_MD,
     BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD, BUCKET_REPL_MRF_DROPPED_COUNT_MD, BUCKET_REPL_MRF_FLUSH_FAILURES_MD,
     BUCKET_REPL_MRF_LAST_FLUSH_DURATION_MILLIS_MD, BUCKET_REPL_MRF_MISSED_COUNT_MD, BUCKET_REPL_MRF_PENDING_BYTES_MD,
@@ -638,7 +639,7 @@ fn repl_backlog_target_live_keys(stats: &[BucketReplicationBacklogStats]) -> Has
     stats
         .iter()
         .flat_map(|stat| {
-            stat.durable_mrf_targets
+            stat.target_backlogs
                 .iter()
                 .map(|target| (stat.bucket.clone(), target.target_arn.clone()))
         })
@@ -1077,10 +1078,20 @@ fn collect_repl_backlog_target_zero_tombstone_metrics(zero_tombstones: &HashMap<
         return Vec::new();
     }
 
-    let mut zero_metrics = Vec::with_capacity(zero_tombstones.len() * 2);
+    let mut zero_metrics = Vec::with_capacity(zero_tombstones.len() * 4);
     for (bucket, target_arn) in zero_tombstones.keys() {
         let bucket_label: Cow<'static, str> = Cow::Owned(bucket.clone());
         let target_arn_label: Cow<'static, str> = Cow::Owned(target_arn.clone());
+        zero_metrics.push(
+            PrometheusMetric::from_descriptor(&BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD, 0.0)
+                .with_label(BUCKET_L, bucket_label.clone())
+                .with_label(TARGET_ARN_L, target_arn_label.clone()),
+        );
+        zero_metrics.push(
+            PrometheusMetric::from_descriptor(&BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD, 0.0)
+                .with_label(BUCKET_L, bucket_label.clone())
+                .with_label(TARGET_ARN_L, target_arn_label.clone()),
+        );
         zero_metrics.push(
             PrometheusMetric::from_descriptor(&BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD, 0.0)
                 .with_label(BUCKET_L, bucket_label.clone())
@@ -1130,7 +1141,9 @@ fn retire_repl_backlog_target_metric_series(bucket: &str, target_arn: &str) -> u
         (BUCKET_L, Cow::Owned(bucket.to_string())),
         (TARGET_ARN_L, Cow::Owned(target_arn.to_string())),
     ];
-    retire_metric_series(&BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD.get_full_metric_name(), &labels)
+    retire_metric_series(&BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD.get_full_metric_name(), &labels)
+        + retire_metric_series(&BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD.get_full_metric_name(), &labels)
+        + retire_metric_series(&BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD.get_full_metric_name(), &labels)
         + retire_metric_series(&BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_BYTES_MD.get_full_metric_name(), &labels)
 }
 
@@ -1151,10 +1164,10 @@ fn expire_repl_backlog_zero_tombstones(monitor_available: bool, zero_tombstones:
 }
 
 fn expire_repl_backlog_target_zero_tombstones(
-    durable_mrf_available: bool,
+    target_metrics_available: bool,
     zero_tombstones: &mut HashMap<ReplBwKey, u8>,
 ) -> Vec<ReplBwKey> {
-    if !durable_mrf_available {
+    if !target_metrics_available {
         return Vec::new();
     }
 
@@ -1489,6 +1502,8 @@ pub fn init_metrics_runtime(token: CancellationToken) {
 
                             let (bucket_replication, bucket_replication_backlog) = collect_bucket_replication_stats_bundle().await;
                             let durable_mrf_available = bucket_replication_backlog.iter().any(|stat| stat.durable_mrf_available);
+                            let backlog_target_metrics_available =
+                                durable_mrf_available || monitor_available || !bucket_replication_backlog.is_empty();
                             update_repl_backlog_zero_tombstones(
                                 monitor_available,
                                 &mut has_seen_valid_backlog_snapshot,
@@ -1497,7 +1512,7 @@ pub fn init_metrics_runtime(token: CancellationToken) {
                                 repl_backlog_live_keys(&bucket_replication_backlog),
                                 repl_bw_zero_tombstone_cycles,
                             );
-                            if durable_mrf_available {
+                            if backlog_target_metrics_available {
                                 update_series_zero_tombstones(
                                     &mut has_seen_valid_backlog_target_snapshot,
                                     &mut prev_backlog_target_live_keys,
@@ -1522,7 +1537,7 @@ pub fn init_metrics_runtime(token: CancellationToken) {
                                 let _ = retire_repl_backlog_metric_series(&bucket);
                             }
                             for (bucket, target_arn) in expire_repl_backlog_target_zero_tombstones(
-                                durable_mrf_available,
+                                backlog_target_metrics_available,
                                 &mut backlog_target_zero_tombstones,
                             ) {
                                 let _ = retire_repl_backlog_target_metric_series(&bucket, &target_arn);
@@ -2357,8 +2372,10 @@ mod tests {
         assert_eq!(zero_tombstones.get(&key), Some(&2));
 
         let metrics = collect_repl_backlog_target_zero_tombstone_metrics(&zero_tombstones);
-        assert_eq!(metrics.len(), 2);
+        assert_eq!(metrics.len(), 4);
         let expected_names = HashSet::from([
+            BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD.get_full_metric_name(),
+            BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD.get_full_metric_name(),
             BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_COUNT_MD.get_full_metric_name(),
             BUCKET_REPL_DURABLE_MRF_TARGET_BACKLOG_BYTES_MD.get_full_metric_name(),
         ]);
@@ -2386,7 +2403,7 @@ mod tests {
     }
 
     #[test]
-    fn repl_backlog_target_tombstones_do_not_advance_when_durable_mrf_unavailable() {
+    fn repl_backlog_target_tombstones_do_not_advance_when_target_metrics_unavailable() {
         let key = repl_bw_key("videos", "arn:rustfs:replication:target-b");
         let mut zero_tombstones = HashMap::from([(key.clone(), 1)]);
 

--- a/crates/obs/src/metrics/schema/bucket_replication.rs
+++ b/crates/obs/src/metrics/schema/bucket_replication.rs
@@ -35,6 +35,8 @@ const RESYNC_CANCELED_TOTAL: &str = "resync_canceled_total";
 const RESYNC_DURATION_MS_TOTAL: &str = "resync_duration_ms_total";
 const CURRENT_BACKLOG_COUNT: &str = "current_backlog_count";
 const CURRENT_BACKLOG_BYTES: &str = "current_backlog_bytes";
+const CURRENT_TARGET_BACKLOG_COUNT: &str = "current_target_backlog_count";
+const CURRENT_TARGET_BACKLOG_BYTES: &str = "current_target_backlog_bytes";
 const DURABLE_MRF_AVAILABLE: &str = "durable_mrf_available";
 const DURABLE_MRF_BACKLOG_COUNT: &str = "durable_mrf_backlog_count";
 const DURABLE_MRF_BACKLOG_BYTES: &str = "durable_mrf_backlog_bytes";
@@ -106,6 +108,24 @@ pub static BUCKET_REPL_CURRENT_BACKLOG_COUNT_MD: LazyLock<MetricDescriptor> = La
         MetricName::from(CURRENT_BACKLOG_COUNT),
         "Current number of objects admitted to the in-memory replication worker queues for a bucket",
         &[BUCKET_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
+
+pub static BUCKET_REPL_CURRENT_TARGET_BACKLOG_COUNT_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::from(CURRENT_TARGET_BACKLOG_COUNT),
+        "Current number of target-scoped operations admitted to in-memory replication worker queues for a bucket and target ARN",
+        &[BUCKET_L, TARGET_ARN_L],
+        subsystems::BUCKET_REPLICATION,
+    )
+});
+
+pub static BUCKET_REPL_CURRENT_TARGET_BACKLOG_BYTES_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
+    new_gauge_md(
+        MetricName::from(CURRENT_TARGET_BACKLOG_BYTES),
+        "Current bytes in target-scoped operations admitted to in-memory replication worker queues for a bucket and target ARN",
+        &[BUCKET_L, TARGET_ARN_L],
         subsystems::BUCKET_REPLICATION,
     )
 });

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -212,11 +212,13 @@ async fn obs_bucket_replication_stats_bundle() -> (Vec<BucketReplicationStats>, 
             mrf_missed_count: stats.mrf_missed_count,
             mrf_flush_failures: stats.mrf_flush_failures,
             mrf_last_flush_duration_millis: stats.mrf_last_flush_duration_millis,
-            durable_mrf_targets: stats
-                .durable_mrf_targets
+            target_backlogs: stats
+                .target_backlogs
                 .iter()
                 .map(|target| BucketReplicationTargetBacklogStats {
                     target_arn: target.target_arn.clone(),
+                    current_backlog_count: target.current_backlog_count,
+                    current_backlog_bytes: target.current_backlog_bytes,
                     durable_mrf_backlog_count: target.durable_mrf_backlog_count,
                     durable_mrf_backlog_bytes: target.durable_mrf_backlog_bytes,
                 })

--- a/crates/obs/src/metrics/storage_api.rs
+++ b/crates/obs/src/metrics/storage_api.rs
@@ -18,8 +18,9 @@ use std::time::Duration;
 pub(crate) use rustfs_ecstore::api::bucket::bandwidth::monitor::Monitor as ObsBucketBandwidthMonitor;
 pub(crate) use rustfs_ecstore::api::bucket::metadata_sys::get_quota_config as obs_get_quota_config;
 use rustfs_ecstore::api::bucket::replication::{
-    DurableMrfBucketBacklog, DurableMrfTargetBacklog, MrfBucketBacklogObservability, durable_mrf_backlog_summary_snapshot,
-    durable_mrf_target_backlog_snapshot, get_global_replication_stats, mrf_backlog_observability_snapshot,
+    DurableMrfBucketBacklog, DurableMrfTargetBacklog, MrfBucketBacklogObservability, RuntimeReplicationTargetBacklog,
+    durable_mrf_backlog_summary_snapshot, durable_mrf_target_backlog_snapshot, get_global_replication_stats,
+    mrf_backlog_observability_snapshot,
 };
 pub(crate) use rustfs_ecstore::api::capacity::{
     get_total_usable_capacity as obs_get_total_usable_capacity,
@@ -47,6 +48,8 @@ pub(crate) struct ObsBucketReplicationTargetStatsSnapshot {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ObsBucketReplicationTargetBacklogSnapshot {
     pub(crate) target_arn: String,
+    pub(crate) current_backlog_count: u64,
+    pub(crate) current_backlog_bytes: u64,
     pub(crate) durable_mrf_backlog_count: u64,
     pub(crate) durable_mrf_backlog_bytes: u64,
 }
@@ -91,7 +94,7 @@ pub(crate) struct ObsBucketReplicationStatsSnapshot {
     pub(crate) mrf_flush_failures: u64,
     pub(crate) mrf_last_flush_duration_millis: u64,
     pub(crate) targets: Vec<ObsBucketReplicationTargetStatsSnapshot>,
-    pub(crate) durable_mrf_targets: Vec<ObsBucketReplicationTargetBacklogSnapshot>,
+    pub(crate) target_backlogs: Vec<ObsBucketReplicationTargetBacklogSnapshot>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -131,6 +134,15 @@ struct ObsBucketReplicationProxySnapshot {
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+struct ObsBucketReplicationBacklogSnapshot {
+    durable_mrf_available: bool,
+    durable_bucket: DurableMrfBucketBacklog,
+    runtime_targets: Vec<RuntimeReplicationTargetBacklog>,
+    durable_targets: Vec<DurableMrfTargetBacklog>,
+    mrf_observability: MrfBucketBacklogObservability,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct ObsReplicationSiteStatsSnapshot {
     pub(crate) average_active_workers: f64,
     pub(crate) average_queued_bytes: i64,
@@ -165,11 +177,40 @@ fn bucket_replication_stats_snapshot_from_parts(
     bucket: String,
     runtime: ObsBucketReplicationRuntimeSnapshot,
     proxy: ObsBucketReplicationProxySnapshot,
-    durable_mrf_available: bool,
-    durable_bucket: DurableMrfBucketBacklog,
-    durable_targets: Vec<DurableMrfTargetBacklog>,
-    mrf_observability: MrfBucketBacklogObservability,
+    backlog: ObsBucketReplicationBacklogSnapshot,
 ) -> ObsBucketReplicationStatsSnapshot {
+    let mut target_backlogs = HashMap::with_capacity(backlog.runtime_targets.len().saturating_add(backlog.durable_targets.len()));
+    for target in backlog.runtime_targets {
+        let entry =
+            target_backlogs
+                .entry(target.target_arn.clone())
+                .or_insert_with(|| ObsBucketReplicationTargetBacklogSnapshot {
+                    target_arn: target.target_arn,
+                    current_backlog_count: 0,
+                    current_backlog_bytes: 0,
+                    durable_mrf_backlog_count: 0,
+                    durable_mrf_backlog_bytes: 0,
+                });
+        entry.current_backlog_count = target.count;
+        entry.current_backlog_bytes = target.bytes;
+    }
+    for target in backlog.durable_targets {
+        let entry =
+            target_backlogs
+                .entry(target.target_arn.clone())
+                .or_insert_with(|| ObsBucketReplicationTargetBacklogSnapshot {
+                    target_arn: target.target_arn,
+                    current_backlog_count: 0,
+                    current_backlog_bytes: 0,
+                    durable_mrf_backlog_count: 0,
+                    durable_mrf_backlog_bytes: 0,
+                });
+        entry.durable_mrf_backlog_count = target.count;
+        entry.durable_mrf_backlog_bytes = target.bytes;
+    }
+    let mut target_backlogs = target_backlogs.into_values().collect::<Vec<_>>();
+    target_backlogs.sort_by(|left, right| left.target_arn.cmp(&right.target_arn));
+
     ObsBucketReplicationStatsSnapshot {
         bucket,
         total_failed_bytes: runtime.total_failed_bytes,
@@ -199,24 +240,17 @@ fn bucket_replication_stats_snapshot_from_parts(
         resync_duration_ms: runtime.resync_duration_ms,
         current_backlog_count: runtime.current_backlog_count,
         current_backlog_bytes: runtime.current_backlog_bytes,
-        durable_mrf_available,
-        durable_mrf_backlog_count: durable_bucket.count,
-        durable_mrf_backlog_bytes: durable_bucket.bytes,
-        mrf_pending_count: mrf_observability.pending_count,
-        mrf_pending_bytes: mrf_observability.pending_bytes,
-        mrf_dropped_count: mrf_observability.dropped_count,
-        mrf_missed_count: mrf_observability.missed_count,
-        mrf_flush_failures: mrf_observability.flush_failure_count,
-        mrf_last_flush_duration_millis: mrf_observability.last_flush_duration_millis,
+        durable_mrf_available: backlog.durable_mrf_available,
+        durable_mrf_backlog_count: backlog.durable_bucket.count,
+        durable_mrf_backlog_bytes: backlog.durable_bucket.bytes,
+        mrf_pending_count: backlog.mrf_observability.pending_count,
+        mrf_pending_bytes: backlog.mrf_observability.pending_bytes,
+        mrf_dropped_count: backlog.mrf_observability.dropped_count,
+        mrf_missed_count: backlog.mrf_observability.missed_count,
+        mrf_flush_failures: backlog.mrf_observability.flush_failure_count,
+        mrf_last_flush_duration_millis: backlog.mrf_observability.last_flush_duration_millis,
         targets: runtime.targets,
-        durable_mrf_targets: durable_targets
-            .into_iter()
-            .map(|target| ObsBucketReplicationTargetBacklogSnapshot {
-                target_arn: target.target_arn,
-                durable_mrf_backlog_count: target.count,
-                durable_mrf_backlog_bytes: target.bytes,
-            })
-            .collect(),
+        target_backlogs,
     }
 }
 
@@ -251,6 +285,15 @@ pub(crate) async fn obs_bucket_replication_stats_snapshot() -> Vec<ObsBucketRepl
             .or_default()
             .push(target);
     }
+    let mut runtime_targets_by_bucket: HashMap<String, Vec<RuntimeReplicationTargetBacklog>> = HashMap::new();
+    if let Some(stats) = &stats {
+        for target in stats.runtime_target_backlog_snapshot() {
+            runtime_targets_by_bucket
+                .entry(target.bucket.clone())
+                .or_default()
+                .push(target);
+        }
+    }
     let mrf_observability = if replication_storage_available {
         mrf_backlog_observability_snapshot()
     } else {
@@ -265,7 +308,8 @@ pub(crate) async fn obs_bucket_replication_stats_snapshot() -> Vec<ObsBucketRepl
         all_bucket_stats
             .len()
             .saturating_add(durable_buckets.len())
-            .saturating_add(mrf_observability_buckets.len()),
+            .saturating_add(mrf_observability_buckets.len())
+            .saturating_add(runtime_targets_by_bucket.len()),
     );
     bucket_names.extend(all_bucket_stats.keys().cloned());
     bucket_names.extend(
@@ -278,6 +322,16 @@ pub(crate) async fn obs_bucket_replication_stats_snapshot() -> Vec<ObsBucketRepl
         mrf_observability_buckets
             .keys()
             .filter(|bucket| !all_bucket_stats.contains_key(*bucket) && !durable_buckets.contains_key(*bucket))
+            .cloned(),
+    );
+    bucket_names.extend(
+        runtime_targets_by_bucket
+            .keys()
+            .filter(|bucket| {
+                !all_bucket_stats.contains_key(*bucket)
+                    && !durable_buckets.contains_key(*bucket)
+                    && !mrf_observability_buckets.contains_key(*bucket)
+            })
             .cloned(),
     );
     let mut buckets = Vec::with_capacity(bucket_names.len());
@@ -356,16 +410,20 @@ pub(crate) async fn obs_bucket_replication_stats_snapshot() -> Vec<ObsBucketRepl
             runtime.current_backlog_bytes = i64_to_u64_floor_zero(bucket_stats.q_stat.curr.bytes);
         }
         let durable_bucket = durable_buckets.get(&bucket).cloned().unwrap_or_default();
+        let runtime_targets = runtime_targets_by_bucket.remove(&bucket).unwrap_or_default();
         let durable_targets = durable_targets_by_bucket.remove(&bucket).unwrap_or_default();
         let mrf_observability = mrf_observability_buckets.get(&bucket).cloned().unwrap_or_default();
         buckets.push(bucket_replication_stats_snapshot_from_parts(
             bucket,
             runtime,
             proxy,
-            durable_mrf_available,
-            durable_bucket,
-            durable_targets,
-            mrf_observability,
+            ObsBucketReplicationBacklogSnapshot {
+                durable_mrf_available,
+                durable_bucket,
+                runtime_targets,
+                durable_targets,
+                mrf_observability,
+            },
         ));
     }
 
@@ -457,26 +515,34 @@ mod tests {
                 proxied_get_requests_failures: 1,
                 ..Default::default()
             },
-            true,
-            DurableMrfBucketBacklog {
-                bucket: "runtime-bucket".to_string(),
-                count: 5,
-                bytes: 8192,
-            },
-            vec![DurableMrfTargetBacklog {
-                bucket: "runtime-bucket".to_string(),
-                target_arn: "arn:rustfs:replication:target-a".to_string(),
-                count: 2,
-                bytes: 4096,
-            }],
-            MrfBucketBacklogObservability {
-                bucket: "runtime-bucket".to_string(),
-                pending_count: 1,
-                pending_bytes: 512,
-                dropped_count: 2,
-                missed_count: 3,
-                flush_failure_count: 4,
-                last_flush_duration_millis: 5,
+            ObsBucketReplicationBacklogSnapshot {
+                durable_mrf_available: true,
+                durable_bucket: DurableMrfBucketBacklog {
+                    bucket: "runtime-bucket".to_string(),
+                    count: 5,
+                    bytes: 8192,
+                },
+                runtime_targets: vec![RuntimeReplicationTargetBacklog {
+                    bucket: "runtime-bucket".to_string(),
+                    target_arn: "arn:rustfs:replication:target-a".to_string(),
+                    count: 3,
+                    bytes: 4096,
+                }],
+                durable_targets: vec![DurableMrfTargetBacklog {
+                    bucket: "runtime-bucket".to_string(),
+                    target_arn: "arn:rustfs:replication:target-a".to_string(),
+                    count: 2,
+                    bytes: 4096,
+                }],
+                mrf_observability: MrfBucketBacklogObservability {
+                    bucket: "runtime-bucket".to_string(),
+                    pending_count: 1,
+                    pending_bytes: 512,
+                    dropped_count: 2,
+                    missed_count: 3,
+                    flush_failure_count: 4,
+                    last_flush_duration_millis: 5,
+                },
             },
         );
 
@@ -486,10 +552,12 @@ mod tests {
         assert!(snapshot.durable_mrf_available);
         assert_eq!(snapshot.durable_mrf_backlog_count, 5);
         assert_eq!(snapshot.durable_mrf_backlog_bytes, 8192);
-        assert_eq!(snapshot.durable_mrf_targets.len(), 1);
-        assert_eq!(snapshot.durable_mrf_targets[0].target_arn, "arn:rustfs:replication:target-a");
-        assert_eq!(snapshot.durable_mrf_targets[0].durable_mrf_backlog_count, 2);
-        assert_eq!(snapshot.durable_mrf_targets[0].durable_mrf_backlog_bytes, 4096);
+        assert_eq!(snapshot.target_backlogs.len(), 1);
+        assert_eq!(snapshot.target_backlogs[0].target_arn, "arn:rustfs:replication:target-a");
+        assert_eq!(snapshot.target_backlogs[0].current_backlog_count, 3);
+        assert_eq!(snapshot.target_backlogs[0].current_backlog_bytes, 4096);
+        assert_eq!(snapshot.target_backlogs[0].durable_mrf_backlog_count, 2);
+        assert_eq!(snapshot.target_backlogs[0].durable_mrf_backlog_bytes, 4096);
         assert_eq!(snapshot.mrf_pending_count, 1);
         assert_eq!(snapshot.mrf_pending_bytes, 512);
         assert_eq!(snapshot.mrf_dropped_count, 2);
@@ -507,14 +575,15 @@ mod tests {
             "durable-only".to_string(),
             ObsBucketReplicationRuntimeSnapshot::default(),
             ObsBucketReplicationProxySnapshot::default(),
-            true,
-            DurableMrfBucketBacklog {
-                bucket: "durable-only".to_string(),
-                count: 11,
-                bytes: 2048,
+            ObsBucketReplicationBacklogSnapshot {
+                durable_mrf_available: true,
+                durable_bucket: DurableMrfBucketBacklog {
+                    bucket: "durable-only".to_string(),
+                    count: 11,
+                    bytes: 2048,
+                },
+                ..Default::default()
             },
-            Vec::new(),
-            MrfBucketBacklogObservability::default(),
         );
 
         assert_eq!(snapshot.bucket, "durable-only");
@@ -530,17 +599,18 @@ mod tests {
             "mrf-observability-only".to_string(),
             ObsBucketReplicationRuntimeSnapshot::default(),
             ObsBucketReplicationProxySnapshot::default(),
-            true,
-            DurableMrfBucketBacklog::default(),
-            Vec::new(),
-            MrfBucketBacklogObservability {
-                bucket: "mrf-observability-only".to_string(),
-                pending_count: 13,
-                pending_bytes: 4096,
-                dropped_count: 1,
-                missed_count: 2,
-                flush_failure_count: 3,
-                last_flush_duration_millis: 4,
+            ObsBucketReplicationBacklogSnapshot {
+                durable_mrf_available: true,
+                mrf_observability: MrfBucketBacklogObservability {
+                    bucket: "mrf-observability-only".to_string(),
+                    pending_count: 13,
+                    pending_bytes: 4096,
+                    dropped_count: 1,
+                    missed_count: 2,
+                    flush_failure_count: 3,
+                    last_flush_duration_millis: 4,
+                },
+                ..Default::default()
             },
         );
 
@@ -568,10 +638,7 @@ mod tests {
                 ..Default::default()
             },
             ObsBucketReplicationProxySnapshot::default(),
-            false,
-            DurableMrfBucketBacklog::default(),
-            Vec::new(),
-            MrfBucketBacklogObservability::default(),
+            ObsBucketReplicationBacklogSnapshot::default(),
         );
 
         assert_eq!(snapshot.current_backlog_count, 1);


### PR DESCRIPTION
## Related Issues
Part of rustfs/backlog#1608 and rustfs/backlog#1604.

Depends on rustfs/rustfs#5584.

## Summary of Changes
Expose runtime replication backlog by target ARN as an additive follow-up to the durable per-target MRF backlog work in #5584. The new runtime sidecar tracks configured target ARNs at successful admission time for regular, large-object, delete, and MRF fallback paths, then decrements through the existing completion, failure, cancellation, and MRF drain guards.

Add target-scoped current backlog Prometheus gauges and merge runtime target backlog with durable MRF target backlog in the obs snapshot path. Existing bucket-level current backlog metrics remain operation-scoped and keep their current names and labels; target-level current backlog is target-operation-scoped, so one object queued to two targets contributes one bucket operation and two target operations.

Preserve public API compatibility by keeping the existing public `ReplicationStats` struct shape unchanged and avoiding a `Drop` implementation on that public struct. The target sidecar uses the existing queue-cache owner identity with weak references and prunes stale entries on later access.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore runtime_target_backlog -- --nocapture`
- `cargo test -p rustfs-ecstore target_backlog -- --nocapture`
- `cargo test -p rustfs-ecstore queue_replica_task_counts_mrf_pending_backlog_when_worker_queue_is_full -- --nocapture`
- `cargo test -p rustfs-ecstore replication_backlog_guard_decrements_on_drop -- --nocapture`
- `cargo test -p rustfs-ecstore mrf -- --nocapture`
- `cargo test -p rustfs-obs bucket_replication_snapshot_maps_runtime_and_durable_backlog -- --nocapture`
- `cargo test -p rustfs-obs test_collect_bucket_replication_backlog_metrics -- --nocapture`
- `cargo test -p rustfs-obs repl_backlog_target_tombstones -- --nocapture`
- `cargo test -p rustfs-obs repl_backlog -- --nocapture`
- `cargo test -p rustfs-obs bucket_replication -- --nocapture`
- `cargo clippy -p rustfs-ecstore -p rustfs-obs --all-targets -- -D warnings`
- `make pre-pr`
- After the final API-compatibility adjustment that removed `Drop` from `ReplicationStats`: `cargo fmt --all --check`, `git diff --check`, `cargo test -p rustfs-ecstore runtime_target_backlog -- --nocapture`, `cargo test -p rustfs-ecstore target_backlog -- --nocapture`, `cargo test -p rustfs-obs bucket_replication -- --nocapture`, and `cargo clippy -p rustfs-ecstore -p rustfs-obs --all-targets -- -D warnings`.

## Impact
This adds new Prometheus series under the bucket replication metric family for target-scoped current backlog count and bytes. Existing metric names, existing bucket-only backlog labels, durable MRF metric names, durable MRF file compatibility, S3 APIs, admin APIs, and replication behavior are unchanged.

The new target ARN label is bounded to configured replication targets already present in replication decisions or delete/MRF entries; object names, endpoints, errors, and secrets are not used as labels.

## Additional Notes
This PR is intentionally stacked on #5584 so reviewers can inspect only the runtime target backlog follow-up. After #5584 merges, this branch can be rebased or retargeted to `main`.

Adversarial validation: correctness attacked multi-target admission, delete admission, MRF fallback, cancellation/drop, saturating decrement, and runtime/durable merge paths; no break found after focused tests. Simplicity attacked public struct field additions and `Drop` on `ReplicationStats`; the `Drop` approach was removed to preserve source compatibility. Security attacked label cardinality and secret/object-key leakage; target labels remain sourced from bounded configured target ARNs. Concurrency/durability attacked await-under-lock, stale sidecar reuse, and admission/decrement windows; sidecar mutex sections are in-memory only, weak-owner pruning avoids pointer reuse, and existing guards drain counts. Compatibility attacked existing metric names/labels, public struct shape, durable MRF format, and mixed rollout; all are additive or unchanged. Performance attacked per-admission allocations and scrape cost; target ARN normalization is bounded by configured target count and no I/O occurs under the sidecar mutex. Coverage attacked revert-detecting paths; focused ecstore and obs tests cover runtime target accounting, MRF decrement, tombstones, and runtime-plus-durable snapshot merge, with full `make pre-pr` also passing before the final compatibility-only adjustment.
