### PR TITLE
docs(kms): guard outward FIPS wording

### DIFF
--- a/.config/make/lint-fmt.mak
+++ b/.config/make/lint-fmt.mak
@@ -60,6 +60,11 @@ body-cache-whitelist-check: ## Check the body-cache eligibility gate stays a fai
 	@echo "🧱 Checking body-cache whitelist guard..."
 	./scripts/check_body_cache_whitelist.sh
 
+.PHONY: fips-wording-check
+fips-wording-check: ## Check outward docs do not make unsupported FIPS claims
+	@echo "📣 Checking FIPS wording guard..."
+	./scripts/check_fips_wording.sh
+
 .PHONY: log-analyzer-rules-check
 log-analyzer-rules-check: core-deps ## Check log-analyzer rule anchors still exist verbatim in source
 	@echo "🩺 Checking log-analyzer rule anchors..."

--- a/.config/make/pre-commit.mak
+++ b/.config/make/pre-commit.mak
@@ -19,13 +19,13 @@ planning-docs-check: ## Check that no planning-type documents are committed
 	./scripts/check_no_planning_docs.sh
 
 .PHONY: pre-commit
-pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check doc-paths-check planning-docs-check quick-check ## Run fast pre-commit checks without clippy/full tests
+pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check fips-wording-check doc-paths-check planning-docs-check quick-check ## Run fast pre-commit checks without clippy/full tests
 	@echo "✅ All pre-commit checks passed!"
 
 .PHONY: pre-pr
-pre-pr: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check doc-paths-check planning-docs-check log-analyzer-rules-check clippy-check test ## Run full pre-PR checks with clippy and tests
+pre-pr: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check fips-wording-check doc-paths-check planning-docs-check log-analyzer-rules-check clippy-check test ## Run full pre-PR checks with clippy and tests
 	@echo "✅ All pre-PR checks passed!"
 
 .PHONY: dev-check
-dev-check: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check doc-paths-check planning-docs-check quick-check ## Run fast local development checks
+dev-check: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check fips-wording-check doc-paths-check planning-docs-check quick-check ## Run fast local development checks
 	@echo "✅ Fast development checks passed!"

--- a/docs/operations/kms-cryptographic-compliance.md
+++ b/docs/operations/kms-cryptographic-compliance.md
@@ -51,7 +51,7 @@ Suggested boilerplate when the topic cannot be avoided:
 
 ### Guard
 
-There is currently no FIPS-related wording anywhere in the repository's Markdown; that clean baseline is what a grep anchor test protects. Any future occurrence of the banned strings in shipped documentation should be treated as a defect and either removed or brought under the qualifier rule above.
+`README.md` and `CHANGELOG.md` currently contain no FIPS-related wording; `scripts/check_fips_wording.sh` is the grep guard for that public baseline. Any future occurrence of the banned strings in either file should be treated as a defect and either removed or brought under the qualifier rule above. This document intentionally contains the terminology needed to define the policy and is not part of that narrow outward-material scan.
 
 ## The `rustfs-crypto` `fips` feature: what it actually does
 

--- a/scripts/check_fips_wording.sh
+++ b/scripts/check_fips_wording.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard: outward README and CHANGELOG material must not make an unsupported
+# FIPS validation or certification claim. The detailed policy and permitted
+# qualifiers live in docs/operations/kms-cryptographic-compliance.md; this
+# check intentionally scans only the two public project-facing documents.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${CHECK_FIPS_WORDING_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+cd "$ROOT_DIR"
+
+TARGETS=(README.md CHANGELOG.md)
+FORBIDDEN_PATTERNS=(
+  'FIPS[[:space:]]+(140-[23](/[[:space:]]*140-[23])?[[:space:]]+)?(validated|certified|compliant)'
+  'FIPS[[:space:]]+mode'
+  'FIPS-enabled'
+  'NIST[[:space:]]+(certified|approved)'
+  'CMVP[[:space:]]+certificate'
+  '(meets|satisfies)[[:space:]]+FIPS'
+)
+
+status=0
+
+for target in "${TARGETS[@]}"; do
+  if [[ ! -f "$target" ]]; then
+    printf 'FIPS wording guard failed: %s is missing\n' "$target" >&2
+    status=1
+    continue
+  fi
+
+  for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+    matches="$(grep -E -i -n -- "$pattern" "$target" || true)"
+    if [[ -n "$matches" ]]; then
+      printf 'FIPS wording guard failed: forbidden pattern /%s/ in %s:\n%s\n' \
+        "$pattern" "$target" "$matches" >&2
+      status=1
+    fi
+  done
+done
+
+if [[ "$status" -ne 0 ]]; then
+  printf 'Remove unsupported FIPS validation wording from README.md or CHANGELOG.md.\n' >&2
+  exit "$status"
+fi
+
+printf 'FIPS wording guard passed (README.md and CHANGELOG.md contain no forbidden claims).\n'


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1587.

## Summary of Changes

Adds a narrow guard for README.md and CHANGELOG.md so unsupported FIPS validation or certification claims cannot be introduced silently. Wires the check into the repository's pre-commit, pre-pr, and dev-check targets, and corrects the compliance runbook to describe the guarded public-document baseline.

## Verification

- `./scripts/check_fips_wording.sh`
- `make fips-wording-check`
- `./scripts/check_doc_paths.sh`
- `./scripts/check_no_planning_docs.sh`
- `shellcheck scripts/check_fips_wording.sh`
- `bash -n scripts/check_fips_wording.sh`
- `git diff --check`
- A temporary fixture containing `FIPS validated` was rejected by the guard.

## Impact

Documentation and developer-check tooling only. README.md and CHANGELOG.md currently contain no FIPS validation claims; the new guard fails closed if prohibited wording is added.

## Additional Notes

N/A.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
