### PR TITLE
fix(s3): strip every encryption marker from a copy destination

### DIFF
--- a/rustfs/src/storage/sse.rs
+++ b/rustfs/src/storage/sse.rs
@@ -3144,12 +3144,14 @@ pub fn is_managed_sse(server_side_encryption: &ServerSideEncryption) -> bool {
 /// Encryption metadata describes the physical source representation and must never be
 /// inherited by a plaintext destination or by a destination using a different key.
 pub fn strip_managed_encryption_metadata(metadata: &mut HashMap<String, String>) {
-    const KEYS: [&str; 19] = [
+    const KEYS: [&str; 21] = [
         "x-amz-server-side-encryption",
         "x-amz-server-side-encryption-aws-kms-key-id",
         "x-amz-server-side-encryption-customer-algorithm",
         "x-amz-server-side-encryption-customer-key-md5",
         SSEC_ORIGINAL_SIZE_HEADER,
+        INTERNAL_ENCRYPTION_KEY_ID_HEADER,
+        INTERNAL_ENCRYPTION_ALGORITHM_HEADER,
         INTERNAL_ENCRYPTION_IV_HEADER,
         "x-rustfs-encryption-tag",
         INTERNAL_ENCRYPTION_KEY_HEADER,
@@ -4546,6 +4548,38 @@ mod tests {
         assert!(!metadata.contains_key(SSEC_ORIGINAL_SIZE_HEADER));
         assert!(!metadata.contains_key("x-rustfs-encryption-key"));
         assert!(!metadata.contains_key(MINIO_INTERNAL_ENCRYPTION_KMS_SEALED_KEY_HEADER));
+        assert!(metadata.contains_key("content-type"));
+    }
+
+    /// A copy destination must not inherit any key that `is_object_encryption_marker`
+    /// accepts as proof the payload is encrypted.
+    ///
+    /// Guards this chain: `ObjectInfo::is_encrypted` is keyed on that predicate, so a
+    /// single leftover marker makes a plaintext destination report itself encrypted.
+    /// `object_api::readers` then takes its encrypted branch and demands read material,
+    /// but the material itself was stripped, so `sse_decryption` reports no encryption
+    /// and the read fails with "encrypted object metadata is incomplete" — a destination
+    /// that CopyObject wrote successfully becomes permanently unreadable.
+    #[test]
+    fn test_strip_managed_encryption_metadata_clears_encryption_markers() {
+        let mut metadata = HashMap::from([
+            ("x-amz-server-side-encryption".to_string(), "aws:kms".to_string()),
+            ("x-amz-server-side-encryption-aws-kms-key-id".to_string(), "source-key".to_string()),
+            (INTERNAL_ENCRYPTION_KEY_ID_HEADER.to_string(), "source-key".to_string()),
+            (INTERNAL_ENCRYPTION_ALGORITHM_HEADER.to_string(), "AES256".to_string()),
+            (INTERNAL_ENCRYPTION_KEY_HEADER.to_string(), "wrapped-dek".to_string()),
+            (INTERNAL_ENCRYPTION_IV_HEADER.to_string(), "base-nonce".to_string()),
+            ("content-type".to_string(), "text/plain".to_string()),
+        ]);
+
+        strip_managed_encryption_metadata(&mut metadata);
+
+        let inherited: Vec<&str> = metadata
+            .keys()
+            .filter(|key| rustfs_utils::http::is_object_encryption_marker(key))
+            .map(String::as_str)
+            .collect();
+        assert!(inherited.is_empty(), "copy destination inherited encryption markers: {inherited:?}");
         assert!(metadata.contains_key("content-type"));
     }
 


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1562

## Summary of Changes

`strip_managed_encryption_metadata` removed 19 keys but not `x-rustfs-encryption-key-id` and `x-rustfs-encryption-algorithm`, while removing their MinIO-spelled counterparts. Its only caller is CopyObject, which strips the source's `user_defined` before applying the destination's own encryption metadata.

When the destination resolves to no SSE — no encryption headers and no bucket default — nothing overwrites those two keys, so a plaintext destination inherits them. `is_object_encryption_marker` treats any `x-rustfs-encryption-*` key other than original-size as proof the payload is encrypted, so `ObjectInfo::is_encrypted()` reports true for a plaintext object. The read path then enters the encrypted branch, `resolve_read_material` finds no material — it really was stripped — and turns that into `encrypted object metadata is incomplete`.

The copy reports success and the destination object can never be read. GET and HEAD both fail. Secondary effects: `decrypt_checksums` suppresses the destination's checksums, and the object loses the inline fast path and data-cache eligibility. A destination that *is* managed-SSE overwrites both keys unconditionally, so only plaintext destinations are affected. Nothing is exposed to clients — `filter_object_metadata` and the notification filter both drop these keys — so this is availability, not confidentiality.

The omission is drift, not design: the commit that grew the list from 7 to 16 entries added the MinIO key-id and algorithm headers while leaving the RustFS-native ones out, and no commit, PR, issue or comment anywhere states an exclusion.

## Verification

- Test committed first and run against the unfixed code: **failed**, reporting `inherited encryption markers: ["x-rustfs-encryption-algorithm", "x-rustfs-encryption-key-id"]`
- `cargo fmt --all`
- `cargo check -p rustfs --all-targets`
- `cargo clippy -p rustfs --all-targets -- -D warnings`
- `cargo test -p rustfs --lib -- storage::sse::tests::test_strip_managed_encryption_metadata` — 2 passed

The regression test does not assert that these two keys are gone. It asserts that nothing surviving the strip can make `is_object_encryption_marker` return true, and names the read-path failure chain in a comment — so a future `x-rustfs-encryption-*` key that misses the list is caught by the same test.

## Impact

Fixes a case where CopyObject produced an unreadable object. Objects already created this way are not repaired by this change; they carry the stale markers in their persisted metadata.