### PR TITLE
docs(kms): correct the claim that rotation is not admin-reachable

### DIFF
--- a/docs/operations/kms-backend-security.md
+++ b/docs/operations/kms-backend-security.md
@@ -51,7 +51,7 @@ Notes:
 
 ## Master key rotation: retention, destruction, and upgrade ordering
 
-Rotation support differs per backend. Local and Static reject rotation outright (`InvalidOperation`); their single key material is never overwritten. Vault Transit delegates rotation to the Transit engine's own key versioning (ciphertext is version-prefixed, e.g. `vault:v1:...`). Vault KV2 rotates by retaining every historical version, as described below. Rotation is currently only reachable through the backend-level `KmsClient::rotate_key` API; it is not exposed through the admin or S3 surface.
+Rotation support differs per backend. Local and Static reject rotation outright (`InvalidOperation`); their single key material is never overwritten. Vault Transit delegates rotation to the Transit engine's own key versioning (ciphertext is version-prefixed, e.g. `vault:v1:...`). Vault KV2 rotates by retaining every historical version, as described below. Rotation is reachable through the admin API as `POST /rustfs/admin/v3/kms/keys/rotate`, which the route policy classifies as high risk and gates behind `kms:RotateKey`; it is not exposed through the S3 surface. The upgrade ordering constraint below therefore applies to an operator action, not only to a call from inside the process.
 
 ### Vault KV2 versioned retention model
 


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1565 (part of rustfs/backlog#1562)

## Summary of Changes

`kms-backend-security.md` states that rotation "is currently only reachable through the backend-level `KmsClient::rotate_key` API; it is not exposed through the admin or S3 surface". That has not been true since the lifecycle endpoints landed: `POST /rustfs/admin/v3/kms/keys/rotate` reaches `manager.rotate_key_with_context`, is registered in the route matrix, and carries `KMS_ROTATE_KEY` at high risk.

This matters beyond accuracy. The section immediately below states a hard constraint — do not rotate any key until every node runs a build that understands `master_key_version`, or objects wrapped by earlier versions stop decrypting. An operator who believes rotation is unreachable from outside the process has no reason to think that constraint applies to them.

## Verification

- `bash scripts/check_doc_paths.sh`
- Endpoint checked against `rustfs/src/admin/handlers/kms_key_lifecycle.rs:125,166`, `rustfs/src/admin/route_policy.rs:795` and `rustfs/src/admin/route_registration_test.rs:345`.

## Impact

Documentation only.