### PR TITLE
refactor(kms): drop the dead duplicate api_types::DeleteKeyRequest

### DIFF
--- a/crates/kms/src/api_types.rs
+++ b/crates/kms/src/api_types.rs
@@ -1343,18 +1343,11 @@ pub struct CreateKeyResponse {
     pub key_metadata: KeyMetadata,
 }
 
-/// Request to delete a key
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeleteKeyRequest {
-    /// Key ID to delete
-    pub key_id: String,
-    /// Number of days to wait before deletion (7-30 days, optional)
-    pub pending_window_in_days: Option<u32>,
-    /// Force immediate deletion (for development/testing only)
-    pub force_immediate: Option<bool>,
-}
-
-/// Response from delete key operation
+/// JSON shape returned by the admin delete-key endpoint.
+///
+/// The delete *request* shape lives in [`crate::types::DeleteKeyRequest`] —
+/// there is deliberately no copy here, because the immediate-deletion gate
+/// (`force_immediate` + `confirm_key_id`) must have exactly one definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteKeyResponse {
     /// Success flag


### PR DESCRIPTION
## Related Issues

N/A — follow-up cleanup after the immediate-deletion gate work (`rustfs/backlog#1585`), which left a stale copy of the delete-key request type behind.

## Summary of Changes

`crates/kms/src/api_types.rs` carried a second `DeleteKeyRequest` alongside the real one in `crates/kms/src/types.rs`. Nothing referenced it. It is absent from the `pub use api_types::{...}` list in `lib.rs`, so `rustfs_kms::DeleteKeyRequest` has always resolved to `types::DeleteKeyRequest` through the `pub use types::*` glob, and the admin handler constructs the real type via `use rustfs_kms::types::*`.

The copy had also drifted apart from the type it shadowed. It still described `force_immediate` as "for development/testing only" and the 7-30 day window as advisory, and it never gained the `confirm_key_id` field that the immediate-deletion gate now requires. That combination is worse than ordinary dead code: a caller reaching into `api_types` and deserializing into it would silently drop `confirm_key_id`, the field whose whole purpose is to force a second, explicit confirmation before key material is destroyed.

`api_types::DeleteKeyResponse` is deliberately kept. Applying the same check to it gives the opposite answer: it is live, pinned by the `kms_management_responses_have_stable_json_shapes` snapshot test next to the list/describe/cancel response shapes, and removing just one of those four would leave a gap in that set. It is also not a duplicate of `types::DeleteKeyResponse` — the fields differ (`success`/`message`/`key_id`/`deletion_date` versus `key_id`/`deletion_date`/`key_metadata`); it mirrors the admin wire response instead. Its doc comment now records why no request twin sits beside it, so the copy does not come back.

No behavior change: the deleted type had no constructors, no callers, and no serialization path.

## Verification

- `cargo check -p rustfs-kms --all-targets` — pass
- `cargo clippy -p rustfs-kms --all-targets -- -D warnings` — pass
- `cargo test -p rustfs-kms --lib api_types` — pass (16 tests, including the response-shape snapshot)
- `make pre-commit` — pass

The branch was rebased onto the current `main` before the final run, because the KMS area has been changing quickly and `api_types.rs` was touched by #5592 in the meantime. All four commands above were re-run after the rebase.

## Impact

None for users or operators. The removed type is not part of any public re-export from `rustfs_kms`; it was reachable only as `rustfs_kms::api_types::DeleteKeyRequest` because the module is `pub`. Any external code that somehow depended on that path was already working with a type missing `confirm_key_id`, and should use `rustfs_kms::DeleteKeyRequest` (that is, `types::DeleteKeyRequest`) instead.

## Additional Notes

Two adjacent observations found while checking, left untouched to keep this change narrow:

- The same block of `api_types.rs` holds five more unreferenced, non-re-exported types: `CreateKeyRequest` (with its `Default` impl), `CreateKeyResponse`, `ListKeysRequest`, `DescribeKeyRequest`, and `CancelKeyDeletionRequest`. None carries the stale-security-doc problem that motivated this change, so they are better handled as a separate cleanup.
- The four response-shape snapshots in `api_types.rs` pin types defined in the `rustfs-kms` crate, while the JSON actually served comes from the mirrors in `rustfs/src/admin/handlers/kms_keys.rs` (`DeleteKmsKeyResponse` and friends). Changing an admin-side type will not fail those snapshots. This is pre-existing and not introduced here; fixing it means moving the snapshots into the `rustfs` crate.
