### PR TITLE
docs(kms): correct the static backend's MinIO compatibility claim

### DIFF
--- a/.github/workflows/minio-interop.yml
+++ b/.github/workflows/minio-interop.yml
@@ -18,7 +18,14 @@
 # This is NOT a PR gate. The fixtures are real MinIO backend trees generated on
 # the fly (they are gitignored, never committed), so the job regenerates them
 # each run with Docker and then runs the `#[ignore]` reader tests in
-# crates/ecstore/tests/minio_generated_read_test.rs.
+# rustfs/src/storage/minio_generated_read_test.rs.
+#
+# Scope: end-to-end MinIO-to-RustFS SSE interop is NOT implemented yet. Both
+# envelope parsers reject MinIO's own wrapped-DEK shape — see
+# `is_data_key_envelope` in crates/kms/src/encryption/dek.rs and the
+# `deny_unknown_fields` `LocalSseDekEnvelope` in rustfs/src/storage/sse.rs — and
+# closing that gap is tracked in rustfs/backlog#1638. Treat this job as the
+# harness for #1638, not as standing evidence that a MinIO migration reads back.
 #
 # Runner: GitHub-hosted `ubuntu-latest`. It reliably ships Docker + Python,
 # unlike the self-hosted fleet, whose pods drift in Docker/pip availability
@@ -55,6 +62,19 @@ jobs:
     env:
       # Fixed 32-byte test KMS key baked into the fixture lab; not a secret.
       RUSTFS_MINIO_STATIC_KMS_KEY_B64: IyqsU3kMFloCNup4BsZtf/rmfHVcTgznO2F25CkEH1g=
+      # Single definition of "the interop tests", shared by the guard step and
+      # the run step so the two cannot drift apart.
+      #
+      # These used to live in crates/ecstore/tests/minio_generated_read_test.rs
+      # and were selected with `-p rustfs-ecstore -E
+      # 'binary(minio_generated_read_test)'`. #5435 moved them into the `rustfs`
+      # crate as a `#[cfg(test)] mod`, which deleted that test binary; the
+      # selector was never updated and has selected zero interop tests ever
+      # since (cargo-nextest 0.9.140 now rejects it outright: "operator didn't
+      # match any binary names", exit 94).
+      INTEROP_PACKAGE: rustfs
+      INTEROP_FEATURES: rio-v2
+      INTEROP_FILTER: "test(minio_generated_read_test::)"
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -71,8 +91,29 @@ jobs:
       - name: Generate real MinIO fixtures via Docker
         run: bash crates/rio-v2/tests/minio_fixture_lab/capture_via_docker.sh
 
+      # `binary(...)` at least dies loudly when nothing matches, but `test(...)`
+      # is a perfectly valid filterset that matches zero tests, so the next
+      # rename or module move would leave this job selecting nothing and
+      # reporting success without executing a single interop assertion. Count
+      # the selection and fail with a reason instead.
+      #
+      # Count only `filter-match.status == "matches"`: the top-level
+      # `test-count` in the JSON is the package total and ignores `-E` entirely.
+      - name: Assert the interop selector still matches tests
+        run: |
+          set -euo pipefail
+          count="$(cargo nextest list --run-ignored all \
+            -p "$INTEROP_PACKAGE" --features "$INTEROP_FEATURES" \
+            -E "$INTEROP_FILTER" --message-format json \
+            | python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for s in d.get("rust-suites", {}).values() for t in s.get("testcases", {}).values() if t.get("filter-match", {}).get("status") == "matches"))')"
+          echo "interop tests selected: ${count}"
+          if [ "${count}" -eq 0 ]; then
+            echo "::error::Selector '${INTEROP_FILTER}' in package '${INTEROP_PACKAGE}' matched 0 tests. The MinIO interop reader tests have moved or been renamed again; fix the selector instead of letting this job pass without running them. Context: rustfs/backlog#1638."
+            exit 1
+          fi
+
       - name: Run MinIO interop reader tests
         run: |
-          cargo nextest run --run-ignored ignored-only \
-            -p rustfs-ecstore --features rio-v2 \
-            -E 'binary(minio_generated_read_test)'
+          cargo nextest run --run-ignored ignored-only --no-tests=fail \
+            -p "$INTEROP_PACKAGE" --features "$INTEROP_FEATURES" \
+            -E "$INTEROP_FILTER"

--- a/crates/kms/src/backends/static_kms.rs
+++ b/crates/kms/src/backends/static_kms.rs
@@ -19,7 +19,10 @@
 //!
 //! ## Ciphertext format
 //!
-//! encrypted_data(plaintext_len+16) || nonce (12 bytes)
+//! A JSON-serialized `DataKeyEnvelope` carrying the AES-256-GCM ciphertext, the
+//! 12-byte nonce and the authenticated encryption context. This is a
+//! RustFS-internal format; it is not interchangeable with MinIO's KMS
+//! ciphertext (see the note on `StaticConfig`).
 
 use crate::backends::{BackendCapabilities, KmsBackend};
 use crate::config::{BackendConfig, KmsConfig};

--- a/crates/kms/src/config.rs
+++ b/crates/kms/src/config.rs
@@ -297,8 +297,15 @@ impl Default for LocalConfig {
 
 /// Static single-key KMS backend configuration
 ///
-/// Uses a pre-configured AES-256 key to derive data encryption keys via
-/// HMAC-SHA256 + AES-256-GCM, matching the MinIO builtin/static KMS wire format.
+/// The configured 32-byte key is used directly as the AES-256-GCM key that
+/// wraps data encryption keys — there is no HMAC-SHA256 derivation step — and
+/// each wrapped DEK is serialized as a RustFS `DataKeyEnvelope` JSON blob.
+///
+/// This mirrors the *concept* of MinIO's builtin/static single-key KMS, but is
+/// not wire-compatible with it: MinIO wraps DEKs in a different (`{"aead": ...}`)
+/// blob that this backend neither produces nor accepts, so KMS ciphertext
+/// written by MinIO cannot be opened here. Reading MinIO-written SSE objects is
+/// tracked separately in rustfs/backlog#1638.
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct StaticConfig {
     /// Key identifier (name) for the single configured key


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1638 (part of rustfs/backlog#1562)

## Summary of Changes

Two claims about MinIO compatibility that the code does not support. Neither behaviour changes.

**`config.rs` described the Static backend as "matching the MinIO builtin/static KMS wire format" and deriving data keys "via HMAC-SHA256".** Both halves are wrong. The backend produces RustFS's own `DataKeyEnvelope` JSON and only accepts that shape; MinIO's `{"aead":...}` form is named `minio_legacy` in the `dek.rs` fixtures and explicitly asserted *not* to be this format, and `LocalSseDekEnvelope` carries `deny_unknown_fields` so it rejects it too. There is no HMAC-SHA256 derivation anywhere in the path — the configured 32-byte key is used directly as the AES-256-GCM key. A migrating operator reading that sentence would reasonably expect their MinIO-encrypted objects to be readable. The doc comment on the backend itself, which still described a raw `ciphertext || nonce` layout rather than the JSON envelope, is corrected in the same commit.

**The MinIO interop workflow selected zero tests.** #5435 moved `minio_generated_read_test` from `crates/ecstore/tests/` into `rustfs/src/storage/` as a `#[cfg(test)] mod`, so the binary the filter named no longer exists. The selector now targets `-p rustfs` with `test(minio_generated_read_test::)`, which selects the four ignored tests. A guard step fails the job when the selection is empty, and `--no-tests=fail` backs it up.

Worth recording: the old selector did not silently pass — `binary()` matching nothing is a filterset parse error, exit 94. The trap only appears *after* this fix, because `test(...)` matching nothing is legal and silent, which is the real reason the guard is needed. The guard counts `filter-match.status == "matches"` entries rather than the JSON `test-count`, which reports the whole package (3016) and ignores `-E` entirely.

## Verification

- `cargo fmt --all`, `cargo check -p rustfs-kms --all-targets`, `cargo clippy -p rustfs-kms --all-targets -- -D warnings`
- New selector: `cargo nextest list --run-ignored all -p rustfs --features rio-v2 -E 'test(minio_generated_read_test::)'` — 4 tests
- Old selector: exit 94, "operator didn't match any binary names"
- Guard step extracted from the YAML and run both ways: 4 selected exits 0; a deliberately wrong selector prints `selected: 0` and exits 1

## Impact

Comments and CI configuration only. The workflow remains `disabled_manually`; this does not enable it. Whether those four tests pass is a separate question — RustFS cannot currently read MinIO-written SSE objects, which is rustfs/backlog#1638. This change only guarantees that the selector selects them, and that selecting nothing fails loudly.