### PR TITLE
chore(kms): remove dead key-management types from api_types

### DIFF
--- a/crates/kms/src/api_types.rs
+++ b/crates/kms/src/api_types.rs
@@ -21,7 +21,7 @@ use crate::config::{
     redacted_secret, redacted_secret_option,
 };
 use crate::service_manager::KmsServiceStatus;
-use crate::types::{KeyMetadata, KeyUsage};
+use crate::types::KeyMetadata;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -1300,49 +1300,6 @@ mod tests {
 // Key Management API Types
 // ========================================
 
-/// Request to create a new key with optional custom name
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateKeyRequest {
-    /// Custom key name (optional, will auto-generate UUID if not provided)
-    pub key_name: Option<String>,
-    /// Key usage type
-    pub key_usage: KeyUsage,
-    /// Key description
-    pub description: Option<String>,
-    /// Key policy JSON string
-    pub policy: Option<String>,
-    /// Tags for the key
-    pub tags: HashMap<String, String>,
-    /// Origin of the key
-    pub origin: Option<String>,
-}
-
-impl Default for CreateKeyRequest {
-    fn default() -> Self {
-        Self {
-            key_name: None,
-            key_usage: KeyUsage::EncryptDecrypt,
-            description: None,
-            policy: None,
-            tags: HashMap::new(),
-            origin: None,
-        }
-    }
-}
-
-/// Response from create key operation
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateKeyResponse {
-    /// Success flag
-    pub success: bool,
-    /// Status message
-    pub message: String,
-    /// Created key ID (either custom name or auto-generated UUID)
-    pub key_id: String,
-    /// Key metadata
-    pub key_metadata: KeyMetadata,
-}
-
 /// JSON shape returned by the admin delete-key endpoint.
 ///
 /// The delete *request* shape lives in [`crate::types::DeleteKeyRequest`] —
@@ -1360,15 +1317,6 @@ pub struct DeleteKeyResponse {
     pub deletion_date: Option<String>,
 }
 
-/// Request to list all keys
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ListKeysRequest {
-    /// Maximum number of keys to return (1-1000)
-    pub limit: Option<u32>,
-    /// Pagination marker
-    pub marker: Option<String>,
-}
-
 /// Response from list keys operation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListKeysResponse {
@@ -1384,13 +1332,6 @@ pub struct ListKeysResponse {
     pub next_marker: Option<String>,
 }
 
-/// Request to describe a key
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DescribeKeyRequest {
-    /// Key ID to describe
-    pub key_id: String,
-}
-
 /// Response from describe key operation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DescribeKeyResponse {
@@ -1400,13 +1341,6 @@ pub struct DescribeKeyResponse {
     pub message: String,
     /// Key metadata
     pub key_metadata: Option<KeyMetadata>,
-}
-
-/// Request to cancel key deletion
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CancelKeyDeletionRequest {
-    /// Key ID to cancel deletion for
-    pub key_id: String,
 }
 
 /// Response from cancel key deletion operation


### PR DESCRIPTION
## Related Issues

N/A — follow-up to the "Additional Notes" of #5601, which removed the sibling dead type `api_types::DeleteKeyRequest` and flagged these five for a separate change.

## Summary of Changes

Removes five unreferenced, non-re-exported types from the "Key Management API Types" block in `crates/kms/src/api_types.rs`: `CreateKeyRequest` (with its `impl Default`), `CreateKeyResponse`, `ListKeysRequest`, `DescribeKeyRequest`, and `CancelKeyDeletionRequest`.

These were dead duplicates. The live definitions all live in `crates/kms/src/types.rs` and reach callers through `pub use types::*` in `lib.rs`. Notably `service.rs` imports only `TagKeyRequest`/`TagKeyResponse`/`UntagKeyRequest`/`UntagKeyResponse`/`UpdateKeyDescription{Request,Response}` from `api_types` and takes everything else from `crate::types::*`, so `ObjectEncryptionService::create_key`, `describe_key`, and `list_keys` were already binding the `types.rs` shapes — the `api_types` copies had no caller anywhere in the workspace and were absent from the `pub use api_types::{...}` list in `lib.rs`.

Removing `CreateKeyRequest` orphaned the `KeyUsage` import, so `use crate::types::{KeyMetadata, KeyUsage}` narrows to `use crate::types::KeyMetadata`. `HashMap` and `KeyMetadata` both remain in use by surviving types (`TagKeyRequest` and `DescribeKeyResponse` respectively) and are untouched.

Deliberately kept: `ListKeysResponse`, `DescribeKeyResponse`, `CancelKeyDeletionResponse`, and `DeleteKeyResponse` in the same block are live — they are exercised by the `kms_management_responses_have_stable_json_shapes` snapshot test with committed snapshots under `crates/kms/src/snapshots/`. `CreateKeyResponse` is *not* in that test, which is why it is safe to drop alongside the request types. No snapshot files are added or removed by this PR.

## Verification

- `cargo check -p rustfs-kms --all-targets` — clean (covers the `examples/kms_local_demo.rs` and `examples/kms_vault_kv_demo.rs` binaries plus `tests/vault_fault_injection.rs`, which use the `types.rs` versions of these names and continue to resolve).
- `cargo clippy -p rustfs-kms --all-targets -- -D warnings` — clean, confirming no newly-unused imports.
- `cargo test -p rustfs-kms --lib api_types` — 16 passed, 0 failed, including `kms_management_responses_have_stable_json_shapes`.
- `make pre-commit` — all checks passed.

## Impact

None. Pure dead-code removal with no behavior change and no wire-format change. The removed items were technically reachable as `rustfs_kms::api_types::*` public paths, but they had no in-workspace consumer, were never part of the crate's curated `lib.rs` re-export surface, and duplicate identically-named types that remain exported via `pub use types::*` — so the names callers actually use are unaffected.

## Additional Notes

Each candidate was re-confirmed unreferenced against `origin/main` at `7463655ae1` immediately before the edit, since the KMS area moves quickly: a workspace-wide grep for both the bare and `api_types::`-qualified names found no consumer, and a search of Markdown/TOML/JSON found no doc references either.

The remaining `api_types` key-management types after this change are the four snapshot-tested responses plus `UpdateKeyDescription{Request,Response}` (which *are* in the `lib.rs` re-export list and imported by `service.rs`), so the block is now free of dead duplicates.
