### PR TITLE
fix(lifecycle): count the first transition sample for each tier

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -1764,10 +1764,7 @@ impl TransitionState {
 
     pub fn add_lastday_stats(&self, tier: &str, ts: TierStats) {
         let mut tier_stats = self.lock_last_day_stats();
-        tier_stats
-            .entry(tier.to_string())
-            .and_modify(|e| e.add_stats(ts))
-            .or_default();
+        tier_stats.entry(tier.to_string()).or_default().add_stats(ts);
     }
 
     pub fn get_daily_all_tier_stats(&self) -> DailyAllTierStats {
@@ -7275,6 +7272,48 @@ mod tests {
         let stats = state.get_daily_all_tier_stats();
         assert!(!stats.contains_key("stale"), "possibly partial statistics must be discarded");
         assert!(stats.contains_key("fresh"), "statistics must accept new samples after recovery");
+    }
+
+    #[test]
+    fn first_tier_sample_is_not_dropped() {
+        // The first completed transition to a tier both creates the map entry
+        // and carries a sample. Creating the entry must not discard that
+        // sample, or the admin GetTierInfo response undercounts every tier by
+        // its first transition while reporting later ones correctly.
+        let state = TransitionState::new_with_capacity(1);
+
+        state.add_lastday_stats(
+            "warm",
+            TierStats {
+                total_size: 10,
+                num_versions: 1,
+                num_objects: 1,
+            },
+        );
+
+        let stats = state.get_daily_all_tier_stats();
+        let total = stats.get("warm").expect("first sample must create the tier entry").total();
+        assert_eq!(total.total_size, 10, "first sample size must be counted");
+        assert_eq!(total.num_versions, 1, "first sample version must be counted");
+        assert_eq!(total.num_objects, 1, "first sample object must be counted");
+
+        // Later samples must accumulate onto the existing entry rather than
+        // replace it; `LastDayTierStats::add_stats` coverage alone does not
+        // reach this path, because it never goes through the tier map.
+        state.add_lastday_stats(
+            "warm",
+            TierStats {
+                total_size: 20,
+                num_versions: 2,
+                num_objects: 1,
+            },
+        );
+
+        let stats = state.get_daily_all_tier_stats();
+        let total = stats.get("warm").expect("tier entry must survive later samples").total();
+        assert_eq!(total.total_size, 30, "later sample size must accumulate");
+        assert_eq!(total.num_versions, 3, "later sample versions must accumulate");
+        assert_eq!(total.num_objects, 2, "later sample objects must accumulate");
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

`TransitionState::add_lastday_stats` recorded daily tier statistics with `entry(tier).and_modify(|e| e.add_stats(ts)).or_default()`. `and_modify` runs only when the key is already present, so on a vacant entry `or_default()` inserted an empty `LastDayTierStats` and the sample that created the entry was dropped on the floor.

The effect is that the first completed transition to each tier is never counted, while every later transition to that tier is counted correctly — which is why the undercount is easy to miss. It surfaces in the admin GetTierInfo response, whose numbers come from this map via `get_daily_all_tier_stats` -> `filter_tier_stats` -> `LastDayTierStats::total`. Every tier is reported short by exactly one transition.

The fix inserts first and then records, so the entry-creating sample lands in the hourly bin like any other: `entry(tier).or_default().add_stats(ts)`.

All checks below ran on the rebased tree, against `main` at `6eddc04b0a`.

- `make pre-pr` — formatting, architecture guards, and clippy all pass. Its test stage reports two failures, both pre-existing and environmental; see below.
- `cargo nextest run --all --exclude e2e_test --no-fail-fast` — 12014 tests run, 12012 passed, 2 failed, 161 skipped.
- `cargo test -p rustfs-ecstore --lib tier` — 309 passed, 0 failed.
- Revert-detection, both branches of the new test, each confirmed by mutating the source and observing the matching assertion fail:
  - restoring `and_modify(..).or_default()` fails `first sample size must be counted` (left: 0, right: 10);
  - replacing the entry with a fresh `insert` fails `later sample size must accumulate` (left: 20, right: 30).

The two failures are `rustfs-ecstore layout::endpoints::test::system_resolver_negative_result_reaches_the_dns_allowlist` and `rustfs-utils net::test::test_resolve_domain_preserves_system_resolver_error_provenance`. Both perform a live system DNS lookup and assert that an unresolvable name fails to resolve; the sandbox this ran in answers every lookup with a synthetic address (`198.18.1.137` and `198.18.1.138` respectively), so the negative lookups succeed and the assertions fire. Both were reproduced on unmodified `main` at `6eddc04b0a` with identical messages and identical synthetic addresses, so they are independent of this change, which touches neither DNS nor endpoint resolution. They are left alone deliberately rather than skipped or relaxed — the tests are correct and the local resolver is not. CI is the authoritative run for these two.

## Impact

Admin GetTierInfo now reports accurate daily per-tier totals. Operators reading that endpoint will see counts increase by one transition per tier relative to previous builds; that is the correction, not a new inflation. No on-disk or on-wire format change, no API shape change, no configuration change. The statistics are in-memory only, so there is no migration concern.

## Additional Notes

The new test drives the production accessors rather than a lookalike helper, and pins both branches of the entry handling: a vacant entry must retain the sample that created it, and a later sample must accumulate onto the existing entry instead of replacing it. The pre-existing `total_sums_all_recorded_stats` test cannot catch either case because it calls `LastDayTierStats::add_stats` directly and never goes through the tier map; `poisoned_tier_stats_are_reset_before_reuse` passes `TierStats::default()`, so its all-zero sample is invisible to this bug.

Adversarial validation, high-risk tier (lifecycle/tiering), one line per role:

- Correctness — attacked the zero-valued sample, the fresh-entry `forward_to` path (`updated_at` is now, `since < 1`, so the sample lands in the current bin), and `TierStats` counter overflow; no break found.
- Simplicity — the diff is the minimal in-place edit and the canonical entry idiom; the initial test comment named the old construct, which belongs in the PR description, so it was rewritten to state the invariant per the file's existing regression-comment style.
- Security — no authz, secret, untrusted-input, path or logging surface; the tier key space is unchanged, since the old code also created the entry.
- Concurrency/durability — single mutex, guard scope unchanged, no nested acquisition and no `.await` in this synchronous function, so no ABBA or held-across-await risk; poison recovery is untouched and the state is in-memory, so no durability surface.
- Compatibility — no metadata key, `xl.meta`, proto or S3 surface touched; the GetTierInfo JSON shape is unchanged and only its values are corrected.
- Performance — identical allocation and hash-lookup count (one `entry` call, one `tier.to_string()` in both versions); the call site runs once per completed transition, after a remote-tier upload.
- Test coverage — the first draft pinned only the vacant branch, leaving accumulation-through-the-map unpinned by any test; covered by extending the test, and both branches are now mutation-verified above.
