### PR TITLE
test(ci): serialize cross-node metadata writes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,6 +9,8 @@
 #   * bucket_lifecycle_ops::tests::concurrent_resend_same_part_commits_one_generation
 #     uses the shared multipart fixture and a deterministic uploadId-lock
 #     handoff, so it must not overlap another process mutating that fixture.
+#   * bucket::metadata_sys::tests::concurrent_config_writes_from_separate_nodes_do_not_lose_writes
+#     uses the shared transaction lock and must not overlap other ecstore tests.
 #
 # serial_test's #[serial] attribute does NOT serialize these across runs:
 # nextest executes each test in its own process, where the in-process
@@ -40,7 +42,7 @@ e2e-inline-boundaries = { max-threads = 1 }
 
 # --- default profile (local): serialize the flaky groups, never retry --------
 [[profile.default.overrides]]
-filter = 'package(rustfs-ecstore) & (test(concurrent_resend_same_part_commits_one_generation) | test(/^store::bucket::tests::bucket_delete_(mark_delete|purge_removes|default_s3_delete)/))'
+filter = 'package(rustfs-ecstore) & (test(concurrent_resend_same_part_commits_one_generation) | test(concurrent_config_writes_from_separate_nodes_do_not_lose_writes) | test(/^store::bucket::tests::bucket_delete_(mark_delete|purge_removes|default_s3_delete)/))'
 test-group = 'ecstore-serial-flaky'
 
 # Serialize the multipart crash-consistency scenarios (dist-2, backlog#1150):
@@ -104,9 +106,9 @@ filter = 'package(rustfs-ecstore) & test(/^store::bucket::tests::bucket_delete_(
 test-group = 'ecstore-serial-flaky'
 retries = 2
 
-# Keep the deterministic multipart handoff isolated across nextest processes.
+# Keep deterministic ECStore write handoffs isolated across nextest processes.
 [[profile.ci.overrides]]
-filter = 'package(rustfs-ecstore) & test(concurrent_resend_same_part_commits_one_generation)'
+filter = 'package(rustfs-ecstore) & (test(concurrent_resend_same_part_commits_one_generation) | test(concurrent_config_writes_from_separate_nodes_do_not_lose_writes))'
 test-group = 'ecstore-serial-flaky'
 
 # QUARANTINE: OPEN rustfs#4690 — walk_dir stall-budget accounting test depends


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Serialize the cross-node bucket metadata writer regression with the existing ECStore nextest group in both default and CI profiles.

## Verification
- `cargo fmt --all --check`
- `cargo nextest run -j 2 -p rustfs-ecstore --features rio-v2 -E 'test(concurrent_config_writes_from_separate_nodes_do_not_lose_writes)'`
- `make pre-commit`

## Impact
- CI-only scheduling; no runtime or compatibility change.

## Additional Notes
- The full local rio-v2 run is affected by a local resolver that synthesizes the reserved `.invalid` domain; the targeted regression passed.
