### PR TITLE
feat(table-catalog): expand core Iceberg REST operations

### DIFF
--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -14,6 +14,7 @@
 
 use crate::admin::runtime_sources::default_admin_usecase;
 use crate::admin::runtime_sources::{current_object_store_handle, current_token_signing_key};
+use crate::admin::storage_api::access::{ReqInfo, authorize_request};
 use crate::admin::storage_api::bucket::{metadata::table_catalog_path_hash, metadata_sys};
 use crate::admin::storage_api::runtime::ECStore;
 use crate::admin::{
@@ -27,13 +28,14 @@ use http::{HeaderMap, HeaderValue, StatusCode};
 use hyper::Method;
 use matchit::Params;
 use metrics::{counter, histogram};
+use percent_encoding::percent_decode_str;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
 use rustfs_iam::sys::SESSION_POLICY_NAME;
 use rustfs_policy::{
     auth::get_new_credentials_with_metadata,
     policy::{
         Policy,
-        action::{Action, AdminAction},
+        action::{Action, AdminAction, S3Action},
     },
 };
 use rustfs_utils::crypto::{base64_decode_url_safe_no_pad, base64_encode_url_safe_no_pad, hex_sha256};
@@ -51,8 +53,13 @@ const ENV_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: &str = "RUSTFS_TABLE_CATALOG_CRE
 const DEFAULT_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: i64 = 15 * 60;
 const MIN_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: i64 = 60;
 const MAX_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: i64 = 60 * 60;
+const NAMESPACE_PROPERTIES_BODY_MAX_SIZE: usize = 64 * 1024;
+const NAMESPACE_PROPERTIES_BODY_TIMEOUT: StdDuration = StdDuration::from_secs(10);
+const RENAME_TABLE_BODY_MAX_SIZE: usize = 16 * 1024;
+const RENAME_TABLE_BODY_TIMEOUT: StdDuration = StdDuration::from_secs(10);
 const WAREHOUSE_PROPERTY: &str = "warehouse";
 const PREFIX_PROPERTY: &str = "prefix";
+const NAMESPACE_SEPARATOR_PROPERTY: &str = "namespace-separator";
 const ICEBERG_ERROR_ALREADY_EXISTS: &str = "AlreadyExistsException";
 const ICEBERG_ERROR_BAD_REQUEST: &str = "BadRequestException";
 const ICEBERG_ERROR_COMMIT_FAILED: &str = "CommitFailedException";
@@ -123,52 +130,16 @@ const TABLE_CATALOG_ENDPOINTS: &[&str] = &[
     "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials",
     "POST /v1/{prefix}/namespaces/{namespace}/tables/{table}",
     "DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}",
-    "PUT /buckets/{warehouse}",
-    "GET /buckets/{warehouse}",
-    "GET /{warehouse}/catalog/migration",
-    "POST /{warehouse}/catalog/migration",
-    "DELETE /{warehouse}/catalog/migration",
-    "GET /{warehouse}/namespaces",
-    "POST /{warehouse}/namespaces",
-    "GET /{warehouse}/namespaces/{namespace}",
-    "HEAD /{warehouse}/namespaces/{namespace}",
-    "DELETE /{warehouse}/namespaces/{namespace}",
-    "GET /{warehouse}/namespaces/{namespace}/tables",
-    "POST /{warehouse}/namespaces/{namespace}/tables",
-    "POST /{warehouse}/namespaces/{namespace}/register",
-    "GET /{warehouse}/namespaces/{namespace}/views",
-    "POST /{warehouse}/namespaces/{namespace}/views",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}",
-    "HEAD /{warehouse}/namespaces/{namespace}/tables/{table}",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/credentials",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}",
-    "DELETE /{warehouse}/namespaces/{namespace}/tables/{table}",
-    "GET /{warehouse}/namespaces/{namespace}/views/{view}",
-    "HEAD /{warehouse}/namespaces/{namespace}/views/{view}",
-    "POST /{warehouse}/namespaces/{namespace}/views/{view}",
-    "DELETE /{warehouse}/namespaces/{namespace}/views/{view}",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/refs",
-    "PUT /{warehouse}/namespaces/{namespace}/tables/{table}/refs/{ref}",
-    "DELETE /{warehouse}/namespaces/{namespace}/tables/{table}/refs/{ref}",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/metadata",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/metadata-location",
-    "PUT /{warehouse}/namespaces/{namespace}/tables/{table}/metadata-location",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/config",
-    "PUT /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/config",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/jobs/{job}",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/scheduler",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/scheduler/run",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/worker/run",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/jobs/{job}/heartbeat",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/maintenance/jobs/{job}/quarantine",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/export",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/import",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/external",
-    "PUT /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/external",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/external/sync",
-    "GET /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/diagnostics",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/recovery",
-    "POST /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/rollback",
+    "GET /v1/{prefix}/namespaces/{namespace}/views",
+    "POST /v1/{prefix}/namespaces/{namespace}/views",
+    "GET /v1/{prefix}/namespaces/{namespace}/views/{view}",
+    "HEAD /v1/{prefix}/namespaces/{namespace}/views/{view}",
+    "POST /v1/{prefix}/namespaces/{namespace}/views/{view}",
+    "DELETE /v1/{prefix}/namespaces/{namespace}/views/{view}",
+];
+const TABLE_CATALOG_DURABLE_STRONG_ENDPOINTS: &[&str] = &[
+    "POST /v1/{prefix}/namespaces/{namespace}/properties",
+    "POST /v1/{prefix}/tables/rename",
 ];
 
 static GET_CONFIG_HANDLER: GetCatalogConfigHandler = GetCatalogConfigHandler {};
@@ -182,6 +153,7 @@ static LIST_NAMESPACES_HANDLER: RestListNamespacesHandler = RestListNamespacesHa
 static CREATE_NAMESPACE_HANDLER: RestCreateNamespaceHandler = RestCreateNamespaceHandler {};
 static GET_NAMESPACE_HANDLER: RestGetNamespaceHandler = RestGetNamespaceHandler {};
 static NAMESPACE_EXISTS_HANDLER: RestNamespaceExistsHandler = RestNamespaceExistsHandler {};
+static UPDATE_NAMESPACE_PROPERTIES_HANDLER: RestUpdateNamespacePropertiesHandler = RestUpdateNamespacePropertiesHandler {};
 static DROP_NAMESPACE_HANDLER: RestDropNamespaceHandler = RestDropNamespaceHandler {};
 static LIST_TABLES_HANDLER: RestListTablesHandler = RestListTablesHandler {};
 static CREATE_TABLE_HANDLER: RestCreateTableHandler = RestCreateTableHandler {};
@@ -193,6 +165,7 @@ static TABLE_EXISTS_HANDLER: RestTableExistsHandler = RestTableExistsHandler {};
 static LOAD_CREDENTIALS_HANDLER: RestLoadCredentialsHandler = RestLoadCredentialsHandler {};
 static COMMIT_TABLE_HANDLER: RestCommitTableHandler = RestCommitTableHandler {};
 static DROP_TABLE_HANDLER: RestDropTableHandler = RestDropTableHandler {};
+static RENAME_TABLE_HANDLER: RestRenameTableHandler = RestRenameTableHandler {};
 static LOAD_VIEW_HANDLER: RestLoadViewHandler = RestLoadViewHandler {};
 static VIEW_EXISTS_HANDLER: RestViewExistsHandler = RestViewExistsHandler {};
 static REPLACE_VIEW_HANDLER: RestReplaceViewHandler = RestReplaceViewHandler {};
@@ -248,6 +221,22 @@ struct CreateNamespaceRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+struct UpdateNamespacePropertiesRequest {
+    #[serde(default)]
+    removals: Vec<String>,
+    #[serde(default)]
+    updates: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RenameTableRequest {
+    source: RestTableIdentifier,
+    destination: RestTableIdentifier,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RegisterTableRequest {
     name: String,
     #[serde(rename = "metadata-location")]
@@ -290,7 +279,7 @@ struct CreateViewRequest {
 #[serde(deny_unknown_fields)]
 struct RestCommitTableRequest {
     #[serde(default, rename = "identifier")]
-    _identifier: Option<serde_json::Value>,
+    identifier: Option<RestTableIdentifier>,
     #[serde(default, rename = "commit-id")]
     commit_id: Option<String>,
     #[serde(default, rename = "idempotency-key")]
@@ -314,8 +303,8 @@ struct RestCommitTableRequest {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RestCommitViewRequest {
-    #[serde(default, rename = "commit-id")]
-    commit_id: Option<String>,
+    #[serde(default, rename = "identifier")]
+    identifier: Option<RestTableIdentifier>,
     #[serde(default, rename = "expected-version-token")]
     expected_version_token: Option<String>,
     #[serde(default, rename = "expected-metadata-location")]
@@ -615,7 +604,8 @@ struct RestListNamespacesResponse {
     next_page_token: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RestTableIdentifier {
     namespace: Vec<String>,
     name: String,
@@ -923,9 +913,19 @@ fn register_table_catalog_prefix_routes(r: &mut S3Router<AdminOperation>, prefix
         AdminOperation(&NAMESPACE_EXISTS_HANDLER),
     )?;
     r.insert(
+        Method::POST,
+        format!("{prefix}/{{warehouse}}/namespaces/{{namespace}}/properties").as_str(),
+        AdminOperation(&UPDATE_NAMESPACE_PROPERTIES_HANDLER),
+    )?;
+    r.insert(
         Method::DELETE,
         format!("{prefix}/{{warehouse}}/namespaces/{{namespace}}").as_str(),
         AdminOperation(&DROP_NAMESPACE_HANDLER),
+    )?;
+    r.insert(
+        Method::POST,
+        format!("{prefix}/{{warehouse}}/tables/rename").as_str(),
+        AdminOperation(&RENAME_TABLE_HANDLER),
     )?;
     r.insert(
         Method::GET,
@@ -1114,7 +1114,8 @@ fn register_table_catalog_prefix_routes(r: &mut S3Router<AdminOperation>, prefix
 fn catalog_config_response(warehouse: Option<&str>) -> S3Result<CatalogConfigResponse> {
     let usecase = default_admin_usecase();
     let backing_mode = crate::table_catalog::TableCatalogBackingMode::from_env().map_err(catalog_store_error)?;
-    let mut overrides = BTreeMap::new();
+    let mut overrides =
+        BTreeMap::from([(NAMESPACE_SEPARATOR_PROPERTY.to_string(), REST_NAMESPACE_SEPARATOR_URL_ENCODED.to_string())]);
     if backing_mode != crate::table_catalog::TableCatalogBackingMode::ObjectBacked {
         overrides.insert(CATALOG_BACKING_CONFIG_KEY.to_string(), backing_mode.as_str().to_string());
     }
@@ -1133,10 +1134,14 @@ fn catalog_config_response(warehouse: Option<&str>) -> S3Result<CatalogConfigRes
     if let Some(warehouse) = warehouse {
         defaults.insert(PREFIX_PROPERTY.to_string(), warehouse.to_string());
     }
+    let mut endpoints = TABLE_CATALOG_ENDPOINTS.to_vec();
+    if backing_mode == crate::table_catalog::TableCatalogBackingMode::DurableStrong {
+        endpoints.extend_from_slice(TABLE_CATALOG_DURABLE_STRONG_ENDPOINTS);
+    }
     Ok(CatalogConfigResponse {
         defaults,
         overrides,
-        endpoints: TABLE_CATALOG_ENDPOINTS.to_vec(),
+        endpoints,
         admin_discovery: CatalogAdminDiscovery {
             runtime_capabilities: usecase.runtime_capabilities_route(),
             cluster_snapshot: usecase.cluster_snapshot_route(),
@@ -1149,6 +1154,16 @@ fn build_json_response<T: Serialize>(status: StatusCode, body: &T) -> S3Result<S
     let data = serde_json::to_vec(body).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE));
+    Ok(S3Response::with_headers((status, Body::from(data)), headers))
+}
+
+fn build_sensitive_json_response<T: Serialize>(status: StatusCode, body: &T) -> S3Result<S3Response<(StatusCode, Body)>> {
+    let data = serde_json::to_vec(body).map_err(|e| s3_error!(InternalError, "failed to serialize response: {}", e))?;
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE));
+    headers.insert(http::header::CACHE_CONTROL, HeaderValue::from_static("no-store, private"));
+    headers.insert(http::header::PRAGMA, HeaderValue::from_static("no-cache"));
+    headers.insert(http::header::EXPIRES, HeaderValue::from_static("0"));
     Ok(S3Response::with_headers((status, Body::from(data)), headers))
 }
 
@@ -1299,19 +1314,28 @@ async fn authorize_table_catalog_resource_request(
     req: &S3Request<Body>,
     resource: &TableCatalogResource<'_>,
     action: AdminAction,
+) -> S3Result<TableCatalogRequestPrincipal> {
+    let principal = table_catalog_request_principal(req).await?;
+    authorize_table_catalog_resource_for_principal(req, &principal, resource, action).await?;
+    Ok(principal)
+}
+
+struct TableCatalogRequestPrincipal {
+    credentials: rustfs_credentials::Credentials,
+    owner: bool,
+}
+
+async fn authorize_table_catalog_resource_for_principal(
+    req: &S3Request<Body>,
+    principal: &TableCatalogRequestPrincipal,
+    resource: &TableCatalogResource<'_>,
+    action: AdminAction,
 ) -> S3Result<()> {
-    let Some(input_cred) = &req.credentials else {
-        return Err(s3_error!(InvalidRequest, "authentication required"));
-    };
-
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-
     let object_path = resource.object_path();
     validate_admin_request_with_bucket_object(
         &req.headers,
-        &cred,
-        owner,
+        &principal.credentials,
+        principal.owner,
         false,
         vec![Action::AdminAction(action)],
         req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
@@ -1320,19 +1344,155 @@ async fn authorize_table_catalog_resource_request(
     .await
 }
 
-async fn table_catalog_request_principal(req: &S3Request<Body>) -> S3Result<rustfs_credentials::Credentials> {
+async fn authorize_table_catalog_s3_actions(
+    req: &mut S3Request<Body>,
+    bucket: &str,
+    object: &str,
+    actions: &[S3Action],
+) -> S3Result<()> {
+    let original = {
+        let req_info = req
+            .extensions
+            .get_mut::<ReqInfo>()
+            .ok_or_else(|| s3_error!(AccessDenied, "authentication required"))?;
+        (
+            req_info.bucket.replace(bucket.to_string()),
+            req_info.object.replace(object.to_string()),
+            req_info.version_id.take(),
+        )
+    };
+
+    let mut result = Ok(());
+    for action in actions {
+        if let Err(err) = authorize_request(req, Action::S3Action(*action)).await {
+            result = Err(err);
+            break;
+        }
+    }
+    if let Some(req_info) = req.extensions.get_mut::<ReqInfo>() {
+        (req_info.bucket, req_info.object, req_info.version_id) = original;
+    }
+    result
+}
+
+fn table_catalog_prefix_authorization_probe(object_prefix: &str) -> String {
+    format!("{}/{}", object_prefix.trim_end_matches('/'), Uuid::new_v4())
+}
+
+async fn authorize_table_warehouse_s3_actions(
+    req: &mut S3Request<Body>,
+    bucket: &str,
+    warehouse_location: &str,
+    actions: &[S3Action],
+) -> S3Result<()> {
+    validate_table_location_in_bucket(bucket, warehouse_location)?;
+    let warehouse_prefix = crate::table_catalog::table_catalog_object_key_from_location(bucket, warehouse_location)
+        .ok_or_else(|| s3_error!(InvalidRequest, "table location must be inside the warehouse bucket"))?;
+    let authorization_probe = table_catalog_prefix_authorization_probe(&warehouse_prefix);
+    authorize_table_catalog_s3_actions(req, bucket, &authorization_probe, actions).await
+}
+
+async fn read_authorized_table_metadata_json(
+    req: &mut S3Request<Body>,
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    bucket: &str,
+    metadata_location: &str,
+) -> S3Result<serde_json::Value> {
+    authorize_table_catalog_s3_actions(req, bucket, metadata_location, &[S3Action::GetObjectAction]).await?;
+    let metadata = read_table_metadata_json(metadata_backend, bucket, metadata_location).await?;
+    authorize_table_warehouse_s3_actions(req, bucket, metadata_table_location(&metadata)?, TABLE_WAREHOUSE_WRITE_ACTIONS).await?;
+    Ok(metadata)
+}
+
+async fn table_catalog_request_principal(req: &S3Request<Body>) -> S3Result<TableCatalogRequestPrincipal> {
     let Some(input_cred) = &req.credentials else {
         return Err(s3_error!(InvalidRequest, "authentication required"));
     };
-    let (cred, _owner) =
+
+    let (cred, owner) =
         check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-    Ok(cred)
+    Ok(TableCatalogRequestPrincipal {
+        credentials: cred,
+        owner,
+    })
 }
 
 async fn read_json_body<T: DeserializeOwned>(mut input: Body) -> S3Result<T> {
     let body = input
         .store_all_limited(MAX_ADMIN_REQUEST_BODY_SIZE)
         .await
+        .map_err(|err| s3_error!(InvalidRequest, "failed to read request body: {}", err))?;
+    if body.is_empty() {
+        return Err(s3_error!(InvalidRequest, "request body is required"));
+    }
+    serde_json::from_slice(&body).map_err(|err| s3_error!(InvalidRequest, "invalid JSON: {}", err))
+}
+
+async fn read_rest_commit_table_request(headers: &HeaderMap, input: Body) -> S3Result<RestCommitTableRequest> {
+    let mut request = read_json_body::<RestCommitTableRequest>(input).await?;
+    let mut values = headers.get_all(IDEMPOTENCY_KEY_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(request);
+    };
+    if values.next().is_some() {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_BAD_REQUEST,
+            StatusCode::BAD_REQUEST,
+            "Idempotency-Key header must not be repeated",
+        ));
+    }
+    let value = value.to_str().map_err(|_| {
+        iceberg_rest_error(
+            ICEBERG_ERROR_BAD_REQUEST,
+            StatusCode::BAD_REQUEST,
+            "Idempotency-Key header must be a UUIDv7",
+        )
+    })?;
+    let idempotency_key = Uuid::parse_str(value).map_err(|_| {
+        iceberg_rest_error(
+            ICEBERG_ERROR_BAD_REQUEST,
+            StatusCode::BAD_REQUEST,
+            "Idempotency-Key header must be a UUIDv7",
+        )
+    })?;
+    if value.len() != 36 || idempotency_key.get_version_num() != 7 {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_BAD_REQUEST,
+            StatusCode::BAD_REQUEST,
+            "Idempotency-Key header must be a UUIDv7",
+        ));
+    }
+    if request.idempotency_key.as_deref().is_some_and(|body_key| body_key != value) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_BAD_REQUEST,
+            StatusCode::BAD_REQUEST,
+            "Idempotency-Key header does not match the request body",
+        ));
+    }
+    request.idempotency_key = Some(value.to_string());
+    Ok(request)
+}
+
+async fn read_bounded_json_body<T: DeserializeOwned>(
+    headers: &HeaderMap,
+    mut input: Body,
+    max_size: usize,
+    timeout: StdDuration,
+    operation: &str,
+) -> S3Result<T> {
+    if let Some(content_length) = headers.get(http::header::CONTENT_LENGTH) {
+        let content_length = content_length
+            .to_str()
+            .map_err(|_| s3_error!(InvalidRequest, "Content-Length must be valid ASCII"))?
+            .parse::<usize>()
+            .map_err(|_| s3_error!(InvalidRequest, "Content-Length must be a non-negative integer"))?;
+        if content_length > max_size {
+            return Err(s3_error!(InvalidRequest, "{operation} request body is too large"));
+        }
+    }
+    let body = tokio::time::timeout(timeout, input.store_all_limited(max_size))
+        .await
+        .map_err(|_| s3_error!(InvalidRequest, "timed out reading {operation} request body"))?
         .map_err(|err| s3_error!(InvalidRequest, "failed to read request body: {}", err))?;
     if body.is_empty() {
         return Err(s3_error!(InvalidRequest, "request body is required"));
@@ -1520,7 +1680,7 @@ fn encode_rest_page_token(cursor: &str, context: &str) -> S3Result<String> {
 
 fn namespace_from_params(params: &Params<'_, '_>) -> S3Result<crate::table_catalog::Namespace> {
     let namespace = params.get("namespace").unwrap_or("");
-    crate::table_catalog::Namespace::parse(namespace).map_err(|err| s3_error!(InvalidRequest, "invalid namespace: {}", err))
+    namespace_from_path_value(namespace)
 }
 
 fn table_name_from_params(params: &Params<'_, '_>) -> S3Result<String> {
@@ -1685,13 +1845,22 @@ fn namespace_segments(namespace: &crate::table_catalog::Namespace) -> Vec<String
         .collect()
 }
 
-fn namespace_from_segments(segments: &[String]) -> S3Result<crate::table_catalog::Namespace> {
-    if segments.is_empty() {
-        return Err(s3_error!(InvalidRequest, "namespace cannot be empty"));
-    }
+fn namespace_from_segments(segments: Vec<String>) -> S3Result<crate::table_catalog::Namespace> {
+    crate::table_catalog::Namespace::from_segments(segments)
+        .map_err(|err| s3_error!(InvalidRequest, "invalid namespace: {}", err))
+}
 
-    let namespace = segments.join(".");
-    crate::table_catalog::Namespace::parse(&namespace).map_err(|err| s3_error!(InvalidRequest, "invalid namespace: {}", err))
+fn validate_rest_commit_identifier(
+    identifier: Option<&RestTableIdentifier>,
+    namespace: &crate::table_catalog::Namespace,
+    name: &str,
+) -> S3Result<()> {
+    if let Some(identifier) = identifier
+        && (identifier.namespace != namespace_segments(namespace) || identifier.name != name)
+    {
+        return Err(s3_error!(InvalidRequest, "request identifier must match the resource URL"));
+    }
+    Ok(())
 }
 
 fn namespace_response_from_entry(entry: crate::table_catalog::NamespaceEntry) -> S3Result<RestNamespaceResponse> {
@@ -1807,6 +1976,9 @@ fn normalize_table_credential_object_prefix(object_prefix: &str) -> S3Result<Str
             "table credential scope prefix contains an invalid path separator"
         ));
     }
+    if object_prefix.contains(['*', '?']) {
+        return Err(s3_error!(InvalidRequest, "table credential scope prefix contains an IAM wildcard"));
+    }
     if object_prefix
         .split('/')
         .any(|segment| segment.is_empty() || segment == "." || segment == "..")
@@ -1896,10 +2068,10 @@ fn storage_credential_from_issued(scope: TableCredentialScope, issued: IssuedTab
 }
 
 fn table_metadata_location_for_client(table_bucket: &str, metadata_location: &str) -> String {
-    if crate::table_catalog::is_reserved_table_object_key(metadata_location) {
-        format!("s3://{table_bucket}/{metadata_location}")
-    } else {
+    if metadata_location.starts_with("s3://") {
         metadata_location.to_string()
+    } else {
+        format!("s3://{table_bucket}/{metadata_location}")
     }
 }
 
@@ -1952,13 +2124,15 @@ fn load_table_response_from_entry(entry: crate::table_catalog::TableEntry, metad
 fn load_view_response_from_entry(entry: crate::table_catalog::ViewEntry, metadata: serde_json::Value) -> RestLoadViewResponse {
     let mut config = BTreeMap::new();
     let warehouse_location = entry.warehouse_location.clone();
+    let metadata_location = table_metadata_location_for_client(&entry.table_bucket, &entry.metadata_location);
+    let metadata = table_metadata_for_client(&entry.table_bucket, metadata);
     config.insert("warehouse-location".to_string(), warehouse_location.clone());
     config.insert(CREDENTIAL_SCOPE_CONFIG_KEY.to_string(), CREDENTIAL_SCOPE_TABLE_PREFIX.to_string());
     config.insert(CREDENTIAL_SCOPE_PREFIX_CONFIG_KEY.to_string(), warehouse_location);
     config.insert(CREDENTIAL_MODE_CONFIG_KEY.to_string(), CREDENTIAL_MODE_CLIENT_PROVIDED.to_string());
 
     RestLoadViewResponse {
-        metadata_location: entry.metadata_location,
+        metadata_location,
         metadata,
         config,
     }
@@ -2139,6 +2313,20 @@ fn validate_metadata_matches_current_metadata(
     Ok(())
 }
 
+fn metadata_sha256(metadata: &serde_json::Value) -> S3Result<String> {
+    let canonical = serde_json::to_vec(metadata)
+        .map_err(|err| s3_error!(InternalError, "failed to encode metadata digest input: {}", err))?;
+    Ok(hex_sha256(&canonical, str::to_string))
+}
+
+fn metadata_digest_requirement(metadata: &serde_json::Value) -> S3Result<serde_json::Value> {
+    let sha256 = metadata_sha256(metadata)?;
+    Ok(serde_json::json!({
+        "type": crate::table_catalog::TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+        "sha256": sha256
+    }))
+}
+
 fn metadata_view_uuid(metadata: &serde_json::Value) -> S3Result<&str> {
     metadata
         .get("view-uuid")
@@ -2152,9 +2340,9 @@ fn validate_metadata_matches_current_view_metadata(
     target_metadata: &serde_json::Value,
 ) -> S3Result<()> {
     let expected_view_uuid = metadata_view_uuid(current_metadata)?;
-    metadata_format_version(current_metadata)?;
+    validate_supported_view_metadata(current_metadata)?;
     let target_view_uuid = metadata_view_uuid(target_metadata)?;
-    metadata_format_version(target_metadata)?;
+    validate_supported_view_metadata(target_metadata)?;
     if target_view_uuid != expected_view_uuid {
         return Err(s3_error!(InvalidRequest, "view metadata view-uuid does not match current view metadata"));
     }
@@ -2177,14 +2365,15 @@ fn table_entry_from_register_request(
     request: RegisterTableRequest,
 ) -> S3Result<crate::table_catalog::TableEntry> {
     if request.overwrite {
-        return Err(s3_error!(NotImplemented, "register table overwrite is not supported"));
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            "register table overwrite is not supported",
+        ));
     }
     let table = crate::table_catalog::IdentifierSegment::parse(request.name)
         .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
     let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
-    if !crate::table_catalog::is_valid_table_metadata_location(namespace, &table, &metadata_location) {
-        return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
-    }
 
     let table_id = Uuid::new_v4().to_string();
     Ok(crate::table_catalog::TableEntry {
@@ -2216,9 +2405,6 @@ fn table_entry_from_import_request(
     let table = crate::table_catalog::IdentifierSegment::parse(table.to_string())
         .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
     let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
-    if !crate::table_catalog::is_valid_table_metadata_location(namespace, &table, &metadata_location) {
-        return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
-    }
 
     let table_id = Uuid::new_v4().to_string();
     Ok(crate::table_catalog::TableEntry {
@@ -2247,7 +2433,11 @@ fn table_entry_from_create_table_request(
     request: CreateTableRequest,
 ) -> S3Result<(crate::table_catalog::TableEntry, serde_json::Value)> {
     if request.stage_create {
-        return Err(s3_error!(NotImplemented, "stage-create is not supported"));
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            "stage-create is not supported",
+        ));
     }
 
     let table = crate::table_catalog::IdentifierSegment::parse(request.name)
@@ -2448,7 +2638,7 @@ fn initial_view_metadata_json(
         .and_then(serde_json::Value::as_i64)
         .unwrap_or_else(current_time_millis);
 
-    Ok(serde_json::json!({
+    let metadata = serde_json::json!({
         "format-version": entry.format_version,
         "view-uuid": entry.view_uuid,
         "location": entry.warehouse_location,
@@ -2461,7 +2651,9 @@ fn initial_view_metadata_json(
         }],
         "metadata-log": [],
         "properties": properties
-    }))
+    });
+    validate_supported_view_metadata(&metadata)?;
+    Ok(metadata)
 }
 
 fn current_time_millis() -> i64 {
@@ -2584,7 +2776,7 @@ fn validate_table_commit_requirements(metadata: &serde_json::Value, requirements
             }
             "assert-ref-snapshot-id" => validate_ref_snapshot_requirement(metadata, requirement)?,
             "assert-current-snapshot-id" => validate_current_snapshot_requirement(metadata, requirement)?,
-            _ => return Err(s3_error!(NotImplemented, "unsupported commit requirement: {requirement_type}")),
+            _ => return Err(s3_error!(InvalidRequest, "unsupported commit requirement: {requirement_type}")),
         }
     }
     Ok(())
@@ -2665,9 +2857,18 @@ fn validate_current_snapshot_requirement(metadata: &serde_json::Value, requireme
 }
 
 fn apply_table_commit_updates(
+    metadata: serde_json::Value,
+    updates: &[serde_json::Value],
+    previous_metadata_location: &str,
+) -> S3Result<serde_json::Value> {
+    apply_table_commit_updates_at(metadata, updates, previous_metadata_location, current_time_millis())
+}
+
+fn apply_table_commit_updates_at(
     mut metadata: serde_json::Value,
     updates: &[serde_json::Value],
     previous_metadata_location: &str,
+    commit_timestamp_ms: i64,
 ) -> S3Result<serde_json::Value> {
     if !metadata.is_object() {
         return Err(s3_error!(InvalidRequest, "current table metadata must be a JSON object"));
@@ -2679,7 +2880,7 @@ fn apply_table_commit_updates(
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| s3_error!(InvalidRequest, "table update action is required"))?;
         match action {
-            "assign-uuid" => apply_assign_uuid_update(&mut metadata, update)?,
+            "assign-uuid" => apply_assign_uuid_update(&mut metadata, update, "table-uuid", "table")?,
             "upgrade-format-version" => apply_upgrade_format_version_update(&mut metadata, update)?,
             "add-schema" => apply_add_schema_update(&mut metadata, update)?,
             "set-current-schema" => apply_set_current_schema_update(&mut metadata, update)?,
@@ -2687,20 +2888,164 @@ fn apply_table_commit_updates(
             "set-default-spec" => apply_set_default_spec_update(&mut metadata, update)?,
             "add-sort-order" => apply_add_sort_order_update(&mut metadata, update)?,
             "set-default-sort-order" => apply_set_default_sort_order_update(&mut metadata, update)?,
-            "add-snapshot" => apply_add_snapshot_update(&mut metadata, update)?,
+            "add-snapshot" => apply_add_snapshot_update(&mut metadata, update, commit_timestamp_ms)?,
             "set-snapshot-ref" => apply_set_snapshot_ref_update(&mut metadata, update)?,
             "remove-snapshots" => apply_remove_snapshots_update(&mut metadata, update)?,
             "remove-snapshot-ref" => apply_remove_snapshot_ref_update(&mut metadata, update)?,
             "set-location" => apply_set_location_update(&mut metadata, update)?,
             "set-properties" => apply_set_properties_update(&mut metadata, update)?,
             "remove-properties" => apply_remove_properties_update(&mut metadata, update)?,
-            _ => return Err(s3_error!(NotImplemented, "unsupported table update: {action}")),
+            "set-statistics" => apply_set_snapshot_file_update(&mut metadata, update, "statistics", "statistics")?,
+            "remove-statistics" => apply_remove_snapshot_file_update(&mut metadata, update, "statistics")?,
+            "set-partition-statistics" => {
+                apply_set_snapshot_file_update(&mut metadata, update, "partition-statistics", "partition-statistics")?;
+            }
+            "remove-partition-statistics" => {
+                apply_remove_snapshot_file_update(&mut metadata, update, "partition-statistics")?;
+            }
+            "remove-partition-specs" => {
+                apply_remove_metadata_ids_update(&mut metadata, update, "partition-specs", "spec-id", "spec-ids")?;
+            }
+            "remove-schemas" => {
+                apply_remove_metadata_ids_update(&mut metadata, update, "schemas", "schema-id", "schema-ids")?;
+            }
+            "add-encryption-key" => apply_add_encryption_key_update(&mut metadata, update)?,
+            "remove-encryption-key" => apply_remove_encryption_key_update(&mut metadata, update)?,
+            _ => return Err(s3_error!(InvalidRequest, "unsupported table update: {action}")),
         }
     }
 
-    append_previous_metadata_log(&mut metadata, previous_metadata_location)?;
-    metadata_object_mut(&mut metadata)?.insert("last-updated-ms".to_string(), serde_json::Value::from(current_time_millis()));
+    validate_table_metadata_references(&metadata)?;
+    append_previous_metadata_log(&mut metadata, previous_metadata_location, commit_timestamp_ms)?;
+    metadata_object_mut(&mut metadata)?.insert("last-updated-ms".to_string(), serde_json::Value::from(commit_timestamp_ms));
     Ok(metadata)
+}
+
+fn metadata_array_ids(metadata: &serde_json::Value, array_field: &str, id_field: &str, label: &str) -> S3Result<BTreeSet<i64>> {
+    let Some(values) = metadata.get(array_field) else {
+        return Ok(BTreeSet::new());
+    };
+    let values = values
+        .as_array()
+        .ok_or_else(|| s3_error!(InvalidRequest, "{array_field} must be an array"))?;
+    let mut ids = BTreeSet::new();
+    for value in values {
+        let id = value
+            .get(id_field)
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| s3_error!(InvalidRequest, "{label} is missing {id_field}"))?;
+        if !ids.insert(id) {
+            return Err(s3_error!(InvalidRequest, "duplicate {label} id {id}"));
+        }
+    }
+    Ok(ids)
+}
+
+fn validate_metadata_id_reference(
+    metadata: &serde_json::Value,
+    reference_field: &str,
+    ids: &BTreeSet<i64>,
+    label: &str,
+) -> S3Result<()> {
+    let Some(value) = metadata.get(reference_field) else {
+        return Ok(());
+    };
+    let id = value
+        .as_i64()
+        .ok_or_else(|| s3_error!(InvalidRequest, "{reference_field} must be an integer"))?;
+    if !ids.contains(&id) {
+        return Err(s3_error!(InvalidRequest, "{reference_field} targets {label} {id}, which does not exist"));
+    }
+    Ok(())
+}
+
+fn validate_table_metadata_references(metadata: &serde_json::Value) -> S3Result<()> {
+    let schema_ids = metadata_array_ids(metadata, "schemas", "schema-id", "schema")?;
+    validate_metadata_id_reference(metadata, "current-schema-id", &schema_ids, "schema")?;
+    let spec_ids = metadata_array_ids(metadata, "partition-specs", "spec-id", "partition spec")?;
+    validate_metadata_id_reference(metadata, "default-spec-id", &spec_ids, "partition spec")?;
+    let sort_order_ids = metadata_array_ids(metadata, "sort-orders", "order-id", "sort order")?;
+    validate_metadata_id_reference(metadata, "default-sort-order-id", &sort_order_ids, "sort order")?;
+    let snapshot_ids = metadata_array_ids(metadata, "snapshots", "snapshot-id", "snapshot")?;
+
+    if let Some(current_snapshot_id) = metadata.get("current-snapshot-id").filter(|value| !value.is_null()) {
+        let current_snapshot_id = current_snapshot_id
+            .as_i64()
+            .ok_or_else(|| s3_error!(InvalidRequest, "current-snapshot-id must be an integer"))?;
+        if current_snapshot_id != -1 && !snapshot_ids.contains(&current_snapshot_id) {
+            return Err(s3_error!(
+                InvalidRequest,
+                "current snapshot {current_snapshot_id} does not exist in table metadata"
+            ));
+        }
+    }
+    if let Some(refs) = metadata.get("refs").filter(|value| !value.is_null()) {
+        let refs = refs
+            .as_object()
+            .ok_or_else(|| s3_error!(InvalidRequest, "refs must be an object"))?;
+        for (name, reference) in refs {
+            let snapshot_id = reference
+                .get("snapshot-id")
+                .and_then(serde_json::Value::as_i64)
+                .ok_or_else(|| s3_error!(InvalidRequest, "snapshot ref {name} is missing snapshot-id"))?;
+            if !snapshot_ids.contains(&snapshot_id) {
+                return Err(s3_error!(
+                    InvalidRequest,
+                    "snapshot ref {name} targets snapshot {snapshot_id}, which does not exist"
+                ));
+            }
+        }
+    }
+    if let Some(snapshots) = metadata.get("snapshots").and_then(serde_json::Value::as_array) {
+        for snapshot in snapshots {
+            if let Some(schema_id) = snapshot.get("schema-id") {
+                let schema_id = schema_id
+                    .as_i64()
+                    .ok_or_else(|| s3_error!(InvalidRequest, "snapshot schema-id must be an integer"))?;
+                if !schema_ids.contains(&schema_id) {
+                    return Err(s3_error!(
+                        InvalidRequest,
+                        "snapshot schema-id targets schema {schema_id}, which does not exist"
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_view_metadata_references(metadata: &serde_json::Value) -> S3Result<()> {
+    let schema_ids = metadata_array_ids(metadata, "schemas", "schema-id", "schema")?;
+    validate_metadata_id_reference(metadata, "current-schema-id", &schema_ids, "schema")?;
+    let version_ids = metadata_array_ids(metadata, "versions", "version-id", "view version")?;
+    validate_metadata_id_reference(metadata, "current-version-id", &version_ids, "view version")?;
+    if let Some(versions) = metadata.get("versions").and_then(serde_json::Value::as_array) {
+        for version in versions {
+            let schema_id = version
+                .get("schema-id")
+                .and_then(serde_json::Value::as_i64)
+                .ok_or_else(|| s3_error!(InvalidRequest, "view version is missing schema-id"))?;
+            if !schema_ids.contains(&schema_id) {
+                return Err(s3_error!(
+                    InvalidRequest,
+                    "view version schema-id targets schema {schema_id}, which does not exist"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_supported_view_metadata(metadata: &serde_json::Value) -> S3Result<()> {
+    let format_version = i64::from(metadata_format_version(metadata)?);
+    if format_version != ICEBERG_VIEW_FORMAT_VERSION {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            format!("unsupported Iceberg view format-version: {format_version}"),
+        ));
+    }
+    validate_view_metadata_references(metadata)
 }
 
 fn validate_view_commit_requirements(metadata: &serde_json::Value, requirements: &[serde_json::Value]) -> S3Result<()> {
@@ -2732,16 +3077,17 @@ fn validate_view_commit_requirements(metadata: &serde_json::Value, requirements:
                     "current view version id",
                 )?;
             }
-            _ => return Err(s3_error!(NotImplemented, "unsupported view commit requirement: {requirement_type}")),
+            _ => return Err(s3_error!(InvalidRequest, "unsupported view commit requirement: {requirement_type}")),
         }
     }
     Ok(())
 }
 
-fn apply_view_commit_updates(
+fn apply_view_commit_updates_at(
     mut metadata: serde_json::Value,
     updates: &[serde_json::Value],
     previous_metadata_location: &str,
+    commit_timestamp_ms: i64,
 ) -> S3Result<serde_json::Value> {
     if !metadata.is_object() {
         return Err(s3_error!(InvalidRequest, "current view metadata must be a JSON object"));
@@ -2753,39 +3099,172 @@ fn apply_view_commit_updates(
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| s3_error!(InvalidRequest, "view update action is required"))?;
         match action {
-            "assign-uuid" => apply_assign_uuid_update(&mut metadata, update)?,
+            "assign-uuid" => apply_assign_uuid_update(&mut metadata, update, "view-uuid", "view")?,
+            "upgrade-format-version" => apply_upgrade_view_format_version_update(&mut metadata, update)?,
             "add-schema" => apply_add_schema_update(&mut metadata, update)?,
             "set-current-schema" => apply_set_current_schema_update(&mut metadata, update)?,
-            "add-view-version" => apply_add_view_version_update(&mut metadata, update)?,
-            "set-current-view-version" => apply_set_current_view_version_update(&mut metadata, update)?,
+            "add-view-version" => apply_add_view_version_update(&mut metadata, update, commit_timestamp_ms)?,
+            "set-current-view-version" => apply_set_current_view_version_update(&mut metadata, update, commit_timestamp_ms)?,
             "set-location" => apply_set_location_update(&mut metadata, update)?,
             "set-properties" => apply_set_properties_update(&mut metadata, update)?,
             "remove-properties" => apply_remove_properties_update(&mut metadata, update)?,
-            _ => return Err(s3_error!(NotImplemented, "unsupported view update: {action}")),
+            _ => return Err(s3_error!(InvalidRequest, "unsupported view update: {action}")),
         }
     }
 
-    append_previous_metadata_log(&mut metadata, previous_metadata_location)?;
-    metadata_object_mut(&mut metadata)?.insert("last-updated-ms".to_string(), serde_json::Value::from(current_time_millis()));
+    validate_supported_view_metadata(&metadata)?;
+    append_previous_metadata_log(&mut metadata, previous_metadata_location, commit_timestamp_ms)?;
+    metadata_object_mut(&mut metadata)?.insert("last-updated-ms".to_string(), serde_json::Value::from(commit_timestamp_ms));
     Ok(metadata)
 }
 
-fn apply_assign_uuid_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+fn apply_set_snapshot_file_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    metadata_field: &str,
+    update_field: &str,
+) -> S3Result<()> {
+    let value = update
+        .get(update_field)
+        .cloned()
+        .ok_or_else(|| s3_error!(InvalidRequest, "{update_field} is required"))?;
+    let snapshot_id = value
+        .get("snapshot-id")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| s3_error!(InvalidRequest, "{update_field}.snapshot-id must be an integer"))?;
+    if update
+        .get("snapshot-id")
+        .and_then(serde_json::Value::as_i64)
+        .is_some_and(|deprecated_snapshot_id| deprecated_snapshot_id != snapshot_id)
+    {
+        return Err(s3_error!(InvalidRequest, "{update_field}.snapshot-id does not match snapshot-id"));
+    }
+    require_snapshot_id(metadata, snapshot_id)?;
+    let values = ensure_array_field(metadata, metadata_field)?;
+    values.retain(|value| value.get("snapshot-id").and_then(serde_json::Value::as_i64) != Some(snapshot_id));
+    values.push(value);
+    Ok(())
+}
+
+fn apply_remove_snapshot_file_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    metadata_field: &str,
+) -> S3Result<()> {
+    let snapshot_id = update
+        .get("snapshot-id")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| s3_error!(InvalidRequest, "remove update requires snapshot-id"))?;
+    if let Some(values) = metadata.get_mut(metadata_field).and_then(serde_json::Value::as_array_mut) {
+        values.retain(|value| value.get("snapshot-id").and_then(serde_json::Value::as_i64) != Some(snapshot_id));
+    }
+    Ok(())
+}
+
+fn apply_remove_metadata_ids_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    metadata_field: &str,
+    id_field: &str,
+    update_field: &str,
+) -> S3Result<()> {
+    let ids = update
+        .get(update_field)
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| s3_error!(InvalidRequest, "{update_field} must be an array"))?
+        .iter()
+        .map(|value| {
+            value
+                .as_i64()
+                .ok_or_else(|| s3_error!(InvalidRequest, "{update_field} must contain integers"))
+        })
+        .collect::<S3Result<BTreeSet<_>>>()?;
+    if let Some(values) = metadata.get_mut(metadata_field).and_then(serde_json::Value::as_array_mut) {
+        values.retain(|value| {
+            value
+                .get(id_field)
+                .and_then(serde_json::Value::as_i64)
+                .is_none_or(|id| !ids.contains(&id))
+        });
+    }
+    Ok(())
+}
+
+fn apply_add_encryption_key_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+    let encryption_key = update
+        .get("encryption-key")
+        .cloned()
+        .ok_or_else(|| s3_error!(InvalidRequest, "add-encryption-key requires encryption-key"))?;
+    let key_id = encryption_key
+        .get("key-id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|key_id| !key_id.is_empty())
+        .ok_or_else(|| s3_error!(InvalidRequest, "encryption-key.key-id is required"))?
+        .to_string();
+    let values = ensure_array_field(metadata, "encryption-keys")?;
+    if values
+        .iter()
+        .any(|value| value.get("key-id").and_then(serde_json::Value::as_str) == Some(key_id.as_str()))
+    {
+        return Err(s3_error!(PreconditionFailed, "encryption key already exists"));
+    }
+    values.push(encryption_key);
+    Ok(())
+}
+
+fn apply_remove_encryption_key_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+    let key_id = update
+        .get("key-id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|key_id| !key_id.is_empty())
+        .ok_or_else(|| s3_error!(InvalidRequest, "remove-encryption-key requires key-id"))?;
+    if let Some(values) = metadata.get_mut("encryption-keys").and_then(serde_json::Value::as_array_mut) {
+        values.retain(|value| value.get("key-id").and_then(serde_json::Value::as_str) != Some(key_id));
+    }
+    Ok(())
+}
+
+fn require_snapshot_id(metadata: &serde_json::Value, snapshot_id: i64) -> S3Result<()> {
+    if metadata
+        .get("snapshots")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|snapshots| {
+            snapshots
+                .iter()
+                .any(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64) == Some(snapshot_id))
+        })
+    {
+        Ok(())
+    } else {
+        Err(s3_error!(InvalidRequest, "snapshot {snapshot_id} does not exist"))
+    }
+}
+
+fn apply_assign_uuid_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    uuid_field: &str,
+    entity: &str,
+) -> S3Result<()> {
     let uuid = update
         .get("uuid")
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| s3_error!(InvalidRequest, "assign-uuid requires uuid"))?;
     let object = metadata_object_mut(metadata)?;
-    if let Some(existing) = object.get("table-uuid").and_then(serde_json::Value::as_str)
+    if let Some(existing) = object.get(uuid_field).and_then(serde_json::Value::as_str)
         && existing != uuid
     {
-        return Err(s3_error!(PreconditionFailed, "cannot reassign table uuid"));
+        return Err(s3_error!(PreconditionFailed, "cannot reassign {entity} uuid"));
     }
-    object.insert("table-uuid".to_string(), serde_json::Value::String(uuid.to_string()));
+    object.insert(uuid_field.to_string(), serde_json::Value::String(uuid.to_string()));
     Ok(())
 }
 
-fn apply_add_view_version_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+fn apply_add_view_version_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    commit_timestamp_ms: i64,
+) -> S3Result<()> {
     let mut view_version = update
         .get("view-version")
         .cloned()
@@ -2804,12 +3283,16 @@ fn apply_add_view_version_update(metadata: &mut serde_json::Value, update: &serd
         .as_object_mut()
         .ok_or_else(|| s3_error!(InvalidRequest, "view-version must be a JSON object"))?
         .entry("timestamp-ms".to_string())
-        .or_insert_with(|| serde_json::Value::from(current_time_millis()));
+        .or_insert_with(|| serde_json::Value::from(commit_timestamp_ms));
     ensure_array_field(metadata, "versions")?.push(view_version);
     Ok(())
 }
 
-fn apply_set_current_view_version_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+fn apply_set_current_view_version_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    commit_timestamp_ms: i64,
+) -> S3Result<()> {
     let requested_id = update
         .get("view-version-id")
         .and_then(serde_json::Value::as_i64)
@@ -2821,7 +3304,7 @@ fn apply_set_current_view_version_update(metadata: &mut serde_json::Value, updat
     };
     metadata_object_mut(metadata)?.insert("current-version-id".to_string(), serde_json::Value::from(version_id));
     ensure_array_field(metadata, "version-log")?.push(serde_json::json!({
-        "timestamp-ms": current_time_millis(),
+        "timestamp-ms": commit_timestamp_ms,
         "version-id": version_id
     }));
     Ok(())
@@ -2841,6 +3324,21 @@ fn apply_upgrade_format_version_update(metadata: &mut serde_json::Value, update:
     }
     metadata_object_mut(metadata)?.insert("format-version".to_string(), serde_json::Value::from(version));
     Ok(())
+}
+
+fn apply_upgrade_view_format_version_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+    let version = update
+        .get("format-version")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| s3_error!(InvalidRequest, "upgrade-format-version requires format-version"))?;
+    if version != ICEBERG_VIEW_FORMAT_VERSION {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            format!("unsupported Iceberg view format-version: {version}"),
+        ));
+    }
+    apply_upgrade_format_version_update(metadata, update)
 }
 
 fn apply_add_schema_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
@@ -2958,7 +3456,11 @@ fn apply_set_default_sort_order_update(metadata: &mut serde_json::Value, update:
     Ok(())
 }
 
-fn apply_add_snapshot_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+fn apply_add_snapshot_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    commit_timestamp_ms: i64,
+) -> S3Result<()> {
     let snapshot = update
         .get("snapshot")
         .cloned()
@@ -2974,7 +3476,7 @@ fn apply_add_snapshot_update(metadata: &mut serde_json::Value, update: &serde_js
     let timestamp_ms = snapshot
         .get("timestamp-ms")
         .and_then(serde_json::Value::as_i64)
-        .unwrap_or_else(current_time_millis);
+        .unwrap_or(commit_timestamp_ms);
     validate_added_snapshot(metadata, &snapshot, snapshot_id, sequence_number)?;
     ensure_array_field(metadata, "snapshots")?.push(snapshot);
     let object = metadata_object_mut(metadata)?;
@@ -3088,6 +3590,48 @@ struct SnapshotFileChanges {
     deleted_delete_files: BTreeSet<String>,
 }
 
+#[derive(Default)]
+struct SnapshotReadBudget {
+    manifest_count: usize,
+    avro_bytes: usize,
+    file_reference_count: usize,
+}
+
+impl SnapshotReadBudget {
+    fn charge_manifests(&mut self, count: usize) -> S3Result<()> {
+        self.manifest_count = self
+            .manifest_count
+            .checked_add(count)
+            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest count exceeds the commit limit"))?;
+        if self.manifest_count > TABLE_COMMIT_MAX_MANIFESTS {
+            return Err(s3_error!(InvalidRequest, "snapshot manifest count exceeds the commit limit"));
+        }
+        Ok(())
+    }
+
+    fn charge_avro_bytes(&mut self, count: usize) -> S3Result<()> {
+        self.avro_bytes = self
+            .avro_bytes
+            .checked_add(count)
+            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot Avro bytes exceed the commit limit"))?;
+        if self.avro_bytes > TABLE_COMMIT_MAX_AVRO_BYTES {
+            return Err(s3_error!(InvalidRequest, "snapshot Avro bytes exceed the commit limit"));
+        }
+        Ok(())
+    }
+
+    fn charge_file_references(&mut self, count: usize) -> S3Result<()> {
+        self.file_reference_count = self
+            .file_reference_count
+            .checked_add(count)
+            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot file references exceed the commit limit"))?;
+        if self.file_reference_count > TABLE_COMMIT_MAX_FILE_REFERENCES {
+            return Err(s3_error!(InvalidRequest, "snapshot file references exceed the commit limit"));
+        }
+        Ok(())
+    }
+}
+
 impl SnapshotFileChanges {
     fn has_delete_or_row_level_change(&self) -> bool {
         !self.added_delete_files.is_empty() || !self.deleted_data_files.is_empty() || !self.deleted_delete_files.is_empty()
@@ -3103,6 +3647,8 @@ impl SnapshotFileChanges {
 }
 
 struct SnapshotChangeContext<'a> {
+    entry: &'a crate::table_catalog::TableEntry,
+    snapshot: &'a serde_json::Value,
     current_live_files: &'a SnapshotLiveFiles,
     snapshot_id: i64,
     sequence_number: i64,
@@ -3149,20 +3695,23 @@ where
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| s3_error!(InvalidRequest, "snapshot summary.operation is required"))?;
 
+    let mut read_budget = SnapshotReadBudget::default();
     let current_live_files =
-        load_current_snapshot_live_files(metadata_backend, bucket, namespace, table, entry, current_metadata).await?;
+        load_current_snapshot_live_files(metadata_backend, bucket, namespace, table, entry, current_metadata, &mut read_budget)
+            .await?;
     let changes = load_snapshot_file_changes(
         metadata_backend,
         bucket,
         namespace,
         table,
-        entry,
-        snapshot,
         SnapshotChangeContext {
+            entry,
+            snapshot,
             current_live_files: &current_live_files,
             snapshot_id,
             sequence_number,
         },
+        &mut read_budget,
     )
     .await?;
 
@@ -3236,6 +3785,7 @@ async fn load_current_snapshot_live_files<B>(
     table: &crate::table_catalog::IdentifierSegment,
     entry: &crate::table_catalog::TableEntry,
     current_metadata: &serde_json::Value,
+    read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<SnapshotLiveFiles>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
@@ -3257,7 +3807,9 @@ where
         .ok_or_else(|| s3_error!(InvalidRequest, "current snapshot metadata is missing"))?;
 
     let mut live_files = SnapshotLiveFiles::default();
-    for manifest in read_snapshot_manifest_references(metadata_backend, bucket, namespace, table, entry, snapshot).await? {
+    for manifest in
+        read_snapshot_manifest_references(metadata_backend, bucket, namespace, table, entry, snapshot, read_budget).await?
+    {
         let SnapshotManifestLocation {
             manifest_path,
             sequence_number,
@@ -3303,15 +3855,24 @@ async fn load_snapshot_file_changes<B>(
     bucket: &str,
     namespace: &crate::table_catalog::Namespace,
     table: &crate::table_catalog::IdentifierSegment,
-    entry: &crate::table_catalog::TableEntry,
-    snapshot: &serde_json::Value,
     context: SnapshotChangeContext<'_>,
+    read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<SnapshotFileChanges>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
     let mut changes = SnapshotFileChanges::default();
-    for manifest in read_snapshot_manifest_references(metadata_backend, bucket, namespace, table, entry, snapshot).await? {
+    for manifest in read_snapshot_manifest_references(
+        metadata_backend,
+        bucket,
+        namespace,
+        table,
+        context.entry,
+        context.snapshot,
+        read_budget,
+    )
+    .await?
+    {
         let inherited_identity = context
             .current_live_files
             .manifest_files
@@ -3415,11 +3976,13 @@ async fn read_snapshot_manifest_references<B>(
     table: &crate::table_catalog::IdentifierSegment,
     entry: &crate::table_catalog::TableEntry,
     snapshot: &serde_json::Value,
+    read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<Vec<SnapshotManifestReferences>>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
-    let manifest_locations = snapshot_manifest_locations(metadata_backend, bucket, namespace, table, entry, snapshot).await?;
+    let manifest_locations =
+        snapshot_manifest_locations(metadata_backend, bucket, namespace, table, entry, snapshot, read_budget).await?;
     let mut manifests = Vec::new();
     for manifest_location in manifest_locations {
         let manifest_key = table_commit_object_key(
@@ -3431,12 +3994,14 @@ where
             crate::table_catalog::TableMetadataMaintenanceObjectKind::ManifestFile,
         )?;
         let manifest_object = metadata_backend
-            .read_object(bucket, &manifest_key)
+            .read_object_limited(bucket, &manifest_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
             .await
             .map_err(catalog_store_error)?
             .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest object is missing"))?;
+        read_budget.charge_avro_bytes(manifest_object.data.len())?;
         let file_references =
             crate::table_catalog::data_file_references_from_manifest_avro(&manifest_object.data).map_err(catalog_store_error)?;
+        read_budget.charge_file_references(file_references.len())?;
         let mut references = Vec::with_capacity(file_references.len());
         for mut reference in file_references {
             if reference.snapshot_id.is_none() {
@@ -3473,6 +4038,7 @@ async fn snapshot_manifest_locations<B>(
     table: &crate::table_catalog::IdentifierSegment,
     entry: &crate::table_catalog::TableEntry,
     snapshot: &serde_json::Value,
+    read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<Vec<SnapshotManifestLocation>>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
@@ -3487,15 +4053,17 @@ where
             crate::table_catalog::TableMetadataMaintenanceObjectKind::ManifestList,
         )?;
         let manifest_list_object = metadata_backend
-            .read_object(bucket, &manifest_list_key)
+            .read_object_limited(bucket, &manifest_list_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
             .await
             .map_err(catalog_store_error)?
             .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest-list object is missing"))?;
+        read_budget.charge_avro_bytes(manifest_list_object.data.len())?;
         let references = crate::table_catalog::manifest_list_references_from_manifest_list_avro(&manifest_list_object.data)
             .map_err(catalog_store_error)?;
         if references.is_empty() {
             return Err(s3_error!(InvalidRequest, "snapshot manifest-list must reference at least one manifest"));
         }
+        read_budget.charge_manifests(references.len())?;
         return Ok(references
             .into_iter()
             .map(|reference| SnapshotManifestLocation {
@@ -3512,6 +4080,7 @@ where
     if manifests.is_empty() {
         return Err(s3_error!(InvalidRequest, "snapshot manifests must reference at least one manifest"));
     }
+    read_budget.charge_manifests(manifests.len())?;
     manifests
         .iter()
         .map(|manifest| {
@@ -3539,9 +4108,8 @@ async fn validate_manifest_data_file_reference<B>(
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
-    table_commit_object_key(bucket, namespace, table, entry, &reference.location, reference.object_kind.clone())?;
-    let object_key = crate::table_catalog::table_catalog_object_key_from_location(bucket, &reference.location)
-        .ok_or_else(|| s3_error!(InvalidRequest, "manifest data file location is invalid"))?;
+    let object_key =
+        table_commit_object_key(bucket, namespace, table, entry, &reference.location, reference.object_kind.clone())?;
     if !metadata_backend
         .object_exists(bucket, &object_key)
         .await
@@ -3560,16 +4128,11 @@ fn table_commit_object_key(
     location: &str,
     expected_kind: crate::table_catalog::TableMetadataMaintenanceObjectKind,
 ) -> S3Result<String> {
-    let object_key = crate::table_catalog::table_catalog_object_key_from_location(bucket, location)
-        .ok_or_else(|| s3_error!(InvalidRequest, "snapshot object location is invalid"))?;
-    let warehouse_object_prefix = crate::table_catalog::table_warehouse_object_prefix(entry).map_err(catalog_store_error)?;
-    let object_kind =
-        crate::table_catalog::table_maintenance_object_kind(namespace, table, Some(&warehouse_object_prefix), &object_key)
-            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot object is outside the table warehouse"))?;
-    if object_kind != expected_kind {
-        return Err(s3_error!(InvalidRequest, "snapshot object kind does not match manifest metadata"));
+    if entry.table_bucket != bucket {
+        return Err(s3_error!(InvalidRequest, "snapshot object is outside the table bucket"));
     }
-    Ok(object_key)
+    crate::table_catalog::table_reference_object_key(namespace, table, entry, location, expected_kind)
+        .ok_or_else(|| s3_error!(InvalidRequest, "snapshot object is outside the table warehouse"))
 }
 
 fn apply_set_snapshot_ref_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
@@ -3665,9 +4228,13 @@ fn apply_remove_properties_update(metadata: &mut serde_json::Value, update: &ser
     Ok(())
 }
 
-fn append_previous_metadata_log(metadata: &mut serde_json::Value, previous_metadata_location: &str) -> S3Result<()> {
+fn append_previous_metadata_log(
+    metadata: &mut serde_json::Value,
+    previous_metadata_location: &str,
+    commit_timestamp_ms: i64,
+) -> S3Result<()> {
     ensure_array_field(metadata, "metadata-log")?.push(serde_json::json!({
-        "timestamp-ms": current_time_millis(),
+        "timestamp-ms": commit_timestamp_ms,
         "metadata-file": previous_metadata_location
     }));
     Ok(())
@@ -3736,7 +4303,7 @@ fn namespace_entry_from_create_request(
     bucket: &str,
     request: CreateNamespaceRequest,
 ) -> S3Result<crate::table_catalog::NamespaceEntry> {
-    let namespace = namespace_from_segments(&request.namespace)?;
+    let namespace = namespace_from_segments(request.namespace)?;
     Ok(crate::table_catalog::NamespaceEntry {
         version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
         table_bucket: bucket.to_string(),
@@ -3760,14 +4327,30 @@ fn catalog_store_error(err: crate::table_catalog::TableCatalogStoreError) -> S3E
         crate::table_catalog::TableCatalogStoreError::NotFound(message) => {
             iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_RESOURCE, StatusCode::NOT_FOUND, message)
         }
+        crate::table_catalog::TableCatalogStoreError::NamespaceNotFound(message) => {
+            iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_NAMESPACE, StatusCode::NOT_FOUND, message)
+        }
+        crate::table_catalog::TableCatalogStoreError::TableNotFound(message) => {
+            iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, message)
+        }
+        crate::table_catalog::TableCatalogStoreError::ViewNotFound(message) => {
+            iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_VIEW, StatusCode::NOT_FOUND, message)
+        }
+        crate::table_catalog::TableCatalogStoreError::AlreadyExists(message) => {
+            iceberg_rest_error(ICEBERG_ERROR_ALREADY_EXISTS, StatusCode::CONFLICT, message)
+        }
         crate::table_catalog::TableCatalogStoreError::Conflict(message) => {
             iceberg_rest_error(ICEBERG_ERROR_COMMIT_FAILED, StatusCode::CONFLICT, message)
         }
         crate::table_catalog::TableCatalogStoreError::Invalid(message) => {
             iceberg_rest_error(ICEBERG_ERROR_BAD_REQUEST, StatusCode::BAD_REQUEST, message)
         }
+        crate::table_catalog::TableCatalogStoreError::Unsupported(message) => {
+            iceberg_rest_error(ICEBERG_ERROR_UNSUPPORTED_OPERATION, StatusCode::NOT_ACCEPTABLE, message)
+        }
         crate::table_catalog::TableCatalogStoreError::Internal(message) => {
-            iceberg_rest_error(ICEBERG_ERROR_REST, StatusCode::INTERNAL_SERVER_ERROR, message)
+            tracing::error!(error = %message, "table catalog store operation failed");
+            iceberg_rest_error(ICEBERG_ERROR_REST, StatusCode::INTERNAL_SERVER_ERROR, "internal table catalog error")
         }
     }
 }
@@ -3787,7 +4370,8 @@ fn catalog_store_already_exists_error(err: crate::table_catalog::TableCatalogSto
 
 fn catalog_store_namespace_drop_error(err: crate::table_catalog::TableCatalogStoreError) -> S3Error {
     match err {
-        crate::table_catalog::TableCatalogStoreError::NotFound(message) => {
+        crate::table_catalog::TableCatalogStoreError::NotFound(message)
+        | crate::table_catalog::TableCatalogStoreError::NamespaceNotFound(message) => {
             iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_NAMESPACE, StatusCode::NOT_FOUND, message)
         }
         err => catalog_store_conflict_error(err, ICEBERG_ERROR_NAMESPACE_NOT_EMPTY),
@@ -3848,6 +4432,7 @@ where
         .get_namespace(bucket, &namespace.public_name())
         .await
         .map_err(catalog_store_error)?
+        .filter(|entry| entry.state == crate::table_catalog::TableCatalogEntryState::Active)
     else {
         return Err(iceberg_rest_error(
             ICEBERG_ERROR_NO_SUCH_NAMESPACE,
@@ -3858,6 +4443,39 @@ where
     namespace_response_from_entry(entry)
 }
 
+fn namespace_properties_update_from_request(
+    request: UpdateNamespacePropertiesRequest,
+) -> S3Result<crate::table_catalog::NamespacePropertiesUpdate> {
+    crate::table_catalog::NamespacePropertiesUpdate::try_new(request.removals, request.updates).map_err(|err| match err {
+        crate::table_catalog::NamespacePropertiesUpdateError::DuplicateRemoval(key) => iceberg_rest_error(
+            ICEBERG_ERROR_BAD_REQUEST,
+            StatusCode::BAD_REQUEST,
+            format!("namespace property removal is repeated: {key}"),
+        ),
+        crate::table_catalog::NamespacePropertiesUpdateError::Overlap(key) => iceberg_rest_error(
+            ICEBERG_ERROR_UNPROCESSABLE_ENTITY,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            format!("namespace property cannot be removed and updated in the same request: {key}"),
+        ),
+    })
+}
+
+async fn update_namespace_properties_response<S>(
+    store: &S,
+    bucket: &str,
+    namespace: &crate::table_catalog::Namespace,
+    request: UpdateNamespacePropertiesRequest,
+) -> S3Result<crate::table_catalog::NamespacePropertiesUpdateResult>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    let update = namespace_properties_update_from_request(request)?;
+    store
+        .update_namespace_properties(bucket, &namespace.public_name(), update)
+        .await
+        .map_err(catalog_store_error)
+}
+
 async fn namespace_exists_status<S>(store: &S, bucket: &str, namespace: &crate::table_catalog::Namespace) -> S3Result<StatusCode>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
@@ -3866,7 +4484,7 @@ where
         .get_namespace(bucket, &namespace.public_name())
         .await
         .map_err(catalog_store_error)?
-        .is_some();
+        .is_some_and(|entry| entry.state == crate::table_catalog::TableCatalogEntryState::Active);
     Ok(exists_status(exists))
 }
 
@@ -3880,12 +4498,21 @@ where
         .map_err(catalog_store_namespace_drop_error)
 }
 
+fn table_identifier_from_request(
+    identifier: RestTableIdentifier,
+) -> S3Result<(crate::table_catalog::Namespace, crate::table_catalog::IdentifierSegment)> {
+    let namespace = namespace_from_segments(identifier.namespace)?;
+    let table = crate::table_catalog::IdentifierSegment::parse(identifier.name)
+        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+    Ok((namespace, table))
+}
+
 async fn register_table_response<S>(
     store: &S,
-    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
     bucket: &str,
     namespace: &crate::table_catalog::Namespace,
     request: RegisterTableRequest,
+    metadata: serde_json::Value,
     table_bucket_enabled: bool,
 ) -> S3Result<RestLoadTableResponse>
 where
@@ -3893,9 +4520,12 @@ where
 {
     let mut entry = table_entry_from_register_request(bucket, namespace, request)?;
     ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
-    let metadata = read_table_metadata_json(metadata_backend, bucket, &entry.metadata_location).await?;
     validate_metadata_table_location_in_bucket(bucket, &metadata)?;
     adopt_registered_metadata_identity(&mut entry, &metadata)?;
+    validate_table_metadata_references(&metadata)?;
+    if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
+        return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
+    }
     store
         .register_table(entry.clone())
         .await
@@ -3918,8 +4548,12 @@ where
     ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
     let metadata_data = serde_json::to_vec(&metadata)
         .map_err(|err| s3_error!(InternalError, "failed to serialize initial table metadata: {}", err))?;
+    let _metadata_guard = metadata_backend
+        .acquire_write_lock(bucket, &entry.metadata_location)
+        .await
+        .map_err(catalog_store_error)?;
     metadata_backend
-        .put_object(
+        .put_object_unlocked(
             bucket,
             &entry.metadata_location,
             metadata_data,
@@ -3949,8 +4583,12 @@ where
     ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
     let metadata_data = serde_json::to_vec(&metadata)
         .map_err(|err| s3_error!(InternalError, "failed to serialize initial view metadata: {}", err))?;
+    let _metadata_guard = metadata_backend
+        .acquire_write_lock(bucket, &entry.metadata_location)
+        .await
+        .map_err(catalog_store_error)?;
     metadata_backend
-        .put_object(
+        .put_object_unlocked(
             bucket,
             &entry.metadata_location,
             metadata_data,
@@ -3971,7 +4609,7 @@ async fn read_table_metadata_json(
     metadata_location: &str,
 ) -> S3Result<serde_json::Value> {
     let Some(object) = metadata_backend
-        .read_object(bucket, metadata_location)
+        .read_object_limited(bucket, metadata_location, crate::table_catalog::TABLE_METADATA_JSON_MAX_SIZE)
         .await
         .map_err(catalog_store_error)?
     else {
@@ -3983,6 +4621,30 @@ async fn read_table_metadata_json(
         return Err(s3_error!(InvalidRequest, "table metadata JSON must be an object"));
     }
     Ok(metadata)
+}
+
+async fn read_existing_table_metadata_target<S>(
+    store: &S,
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    bucket: &str,
+    namespace: &crate::table_catalog::Namespace,
+    table: &str,
+    metadata_location: &str,
+) -> S3Result<serde_json::Value>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    let Some(current) = store
+        .load_table(bucket, &namespace.public_name(), table)
+        .await
+        .map_err(catalog_store_error)?
+    else {
+        return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
+    };
+    if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, metadata_location) {
+        return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
+    }
+    read_table_metadata_json(metadata_backend, bucket, metadata_location).await
 }
 
 async fn list_tables_response<S>(
@@ -4032,6 +4694,13 @@ where
     else {
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
+    if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_REST,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "persisted table metadata location is outside the protected table metadata directory",
+        ));
+    }
     let metadata = read_table_metadata_json(metadata_backend, bucket, &entry.metadata_location).await?;
     Ok(load_table_response_from_entry(entry, metadata))
 }
@@ -4083,6 +4752,15 @@ where
     else {
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_VIEW, StatusCode::NOT_FOUND, "view not found"));
     };
+    let view = crate::table_catalog::IdentifierSegment::parse(view)
+        .map_err(|err| s3_error!(InvalidRequest, "invalid view name: {}", err))?;
+    if !crate::table_catalog::is_valid_view_metadata_location(namespace, &view, &entry.metadata_location) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_REST,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "persisted view metadata location is outside the protected view metadata directory",
+        ));
+    }
     let metadata = read_table_metadata_json(metadata_backend, bucket, &entry.metadata_location).await?;
     Ok(load_view_response_from_entry(entry, metadata))
 }
@@ -4115,6 +4793,7 @@ async fn replace_view_response<S>(
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    validate_rest_commit_identifier(request.identifier.as_ref(), namespace, view)?;
     let Some(current) = store
         .load_view(bucket, &namespace.public_name(), view)
         .await
@@ -4126,7 +4805,12 @@ where
     validate_view_commit_requirements(&current_metadata, &request.requirements)?;
     let view_name = crate::table_catalog::IdentifierSegment::parse(view.to_string())
         .map_err(|err| s3_error!(InvalidRequest, "invalid view name: {}", err))?;
-    let (next_metadata_location, next_metadata) = if let Some(new_metadata_location) = request.new_metadata_location {
+    let requested_new_metadata_location = request
+        .new_metadata_location
+        .as_deref()
+        .map(|location| table_metadata_location_for_catalog(bucket, location))
+        .transpose()?;
+    let (next_metadata_location, next_metadata) = if let Some(new_metadata_location) = requested_new_metadata_location {
         if !crate::table_catalog::is_valid_view_metadata_location(namespace, &view_name, &new_metadata_location) {
             return Err(s3_error!(InvalidRequest, "metadata location must be inside the view metadata directory"));
         }
@@ -4135,10 +4819,17 @@ where
         validate_metadata_matches_current_view_metadata(&current_metadata, &target_metadata)?;
         (new_metadata_location, target_metadata)
     } else {
-        let next_metadata = apply_view_commit_updates(current_metadata.clone(), &request.updates, &current.metadata_location)?;
+        let previous_metadata_location = table_metadata_location_for_client(bucket, &current.metadata_location);
+        let commit_timestamp_ms = current_time_millis();
+        let mut next_metadata = apply_view_commit_updates_at(
+            current_metadata.clone(),
+            &request.updates,
+            &previous_metadata_location,
+            commit_timestamp_ms,
+        )?;
         validate_metadata_view_location_in_bucket(bucket, &next_metadata)?;
         validate_metadata_matches_current_view_metadata(&current_metadata, &next_metadata)?;
-        let (_, metadata_file_token) = standard_commit_ids(request.commit_id);
+        let metadata_file_token = Uuid::new_v4().to_string();
         let next_generation = current.generation.saturating_add(1);
         let next_metadata_location = crate::table_catalog::default_view_metadata_file_path(
             namespace,
@@ -4147,18 +4838,49 @@ where
         );
         let next_metadata_data = serde_json::to_vec(&next_metadata)
             .map_err(|err| s3_error!(InternalError, "failed to serialize view metadata update: {}", err))?;
-        metadata_backend
+        let put_result = metadata_backend
             .put_object(
                 bucket,
                 &next_metadata_location,
                 next_metadata_data,
                 crate::table_catalog::TableCatalogPutPrecondition::IfAbsent,
             )
-            .await
-            .map_err(catalog_store_error)?;
+            .await;
+        match put_result {
+            Ok(()) => {}
+            Err(crate::table_catalog::TableCatalogStoreError::Conflict(_)) => {
+                let existing_metadata = read_table_metadata_json(metadata_backend, bucket, &next_metadata_location).await?;
+                let persisted_timestamp = existing_metadata
+                    .get("last-updated-ms")
+                    .and_then(serde_json::Value::as_i64)
+                    .ok_or_else(|| s3_error!(InvalidRequest, "existing generated view metadata is missing last-updated-ms"))?;
+                let rebuilt_metadata = apply_view_commit_updates_at(
+                    current_metadata,
+                    &request.updates,
+                    &previous_metadata_location,
+                    persisted_timestamp,
+                )?;
+                if existing_metadata != rebuilt_metadata {
+                    return Err(iceberg_rest_error(
+                        ICEBERG_ERROR_COMMIT_FAILED,
+                        StatusCode::CONFLICT,
+                        "generated view metadata location already contains a different commit",
+                    ));
+                }
+                next_metadata = existing_metadata;
+            }
+            Err(err) => return Err(catalog_store_error(err)),
+        }
         (next_metadata_location, next_metadata)
     };
 
+    let new_metadata_sha256 = metadata_sha256(&next_metadata)?;
+    let expected_metadata_location = request
+        .expected_metadata_location
+        .as_deref()
+        .map(|location| table_metadata_location_for_catalog(bucket, location))
+        .transpose()?
+        .unwrap_or_else(|| current.metadata_location.clone());
     let result = store
         .replace_view(crate::table_catalog::ViewCommitRequest {
             table_bucket: bucket.to_string(),
@@ -4167,10 +4889,9 @@ where
             expected_version_token: request
                 .expected_version_token
                 .unwrap_or_else(|| current.version_token.clone()),
-            expected_metadata_location: request
-                .expected_metadata_location
-                .unwrap_or_else(|| current.metadata_location.clone()),
+            expected_metadata_location,
             new_metadata_location: next_metadata_location,
+            new_metadata_sha256: Some(new_metadata_sha256),
         })
         .await
         .map_err(catalog_store_error)?;
@@ -4241,6 +4962,7 @@ async fn update_table_metadata_location_response<S>(
     namespace: &crate::table_catalog::Namespace,
     table: &str,
     request: UpdateTableMetadataLocationRequest,
+    target_metadata: serde_json::Value,
 ) -> S3Result<TableMetadataLocationResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
@@ -4252,15 +4974,12 @@ where
     else {
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
-    let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
-        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
     let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
-    if !crate::table_catalog::is_valid_table_metadata_location(namespace, &table_name, &metadata_location) {
+    if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &metadata_location) {
         return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
     }
     let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
     validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
-    let target_metadata = read_table_metadata_json(metadata_backend, bucket, &metadata_location).await?;
     validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
     validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
     let commit_request = crate::table_catalog::TableCommitRequest {
@@ -4273,29 +4992,128 @@ where
         expected_version_token: request.version_token,
         expected_metadata_location: current.metadata_location,
         new_metadata_location: metadata_location,
-        requirements: Vec::new(),
+        requirements: vec![metadata_digest_requirement(&target_metadata)?],
         writer: Some("rustfs-metadata-location-api".to_string()),
     };
     let result = store.commit_table(commit_request).await.map_err(catalog_store_error)?;
     Ok(table_metadata_location_response_from_entry(result.table))
 }
 
+#[cfg(test)]
 async fn commit_table_response<S>(
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
     bucket: &str,
     namespace: &crate::table_catalog::Namespace,
     table: &str,
-    request: RestCommitTableRequest,
+    mut request: RestCommitTableRequest,
 ) -> S3Result<RestCommitTableResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    let target_metadata = if let Some(metadata_location) = request.new_metadata_location.as_deref() {
+        let metadata_location = table_metadata_location_for_catalog(bucket, metadata_location)?;
+        let metadata =
+            read_existing_table_metadata_target(store, metadata_backend, bucket, namespace, table, &metadata_location).await?;
+        request.new_metadata_location = Some(metadata_location);
+        Some(metadata)
+    } else {
+        None
+    };
+    commit_table_response_with_target_metadata(store, metadata_backend, bucket, namespace, table, request, target_metadata).await
+}
+
+async fn table_commit_for_retry<S>(
+    store: &S,
+    bucket: &str,
+    table_id: &str,
+    request: &RestCommitTableRequest,
+) -> S3Result<Option<crate::table_catalog::CommitLogEntry>>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    let by_commit_id = match request.commit_id.as_deref() {
+        Some(commit_id) => store
+            .get_commit_by_id(bucket, table_id, commit_id)
+            .await
+            .map_err(catalog_store_error)?,
+        None => None,
+    };
+    let by_idempotency_key = match request.idempotency_key.as_deref() {
+        Some(idempotency_key) => store
+            .get_commit_by_idempotency_key(bucket, table_id, idempotency_key)
+            .await
+            .map_err(catalog_store_error)?,
+        None => None,
+    };
+    if let (Some(by_commit_id), Some(by_idempotency_key)) = (&by_commit_id, &by_idempotency_key)
+        && by_commit_id.commit_id != by_idempotency_key.commit_id
+    {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_COMMIT_FAILED,
+            StatusCode::CONFLICT,
+            "commit id and idempotency key identify different commits",
+        ));
+    }
+    Ok(by_commit_id.or(by_idempotency_key))
+}
+
+async fn table_commit_warehouse_read_location<S>(
+    store: &S,
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    bucket: &str,
+    current: &crate::table_catalog::TableEntry,
+    request: &RestCommitTableRequest,
+) -> S3Result<String>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    let Some(commit) = table_commit_for_retry(store, bucket, &current.table_id, request).await? else {
+        return Ok(current.warehouse_location.clone());
+    };
+    let previous_metadata = read_table_metadata_json(metadata_backend, bucket, &commit.previous_metadata_location).await?;
+    validate_metadata_table_location_in_bucket(bucket, &previous_metadata)?;
+    Ok(metadata_table_location(&previous_metadata)?.to_string())
+}
+
+async fn commit_table_replay_response(
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    bucket: &str,
+    result: crate::table_catalog::TableCommitResult,
+    committed_metadata_location: &str,
+    committed_metadata: serde_json::Value,
+) -> S3Result<RestCommitTableResponse> {
+    let metadata = if result.table.metadata_location == committed_metadata_location {
+        committed_metadata
+    } else if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&result.table, &result.table.metadata_location) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_REST,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "persisted table metadata location is outside the protected table metadata directory",
+        ));
+    } else {
+        read_table_metadata_json(metadata_backend, bucket, &result.table.metadata_location).await?
+    };
+    Ok(commit_table_response_from_result(result, metadata))
+}
+
+async fn commit_table_response_with_target_metadata<S>(
+    store: &S,
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    bucket: &str,
+    namespace: &crate::table_catalog::Namespace,
+    table: &str,
+    request: RestCommitTableRequest,
+    target_metadata: Option<serde_json::Value>,
+) -> S3Result<RestCommitTableResponse>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    validate_rest_commit_identifier(request.identifier.as_ref(), namespace, table)?;
     if request.new_metadata_location.is_none() {
         return standard_commit_table_response(store, metadata_backend, bucket, namespace, table, request).await;
     }
 
-    let request = table_commit_request_from_rest_request(bucket, namespace, table, request)?;
     let Some(current) = store
         .load_table(bucket, &namespace.public_name(), table)
         .await
@@ -4303,15 +5121,44 @@ where
     else {
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
-    let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
-        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
-    if !crate::table_catalog::is_valid_table_metadata_location(namespace, &table_name, &request.new_metadata_location) {
+    let mut request = request;
+    let existing_commit = table_commit_for_retry(store, bucket, &current.table_id, &request).await?;
+    if request.commit_id.is_none()
+        && let Some(existing_commit) = existing_commit.as_ref()
+    {
+        request.commit_id = Some(existing_commit.commit_id.clone());
+    }
+    let client_requirements = request.requirements.clone();
+    let mut request = table_commit_request_from_rest_request(bucket, namespace, table, request)?;
+    if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &request.new_metadata_location) {
         return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
     }
+    let target_metadata =
+        target_metadata.ok_or_else(|| s3_error!(InternalError, "authorized target metadata snapshot is required"))?;
+    validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
+    request.requirements.push(metadata_digest_requirement(&target_metadata)?);
+    if let Some(existing_commit) = existing_commit {
+        if !crate::table_catalog::commit_log_matches_request(&existing_commit, &request, &current.table_id) {
+            return Err(iceberg_rest_error(
+                ICEBERG_ERROR_COMMIT_FAILED,
+                StatusCode::CONFLICT,
+                "commit retry does not match the original request",
+            ));
+        }
+        let previous_metadata =
+            read_table_metadata_json(metadata_backend, bucket, &existing_commit.previous_metadata_location).await?;
+        validate_metadata_table_location_in_bucket(bucket, &previous_metadata)?;
+        validate_table_commit_requirements(&previous_metadata, &client_requirements)?;
+        validate_metadata_matches_current_metadata(&previous_metadata, &target_metadata)?;
+        let committed_metadata_location = request.new_metadata_location.clone();
+        let result = store.commit_table(request).await.map_err(catalog_store_error)?;
+        return commit_table_replay_response(metadata_backend, bucket, result, &committed_metadata_location, target_metadata)
+            .await;
+    }
+
     let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
     validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
-    let target_metadata = read_table_metadata_json(metadata_backend, bucket, &request.new_metadata_location).await?;
-    validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
+    validate_table_commit_requirements(&current_metadata, &client_requirements)?;
     validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
     let result = store.commit_table(request).await.map_err(catalog_store_error)?;
     Ok(commit_table_response_from_result(result, target_metadata))
@@ -4335,15 +5182,24 @@ where
     else {
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
+    if let Some(response) =
+        replay_standard_table_commit(store, metadata_backend, bucket, namespace, table, &current, &request).await?
+    {
+        return Ok(response);
+    }
     let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
         .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
     let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
     validate_table_commit_requirements(&current_metadata, &request.requirements)?;
     let expected_metadata = current_metadata.clone();
     let previous_metadata_location = table_metadata_location_for_client(bucket, &current.metadata_location);
-    let next_metadata = apply_table_commit_updates(current_metadata, &request.updates, &previous_metadata_location)?;
+    let commit_timestamp_ms = current_time_millis();
+    let mut next_metadata =
+        apply_table_commit_updates_at(current_metadata, &request.updates, &previous_metadata_location, commit_timestamp_ms)?;
     validate_metadata_table_location_in_bucket(bucket, &next_metadata)?;
     validate_metadata_matches_current_metadata(&expected_metadata, &next_metadata)?;
+    crate::table_catalog::validate_table_warehouse_relocation(&current, metadata_table_location(&next_metadata)?)
+        .map_err(catalog_store_error)?;
     validate_table_snapshot_commit_conflicts(
         metadata_backend,
         bucket,
@@ -4356,23 +5212,49 @@ where
     .await?;
     let (commit_id, metadata_file_token) = standard_commit_ids(request.commit_id);
     let next_generation = current.generation.saturating_add(1);
-    let next_metadata_location = crate::table_catalog::default_table_metadata_file_path(
-        namespace,
-        &table_name,
+    let next_metadata_location = crate::table_catalog::table_metadata_file_path_for_entry(
+        &current,
         &next_metadata_file_name(next_generation, &metadata_file_token),
-    );
+    )
+    .map_err(catalog_store_error)?;
     let next_metadata_data = serde_json::to_vec(&next_metadata)
         .map_err(|err| s3_error!(InternalError, "failed to serialize table metadata update: {}", err))?;
-    metadata_backend
+    let put_result = metadata_backend
         .put_object(
             bucket,
             &next_metadata_location,
             next_metadata_data,
             crate::table_catalog::TableCatalogPutPrecondition::IfAbsent,
         )
-        .await
-        .map_err(catalog_store_error)?;
+        .await;
+    match put_result {
+        Ok(()) => {}
+        Err(crate::table_catalog::TableCatalogStoreError::Conflict(_)) => {
+            let existing_metadata = read_table_metadata_json(metadata_backend, bucket, &next_metadata_location).await?;
+            let persisted_timestamp = existing_metadata
+                .get("last-updated-ms")
+                .and_then(serde_json::Value::as_i64)
+                .ok_or_else(|| s3_error!(InvalidRequest, "existing generated metadata is missing last-updated-ms"))?;
+            let rebuilt_metadata = apply_table_commit_updates_at(
+                expected_metadata.clone(),
+                &request.updates,
+                &previous_metadata_location,
+                persisted_timestamp,
+            )?;
+            if existing_metadata != rebuilt_metadata {
+                return Err(iceberg_rest_error(
+                    ICEBERG_ERROR_COMMIT_FAILED,
+                    StatusCode::CONFLICT,
+                    "generated metadata location already contains a different commit",
+                ));
+            }
+            next_metadata = existing_metadata;
+        }
+        Err(err) => return Err(catalog_store_error(err)),
+    }
 
+    let mut requirements = request.requirements;
+    requirements.push(metadata_digest_requirement(&next_metadata)?);
     let commit_request = crate::table_catalog::TableCommitRequest {
         table_bucket: bucket.to_string(),
         namespace: namespace.public_name(),
@@ -4383,11 +5265,91 @@ where
         expected_version_token: current.version_token,
         expected_metadata_location: current.metadata_location,
         new_metadata_location: next_metadata_location,
-        requirements: request.requirements,
+        requirements,
         writer: request.writer,
     };
     let result = store.commit_table(commit_request).await.map_err(catalog_store_error)?;
     Ok(commit_table_response_from_result(result, next_metadata))
+}
+
+async fn replay_standard_table_commit<S>(
+    store: &S,
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    bucket: &str,
+    namespace: &crate::table_catalog::Namespace,
+    table: &str,
+    current: &crate::table_catalog::TableEntry,
+    request: &RestCommitTableRequest,
+) -> S3Result<Option<RestCommitTableResponse>>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    let Some(commit) = table_commit_for_retry(store, bucket, &current.table_id, request).await? else {
+        return Ok(None);
+    };
+    if request
+        .commit_id
+        .as_deref()
+        .is_some_and(|commit_id| commit_id != commit.commit_id)
+        || request.idempotency_key != commit.idempotency_key
+        || request.writer != commit.writer
+    {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_COMMIT_FAILED,
+            StatusCode::CONFLICT,
+            "commit retry does not match the original request",
+        ));
+    }
+    let previous_metadata = read_table_metadata_json(metadata_backend, bucket, &commit.previous_metadata_location).await?;
+    validate_table_commit_requirements(&previous_metadata, &request.requirements)?;
+    let target_metadata = read_table_metadata_json(metadata_backend, bucket, &commit.new_metadata_location).await?;
+    let commit_timestamp_ms = target_metadata
+        .get("last-updated-ms")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| s3_error!(InvalidRequest, "committed metadata is missing last-updated-ms"))?;
+    let previous_metadata_location = table_metadata_location_for_client(bucket, &commit.previous_metadata_location);
+    let rebuilt_metadata =
+        apply_table_commit_updates_at(previous_metadata, &request.updates, &previous_metadata_location, commit_timestamp_ms)?;
+    if rebuilt_metadata != target_metadata {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_COMMIT_FAILED,
+            StatusCode::CONFLICT,
+            "commit retry updates do not match the original commit",
+        ));
+    }
+    let operation = request
+        .operation
+        .clone()
+        .unwrap_or_else(|| table_commit_operation(&target_metadata));
+    if operation != commit.operation {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_COMMIT_FAILED,
+            StatusCode::CONFLICT,
+            "commit retry operation does not match the original commit",
+        ));
+    }
+    let mut requirements = request.requirements.clone();
+    requirements.push(metadata_digest_requirement(&target_metadata)?);
+    let committed_metadata_location = commit.new_metadata_location.clone();
+    let result = store
+        .commit_table(crate::table_catalog::TableCommitRequest {
+            table_bucket: bucket.to_string(),
+            namespace: namespace.public_name(),
+            table: table.to_string(),
+            commit_id: commit.commit_id,
+            idempotency_key: request.idempotency_key.clone(),
+            operation,
+            expected_version_token: commit.expected_version_token,
+            expected_metadata_location: commit.previous_metadata_location,
+            new_metadata_location: commit.new_metadata_location,
+            requirements,
+            writer: request.writer.clone(),
+        })
+        .await
+        .map_err(catalog_store_error)?;
+    Ok(Some(
+        commit_table_replay_response(metadata_backend, bucket, result, &committed_metadata_location, target_metadata).await?,
+    ))
 }
 
 async fn drop_table_in_store<S>(store: &S, bucket: &str, namespace: &crate::table_catalog::Namespace, table: &str) -> S3Result<()>
@@ -4588,7 +5550,7 @@ where
         expected_version_token: current.version_token,
         expected_metadata_location: current.metadata_location,
         new_metadata_location: next_metadata_location,
-        requirements: Vec::new(),
+        requirements: vec![metadata_digest_requirement(&next_metadata)?],
         writer: Some("rustfs-maintenance".to_string()),
     };
     let result = store.commit_table(commit_request).await.map_err(catalog_store_error)?;
@@ -4691,7 +5653,7 @@ where
         namespace,
         table,
         RestCommitTableRequest {
-            _identifier: None,
+            identifier: None,
             commit_id: request.commit_id,
             idempotency_key: request.idempotency_key,
             operation: Some("set-snapshot-ref".to_string()),
@@ -4751,7 +5713,7 @@ where
         namespace,
         table,
         RestCommitTableRequest {
-            _identifier: None,
+            identifier: None,
             commit_id: request.commit_id,
             idempotency_key: request.idempotency_key,
             operation: Some("remove-snapshot-ref".to_string()),
@@ -5027,6 +5989,7 @@ where
     Ok(external_catalog_bridge_response_from_entry(bucket, namespace, table, Some(entry)))
 }
 
+#[cfg(test)]
 async fn sync_external_catalog_bridge_response<B>(
     store: &crate::table_catalog::ObjectTableCatalogStore<B>,
     metadata_backend: &B,
@@ -5047,15 +6010,53 @@ where
         .transpose()?;
     ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
     validate_external_catalog_metadata_location(namespace, table, &request.metadata_location)?;
+    let current = store
+        .load_table(bucket, &namespace.public_name(), table)
+        .await
+        .map_err(catalog_store_error)?;
     let target_metadata = read_table_metadata_json(metadata_backend, bucket, &request.metadata_location).await?;
+    sync_external_catalog_bridge_response_with_snapshot(
+        store,
+        metadata_backend,
+        bucket,
+        namespace,
+        table,
+        ExternalCatalogBridgeSyncSnapshot {
+            request,
+            target_metadata,
+            current,
+        },
+    )
+    .await
+}
+
+struct ExternalCatalogBridgeSyncSnapshot {
+    request: ExternalCatalogBridgeSyncRequest,
+    target_metadata: serde_json::Value,
+    current: Option<crate::table_catalog::TableEntry>,
+}
+
+async fn sync_external_catalog_bridge_response_with_snapshot<B>(
+    store: &crate::table_catalog::ObjectTableCatalogStore<B>,
+    metadata_backend: &B,
+    bucket: &str,
+    namespace: &crate::table_catalog::Namespace,
+    table: &str,
+    snapshot: ExternalCatalogBridgeSyncSnapshot,
+) -> S3Result<ExternalCatalogBridgeSyncResponse>
+where
+    B: crate::table_catalog::TableCatalogObjectBackend,
+{
+    let ExternalCatalogBridgeSyncSnapshot {
+        request,
+        target_metadata,
+        current,
+    } = snapshot;
+    validate_external_catalog_metadata_location(namespace, table, &request.metadata_location)?;
     validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
     let external_table_uuid = validate_external_catalog_metadata_uuid(request.external_table_uuid.as_deref(), &target_metadata)?;
 
-    let (action, table_response) = if let Some(current) = store
-        .load_table(bucket, &namespace.public_name(), table)
-        .await
-        .map_err(catalog_store_error)?
-    {
+    let (action, table_response) = if let Some(current) = current {
         let expected_version_token = request
             .expected_version_token
             .clone()
@@ -5078,7 +6079,7 @@ where
                 expected_version_token,
                 expected_metadata_location,
                 new_metadata_location: request.metadata_location.clone(),
-                requirements: Vec::new(),
+                requirements: vec![metadata_digest_requirement(&target_metadata)?],
                 writer: Some(EXTERNAL_CATALOG_SYNC_WRITER.to_string()),
             })
             .await
@@ -5123,6 +6124,7 @@ where
     })
 }
 
+#[cfg(test)]
 async fn catalog_import_response<S, B>(
     store: &S,
     metadata_backend: &B,
@@ -5136,13 +6138,32 @@ where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
+    let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
+    let metadata = read_table_metadata_json(metadata_backend, bucket, &metadata_location).await?;
+    catalog_import_response_with_metadata(store, bucket, namespace, table, request, metadata, table_bucket_enabled).await
+}
+
+async fn catalog_import_response_with_metadata<S>(
+    store: &S,
+    bucket: &str,
+    namespace: &crate::table_catalog::Namespace,
+    table: &str,
+    request: CatalogImportRequest,
+    metadata: serde_json::Value,
+    table_bucket_enabled: bool,
+) -> S3Result<RestLoadTableResponse>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
     let started = Instant::now();
     let result = async {
         ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
         let mut entry = table_entry_from_import_request(bucket, namespace, table, request)?;
-        let metadata = read_table_metadata_json(metadata_backend, bucket, &entry.metadata_location).await?;
         validate_metadata_table_location_in_bucket(bucket, &metadata)?;
         adopt_registered_metadata_identity(&mut entry, &metadata)?;
+        if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
+            return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
+        }
         if let Some(existing) = store
             .load_table(bucket, &namespace.public_name(), table)
             .await
@@ -5174,6 +6195,7 @@ async fn rollback_table_response<S>(
     namespace: &crate::table_catalog::Namespace,
     table: &str,
     request: RollbackTableRequest,
+    target_metadata: serde_json::Value,
 ) -> S3Result<RestCommitTableResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
@@ -5187,15 +6209,12 @@ where
         else {
             return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
         };
-        let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
-            .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
         let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
-        if !crate::table_catalog::is_valid_table_metadata_location(namespace, &table_name, &metadata_location) {
+        if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &metadata_location) {
             return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
         }
         let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
         validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
-        let target_metadata = read_table_metadata_json(metadata_backend, bucket, &metadata_location).await?;
         validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
         validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
         let commit_request = crate::table_catalog::TableCommitRequest {
@@ -5208,7 +6227,7 @@ where
             expected_version_token: request.version_token,
             expected_metadata_location: current.metadata_location,
             new_metadata_location: metadata_location,
-            requirements: Vec::new(),
+            requirements: vec![metadata_digest_requirement(&target_metadata)?],
             writer: Some("rustfs-catalog-rollback-api".to_string()),
         };
         let result = store.commit_table(commit_request).await.map_err(catalog_store_error)?;
@@ -5326,9 +6345,22 @@ pub struct RestListNamespacesHandler {}
 impl Operation for RestListNamespacesHandler {
     async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
-        let resource = TableCatalogResource::warehouse(&warehouse);
+        let parent = rest_namespace_parent_from_query(&req.uri)?;
+        let resource = match &parent {
+            Some(parent) => TableCatalogResource::namespace(&warehouse, parent),
+            None => TableCatalogResource::warehouse(&warehouse),
+        };
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableNamespaceAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
+        let parent_name = parent.as_ref().map(crate::table_catalog::Namespace::public_name);
+        let pagination = rest_pagination_from_query(
+            &req.uri,
+            RestPageContext {
+                resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+                warehouse: &warehouse,
+                namespace: parent_name.as_deref(),
+            },
+        )?;
         let store = table_catalog_store()?;
         let response = list_namespaces_response(&store, &warehouse, &req.uri).await?;
         build_json_response(StatusCode::OK, &response)
@@ -5383,6 +6415,30 @@ impl Operation for RestDropNamespaceHandler {
     }
 }
 
+pub struct RestUpdateNamespacePropertiesHandler {}
+
+#[async_trait::async_trait]
+impl Operation for RestUpdateNamespacePropertiesHandler {
+    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+        let warehouse = warehouse_from_params(&params)?;
+        let namespace = namespace_from_params(&params)?;
+        let resource = TableCatalogResource::namespace(&warehouse, &namespace);
+        authorize_table_catalog_resource_request(&req, &resource, AdminAction::UpdateTableNamespacePropertiesAction).await?;
+        ensure_table_bucket_enabled(&warehouse).await?;
+        let request = read_bounded_json_body::<UpdateNamespacePropertiesRequest>(
+            &req.headers,
+            req.input,
+            NAMESPACE_PROPERTIES_BODY_MAX_SIZE,
+            NAMESPACE_PROPERTIES_BODY_TIMEOUT,
+            "namespace properties",
+        )
+        .await?;
+        let store = table_catalog_store()?;
+        let response = update_namespace_properties_response(&store, &warehouse, &namespace, request).await?;
+        build_json_response(StatusCode::OK, &response)
+    }
+}
+
 pub struct RestNamespaceExistsHandler {}
 
 #[async_trait::async_trait]
@@ -5408,9 +6464,59 @@ impl Operation for RestListTablesHandler {
         let resource = TableCatalogResource::namespace(&warehouse, &namespace);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
+        let namespace_name = namespace.public_name();
+        let pagination = rest_pagination_from_query(
+            &req.uri,
+            RestPageContext {
+                resource: TABLE_CATALOG_TABLE_RESOURCE_ROOT,
+                warehouse: &warehouse,
+                namespace: Some(&namespace_name),
+            },
+        )?;
         let store = table_catalog_store()?;
         let response = list_tables_response(&store, &warehouse, &namespace, &req.uri).await?;
         build_json_response(StatusCode::OK, &response)
+    }
+}
+
+pub struct RestRenameTableHandler {}
+
+#[async_trait::async_trait]
+impl Operation for RestRenameTableHandler {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+        let warehouse = warehouse_from_params(&params)?;
+        let principal = table_catalog_request_principal(&req).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let request = read_bounded_json_body::<RenameTableRequest>(
+            &req.headers,
+            input,
+            RENAME_TABLE_BODY_MAX_SIZE,
+            RENAME_TABLE_BODY_TIMEOUT,
+            "rename table",
+        )
+        .await?;
+        let (source_namespace, source_table) = table_identifier_from_request(request.source)?;
+        let (destination_namespace, destination_table) = table_identifier_from_request(request.destination)?;
+
+        let source_resource = TableCatalogResource::table(&warehouse, &source_namespace, source_table.as_str());
+        authorize_table_catalog_resource_for_principal(&req, &principal, &source_resource, AdminAction::SetTableAction).await?;
+        let destination_resource = TableCatalogResource::table(&warehouse, &destination_namespace, destination_table.as_str());
+        authorize_table_catalog_resource_for_principal(&req, &principal, &destination_resource, AdminAction::SetTableAction)
+            .await?;
+        ensure_table_bucket_enabled(&warehouse).await?;
+
+        let store = table_catalog_store()?;
+        store
+            .rename_table(
+                &warehouse,
+                &source_namespace.public_name(),
+                source_table.as_str(),
+                &destination_namespace.public_name(),
+                destination_table.as_str(),
+            )
+            .await
+            .map_err(catalog_store_error)?;
+        Ok(empty_response(StatusCode::NO_CONTENT))
     }
 }
 
@@ -5418,12 +6524,17 @@ pub struct RestCreateTableHandler {}
 
 #[async_trait::async_trait]
 impl Operation for RestCreateTableHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let resource = TableCatalogResource::namespace(&warehouse, &namespace);
-        authorize_table_catalog_resource_request(&req, &resource, AdminAction::CreateTableAction).await?;
-        let request = read_json_body::<CreateTableRequest>(req.input).await?;
+        let principal = authorize_table_catalog_resource_request(&req, &resource, AdminAction::CreateTableAction).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let request = read_json_body::<CreateTableRequest>(input).await?;
+        if let Some(location) = request.location.as_deref() {
+            authorize_table_catalog_resource_for_principal(&req, &principal, &resource, AdminAction::RegisterTableAction).await?;
+            authorize_table_warehouse_s3_actions(&mut req, &warehouse, location, TABLE_WAREHOUSE_WRITE_ACTIONS).await?;
+        }
         let metadata_backend = table_catalog_backend()?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
@@ -5437,17 +6548,19 @@ pub struct RestRegisterTableHandler {}
 
 #[async_trait::async_trait]
 impl Operation for RestRegisterTableHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let resource = TableCatalogResource::namespace(&warehouse, &namespace);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::RegisterTableAction).await?;
-        let request = read_json_body::<RegisterTableRequest>(req.input).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let request = read_json_body::<RegisterTableRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
+        let metadata_location = table_metadata_location_for_catalog(&warehouse, &request.metadata_location)?;
+        let metadata = read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &metadata_location).await?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
-        let response =
-            register_table_response(&store, &metadata_backend, &warehouse, &namespace, request, table_bucket_enabled).await?;
+        let response = register_table_response(&store, &warehouse, &namespace, request, metadata, table_bucket_enabled).await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -5462,6 +6575,15 @@ impl Operation for RestListViewsHandler {
         let resource = TableCatalogResource::namespace(&warehouse, &namespace);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableMetadataAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
+        let namespace_name = namespace.public_name();
+        let pagination = rest_pagination_from_query(
+            &req.uri,
+            RestPageContext {
+                resource: TABLE_CATALOG_VIEW_RESOURCE_ROOT,
+                warehouse: &warehouse,
+                namespace: Some(&namespace_name),
+            },
+        )?;
         let store = table_catalog_store()?;
         let response = list_views_response(&store, &warehouse, &namespace, &req.uri).await?;
         build_json_response(StatusCode::OK, &response)
@@ -5530,13 +6652,13 @@ impl Operation for RestLoadCredentialsHandler {
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
-        authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableCredentialsAction).await?;
+        let principal = authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableCredentialsAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let principal = table_catalog_request_principal(&req).await?;
         let store = table_catalog_store()?;
         let issuer = IamTableCredentialIssuer::from_env();
-        let response = load_credentials_response(&store, &warehouse, &namespace, &table, &issuer, Some(&principal)).await?;
-        build_json_response(StatusCode::OK, &response)
+        let response =
+            load_credentials_response(&store, &warehouse, &namespace, &table, &issuer, Some(&principal.credentials)).await?;
+        build_sensitive_json_response(StatusCode::OK, &response)
     }
 }
 
@@ -5544,17 +6666,72 @@ pub struct RestCommitTableHandler {}
 
 #[async_trait::async_trait]
 impl Operation for RestCommitTableHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::CommitTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let request = read_json_body::<RestCommitTableRequest>(req.input).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let mut request = read_rest_commit_table_request(&req.headers, input).await?;
         let metadata_backend = table_catalog_backend()?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
-        let response = commit_table_response(&store, &metadata_backend, &warehouse, &namespace, &table, request).await?;
+        let current = store
+            .load_table(&warehouse, &namespace.public_name(), &table)
+            .await
+            .map_err(catalog_store_error)?
+            .ok_or_else(|| iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"))?;
+        let warehouse_read_location =
+            table_commit_warehouse_read_location(&store, &metadata_backend, &warehouse, &current, &request).await?;
+        authorize_table_warehouse_s3_actions(&mut req, &warehouse, &warehouse_read_location, TABLE_WAREHOUSE_READ_ACTIONS)
+            .await?;
+        let target_metadata = if let Some(metadata_location) = request.new_metadata_location.as_deref() {
+            let metadata_location = table_metadata_location_for_catalog(&warehouse, metadata_location)?;
+            authorize_table_catalog_s3_actions(&mut req, &warehouse, &metadata_location, &[S3Action::GetObjectAction]).await?;
+            let metadata = read_existing_table_metadata_target(
+                &store,
+                &metadata_backend,
+                &warehouse,
+                &namespace,
+                &table,
+                &metadata_location,
+            )
+            .await?;
+            authorize_table_warehouse_s3_actions(
+                &mut req,
+                &warehouse,
+                metadata_table_location(&metadata)?,
+                TABLE_WAREHOUSE_WRITE_ACTIONS,
+            )
+            .await?;
+            request.new_metadata_location = Some(metadata_location);
+            Some(metadata)
+        } else {
+            if let Some(update) = request
+                .updates
+                .iter()
+                .rev()
+                .find(|update| update.get("action").and_then(serde_json::Value::as_str) == Some("set-location"))
+            {
+                let location = update
+                    .get("location")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| s3_error!(InvalidRequest, "set-location requires location"))?;
+                authorize_table_warehouse_s3_actions(&mut req, &warehouse, location, TABLE_WAREHOUSE_WRITE_ACTIONS).await?;
+            }
+            None
+        };
+        let response = commit_table_response_with_target_metadata(
+            &store,
+            &metadata_backend,
+            &warehouse,
+            &namespace,
+            &table,
+            request,
+            target_metadata,
+        )
+        .await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -5567,6 +6744,13 @@ impl Operation for RestDropTableHandler {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
+        if rest_purge_requested_from_query(&req.uri)? {
+            return Err(iceberg_rest_error(
+                ICEBERG_ERROR_BAD_REQUEST,
+                StatusCode::BAD_REQUEST,
+                "purgeRequested=true is not supported",
+            ));
+        }
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::DeleteTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
@@ -5727,18 +6911,46 @@ pub struct UpdateTableMetadataLocationHandler {}
 
 #[async_trait::async_trait]
 impl Operation for UpdateTableMetadataLocationHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::SetTableMetadataLocationAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let request = read_json_body::<UpdateTableMetadataLocationRequest>(req.input).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let mut request = read_json_body::<UpdateTableMetadataLocationRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
+        request.metadata_location = table_metadata_location_for_catalog(&warehouse, &request.metadata_location)?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
-        let response =
-            update_table_metadata_location_response(&store, &metadata_backend, &warehouse, &namespace, &table, request).await?;
+        authorize_table_catalog_s3_actions(&mut req, &warehouse, &request.metadata_location, &[S3Action::GetObjectAction])
+            .await?;
+        let target_metadata = read_existing_table_metadata_target(
+            &store,
+            &metadata_backend,
+            &warehouse,
+            &namespace,
+            &table,
+            &request.metadata_location,
+        )
+        .await?;
+        authorize_table_warehouse_s3_actions(
+            &mut req,
+            &warehouse,
+            metadata_table_location(&target_metadata)?,
+            TABLE_WAREHOUSE_WRITE_ACTIONS,
+        )
+        .await?;
+        let response = update_table_metadata_location_response(
+            &store,
+            &metadata_backend,
+            &warehouse,
+            &namespace,
+            &table,
+            request,
+            target_metadata,
+        )
+        .await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -5978,19 +7190,30 @@ pub struct ImportTableCatalogHandler {}
 
 #[async_trait::async_trait]
 impl Operation for ImportTableCatalogHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::RegisterTableAction).await?;
-        let request = read_json_body::<CatalogImportRequest>(req.input).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let mut request = read_json_body::<CatalogImportRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
+        request.metadata_location = table_metadata_location_for_catalog(&warehouse, &request.metadata_location)?;
+        let metadata =
+            read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &request.metadata_location).await?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
-        let response =
-            catalog_import_response(&store, &metadata_backend, &warehouse, &namespace, &table, request, table_bucket_enabled)
-                .await?;
+        let response = catalog_import_response_with_metadata(
+            &store,
+            &warehouse,
+            &namespace,
+            &table,
+            request,
+            metadata,
+            table_bucket_enabled,
+        )
+        .await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -6034,33 +7257,46 @@ pub struct SyncExternalCatalogBridgeHandler {}
 
 #[async_trait::async_trait]
 impl Operation for SyncExternalCatalogBridgeHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
-        authorize_table_catalog_resource_request(&req, &resource, AdminAction::SetTableMetadataLocationAction).await?;
+        let principal =
+            authorize_table_catalog_resource_request(&req, &resource, AdminAction::SetTableMetadataLocationAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
         let metadata_backend = table_catalog_backend()?;
         let store = table_catalog_object_store()?;
-        if store
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let mut request = read_json_body::<ExternalCatalogBridgeSyncRequest>(input).await?;
+        request.metadata_location = table_metadata_location_for_catalog(&warehouse, &request.metadata_location)?;
+        request.expected_metadata_location = request
+            .expected_metadata_location
+            .map(|metadata_location| table_metadata_location_for_catalog(&warehouse, &metadata_location))
+            .transpose()?;
+        let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
+        ensure_table_bucket_entry(&store, &warehouse, table_bucket_enabled).await?;
+        validate_external_catalog_metadata_location(&namespace, &table, &request.metadata_location)?;
+        let current = store
             .load_table(&warehouse, &namespace.public_name(), &table)
             .await
-            .map_err(catalog_store_error)?
-            .is_none()
-        {
-            authorize_table_catalog_resource_request(&req, &resource, AdminAction::RegisterTableAction).await?;
+            .map_err(catalog_store_error)?;
+        let target_metadata =
+            read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &request.metadata_location).await?;
+        if current.is_none() {
+            authorize_table_catalog_resource_for_principal(&req, &principal, &resource, AdminAction::RegisterTableAction).await?;
         }
-        let request = read_json_body::<ExternalCatalogBridgeSyncRequest>(req.input).await?;
-        let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
-        let response = sync_external_catalog_bridge_response(
+        let response = sync_external_catalog_bridge_response_with_snapshot(
             &store,
             &metadata_backend,
             &warehouse,
             &namespace,
             &table,
-            request,
-            table_bucket_enabled,
+            ExternalCatalogBridgeSyncSnapshot {
+                request,
+                target_metadata,
+                current,
+            },
         )
         .await?;
         build_json_response(StatusCode::OK, &response)
@@ -6128,17 +7364,38 @@ pub struct RollbackTableCatalogHandler {}
 
 #[async_trait::async_trait]
 impl Operation for RollbackTableCatalogHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::CommitTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let request = read_json_body::<RollbackTableRequest>(req.input).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let mut request = read_json_body::<RollbackTableRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
+        request.metadata_location = table_metadata_location_for_catalog(&warehouse, &request.metadata_location)?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
-        let response = rollback_table_response(&store, &metadata_backend, &warehouse, &namespace, &table, request).await?;
+        authorize_table_catalog_s3_actions(&mut req, &warehouse, &request.metadata_location, &[S3Action::GetObjectAction])
+            .await?;
+        let target_metadata = read_existing_table_metadata_target(
+            &store,
+            &metadata_backend,
+            &warehouse,
+            &namespace,
+            &table,
+            &request.metadata_location,
+        )
+        .await?;
+        authorize_table_warehouse_s3_actions(
+            &mut req,
+            &warehouse,
+            metadata_table_location(&target_metadata)?,
+            TABLE_WAREHOUSE_WRITE_ACTIONS,
+        )
+        .await?;
+        let response =
+            rollback_table_response(&store, &metadata_backend, &warehouse, &namespace, &table, request, target_metadata).await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -6147,7 +7404,36 @@ impl Operation for RollbackTableCatalogHandler {
 mod tests {
     use super::*;
     use crate::table_catalog::{TableCatalogObjectBackend, TableCatalogStore};
+    use bytes::Bytes;
     use std::sync::Arc;
+
+    #[test]
+    fn snapshot_read_budget_accepts_exact_limits_and_rejects_excess() {
+        let mut budget = SnapshotReadBudget {
+            manifest_count: TABLE_COMMIT_MAX_MANIFESTS - 2,
+            avro_bytes: TABLE_COMMIT_MAX_AVRO_BYTES - 3,
+            file_reference_count: TABLE_COMMIT_MAX_FILE_REFERENCES - 4,
+        };
+
+        budget.charge_manifests(2).expect("exact manifest limit should be accepted");
+        budget.charge_avro_bytes(3).expect("exact Avro byte limit should be accepted");
+        budget
+            .charge_file_references(4)
+            .expect("exact file reference limit should be accepted");
+
+        let manifest_error = budget
+            .charge_manifests(1)
+            .expect_err("manifest count above the limit should fail");
+        let avro_error = budget
+            .charge_avro_bytes(1)
+            .expect_err("Avro bytes above the limit should fail");
+        let reference_error = budget
+            .charge_file_references(1)
+            .expect_err("file reference count above the limit should fail");
+        for error in [manifest_error, avro_error, reference_error] {
+            assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        }
+    }
 
     #[test]
     #[serial_test::serial]
@@ -6173,110 +7459,15 @@ mod tests {
             Some(crate::table_catalog::TABLE_CATALOG_BACKING_OBJECT)
         );
         assert!(!response.defaults.contains_key(PREFIX_PROPERTY));
-        assert!(response.overrides.is_empty());
+        assert_eq!(
+            response.overrides.get(NAMESPACE_SEPARATOR_PROPERTY).map(String::as_str),
+            Some(REST_NAMESPACE_SEPARATOR_URL_ENCODED)
+        );
         assert_eq!(response.admin_discovery.runtime_capabilities, "/rustfs/admin/v4/runtime/capabilities");
         assert_eq!(response.admin_discovery.cluster_snapshot, "/rustfs/admin/v4/cluster/snapshot");
         assert_eq!(response.admin_discovery.extensions_catalog, "/rustfs/admin/v4/extensions/catalog");
-        assert!(response.endpoints.contains(&"GET /v1/{prefix}/namespaces"));
-        assert!(response.endpoints.contains(&"GET /{warehouse}/catalog/migration"));
-        assert!(response.endpoints.contains(&"POST /{warehouse}/catalog/migration"));
-        assert!(response.endpoints.contains(&"DELETE /{warehouse}/catalog/migration"));
-        assert!(response.endpoints.contains(&"HEAD /v1/{prefix}/namespaces/{namespace}"));
-        assert!(
-            response
-                .endpoints
-                .contains(&"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials")
-        );
-        assert!(response.endpoints.contains(&"GET /{warehouse}/namespaces"));
-        assert!(response.endpoints.contains(&"POST /{warehouse}/namespaces"));
-        assert!(response.endpoints.contains(&"HEAD /{warehouse}/namespaces/{namespace}"));
-        assert!(
-            response
-                .endpoints
-                .contains(&"POST /{warehouse}/namespaces/{namespace}/register")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"POST /{warehouse}/namespaces/{namespace}/tables")
-        );
-        assert!(response.endpoints.contains(&"GET /{warehouse}/namespaces/{namespace}/views"));
-        assert!(response.endpoints.contains(&"POST /{warehouse}/namespaces/{namespace}/views"));
-        assert!(
-            response
-                .endpoints
-                .contains(&"HEAD /{warehouse}/namespaces/{namespace}/views/{view}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"GET /{warehouse}/namespaces/{namespace}/tables/{table}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"HEAD /{warehouse}/namespaces/{namespace}/tables/{table}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"POST /{warehouse}/namespaces/{namespace}/tables/{table}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"GET /{warehouse}/namespaces/{namespace}/tables/{table}/credentials")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"GET /{warehouse}/namespaces/{namespace}/views/{view}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"GET /{warehouse}/namespaces/{namespace}/tables/{table}/refs")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"PUT /{warehouse}/namespaces/{namespace}/tables/{table}/refs/{ref}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"DELETE /{warehouse}/namespaces/{namespace}/tables/{table}/refs/{ref}")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"GET /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/external")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"PUT /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/external")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"POST /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/external/sync")
-        );
-        assert!(
-            response
-                .endpoints
-                .contains(&"POST /{warehouse}/namespaces/{namespace}/tables/{table}/catalog/recovery")
-        );
+        assert_eq!(response.endpoints.as_slice(), TABLE_CATALOG_ENDPOINTS);
+        assert!(response.endpoints.iter().all(|endpoint| endpoint.contains("/v1/{prefix}/")));
     }
 
     #[test]
@@ -6293,6 +7484,13 @@ mod tests {
             response.overrides.get(CATALOG_BACKING_CONFIG_KEY).map(String::as_str),
             Some(crate::table_catalog::TABLE_CATALOG_BACKING_DURABLE_STRONG)
         );
+        assert!(
+            response
+                .endpoints
+                .contains(&"POST /v1/{prefix}/namespaces/{namespace}/properties")
+        );
+        assert!(response.endpoints.contains(&"POST /v1/{prefix}/tables/rename"));
+        assert!(!response.endpoints.contains(&"POST /{warehouse}/tables/rename"));
     }
 
     #[test]
@@ -6319,6 +7517,271 @@ mod tests {
     }
 
     #[test]
+    fn drop_table_purge_query_is_explicit_and_strict() {
+        for (uri, expected) in [
+            ("/iceberg/v1/analytics/namespaces/sales/tables/orders", false),
+            ("/iceberg/v1/analytics/namespaces/sales/tables/orders?purgeRequested=false", false),
+            ("/iceberg/v1/analytics/namespaces/sales/tables/orders?purgeRequested=true", true),
+        ] {
+            assert_eq!(
+                rest_purge_requested_from_query(&uri.parse().expect("URI")).expect("purge query should parse"),
+                expected
+            );
+        }
+
+        for uri in [
+            "/iceberg/v1/analytics/namespaces/sales/tables/orders?purgeRequested=1",
+            "/iceberg/v1/analytics/namespaces/sales/tables/orders?purgeRequested=true&purgeRequested=false",
+        ] {
+            let error = rest_purge_requested_from_query(&uri.parse().expect("URI")).expect_err("invalid purge query should fail");
+            assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+            assert_eq!(error.status_code(), Some(StatusCode::BAD_REQUEST));
+        }
+    }
+
+    #[test]
+    fn rest_pagination_round_trips_opaque_context_bound_tokens() {
+        let context = RestPageContext {
+            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+            warehouse: "analytics",
+            namespace: None,
+        };
+        let first_uri = "/iceberg/v1/analytics/namespaces?pageToken=&pageSize=2".parse().expect("URI");
+        let first_pagination = rest_pagination_from_query(&first_uri, context).expect("first page query should parse");
+        let (first, next_page_token) = paginate_rest_entries(
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            first_pagination,
+            context,
+            String::as_str,
+        )
+        .expect("first page should paginate");
+        assert_eq!(first, vec!["a".to_string(), "b".to_string()]);
+        let next_page_token = next_page_token.expect("first page should return a token");
+
+        let exact_page_uri = "/iceberg/v1/analytics/namespaces?pageToken=&pageSize=2"
+            .parse()
+            .expect("exact page URI");
+        let exact_page_pagination = rest_pagination_from_query(&exact_page_uri, context).expect("exact page query should parse");
+        let (exact_page, exact_page_token) =
+            paginate_rest_entries(vec!["a".to_string(), "b".to_string()], exact_page_pagination, context, String::as_str)
+                .expect("exact page should paginate");
+        assert_eq!(exact_page, vec!["a".to_string(), "b".to_string()]);
+        assert!(exact_page_token.is_none());
+
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("pageToken", &next_page_token)
+            .append_pair("pageSize", "2")
+            .finish();
+        let second_uri = format!("/iceberg/v1/analytics/namespaces?{query}")
+            .parse()
+            .expect("second page URI");
+        let second_pagination = rest_pagination_from_query(&second_uri, context).expect("second page query should parse");
+        let (second, final_token) = paginate_rest_entries(
+            vec!["aa".to_string(), "c".to_string(), "d".to_string()],
+            second_pagination,
+            context,
+            String::as_str,
+        )
+        .expect("second page should paginate after a deleted cursor");
+        assert_eq!(second, vec!["c".to_string(), "d".to_string()]);
+        assert!(final_token.is_none());
+    }
+
+    #[test]
+    fn rest_pagination_rejects_malformed_repeated_and_cross_context_tokens() {
+        let namespace_context = RestPageContext {
+            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+            warehouse: "analytics",
+            namespace: None,
+        };
+        for uri in [
+            "/iceberg/v1/analytics/namespaces?pageToken=not-base64!",
+            "/iceberg/v1/analytics/namespaces?pageToken=one&pageToken=two",
+            "/iceberg/v1/analytics/namespaces?pageSize=0",
+            "/iceberg/v1/analytics/namespaces?pageSize=one",
+            "/iceberg/v1/analytics/namespaces?pageSize=1&pageSize=2",
+        ] {
+            let error = rest_pagination_from_query(&uri.parse().expect("URI"), namespace_context)
+                .expect_err("invalid pagination query should fail");
+            assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+            assert_eq!(error.status_code(), Some(StatusCode::BAD_REQUEST));
+        }
+
+        let table_context = RestPageContext {
+            resource: TABLE_CATALOG_TABLE_RESOURCE_ROOT,
+            warehouse: "analytics",
+            namespace: Some("sales"),
+        };
+        let table_token = encode_rest_page_token("orders", table_context).expect("table token should encode");
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("pageToken", &table_token)
+            .finish();
+        let uri = format!("/iceberg/v1/analytics/namespaces?{query}")
+            .parse()
+            .expect("cross-context URI");
+        let error = rest_pagination_from_query(&uri, namespace_context).expect_err("cross-context token should fail");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::BAD_REQUEST));
+
+        let other_warehouse_context = RestPageContext {
+            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+            warehouse: "archive",
+            namespace: None,
+        };
+        let warehouse_token = encode_rest_page_token("sales", namespace_context).expect("namespace page token should encode");
+        assert!(
+            decode_rest_page_token(&warehouse_token, other_warehouse_context).is_err(),
+            "namespace page tokens must remain warehouse-scoped"
+        );
+
+        let namespace_resource_context = RestPageContext {
+            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+            warehouse: "analytics",
+            namespace: Some("sales"),
+        };
+        assert!(
+            decode_rest_page_token(&table_token, namespace_resource_context).is_err(),
+            "page tokens must remain resource-scoped even when warehouse and namespace match"
+        );
+
+        let oversized = "a".repeat(REST_PAGE_TOKEN_MAX_LENGTH + 1);
+        assert!(decode_rest_page_token(&oversized, namespace_context).is_err());
+
+        for token in [
+            RestPageToken {
+                version: REST_PAGE_TOKEN_VERSION + 1,
+                context: rest_page_context_fingerprint(namespace_context),
+                after: "sales".to_string(),
+            },
+            RestPageToken {
+                version: REST_PAGE_TOKEN_VERSION,
+                context: rest_page_context_fingerprint(namespace_context),
+                after: String::new(),
+            },
+        ] {
+            let encoded =
+                base64_encode_url_safe_no_pad(&serde_json::to_vec(&token).expect("invalid test token should serialize"));
+            assert!(decode_rest_page_token(&encoded, namespace_context).is_err());
+        }
+
+        let invalid_json = base64_encode_url_safe_no_pad(b"not-json");
+        assert!(decode_rest_page_token(&invalid_json, namespace_context).is_err());
+
+        let unknown_field = base64_encode_url_safe_no_pad(
+            &serde_json::to_vec(&serde_json::json!({
+                "version": REST_PAGE_TOKEN_VERSION,
+                "context": rest_page_context_fingerprint(namespace_context),
+                "after": "sales",
+                "unexpected": true
+            }))
+            .expect("unknown-field token should serialize"),
+        );
+        assert!(decode_rest_page_token(&unknown_field, namespace_context).is_err());
+    }
+
+    #[test]
+    fn rest_pagination_requires_page_token_to_start_pagination() {
+        let context = RestPageContext {
+            resource: TABLE_CATALOG_TABLE_RESOURCE_ROOT,
+            warehouse: "analytics",
+            namespace: Some("sales"),
+        };
+        let uri = "/iceberg/v1/analytics/namespaces/sales/tables?pageToken=&pageSize=999999"
+            .parse()
+            .expect("URI");
+        let pagination = rest_pagination_from_query(&uri, context).expect("empty token should start pagination");
+        assert_eq!(pagination.after, None);
+        assert_eq!(pagination.limit, Some(REST_MAX_PAGE_SIZE));
+
+        let uri = "/iceberg/v1/analytics/namespaces/sales/tables?pageSize=2"
+            .parse()
+            .expect("URI");
+        let pagination = rest_pagination_from_query(&uri, context).expect("page size without a token should parse");
+        assert_eq!(pagination.after, None);
+        assert_eq!(pagination.limit, None);
+
+        let uri = "/iceberg/v1/analytics/namespaces/sales/tables".parse().expect("URI");
+        let pagination = rest_pagination_from_query(&uri, context).expect("request without pagination should parse");
+        let entries = (0..=REST_DEFAULT_PAGE_SIZE)
+            .map(|index| format!("table-{index:04}"))
+            .collect::<Vec<_>>();
+        let (page, next_page_token) = paginate_rest_entries(entries.clone(), pagination, context, String::as_str)
+            .expect("unpaginated request should preserve legacy behavior");
+        assert_eq!(page, entries);
+        assert!(next_page_token.is_none());
+    }
+
+    #[test]
+    fn namespace_parent_query_accepts_standard_and_legacy_path_separators() {
+        let path_namespace = namespace_from_path_value("accounting%1Ftax").expect("encoded path namespace should parse");
+        assert_eq!(path_namespace.public_name(), "accounting.tax");
+        let lowercase_path_namespace =
+            namespace_from_path_value("accounting%1ftax").expect("lowercase encoded path namespace should parse");
+        assert_eq!(lowercase_path_namespace.public_name(), "accounting.tax");
+        let legacy_path_namespace =
+            namespace_from_path_value("accounting.tax").expect("legacy dotted path namespace should parse");
+        assert_eq!(legacy_path_namespace.public_name(), "accounting.tax");
+        assert!(namespace_from_path_value("accounting%2Etax").is_err());
+        assert!(namespace_from_path_value("accounting%2Ftax").is_err());
+        assert!(namespace_from_path_value("%FF").is_err());
+
+        let uri = "/iceberg/v1/analytics/namespaces?parent=accounting%1Ftax"
+            .parse()
+            .expect("URI");
+        let parent = rest_namespace_parent_from_query(&uri)
+            .expect("parent query should parse")
+            .expect("parent should be present");
+        assert_eq!(parent.public_name(), "accounting.tax");
+
+        let uri = "/iceberg/v1/analytics/namespaces?parent=".parse().expect("URI");
+        assert!(
+            rest_namespace_parent_from_query(&uri)
+                .expect("empty parent should parse")
+                .is_none()
+        );
+
+        let uri = "/iceberg/v1/analytics/namespaces?parent=one&parent=two".parse().expect("URI");
+        let error = rest_namespace_parent_from_query(&uri).expect_err("repeated parent should fail");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::BAD_REQUEST));
+    }
+
+    #[test]
+    fn list_responses_expose_null_next_page_token_at_end() {
+        let response = RestListNamespacesResponse {
+            namespaces: vec![vec!["sales".to_string()]],
+            next_page_token: None,
+        };
+        let value = serde_json::to_value(response).expect("list response should serialize");
+        assert_eq!(value["next-page-token"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn unknown_commit_requirements_and_updates_are_bad_requests() {
+        let unknown_requirement = vec![serde_json::json!({"type": "unknown-requirement"})];
+        let unknown_update = vec![serde_json::json!({"action": "unknown-update"})];
+        let table_requirement_error = validate_table_commit_requirements(&serde_json::json!({}), &unknown_requirement)
+            .expect_err("unknown table requirement should fail");
+        let table_update_error =
+            apply_table_commit_updates(serde_json::json!({}), &unknown_update, "metadata/00001.metadata.json")
+                .expect_err("unknown table update should fail");
+        let view_requirement_error = validate_view_commit_requirements(&serde_json::json!({}), &unknown_requirement)
+            .expect_err("unknown view requirement should fail");
+        let view_update_error =
+            apply_view_commit_updates_at(serde_json::json!({}), &unknown_update, "metadata/00001.metadata.json", 0)
+                .expect_err("unknown view update should fail");
+
+        for error in [
+            table_requirement_error,
+            table_update_error,
+            view_requirement_error,
+            view_update_error,
+        ] {
+            assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        }
+    }
+
+    #[test]
     fn catalog_conflicts_use_operation_specific_iceberg_errors() {
         let already_exists = catalog_store_already_exists_error(crate::table_catalog::TableCatalogStoreError::Conflict(
             "table already exists".to_string(),
@@ -6337,6 +7800,47 @@ mod tests {
         ));
         assert_eq!(namespace_not_found.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
         assert_eq!(namespace_not_found.status_code(), Some(StatusCode::NOT_FOUND));
+
+        let destination_conflict = catalog_store_error(crate::table_catalog::TableCatalogStoreError::AlreadyExists(
+            "destination exists".to_string(),
+        ));
+        assert_eq!(destination_conflict.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_ALREADY_EXISTS.into()));
+        assert_eq!(destination_conflict.status_code(), Some(StatusCode::CONFLICT));
+
+        let snapshot_conflict = catalog_store_error(crate::table_catalog::TableCatalogStoreError::Conflict(
+            "catalog snapshot changed".to_string(),
+        ));
+        assert_eq!(snapshot_conflict.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_COMMIT_FAILED.into()));
+        assert_eq!(snapshot_conflict.status_code(), Some(StatusCode::CONFLICT));
+
+        let unsupported = catalog_store_error(crate::table_catalog::TableCatalogStoreError::Unsupported(
+            "rename requires durable backing".to_string(),
+        ));
+        assert_eq!(unsupported.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(unsupported.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+
+        let table_not_found =
+            catalog_store_error(crate::table_catalog::TableCatalogStoreError::TableNotFound("table not found".to_string()));
+        assert_eq!(table_not_found.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_TABLE.into()));
+        assert_eq!(table_not_found.status_code(), Some(StatusCode::NOT_FOUND));
+
+        let view_not_found =
+            catalog_store_error(crate::table_catalog::TableCatalogStoreError::ViewNotFound("view not found".to_string()));
+        assert_eq!(view_not_found.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_VIEW.into()));
+        assert_eq!(view_not_found.status_code(), Some(StatusCode::NOT_FOUND));
+
+        let namespace_not_found = catalog_store_error(crate::table_catalog::TableCatalogStoreError::NamespaceNotFound(
+            "namespace not found".to_string(),
+        ));
+        assert_eq!(namespace_not_found.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
+        assert_eq!(namespace_not_found.status_code(), Some(StatusCode::NOT_FOUND));
+
+        let internal = catalog_store_error(crate::table_catalog::TableCatalogStoreError::Internal(
+            "sensitive backend detail".to_string(),
+        ));
+        assert_eq!(internal.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_REST.into()));
+        assert_eq!(internal.status_code(), Some(StatusCode::INTERNAL_SERVER_ERROR));
+        assert_eq!(internal.message(), Some("internal table catalog error"));
     }
 
     #[test]
@@ -6369,6 +7873,10 @@ mod tests {
             ("RestCreateNamespaceHandler", "AdminAction::SetTableNamespaceAction"),
             ("RestGetNamespaceHandler", "AdminAction::GetTableNamespaceAction"),
             ("RestNamespaceExistsHandler", "AdminAction::GetTableNamespaceAction"),
+            (
+                "RestUpdateNamespacePropertiesHandler",
+                "AdminAction::UpdateTableNamespacePropertiesAction",
+            ),
             ("RestDropNamespaceHandler", "AdminAction::DeleteTableNamespaceAction"),
             ("RestListTablesHandler", "AdminAction::GetTableAction"),
             ("RestCreateTableHandler", "AdminAction::CreateTableAction"),
@@ -6417,14 +7925,61 @@ mod tests {
             );
         }
 
+        let create_table_block = operation_block(src, "RestCreateTableHandler");
+        assert!(create_table_block.contains("request.location.as_deref()"));
+        assert!(create_table_block.contains("AdminAction::RegisterTableAction"));
+        assert!(create_table_block.contains("authorize_table_warehouse_s3_actions"));
+
+        let register_table_block = operation_block(src, "RestRegisterTableHandler");
+        assert!(register_table_block.contains("read_authorized_table_metadata_json"));
+        assert!(register_table_block.contains("request, metadata, table_bucket_enabled"));
+        assert!(
+            !function_block(src, "async fn register_table_response").contains("read_table_metadata_json"),
+            "register should persist the metadata snapshot used for authorization"
+        );
+        let warehouse_auth_block = function_block(src, "async fn authorize_table_warehouse_s3_actions");
+        assert!(warehouse_auth_block.contains("table_catalog_prefix_authorization_probe"));
+        assert!(warehouse_auth_block.contains("actions"));
+        assert_eq!(TABLE_WAREHOUSE_READ_ACTIONS, &[S3Action::GetObjectAction]);
+        assert_eq!(TABLE_WAREHOUSE_WRITE_ACTIONS, &[S3Action::PutObjectAction, S3Action::DeleteObjectAction]);
+        let metadata_auth_block = function_block(src, "async fn read_authorized_table_metadata_json");
+        assert!(metadata_auth_block.contains("S3Action::GetObjectAction"));
+        assert!(metadata_auth_block.contains("authorize_table_warehouse_s3_actions"));
+
         let sync_bridge_block = operation_block(src, "SyncExternalCatalogBridgeHandler");
         assert!(
             sync_bridge_block.contains("AdminAction::RegisterTableAction"),
             "external catalog sync should require register authorization before creating a missing table"
         );
+        assert!(sync_bridge_block.contains("read_authorized_table_metadata_json"));
         assert!(
             sync_bridge_block.contains(".load_table(&warehouse, &namespace.public_name(), &table)"),
             "external catalog sync should branch authorization on current table existence"
+        );
+        assert!(
+            sync_bridge_block.contains("sync_external_catalog_bridge_response_with_snapshot")
+                && sync_bridge_block.contains("target_metadata")
+                && sync_bridge_block.contains("current"),
+            "external catalog sync should use the state and metadata snapshot authorized by the handler"
+        );
+
+        let import_block = operation_block(src, "ImportTableCatalogHandler");
+        assert!(import_block.contains("read_authorized_table_metadata_json"));
+        assert!(import_block.contains("catalog_import_response_with_metadata"));
+
+        for handler in [
+            "RestCommitTableHandler",
+            "UpdateTableMetadataLocationHandler",
+            "RollbackTableCatalogHandler",
+        ] {
+            assert!(
+                operation_block(src, handler).contains("authorize_table_warehouse_s3_actions"),
+                "{handler} should authorize the warehouse prefix before publishing a relocated table"
+            );
+        }
+        assert!(
+            operation_block(src, "RestCommitTableHandler").contains("TABLE_WAREHOUSE_READ_ACTIONS"),
+            "table commits should require read access to manifest and data objects under the warehouse prefix"
         );
 
         let migration_block = operation_block(src, "GetTableCatalogMigrationHandler");
@@ -6446,6 +8001,34 @@ mod tests {
                 "{handler} must not imply that a global backing cutover is warehouse-scoped"
             );
         }
+
+        let rename_block = operation_block(src, "RestRenameTableHandler");
+        assert!(rename_block.contains("TableCatalogResource::table(&warehouse, &source_namespace, source_table.as_str())"));
+        assert!(
+            rename_block.contains("TableCatalogResource::table(&warehouse, &destination_namespace, destination_table.as_str())")
+        );
+        assert!(rename_block.contains("read_bounded_json_body::<RenameTableRequest>"));
+        assert!(rename_block.contains("RENAME_TABLE_BODY_MAX_SIZE"));
+        assert!(rename_block.contains("RENAME_TABLE_BODY_TIMEOUT"));
+        assert_eq!(
+            rename_block.matches("table_catalog_request_principal(&req).await?;").count(),
+            1,
+            "table rename should authenticate the request once"
+        );
+        assert_eq!(
+            rename_block
+                .matches("authorize_table_catalog_resource_for_principal(")
+                .count(),
+            2,
+            "table rename should authorize both the source and destination resources"
+        );
+        assert_eq!(rename_block.matches("AdminAction::SetTableAction").count(), 2);
+        assert!(!rename_block.contains("authorize_table_catalog_request(&req,"));
+
+        let namespace_properties_block = operation_block(src, "RestUpdateNamespacePropertiesHandler");
+        assert!(namespace_properties_block.contains("read_bounded_json_body::<UpdateNamespacePropertiesRequest>"));
+        assert!(namespace_properties_block.contains("NAMESPACE_PROPERTIES_BODY_MAX_SIZE"));
+        assert!(namespace_properties_block.contains("NAMESPACE_PROPERTIES_BODY_TIMEOUT"));
 
         for (handler, action) in [
             ("RestLoadTableHandler", "AdminAction::GetTableMetadataAction"),
@@ -6521,8 +8104,10 @@ mod tests {
             "RestCreateNamespaceHandler",
             "RestGetNamespaceHandler",
             "RestNamespaceExistsHandler",
+            "RestUpdateNamespacePropertiesHandler",
             "RestDropNamespaceHandler",
             "RestListTablesHandler",
+            "RestRenameTableHandler",
             "RestCreateTableHandler",
             "RestRegisterTableHandler",
             "RestListViewsHandler",
@@ -6615,11 +8200,65 @@ mod tests {
         &block[..end]
     }
 
+    #[test]
+    fn table_catalog_prefix_authorization_probe_is_an_unpredictable_descendant() {
+        let probe = table_catalog_prefix_authorization_probe("tables/existing/");
+        let suffix = probe
+            .strip_prefix("tables/existing/")
+            .expect("authorization probe should stay inside the warehouse prefix");
+        Uuid::parse_str(suffix).expect("authorization probe suffix should be a UUID");
+    }
+
+    #[tokio::test]
+    async fn table_catalog_prefix_authorization_probe_rejects_marker_only_policy() {
+        let marker_policy = Policy::parse_config(
+            br#"{
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": "s3:PutObject",
+                    "Resource": "arn:aws:s3:::warehouse/tables/existing/"
+                }]
+            }"#,
+        )
+        .expect("marker-only policy should parse");
+        let prefix_policy = Policy::parse_config(
+            br#"{
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": "s3:PutObject",
+                    "Resource": "arn:aws:s3:::warehouse/tables/existing/*"
+                }]
+            }"#,
+        )
+        .expect("prefix policy should parse");
+        let probe = table_catalog_prefix_authorization_probe("tables/existing/");
+        let groups = None;
+        let conditions = HashMap::new();
+        let claims = HashMap::new();
+        let args = rustfs_policy::policy::Args {
+            account: "testuser",
+            groups: &groups,
+            action: Action::S3Action(S3Action::PutObjectAction),
+            bucket: "warehouse",
+            conditions: &conditions,
+            is_owner: false,
+            object: &probe,
+            claims: &claims,
+            deny_only: false,
+        };
+
+        assert!(!marker_policy.is_allowed(&args).await);
+        assert!(prefix_policy.is_allowed(&args).await);
+    }
+
     fn function_block<'a>(src: &'a str, signature: &str) -> &'a str {
         let block = src.split_once(signature).expect("function should exist").1;
-        let end = block
-            .find("\nfn ")
-            .or_else(|| block.find("\nasync fn "))
+        let end = [block.find("\nfn "), block.find("\nasync fn ")]
+            .into_iter()
+            .flatten()
+            .min()
             .unwrap_or(block.len());
         &block[..end]
     }
@@ -6637,8 +8276,10 @@ mod tests {
         let _: &RestCreateNamespaceHandler = &CREATE_NAMESPACE_HANDLER;
         let _: &RestGetNamespaceHandler = &GET_NAMESPACE_HANDLER;
         let _: &RestNamespaceExistsHandler = &NAMESPACE_EXISTS_HANDLER;
+        let _: &RestUpdateNamespacePropertiesHandler = &UPDATE_NAMESPACE_PROPERTIES_HANDLER;
         let _: &RestDropNamespaceHandler = &DROP_NAMESPACE_HANDLER;
         let _: &RestListTablesHandler = &LIST_TABLES_HANDLER;
+        let _: &RestRenameTableHandler = &RENAME_TABLE_HANDLER;
         let _: &RestCreateTableHandler = &CREATE_TABLE_HANDLER;
         let _: &RestRegisterTableHandler = &REGISTER_TABLE_HANDLER;
         let _: &RestListViewsHandler = &LIST_VIEWS_HANDLER;
@@ -6679,8 +8320,10 @@ mod tests {
         assert_operation::<RestCreateNamespaceHandler>();
         assert_operation::<RestGetNamespaceHandler>();
         assert_operation::<RestNamespaceExistsHandler>();
+        assert_operation::<RestUpdateNamespacePropertiesHandler>();
         assert_operation::<RestDropNamespaceHandler>();
         assert_operation::<RestListTablesHandler>();
+        assert_operation::<RestRenameTableHandler>();
         assert_operation::<RestCreateTableHandler>();
         assert_operation::<RestRegisterTableHandler>();
         assert_operation::<RestListViewsHandler>();
@@ -6966,7 +8609,7 @@ mod tests {
             }
         }))
         .expect("request should parse");
-        let namespace = namespace_from_segments(&request.namespace).expect("namespace should be valid");
+        let namespace = namespace_from_segments(request.namespace.clone()).expect("namespace should be valid");
         let response = namespace_response_from_entry(crate::table_catalog::NamespaceEntry {
             version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
             table_bucket: "warehouse".to_string(),
@@ -6982,6 +8625,175 @@ mod tests {
         assert_eq!(namespace.public_name(), "analytics.daily_events");
         assert_eq!(response.namespace, vec!["analytics".to_string(), "daily_events".to_string()]);
         assert_eq!(response.properties.get("owner").map(String::as_str), Some("lakehouse"));
+        assert!(namespace_from_segments(vec!["analytics.daily_events".to_string()]).is_err());
+    }
+
+    #[test]
+    fn namespace_property_update_uses_standard_shape_and_rejects_overlap() {
+        let request: UpdateNamespacePropertiesRequest = serde_json::from_value(serde_json::json!({
+            "removals": ["retention"],
+            "updates": {
+                "owner": "platform"
+            }
+        }))
+        .expect("namespace property update should parse");
+        let update = namespace_properties_update_from_request(request).expect("disjoint property update should validate");
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let mut entry = crate::table_catalog::NamespaceEntry {
+            version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+            table_bucket: "warehouse".to_string(),
+            namespace: namespace.public_name(),
+            namespace_id: namespace.storage_id(),
+            state: crate::table_catalog::TableCatalogEntryState::Active,
+            properties: BTreeMap::from([("retention".to_string(), "30d".to_string())]),
+            created_at: None,
+            updated_at: None,
+        };
+        let result = update.apply_to(&mut entry);
+        assert_eq!(result.removed, vec!["retention".to_string()]);
+        assert_eq!(result.updated, vec!["owner".to_string()]);
+        assert_eq!(entry.properties.get("owner").map(String::as_str), Some("platform"));
+
+        let overlap: UpdateNamespacePropertiesRequest = serde_json::from_value(serde_json::json!({
+            "removals": ["owner"],
+            "updates": {
+                "owner": "platform"
+            }
+        }))
+        .expect("overlapping request should parse before semantic validation");
+        let error = namespace_properties_update_from_request(overlap).expect_err("overlapping property update should fail");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNPROCESSABLE_ENTITY.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::UNPROCESSABLE_ENTITY));
+
+        assert_rejects_unknown_field::<UpdateNamespacePropertiesRequest>(
+            "namespace property update request",
+            serde_json::json!({"updates": {}, "unknown": true}),
+        );
+    }
+
+    #[test]
+    fn rename_table_request_uses_standard_identifiers_and_strict_serde() {
+        let request: RenameTableRequest = serde_json::from_value(serde_json::json!({
+            "source": {
+                "namespace": ["sales"],
+                "name": "orders"
+            },
+            "destination": {
+                "namespace": ["curated"],
+                "name": "orders_v2"
+            }
+        }))
+        .expect("rename request should parse");
+        let (source_namespace, source_table) = table_identifier_from_request(request.source).expect("source should validate");
+        let (destination_namespace, destination_table) =
+            table_identifier_from_request(request.destination).expect("destination should validate");
+        assert_eq!(source_namespace.public_name(), "sales");
+        assert_eq!(source_table.as_str(), "orders");
+        assert_eq!(destination_namespace.public_name(), "curated");
+        assert_eq!(destination_table.as_str(), "orders_v2");
+
+        assert_rejects_unknown_field::<RenameTableRequest>(
+            "rename table request",
+            serde_json::json!({
+                "source": {"namespace": ["sales"], "name": "orders"},
+                "destination": {"namespace": ["curated"], "name": "orders_v2"},
+                "unknown": true
+            }),
+        );
+        assert_rejects_unknown_field::<RenameTableRequest>(
+            "rename table source identifier",
+            serde_json::json!({
+                "source": {"namespace": ["sales"], "name": "orders", "unknown": true},
+                "destination": {"namespace": ["curated"], "name": "orders_v2"}
+            }),
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_table_body_rejects_declared_and_streamed_oversize_payloads() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_LENGTH,
+            HeaderValue::from_str(&(RENAME_TABLE_BODY_MAX_SIZE + 1).to_string()).expect("content length should parse"),
+        );
+        let error = read_bounded_json_body::<RenameTableRequest>(
+            &headers,
+            Body::empty(),
+            RENAME_TABLE_BODY_MAX_SIZE,
+            RENAME_TABLE_BODY_TIMEOUT,
+            "rename table",
+        )
+        .await
+        .expect_err("oversized Content-Length should fail before reading the body");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+
+        let error = read_bounded_json_body::<RenameTableRequest>(
+            &HeaderMap::new(),
+            Body::from(vec![b'x'; RENAME_TABLE_BODY_MAX_SIZE + 1]),
+            RENAME_TABLE_BODY_MAX_SIZE,
+            RENAME_TABLE_BODY_TIMEOUT,
+            "rename table",
+        )
+        .await
+        .expect_err("oversized streamed body should fail");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "source": {
+                "namespace": ["sales"],
+                "name": "orders"
+            },
+            "destination": {
+                "namespace": ["curated"],
+                "name": "orders_v2"
+            }
+        }))
+        .expect("rename request should serialize");
+        let request = read_bounded_json_body::<RenameTableRequest>(
+            &HeaderMap::new(),
+            Body::from(body),
+            RENAME_TABLE_BODY_MAX_SIZE,
+            RENAME_TABLE_BODY_TIMEOUT,
+            "rename table",
+        )
+        .await
+        .expect("bounded rename request should parse");
+        assert_eq!(request.source.name, "orders");
+        assert_eq!(request.destination.name, "orders_v2");
+
+        let mut exact_limit_body = b"{}".to_vec();
+        exact_limit_body.resize(RENAME_TABLE_BODY_MAX_SIZE, b' ');
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_LENGTH,
+            HeaderValue::from_str(&RENAME_TABLE_BODY_MAX_SIZE.to_string()).expect("content length should parse"),
+        );
+        let value = read_bounded_json_body::<serde_json::Value>(
+            &headers,
+            Body::from(exact_limit_body),
+            RENAME_TABLE_BODY_MAX_SIZE,
+            RENAME_TABLE_BODY_TIMEOUT,
+            "rename table",
+        )
+        .await
+        .expect("a valid body exactly at the limit should parse");
+        assert!(value.is_object());
+    }
+
+    #[tokio::test]
+    async fn bounded_json_body_times_out_stalled_namespace_property_streams() {
+        let stream = futures::stream::pending::<Result<http_body::Frame<Bytes>, std::io::Error>>();
+        let error = read_bounded_json_body::<UpdateNamespacePropertiesRequest>(
+            &HeaderMap::new(),
+            Body::http_body(http_body_util::StreamBody::new(stream)),
+            NAMESPACE_PROPERTIES_BODY_MAX_SIZE,
+            StdDuration::ZERO,
+            "namespace properties",
+        )
+        .await
+        .expect_err("stalled namespace property request should time out");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
     }
 
     #[test]
@@ -7489,6 +9301,120 @@ mod tests {
         assert_eq!(request.requirements.len(), 1);
     }
 
+    #[tokio::test]
+    async fn commit_table_request_honors_standard_idempotency_header() {
+        let request_body = |body_key: Option<&str>| {
+            Body::from(
+                serde_json::to_vec(&serde_json::json!({
+                    "idempotency-key": body_key,
+                    "requirements": [],
+                    "updates": []
+                }))
+                .expect("commit request should serialize"),
+            )
+        };
+        let header_key = Uuid::now_v7().to_string();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            IDEMPOTENCY_KEY_HEADER,
+            HeaderValue::from_str(&header_key).expect("UUIDv7 header should parse"),
+        );
+
+        let request = read_rest_commit_table_request(&headers, request_body(None))
+            .await
+            .expect("standard Idempotency-Key header should parse");
+        assert_eq!(request.idempotency_key.as_deref(), Some(header_key.as_str()));
+
+        let request = read_rest_commit_table_request(&headers, request_body(Some(&header_key)))
+            .await
+            .expect("matching header and body keys should parse");
+        assert_eq!(request.idempotency_key.as_deref(), Some(header_key.as_str()));
+
+        let mismatch = read_rest_commit_table_request(&headers, request_body(Some("different-key")))
+            .await
+            .expect_err("mismatched header and body keys must fail");
+        assert_eq!(mismatch.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+        assert_eq!(mismatch.status_code(), Some(StatusCode::BAD_REQUEST));
+
+        let mut invalid_headers = HeaderMap::new();
+        invalid_headers.insert(
+            IDEMPOTENCY_KEY_HEADER,
+            HeaderValue::from_str(&Uuid::new_v4().to_string()).expect("UUIDv4 header should parse"),
+        );
+        let invalid = read_rest_commit_table_request(&invalid_headers, request_body(None))
+            .await
+            .expect_err("non-v7 idempotency keys must fail");
+        assert_eq!(invalid.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+        assert_eq!(invalid.status_code(), Some(StatusCode::BAD_REQUEST));
+
+        let mut repeated_headers = HeaderMap::new();
+        repeated_headers.append(
+            IDEMPOTENCY_KEY_HEADER,
+            HeaderValue::from_str(&header_key).expect("UUIDv7 header should parse"),
+        );
+        repeated_headers.append(
+            IDEMPOTENCY_KEY_HEADER,
+            HeaderValue::from_str(&Uuid::now_v7().to_string()).expect("UUIDv7 header should parse"),
+        );
+        let repeated = read_rest_commit_table_request(&repeated_headers, request_body(None))
+            .await
+            .expect_err("repeated idempotency headers must fail");
+        assert_eq!(repeated.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+        assert_eq!(repeated.status_code(), Some(StatusCode::BAD_REQUEST));
+    }
+
+    #[test]
+    fn commit_requests_accept_legacy_empty_defaults_and_reject_unsupported_view_commit_ids() {
+        let table = serde_json::from_value::<RestCommitTableRequest>(serde_json::json!({}))
+            .expect("legacy table commit should default omitted requirements and updates");
+        assert!(table.requirements.is_empty());
+        assert!(table.updates.is_empty());
+        let view = serde_json::from_value::<RestCommitViewRequest>(serde_json::json!({}))
+            .expect("legacy view commit should default omitted requirements and updates");
+        assert!(view.requirements.is_empty());
+        assert!(view.updates.is_empty());
+        assert!(
+            serde_json::from_value::<RestCommitViewRequest>(serde_json::json!({
+                "commit-id": "non-standard-extension",
+                "requirements": [],
+                "updates": []
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn unsupported_create_and_register_modes_return_iceberg_errors() {
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let register_error = table_entry_from_register_request(
+            "warehouse",
+            &namespace,
+            RegisterTableRequest {
+                name: "events".to_string(),
+                metadata_location: "s3://warehouse/metadata/00001.metadata.json".to_string(),
+                overwrite: true,
+            },
+        )
+        .expect_err("register overwrite should remain unsupported");
+        assert_eq!(register_error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(register_error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+
+        let create_request: CreateTableRequest = serde_json::from_value(serde_json::json!({
+            "name": "events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            },
+            "stage-create": true
+        }))
+        .expect("stage-create request should parse");
+        let create_error = table_entry_from_create_table_request("warehouse", &namespace, create_request)
+            .expect_err("staged create should remain unsupported");
+        assert_eq!(create_error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(create_error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+    }
+
     #[test]
     fn standard_commit_ids_use_uuid_for_metadata_file_when_provided() {
         let commit_id = "11111111-1111-4111-8111-111111111111";
@@ -7581,6 +9507,128 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_table_response_holds_initial_metadata_lock_until_catalog_publish() {
+        let pause = TestCatalogPublishPause::default();
+        let store = Arc::new(TestTableCatalogStore {
+            create_table_pause: Some(pause.clone()),
+            ..Default::default()
+        });
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(store.as_ref(), "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            store.as_ref(),
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        let request = serde_json::from_value(serde_json::json!({
+            "name": "events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            }
+        }))
+        .expect("create table request should parse");
+        let create_store = Arc::clone(&store);
+        let create_backend = metadata_backend.clone();
+        let create_namespace = namespace.clone();
+        let create = tokio::spawn(async move {
+            create_table_response(create_store.as_ref(), &create_backend, "warehouse", &create_namespace, request, true).await
+        });
+
+        pause.wait_started().await;
+        let metadata_location = metadata_backend
+            .objects
+            .lock()
+            .await
+            .keys()
+            .find(|(bucket, _)| bucket == "warehouse")
+            .map(|(_, object)| object.clone())
+            .expect("initial metadata object should exist before catalog publish");
+        assert!(metadata_backend.write_lock_is_held("warehouse", &metadata_location).await);
+
+        pause.release();
+        create
+            .await
+            .expect("create task should join")
+            .expect("table creation should succeed");
+        assert!(!metadata_backend.write_lock_is_held("warehouse", &metadata_location).await);
+    }
+
+    #[tokio::test]
+    async fn create_view_response_holds_initial_metadata_lock_until_catalog_publish() {
+        let pause = TestCatalogPublishPause::default();
+        let store = Arc::new(TestTableCatalogStore {
+            create_view_pause: Some(pause.clone()),
+            ..Default::default()
+        });
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(store.as_ref(), "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            store.as_ref(),
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        let request = serde_json::from_value(serde_json::json!({
+            "name": "recent_events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            },
+            "view-version": {
+                "version-id": 1,
+                "schema-id": 0,
+                "summary": {},
+                "representations": []
+            }
+        }))
+        .expect("create view request should parse");
+        let create_store = Arc::clone(&store);
+        let create_backend = metadata_backend.clone();
+        let create_namespace = namespace.clone();
+        let create = tokio::spawn(async move {
+            create_view_response(create_store.as_ref(), &create_backend, "warehouse", &create_namespace, request, true).await
+        });
+
+        pause.wait_started().await;
+        let metadata_location = metadata_backend
+            .objects
+            .lock()
+            .await
+            .keys()
+            .find(|(bucket, _)| bucket == "warehouse")
+            .map(|(_, object)| object.clone())
+            .expect("initial view metadata object should exist before catalog publish");
+        assert!(metadata_backend.write_lock_is_held("warehouse", &metadata_location).await);
+
+        pause.release();
+        create
+            .await
+            .expect("create task should join")
+            .expect("view creation should succeed");
+        assert!(!metadata_backend.write_lock_is_held("warehouse", &metadata_location).await);
+    }
+
+    #[tokio::test]
     async fn create_table_response_recreates_dropped_identifier_without_overwriting_retained_metadata() {
         let store = TestTableCatalogStore::default();
         let metadata_backend = TestTableCatalogObjectBackend::default();
@@ -7598,6 +9646,7 @@ mod tests {
             .expect("first metadata should exist");
 
         let commit_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "set-properties",
@@ -7696,6 +9745,7 @@ mod tests {
         let metadata_backend = TestTableCatalogObjectBackend {
             objects: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
             put_object_barrier: Some(Arc::new(tokio::sync::Barrier::new(2))),
+            ..Default::default()
         };
         let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
         ensure_table_bucket_entry(&store, "warehouse", true)
@@ -7889,6 +9939,7 @@ mod tests {
         let commit_id = "11111111-1111-4111-8111-111111111111";
         let commit_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
             "commit-id": commit_id,
+            "requirements": [],
             "updates": [
                 {
                     "action": "set-properties",
@@ -7930,6 +9981,7 @@ mod tests {
 
         let commit_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
             "commit-id": "commit-1",
+            "requirements": [],
             "updates": [
                 {
                     "action": "set-properties",
@@ -7958,6 +10010,172 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn catalog_backings_replay_old_standard_commit_with_current_table_state() {
+        for mode in [
+            crate::table_catalog::TableCatalogBackingMode::ObjectBacked,
+            crate::table_catalog::TableCatalogBackingMode::DurableStrong,
+        ] {
+            let metadata_backend = TestTableCatalogObjectBackend::default();
+            let store = crate::table_catalog::ConfiguredTableCatalogStore::new(metadata_backend.clone(), mode);
+            let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+            let created = create_standard_events_table(&store, &metadata_backend, &namespace).await;
+            let original_warehouse_location = created.metadata["location"]
+                .as_str()
+                .expect("created metadata should have a warehouse location")
+                .to_string();
+            let first_request = serde_json::json!({
+                "commit-id": "commit-a",
+                "idempotency-key": "request-a",
+                "writer": "test-client",
+                "requirements": [],
+                "updates": [{
+                    "action": "set-location",
+                    "location": "s3://warehouse/tables/relocated-events"
+                }]
+            });
+            standard_commit_table_response(
+                &store,
+                &metadata_backend,
+                "warehouse",
+                &namespace,
+                "events",
+                serde_json::from_value(first_request.clone()).expect("first commit request should parse"),
+            )
+            .await
+            .expect("first commit should relocate the table");
+
+            let second = standard_commit_table_response(
+                &store,
+                &metadata_backend,
+                "warehouse",
+                &namespace,
+                "events",
+                serde_json::from_value(serde_json::json!({
+                    "commit-id": "commit-b",
+                    "idempotency-key": "request-b",
+                    "requirements": [],
+                    "updates": [{
+                        "action": "set-properties",
+                        "updates": {
+                            "owner": "current"
+                        }
+                    }]
+                }))
+                .expect("second commit request should parse"),
+            )
+            .await
+            .expect("second commit should advance the table");
+            let current = store
+                .load_table("warehouse", "analytics", "events")
+                .await
+                .expect("current table lookup should succeed")
+                .expect("current table should exist");
+            let retry: RestCommitTableRequest = serde_json::from_value(first_request).expect("first commit retry should parse");
+
+            let read_location = table_commit_warehouse_read_location(&store, &metadata_backend, "warehouse", &current, &retry)
+                .await
+                .expect("retry read scope should resolve");
+            assert_eq!(read_location, original_warehouse_location, "{mode:?}");
+
+            let replay = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", retry)
+                .await
+                .expect("an exact old commit retry should succeed");
+
+            assert_eq!(replay.commit_id, "commit-a", "{mode:?}");
+            assert_eq!(replay.metadata_location, second.metadata_location, "{mode:?}");
+            assert_eq!(replay.version_token, second.version_token, "{mode:?}");
+            assert_eq!(replay.generation, second.generation, "{mode:?}");
+            assert_eq!(replay.metadata["properties"]["owner"], "current", "{mode:?}");
+            let unchanged = store
+                .load_table("warehouse", "analytics", "events")
+                .await
+                .expect("table lookup after replay should succeed")
+                .expect("table should remain present");
+            assert_eq!(unchanged.metadata_location, current.metadata_location, "{mode:?}");
+            assert_eq!(unchanged.version_token, current.version_token, "{mode:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_replay_legacy_commit_against_original_requirements() {
+        for mode in [
+            crate::table_catalog::TableCatalogBackingMode::ObjectBacked,
+            crate::table_catalog::TableCatalogBackingMode::DurableStrong,
+        ] {
+            let metadata_backend = TestTableCatalogObjectBackend::default();
+            let store = crate::table_catalog::ConfiguredTableCatalogStore::new(metadata_backend.clone(), mode);
+            let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+            let created = create_standard_events_table(&store, &metadata_backend, &namespace).await;
+            let current = store
+                .load_table("warehouse", "analytics", "events")
+                .await
+                .expect("current table lookup should succeed")
+                .expect("current table should exist");
+            let target_location = crate::table_catalog::table_metadata_file_path_for_entry(
+                &current,
+                "00002-11111111-1111-4111-8111-111111111111.metadata.json",
+            )
+            .expect("target metadata path should resolve");
+            let mut target_metadata = created.metadata.clone();
+            target_metadata["schemas"]
+                .as_array_mut()
+                .expect("schemas should be an array")
+                .push(serde_json::json!({
+                    "type": "struct",
+                    "schema-id": 1,
+                    "fields": []
+                }));
+            target_metadata["current-schema-id"] = serde_json::Value::from(1);
+            target_metadata["last-updated-ms"] = serde_json::Value::from(current_time_millis());
+            metadata_backend
+                .put_json("warehouse", &target_location, target_metadata)
+                .await;
+            let request = serde_json::json!({
+                "idempotency-key": "legacy-request",
+                "operation": "schema-update",
+                "expected-version-token": current.version_token,
+                "expected-metadata-location": current.metadata_location,
+                "new-metadata-location": target_location,
+                "requirements": [{
+                    "type": "assert-current-schema-id",
+                    "current-schema-id": 0
+                }],
+                "updates": [],
+                "writer": "test-client"
+            });
+
+            let committed = commit_table_response(
+                &store,
+                &metadata_backend,
+                "warehouse",
+                &namespace,
+                "events",
+                serde_json::from_value(request.clone()).expect("legacy commit request should parse"),
+            )
+            .await
+            .expect("legacy commit should succeed");
+            assert_eq!(committed.metadata["current-schema-id"], 1, "{mode:?}");
+
+            let replay = commit_table_response(
+                &store,
+                &metadata_backend,
+                "warehouse",
+                &namespace,
+                "events",
+                serde_json::from_value(request).expect("legacy retry should parse"),
+            )
+            .await
+            .expect("legacy retry should validate requirements against the original base");
+
+            assert_eq!(replay.commit_id, committed.commit_id, "{mode:?}");
+            assert_eq!(replay.metadata_location, committed.metadata_location, "{mode:?}");
+            assert_eq!(replay.version_token, committed.version_token, "{mode:?}");
+            assert_eq!(replay.generation, committed.generation, "{mode:?}");
+            assert_eq!(replay.metadata["current-schema-id"], 1, "{mode:?}");
+        }
+    }
+
+    #[tokio::test]
     async fn standard_commit_ignores_generation_only_orphan_metadata_file() {
         let store = TestTableCatalogStore::default();
         let metadata_backend = TestTableCatalogObjectBackend::default();
@@ -7978,6 +10196,7 @@ mod tests {
         let commit_id = "22222222-2222-4222-8222-222222222222";
         let commit_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
             "commit-id": commit_id,
+            "requirements": [],
             "updates": [
                 {
                     "action": "set-properties",
@@ -8010,11 +10229,13 @@ mod tests {
         let metadata_backend = TestTableCatalogObjectBackend {
             objects: Arc::clone(&metadata_backend.objects),
             put_object_barrier: Some(barrier),
+            ..Default::default()
         };
         let first_commit_id = "33333333-3333-4333-8333-333333333333";
         let second_commit_id = "44444444-4444-4444-8444-444444444444";
         let first_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
             "commit-id": first_commit_id,
+            "requirements": [],
             "updates": [
                 {
                     "action": "set-properties",
@@ -8027,6 +10248,7 @@ mod tests {
         .expect("first standard commit table request should parse");
         let second_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
             "commit-id": second_commit_id,
+            "requirements": [],
             "updates": [
                 {
                     "action": "set-properties",
@@ -8114,6 +10336,7 @@ mod tests {
             .await;
 
         let commit_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "set-properties",
@@ -8205,6 +10428,9 @@ mod tests {
                 commit_id: Some("commit-1".to_string()),
                 idempotency_key: None,
             },
+            read_table_metadata_json(&metadata_backend, "warehouse", next_location)
+                .await
+                .expect("target metadata should load"),
         )
         .await
         .expect("legacy catalog uuid should not block metadata-location update");
@@ -8232,6 +10458,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "current-snapshot-id": 20,
                     "metadata-log": [],
                     "snapshots": [
@@ -8399,11 +10626,26 @@ mod tests {
                     "last-sequence-number": 2,
                     "last-updated-ms": 2000,
                     "last-column-id": 1,
-                    "schemas": [],
+                    "schemas": [{
+                        "type": "struct",
+                        "schema-id": 0,
+                        "fields": [{
+                            "id": 1,
+                            "name": "id",
+                            "required": true,
+                            "type": "long"
+                        }]
+                    }],
                     "current-schema-id": 0,
-                    "partition-specs": [],
+                    "partition-specs": [{
+                        "spec-id": 0,
+                        "fields": []
+                    }],
                     "default-spec-id": 0,
-                    "sort-orders": [],
+                    "sort-orders": [{
+                        "order-id": 0,
+                        "fields": []
+                    }],
                     "default-sort-order-id": 0,
                     "current-snapshot-id": 20,
                     "metadata-log": [],
@@ -9000,6 +11242,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn external_catalog_bridge_sync_does_not_register_after_captured_table_is_dropped() {
+        let backend = TestTableCatalogObjectBackend::default();
+        let store = crate::table_catalog::ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "warehouse";
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let table = crate::table_catalog::IdentifierSegment::parse("events").expect("table should parse");
+        let current_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let next_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        seed_object_table_for_metadata_maintenance(&store, &backend, bucket, &namespace, &table, current_location.clone()).await;
+        let target_metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "table-uuid",
+            "location": "s3://warehouse/tables/table-id"
+        });
+        backend.put_json(bucket, &next_location, target_metadata.clone()).await;
+        let captured_current = store
+            .load_table(bucket, "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist before the race");
+        store
+            .drop_table(bucket, "analytics", "events")
+            .await
+            .expect("concurrent table drop should succeed");
+
+        let result = sync_external_catalog_bridge_response_with_snapshot(
+            &store,
+            &backend,
+            bucket,
+            &namespace,
+            "events",
+            ExternalCatalogBridgeSyncSnapshot {
+                request: ExternalCatalogBridgeSyncRequest {
+                    catalog: "glue".to_string(),
+                    external_catalog_id: Some("aws-glue-prod".to_string()),
+                    external_namespace: "sales".to_string(),
+                    external_table: "orders".to_string(),
+                    external_table_uuid: Some("table-uuid".to_string()),
+                    metadata_location: next_location,
+                    external_version_token: Some("glue-version-2".to_string()),
+                    expected_version_token: Some(captured_current.version_token.clone()),
+                    expected_metadata_location: Some(captured_current.metadata_location.clone()),
+                    commit_id: Some("external-sync-race".to_string()),
+                    idempotency_key: Some("external-sync-race-request".to_string()),
+                    policy_mode: Some("rustfs-authoritative".to_string()),
+                    credential_mode: Some("rustfs-table-credentials".to_string()),
+                    rollback_strategy: Some("retain-current-pointer".to_string()),
+                    properties: BTreeMap::new(),
+                },
+                target_metadata,
+                current: Some(captured_current),
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            store
+                .load_table(bucket, "analytics", "events")
+                .await
+                .expect("table lookup should succeed")
+                .is_none(),
+            "sync must not fall back to registration after the authorized table state changes"
+        );
+    }
+
+    #[tokio::test]
     async fn external_catalog_bridge_sync_conflicts_leave_pointer_unchanged() {
         let backend = TestTableCatalogObjectBackend::default();
         let store = crate::table_catalog::ObjectTableCatalogStore::new(backend.clone());
@@ -9110,6 +11419,198 @@ mod tests {
     }
 
     #[test]
+    fn table_commit_rejects_refs_to_missing_snapshots() {
+        let metadata = serde_json::json!({
+            "current-snapshot-id": 10,
+            "snapshots": [
+                {
+                    "snapshot-id": 10,
+                    "sequence-number": 1,
+                    "timestamp-ms": 1234,
+                    "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-10.avro",
+                    "summary": {
+                        "operation": "append"
+                    }
+                }
+            ],
+            "refs": {
+                "main": {
+                    "snapshot-id": 10,
+                    "type": "branch"
+                }
+            },
+            "metadata-log": []
+        });
+        let updates = vec![serde_json::json!({
+            "action": "set-snapshot-ref",
+            "ref-name": "main",
+            "snapshot-id": 999,
+            "type": "branch"
+        })];
+
+        let error = apply_table_commit_updates(metadata, &updates, "s3://warehouse/tables/table-id/metadata/v1.metadata.json")
+            .expect_err("a snapshot ref must not target a missing snapshot");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn table_commit_rejects_dangling_schema_spec_and_sort_order_ids() {
+        let metadata = serde_json::json!({
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+            "current-schema-id": 0,
+            "partition-specs": [{"spec-id": 0, "fields": []}],
+            "default-spec-id": 0,
+            "sort-orders": [{"order-id": 0, "fields": []}],
+            "default-sort-order-id": 0,
+            "metadata-log": []
+        });
+        let updates = [
+            serde_json::json!({"action": "set-current-schema", "schema-id": 999}),
+            serde_json::json!({"action": "set-default-spec", "spec-id": 999}),
+            serde_json::json!({"action": "set-default-sort-order", "sort-order-id": 999}),
+        ];
+
+        for update in updates {
+            let error = apply_table_commit_updates(
+                metadata.clone(),
+                &[update],
+                "s3://warehouse/tables/table-id/metadata/v1.metadata.json",
+            )
+            .expect_err("a current or default id must reference existing metadata");
+
+            assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        }
+    }
+
+    #[test]
+    fn table_metadata_reference_validation_rejects_malformed_typed_fields() {
+        let metadata = serde_json::json!({
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+            "current-schema-id": 0,
+            "snapshots": [{"snapshot-id": 10, "schema-id": 0}],
+            "current-snapshot-id": 10,
+            "refs": {
+                "main": {
+                    "snapshot-id": 10,
+                    "type": "branch"
+                }
+            }
+        });
+        let cases = [
+            ("current-snapshot-id", serde_json::json!("10"), "current-snapshot-id must be an integer"),
+            ("refs", serde_json::json!([]), "refs must be an object"),
+        ];
+
+        for (field, value, expected_message) in cases {
+            let mut malformed = metadata.clone();
+            malformed[field] = value;
+            let error =
+                validate_table_metadata_references(&malformed).expect_err("malformed table metadata field must be rejected");
+            assert_eq!(error.message(), Some(expected_message));
+        }
+
+        let mut malformed_snapshot_schema = metadata;
+        malformed_snapshot_schema["snapshots"][0]["schema-id"] = serde_json::json!("0");
+        let error = validate_table_metadata_references(&malformed_snapshot_schema)
+            .expect_err("a malformed snapshot schema-id must be rejected");
+        assert_eq!(error.message(), Some("snapshot schema-id must be an integer"));
+
+        let metadata_without_current_snapshot = serde_json::json!({
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+            "current-schema-id": 0,
+            "snapshots": [],
+            "current-snapshot-id": null,
+            "refs": null
+        });
+        validate_table_metadata_references(&metadata_without_current_snapshot)
+            .expect("Iceberg null snapshot fields should represent a table without a current snapshot");
+    }
+
+    #[test]
+    fn view_commit_rejects_a_dangling_current_version_id() {
+        let metadata = serde_json::json!({
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+            "current-schema-id": 0,
+            "versions": [{"version-id": 1, "schema-id": 0, "representations": []}],
+            "current-version-id": 1,
+            "version-log": [],
+            "metadata-log": []
+        });
+
+        let error = apply_view_commit_updates_at(
+            metadata,
+            &[serde_json::json!({
+                "action": "set-current-view-version",
+                "view-version-id": 999
+            })],
+            "s3://warehouse/views/analytics/recent_events/metadata/v1.metadata.json",
+            0,
+        )
+        .expect_err("the current view version must exist");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn view_commit_rejects_unsupported_format_version_upgrade() {
+        let metadata = serde_json::json!({
+            "format-version": 1,
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+            "current-schema-id": 0,
+            "versions": [{"version-id": 1, "schema-id": 0, "representations": []}],
+            "current-version-id": 1,
+            "version-log": [],
+            "metadata-log": []
+        });
+
+        let error = apply_view_commit_updates_at(
+            metadata,
+            &[serde_json::json!({
+                "action": "upgrade-format-version",
+                "format-version": 2
+            })],
+            "s3://warehouse/views/analytics/recent_events/metadata/v1.metadata.json",
+            0,
+        )
+        .expect_err("Iceberg view format-version 2 is unsupported");
+
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+    }
+
+    #[test]
+    fn commit_identifier_must_match_the_resource_url() {
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let matching = RestTableIdentifier {
+            namespace: vec!["analytics".to_string()],
+            name: "events".to_string(),
+        };
+        validate_rest_commit_identifier(Some(&matching), &namespace, "events").expect("matching identifier should be accepted");
+
+        let wrong_namespace = RestTableIdentifier {
+            namespace: vec!["staging".to_string()],
+            name: "events".to_string(),
+        };
+        let wrong_name = RestTableIdentifier {
+            namespace: vec!["analytics".to_string()],
+            name: "other".to_string(),
+        };
+        assert_eq!(
+            validate_rest_commit_identifier(Some(&wrong_namespace), &namespace, "events")
+                .expect_err("namespace mismatch should fail")
+                .code(),
+            &S3ErrorCode::InvalidRequest
+        );
+        assert_eq!(
+            validate_rest_commit_identifier(Some(&wrong_name), &namespace, "events")
+                .expect_err("name mismatch should fail")
+                .code(),
+            &S3ErrorCode::InvalidRequest
+        );
+    }
+
+    #[test]
     fn snapshot_conflict_rejects_stale_parent_or_sequence_number() {
         let metadata = serde_json::json!({
             "current-snapshot-id": 10,
@@ -9217,6 +11718,7 @@ mod tests {
         )
         .await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9324,6 +11826,7 @@ mod tests {
         let data_file = format!("{table_location}/data/part-10.parquet");
         seed_test_manifest(&metadata_backend, "warehouse", &manifest, &[(&data_file, 0, 1, 10, 1)]).await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9423,6 +11926,7 @@ mod tests {
         seed_test_manifest_with_nullable_sequences(&metadata_backend, "warehouse", &manifest, &[(&data_file, 0, 1, 10, None)])
             .await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9469,6 +11973,7 @@ mod tests {
         seed_test_manifest_list(&metadata_backend, "warehouse", &first_manifest_list, &[&first_manifest], 1, 10).await;
         seed_test_manifest(&metadata_backend, "warehouse", &first_manifest, &[(&first_data_file, 0, 1, 10, 1)]).await;
         let first_append: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9561,6 +12066,7 @@ mod tests {
         seed_test_manifest_list(&metadata_backend, "warehouse", &first_manifest_list, &[&first_manifest], 1, 10).await;
         seed_test_manifest(&metadata_backend, "warehouse", &first_manifest, &[(&first_data_file, 0, 1, 10, 1)]).await;
         let first_append: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9654,6 +12160,7 @@ mod tests {
         seed_test_manifest_list(&metadata_backend, "warehouse", &manifest_list, &[&manifest], 1, 11).await;
         seed_test_manifest(&metadata_backend, "warehouse", &manifest, &[(&data_file, 0, 1, 11, 1)]).await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9706,6 +12213,7 @@ mod tests {
         seed_test_manifest_list(&metadata_backend, "warehouse", &manifest_list, &[&manifest], 2, 11).await;
         seed_test_manifest(&metadata_backend, "warehouse", &manifest, &[(&data_file, 0, 1, 11, 1)]).await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9758,6 +12266,7 @@ mod tests {
         seed_test_manifest_list(&metadata_backend, "warehouse", &manifest_list, &[&manifest], 2, 11).await;
         seed_test_manifest(&metadata_backend, "warehouse", &manifest, &[(&data_file, 0, 1, 10, 1)]).await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9811,6 +12320,7 @@ mod tests {
         )
         .await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -9908,6 +12418,7 @@ mod tests {
         )
         .await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -10010,6 +12521,7 @@ mod tests {
         let delete_file = format!("{table_location}/delete/delete-10.parquet");
         seed_test_snapshot_manifest(&metadata_backend, "warehouse", &manifest_list, 10, 1, &[(&delete_file, 1, 1, 10, 1)]).await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -10063,6 +12575,7 @@ mod tests {
         )
         .await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -10155,6 +12668,7 @@ mod tests {
         )
         .await;
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -10249,6 +12763,73 @@ mod tests {
         })];
 
         assert!(apply_table_commit_updates(metadata, &updates, "metadata/00001.metadata.json").is_err());
+    }
+
+    #[test]
+    fn table_updates_apply_standard_statistics_cleanup_and_encryption_actions() {
+        let metadata = serde_json::json!({
+            "schemas": [
+                {"type": "struct", "schema-id": 0, "fields": []},
+                {"type": "struct", "schema-id": 1, "fields": []}
+            ],
+            "current-schema-id": 0,
+            "partition-specs": [
+                {"spec-id": 0, "fields": []},
+                {"spec-id": 1, "fields": []}
+            ],
+            "default-spec-id": 0,
+            "sort-orders": [{"order-id": 0, "fields": []}],
+            "default-sort-order-id": 0,
+            "snapshots": [{"snapshot-id": 10, "schema-id": 0}],
+            "current-snapshot-id": 10,
+            "refs": {"main": {"type": "branch", "snapshot-id": 10}},
+            "metadata-log": []
+        });
+        let updates = vec![
+            serde_json::json!({
+                "action": "set-statistics",
+                "statistics": {
+                    "snapshot-id": 10,
+                    "statistics-path": "s3://warehouse/tables/table-id/metadata/stats.puffin"
+                }
+            }),
+            serde_json::json!({
+                "action": "set-partition-statistics",
+                "partition-statistics": {
+                    "snapshot-id": 10,
+                    "statistics-path": "s3://warehouse/tables/table-id/metadata/partition-stats.parquet"
+                }
+            }),
+            serde_json::json!({"action": "remove-partition-specs", "spec-ids": [1]}),
+            serde_json::json!({"action": "remove-schemas", "schema-ids": [1]}),
+            serde_json::json!({
+                "action": "add-encryption-key",
+                "encryption-key": {"key-id": "key-1", "encrypted-key-metadata": "AQID"}
+            }),
+        ];
+
+        let updated = apply_table_commit_updates_at(metadata, &updates, "metadata/00001.metadata.json", 100)
+            .expect("standard table updates should apply");
+        assert_eq!(updated["statistics"][0]["snapshot-id"], 10);
+        assert_eq!(updated["partition-statistics"][0]["snapshot-id"], 10);
+        assert_eq!(updated["partition-specs"].as_array().map(Vec::len), Some(1));
+        assert_eq!(updated["schemas"].as_array().map(Vec::len), Some(1));
+        assert_eq!(updated["encryption-keys"][0]["key-id"], "key-1");
+
+        let removed = apply_table_commit_updates_at(
+            updated,
+            &[
+                serde_json::json!({"action": "remove-statistics", "snapshot-id": 10}),
+                serde_json::json!({"action": "remove-partition-statistics", "snapshot-id": 10}),
+                serde_json::json!({"action": "remove-encryption-key", "key-id": "key-1"}),
+            ],
+            "metadata/00002.metadata.json",
+            101,
+        )
+        .expect("standard table removals should apply");
+        assert!(removed["statistics"].as_array().is_some_and(Vec::is_empty));
+        assert!(removed["partition-statistics"].as_array().is_some_and(Vec::is_empty));
+        assert!(removed["encryption-keys"].as_array().is_some_and(Vec::is_empty));
     }
 
     #[test]
@@ -10352,6 +12933,39 @@ mod tests {
             .expect("view metadata location should not inherit table warehouse index depth limits");
     }
 
+    #[test]
+    fn create_view_rejects_versions_with_unknown_schemas() {
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let request: CreateViewRequest = serde_json::from_value(serde_json::json!({
+            "name": "recent_events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            },
+            "view-version": {
+                "version-id": 1,
+                "schema-id": 99,
+                "summary": {
+                    "engine-name": "spark"
+                },
+                "default-catalog": "warehouse",
+                "default-namespace": ["analytics"],
+                "representations": [{
+                    "type": "sql",
+                    "sql": "SELECT 1",
+                    "dialect": "spark"
+                }]
+            }
+        }))
+        .expect("view request should parse");
+
+        let error = view_entry_from_create_view_request("warehouse", &namespace, request)
+            .expect_err("view versions must reference a declared schema");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(error.status_code(), Some(StatusCode::BAD_REQUEST));
+    }
+
     #[tokio::test]
     async fn view_catalog_responses_persist_replace_and_drop_view_metadata() {
         let store = TestTableCatalogStore::default();
@@ -10411,9 +13025,11 @@ mod tests {
         assert_eq!(created.metadata["format-version"], 1);
         assert_eq!(created.metadata["current-version-id"], 1);
         assert_eq!(created.metadata["versions"][0]["representations"][0]["dialect"], "spark");
+        let created_metadata_key = table_metadata_location_for_catalog("warehouse", &created.metadata_location)
+            .expect("client metadata location should map to the catalog object key");
         assert!(
             metadata_backend
-                .object_exists("warehouse", &created.metadata_location)
+                .object_exists("warehouse", &created_metadata_key)
                 .await
                 .expect("view metadata object lookup should succeed")
         );
@@ -10429,8 +13045,18 @@ mod tests {
             .await
             .expect("view should load");
         assert_eq!(loaded.metadata_location, created.metadata_location);
+        let view_uuid = created.metadata["view-uuid"].clone();
         let replace_request: RestCommitViewRequest = serde_json::from_value(serde_json::json!({
+            "identifier": {
+                "namespace": ["analytics"],
+                "name": "recent_events"
+            },
+            "expected-metadata-location": created.metadata_location,
             "updates": [
+                {
+                    "action": "assign-uuid",
+                    "uuid": view_uuid
+                },
                 {
                     "action": "add-view-version",
                     "view-version": {
@@ -10463,12 +13089,79 @@ mod tests {
                 .expect("view should replace");
         assert_ne!(replaced.metadata_location, created.metadata_location);
         assert_eq!(replaced.metadata["current-version-id"], 2);
+        assert_eq!(replaced.metadata["view-uuid"], created.metadata["view-uuid"]);
+        assert!(replaced.metadata.get("table-uuid").is_none());
+        assert_eq!(replaced.metadata["metadata-log"][0]["metadata-file"], created.metadata_location);
         assert_eq!(
             replaced.metadata["version-log"]
                 .as_array()
                 .expect("version log should be an array")
                 .len(),
             2
+        );
+
+        let current = store
+            .load_view("warehouse", "analytics", "recent_events")
+            .await
+            .expect("view lookup should succeed")
+            .expect("view should exist");
+        let explicit_metadata_location =
+            ".rustfs-table/warehouses/default/namespaces/analytics/views/recent_events/metadata/00003.metadata.json";
+        let mut unsupported_metadata = replaced.metadata.clone();
+        unsupported_metadata["format-version"] = serde_json::Value::from(2);
+        metadata_backend
+            .put_json("warehouse", explicit_metadata_location, unsupported_metadata)
+            .await;
+        let unsupported_replace_request: RestCommitViewRequest = serde_json::from_value(serde_json::json!({
+            "expected-version-token": current.version_token,
+            "expected-metadata-location": replaced.metadata_location,
+            "new-metadata-location": table_metadata_location_for_client("warehouse", explicit_metadata_location),
+            "updates": []
+        }))
+        .expect("unsupported metadata replace request should parse");
+        let error = replace_view_response(
+            &store,
+            &metadata_backend,
+            "warehouse",
+            &namespace,
+            "recent_events",
+            unsupported_replace_request,
+        )
+        .await
+        .expect_err("external view metadata must use format version 1");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+        let unchanged = store
+            .load_view("warehouse", "analytics", "recent_events")
+            .await
+            .expect("view lookup should succeed")
+            .expect("view should remain present");
+        assert_eq!(unchanged.version_token, current.version_token);
+        assert_eq!(unchanged.metadata_location, current.metadata_location);
+
+        metadata_backend
+            .put_json("warehouse", explicit_metadata_location, replaced.metadata.clone())
+            .await;
+        let explicit_replace_request: RestCommitViewRequest = serde_json::from_value(serde_json::json!({
+            "expected-version-token": current.version_token,
+            "expected-metadata-location": replaced.metadata_location,
+            "new-metadata-location": table_metadata_location_for_client("warehouse", explicit_metadata_location),
+            "updates": []
+        }))
+        .expect("explicit metadata replace request should parse");
+        let explicitly_replaced = replace_view_response(
+            &store,
+            &metadata_backend,
+            "warehouse",
+            &namespace,
+            "recent_events",
+            explicit_replace_request,
+        )
+        .await
+        .expect("client metadata locations should map to catalog object keys");
+        assert_eq!(
+            explicitly_replaced.metadata_location,
+            table_metadata_location_for_client("warehouse", explicit_metadata_location)
         );
 
         drop_view_in_store(&store, "warehouse", &namespace, "recent_events")
@@ -10518,6 +13211,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_responses_reject_persisted_metadata_pointers_outside_protected_roots() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        create_standard_events_table(&store, &metadata_backend, &namespace).await;
+        store.tables.lock().await[0].metadata_location = "outside/table.metadata.json".to_string();
+        metadata_backend
+            .put_json("warehouse", "outside/table.metadata.json", serde_json::json!({}))
+            .await;
+
+        let table_error = load_table_response(&store, &metadata_backend, "warehouse", &namespace, "events")
+            .await
+            .expect_err("table metadata outside the protected root should fail closed");
+        assert_eq!(table_error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_REST.into()));
+        assert_eq!(table_error.status_code(), Some(StatusCode::INTERNAL_SERVER_ERROR));
+
+        let view = crate::table_catalog::IdentifierSegment::parse("recent_events").expect("view should parse");
+        store.views.lock().await.push(crate::table_catalog::ViewEntry {
+            version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+            table_bucket: "warehouse".to_string(),
+            namespace: namespace.public_name(),
+            view: view.as_str().to_string(),
+            view_id: "view-id".to_string(),
+            view_uuid: "view-uuid".to_string(),
+            format: "ICEBERG_VIEW".to_string(),
+            format_version: 1,
+            warehouse_location: "s3://warehouse/views/view-id".to_string(),
+            metadata_location: "outside/view.metadata.json".to_string(),
+            version_token: "token-v1".to_string(),
+            generation: 1,
+            state: crate::table_catalog::TableCatalogEntryState::Active,
+            properties: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
+        });
+        metadata_backend
+            .put_json("warehouse", "outside/view.metadata.json", serde_json::json!({}))
+            .await;
+
+        let view_error = load_view_response(&store, &metadata_backend, "warehouse", &namespace, view.as_str())
+            .await
+            .expect_err("view metadata outside the protected root should fail closed");
+        assert_eq!(view_error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_REST.into()));
+        assert_eq!(view_error.status_code(), Some(StatusCode::INTERNAL_SERVER_ERROR));
+    }
+
+    #[tokio::test]
     async fn table_ref_write_responses_commit_retention_refs_and_protect_deletes() {
         let store = TestTableCatalogStore::default();
         let metadata_backend = TestTableCatalogObjectBackend::default();
@@ -10531,6 +13271,7 @@ mod tests {
         seed_test_snapshot_manifest(&metadata_backend, "warehouse", &manifest_list, 10, 1, &[(&data_file, 0, 1, 10, 1)]).await;
 
         let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
             "updates": [
                 {
                     "action": "add-snapshot",
@@ -10605,6 +13346,41 @@ mod tests {
             .await
             .expect_err("main ref should remain protected");
         assert_eq!(error.code(), &s3s::S3ErrorCode::InvalidRequest);
+    }
+
+    #[tokio::test]
+    async fn put_table_ref_rejects_a_missing_snapshot_without_advancing_the_table() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        create_standard_events_table(&store, &metadata_backend, &namespace).await;
+        let before = store
+            .load_table("warehouse", &namespace.public_name(), "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+        let object_count_before = metadata_backend.objects.lock().await.len();
+        let request: PutTableRefRequest = serde_json::from_value(serde_json::json!({
+            "snapshot-id": 999,
+            "type": "tag"
+        }))
+        .expect("ref put request should parse");
+
+        let error = put_table_ref_response(&store, &metadata_backend, "warehouse", &namespace, "events", "missing", request)
+            .await
+            .expect_err("a ref must not target a missing snapshot");
+
+        assert_eq!(error.code(), &s3s::S3ErrorCode::InvalidRequest);
+        assert_eq!(error.message(), Some("snapshot ref missing targets snapshot 999, which does not exist"));
+        let after = store
+            .load_table("warehouse", &namespace.public_name(), "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should remain");
+        assert_eq!(after.metadata_location, before.metadata_location);
+        assert_eq!(after.version_token, before.version_token);
+        assert_eq!(after.generation, before.generation);
+        assert_eq!(metadata_backend.objects.lock().await.len(), object_count_before);
     }
 
     #[test]
@@ -10889,6 +13665,19 @@ mod tests {
     }
 
     #[test]
+    fn credential_http_response_disables_caching() {
+        let response = build_sensitive_json_response(StatusCode::OK, &serde_json::json!({"storage-credentials": []}))
+            .expect("sensitive response should build");
+
+        assert_eq!(
+            response.headers.get(http::header::CACHE_CONTROL),
+            Some(&HeaderValue::from_static("no-store, private"))
+        );
+        assert_eq!(response.headers.get(http::header::PRAGMA), Some(&HeaderValue::from_static("no-cache")));
+        assert_eq!(response.headers.get(http::header::EXPIRES), Some(&HeaderValue::from_static("0")));
+    }
+
+    #[test]
     fn table_credentials_do_not_snapshot_parent_groups() {
         let principal = rustfs_credentials::Credentials {
             access_key: "parent-access-key".to_string(),
@@ -11052,6 +13841,12 @@ mod tests {
         let mut entry = table_entry_for_credentials();
         entry.warehouse_location = "s3://warehouse/tables/../table-id".to_string();
         assert!(table_credential_scope(&entry).is_err());
+
+        for prefix in ["tables/*/table-id", "tables/?/table-id"] {
+            let mut entry = table_entry_for_credentials();
+            entry.warehouse_location = format!("s3://warehouse/{prefix}");
+            assert!(table_credential_scope(&entry).is_err());
+        }
     }
 
     #[test]
@@ -11069,6 +13864,7 @@ mod tests {
                     "snapshot-id": 10
                 }
             ],
+            "updates": [],
             "writer": "pyiceberg"
         }))
         .expect("commit request should parse");
@@ -11093,15 +13889,51 @@ mod tests {
         views: tokio::sync::Mutex<Vec<crate::table_catalog::ViewEntry>>,
         commits: tokio::sync::Mutex<Vec<crate::table_catalog::CommitLogEntry>>,
         fail_put_table_bucket: tokio::sync::Mutex<bool>,
+        create_table_pause: Option<TestCatalogPublishPause>,
+        create_view_pause: Option<TestCatalogPublishPause>,
     }
+
+    #[derive(Clone, Default)]
+    struct TestCatalogPublishPause {
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    impl TestCatalogPublishPause {
+        async fn wait_started(&self) {
+            self.started.notified().await;
+        }
+
+        fn release(&self) {
+            self.release.notify_one();
+        }
+    }
+
+    type TestTableCatalogObjectLocks = Arc<tokio::sync::Mutex<BTreeMap<(String, String), Arc<tokio::sync::Mutex<()>>>>>;
 
     #[derive(Clone, Default)]
     struct TestTableCatalogObjectBackend {
         objects: Arc<tokio::sync::Mutex<BTreeMap<(String, String), crate::table_catalog::TableCatalogObject>>>,
         put_object_barrier: Option<Arc<tokio::sync::Barrier>>,
+        read_object_calls: Arc<std::sync::atomic::AtomicUsize>,
+        locks: TestTableCatalogObjectLocks,
     }
 
     impl TestTableCatalogObjectBackend {
+        fn read_object_call_count(&self) -> usize {
+            self.read_object_calls.load(std::sync::atomic::Ordering::Relaxed)
+        }
+
+        async fn write_lock_is_held(&self, bucket: &str, object: &str) -> bool {
+            let lock = self
+                .locks
+                .lock()
+                .await
+                .get(&(bucket.to_string(), object.to_string()))
+                .cloned();
+            lock.is_some_and(|lock| lock.try_lock_owned().is_err())
+        }
+
         async fn put_bytes(&self, bucket: &str, object: &str, data: Vec<u8>) {
             self.objects.lock().await.insert(
                 (bucket.to_string(), object.to_string()),
@@ -11381,11 +14213,14 @@ mod tests {
         }
     }
 
-    async fn create_standard_events_table(
-        store: &TestTableCatalogStore,
+    async fn create_standard_events_table<S>(
+        store: &S,
         metadata_backend: &TestTableCatalogObjectBackend,
         namespace: &crate::table_catalog::Namespace,
-    ) -> RestLoadTableResponse {
+    ) -> RestLoadTableResponse
+    where
+        S: crate::table_catalog::TableCatalogStore + ?Sized,
+    {
         ensure_table_bucket_entry(store, "warehouse", true)
             .await
             .expect("table bucket entry should be seeded");
@@ -11488,6 +14323,7 @@ mod tests {
             bucket: &str,
             object: &str,
         ) -> crate::table_catalog::TableCatalogStoreResult<Option<crate::table_catalog::TableCatalogObject>> {
+            self.read_object_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Ok(self
                 .objects
                 .lock()
@@ -11555,10 +14391,17 @@ mod tests {
 
         async fn acquire_write_lock(
             &self,
-            _bucket: &str,
-            _object: &str,
+            bucket: &str,
+            object: &str,
         ) -> crate::table_catalog::TableCatalogStoreResult<Box<dyn Send>> {
-            Ok(Box::new(()))
+            let lock = {
+                let mut locks = self.locks.lock().await;
+                locks
+                    .entry((bucket.to_string(), object.to_string()))
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone()
+            };
+            Ok(Box::new(lock.lock_owned().await))
         }
     }
 
@@ -11638,6 +14481,24 @@ mod tests {
                 .cloned())
         }
 
+        async fn update_namespace_properties(
+            &self,
+            table_bucket: &str,
+            namespace: &str,
+            update: crate::table_catalog::NamespacePropertiesUpdate,
+        ) -> crate::table_catalog::TableCatalogStoreResult<crate::table_catalog::NamespacePropertiesUpdateResult> {
+            let mut namespaces = self.namespaces.lock().await;
+            let Some(entry) = namespaces
+                .iter_mut()
+                .find(|entry| entry.table_bucket == table_bucket && entry.namespace == namespace)
+            else {
+                return Err(crate::table_catalog::TableCatalogStoreError::NamespaceNotFound(format!(
+                    "{table_bucket}/{namespace}"
+                )));
+            };
+            Ok(update.apply_to(entry))
+        }
+
         async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> crate::table_catalog::TableCatalogStoreResult<()> {
             self.namespaces
                 .lock()
@@ -11661,6 +14522,10 @@ mod tests {
                     "namespace {}/{}",
                     entry.table_bucket, entry.namespace
                 )));
+            }
+            if let Some(pause) = &self.create_table_pause {
+                pause.started.notify_one();
+                pause.release.notified().await;
             }
             self.tables.lock().await.push(entry);
             Ok(())
@@ -11795,6 +14660,10 @@ mod tests {
                     "namespace {}/{}",
                     entry.table_bucket, entry.namespace
                 )));
+            }
+            if let Some(pause) = &self.create_view_pause {
+                pause.started.notify_one();
+                pause.release.notified().await;
             }
             self.views.lock().await.push(entry);
             Ok(())
@@ -11969,6 +14838,27 @@ mod tests {
             .expect("namespace list should load");
         assert_eq!(list.namespaces, vec![vec!["analytics".to_string()]]);
 
+        let update = update_namespace_properties_response(
+            &store,
+            "warehouse",
+            &crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse"),
+            UpdateNamespacePropertiesRequest {
+                removals: vec!["missing".to_string()],
+                updates: BTreeMap::from([("owner".to_string(), "platform".to_string())]),
+            },
+        )
+        .await
+        .expect("namespace properties should update");
+        assert_eq!(update.updated, vec!["owner".to_string()]);
+        assert!(update.removed.is_empty());
+        assert_eq!(update.missing, vec!["missing".to_string()]);
+        let namespace = store
+            .get_namespace("warehouse", "analytics")
+            .await
+            .expect("namespace lookup should succeed")
+            .expect("namespace should remain");
+        assert_eq!(namespace.properties.get("owner").map(String::as_str), Some("platform"));
+
         drop_namespace_in_store(&store, "warehouse", "analytics")
             .await
             .expect("namespace should drop");
@@ -11976,6 +14866,311 @@ mod tests {
             .await
             .expect("namespace list should load after drop");
         assert!(list.namespaces.is_empty());
+    }
+
+    #[tokio::test]
+    async fn namespace_list_returns_only_direct_children_and_binds_parent_pagination() {
+        let store = TestTableCatalogStore::default();
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        for namespace in [
+            vec!["analytics"],
+            vec!["analytics", "curated"],
+            vec!["analytics", "raw"],
+            vec!["analytics", "raw", "daily"],
+            vec!["sales"],
+        ] {
+            create_namespace_response(
+                &store,
+                "warehouse",
+                CreateNamespaceRequest {
+                    namespace: namespace.into_iter().map(str::to_string).collect(),
+                    properties: BTreeMap::new(),
+                },
+                true,
+            )
+            .await
+            .expect("namespace should be created");
+        }
+
+        let top_level = list_namespaces_response(&store, "warehouse", None, RestPagination::default())
+            .await
+            .expect("top-level namespaces should list");
+        assert_eq!(top_level.namespaces, vec![vec!["analytics".to_string()], vec!["sales".to_string()]]);
+
+        let analytics = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let children = list_namespaces_response(
+            &store,
+            "warehouse",
+            Some(&analytics),
+            RestPagination {
+                after: None,
+                limit: Some(1),
+            },
+        )
+        .await
+        .expect("direct children should list");
+        assert_eq!(children.namespaces, vec![vec!["analytics".to_string(), "curated".to_string()]]);
+        let next_page_token = children.next_page_token.expect("first child page should return a token");
+        let parent_context = RestPageContext {
+            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+            warehouse: "warehouse",
+            namespace: Some("analytics"),
+        };
+        let second_page = list_namespaces_response(
+            &store,
+            "warehouse",
+            Some(&analytics),
+            RestPagination {
+                after: Some(decode_rest_page_token(&next_page_token, parent_context).expect("parent token should decode")),
+                limit: Some(1),
+            },
+        )
+        .await
+        .expect("second child page should list");
+        assert_eq!(second_page.namespaces, vec![vec!["analytics".to_string(), "raw".to_string()]]);
+        assert!(second_page.next_page_token.is_none());
+
+        let missing = crate::table_catalog::Namespace::parse("missing").expect("namespace should parse");
+        let error = list_namespaces_response(&store, "warehouse", Some(&missing), RestPagination::default())
+            .await
+            .expect_err("missing parent should fail");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_FOUND));
+
+        let parent_context = RestPageContext {
+            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+            warehouse: "warehouse",
+            namespace: Some("analytics"),
+        };
+        let token = encode_rest_page_token("analytics.raw", parent_context).expect("parent token should encode");
+        let wrong_parent_context = RestPageContext {
+            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
+            warehouse: "warehouse",
+            namespace: Some("sales"),
+        };
+        let error = decode_rest_page_token(&token, wrong_parent_context).expect_err("token must stay parent-scoped");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
+    }
+
+    #[tokio::test]
+    async fn namespace_list_synthesizes_ancestors_and_hides_inactive_entries() {
+        let store = TestTableCatalogStore::default();
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        for namespace in [vec!["analytics", "raw", "daily"], vec!["archived"]] {
+            create_namespace_response(
+                &store,
+                "warehouse",
+                CreateNamespaceRequest {
+                    namespace: namespace.into_iter().map(str::to_string).collect(),
+                    properties: BTreeMap::new(),
+                },
+                true,
+            )
+            .await
+            .expect("namespace should be created");
+        }
+        store
+            .namespaces
+            .lock()
+            .await
+            .iter_mut()
+            .find(|entry| entry.namespace == "archived")
+            .expect("archived namespace should exist")
+            .state = crate::table_catalog::TableCatalogEntryState::Deleted;
+
+        let top_level = list_namespaces_response(&store, "warehouse", None, RestPagination::default())
+            .await
+            .expect("top-level namespaces should list");
+        assert_eq!(top_level.namespaces, vec![vec!["analytics".to_string()]]);
+
+        let analytics = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let children = list_namespaces_response(&store, "warehouse", Some(&analytics), RestPagination::default())
+            .await
+            .expect("synthesized namespace children should list");
+        assert_eq!(children.namespaces, vec![vec!["analytics".to_string(), "raw".to_string()]]);
+
+        let archived = crate::table_catalog::Namespace::parse("archived").expect("namespace should parse");
+        let error = get_namespace_response(&store, "warehouse", &archived)
+            .await
+            .expect_err("inactive namespace should not load");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
+        assert_eq!(
+            namespace_exists_status(&store, "warehouse", &archived)
+                .await
+                .expect("namespace status should resolve"),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn table_list_reports_missing_namespace() {
+        let store = TestTableCatalogStore::default();
+        let namespace = crate::table_catalog::Namespace::parse("missing").expect("namespace should parse");
+        let error = list_tables_response(&store, "warehouse", &namespace, RestPagination::default())
+            .await
+            .expect_err("missing namespace should fail");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_FOUND));
+    }
+
+    #[tokio::test]
+    async fn view_list_reports_missing_namespace_and_paginates_active_entries() {
+        let store = TestTableCatalogStore::default();
+        let missing = crate::table_catalog::Namespace::parse("missing").expect("namespace should parse");
+        let error = list_views_response(&store, "warehouse", &missing, RestPagination::default())
+            .await
+            .expect_err("missing namespace should fail");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_FOUND));
+
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            &store,
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        for (name, state) in [
+            ("alpha", crate::table_catalog::TableCatalogEntryState::Active),
+            ("beta", crate::table_catalog::TableCatalogEntryState::Active),
+            ("deleted", crate::table_catalog::TableCatalogEntryState::Deleted),
+            ("gamma", crate::table_catalog::TableCatalogEntryState::Active),
+        ] {
+            store.views.lock().await.push(crate::table_catalog::ViewEntry {
+                version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+                table_bucket: "warehouse".to_string(),
+                namespace: namespace.public_name(),
+                view: name.to_string(),
+                view_id: format!("{name}-id"),
+                view_uuid: format!("{name}-uuid"),
+                format: "ICEBERG_VIEW".to_string(),
+                format_version: 1,
+                warehouse_location: format!("s3://warehouse/views/{name}-id"),
+                metadata_location: crate::table_catalog::default_view_metadata_file_path(
+                    &namespace,
+                    &crate::table_catalog::IdentifierSegment::parse(name).expect("view should parse"),
+                    "00001.metadata.json",
+                ),
+                version_token: "token-v1".to_string(),
+                generation: 1,
+                state,
+                properties: BTreeMap::new(),
+                created_at: None,
+                updated_at: None,
+            });
+        }
+
+        let first = list_views_response(
+            &store,
+            "warehouse",
+            &namespace,
+            RestPagination {
+                after: None,
+                limit: Some(2),
+            },
+        )
+        .await
+        .expect("first view page should load");
+        assert_eq!(
+            first
+                .identifiers
+                .iter()
+                .map(|identifier| identifier.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+        let token = first.next_page_token.expect("first view page should return a token");
+        let context = RestPageContext {
+            resource: TABLE_CATALOG_VIEW_RESOURCE_ROOT,
+            warehouse: "warehouse",
+            namespace: Some("analytics"),
+        };
+        let second = list_views_response(
+            &store,
+            "warehouse",
+            &namespace,
+            RestPagination {
+                after: Some(decode_rest_page_token(&token, context).expect("view token should decode")),
+                limit: Some(2),
+            },
+        )
+        .await
+        .expect("second view page should load");
+        assert_eq!(
+            second
+                .identifiers
+                .iter()
+                .map(|identifier| identifier.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gamma"]
+        );
+        assert!(second.next_page_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn table_list_hides_inactive_entries() {
+        let store = TestTableCatalogStore::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            &store,
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        for (name, state) in [
+            ("active", crate::table_catalog::TableCatalogEntryState::Active),
+            ("deleted", crate::table_catalog::TableCatalogEntryState::Deleted),
+        ] {
+            store.tables.lock().await.push(crate::table_catalog::TableEntry {
+                version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+                table_bucket: "warehouse".to_string(),
+                namespace: "analytics".to_string(),
+                table: name.to_string(),
+                table_id: format!("{name}-id"),
+                table_uuid: format!("{name}-uuid"),
+                format: "ICEBERG".to_string(),
+                format_version: 2,
+                warehouse_location: format!("s3://warehouse/tables/{name}-id"),
+                metadata_location: format!("metadata/{name}.metadata.json"),
+                version_token: "token-v1".to_string(),
+                generation: 1,
+                state,
+                properties: BTreeMap::new(),
+                created_at: None,
+                updated_at: None,
+            });
+        }
+
+        let response = list_tables_response(&store, "warehouse", &namespace, RestPagination::default())
+            .await
+            .expect("table list should load");
+        assert_eq!(
+            response.identifiers,
+            vec![RestTableIdentifier {
+                namespace: vec!["analytics".to_string()],
+                name: "active".to_string(),
+            }]
+        );
     }
 
     #[tokio::test]
@@ -12000,20 +15195,16 @@ mod tests {
 
         let metadata_location =
             ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
+        let metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "table-uuid",
+            "location": "s3://warehouse/tables/table-id"
+        });
         metadata_backend
-            .put_json(
-                "warehouse",
-                metadata_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
-            )
+            .put_json("warehouse", metadata_location, metadata.clone())
             .await;
         let register = register_table_response(
             &store,
-            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -12021,6 +15212,7 @@ mod tests {
                 metadata_location: metadata_location.to_string(),
                 overwrite: false,
             },
+            metadata,
             true,
         )
         .await
@@ -12076,7 +15268,7 @@ mod tests {
                 new_metadata_location: Some(table_metadata_location_for_client("warehouse", next_metadata_location)),
                 requirements: Vec::new(),
                 updates: Vec::new(),
-                _identifier: None,
+                identifier: None,
                 writer: Some("pyiceberg".to_string()),
             },
         )
@@ -12128,21 +15320,17 @@ mod tests {
         .expect("namespace should be created");
         let metadata_location =
             ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
+        let metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "metadata-table-uuid",
+            "location": "s3://warehouse/tables/table-id"
+        });
         metadata_backend
-            .put_json(
-                "warehouse",
-                metadata_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "metadata-table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
-            )
+            .put_json("warehouse", metadata_location, metadata.clone())
             .await;
 
         register_table_response(
             &store,
-            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -12150,6 +15338,7 @@ mod tests {
                 metadata_location: metadata_location.to_string(),
                 overwrite: false,
             },
+            metadata,
             true,
         )
         .await
@@ -12161,6 +15350,119 @@ mod tests {
             .expect("table lookup should succeed")
             .expect("table should exist");
         assert_eq!(entry.table_uuid, "metadata-table-uuid");
+    }
+
+    #[tokio::test]
+    async fn register_table_response_accepts_metadata_in_existing_warehouse() {
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let store = crate::table_catalog::ObjectTableCatalogStore::new(metadata_backend.clone());
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            &store,
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        let metadata_location = "tables/existing-table/metadata/00001.metadata.json";
+        let metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "existing-table-uuid",
+            "location": "s3://warehouse/tables/existing-table"
+        });
+        metadata_backend
+            .put_json("warehouse", metadata_location, metadata.clone())
+            .await;
+
+        let response = register_table_response(
+            &store,
+            "warehouse",
+            &namespace,
+            RegisterTableRequest {
+                name: "events".to_string(),
+                metadata_location: format!("s3://warehouse/{metadata_location}"),
+                overwrite: false,
+            },
+            metadata,
+            true,
+        )
+        .await
+        .expect("existing table metadata should register");
+
+        assert_eq!(response.metadata_location, format!("s3://warehouse/{metadata_location}"));
+        let entry = store
+            .load_table("warehouse", "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+        assert_eq!(entry.metadata_location, metadata_location);
+        assert_eq!(entry.warehouse_location, "s3://warehouse/tables/existing-table");
+    }
+
+    #[tokio::test]
+    async fn standard_commit_rejects_external_metadata_root_relocation_before_writing() {
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let store = crate::table_catalog::ObjectTableCatalogStore::new(metadata_backend.clone());
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            &store,
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        let metadata_location = "tables/existing-table/metadata/00001.metadata.json";
+        let metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "existing-table-uuid",
+            "location": "s3://warehouse/tables/existing-table"
+        });
+        metadata_backend
+            .put_json("warehouse", metadata_location, metadata.clone())
+            .await;
+        register_table_response(
+            &store,
+            "warehouse",
+            &namespace,
+            RegisterTableRequest {
+                name: "events".to_string(),
+                metadata_location: metadata_location.to_string(),
+                overwrite: false,
+            },
+            metadata,
+            true,
+        )
+        .await
+        .expect("existing table metadata should register");
+        let object_count = metadata_backend.objects.lock().await.len();
+        let request = serde_json::from_value(serde_json::json!({
+            "requirements": [],
+            "updates": [{
+                "action": "set-location",
+                "location": "s3://warehouse/tables/relocated-table"
+            }]
+        }))
+        .expect("set-location request should parse");
+
+        let error = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
+            .await
+            .expect_err("external metadata root relocation should be rejected");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(metadata_backend.objects.lock().await.len(), object_count);
     }
 
     #[tokio::test]
@@ -12184,21 +15486,17 @@ mod tests {
         .expect("namespace should be created");
         let metadata_location =
             ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
+        let metadata = serde_json::json!({
+            "table-uuid": "metadata-table-uuid",
+            "location": "s3://warehouse/tables/table-id"
+        });
         metadata_backend
-            .put_json(
-                "warehouse",
-                metadata_location,
-                serde_json::json!({
-                    "table-uuid": "metadata-table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
-            )
+            .put_json("warehouse", metadata_location, metadata.clone())
             .await;
 
         assert!(
             register_table_response(
                 &store,
-                &metadata_backend,
                 "warehouse",
                 &namespace,
                 RegisterTableRequest {
@@ -12206,11 +15504,69 @@ mod tests {
                     metadata_location: metadata_location.to_string(),
                     overwrite: false,
                 },
+                metadata,
                 true,
             )
             .await
             .is_err()
         );
+        assert!(
+            store
+                .load_table("warehouse", "analytics", "events")
+                .await
+                .expect("table lookup should succeed")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn register_table_response_rejects_dangling_metadata_references() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            &store,
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        let metadata_location =
+            ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
+        let metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "metadata-table-uuid",
+            "location": "s3://warehouse/tables/table-id",
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+            "current-schema-id": 99
+        });
+        metadata_backend
+            .put_json("warehouse", metadata_location, metadata.clone())
+            .await;
+
+        let error = register_table_response(
+            &store,
+            "warehouse",
+            &namespace,
+            RegisterTableRequest {
+                name: "events".to_string(),
+                metadata_location: metadata_location.to_string(),
+                overwrite: false,
+            },
+            metadata,
+            true,
+        )
+        .await
+        .expect_err("registration must reject dangling metadata references");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
         assert!(
             store
                 .load_table("warehouse", "analytics", "events")
@@ -12295,6 +15651,9 @@ mod tests {
                 commit_id: Some("commit-1".to_string()),
                 idempotency_key: Some("retry-1".to_string()),
             },
+            read_table_metadata_json(&metadata_backend, "warehouse", next_location)
+                .await
+                .expect("target metadata should load"),
         )
         .await
         .expect("metadata location should update");
@@ -12302,6 +15661,25 @@ mod tests {
         assert_eq!(updated.metadata_location, table_metadata_location_for_client("warehouse", next_location));
         assert_eq!(updated.generation, current.generation + 1);
         assert_ne!(updated.version_token, current.version_token);
+    }
+
+    #[tokio::test]
+    async fn metadata_pointer_mutations_reject_outside_target_before_reading_it() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        create_standard_events_table(&store, &metadata_backend, &namespace).await;
+        let outside_location = "unrelated/metadata/00002.metadata.json";
+        let read_object_calls_before = metadata_backend.read_object_call_count();
+
+        let error =
+            read_existing_table_metadata_target(&store, &metadata_backend, "warehouse", &namespace, "events", outside_location)
+                .await
+                .expect_err("an outside metadata target should be rejected before object lookup");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(error.message(), Some("metadata location must be inside the table metadata directory"));
+        assert_eq!(metadata_backend.read_object_call_count(), read_object_calls_before);
     }
 
     #[tokio::test]
@@ -12368,6 +15746,9 @@ mod tests {
                     commit_id: Some("commit-1".to_string()),
                     idempotency_key: None,
                 },
+                read_table_metadata_json(&metadata_backend, "warehouse", invalid_location)
+                    .await
+                    .expect("target metadata should load"),
             )
             .await
             .is_err()
@@ -12402,20 +15783,16 @@ mod tests {
         .await
         .expect("namespace should be created");
         let current_location = ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
+        let current_metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "table-uuid",
+            "location": "s3://warehouse/tables/table-id"
+        });
         metadata_backend
-            .put_json(
-                "warehouse",
-                current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
-            )
+            .put_json("warehouse", current_location, current_metadata.clone())
             .await;
         register_table_response(
             &store,
-            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -12423,6 +15800,7 @@ mod tests {
                 metadata_location: current_location.to_string(),
                 overwrite: false,
             },
+            current_metadata,
             true,
         )
         .await
@@ -12457,6 +15835,9 @@ mod tests {
                     commit_id: Some("commit-1".to_string()),
                     idempotency_key: None,
                 },
+                read_table_metadata_json(&metadata_backend, "warehouse", mismatched_location)
+                    .await
+                    .expect("target metadata should load"),
             )
             .await
             .is_err()
@@ -12571,6 +15952,9 @@ mod tests {
                 commit_id: Some("rollback-1".to_string()),
                 idempotency_key: None,
             },
+            read_table_metadata_json(&backend, bucket, &rollback_location)
+                .await
+                .expect("rollback metadata should load"),
         )
         .await
         .expect("rollback should commit selected metadata");
@@ -12653,11 +16037,14 @@ mod tests {
                 &namespace,
                 "events",
                 RollbackTableRequest {
-                    metadata_location: invalid_location,
+                    metadata_location: invalid_location.clone(),
                     version_token: current.version_token,
                     commit_id: Some("rollback-1".to_string()),
                     idempotency_key: None,
                 },
+                read_table_metadata_json(&backend, bucket, &invalid_location)
+                    .await
+                    .expect("rollback metadata should load"),
             )
             .await
             .is_err()
@@ -12747,11 +16134,14 @@ mod tests {
                 &namespace,
                 "events",
                 RollbackTableRequest {
-                    metadata_location: mismatched_location,
+                    metadata_location: mismatched_location.clone(),
                     version_token: current.version_token,
                     commit_id: Some("rollback-1".to_string()),
                     idempotency_key: None,
                 },
+                read_table_metadata_json(&backend, bucket, &mismatched_location)
+                    .await
+                    .expect("rollback metadata should load"),
             )
             .await
             .is_err()
@@ -12785,20 +16175,16 @@ mod tests {
         .await
         .expect("namespace should be created");
         let current_location = ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
+        let current_metadata = serde_json::json!({
+            "format-version": 2,
+            "table-uuid": "table-uuid",
+            "location": "s3://warehouse/tables/table-id"
+        });
         metadata_backend
-            .put_json(
-                "warehouse",
-                current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
-            )
+            .put_json("warehouse", current_location, current_metadata.clone())
             .await;
         register_table_response(
             &store,
-            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -12806,6 +16192,7 @@ mod tests {
                 metadata_location: current_location.to_string(),
                 overwrite: false,
             },
+            current_metadata,
             true,
         )
         .await
@@ -12845,7 +16232,7 @@ mod tests {
                     new_metadata_location: Some(mismatched_location.to_string()),
                     requirements: Vec::new(),
                     updates: Vec::new(),
-                    _identifier: None,
+                    identifier: None,
                     writer: Some("pyiceberg".to_string()),
                 },
             )

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -24,6 +24,8 @@ use crate::admin::{
 use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{RemoteAddr, TABLE_CATALOG_COMPAT_PREFIX, TABLE_CATALOG_PREFIX};
 use crate::table_catalog::{DEFAULT_WAREHOUSE_ID, TableCatalogStore};
+use bytes::Bytes;
+use futures::{StreamExt, TryStreamExt, stream};
 use http::{HeaderMap, HeaderValue, StatusCode};
 use hyper::Method;
 use matchit::Params;
@@ -57,6 +59,7 @@ const NAMESPACE_PROPERTIES_BODY_MAX_SIZE: usize = 64 * 1024;
 const NAMESPACE_PROPERTIES_BODY_TIMEOUT: StdDuration = StdDuration::from_secs(10);
 const RENAME_TABLE_BODY_MAX_SIZE: usize = 16 * 1024;
 const RENAME_TABLE_BODY_TIMEOUT: StdDuration = StdDuration::from_secs(10);
+const TABLE_CATALOG_REQUEST_BODY_TIMEOUT: StdDuration = StdDuration::from_secs(30);
 const WAREHOUSE_PROPERTY: &str = "warehouse";
 const PREFIX_PROPERTY: &str = "prefix";
 const NAMESPACE_SEPARATOR_PROPERTY: &str = "namespace-separator";
@@ -87,6 +90,7 @@ const TABLE_WAREHOUSE_WRITE_ACTIONS: &[S3Action] = &[S3Action::PutObjectAction, 
 const TABLE_COMMIT_MAX_MANIFESTS: usize = 10_000;
 const TABLE_COMMIT_MAX_AVRO_BYTES: usize = 512 * 1024 * 1024;
 const TABLE_COMMIT_MAX_FILE_REFERENCES: usize = 1_000_000;
+const TABLE_COMMIT_OBJECT_VALIDATION_CONCURRENCY: usize = 16;
 const CATALOG_ENDPOINT_PREFIX_CONFIG_KEY: &str = "rustfs.catalog-endpoint-prefix";
 const CATALOG_COMPAT_ENDPOINT_PREFIX_CONFIG_KEY: &str = "rustfs.catalog-compat-endpoint-prefix";
 const CATALOG_BACKING_CONFIG_KEY: &str = "rustfs.catalog-backing";
@@ -704,8 +708,7 @@ struct TableCredentialScope {
 struct TableCredentialIssueRequest<'a> {
     entry: &'a crate::table_catalog::TableEntry,
     principal: Option<&'a rustfs_credentials::Credentials>,
-    scope_prefix: String,
-    object_prefix: String,
+    scope: &'a TableCredentialScope,
 }
 
 #[derive(Debug, Clone)]
@@ -782,7 +785,7 @@ impl TableCredentialIssuer for IamTableCredentialIssuer {
             ));
         }
 
-        let policy = table_credential_session_policy(request.entry, &request.object_prefix)?;
+        let policy = table_credential_session_policy(request.entry, request.scope)?;
         let policy_buf = serde_json::to_vec(&policy)
             .map_err(|err| s3_error!(InternalError, "failed to serialize table credential session policy: {}", err))?;
         let expiration = OffsetDateTime::now_utc().saturating_add(Duration::seconds(self.ttl_seconds));
@@ -797,13 +800,16 @@ impl TableCredentialIssuer for IamTableCredentialIssuer {
             serde_json::Value::String(base64_simd::URL_SAFE_NO_PAD.encode_to_string(&policy_buf)),
         );
         claims.insert(
-            "rustfs:table-bucket".to_string(),
+            crate::table_catalog::TABLE_CREDENTIAL_BUCKET_CLAIM.to_string(),
             serde_json::Value::String(request.entry.table_bucket.clone()),
         );
-        claims.insert("rustfs:table-id".to_string(), serde_json::Value::String(request.entry.table_id.clone()));
         claims.insert(
-            "rustfs:credential-scope-prefix".to_string(),
-            serde_json::Value::String(request.scope_prefix.clone()),
+            crate::table_catalog::TABLE_CREDENTIAL_TABLE_ID_CLAIM.to_string(),
+            serde_json::Value::String(request.entry.table_id.clone()),
+        );
+        claims.insert(
+            crate::table_catalog::TABLE_CREDENTIAL_SCOPE_PREFIX_CLAIM.to_string(),
+            serde_json::Value::String(request.scope.scope_prefix.clone()),
         );
 
         let secret = current_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
@@ -1430,11 +1436,23 @@ async fn read_authorized_table_metadata_json(
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
     bucket: &str,
     metadata_location: &str,
-) -> S3Result<serde_json::Value> {
+) -> S3Result<(serde_json::Value, crate::table_catalog::TableCatalogObjectLock)> {
     authorize_table_catalog_s3_actions(req, bucket, metadata_location, &[S3Action::GetObjectAction]).await?;
-    let metadata = read_table_metadata_json(metadata_backend, bucket, metadata_location).await?;
+    let metadata_guard = metadata_backend
+        .acquire_read_lock(bucket, metadata_location)
+        .await
+        .map_err(catalog_store_error)?;
+    let Some(object) = metadata_backend
+        .read_object_unlocked_limited(bucket, metadata_location, crate::table_catalog::TABLE_METADATA_JSON_MAX_SIZE)
+        .await
+        .map_err(catalog_store_error)?
+    else {
+        return Err(s3_error!(InvalidRequest, "table metadata object not found: {metadata_location}"));
+    };
+    let metadata = parse_table_metadata_json(&object.data)?;
     authorize_table_warehouse_s3_actions(req, bucket, metadata_table_location(&metadata)?, TABLE_WAREHOUSE_WRITE_ACTIONS).await?;
-    Ok(metadata)
+    crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
+    Ok((metadata, metadata_guard))
 }
 
 async fn table_catalog_request_principal(req: &S3Request<Body>) -> S3Result<TableCatalogRequestPrincipal> {
@@ -1450,11 +1468,20 @@ async fn table_catalog_request_principal(req: &S3Request<Body>) -> S3Result<Tabl
     })
 }
 
-async fn read_json_body<T: DeserializeOwned>(mut input: Body) -> S3Result<T> {
-    let body = input
-        .store_all_limited(MAX_ADMIN_REQUEST_BODY_SIZE)
+async fn read_limited_body(mut input: Body, max_size: usize, timeout: StdDuration, operation: Option<&str>) -> S3Result<Bytes> {
+    tokio::time::timeout(timeout, input.store_all_limited(max_size))
         .await
-        .map_err(|err| s3_error!(InvalidRequest, "failed to read request body: {}", err))?;
+        .map_err(|_| {
+            operation.map_or_else(
+                || s3_error!(InvalidRequest, "timed out reading request body"),
+                |operation| s3_error!(InvalidRequest, "timed out reading {operation} request body"),
+            )
+        })?
+        .map_err(|err| s3_error!(InvalidRequest, "failed to read request body: {}", err))
+}
+
+async fn read_json_body<T: DeserializeOwned>(input: Body) -> S3Result<T> {
+    let body = read_limited_body(input, MAX_ADMIN_REQUEST_BODY_SIZE, TABLE_CATALOG_REQUEST_BODY_TIMEOUT, None).await?;
     if body.is_empty() {
         return Err(s3_error!(InvalidRequest, "request body is required"));
     }
@@ -1508,7 +1535,7 @@ async fn read_rest_commit_table_request(headers: &HeaderMap, input: Body) -> S3R
 
 async fn read_bounded_json_body<T: DeserializeOwned>(
     headers: &HeaderMap,
-    mut input: Body,
+    input: Body,
     max_size: usize,
     timeout: StdDuration,
     operation: &str,
@@ -1523,24 +1550,18 @@ async fn read_bounded_json_body<T: DeserializeOwned>(
             return Err(s3_error!(InvalidRequest, "{operation} request body is too large"));
         }
     }
-    let body = tokio::time::timeout(timeout, input.store_all_limited(max_size))
-        .await
-        .map_err(|_| s3_error!(InvalidRequest, "timed out reading {operation} request body"))?
-        .map_err(|err| s3_error!(InvalidRequest, "failed to read request body: {}", err))?;
+    let body = read_limited_body(input, max_size, timeout, Some(operation)).await?;
     if body.is_empty() {
         return Err(s3_error!(InvalidRequest, "request body is required"));
     }
     serde_json::from_slice(&body).map_err(|err| s3_error!(InvalidRequest, "invalid JSON: {}", err))
 }
 
-async fn read_json_body_or_default<T>(mut input: Body) -> S3Result<T>
+async fn read_json_body_or_default<T>(input: Body) -> S3Result<T>
 where
     T: Default + DeserializeOwned,
 {
-    let body = input
-        .store_all_limited(MAX_ADMIN_REQUEST_BODY_SIZE)
-        .await
-        .map_err(|err| s3_error!(InvalidRequest, "failed to read request body: {}", err))?;
+    let body = read_limited_body(input, MAX_ADMIN_REQUEST_BODY_SIZE, TABLE_CATALOG_REQUEST_BODY_TIMEOUT, None).await?;
     if body.is_empty() {
         return Ok(T::default());
     }
@@ -1909,8 +1930,11 @@ where
     if !table_bucket_enabled {
         return Err(s3_error!(InvalidRequest, "bucket {bucket} is not table-enabled"));
     }
-    if store.get_table_bucket(bucket).await.map_err(catalog_store_error)?.is_some() {
-        return Ok(());
+    if let Some(entry) = store.get_table_bucket(bucket).await.map_err(catalog_store_error)? {
+        if entry.state == crate::table_catalog::TableCatalogEntryState::Active {
+            return Ok(());
+        }
+        return Err(s3_error!(InvalidRequest, "table bucket {bucket} catalog entry is not active"));
     }
     store
         .put_table_bucket(table_bucket_entry_from_metadata_marker(bucket))
@@ -2051,50 +2075,12 @@ fn table_credential_ttl_seconds() -> i64 {
 }
 
 fn table_credential_scope(entry: &crate::table_catalog::TableEntry) -> S3Result<TableCredentialScope> {
-    let location = entry
-        .warehouse_location
-        .strip_prefix("s3://")
-        .ok_or_else(|| s3_error!(InvalidRequest, "table warehouse location must be an s3 URI"))?;
-    let (bucket, object_prefix) = location
-        .split_once('/')
-        .ok_or_else(|| s3_error!(InvalidRequest, "table warehouse location must include an object prefix"))?;
-    if bucket != entry.table_bucket {
-        return Err(s3_error!(InvalidRequest, "table warehouse location must be inside the table bucket"));
-    }
-    let object_prefix = normalize_table_credential_object_prefix(object_prefix)?;
+    let object_prefix = crate::table_catalog::table_warehouse_object_prefix(entry)
+        .map_err(|err| s3_error!(InvalidRequest, "invalid table credential warehouse location: {}", err))?;
     Ok(TableCredentialScope {
-        scope_prefix: format!("s3://{bucket}/{object_prefix}"),
+        scope_prefix: format!("s3://{}/{object_prefix}", entry.table_bucket),
         object_prefix,
     })
-}
-
-fn normalize_table_credential_object_prefix(object_prefix: &str) -> S3Result<String> {
-    let object_prefix = object_prefix.strip_suffix('/').unwrap_or(object_prefix);
-    if object_prefix.is_empty() {
-        return Err(s3_error!(InvalidRequest, "table credential scope prefix is empty"));
-    }
-    if object_prefix.contains('\\') {
-        return Err(s3_error!(
-            InvalidRequest,
-            "table credential scope prefix contains an invalid path separator"
-        ));
-    }
-    if object_prefix.contains(['*', '?']) {
-        return Err(s3_error!(InvalidRequest, "table credential scope prefix contains an IAM wildcard"));
-    }
-    if object_prefix
-        .split('/')
-        .any(|segment| segment.is_empty() || segment == "." || segment == "..")
-    {
-        return Err(s3_error!(
-            InvalidRequest,
-            "table credential scope prefix contains an invalid path segment"
-        ));
-    }
-
-    let mut normalized = object_prefix.to_string();
-    normalized.push('/');
-    Ok(normalized)
 }
 
 fn table_credential_catalog_resource(entry: &crate::table_catalog::TableEntry) -> S3Result<String> {
@@ -2105,9 +2091,9 @@ fn table_credential_catalog_resource(entry: &crate::table_catalog::TableEntry) -
     Ok(format!("namespaces/{}/tables/{}", namespace.storage_id(), table.as_str()))
 }
 
-fn table_credential_session_policy(entry: &crate::table_catalog::TableEntry, object_prefix: &str) -> S3Result<Policy> {
+fn table_credential_session_policy(entry: &crate::table_catalog::TableEntry, scope: &TableCredentialScope) -> S3Result<Policy> {
     let bucket = &entry.table_bucket;
-    let object_prefix = normalize_table_credential_object_prefix(object_prefix)?;
+    let object_prefix = &scope.object_prefix;
     let catalog_resource = table_credential_catalog_resource(entry)?;
     let policy = serde_json::json!({
         "Version": "2012-10-17",
@@ -2275,8 +2261,7 @@ async fn load_credentials_response_from_entry(
     let request = TableCredentialIssueRequest {
         entry,
         principal,
-        scope_prefix: scope.scope_prefix.clone(),
-        object_prefix: scope.object_prefix.clone(),
+        scope: &scope,
     };
     let scope_prefix = scope.scope_prefix.clone();
     let storage_credentials = match issuer.issue_table_credentials(request).await? {
@@ -2384,7 +2369,15 @@ fn metadata_format_version(metadata: &serde_json::Value) -> S3Result<u16> {
         .and_then(serde_json::Value::as_u64)
         .filter(|version| *version > 0)
         .ok_or_else(|| s3_error!(InvalidRequest, "table metadata is missing format-version"))?;
-    u16::try_from(version).map_err(|_| s3_error!(InvalidRequest, "table metadata format-version is too large"))
+    let version = u16::try_from(version).map_err(|_| s3_error!(InvalidRequest, "table metadata format-version is too large"))?;
+    if !(1..=2).contains(&version) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            format!("unsupported Iceberg table format-version: {version}"),
+        ));
+    }
+    Ok(version)
 }
 
 fn metadata_table_location(metadata: &serde_json::Value) -> S3Result<&str> {
@@ -2428,12 +2421,23 @@ fn metadata_sha256(metadata: &serde_json::Value) -> S3Result<String> {
     Ok(hex_sha256(&canonical, str::to_string))
 }
 
-fn metadata_digest_requirement(metadata: &serde_json::Value) -> S3Result<serde_json::Value> {
+fn metadata_digest_requirement_with_type(
+    metadata: &serde_json::Value,
+    requirement_type: &'static str,
+) -> S3Result<serde_json::Value> {
     let sha256 = metadata_sha256(metadata)?;
     Ok(serde_json::json!({
-        "type": crate::table_catalog::TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+        "type": requirement_type,
         "sha256": sha256
     }))
+}
+
+fn metadata_digest_requirement(metadata: &serde_json::Value) -> S3Result<serde_json::Value> {
+    metadata_digest_requirement_with_type(metadata, crate::table_catalog::TABLE_METADATA_DIGEST_REQUIREMENT_TYPE)
+}
+
+fn base_metadata_digest_requirement(metadata: &serde_json::Value) -> S3Result<serde_json::Value> {
+    metadata_digest_requirement_with_type(metadata, crate::table_catalog::TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE)
 }
 
 fn metadata_view_uuid(metadata: &serde_json::Value) -> S3Result<&str> {
@@ -2553,12 +2557,25 @@ fn table_entry_from_create_table_request(
         .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
     let table_id = Uuid::new_v4().to_string();
     let table_uuid = Uuid::new_v4().to_string();
+    let format_version = match request.properties.get("format-version") {
+        Some(version) => version
+            .parse::<u16>()
+            .map_err(|_| s3_error!(InvalidRequest, "format-version property must be an integer"))?,
+        None => 2,
+    };
+    if !(1..=2).contains(&format_version) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            format!("unsupported Iceberg table format-version: {format_version}"),
+        ));
+    }
     let warehouse_location = request.location.unwrap_or_else(|| format!("s3://{bucket}/tables/{table_id}"));
     validate_table_location_in_bucket(bucket, &warehouse_location)?;
     let metadata_location =
         crate::table_catalog::default_table_metadata_file_path(namespace, &table, &next_metadata_file_name(1, &table_id));
 
-    let mut entry = crate::table_catalog::TableEntry {
+    let entry = crate::table_catalog::TableEntry {
         version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
         table_bucket: bucket.to_string(),
         namespace: namespace.public_name(),
@@ -2566,7 +2583,7 @@ fn table_entry_from_create_table_request(
         table_id,
         table_uuid,
         format: "ICEBERG".to_string(),
-        format_version: 2,
+        format_version,
         warehouse_location,
         metadata_location,
         version_token: format!("token-{}", Uuid::new_v4()),
@@ -2583,11 +2600,6 @@ fn table_entry_from_create_table_request(
         request.write_order,
         entry.properties.clone(),
     )?;
-    entry.format_version = metadata
-        .get("format-version")
-        .and_then(serde_json::Value::as_u64)
-        .and_then(|version| u16::try_from(version).ok())
-        .unwrap_or(2);
     Ok((entry, metadata))
 }
 
@@ -2831,6 +2843,82 @@ fn standard_commit_ids(commit_id: Option<String>, idempotency_key: Option<&str>)
     }
 }
 
+struct PublishedApiCommitReplay<'a> {
+    route: RestTableRoute<'a>,
+    current: &'a crate::table_catalog::TableEntry,
+    commit_id: &'a str,
+    idempotency_key: Option<&'a str>,
+    operation: &'a str,
+    expected_version_token: &'a str,
+    new_metadata_location: &'a str,
+    expected_metadata_location: Option<&'a str>,
+}
+
+async fn published_api_commit_replay<S>(
+    store: &S,
+    replay: PublishedApiCommitReplay<'_>,
+) -> S3Result<Option<crate::table_catalog::TableCommitRequest>>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    let PublishedApiCommitReplay {
+        route,
+        current,
+        commit_id,
+        idempotency_key,
+        operation,
+        expected_version_token,
+        new_metadata_location,
+        expected_metadata_location,
+    } = replay;
+    let mut existing = store
+        .get_commit_by_id(&current.table_bucket, &current.table_id, commit_id)
+        .await
+        .map_err(catalog_store_error)?;
+    if existing.is_none()
+        && let Some(idempotency_key) = idempotency_key
+    {
+        existing = store
+            .get_commit_by_idempotency_key(&current.table_bucket, &current.table_id, idempotency_key)
+            .await
+            .map_err(catalog_store_error)?;
+    }
+    let Some(existing) = existing else {
+        return Ok(None);
+    };
+    if existing.commit_id != commit_id
+        || existing.idempotency_key.as_deref() != idempotency_key
+        || existing.operation != operation
+        || existing.expected_version_token != expected_version_token
+        || existing.new_metadata_location != new_metadata_location
+        || expected_metadata_location.is_some_and(|location| existing.previous_metadata_location != location)
+    {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_COMMIT_FAILED,
+            StatusCode::CONFLICT,
+            "commit id or idempotency key is already bound to a different request",
+        ));
+    }
+    if !matches!(existing.status, crate::table_catalog::CommitLogStatus::Committed)
+        && (current.metadata_location != existing.new_metadata_location || current.version_token != existing.new_version_token)
+    {
+        return Ok(None);
+    }
+    Ok(Some(crate::table_catalog::TableCommitRequest {
+        table_bucket: current.table_bucket.clone(),
+        namespace: route.namespace.public_name(),
+        table: route.table.to_string(),
+        commit_id: existing.commit_id,
+        idempotency_key: existing.idempotency_key,
+        operation: existing.operation,
+        expected_version_token: existing.expected_version_token,
+        expected_metadata_location: existing.previous_metadata_location,
+        new_metadata_location: existing.new_metadata_location,
+        requirements: existing.requirements,
+        writer: existing.writer,
+    }))
+}
+
 fn next_metadata_file_name(generation: u64, metadata_file_token: &str) -> String {
     format!("{generation:05}-{metadata_file_token}.metadata.json")
 }
@@ -2999,8 +3087,8 @@ fn apply_table_commit_updates_at(
             "set-default-spec" => apply_set_default_spec_update(&mut metadata, update)?,
             "add-sort-order" => apply_add_sort_order_update(&mut metadata, update)?,
             "set-default-sort-order" => apply_set_default_sort_order_update(&mut metadata, update)?,
-            "add-snapshot" => apply_add_snapshot_update(&mut metadata, update, commit_timestamp_ms)?,
-            "set-snapshot-ref" => apply_set_snapshot_ref_update(&mut metadata, update)?,
+            "add-snapshot" => apply_add_snapshot_update(&mut metadata, update)?,
+            "set-snapshot-ref" => apply_set_snapshot_ref_update(&mut metadata, update, commit_timestamp_ms)?,
             "remove-snapshots" => apply_remove_snapshots_update(&mut metadata, update)?,
             "remove-snapshot-ref" => apply_remove_snapshot_ref_update(&mut metadata, update)?,
             "set-location" => apply_set_location_update(&mut metadata, update)?,
@@ -3429,7 +3517,14 @@ fn apply_upgrade_format_version_update(metadata: &mut serde_json::Value, update:
     let current = metadata
         .get("format-version")
         .and_then(serde_json::Value::as_i64)
-        .unwrap_or_default();
+        .ok_or_else(|| s3_error!(InvalidRequest, "current table metadata is missing format-version"))?;
+    if !(1..=2).contains(&version) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            format!("unsupported Iceberg table format-version: {version}"),
+        ));
+    }
     if version < current {
         return Err(s3_error!(InvalidRequest, "format-version cannot be downgraded"));
     }
@@ -3567,11 +3662,7 @@ fn apply_set_default_sort_order_update(metadata: &mut serde_json::Value, update:
     Ok(())
 }
 
-fn apply_add_snapshot_update(
-    metadata: &mut serde_json::Value,
-    update: &serde_json::Value,
-    commit_timestamp_ms: i64,
-) -> S3Result<()> {
+fn apply_add_snapshot_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
     let snapshot = update
         .get("snapshot")
         .cloned()
@@ -3580,23 +3671,44 @@ fn apply_add_snapshot_update(
         .get("snapshot-id")
         .and_then(serde_json::Value::as_i64)
         .ok_or_else(|| s3_error!(InvalidRequest, "snapshot-id must be an integer"))?;
-    let sequence_number = snapshot
-        .get("sequence-number")
+    let format_version = metadata
+        .get("format-version")
         .and_then(serde_json::Value::as_i64)
-        .ok_or_else(|| s3_error!(InvalidRequest, "snapshot sequence-number must be an integer"))?;
-    let timestamp_ms = snapshot
+        .ok_or_else(|| s3_error!(InvalidRequest, "current table metadata is missing format-version"))?;
+    if !matches!(format_version, 1 | 2) {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            format!("unsupported Iceberg table format-version: {format_version}"),
+        ));
+    }
+    let sequence_number = if format_version == 1 {
+        snapshot
+            .get("sequence-number")
+            .map(|value| {
+                value
+                    .as_i64()
+                    .filter(|sequence_number| *sequence_number == 0)
+                    .ok_or_else(|| s3_error!(InvalidRequest, "v1 snapshot sequence-number must be zero when present"))
+            })
+            .transpose()?
+            .unwrap_or(0)
+    } else {
+        snapshot
+            .get("sequence-number")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot sequence-number must be an integer"))?
+    };
+    snapshot
         .get("timestamp-ms")
         .and_then(serde_json::Value::as_i64)
-        .unwrap_or(commit_timestamp_ms);
-    validate_added_snapshot(metadata, &snapshot, snapshot_id, sequence_number)?;
+        .ok_or_else(|| s3_error!(InvalidRequest, "snapshot timestamp-ms must be an integer"))?;
+    validate_added_snapshot(metadata, &snapshot, snapshot_id, sequence_number, format_version)?;
     ensure_array_field(metadata, "snapshots")?.push(snapshot);
     let object = metadata_object_mut(metadata)?;
-    object.insert("last-sequence-number".to_string(), serde_json::Value::from(sequence_number));
-    object.insert("current-snapshot-id".to_string(), serde_json::Value::from(snapshot_id));
-    ensure_array_field(metadata, "snapshot-log")?.push(serde_json::json!({
-        "timestamp-ms": timestamp_ms,
-        "snapshot-id": snapshot_id
-    }));
+    if format_version >= 2 {
+        object.insert("last-sequence-number".to_string(), serde_json::Value::from(sequence_number));
+    }
     Ok(())
 }
 
@@ -3605,6 +3717,7 @@ fn validate_added_snapshot(
     snapshot: &serde_json::Value,
     snapshot_id: i64,
     sequence_number: i64,
+    format_version: i64,
 ) -> S3Result<()> {
     if metadata
         .get("snapshots")
@@ -3618,19 +3731,31 @@ fn validate_added_snapshot(
         return Err(s3_error!(PreconditionFailed, "snapshot id already exists"));
     }
 
-    let current_snapshot_id = metadata.get("current-snapshot-id").and_then(serde_json::Value::as_i64);
-    if let Some(parent_snapshot_id) = snapshot.get("parent-snapshot-id").and_then(serde_json::Value::as_i64)
-        && Some(parent_snapshot_id) != current_snapshot_id
-    {
-        return Err(s3_error!(PreconditionFailed, "snapshot parent no longer matches current snapshot"));
+    if let Some(parent_snapshot_id) = snapshot.get("parent-snapshot-id") {
+        let parent_snapshot_id = parent_snapshot_id
+            .as_i64()
+            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot parent-snapshot-id must be an integer"))?;
+        if !metadata
+            .get("snapshots")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|snapshots| {
+                snapshots
+                    .iter()
+                    .any(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64) == Some(parent_snapshot_id))
+            })
+        {
+            return Err(s3_error!(PreconditionFailed, "snapshot parent does not exist"));
+        }
     }
 
-    let current_sequence_number = metadata
-        .get("last-sequence-number")
-        .and_then(serde_json::Value::as_i64)
-        .unwrap_or_default();
-    if sequence_number <= current_sequence_number {
-        return Err(s3_error!(PreconditionFailed, "snapshot sequence number must advance"));
+    if format_version >= 2 {
+        let current_sequence_number = metadata
+            .get("last-sequence-number")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| s3_error!(InvalidRequest, "current table metadata is missing last-sequence-number"))?;
+        if sequence_number <= current_sequence_number {
+            return Err(s3_error!(PreconditionFailed, "snapshot sequence number must advance"));
+        }
     }
 
     if !snapshot_has_manifest_references(snapshot) {
@@ -3800,25 +3925,44 @@ where
         .get("snapshot-id")
         .and_then(serde_json::Value::as_i64)
         .ok_or_else(|| s3_error!(InvalidRequest, "snapshot-id must be an integer"))?;
-    let sequence_number = snapshot
-        .get("sequence-number")
+    let format_version = current_metadata
+        .get("format-version")
         .and_then(serde_json::Value::as_i64)
-        .ok_or_else(|| s3_error!(InvalidRequest, "snapshot sequence-number must be an integer"))?;
+        .ok_or_else(|| s3_error!(InvalidRequest, "current table metadata is missing format-version"))?;
+    let sequence_number = if format_version == 1 {
+        snapshot
+            .get("sequence-number")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0)
+    } else {
+        snapshot
+            .get("sequence-number")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot sequence-number must be an integer"))?
+    };
     let operation = snapshot
         .get("summary")
         .and_then(|summary| summary.get("operation"))
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| s3_error!(InvalidRequest, "snapshot summary.operation is required"))?;
 
+    let parent_snapshot_id = snapshot
+        .get("parent-snapshot-id")
+        .map(|snapshot_id| {
+            snapshot_id
+                .as_i64()
+                .ok_or_else(|| s3_error!(InvalidRequest, "snapshot parent-snapshot-id must be an integer"))
+        })
+        .transpose()?;
     let mut read_budget = SnapshotReadBudget::default();
-    let current_live_files =
-        load_current_snapshot_live_files(req.as_deref_mut(), context, current_metadata, &mut read_budget).await?;
+    let parent_live_files =
+        load_snapshot_live_files(req.as_deref_mut(), context, current_metadata, parent_snapshot_id, &mut read_budget).await?;
     let changes = load_snapshot_file_changes(
         req,
         context,
         SnapshotChangeContext {
             snapshot,
-            current_live_files: &current_live_files,
+            current_live_files: &parent_live_files,
             snapshot_id,
             sequence_number,
         },
@@ -3827,7 +3971,7 @@ where
     .await?;
 
     for location in changes.added_data_files.iter().chain(changes.added_delete_files.iter()) {
-        if current_live_files.contains(location) {
+        if parent_live_files.contains(location) {
             return Err(s3_error!(
                 PreconditionFailed,
                 "commit requirement failed: added file already exists in current snapshot"
@@ -3842,12 +3986,8 @@ where
             }
         }
         "overwrite" | "delete" | "replace" => {
-            if current_metadata
-                .get("current-snapshot-id")
-                .and_then(serde_json::Value::as_i64)
-                .is_none()
-            {
-                return Err(s3_error!(InvalidRequest, "row-level snapshot operation requires a current snapshot"));
+            if parent_snapshot_id.is_none() {
+                return Err(s3_error!(InvalidRequest, "row-level snapshot operation requires a parent snapshot"));
             }
             if operation == "overwrite" {
                 if !changes.has_any_change() {
@@ -3860,8 +4000,11 @@ where
                 ));
             }
             for location in changes.deleted_data_files.iter().chain(changes.deleted_delete_files.iter()) {
-                if !current_live_files.contains(location) {
-                    return Err(s3_error!(PreconditionFailed, "commit requirement failed: deleted file is not current"));
+                if !parent_live_files.contains(location) {
+                    return Err(s3_error!(
+                        PreconditionFailed,
+                        "commit requirement failed: deleted file is not in the parent snapshot"
+                    ));
                 }
             }
         }
@@ -3889,19 +4032,17 @@ fn added_snapshot_update(updates: &[serde_json::Value]) -> S3Result<Option<&serd
     Ok(snapshot)
 }
 
-async fn load_current_snapshot_live_files<B>(
+async fn load_snapshot_live_files<B>(
     req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
     current_metadata: &serde_json::Value,
+    snapshot_id: Option<i64>,
     read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<SnapshotLiveFiles>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
-    let Some(current_snapshot_id) = current_metadata
-        .get("current-snapshot-id")
-        .and_then(serde_json::Value::as_i64)
-    else {
+    let Some(snapshot_id) = snapshot_id else {
         return Ok(SnapshotLiveFiles::default());
     };
     let snapshot = current_metadata
@@ -3910,11 +4051,12 @@ where
         .and_then(|snapshots| {
             snapshots
                 .iter()
-                .find(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64) == Some(current_snapshot_id))
+                .find(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64) == Some(snapshot_id))
         })
-        .ok_or_else(|| s3_error!(InvalidRequest, "current snapshot metadata is missing"))?;
+        .ok_or_else(|| s3_error!(InvalidRequest, "parent snapshot metadata is missing"))?;
 
     let mut live_files = SnapshotLiveFiles::default();
+    let mut seen_locations = BTreeSet::new();
     for manifest in read_snapshot_manifest_references(req, context, snapshot, read_budget).await? {
         let SnapshotManifestLocation {
             manifest_path,
@@ -3934,6 +4076,9 @@ where
                 .ok_or_else(|| s3_error!(InvalidRequest, "manifest entry status is required"))?;
             match status {
                 0 | 1 => {
+                    if !seen_locations.insert(reference.location.clone()) {
+                        return Err(s3_error!(InvalidRequest, "snapshot contains a duplicate file reference"));
+                    }
                     let identity = SnapshotFileIdentity {
                         sequence_number: reference.sequence_number,
                         file_sequence_number: reference.file_sequence_number,
@@ -3966,7 +4111,13 @@ where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
     let mut changes = SnapshotFileChanges::default();
+    let mut seen_locations = BTreeSet::new();
     for manifest in read_snapshot_manifest_references(req, read_context, change_context.snapshot, read_budget).await? {
+        for reference in &manifest.references {
+            if !seen_locations.insert(reference.location.clone()) {
+                return Err(s3_error!(InvalidRequest, "snapshot contains a duplicate file reference"));
+            }
+        }
         let inherited_identity = change_context
             .current_live_files
             .manifest_files
@@ -4036,6 +4187,28 @@ where
                     "deleted manifest entry must preserve the current file sequence"
                 ));
             }
+            if status == 0 {
+                let Some(current_identity) = change_context
+                    .current_live_files
+                    .identity(&reference.location, &reference.object_kind)
+                else {
+                    return Err(s3_error!(
+                        PreconditionFailed,
+                        "commit requirement failed: existing file is not in the parent snapshot"
+                    ));
+                };
+                if current_identity
+                    != &(SnapshotFileIdentity {
+                        sequence_number: reference.sequence_number,
+                        file_sequence_number: reference.file_sequence_number,
+                    })
+                {
+                    return Err(s3_error!(
+                        InvalidRequest,
+                        "existing manifest entry must preserve the parent file sequence"
+                    ));
+                }
+            }
 
             match (status, reference.object_kind) {
                 (0, _) => {}
@@ -4074,7 +4247,11 @@ where
 {
     let manifest_locations = snapshot_manifest_locations(req.as_deref_mut(), context, snapshot, read_budget).await?;
     let mut manifests = Vec::new();
+    let mut seen_manifest_paths = BTreeSet::new();
     for manifest_location in manifest_locations {
+        if !seen_manifest_paths.insert(manifest_location.manifest_path.clone()) {
+            return Err(s3_error!(InvalidRequest, "snapshot contains a duplicate manifest reference"));
+        }
         let manifest_key = table_commit_object_key(
             context.bucket,
             context.namespace,
@@ -4105,9 +4282,9 @@ where
             if reference.file_sequence_number.is_none() {
                 reference.file_sequence_number = manifest_location.sequence_number;
             }
-            validate_manifest_data_file_reference(req.as_deref_mut(), context, &reference).await?;
             references.push(reference);
         }
+        validate_manifest_data_file_references(req.as_deref_mut(), context, &references).await?;
         manifests.push(SnapshotManifestReferences {
             location: manifest_location,
             references,
@@ -4188,30 +4365,49 @@ where
         .collect()
 }
 
-async fn validate_manifest_data_file_reference<B>(
-    req: Option<&mut S3Request<Body>>,
+async fn validate_manifest_data_file_references<B>(
+    mut req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
-    reference: &crate::table_catalog::ManifestDataFileReference,
+    references: &[crate::table_catalog::ManifestDataFileReference],
 ) -> S3Result<()>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
-    let object_key = table_commit_object_key(
-        context.bucket,
-        context.namespace,
-        context.table,
-        context.entry,
-        &reference.location,
-        reference.object_kind.clone(),
-    )?;
-    authorize_optional_table_catalog_object_read(req, context.bucket, &object_key).await?;
-    if !context
-        .metadata_backend
-        .object_exists(context.bucket, &object_key)
-        .await
-        .map_err(catalog_store_error)?
-    {
-        return Err(s3_error!(InvalidRequest, "manifest referenced data file is missing"));
+    for references in references.chunks(TABLE_COMMIT_OBJECT_VALIDATION_CONCURRENCY) {
+        let mut object_keys = Vec::with_capacity(references.len());
+        for reference in references {
+            let object_key = table_commit_object_key(
+                context.bucket,
+                context.namespace,
+                context.table,
+                context.entry,
+                &reference.location,
+                reference.object_kind.clone(),
+            )?;
+            authorize_optional_table_catalog_object_read(req.as_deref_mut(), context.bucket, &object_key).await?;
+            object_keys.push(object_key);
+        }
+
+        let metadata_backend = context.metadata_backend.clone();
+        let bucket = context.bucket.to_string();
+        stream::iter(object_keys)
+            .map(move |object_key| {
+                let metadata_backend = metadata_backend.clone();
+                let bucket = bucket.clone();
+                async move {
+                    if !metadata_backend
+                        .object_exists(&bucket, &object_key)
+                        .await
+                        .map_err(catalog_store_error)?
+                    {
+                        return Err(s3_error!(InvalidRequest, "manifest referenced data file is missing"));
+                    }
+                    Ok(())
+                }
+            })
+            .buffered(TABLE_COMMIT_OBJECT_VALIDATION_CONCURRENCY)
+            .try_for_each(|()| async { Ok(()) })
+            .await?;
     }
     Ok(())
 }
@@ -4231,7 +4427,11 @@ fn table_commit_object_key(
         .ok_or_else(|| s3_error!(InvalidRequest, "snapshot object is outside the table warehouse"))
 }
 
-fn apply_set_snapshot_ref_update(metadata: &mut serde_json::Value, update: &serde_json::Value) -> S3Result<()> {
+fn apply_set_snapshot_ref_update(
+    metadata: &mut serde_json::Value,
+    update: &serde_json::Value,
+    commit_timestamp_ms: i64,
+) -> S3Result<()> {
     let ref_name = update
         .get("ref-name")
         .and_then(serde_json::Value::as_str)
@@ -4247,6 +4447,23 @@ fn apply_set_snapshot_ref_update(metadata: &mut serde_json::Value, update: &serd
     if !matches!(ref_type, "branch" | "tag") {
         return Err(s3_error!(InvalidRequest, "set-snapshot-ref type must be branch or tag"));
     }
+    if ref_name == "main" && ref_type != "branch" {
+        return Err(s3_error!(InvalidRequest, "main snapshot ref must be a branch"));
+    }
+    let snapshot_exists = metadata
+        .get("snapshots")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|snapshots| {
+            snapshots
+                .iter()
+                .any(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64) == Some(snapshot_id))
+        });
+    if !snapshot_exists {
+        return Err(s3_error!(
+            InvalidRequest,
+            "snapshot ref {ref_name} targets snapshot {snapshot_id}, which does not exist"
+        ));
+    }
     let reference = update
         .as_object()
         .ok_or_else(|| s3_error!(InvalidRequest, "set-snapshot-ref must be a JSON object"))?
@@ -4255,8 +4472,12 @@ fn apply_set_snapshot_ref_update(metadata: &mut serde_json::Value, update: &serd
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect::<serde_json::Map<_, _>>();
     ensure_object_field(metadata, "refs")?.insert(ref_name.to_string(), serde_json::Value::Object(reference));
-    if ref_name == "main" {
+    if ref_name == "main" && metadata.get("current-snapshot-id").and_then(serde_json::Value::as_i64) != Some(snapshot_id) {
         metadata_object_mut(metadata)?.insert("current-snapshot-id".to_string(), serde_json::Value::from(snapshot_id));
+        ensure_array_field(metadata, "snapshot-log")?.push(serde_json::json!({
+            "timestamp-ms": commit_timestamp_ms,
+            "snapshot-id": snapshot_id
+        }));
     }
     Ok(())
 }
@@ -4267,8 +4488,12 @@ fn apply_remove_snapshots_update(metadata: &mut serde_json::Value, update: &serd
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| s3_error!(InvalidRequest, "remove-snapshots requires snapshot-ids"))?
         .iter()
-        .filter_map(serde_json::Value::as_i64)
-        .collect::<std::collections::BTreeSet<_>>();
+        .map(|snapshot_id| {
+            snapshot_id
+                .as_i64()
+                .ok_or_else(|| s3_error!(InvalidRequest, "remove-snapshots snapshot-ids must contain integers"))
+        })
+        .collect::<S3Result<std::collections::BTreeSet<_>>>()?;
     ensure_array_field(metadata, "snapshots")?.retain(|snapshot| {
         snapshot
             .get("snapshot-id")
@@ -4288,6 +4513,9 @@ fn apply_remove_snapshot_ref_update(metadata: &mut serde_json::Value, update: &s
         .get("ref-name")
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| s3_error!(InvalidRequest, "remove-snapshot-ref requires ref-name"))?;
+    if ref_name == "main" {
+        return Err(s3_error!(InvalidRequest, "main snapshot ref cannot be deleted"));
+    }
     ensure_object_field(metadata, "refs")?.remove(ref_name);
     Ok(())
 }
@@ -4375,7 +4603,9 @@ fn ensure_object_field<'a>(
 }
 
 fn next_array_object_i64(metadata: &serde_json::Value, array_key: &str, id_key: &str) -> S3Result<i64> {
-    Ok(last_array_object_i64(metadata, array_key, id_key)?.saturating_add(1))
+    last_array_object_i64(metadata, array_key, id_key)?
+        .checked_add(1)
+        .ok_or_else(|| s3_error!(InvalidRequest, "metadata field {array_key} has exhausted {id_key} values"))
 }
 
 fn last_array_object_i64(metadata: &serde_json::Value, array_key: &str, id_key: &str) -> S3Result<i64> {
@@ -4720,10 +4950,14 @@ where
         )
         .await
         .map_err(catalog_store_already_exists_error)?;
-    store
+    if let Err(err) = store
         .create_table(entry.clone())
         .await
-        .map_err(catalog_store_already_exists_error)?;
+        .map_err(catalog_store_already_exists_error)
+    {
+        rollback_initial_metadata(metadata_backend, bucket, &entry.metadata_location, "table").await;
+        return Err(err);
+    }
     Ok(load_table_response_from_entry(entry, metadata))
 }
 
@@ -4755,11 +4989,32 @@ where
         )
         .await
         .map_err(catalog_store_already_exists_error)?;
-    store
+    if let Err(err) = store
         .create_view(entry.clone())
         .await
-        .map_err(catalog_store_already_exists_error)?;
+        .map_err(catalog_store_already_exists_error)
+    {
+        rollback_initial_metadata(metadata_backend, bucket, &entry.metadata_location, "view").await;
+        return Err(err);
+    }
     Ok(load_view_response_from_entry(entry, metadata))
+}
+
+async fn rollback_initial_metadata(
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    bucket: &str,
+    metadata_location: &str,
+    object_kind: &'static str,
+) {
+    if let Err(err) = metadata_backend.delete_object_unlocked(bucket, metadata_location).await {
+        tracing::warn!(
+            bucket = %bucket,
+            metadata_location = %metadata_location,
+            object_kind,
+            error = %err,
+            "failed to roll back initial catalog metadata"
+        );
+    }
 }
 
 async fn read_table_metadata_json(
@@ -4774,7 +5029,11 @@ async fn read_table_metadata_json(
     else {
         return Err(s3_error!(InvalidRequest, "table metadata object not found: {metadata_location}"));
     };
-    let metadata = serde_json::from_slice::<serde_json::Value>(&object.data)
+    parse_table_metadata_json(&object.data)
+}
+
+fn parse_table_metadata_json(data: &[u8]) -> S3Result<serde_json::Value> {
+    let metadata = serde_json::from_slice::<serde_json::Value>(data)
         .map_err(|err| s3_error!(InvalidRequest, "failed to parse table metadata JSON: {}", err))?;
     if !metadata.is_object() {
         return Err(s3_error!(InvalidRequest, "table metadata JSON must be an object"));
@@ -5021,7 +5280,8 @@ where
         validate_metadata_view_location_in_bucket(bucket, &next_metadata)?;
         validate_metadata_matches_current_view_metadata(&current_metadata, &next_metadata)?;
         let (_, metadata_file_token) = standard_commit_ids(request.commit_id.clone(), None);
-        let next_generation = current.generation.saturating_add(1);
+        let next_generation =
+            crate::table_catalog::next_table_catalog_generation(current.generation).map_err(catalog_store_error)?;
         let next_metadata_location = crate::table_catalog::default_view_metadata_file_path(
             namespace,
             &view_name,
@@ -5166,6 +5426,29 @@ where
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
     let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
+    let (commit_id, _) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
+    if let Some(replay) = published_api_commit_replay(
+        store,
+        PublishedApiCommitReplay {
+            route: RestTableRoute {
+                bucket,
+                namespace,
+                table,
+            },
+            current: &current,
+            commit_id: &commit_id,
+            idempotency_key: request.idempotency_key.as_deref(),
+            operation: "update-metadata-location",
+            expected_version_token: &request.version_token,
+            new_metadata_location: &metadata_location,
+            expected_metadata_location: None,
+        },
+    )
+    .await?
+    {
+        let result = store.commit_table(replay).await.map_err(catalog_store_error)?;
+        return Ok(table_metadata_location_response_from_entry(result.table));
+    }
     if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &metadata_location) {
         return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
     }
@@ -5177,13 +5460,16 @@ where
         table_bucket: bucket.to_string(),
         namespace: namespace.public_name(),
         table: table.to_string(),
-        commit_id: request.commit_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+        commit_id,
         idempotency_key: request.idempotency_key,
         operation: "update-metadata-location".to_string(),
         expected_version_token: request.version_token,
         expected_metadata_location: current.metadata_location,
         new_metadata_location: metadata_location,
-        requirements: vec![metadata_digest_requirement(&target_metadata)?],
+        requirements: vec![
+            base_metadata_digest_requirement(&current_metadata)?,
+            metadata_digest_requirement(&target_metadata)?,
+        ],
         writer: Some("rustfs-metadata-location-api".to_string()),
     };
     let result = store.commit_table(commit_request).await.map_err(catalog_store_error)?;
@@ -5376,6 +5662,9 @@ where
         validate_metadata_table_location_in_bucket(bucket, &previous_metadata)?;
         validate_table_commit_requirements(&previous_metadata, &client_requirements)?;
         validate_metadata_matches_current_metadata(&previous_metadata, &target_metadata)?;
+        request
+            .requirements
+            .push(base_metadata_digest_requirement(&previous_metadata)?);
         let committed_metadata_location = request.new_metadata_location.clone();
         let result = store.commit_table(request).await.map_err(catalog_store_error)?;
         return commit_table_replay_response(
@@ -5394,10 +5683,14 @@ where
     validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
     validate_table_commit_requirements(&current_metadata, &client_requirements)?;
     validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
+    request
+        .requirements
+        .push(base_metadata_digest_requirement(&current_metadata)?);
     let result = store.commit_table(request).await.map_err(catalog_store_error)?;
     Ok(commit_table_response_from_result(result, target_metadata))
 }
 
+#[cfg(test)]
 async fn standard_commit_table_response<S>(
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
@@ -5473,7 +5766,7 @@ where
     };
     validate_table_snapshot_commit_conflicts(req.as_deref_mut(), &snapshot_context, &expected_metadata, &request.updates).await?;
     let (commit_id, metadata_file_token) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
-    let next_generation = current.generation.saturating_add(1);
+    let next_generation = crate::table_catalog::next_table_catalog_generation(current.generation).map_err(catalog_store_error)?;
     let next_metadata_location = crate::table_catalog::table_metadata_file_path_for_entry(
         &current,
         &next_metadata_file_name(next_generation, &metadata_file_token),
@@ -5517,6 +5810,7 @@ where
     }
 
     let mut requirements = request.requirements;
+    requirements.push(base_metadata_digest_requirement(&expected_metadata)?);
     requirements.push(metadata_digest_requirement(&next_metadata)?);
     let commit_request = crate::table_catalog::TableCommitRequest {
         table_bucket: bucket.to_string(),
@@ -5577,8 +5871,12 @@ where
         .and_then(serde_json::Value::as_i64)
         .ok_or_else(|| s3_error!(InvalidRequest, "committed metadata is missing last-updated-ms"))?;
     let previous_metadata_location = table_metadata_location_for_client(bucket, &commit.previous_metadata_location);
-    let rebuilt_metadata =
-        apply_table_commit_updates_at(previous_metadata, &request.updates, &previous_metadata_location, commit_timestamp_ms)?;
+    let rebuilt_metadata = apply_table_commit_updates_at(
+        previous_metadata.clone(),
+        &request.updates,
+        &previous_metadata_location,
+        commit_timestamp_ms,
+    )?;
     if rebuilt_metadata != target_metadata {
         return Err(iceberg_rest_error(
             ICEBERG_ERROR_COMMIT_FAILED,
@@ -5598,6 +5896,7 @@ where
         ));
     }
     let mut requirements = request.requirements.clone();
+    requirements.push(base_metadata_digest_requirement(&previous_metadata)?);
     requirements.push(metadata_digest_requirement(&target_metadata)?);
     let committed_metadata_location = commit.new_metadata_location.clone();
     let result = store
@@ -5792,7 +6091,7 @@ where
     let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
         .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
     let (commit_id, metadata_file_token) = standard_commit_ids(None, None);
-    let next_generation = current.generation.saturating_add(1);
+    let next_generation = crate::table_catalog::next_table_catalog_generation(current.generation).map_err(catalog_store_error)?;
     let next_metadata_location = crate::table_catalog::default_table_metadata_file_path(
         namespace,
         &table_name,
@@ -5820,7 +6119,10 @@ where
         expected_version_token: current.version_token,
         expected_metadata_location: current.metadata_location,
         new_metadata_location: next_metadata_location,
-        requirements: vec![metadata_digest_requirement(&next_metadata)?],
+        requirements: vec![
+            base_metadata_digest_requirement(&current_metadata)?,
+            metadata_digest_requirement(&next_metadata)?,
+        ],
         writer: Some("rustfs-maintenance".to_string()),
     };
     let result = store.commit_table(commit_request).await.map_err(catalog_store_error)?;
@@ -5879,17 +6181,21 @@ where
 }
 
 async fn put_table_ref_response<S>(
+    req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &str,
+    route: RestTableRoute<'_>,
     ref_name: &str,
     request: PutTableRefRequest,
 ) -> S3Result<RestCommitTableResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    let RestTableRoute {
+        bucket,
+        namespace,
+        table,
+    } = route;
     if !matches!(request.ref_type.as_str(), "branch" | "tag") {
         return Err(s3_error!(InvalidRequest, "snapshot ref type must be branch or tag"));
     }
@@ -5916,12 +6222,15 @@ where
             "snapshot-id": expected_snapshot_id
         }));
     }
-    standard_commit_table_response(
+    standard_commit_table_response_inner(
+        req,
         store,
         metadata_backend,
-        bucket,
-        namespace,
-        table,
+        RestTableRoute {
+            bucket,
+            namespace,
+            table,
+        },
         RestCommitTableRequest {
             identifier: None,
             commit_id: request.commit_id,
@@ -5939,17 +6248,21 @@ where
 }
 
 async fn delete_table_ref_response<S>(
+    mut req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &str,
+    route: RestTableRoute<'_>,
     ref_name: &str,
     request: DeleteTableRefRequest,
 ) -> S3Result<RestCommitTableResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    let RestTableRoute {
+        bucket,
+        namespace,
+        table,
+    } = route;
     if ref_name == "main" {
         return Err(s3_error!(InvalidRequest, "main snapshot ref cannot be deleted"));
     }
@@ -5960,6 +6273,7 @@ where
     else {
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
+    authorize_optional_table_catalog_object_read(req.as_deref_mut(), bucket, &entry.metadata_location).await?;
     let metadata = read_table_metadata_json(metadata_backend, bucket, &entry.metadata_location).await?;
     let reference = metadata
         .get("refs")
@@ -5976,12 +6290,15 @@ where
             "snapshot-id": expected_snapshot_id
         }));
     }
-    standard_commit_table_response(
+    standard_commit_table_response_inner(
+        req,
         store,
         metadata_backend,
-        bucket,
-        namespace,
-        table,
+        RestTableRoute {
+            bucket,
+            namespace,
+            table,
+        },
         RestCommitTableRequest {
             identifier: None,
             commit_id: request.commit_id,
@@ -6167,6 +6484,7 @@ fn external_catalog_bridge_entry_from_request(
         table_bucket: bucket.to_string(),
         namespace: namespace.public_name(),
         table: table.to_string(),
+        table_id: String::new(),
         catalog,
         external_catalog_id,
         external_namespace,
@@ -6217,6 +6535,7 @@ fn external_catalog_bridge_entry_from_sync_request(
         table_bucket: bucket.to_string(),
         namespace: namespace.public_name(),
         table: table.to_string(),
+        table_id: String::new(),
         catalog,
         external_catalog_id,
         external_namespace,
@@ -6326,38 +6645,84 @@ where
     validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
     let external_table_uuid = validate_external_catalog_metadata_uuid(request.external_table_uuid.as_deref(), &target_metadata)?;
 
-    let (action, table_response) = if let Some(current) = current {
-        let expected_version_token = request
-            .expected_version_token
-            .clone()
-            .ok_or_else(|| s3_error!(InvalidRequest, "external catalog sync requires expected-version-token"))?;
-        let expected_metadata_location = request
-            .expected_metadata_location
-            .clone()
-            .ok_or_else(|| s3_error!(InvalidRequest, "external catalog sync requires expected-metadata-location"))?;
-        let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
-        validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
-        validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
-        let result = store
-            .commit_table(crate::table_catalog::TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: table.to_string(),
-                commit_id: request.commit_id.clone().unwrap_or_else(|| Uuid::new_v4().to_string()),
-                idempotency_key: request.idempotency_key.clone(),
-                operation: EXTERNAL_CATALOG_SYNC_OPERATION.to_string(),
-                expected_version_token,
-                expected_metadata_location,
-                new_metadata_location: request.metadata_location.clone(),
-                requirements: vec![metadata_digest_requirement(&target_metadata)?],
-                writer: Some(EXTERNAL_CATALOG_SYNC_WRITER.to_string()),
-            })
-            .await
-            .map_err(catalog_store_error)?;
-        (
-            EXTERNAL_CATALOG_ACTION_COMMITTED.to_string(),
-            load_table_response_from_entry(result.table, target_metadata),
-        )
+    let (action, table_response, table_id) = if let Some(current) = current {
+        if request.expected_version_token.is_none() && request.expected_metadata_location.is_none() {
+            if current.metadata_location != request.metadata_location
+                || current.table_uuid != metadata_table_uuid(&target_metadata)?
+            {
+                return Err(iceberg_rest_error(
+                    ICEBERG_ERROR_COMMIT_FAILED,
+                    StatusCode::CONFLICT,
+                    "external catalog sync target already exists with a different table state",
+                ));
+            }
+            let table_id = current.table_id.clone();
+            (
+                EXTERNAL_CATALOG_ACTION_REGISTERED.to_string(),
+                load_table_response_from_entry(current, target_metadata),
+                table_id,
+            )
+        } else {
+            let expected_version_token = request
+                .expected_version_token
+                .clone()
+                .ok_or_else(|| s3_error!(InvalidRequest, "external catalog sync requires expected-version-token"))?;
+            let expected_metadata_location = request
+                .expected_metadata_location
+                .clone()
+                .ok_or_else(|| s3_error!(InvalidRequest, "external catalog sync requires expected-metadata-location"))?;
+            let (commit_id, _) = standard_commit_ids(request.commit_id.clone(), request.idempotency_key.as_deref());
+            let result = if let Some(replay) = published_api_commit_replay(
+                store,
+                PublishedApiCommitReplay {
+                    route: RestTableRoute {
+                        bucket,
+                        namespace,
+                        table,
+                    },
+                    current: &current,
+                    commit_id: &commit_id,
+                    idempotency_key: request.idempotency_key.as_deref(),
+                    operation: EXTERNAL_CATALOG_SYNC_OPERATION,
+                    expected_version_token: &expected_version_token,
+                    new_metadata_location: &request.metadata_location,
+                    expected_metadata_location: Some(&expected_metadata_location),
+                },
+            )
+            .await?
+            {
+                store.commit_table(replay).await.map_err(catalog_store_error)?
+            } else {
+                let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
+                validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
+                validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
+                store
+                    .commit_table(crate::table_catalog::TableCommitRequest {
+                        table_bucket: bucket.to_string(),
+                        namespace: namespace.public_name(),
+                        table: table.to_string(),
+                        commit_id,
+                        idempotency_key: request.idempotency_key.clone(),
+                        operation: EXTERNAL_CATALOG_SYNC_OPERATION.to_string(),
+                        expected_version_token,
+                        expected_metadata_location,
+                        new_metadata_location: request.metadata_location.clone(),
+                        requirements: vec![
+                            base_metadata_digest_requirement(&current_metadata)?,
+                            metadata_digest_requirement(&target_metadata)?,
+                        ],
+                        writer: Some(EXTERNAL_CATALOG_SYNC_WRITER.to_string()),
+                    })
+                    .await
+                    .map_err(catalog_store_error)?
+            };
+            let table_id = result.table.table_id.clone();
+            (
+                EXTERNAL_CATALOG_ACTION_COMMITTED.to_string(),
+                load_table_response_from_entry(result.table, target_metadata),
+                table_id,
+            )
+        }
     } else {
         if request.expected_version_token.is_some() || request.expected_metadata_location.is_some() {
             return Err(s3_error!(
@@ -6376,13 +6741,17 @@ where
         )?;
         adopt_registered_metadata_identity(&mut entry, &target_metadata)?;
         store.register_table(entry.clone()).await.map_err(catalog_store_error)?;
+        let table_id = entry.table_id.clone();
         (
             EXTERNAL_CATALOG_ACTION_REGISTERED.to_string(),
             load_table_response_from_entry(entry, target_metadata),
+            table_id,
         )
     };
 
-    let bridge_entry = external_catalog_bridge_entry_from_sync_request(bucket, namespace, table, &request, external_table_uuid)?;
+    let mut bridge_entry =
+        external_catalog_bridge_entry_from_sync_request(bucket, namespace, table, &request, external_table_uuid)?;
+    bridge_entry.table_id = table_id;
     let bridge_entry = store
         .put_external_catalog_bridge(bridge_entry)
         .await
@@ -6480,6 +6849,29 @@ where
             return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
         };
         let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
+        let (commit_id, _) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
+        if let Some(replay) = published_api_commit_replay(
+            store,
+            PublishedApiCommitReplay {
+                route: RestTableRoute {
+                    bucket,
+                    namespace,
+                    table,
+                },
+                current: &current,
+                commit_id: &commit_id,
+                idempotency_key: request.idempotency_key.as_deref(),
+                operation: "rollback",
+                expected_version_token: &request.version_token,
+                new_metadata_location: &metadata_location,
+                expected_metadata_location: None,
+            },
+        )
+        .await?
+        {
+            let result = store.commit_table(replay).await.map_err(catalog_store_error)?;
+            return Ok(commit_table_response_from_result(result, target_metadata));
+        }
         if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &metadata_location) {
             return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
         }
@@ -6491,13 +6883,16 @@ where
             table_bucket: bucket.to_string(),
             namespace: namespace.public_name(),
             table: table.to_string(),
-            commit_id: request.commit_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+            commit_id,
             idempotency_key: request.idempotency_key,
             operation: "rollback".to_string(),
             expected_version_token: request.version_token,
             expected_metadata_location: current.metadata_location,
             new_metadata_location: metadata_location,
-            requirements: vec![metadata_digest_requirement(&target_metadata)?],
+            requirements: vec![
+                base_metadata_digest_requirement(&current_metadata)?,
+                metadata_digest_requirement(&target_metadata)?,
+            ],
             writer: Some("rustfs-catalog-rollback-api".to_string()),
         };
         let result = store.commit_table(commit_request).await.map_err(catalog_store_error)?;
@@ -6809,10 +7204,13 @@ impl Operation for RestRegisterTableHandler {
         let request = read_json_body::<RegisterTableRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
         let metadata_location = table_metadata_location_for_catalog(&warehouse, &request.metadata_location)?;
-        let metadata = read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &metadata_location).await?;
+        let (metadata, metadata_guard) =
+            read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &metadata_location).await?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
+        crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
         let response = register_table_response(&store, &warehouse, &namespace, request, metadata, table_bucket_enabled).await?;
+        drop(metadata_guard);
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -7099,7 +7497,7 @@ pub struct PutTableRefHandler {}
 
 #[async_trait::async_trait]
 impl Operation for PutTableRefHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
@@ -7107,11 +7505,23 @@ impl Operation for PutTableRefHandler {
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::CommitTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let request = read_json_body::<PutTableRefRequest>(req.input).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let request = read_json_body::<PutTableRefRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
-        let response =
-            put_table_ref_response(&store, &metadata_backend, &warehouse, &namespace, &table, &ref_name, request).await?;
+        let response = put_table_ref_response(
+            Some(&mut req),
+            &store,
+            &metadata_backend,
+            RestTableRoute {
+                bucket: &warehouse,
+                namespace: &namespace,
+                table: &table,
+            },
+            &ref_name,
+            request,
+        )
+        .await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -7120,7 +7530,7 @@ pub struct DeleteTableRefHandler {}
 
 #[async_trait::async_trait]
 impl Operation for DeleteTableRefHandler {
-    async fn call(&self, req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
+    async fn call(&self, mut req: S3Request<Body>, params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
         let warehouse = warehouse_from_params(&params)?;
         let namespace = namespace_from_params(&params)?;
         let table = table_name_from_params(&params)?;
@@ -7128,11 +7538,23 @@ impl Operation for DeleteTableRefHandler {
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::CommitTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let request = read_json_body_or_default::<DeleteTableRefRequest>(req.input).await?;
+        let input = std::mem::replace(&mut req.input, Body::empty());
+        let request = read_json_body_or_default::<DeleteTableRefRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
-        let response =
-            delete_table_ref_response(&store, &metadata_backend, &warehouse, &namespace, &table, &ref_name, request).await?;
+        let response = delete_table_ref_response(
+            Some(&mut req),
+            &store,
+            &metadata_backend,
+            RestTableRoute {
+                bucket: &warehouse,
+                namespace: &namespace,
+                table: &table,
+            },
+            &ref_name,
+            request,
+        )
+        .await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -7447,10 +7869,11 @@ impl Operation for ImportTableCatalogHandler {
         let mut request = read_json_body::<CatalogImportRequest>(input).await?;
         let metadata_backend = table_catalog_backend()?;
         request.metadata_location = table_metadata_location_for_catalog(&warehouse, &request.metadata_location)?;
-        let metadata =
+        let (metadata, metadata_guard) =
             read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &request.metadata_location).await?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
+        crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
         let response = catalog_import_response_with_metadata(
             &store,
             &warehouse,
@@ -7461,6 +7884,7 @@ impl Operation for ImportTableCatalogHandler {
             table_bucket_enabled,
         )
         .await?;
+        drop(metadata_guard);
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -7529,8 +7953,9 @@ impl Operation for SyncExternalCatalogBridgeHandler {
             .load_table(&warehouse, &namespace.public_name(), &table)
             .await
             .map_err(catalog_store_error)?;
-        let target_metadata =
+        let (target_metadata, metadata_guard) =
             read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &request.metadata_location).await?;
+        crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
         let response = sync_external_catalog_bridge_response_with_snapshot(
             &store,
             &metadata_backend,
@@ -7544,6 +7969,7 @@ impl Operation for SyncExternalCatalogBridgeHandler {
             },
         )
         .await?;
+        drop(metadata_guard);
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -7678,6 +8104,74 @@ mod tests {
         for error in [manifest_error, avro_error, reference_error] {
             assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
         }
+    }
+
+    #[tokio::test]
+    async fn manifest_object_validation_is_bounded_and_preserves_missing_object_errors() {
+        let backend = TestTableCatalogObjectBackend {
+            object_exists_delay: Some(StdDuration::from_millis(20)),
+            ..Default::default()
+        };
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let table = crate::table_catalog::IdentifierSegment::parse("events").expect("table should parse");
+        let entry = crate::table_catalog::TableEntry {
+            version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+            table_bucket: "warehouse".to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            table_id: "table-id".to_string(),
+            table_uuid: "table-uuid".to_string(),
+            format: "ICEBERG".to_string(),
+            format_version: 2,
+            warehouse_location: "s3://warehouse/tables/table-id".to_string(),
+            metadata_location: "tables/table-id/metadata/00001.metadata.json".to_string(),
+            version_token: "token-v1".to_string(),
+            generation: 1,
+            state: crate::table_catalog::TableCatalogEntryState::Active,
+            properties: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
+        };
+        let mut references = Vec::new();
+        for index in 0..(TABLE_COMMIT_OBJECT_VALIDATION_CONCURRENCY * 2) {
+            let location = format!("tables/table-id/data/part-{index}.parquet");
+            backend.put_bytes("warehouse", &location, b"data".to_vec()).await;
+            references.push(crate::table_catalog::ManifestDataFileReference {
+                location,
+                content: crate::table_catalog::ManifestDataFileContent::Data,
+                object_kind: crate::table_catalog::TableMetadataMaintenanceObjectKind::DataFile,
+                entry_status: Some(1),
+                snapshot_id: Some(1),
+                sequence_number: Some(1),
+                file_sequence_number: Some(1),
+                record_count: Some(1),
+                file_size_bytes: Some(4),
+                partition: Vec::new(),
+                sort_order_id: None,
+            });
+        }
+        let context = SnapshotReadContext {
+            metadata_backend: &backend,
+            bucket: "warehouse",
+            namespace: &namespace,
+            table: &table,
+            entry: &entry,
+        };
+
+        validate_manifest_data_file_references(None, &context, &references)
+            .await
+            .expect("existing manifest objects should validate");
+        assert!(backend.object_exists_max_in_flight() > 1);
+        assert!(backend.object_exists_max_in_flight() <= TABLE_COMMIT_OBJECT_VALIDATION_CONCURRENCY);
+
+        backend
+            .delete_object("warehouse", &references[0].location)
+            .await
+            .expect("test object should be removed");
+        let error = validate_manifest_data_file_references(None, &context, &references)
+            .await
+            .expect_err("a missing manifest object should still fail validation");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
     }
 
     #[test]
@@ -8171,6 +8665,38 @@ mod tests {
         let metadata_auth_block = function_block(src, "async fn read_authorized_table_metadata_json");
         assert!(metadata_auth_block.contains("S3Action::GetObjectAction"));
         assert!(metadata_auth_block.contains("authorize_table_warehouse_s3_actions"));
+        assert!(metadata_auth_block.contains("acquire_read_lock"));
+        assert!(metadata_auth_block.contains("ensure_table_catalog_lock_held"));
+
+        for handler in [
+            "RestRegisterTableHandler",
+            "ImportTableCatalogHandler",
+            "SyncExternalCatalogBridgeHandler",
+        ] {
+            let block = operation_block(src, handler);
+            assert!(block.contains("metadata_guard"), "{handler} should retain the authorized metadata lock");
+            assert!(
+                block.contains("ensure_table_catalog_lock_held"),
+                "{handler} should recheck the metadata lock before publication"
+            );
+            assert!(
+                block.contains("drop(metadata_guard)"),
+                "{handler} should hold the metadata lock through catalog publication"
+            );
+        }
+
+        for handler in ["PutTableRefHandler", "DeleteTableRefHandler"] {
+            assert!(
+                operation_block(src, handler).contains("Some(&mut req)"),
+                "{handler} should preserve request context for object-level authorization"
+            );
+        }
+        for helper in ["async fn put_table_ref_response", "async fn delete_table_ref_response"] {
+            assert!(
+                function_block(src, helper).contains("standard_commit_table_response_inner"),
+                "{helper} should route ref commits through the authorized commit path"
+            );
+        }
 
         let sync_bridge_block = operation_block(src, "SyncExternalCatalogBridgeHandler");
         assert!(
@@ -8958,22 +9484,6 @@ mod tests {
 
     #[tokio::test]
     async fn rename_table_body_rejects_declared_and_streamed_oversize_payloads() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            http::header::CONTENT_LENGTH,
-            HeaderValue::from_str(&(RENAME_TABLE_BODY_MAX_SIZE + 1).to_string()).expect("content length should parse"),
-        );
-        let error = read_bounded_json_body::<RenameTableRequest>(
-            &headers,
-            Body::empty(),
-            RENAME_TABLE_BODY_MAX_SIZE,
-            RENAME_TABLE_BODY_TIMEOUT,
-            "rename table",
-        )
-        .await
-        .expect_err("oversized Content-Length should fail before reading the body");
-        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
-
         let error = read_bounded_json_body::<RenameTableRequest>(
             &HeaderMap::new(),
             Body::from(vec![b'x'; RENAME_TABLE_BODY_MAX_SIZE + 1]),
@@ -9039,6 +9549,56 @@ mod tests {
         )
         .await
         .expect_err("stalled namespace property request should time out");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn generic_json_body_readers_time_out_stalled_streams() {
+        let required_stream = futures::stream::pending::<Result<http_body::Frame<Bytes>, std::io::Error>>();
+        let required = tokio::spawn(read_json_body::<serde_json::Value>(Body::http_body(http_body_util::StreamBody::new(
+            required_stream,
+        ))));
+        let optional_stream = futures::stream::pending::<Result<http_body::Frame<Bytes>, std::io::Error>>();
+        let optional = tokio::spawn(read_json_body_or_default::<serde_json::Value>(Body::http_body(
+            http_body_util::StreamBody::new(optional_stream),
+        )));
+        tokio::task::yield_now().await;
+        tokio::time::advance(TABLE_CATALOG_REQUEST_BODY_TIMEOUT).await;
+
+        let required_error = required
+            .await
+            .expect("required body task should complete")
+            .expect_err("stalled required body should time out");
+        let optional_error = optional
+            .await
+            .expect("optional body task should complete")
+            .expect_err("stalled optional body should time out");
+
+        assert_eq!(required_error.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(optional_error.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[tokio::test]
+    async fn bounded_json_body_rejects_oversized_content_length_without_polling_the_body() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_LENGTH,
+            HeaderValue::from_str(&(RENAME_TABLE_BODY_MAX_SIZE + 1).to_string()).expect("content length should parse"),
+        );
+        let stream = futures::stream::poll_fn(|_| -> std::task::Poll<Option<Result<http_body::Frame<Bytes>, std::io::Error>>> {
+            panic!("an oversized declared body must not be polled")
+        });
+
+        let error = read_bounded_json_body::<RenameTableRequest>(
+            &headers,
+            Body::http_body(http_body_util::StreamBody::new(stream)),
+            RENAME_TABLE_BODY_MAX_SIZE,
+            RENAME_TABLE_BODY_TIMEOUT,
+            "rename table",
+        )
+        .await
+        .expect_err("an oversized declared body should fail before body polling");
 
         assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
     }
@@ -9668,6 +10228,66 @@ mod tests {
     }
 
     #[test]
+    fn table_format_versions_accept_v1_and_v2_and_reject_v3() {
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        for version in [1, 2] {
+            let request = serde_json::from_value(serde_json::json!({
+                "name": format!("events_v{version}"),
+                "schema": {
+                    "type": "struct",
+                    "schema-id": 0,
+                    "fields": []
+                },
+                "properties": {
+                    "format-version": version.to_string()
+                }
+            }))
+            .expect("create request should parse");
+            let (entry, metadata) = table_entry_from_create_table_request("warehouse", &namespace, request)
+                .expect("supported format version should create metadata");
+            assert_eq!(entry.format_version, version);
+            assert_eq!(metadata["format-version"], version);
+        }
+
+        let request = serde_json::from_value(serde_json::json!({
+            "name": "events_v3",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            },
+            "properties": {
+                "format-version": "3"
+            }
+        }))
+        .expect("create request should parse");
+        let error = table_entry_from_create_table_request("warehouse", &namespace, request)
+            .expect_err("format version 3 is not implemented");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+
+        let mut entry = table_entry_from_register_request(
+            "warehouse",
+            &namespace,
+            RegisterTableRequest {
+                name: "registered_v3".to_string(),
+                metadata_location: "s3://warehouse/tables/registered-v3/metadata/00001.metadata.json".to_string(),
+                overwrite: false,
+            },
+        )
+        .expect("register request should build an entry");
+        let metadata = serde_json::json!({
+            "format-version": 3,
+            "table-uuid": "registered-v3-uuid",
+            "location": "s3://warehouse/tables/registered-v3"
+        });
+        let error = adopt_registered_metadata_identity(&mut entry, &metadata)
+            .expect_err("registered format version 3 is not implemented");
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+    }
+
+    #[test]
     fn standard_commit_ids_use_uuid_for_metadata_file_when_provided() {
         let commit_id = "11111111-1111-4111-8111-111111111111";
         assert_eq!(
@@ -9766,6 +10386,47 @@ mod tests {
                 .await
                 .expect("metadata object lookup should succeed")
         );
+    }
+
+    #[tokio::test]
+    async fn create_responses_remove_initial_metadata_when_catalog_publication_fails() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("missing").expect("namespace should parse");
+
+        let table_request = serde_json::from_value(serde_json::json!({
+            "name": "events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            }
+        }))
+        .expect("table request should parse");
+        create_table_response(&store, &metadata_backend, "warehouse", &namespace, table_request, true)
+            .await
+            .expect_err("missing namespace should reject table publication");
+        assert!(metadata_backend.objects.lock().await.is_empty());
+
+        let view_request = serde_json::from_value(serde_json::json!({
+            "name": "recent_events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            },
+            "view-version": {
+                "version-id": 1,
+                "schema-id": 0,
+                "summary": {},
+                "representations": []
+            }
+        }))
+        .expect("view request should parse");
+        create_view_response(&store, &metadata_backend, "warehouse", &namespace, view_request, true)
+            .await
+            .expect_err("missing namespace should reject view publication");
+        assert!(metadata_backend.objects.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -11431,6 +12092,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn external_catalog_bridge_sync_recovers_after_registration_bridge_write_failure() {
+        let backend = TestTableCatalogObjectBackend::default();
+        let store = crate::table_catalog::ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "warehouse";
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let table = crate::table_catalog::IdentifierSegment::parse("events").expect("table should parse");
+        ensure_table_bucket_entry(&store, bucket, true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            &store,
+            bucket,
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        let metadata_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        backend
+            .put_json(
+                bucket,
+                &metadata_location,
+                serde_json::json!({
+                    "format-version": 2,
+                    "table-uuid": "table-uuid",
+                    "location": "s3://warehouse/tables/table-id"
+                }),
+            )
+            .await;
+        let bridge_path =
+            crate::table_catalog::TableCatalogObjectPaths::default().external_catalog_bridge_path(bucket, &namespace, &table);
+        backend
+            .fail_next_put(crate::storage_api::table::RUSTFS_META_BUCKET, &bridge_path)
+            .await;
+        let sync_request = || ExternalCatalogBridgeSyncRequest {
+            catalog: "glue".to_string(),
+            external_catalog_id: Some("aws-glue-prod".to_string()),
+            external_namespace: "sales".to_string(),
+            external_table: "orders".to_string(),
+            external_table_uuid: Some("table-uuid".to_string()),
+            metadata_location: metadata_location.clone(),
+            external_version_token: Some("glue-version-1".to_string()),
+            expected_version_token: None,
+            expected_metadata_location: None,
+            commit_id: None,
+            idempotency_key: Some("external-register-retry".to_string()),
+            policy_mode: Some("rustfs-authoritative".to_string()),
+            credential_mode: Some("rustfs-table-credentials".to_string()),
+            rollback_strategy: Some("retain-current-pointer".to_string()),
+            properties: BTreeMap::new(),
+        };
+
+        sync_external_catalog_bridge_response(&store, &backend, bucket, &namespace, "events", sync_request(), true)
+            .await
+            .expect_err("bridge write failure should surface after table registration");
+        let registered = store
+            .load_table(bucket, "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table registration should remain durable");
+
+        let recovered =
+            sync_external_catalog_bridge_response(&store, &backend, bucket, &namespace, "events", sync_request(), true)
+                .await
+                .expect("exact retry should finish the bridge write");
+
+        assert_eq!(recovered.action, EXTERNAL_CATALOG_ACTION_REGISTERED);
+        let bridge = store
+            .get_external_catalog_bridge(bucket, "analytics", "events")
+            .await
+            .expect("bridge lookup should succeed")
+            .expect("bridge should be stored");
+        assert_eq!(bridge.table_id, registered.table_id);
+        assert_eq!(bridge.last_synced_metadata_location.as_deref(), Some(metadata_location.as_str()));
+    }
+
+    #[tokio::test]
     async fn external_catalog_bridge_sync_commits_existing_table_pointer() {
         let backend = TestTableCatalogObjectBackend::default();
         let store = crate::table_catalog::ObjectTableCatalogStore::new(backend.clone());
@@ -11465,33 +12206,26 @@ mod tests {
             )
             .await;
 
-        let synced = sync_external_catalog_bridge_response(
-            &store,
-            &backend,
-            bucket,
-            &namespace,
-            "events",
-            ExternalCatalogBridgeSyncRequest {
-                catalog: "hive-metastore".to_string(),
-                external_catalog_id: Some("hms-prod".to_string()),
-                external_namespace: "sales".to_string(),
-                external_table: "orders".to_string(),
-                external_table_uuid: Some("table-uuid".to_string()),
-                metadata_location: table_metadata_location_for_client(bucket, &next_location),
-                external_version_token: Some("hms-version-2".to_string()),
-                expected_version_token: Some("token-v1".to_string()),
-                expected_metadata_location: Some(table_metadata_location_for_client(bucket, &current_location)),
-                commit_id: Some("external-sync-2".to_string()),
-                idempotency_key: Some("external-sync-idempotency-2".to_string()),
-                policy_mode: Some("rustfs-authoritative".to_string()),
-                credential_mode: Some("rustfs-table-credentials".to_string()),
-                rollback_strategy: Some("retain-current-pointer".to_string()),
-                properties: BTreeMap::new(),
-            },
-            true,
-        )
-        .await
-        .expect("external sync should commit existing table");
+        let sync_request = || ExternalCatalogBridgeSyncRequest {
+            catalog: "hive-metastore".to_string(),
+            external_catalog_id: Some("hms-prod".to_string()),
+            external_namespace: "sales".to_string(),
+            external_table: "orders".to_string(),
+            external_table_uuid: Some("table-uuid".to_string()),
+            metadata_location: table_metadata_location_for_client(bucket, &next_location),
+            external_version_token: Some("hms-version-2".to_string()),
+            expected_version_token: Some("token-v1".to_string()),
+            expected_metadata_location: Some(table_metadata_location_for_client(bucket, &current_location)),
+            commit_id: None,
+            idempotency_key: Some("external-sync-idempotency-2".to_string()),
+            policy_mode: Some("rustfs-authoritative".to_string()),
+            credential_mode: Some("rustfs-table-credentials".to_string()),
+            rollback_strategy: Some("retain-current-pointer".to_string()),
+            properties: BTreeMap::new(),
+        };
+        let synced = sync_external_catalog_bridge_response(&store, &backend, bucket, &namespace, "events", sync_request(), true)
+            .await
+            .expect("external sync should commit existing table");
 
         assert_eq!(synced.action, "committed");
         assert_eq!(synced.table.metadata_location, table_metadata_location_for_client(bucket, &next_location));
@@ -11502,6 +12236,22 @@ mod tests {
             .expect("table should exist");
         assert_eq!(current.metadata_location, next_location);
         assert_eq!(current.generation, 2);
+
+        let replayed =
+            sync_external_catalog_bridge_response(&store, &backend, bucket, &namespace, "events", sync_request(), true)
+                .await
+                .expect("idempotency-only external sync retry should replay the published result");
+
+        assert_eq!(replayed.action, EXTERNAL_CATALOG_ACTION_COMMITTED);
+        assert_eq!(replayed.table.metadata_location, synced.table.metadata_location);
+        assert_eq!(replayed.table.config, synced.table.config);
+        let replayed_current = store
+            .load_table(bucket, "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+        assert_eq!(replayed_current.version_token, current.version_token);
+        assert_eq!(replayed_current.generation, current.generation);
     }
 
     #[tokio::test]
@@ -11925,6 +12675,210 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_updates_apply_v1_sequence_rules_and_reject_unsupported_versions() {
+        let add_snapshot = serde_json::json!({
+            "action": "add-snapshot",
+            "snapshot": {
+                "snapshot-id": 10,
+                "timestamp-ms": 1234,
+                "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-10.avro",
+                "summary": {"operation": "append"}
+            }
+        });
+        let set_main = serde_json::json!({
+            "action": "set-snapshot-ref",
+            "ref-name": "main",
+            "snapshot-id": 10,
+            "type": "branch"
+        });
+        let base_metadata = |format_version| {
+            serde_json::json!({
+                "format-version": format_version,
+                "last-sequence-number": 0,
+                "snapshots": [],
+                "refs": {},
+                "snapshot-log": [],
+                "metadata-log": []
+            })
+        };
+
+        let v1 = apply_table_commit_updates(
+            base_metadata(1),
+            &[add_snapshot.clone(), set_main.clone()],
+            "metadata/00001.metadata.json",
+        )
+        .expect("v1 snapshot may omit sequence-number");
+        assert_eq!(v1["current-snapshot-id"], 10);
+        assert!(v1["snapshots"][0].get("sequence-number").is_none());
+
+        let v2_error =
+            apply_table_commit_updates(base_metadata(2), &[add_snapshot.clone(), set_main], "metadata/00001.metadata.json")
+                .expect_err("v2 snapshot must include sequence-number");
+        assert_eq!(v2_error.code(), &S3ErrorCode::InvalidRequest);
+
+        let unsupported = apply_table_commit_updates(base_metadata(3), &[add_snapshot], "metadata/00001.metadata.json")
+            .expect_err("format version 3 is not implemented");
+        assert_eq!(unsupported.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+
+        let remove_main = apply_table_commit_updates(
+            base_metadata(2),
+            &[serde_json::json!({
+                "action": "remove-snapshot-ref",
+                "ref-name": "main"
+            })],
+            "metadata/00001.metadata.json",
+        )
+        .expect_err("generic commits must not remove main");
+        assert_eq!(remove_main.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn snapshot_updates_advance_only_the_main_branch_and_record_main_history() {
+        let metadata = serde_json::json!({
+            "current-snapshot-id": 10,
+            "last-sequence-number": 4,
+            "snapshots": [
+                {
+                    "snapshot-id": 5,
+                    "sequence-number": 3,
+                    "timestamp-ms": 1000,
+                    "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-5.avro",
+                    "summary": {"operation": "append"}
+                },
+                {
+                    "snapshot-id": 10,
+                    "sequence-number": 4,
+                    "timestamp-ms": 1234,
+                    "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-10.avro",
+                    "summary": {"operation": "append"}
+                }
+            ],
+            "refs": {
+                "main": {"snapshot-id": 10, "type": "branch"}
+            },
+            "snapshot-log": [
+                {"timestamp-ms": 1234, "snapshot-id": 10}
+            ],
+            "metadata-log": []
+        });
+        let add_snapshot = serde_json::json!({
+            "action": "add-snapshot",
+            "snapshot": {
+                "snapshot-id": 11,
+                "parent-snapshot-id": 5,
+                "sequence-number": 5,
+                "timestamp-ms": 2234,
+                "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-11.avro",
+                "summary": {"operation": "append"}
+            }
+        });
+        let branch = apply_table_commit_updates_at(
+            metadata.clone(),
+            &[
+                add_snapshot.clone(),
+                serde_json::json!({
+                    "action": "set-snapshot-ref",
+                    "ref-name": "audit",
+                    "snapshot-id": 11,
+                    "type": "branch"
+                }),
+            ],
+            "metadata/00001.metadata.json",
+            3000,
+        )
+        .expect("a branch snapshot may descend from an existing non-current snapshot");
+        assert_eq!(branch["current-snapshot-id"], 10);
+        assert_eq!(branch["refs"]["main"]["snapshot-id"], 10);
+        assert_eq!(branch["refs"]["audit"]["snapshot-id"], 11);
+        assert_eq!(
+            branch["snapshot-log"]
+                .as_array()
+                .expect("snapshot log should be an array")
+                .len(),
+            1
+        );
+
+        let main = apply_table_commit_updates_at(
+            metadata,
+            &[
+                add_snapshot,
+                serde_json::json!({
+                    "action": "set-snapshot-ref",
+                    "ref-name": "main",
+                    "snapshot-id": 11,
+                    "type": "branch"
+                }),
+            ],
+            "metadata/00001.metadata.json",
+            3000,
+        )
+        .expect("advancing main should succeed");
+        assert_eq!(main["current-snapshot-id"], 11);
+        assert_eq!(main["snapshot-log"][1]["snapshot-id"], 11);
+        assert_eq!(main["snapshot-log"][1]["timestamp-ms"], 3000);
+    }
+
+    #[test]
+    fn snapshot_updates_reject_missing_timestamps_malformed_removals_and_main_tags() {
+        let metadata = serde_json::json!({
+            "current-snapshot-id": 10,
+            "last-sequence-number": 1,
+            "snapshots": [{
+                "snapshot-id": 10,
+                "sequence-number": 1,
+                "timestamp-ms": 1234,
+                "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-10.avro",
+                "summary": {"operation": "append"}
+            }],
+            "refs": {"main": {"snapshot-id": 10, "type": "branch"}},
+            "snapshot-log": [],
+            "metadata-log": []
+        });
+        let missing_timestamp = serde_json::json!({
+            "action": "add-snapshot",
+            "snapshot": {
+                "snapshot-id": 11,
+                "parent-snapshot-id": 10,
+                "sequence-number": 2,
+                "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-11.avro",
+                "summary": {"operation": "append"}
+            }
+        });
+        let malformed_removal = serde_json::json!({
+            "action": "remove-snapshots",
+            "snapshot-ids": ["10"]
+        });
+        let malformed_parent = serde_json::json!({
+            "action": "add-snapshot",
+            "snapshot": {
+                "snapshot-id": 11,
+                "parent-snapshot-id": "10",
+                "sequence-number": 2,
+                "timestamp-ms": 2234,
+                "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-11.avro",
+                "summary": {"operation": "append"}
+            }
+        });
+        let main_tag = serde_json::json!({
+            "action": "set-snapshot-ref",
+            "ref-name": "main",
+            "snapshot-id": 10,
+            "type": "tag"
+        });
+
+        for (update, expected) in [
+            (missing_timestamp, "snapshot timestamp-ms must be an integer"),
+            (malformed_parent, "snapshot parent-snapshot-id must be an integer"),
+            (malformed_removal, "remove-snapshots snapshot-ids must contain integers"),
+            (main_tag, "main snapshot ref must be a branch"),
+        ] {
+            let error = apply_table_commit_updates(metadata.clone(), &[update], "metadata/00001.metadata.json")
+                .expect_err("malformed snapshot update should fail");
+            assert_eq!(error.message(), Some(expected));
+        }
+    }
+
+    #[test]
     fn snapshot_conflict_rejects_unknown_snapshot_operations() {
         let metadata = serde_json::json!({
             "current-snapshot-id": 10,
@@ -11958,6 +12912,94 @@ mod tests {
             }
         })];
         assert!(apply_table_commit_updates(metadata, &updates, "metadata/00001.metadata.json").is_err());
+    }
+
+    #[tokio::test]
+    async fn row_level_conflict_uses_the_declared_branch_parent_snapshot() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let created = create_standard_events_table(&store, &metadata_backend, &namespace).await;
+        let table_location = created.metadata["location"]
+            .as_str()
+            .expect("created metadata should have table location");
+        let branch_manifest_list = format!("{table_location}/metadata/snap-10.avro");
+        let main_manifest_list = format!("{table_location}/metadata/snap-20.avro");
+        let overwrite_manifest_list = format!("{table_location}/metadata/snap-30.avro");
+        let branch_data_file = format!("{table_location}/data/branch.parquet");
+        let main_data_file = format!("{table_location}/data/main.parquet");
+        seed_test_snapshot_manifest(
+            &metadata_backend,
+            "warehouse",
+            &branch_manifest_list,
+            10,
+            1,
+            &[(&branch_data_file, 0, 1, 10, 1)],
+        )
+        .await;
+        seed_test_snapshot_manifest(
+            &metadata_backend,
+            "warehouse",
+            &main_manifest_list,
+            20,
+            2,
+            &[(&main_data_file, 0, 1, 20, 2)],
+        )
+        .await;
+        seed_test_snapshot_manifest(
+            &metadata_backend,
+            "warehouse",
+            &overwrite_manifest_list,
+            30,
+            3,
+            &[(&branch_data_file, 0, 2, 30, 1)],
+        )
+        .await;
+        let current_metadata = serde_json::json!({
+            "current-snapshot-id": 20,
+            "snapshots": [
+                {
+                    "snapshot-id": 10,
+                    "sequence-number": 1,
+                    "manifest-list": branch_manifest_list
+                },
+                {
+                    "snapshot-id": 20,
+                    "sequence-number": 2,
+                    "manifest-list": main_manifest_list
+                }
+            ]
+        });
+        let entry = store
+            .load_table("warehouse", "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+        let table = crate::table_catalog::IdentifierSegment::parse("events").expect("table should parse");
+        let context = SnapshotReadContext {
+            metadata_backend: &metadata_backend,
+            bucket: "warehouse",
+            namespace: &namespace,
+            table: &table,
+            entry: &entry,
+        };
+        let updates = vec![serde_json::json!({
+            "action": "add-snapshot",
+            "snapshot": {
+                "snapshot-id": 30,
+                "parent-snapshot-id": 10,
+                "sequence-number": 3,
+                "timestamp-ms": 3000,
+                "manifest-list": overwrite_manifest_list,
+                "summary": {
+                    "operation": "overwrite"
+                }
+            }
+        })];
+
+        validate_table_snapshot_commit_conflicts(None, &context, &current_metadata, &updates)
+            .await
+            .expect("a branch commit should validate deletes against its declared parent snapshot");
     }
 
     #[tokio::test]
@@ -12074,6 +13116,74 @@ mod tests {
 
         assert_eq!(commit.metadata["current-snapshot-id"], 11);
         assert_eq!(commit.metadata["last-sequence-number"], 2);
+    }
+
+    #[tokio::test]
+    async fn row_level_conflict_rejects_duplicate_manifest_and_file_references() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let created = create_standard_events_table(&store, &metadata_backend, &namespace).await;
+        let table_location = created.metadata["location"]
+            .as_str()
+            .expect("created metadata should have table location");
+        let manifest_list = format!("{table_location}/metadata/snap-10.avro");
+        let manifest = format!("{table_location}/metadata/manifest-10.avro");
+        let data_file = format!("{table_location}/data/part-10.parquet");
+        let manifest_list_key = test_snapshot_object_key("warehouse", &manifest_list);
+        metadata_backend
+            .put_bytes(
+                "warehouse",
+                &manifest_list_key,
+                test_manifest_list_avro_entries(&[(&manifest, 1, 10), (&manifest, 1, 10)]),
+            )
+            .await;
+        seed_test_manifest(&metadata_backend, "warehouse", &manifest, &[(&data_file, 0, 1, 10, 1)]).await;
+        let request = serde_json::from_value(serde_json::json!({
+            "requirements": [],
+            "updates": [{
+                "action": "add-snapshot",
+                "snapshot": {
+                    "snapshot-id": 10,
+                    "sequence-number": 1,
+                    "timestamp-ms": 1234,
+                    "manifest-list": manifest_list,
+                    "summary": {"operation": "append"}
+                }
+            }]
+        }))
+        .expect("duplicate manifest request should parse");
+        let error = commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
+            .await
+            .expect_err("duplicate manifest references must fail");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+
+        let duplicate_file_manifest = format!("{table_location}/metadata/manifest-duplicate-files.avro");
+        seed_test_manifest(
+            &metadata_backend,
+            "warehouse",
+            &duplicate_file_manifest,
+            &[(&data_file, 0, 1, 11, 1), (&data_file, 0, 1, 11, 1)],
+        )
+        .await;
+        let request = serde_json::from_value(serde_json::json!({
+            "requirements": [],
+            "updates": [{
+                "action": "add-snapshot",
+                "snapshot": {
+                    "snapshot-id": 11,
+                    "sequence-number": 1,
+                    "timestamp-ms": 2234,
+                    "manifests": [duplicate_file_manifest],
+                    "summary": {"operation": "append"}
+                }
+            }]
+        }))
+        .expect("duplicate file request should parse");
+        let error = commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
+            .await
+            .expect_err("duplicate file references must fail");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
     }
 
     #[tokio::test]
@@ -12563,6 +13673,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn row_level_conflict_rejects_existing_file_absent_from_parent_snapshot() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let created = create_standard_events_table(&store, &metadata_backend, &namespace).await;
+        let table_location = created.metadata["location"]
+            .as_str()
+            .expect("created metadata should have table location");
+        let parent_manifest_list = format!("{table_location}/metadata/snap-10.avro");
+        let parent_data_file = format!("{table_location}/data/part-10.parquet");
+        seed_test_snapshot_manifest(
+            &metadata_backend,
+            "warehouse",
+            &parent_manifest_list,
+            10,
+            1,
+            &[(&parent_data_file, 0, 1, 10, 1)],
+        )
+        .await;
+        let append_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [],
+            "updates": [
+                {
+                    "action": "add-snapshot",
+                    "snapshot": {
+                        "snapshot-id": 10,
+                        "sequence-number": 1,
+                        "timestamp-ms": 1234,
+                        "manifest-list": parent_manifest_list,
+                        "summary": {"operation": "append"}
+                    }
+                },
+                {
+                    "action": "set-snapshot-ref",
+                    "ref-name": "main",
+                    "snapshot-id": 10,
+                    "type": "branch"
+                }
+            ]
+        }))
+        .expect("append request should parse");
+        commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", append_request)
+            .await
+            .expect("parent snapshot should commit");
+        let committed = store
+            .load_table("warehouse", "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+
+        let next_manifest_list = format!("{table_location}/metadata/snap-11.avro");
+        let absent_parent_file = format!("{table_location}/data/not-in-parent.parquet");
+        seed_test_snapshot_manifest(
+            &metadata_backend,
+            "warehouse",
+            &next_manifest_list,
+            11,
+            2,
+            &[(&absent_parent_file, 0, 0, 10, 1)],
+        )
+        .await;
+        let overwrite_request: RestCommitTableRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [{"type": "assert-current-snapshot-id", "snapshot-id": 10}],
+            "updates": [
+                {
+                    "action": "add-snapshot",
+                    "snapshot": {
+                        "snapshot-id": 11,
+                        "parent-snapshot-id": 10,
+                        "sequence-number": 2,
+                        "timestamp-ms": 2234,
+                        "manifest-list": next_manifest_list,
+                        "summary": {"operation": "overwrite"}
+                    }
+                },
+                {
+                    "action": "set-snapshot-ref",
+                    "ref-name": "main",
+                    "snapshot-id": 11,
+                    "type": "branch"
+                }
+            ]
+        }))
+        .expect("overwrite request should parse");
+
+        let error = commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", overwrite_request)
+            .await
+            .expect_err("an existing entry absent from the parent snapshot must conflict");
+
+        assert_eq!(error.code(), &S3ErrorCode::PreconditionFailed);
+        let unchanged = store
+            .load_table("warehouse", "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should still exist");
+        assert_eq!(unchanged.metadata_location, committed.metadata_location);
+        assert_eq!(unchanged.version_token, committed.version_token);
+        assert_eq!(unchanged.generation, committed.generation);
+    }
+
+    #[tokio::test]
     async fn row_level_conflict_allows_add_only_overwrite_snapshot() {
         let store = TestTableCatalogStore::default();
         let metadata_backend = TestTableCatalogObjectBackend::default();
@@ -13026,6 +14237,18 @@ mod tests {
         })];
 
         assert!(apply_table_commit_updates(metadata, &updates, "metadata/00001.metadata.json").is_err());
+    }
+
+    #[test]
+    fn metadata_id_assignment_rejects_exhausted_integer_space() {
+        let metadata = serde_json::json!({
+            "schemas": [{"schema-id": i64::MAX}]
+        });
+
+        let error = next_array_object_i64(&metadata, "schemas", "schema-id")
+            .expect_err("the next schema id must not reuse the maximum integer");
+
+        assert_eq!(error.code(), &s3s::S3ErrorCode::InvalidRequest);
     }
 
     #[test]
@@ -13525,6 +14748,11 @@ mod tests {
         let store = TestTableCatalogStore::default();
         let metadata_backend = TestTableCatalogObjectBackend::default();
         let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let route = RestTableRoute {
+            bucket: "warehouse",
+            namespace: &namespace,
+            table: "events",
+        };
         let created = create_standard_events_table(&store, &metadata_backend, &namespace).await;
         let table_location = created.metadata["location"]
             .as_str()
@@ -13568,7 +14796,7 @@ mod tests {
             "expected-snapshot-id": null
         }))
         .expect("ref put request should parse");
-        put_table_ref_response(&store, &metadata_backend, "warehouse", &namespace, "events", "audit", ref_request)
+        put_table_ref_response(None, &store, &metadata_backend, route, "audit", ref_request)
             .await
             .expect("ref put should commit");
 
@@ -13580,22 +14808,14 @@ mod tests {
 
         let delete_without_force: DeleteTableRefRequest =
             serde_json::from_value(serde_json::json!({})).expect("ref delete request should parse");
-        let error = delete_table_ref_response(
-            &store,
-            &metadata_backend,
-            "warehouse",
-            &namespace,
-            "events",
-            "audit",
-            delete_without_force,
-        )
-        .await
-        .expect_err("retention refs should require force delete");
+        let error = delete_table_ref_response(None, &store, &metadata_backend, route, "audit", delete_without_force)
+            .await
+            .expect_err("retention refs should require force delete");
         assert_eq!(error.code(), &s3s::S3ErrorCode::InvalidRequest);
 
         let force_delete: DeleteTableRefRequest =
             serde_json::from_value(serde_json::json!({ "force": true })).expect("ref force delete should parse");
-        delete_table_ref_response(&store, &metadata_backend, "warehouse", &namespace, "events", "audit", force_delete)
+        delete_table_ref_response(None, &store, &metadata_backend, route, "audit", force_delete)
             .await
             .expect("force delete should commit");
         let refs = table_refs_response(&store, &metadata_backend, "warehouse", &namespace, "events")
@@ -13605,7 +14825,7 @@ mod tests {
 
         let main_delete: DeleteTableRefRequest =
             serde_json::from_value(serde_json::json!({ "force": true })).expect("main delete request should parse");
-        let error = delete_table_ref_response(&store, &metadata_backend, "warehouse", &namespace, "events", "main", main_delete)
+        let error = delete_table_ref_response(None, &store, &metadata_backend, route, "main", main_delete)
             .await
             .expect_err("main ref should remain protected");
         assert_eq!(error.code(), &s3s::S3ErrorCode::InvalidRequest);
@@ -13616,6 +14836,11 @@ mod tests {
         let store = TestTableCatalogStore::default();
         let metadata_backend = TestTableCatalogObjectBackend::default();
         let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let route = RestTableRoute {
+            bucket: "warehouse",
+            namespace: &namespace,
+            table: "events",
+        };
         create_standard_events_table(&store, &metadata_backend, &namespace).await;
         let before = store
             .load_table("warehouse", &namespace.public_name(), "events")
@@ -13629,7 +14854,7 @@ mod tests {
         }))
         .expect("ref put request should parse");
 
-        let error = put_table_ref_response(&store, &metadata_backend, "warehouse", &namespace, "events", "missing", request)
+        let error = put_table_ref_response(None, &store, &metadata_backend, route, "missing", request)
             .await
             .expect_err("a ref must not target a missing snapshot");
 
@@ -13805,7 +15030,7 @@ mod tests {
             &self,
             request: TableCredentialIssueRequest<'_>,
         ) -> S3Result<Option<IssuedTableCredentials>> {
-            assert_eq!(request.scope_prefix, "s3://warehouse/tables/table-id/");
+            assert_eq!(request.scope.scope_prefix, "s3://warehouse/tables/table-id/");
             Ok(None)
         }
     }
@@ -13849,8 +15074,8 @@ mod tests {
             request: TableCredentialIssueRequest<'_>,
         ) -> S3Result<Option<IssuedTableCredentials>> {
             assert_eq!(request.entry.table_bucket, "warehouse");
-            assert_eq!(request.scope_prefix, "s3://warehouse/tables/table-id/");
-            assert_eq!(request.object_prefix, "tables/table-id/");
+            assert_eq!(request.scope.scope_prefix, "s3://warehouse/tables/table-id/");
+            assert_eq!(request.scope.object_prefix, "tables/table-id/");
             Ok(Some(IssuedTableCredentials {
                 access_key_id: "temporary-access-key".to_string(),
                 secret_access_key: "temporary-secret-key".to_string(),
@@ -13957,8 +15182,9 @@ mod tests {
 
     #[tokio::test]
     async fn table_credential_session_policy_is_limited_to_table_prefix() {
-        let policy = table_credential_session_policy(&table_entry_for_credentials(), "tables/table-id/")
-            .expect("table credential policy should build");
+        let entry = table_entry_for_credentials();
+        let scope = table_credential_scope(&entry).expect("table credential scope should build");
+        let policy = table_credential_session_policy(&entry, &scope).expect("table credential policy should build");
         let groups = None;
         let conditions = std::collections::HashMap::new();
         let claims = std::collections::HashMap::new();
@@ -14042,8 +15268,9 @@ mod tests {
 
     #[tokio::test]
     async fn table_credential_session_policy_includes_table_resource_actions() {
-        let policy = table_credential_session_policy(&table_entry_for_credentials(), "tables/table-id/")
-            .expect("table credential policy should build");
+        let entry = table_entry_for_credentials();
+        let scope = table_credential_scope(&entry).expect("table credential scope should build");
+        let policy = table_credential_session_policy(&entry, &scope).expect("table credential policy should build");
         let groups = None;
         let conditions = std::collections::HashMap::new();
         let claims = std::collections::HashMap::new();
@@ -14110,6 +15337,10 @@ mod tests {
             entry.warehouse_location = format!("s3://warehouse/{prefix}");
             assert!(table_credential_scope(&entry).is_err());
         }
+
+        let mut entry = table_entry_for_credentials();
+        entry.warehouse_location = "s3://warehouse/.rustfs-table/private".to_string();
+        assert!(table_credential_scope(&entry).is_err());
     }
 
     #[test]
@@ -14177,14 +15408,22 @@ mod tests {
     #[derive(Clone, Default)]
     struct TestTableCatalogObjectBackend {
         objects: Arc<tokio::sync::Mutex<BTreeMap<(String, String), crate::table_catalog::TableCatalogObject>>>,
+        fail_next_puts: Arc<tokio::sync::Mutex<BTreeSet<(String, String)>>>,
         put_object_barrier: Option<Arc<tokio::sync::Barrier>>,
         read_object_calls: Arc<std::sync::atomic::AtomicUsize>,
+        object_exists_delay: Option<StdDuration>,
+        object_exists_in_flight: Arc<std::sync::atomic::AtomicUsize>,
+        object_exists_max_in_flight: Arc<std::sync::atomic::AtomicUsize>,
         locks: TestTableCatalogObjectLocks,
     }
 
     impl TestTableCatalogObjectBackend {
         fn read_object_call_count(&self) -> usize {
             self.read_object_calls.load(std::sync::atomic::Ordering::Relaxed)
+        }
+
+        fn object_exists_max_in_flight(&self) -> usize {
+            self.object_exists_max_in_flight.load(std::sync::atomic::Ordering::Relaxed)
         }
 
         async fn write_lock_is_held(&self, bucket: &str, object: &str) -> bool {
@@ -14206,6 +15445,13 @@ mod tests {
                     mod_time: None,
                 },
             );
+        }
+
+        async fn fail_next_put(&self, bucket: &str, object: &str) {
+            self.fail_next_puts
+                .lock()
+                .await
+                .insert((bucket.to_string(), object.to_string()));
         }
 
         async fn put_json(&self, bucket: &str, object: &str, value: serde_json::Value) {
@@ -14596,11 +15842,23 @@ mod tests {
         }
 
         async fn object_exists(&self, bucket: &str, object: &str) -> crate::table_catalog::TableCatalogStoreResult<bool> {
-            Ok(self
+            let in_flight = self
+                .object_exists_in_flight
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                + 1;
+            self.object_exists_max_in_flight
+                .fetch_max(in_flight, std::sync::atomic::Ordering::Relaxed);
+            if let Some(delay) = self.object_exists_delay {
+                tokio::time::sleep(delay).await;
+            }
+            let exists = self
                 .objects
                 .lock()
                 .await
-                .contains_key(&(bucket.to_string(), object.to_string())))
+                .contains_key(&(bucket.to_string(), object.to_string()));
+            self.object_exists_in_flight
+                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(exists)
         }
 
         async fn put_object(
@@ -14611,6 +15869,11 @@ mod tests {
             precondition: crate::table_catalog::TableCatalogPutPrecondition,
         ) -> crate::table_catalog::TableCatalogStoreResult<()> {
             let key = (bucket.to_string(), object.to_string());
+            if self.fail_next_puts.lock().await.remove(&key) {
+                return Err(crate::table_catalog::TableCatalogStoreError::Internal(format!(
+                    "injected object write failure for {object}"
+                )));
+            }
             let mut objects = self.objects.lock().await;
             let result = if matches!(precondition, crate::table_catalog::TableCatalogPutPrecondition::IfAbsent)
                 && objects.contains_key(&key)
@@ -14873,7 +16136,7 @@ mod tests {
             let mut next = current.clone();
             next.metadata_location = request.new_metadata_location.clone();
             next.version_token = "token-committed".to_string();
-            next.generation = next.generation.saturating_add(1);
+            next.generation = crate::table_catalog::next_table_catalog_generation(next.generation)?;
             tables[index] = next.clone();
             drop(tables);
 
@@ -14989,7 +16252,7 @@ mod tests {
             let mut next = current;
             next.metadata_location = request.new_metadata_location;
             next.version_token = "token-view-committed".to_string();
-            next.generation = next.generation.saturating_add(1);
+            next.generation = crate::table_catalog::next_table_catalog_generation(next.generation)?;
             views[index] = next.clone();
             Ok(crate::table_catalog::ViewCommitResult { view: next })
         }
@@ -15607,7 +16870,7 @@ mod tests {
         )
         .await
         .expect("namespace should be created");
-        let metadata_location = "tables/existing-table/metadata/00001.metadata.json";
+        let metadata_location = "catalog-meta/events/00001.metadata.json";
         let metadata = serde_json::json!({
             "format-version": 2,
             "table-uuid": "existing-table-uuid",
@@ -15643,7 +16906,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn standard_commit_rejects_external_metadata_root_relocation_before_writing() {
+    async fn standard_commit_relocates_a_table_with_an_external_metadata_root() {
         let metadata_backend = TestTableCatalogObjectBackend::default();
         let store = crate::table_catalog::ObjectTableCatalogStore::new(metadata_backend.clone());
         let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
@@ -15661,7 +16924,7 @@ mod tests {
         )
         .await
         .expect("namespace should be created");
-        let metadata_location = "tables/existing-table/metadata/00001.metadata.json";
+        let metadata_location = "catalog-meta/events/00001.metadata.json";
         let metadata = serde_json::json!({
             "format-version": 2,
             "table-uuid": "existing-table-uuid",
@@ -15694,11 +16957,17 @@ mod tests {
         }))
         .expect("set-location request should parse");
 
-        let error = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
+        let response = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
             .await
-            .expect_err("external metadata root relocation should be rejected");
-        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
-        assert_eq!(metadata_backend.objects.lock().await.len(), object_count);
+            .expect("external metadata root relocation should commit");
+        assert!(response.metadata_location.starts_with("s3://warehouse/catalog-meta/events/"));
+        assert_eq!(metadata_backend.objects.lock().await.len(), object_count + 1);
+        let relocated = store
+            .load_table("warehouse", "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+        assert_eq!(relocated.warehouse_location, "s3://warehouse/tables/relocated-table");
     }
 
     #[tokio::test]
@@ -15884,7 +17153,7 @@ mod tests {
             UpdateTableMetadataLocationRequest {
                 metadata_location: table_metadata_location_for_client("warehouse", next_location),
                 version_token: current.version_token.clone(),
-                commit_id: Some("commit-1".to_string()),
+                commit_id: None,
                 idempotency_key: Some("retry-1".to_string()),
             },
             read_table_metadata_json(&metadata_backend, "warehouse", next_location)
@@ -15897,6 +17166,29 @@ mod tests {
         assert_eq!(updated.metadata_location, table_metadata_location_for_client("warehouse", next_location));
         assert_eq!(updated.generation, current.generation + 1);
         assert_ne!(updated.version_token, current.version_token);
+
+        let replayed = update_table_metadata_location_response(
+            &store,
+            &metadata_backend,
+            "warehouse",
+            &namespace,
+            "events",
+            UpdateTableMetadataLocationRequest {
+                metadata_location: table_metadata_location_for_client("warehouse", next_location),
+                version_token: current.version_token,
+                commit_id: None,
+                idempotency_key: Some("retry-1".to_string()),
+            },
+            read_table_metadata_json(&metadata_backend, "warehouse", next_location)
+                .await
+                .expect("target metadata should load"),
+        )
+        .await
+        .expect("idempotency-only retry should replay the published result");
+
+        assert_eq!(replayed.metadata_location, updated.metadata_location);
+        assert_eq!(replayed.version_token, updated.version_token);
+        assert_eq!(replayed.generation, updated.generation);
     }
 
     #[tokio::test]
@@ -16184,9 +17476,9 @@ mod tests {
             "events",
             RollbackTableRequest {
                 metadata_location: table_metadata_location_for_client(bucket, &rollback_location),
-                version_token: current.version_token,
-                commit_id: Some("rollback-1".to_string()),
-                idempotency_key: None,
+                version_token: current.version_token.clone(),
+                commit_id: None,
+                idempotency_key: Some("rollback-request-1".to_string()),
             },
             read_table_metadata_json(&backend, bucket, &rollback_location)
                 .await
@@ -16196,7 +17488,30 @@ mod tests {
         .expect("rollback should commit selected metadata");
 
         assert_eq!(rollback.metadata_location, table_metadata_location_for_client(bucket, &rollback_location));
-        assert_eq!(rollback.commit_id, "rollback-1");
+        assert!(rollback.commit_id.starts_with("idempotency-"));
+
+        let replayed = rollback_table_response(
+            &store,
+            &backend,
+            bucket,
+            &namespace,
+            "events",
+            RollbackTableRequest {
+                metadata_location: table_metadata_location_for_client(bucket, &rollback_location),
+                version_token: current.version_token,
+                commit_id: None,
+                idempotency_key: Some("rollback-request-1".to_string()),
+            },
+            read_table_metadata_json(&backend, bucket, &rollback_location)
+                .await
+                .expect("rollback metadata should load"),
+        )
+        .await
+        .expect("idempotency-only rollback retry should replay the published result");
+
+        assert_eq!(replayed.commit_id, rollback.commit_id);
+        assert_eq!(replayed.version_token, rollback.version_token);
+        assert_eq!(replayed.generation, rollback.generation);
     }
 
     #[tokio::test]

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::admin::runtime_sources::current_object_store_handle;
 use crate::admin::runtime_sources::default_admin_usecase;
-use crate::admin::runtime_sources::{current_object_store_handle, current_token_signing_key};
 use crate::admin::storage_api::access::{ReqInfo, authorize_request};
 use crate::admin::storage_api::bucket::{metadata::table_catalog_path_hash, metadata_sys};
 use crate::admin::storage_api::runtime::ECStore;
@@ -32,29 +32,22 @@ use matchit::Params;
 use metrics::{counter, histogram};
 use percent_encoding::percent_decode_str;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
-use rustfs_iam::sys::SESSION_POLICY_NAME;
-use rustfs_policy::{
-    auth::get_new_credentials_with_metadata,
-    policy::{
-        Policy,
-        action::{Action, AdminAction, S3Action},
-    },
-};
+#[cfg(test)]
+use rustfs_policy::policy::Policy;
+use rustfs_policy::policy::action::{Action, AdminAction, S3Action};
 use rustfs_utils::crypto::{base64_decode_url_safe_no_pad, base64_encode_url_safe_no_pad, hex_sha256};
 use s3s::{Body, S3Error, S3ErrorCode, S3Request, S3Response, S3Result, header::CONTENT_TYPE, s3_error};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+#[cfg(test)]
+use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroUsize;
 use std::time::{Duration as StdDuration, Instant};
-use time::{Duration, OffsetDateTime};
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 const JSON_CONTENT_TYPE: &str = "application/json";
 const ENV_TABLE_CATALOG_CREDENTIAL_VENDING: &str = "RUSTFS_TABLE_CATALOG_CREDENTIAL_VENDING";
-const ENV_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: &str = "RUSTFS_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS";
-const DEFAULT_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: i64 = 15 * 60;
-const MIN_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: i64 = 60;
-const MAX_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS: i64 = 60 * 60;
 const NAMESPACE_PROPERTIES_BODY_MAX_SIZE: usize = 64 * 1024;
 const NAMESPACE_PROPERTIES_BODY_TIMEOUT: StdDuration = StdDuration::from_secs(10);
 const RENAME_TABLE_BODY_MAX_SIZE: usize = 16 * 1024;
@@ -321,8 +314,6 @@ struct RestCommitTableRequest {
 struct RestCommitViewRequest {
     #[serde(default, rename = "identifier")]
     identifier: Option<RestTableIdentifier>,
-    #[serde(default, rename = "commit-id")]
-    commit_id: Option<String>,
     #[serde(default, rename = "expected-version-token")]
     expected_version_token: Option<String>,
     #[serde(default, rename = "expected-metadata-location")]
@@ -701,14 +692,11 @@ struct RestStorageCredential {
 #[derive(Debug, Clone)]
 struct TableCredentialScope {
     scope_prefix: String,
-    object_prefix: String,
 }
 
 #[derive(Debug, Clone)]
 struct TableCredentialIssueRequest<'a> {
-    entry: &'a crate::table_catalog::TableEntry,
     principal: Option<&'a rustfs_credentials::Credentials>,
-    scope: &'a TableCredentialScope,
 }
 
 #[derive(Debug, Clone)]
@@ -749,14 +737,12 @@ impl TableCredentialIssuer for DisabledTableCredentialIssuer {
 
 struct IamTableCredentialIssuer {
     enabled: bool,
-    ttl_seconds: i64,
 }
 
 impl IamTableCredentialIssuer {
     fn from_env() -> Self {
         Self {
             enabled: table_credential_vending_enabled(),
-            ttl_seconds: table_credential_ttl_seconds(),
         }
     }
 }
@@ -775,66 +761,15 @@ impl TableCredentialIssuer for IamTableCredentialIssuer {
             return Ok(None);
         }
 
-        let Some(principal) = request.principal else {
+        let Some(_principal) = request.principal else {
             return Err(s3_error!(InvalidRequest, "authentication required for table credentials"));
         };
-        if principal.is_temp() || principal.is_service_account() {
-            return Err(s3_error!(
-                AccessDenied,
-                "table credential vending does not allow chained temporary credentials"
-            ));
-        }
-
-        let policy = table_credential_session_policy(request.entry, request.scope)?;
-        let policy_buf = serde_json::to_vec(&policy)
-            .map_err(|err| s3_error!(InternalError, "failed to serialize table credential session policy: {}", err))?;
-        let expiration = OffsetDateTime::now_utc().saturating_add(Duration::seconds(self.ttl_seconds));
-        let mut claims: HashMap<String, serde_json::Value> = principal.claims.clone().unwrap_or_default();
-        claims.insert(
-            "exp".to_string(),
-            serde_json::Value::Number(serde_json::Number::from(expiration.unix_timestamp())),
-        );
-        claims.insert("parent".to_string(), serde_json::Value::String(principal.access_key.clone()));
-        claims.insert(
-            SESSION_POLICY_NAME.to_string(),
-            serde_json::Value::String(base64_simd::URL_SAFE_NO_PAD.encode_to_string(&policy_buf)),
-        );
-        claims.insert(
-            crate::table_catalog::TABLE_CREDENTIAL_BUCKET_CLAIM.to_string(),
-            serde_json::Value::String(request.entry.table_bucket.clone()),
-        );
-        claims.insert(
-            crate::table_catalog::TABLE_CREDENTIAL_TABLE_ID_CLAIM.to_string(),
-            serde_json::Value::String(request.entry.table_id.clone()),
-        );
-        claims.insert(
-            crate::table_catalog::TABLE_CREDENTIAL_SCOPE_PREFIX_CLAIM.to_string(),
-            serde_json::Value::String(request.scope.scope_prefix.clone()),
-        );
-
-        let secret = current_token_signing_key().ok_or_else(|| s3_error!(InternalError, "token signing key not initialized"))?;
-        let mut credential = get_new_credentials_with_metadata(&claims, &secret)
-            .map_err(|err| s3_error!(InternalError, "failed to generate table credentials: {}", err))?;
-        bind_table_credential_parent(&mut credential, principal);
-
-        let iam_store =
-            crate::admin::runtime_sources::current_ready_iam_handle().map_err(|_| s3_error!(InternalError, "iam not init"))?;
-        iam_store
-            .set_temp_user(&credential.access_key, &credential, None)
-            .await
-            .map_err(|_| s3_error!(InternalError, "failed to store table credentials"))?;
-
-        Ok(Some(IssuedTableCredentials {
-            access_key_id: credential.access_key,
-            secret_access_key: credential.secret_key,
-            session_token: credential.session_token,
-            expiration,
-        }))
+        Err(iceberg_rest_error(
+            ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+            StatusCode::NOT_ACCEPTABLE,
+            "table credential vending requires a dedicated rotatable IAM token-signing key",
+        ))
     }
-}
-
-fn bind_table_credential_parent(credential: &mut rustfs_credentials::Credentials, principal: &rustfs_credentials::Credentials) {
-    credential.parent_user = principal.access_key.clone();
 }
 
 #[derive(Debug, Serialize)]
@@ -2066,75 +2001,12 @@ fn table_credential_vending_enabled() -> bool {
         .unwrap_or(false)
 }
 
-fn table_credential_ttl_seconds() -> i64 {
-    std::env::var(ENV_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS)
-        .ok()
-        .and_then(|value| value.parse::<i64>().ok())
-        .map(|seconds| seconds.clamp(MIN_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS, MAX_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS))
-        .unwrap_or(DEFAULT_TABLE_CATALOG_CREDENTIAL_TTL_SECONDS)
-}
-
 fn table_credential_scope(entry: &crate::table_catalog::TableEntry) -> S3Result<TableCredentialScope> {
     let object_prefix = crate::table_catalog::table_warehouse_object_prefix(entry)
         .map_err(|err| s3_error!(InvalidRequest, "invalid table credential warehouse location: {}", err))?;
     Ok(TableCredentialScope {
         scope_prefix: format!("s3://{}/{object_prefix}", entry.table_bucket),
-        object_prefix,
     })
-}
-
-fn table_credential_catalog_resource(entry: &crate::table_catalog::TableEntry) -> S3Result<String> {
-    let namespace = crate::table_catalog::Namespace::parse(&entry.namespace)
-        .map_err(|err| s3_error!(InvalidRequest, "invalid table credential namespace: {}", err))?;
-    let table = crate::table_catalog::IdentifierSegment::parse(&entry.table)
-        .map_err(|err| s3_error!(InvalidRequest, "invalid table credential table name: {}", err))?;
-    Ok(format!("namespaces/{}/tables/{}", namespace.storage_id(), table.as_str()))
-}
-
-fn table_credential_session_policy(entry: &crate::table_catalog::TableEntry, scope: &TableCredentialScope) -> S3Result<Policy> {
-    let bucket = &entry.table_bucket;
-    let object_prefix = &scope.object_prefix;
-    let catalog_resource = table_credential_catalog_resource(entry)?;
-    let policy = serde_json::json!({
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "s3:GetObject",
-                    "s3:PutObject",
-                    "s3:DeleteObject",
-                    "s3:AbortMultipartUpload",
-                    "s3:ListMultipartUploadParts"
-                ],
-                "Resource": [
-                    format!("arn:aws:s3:::{bucket}/{object_prefix}*")
-                ]
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "s3:GetBucketLocation"
-                ],
-                "Resource": [
-                    format!("arn:aws:s3:::{bucket}")
-                ]
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "admin:GetTableMetadata",
-                    "admin:SetTableMetadata"
-                ],
-                "Resource": [
-                    format!("arn:aws:s3:::{bucket}/{catalog_resource}")
-                ]
-            }
-        ]
-    });
-    let data = serde_json::to_vec(&policy)
-        .map_err(|err| s3_error!(InternalError, "failed to serialize table credential policy: {}", err))?;
-    Policy::parse_config(&data).map_err(|err| s3_error!(InvalidRequest, "invalid table credential policy: {}", err))
 }
 
 fn storage_credential_from_issued(scope: TableCredentialScope, issued: IssuedTableCredentials) -> RestStorageCredential {
@@ -2258,11 +2130,7 @@ async fn load_credentials_response_from_entry(
         });
     }
     let scope = table_credential_scope(entry)?;
-    let request = TableCredentialIssueRequest {
-        entry,
-        principal,
-        scope: &scope,
-    };
+    let request = TableCredentialIssueRequest { principal };
     let scope_prefix = scope.scope_prefix.clone();
     let storage_credentials = match issuer.issue_table_credentials(request).await? {
         Some(issued) => vec![storage_credential_from_issued(scope, issued)],
@@ -2403,9 +2271,9 @@ fn validate_metadata_matches_current_metadata(
     target_metadata: &serde_json::Value,
 ) -> S3Result<()> {
     let expected_table_uuid = metadata_table_uuid(current_metadata)?;
-    metadata_format_version(current_metadata)?;
+    validate_supported_table_metadata(current_metadata)?;
     let target_table_uuid = metadata_table_uuid(target_metadata)?;
-    metadata_format_version(target_metadata)?;
+    validate_supported_table_metadata(target_metadata)?;
     if target_table_uuid != expected_table_uuid {
         return Err(s3_error!(
             InvalidRequest,
@@ -2699,11 +2567,10 @@ fn initial_table_metadata_json(
         .and_then(serde_json::Value::as_i64)
         .ok_or_else(|| s3_error!(InvalidRequest, "sort order-id must be an integer"))?;
 
-    Ok(serde_json::json!({
+    let mut metadata = serde_json::json!({
         "format-version": entry.format_version,
         "table-uuid": entry.table_uuid,
         "location": entry.warehouse_location,
-        "last-sequence-number": 0,
         "last-updated-ms": current_time_millis(),
         "last-column-id": last_column_id,
         "schemas": [schema],
@@ -2718,7 +2585,13 @@ fn initial_table_metadata_json(
         "snapshot-log": [],
         "metadata-log": [],
         "refs": {}
-    }))
+    });
+    if entry.format_version == 2 {
+        metadata_object_mut(&mut metadata)?.insert("last-sequence-number".to_string(), serde_json::Value::from(0));
+    }
+    synchronize_table_metadata_version_fields(&mut metadata)?;
+    validate_supported_table_metadata(&metadata)?;
+    Ok(metadata)
 }
 
 fn initial_view_metadata_json(
@@ -2747,6 +2620,9 @@ fn initial_view_metadata_json(
     view_version_object
         .entry("schema-id".to_string())
         .or_insert_with(|| serde_json::Value::from(schema_id));
+    if view_version_object.get("schema-id").and_then(serde_json::Value::as_i64) == Some(-1) {
+        view_version_object.insert("schema-id".to_string(), serde_json::Value::from(schema_id));
+    }
     view_version_object
         .entry("timestamp-ms".to_string())
         .or_insert_with(|| serde_json::Value::from(current_time_millis()));
@@ -3114,10 +2990,137 @@ fn apply_table_commit_updates_at(
         }
     }
 
+    if metadata.get("format-version").is_some() {
+        synchronize_table_metadata_version_fields(&mut metadata)?;
+    }
     validate_table_metadata_references(&metadata)?;
     append_previous_metadata_log(&mut metadata, previous_metadata_location, commit_timestamp_ms)?;
     metadata_object_mut(&mut metadata)?.insert("last-updated-ms".to_string(), serde_json::Value::from(commit_timestamp_ms));
     Ok(metadata)
+}
+
+fn synchronize_table_metadata_version_fields(metadata: &mut serde_json::Value) -> S3Result<()> {
+    match metadata_format_version(metadata)? {
+        1 => {
+            if let Some(schemas) = metadata.get("schemas").and_then(serde_json::Value::as_array)
+                && !schemas.is_empty()
+            {
+                let current_schema_id = metadata
+                    .get("current-schema-id")
+                    .and_then(serde_json::Value::as_i64)
+                    .or_else(|| {
+                        schemas
+                            .last()
+                            .and_then(|schema| schema.get("schema-id"))
+                            .and_then(serde_json::Value::as_i64)
+                    });
+                let schema = current_schema_id
+                    .and_then(|schema_id| {
+                        schemas
+                            .iter()
+                            .find(|schema| schema.get("schema-id").and_then(serde_json::Value::as_i64) == Some(schema_id))
+                    })
+                    .cloned()
+                    .ok_or_else(|| s3_error!(InvalidRequest, "Iceberg v1 current schema does not exist"))?;
+                metadata_object_mut(metadata)?.insert("schema".to_string(), schema);
+            }
+            if let Some(specs) = metadata.get("partition-specs").and_then(serde_json::Value::as_array)
+                && !specs.is_empty()
+            {
+                let default_spec_id = metadata
+                    .get("default-spec-id")
+                    .and_then(serde_json::Value::as_i64)
+                    .or_else(|| {
+                        specs
+                            .last()
+                            .and_then(|spec| spec.get("spec-id"))
+                            .and_then(serde_json::Value::as_i64)
+                    });
+                let fields = default_spec_id
+                    .and_then(|spec_id| {
+                        specs
+                            .iter()
+                            .find(|spec| spec.get("spec-id").and_then(serde_json::Value::as_i64) == Some(spec_id))
+                    })
+                    .and_then(|spec| spec.get("fields"))
+                    .cloned()
+                    .ok_or_else(|| s3_error!(InvalidRequest, "Iceberg v1 default partition spec does not exist"))?;
+                metadata_object_mut(metadata)?.insert("partition-spec".to_string(), fields);
+            }
+            let object = metadata_object_mut(metadata)?;
+            object.remove("schemas");
+            object.remove("current-schema-id");
+            object.remove("partition-specs");
+            object.remove("default-spec-id");
+            object.remove("last-partition-id");
+            object.remove("sort-orders");
+            object.remove("default-sort-order-id");
+            object.remove("last-sequence-number");
+        }
+        2 => {
+            if metadata.get("schemas").is_none() {
+                let mut schema = metadata
+                    .get("schema")
+                    .cloned()
+                    .ok_or_else(|| s3_error!(InvalidRequest, "Iceberg v1 table metadata is missing schema"))?;
+                schema
+                    .as_object_mut()
+                    .ok_or_else(|| s3_error!(InvalidRequest, "Iceberg v1 schema must be an object"))?
+                    .entry("schema-id".to_string())
+                    .or_insert_with(|| serde_json::Value::from(0));
+                let schema_id = schema
+                    .get("schema-id")
+                    .and_then(serde_json::Value::as_i64)
+                    .ok_or_else(|| s3_error!(InvalidRequest, "Iceberg v1 schema-id must be an integer"))?;
+                metadata_object_mut(metadata)?.insert("schemas".to_string(), serde_json::json!([schema]));
+                metadata_object_mut(metadata)?.insert("current-schema-id".to_string(), serde_json::Value::from(schema_id));
+            }
+            if metadata.get("partition-specs").is_none() {
+                let fields = metadata
+                    .get("partition-spec")
+                    .cloned()
+                    .ok_or_else(|| s3_error!(InvalidRequest, "Iceberg v1 table metadata is missing partition-spec"))?;
+                metadata_object_mut(metadata)?
+                    .insert("partition-specs".to_string(), serde_json::json!([{"spec-id": 0, "fields": fields}]));
+                metadata_object_mut(metadata)?.insert("default-spec-id".to_string(), serde_json::Value::from(0));
+            }
+            if metadata.get("sort-orders").is_none() {
+                metadata_object_mut(metadata)?
+                    .insert("sort-orders".to_string(), serde_json::json!([{"order-id": 0, "fields": []}]));
+                metadata_object_mut(metadata)?.insert("default-sort-order-id".to_string(), serde_json::Value::from(0));
+            }
+            if metadata.get("last-partition-id").is_none() {
+                let last_partition_id = metadata
+                    .get("partition-specs")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|specs| specs.iter().map(max_partition_field_id).max().unwrap_or(999))
+                    .unwrap_or(999);
+                metadata_object_mut(metadata)?
+                    .insert("last-partition-id".to_string(), serde_json::Value::from(last_partition_id));
+            }
+            if metadata.get("last-sequence-number").is_none() {
+                let last_sequence_number = metadata
+                    .get("snapshots")
+                    .and_then(serde_json::Value::as_array)
+                    .and_then(|snapshots| {
+                        snapshots
+                            .iter()
+                            .filter_map(|snapshot| snapshot.get("sequence-number").and_then(serde_json::Value::as_i64))
+                            .max()
+                    })
+                    .unwrap_or(0);
+                metadata_object_mut(metadata)?
+                    .insert("last-sequence-number".to_string(), serde_json::Value::from(last_sequence_number));
+            }
+            let object = metadata_object_mut(metadata)?;
+            object.remove("schema");
+            object.remove("partition-spec");
+        }
+        _ => {
+            return Err(s3_error!(InvalidRequest, "unsupported Iceberg table format-version"));
+        }
+    }
+    Ok(())
 }
 
 fn metadata_array_ids(metadata: &serde_json::Value, array_field: &str, id_field: &str, label: &str) -> S3Result<BTreeSet<i64>> {
@@ -3140,6 +3143,72 @@ fn metadata_array_ids(metadata: &serde_json::Value, array_field: &str, id_field:
     Ok(ids)
 }
 
+fn metadata_array_i32_ids(
+    metadata: &serde_json::Value,
+    array_field: &str,
+    id_field: &str,
+    label: &str,
+) -> S3Result<BTreeSet<i64>> {
+    let ids = metadata_array_ids(metadata, array_field, id_field, label)?;
+    if let Some(id) = ids.iter().find(|id| i32::try_from(**id).is_err()) {
+        return Err(s3_error!(InvalidRequest, "{label} id {id} exceeds the signed 32-bit range"));
+    }
+    Ok(ids)
+}
+
+fn require_metadata_i64(metadata: &serde_json::Value, field: &str) -> S3Result<i64> {
+    metadata
+        .get(field)
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| s3_error!(InvalidRequest, "table metadata is missing integer field {field}"))
+}
+
+fn require_metadata_i32(metadata: &serde_json::Value, field: &str) -> S3Result<i32> {
+    let value = require_metadata_i64(metadata, field)?;
+    i32::try_from(value).map_err(|_| s3_error!(InvalidRequest, "table metadata field {field} exceeds the signed 32-bit range"))
+}
+
+fn require_metadata_array<'a>(metadata: &'a serde_json::Value, field: &str) -> S3Result<&'a Vec<serde_json::Value>> {
+    metadata
+        .get(field)
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| s3_error!(InvalidRequest, "table metadata is missing array field {field}"))
+}
+
+fn validate_supported_table_metadata(metadata: &serde_json::Value) -> S3Result<()> {
+    metadata_table_uuid(metadata)?;
+    metadata_table_location(metadata)?;
+    require_metadata_i64(metadata, "last-updated-ms")?;
+    require_metadata_i32(metadata, "last-column-id")?;
+
+    match metadata_format_version(metadata)? {
+        1 => {
+            if !metadata.get("schema").is_some_and(serde_json::Value::is_object) {
+                return Err(s3_error!(InvalidRequest, "Iceberg v1 table metadata is missing schema"));
+            }
+            require_metadata_array(metadata, "partition-spec")?;
+        }
+        2 => {
+            require_metadata_i64(metadata, "last-sequence-number")?;
+            if require_metadata_array(metadata, "schemas")?.is_empty() {
+                return Err(s3_error!(InvalidRequest, "table metadata schemas must not be empty"));
+            }
+            require_metadata_i32(metadata, "current-schema-id")?;
+            if require_metadata_array(metadata, "partition-specs")?.is_empty() {
+                return Err(s3_error!(InvalidRequest, "table metadata partition-specs must not be empty"));
+            }
+            require_metadata_i32(metadata, "default-spec-id")?;
+            require_metadata_i32(metadata, "last-partition-id")?;
+            if require_metadata_array(metadata, "sort-orders")?.is_empty() {
+                return Err(s3_error!(InvalidRequest, "table metadata sort-orders must not be empty"));
+            }
+            require_metadata_i32(metadata, "default-sort-order-id")?;
+        }
+        _ => return Err(s3_error!(InvalidRequest, "unsupported Iceberg table format-version")),
+    }
+    validate_table_metadata_references(metadata)
+}
+
 fn validate_metadata_id_reference(
     metadata: &serde_json::Value,
     reference_field: &str,
@@ -3159,11 +3228,11 @@ fn validate_metadata_id_reference(
 }
 
 fn validate_table_metadata_references(metadata: &serde_json::Value) -> S3Result<()> {
-    let schema_ids = metadata_array_ids(metadata, "schemas", "schema-id", "schema")?;
+    let schema_ids = metadata_array_i32_ids(metadata, "schemas", "schema-id", "schema")?;
     validate_metadata_id_reference(metadata, "current-schema-id", &schema_ids, "schema")?;
-    let spec_ids = metadata_array_ids(metadata, "partition-specs", "spec-id", "partition spec")?;
+    let spec_ids = metadata_array_i32_ids(metadata, "partition-specs", "spec-id", "partition spec")?;
     validate_metadata_id_reference(metadata, "default-spec-id", &spec_ids, "partition spec")?;
-    let sort_order_ids = metadata_array_ids(metadata, "sort-orders", "order-id", "sort order")?;
+    let sort_order_ids = metadata_array_i32_ids(metadata, "sort-orders", "order-id", "sort order")?;
     validate_metadata_id_reference(metadata, "default-sort-order-id", &sort_order_ids, "sort order")?;
     let snapshot_ids = metadata_array_ids(metadata, "snapshots", "snapshot-id", "snapshot")?;
 
@@ -3213,10 +3282,26 @@ fn validate_table_metadata_references(metadata: &serde_json::Value) -> S3Result<
     Ok(())
 }
 
+fn table_metadata_partition_spec_ids(metadata: &serde_json::Value) -> S3Result<BTreeSet<i32>> {
+    let ids = metadata_array_i32_ids(metadata, "partition-specs", "spec-id", "partition spec")?;
+    if !ids.is_empty() {
+        return ids
+            .into_iter()
+            .map(|id| {
+                i32::try_from(id).map_err(|_| s3_error!(InvalidRequest, "partition spec id {id} exceeds the signed 32-bit range"))
+            })
+            .collect();
+    }
+    if metadata.get("partition-spec").is_some_and(serde_json::Value::is_array) || metadata.get("partition-specs").is_none() {
+        return Ok(BTreeSet::from([0]));
+    }
+    Err(s3_error!(InvalidRequest, "table metadata has no partition specs"))
+}
+
 fn validate_view_metadata_references(metadata: &serde_json::Value) -> S3Result<()> {
-    let schema_ids = metadata_array_ids(metadata, "schemas", "schema-id", "schema")?;
+    let schema_ids = metadata_array_i32_ids(metadata, "schemas", "schema-id", "schema")?;
     validate_metadata_id_reference(metadata, "current-schema-id", &schema_ids, "schema")?;
-    let version_ids = metadata_array_ids(metadata, "versions", "version-id", "view version")?;
+    let version_ids = metadata_array_i32_ids(metadata, "versions", "version-id", "view version")?;
     validate_metadata_id_reference(metadata, "current-version-id", &version_ids, "view version")?;
     if let Some(versions) = metadata.get("versions").and_then(serde_json::Value::as_array) {
         for version in versions {
@@ -3477,6 +3562,13 @@ fn apply_add_view_version_update(
             .as_object_mut()
             .ok_or_else(|| s3_error!(InvalidRequest, "view-version must be a JSON object"))?
             .insert("version-id".to_string(), serde_json::Value::from(next_id));
+    }
+    if view_version.get("schema-id").and_then(serde_json::Value::as_i64) == Some(-1) {
+        let schema_id = last_array_object_i64(metadata, "schemas", "schema-id")?;
+        view_version
+            .as_object_mut()
+            .ok_or_else(|| s3_error!(InvalidRequest, "view-version must be a JSON object"))?
+            .insert("schema-id".to_string(), serde_json::Value::from(schema_id));
     }
     view_version
         .as_object_mut()
@@ -3883,6 +3975,7 @@ impl SnapshotFileChanges {
 }
 
 struct SnapshotChangeContext<'a> {
+    metadata: &'a serde_json::Value,
     snapshot: &'a serde_json::Value,
     current_live_files: &'a SnapshotLiveFiles,
     snapshot_id: i64,
@@ -3913,6 +4006,7 @@ async fn validate_table_snapshot_commit_conflicts<B>(
     mut req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
     current_metadata: &serde_json::Value,
+    next_metadata: &serde_json::Value,
     updates: &[serde_json::Value],
 ) -> S3Result<()>
 where
@@ -3961,6 +4055,7 @@ where
         req,
         context,
         SnapshotChangeContext {
+            metadata: next_metadata,
             snapshot,
             current_live_files: &parent_live_files,
             snapshot_id,
@@ -4014,6 +4109,32 @@ where
     Ok(())
 }
 
+async fn validate_table_snapshot_graph<B>(
+    mut req: Option<&mut S3Request<Body>>,
+    context: &SnapshotReadContext<'_, B>,
+    metadata: &serde_json::Value,
+) -> S3Result<()>
+where
+    B: crate::table_catalog::TableCatalogObjectBackend,
+{
+    validate_supported_table_metadata(metadata)?;
+    let Some(snapshots) = metadata.get("snapshots") else {
+        return Ok(());
+    };
+    let snapshots = snapshots
+        .as_array()
+        .ok_or_else(|| s3_error!(InvalidRequest, "snapshots must be an array"))?;
+    let mut read_budget = SnapshotReadBudget::default();
+    for snapshot in snapshots {
+        let snapshot_id = snapshot
+            .get("snapshot-id")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot-id must be an integer"))?;
+        load_snapshot_live_files(req.as_deref_mut(), context, metadata, Some(snapshot_id), &mut read_budget).await?;
+    }
+    Ok(())
+}
+
 fn added_snapshot_update(updates: &[serde_json::Value]) -> S3Result<Option<&serde_json::Value>> {
     let mut snapshot = None;
     for update in updates {
@@ -4057,9 +4178,10 @@ where
 
     let mut live_files = SnapshotLiveFiles::default();
     let mut seen_locations = BTreeSet::new();
-    for manifest in read_snapshot_manifest_references(req, context, snapshot, read_budget).await? {
+    for manifest in read_snapshot_manifest_references(req, context, current_metadata, snapshot, read_budget).await? {
         let SnapshotManifestLocation {
             manifest_path,
+            partition_spec_id: _,
             sequence_number,
             added_snapshot_id,
         } = manifest.location;
@@ -4112,7 +4234,10 @@ where
 {
     let mut changes = SnapshotFileChanges::default();
     let mut seen_locations = BTreeSet::new();
-    for manifest in read_snapshot_manifest_references(req, read_context, change_context.snapshot, read_budget).await? {
+    for manifest in
+        read_snapshot_manifest_references(req, read_context, change_context.metadata, change_context.snapshot, read_budget)
+            .await?
+    {
         for reference in &manifest.references {
             if !seen_locations.insert(reference.location.clone()) {
                 return Err(s3_error!(InvalidRequest, "snapshot contains a duplicate file reference"));
@@ -4239,6 +4364,7 @@ struct SnapshotManifestReferences {
 async fn read_snapshot_manifest_references<B>(
     mut req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
+    metadata: &serde_json::Value,
     snapshot: &serde_json::Value,
     read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<Vec<SnapshotManifestReferences>>
@@ -4246,9 +4372,23 @@ where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
     let manifest_locations = snapshot_manifest_locations(req.as_deref_mut(), context, snapshot, read_budget).await?;
+    let partition_spec_ids = table_metadata_partition_spec_ids(metadata)?;
+    let format_version = metadata_format_version(metadata)?;
     let mut manifests = Vec::new();
     let mut seen_manifest_paths = BTreeSet::new();
     for manifest_location in manifest_locations {
+        match manifest_location.partition_spec_id {
+            Some(partition_spec_id) if !partition_spec_ids.contains(&partition_spec_id) => {
+                return Err(s3_error!(
+                    InvalidRequest,
+                    "snapshot manifest references missing partition spec {partition_spec_id}"
+                ));
+            }
+            None if format_version == 2 => {
+                return Err(s3_error!(InvalidRequest, "Iceberg v2 manifest-list entry is missing partition_spec_id"));
+            }
+            _ => {}
+        }
         if !seen_manifest_paths.insert(manifest_location.manifest_path.clone()) {
             return Err(s3_error!(InvalidRequest, "snapshot contains a duplicate manifest reference"));
         }
@@ -4296,6 +4436,7 @@ where
 #[derive(Debug)]
 struct SnapshotManifestLocation {
     manifest_path: String,
+    partition_spec_id: Option<i32>,
     sequence_number: Option<i64>,
     added_snapshot_id: Option<i64>,
 }
@@ -4336,6 +4477,7 @@ where
             .into_iter()
             .map(|reference| SnapshotManifestLocation {
                 manifest_path: reference.manifest_path,
+                partition_spec_id: reference.partition_spec_id,
                 sequence_number: reference.sequence_number,
                 added_snapshot_id: reference.added_snapshot_id,
             })
@@ -4357,6 +4499,7 @@ where
                 .filter(|manifest| !manifest.is_empty())
                 .map(|manifest| SnapshotManifestLocation {
                     manifest_path: manifest.to_string(),
+                    partition_spec_id: None,
                     sequence_number: None,
                     added_snapshot_id: None,
                 })
@@ -4603,9 +4746,16 @@ fn ensure_object_field<'a>(
 }
 
 fn next_array_object_i64(metadata: &serde_json::Value, array_key: &str, id_key: &str) -> S3Result<i64> {
-    last_array_object_i64(metadata, array_key, id_key)?
+    let next = last_array_object_i64(metadata, array_key, id_key)?
         .checked_add(1)
-        .ok_or_else(|| s3_error!(InvalidRequest, "metadata field {array_key} has exhausted {id_key} values"))
+        .ok_or_else(|| s3_error!(InvalidRequest, "metadata field {array_key} has exhausted signed 32-bit {id_key} values"))?;
+    if next > i64::from(i32::MAX) {
+        return Err(s3_error!(
+            InvalidRequest,
+            "metadata field {array_key} has exhausted signed 32-bit {id_key} values"
+        ));
+    }
+    Ok(next)
 }
 
 fn last_array_object_i64(metadata: &serde_json::Value, array_key: &str, id_key: &str) -> S3Result<i64> {
@@ -4613,11 +4763,14 @@ fn last_array_object_i64(metadata: &serde_json::Value, array_key: &str, id_key: 
         .get(array_key)
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| s3_error!(InvalidRequest, "metadata field {array_key} must be an array"))?;
-    values
+    let id = values
         .iter()
         .filter_map(|value| value.get(id_key).and_then(serde_json::Value::as_i64))
         .max()
-        .ok_or_else(|| s3_error!(InvalidRequest, "metadata field {array_key} has no {id_key}"))
+        .ok_or_else(|| s3_error!(InvalidRequest, "metadata field {array_key} has no {id_key}"))?;
+    i32::try_from(id)
+        .map(i64::from)
+        .map_err(|_| s3_error!(InvalidRequest, "metadata field {array_key} has an out-of-range {id_key}"))
 }
 
 fn table_commit_operation(metadata: &serde_json::Value) -> String {
@@ -4896,8 +5049,10 @@ fn table_identifier_from_request(
     Ok((namespace, table))
 }
 
-async fn register_table_response<S>(
+async fn register_table_response<S, B>(
+    req: Option<&mut S3Request<Body>>,
     store: &S,
+    metadata_backend: &B,
     bucket: &str,
     namespace: &crate::table_catalog::Namespace,
     request: RegisterTableRequest,
@@ -4906,15 +5061,26 @@ async fn register_table_response<S>(
 ) -> S3Result<RestLoadTableResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
+    B: crate::table_catalog::TableCatalogObjectBackend,
 {
     let mut entry = table_entry_from_register_request(bucket, namespace, request)?;
     ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
     validate_metadata_table_location_in_bucket(bucket, &metadata)?;
     adopt_registered_metadata_identity(&mut entry, &metadata)?;
-    validate_table_metadata_references(&metadata)?;
+    validate_supported_table_metadata(&metadata)?;
     if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
         return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
     }
+    let table = crate::table_catalog::IdentifierSegment::parse(&entry.table)
+        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+    let snapshot_context = SnapshotReadContext {
+        metadata_backend,
+        bucket,
+        namespace,
+        table: &table,
+        entry: &entry,
+    };
+    validate_table_snapshot_graph(req, &snapshot_context, &metadata).await?;
     store
         .register_table(entry.clone())
         .await
@@ -5279,7 +5445,7 @@ where
         )?;
         validate_metadata_view_location_in_bucket(bucket, &next_metadata)?;
         validate_metadata_matches_current_view_metadata(&current_metadata, &next_metadata)?;
-        let (_, metadata_file_token) = standard_commit_ids(request.commit_id.clone(), None);
+        let (_, metadata_file_token) = standard_commit_ids(None, None);
         let next_generation =
             crate::table_catalog::next_table_catalog_generation(current.generation).map_err(catalog_store_error)?;
         let next_metadata_location = crate::table_catalog::default_view_metadata_file_path(
@@ -5407,6 +5573,7 @@ where
 }
 
 async fn update_table_metadata_location_response<S>(
+    mut req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
     bucket: &str,
@@ -5426,6 +5593,28 @@ where
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
     let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
+    if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &metadata_location) {
+        return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
+    }
+    validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
+    if metadata_table_uuid(&target_metadata)? != current.table_uuid {
+        return Err(s3_error!(
+            InvalidRequest,
+            "table metadata table-uuid does not match catalog table identity"
+        ));
+    }
+    crate::table_catalog::validate_table_warehouse_relocation(&current, metadata_table_location(&target_metadata)?)
+        .map_err(catalog_store_error)?;
+    let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
+        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+    let snapshot_context = SnapshotReadContext {
+        metadata_backend,
+        bucket,
+        namespace,
+        table: &table_name,
+        entry: &current,
+    };
+    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
     let (commit_id, _) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
     if let Some(replay) = published_api_commit_replay(
         store,
@@ -5449,12 +5638,8 @@ where
         let result = store.commit_table(replay).await.map_err(catalog_store_error)?;
         return Ok(table_metadata_location_response_from_entry(result.table));
     }
-    if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &metadata_location) {
-        return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
-    }
     let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
     validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
-    validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
     validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
     let commit_request = crate::table_catalog::TableCommitRequest {
         table_bucket: bucket.to_string(),
@@ -5646,6 +5831,16 @@ where
     let target_metadata =
         target_metadata.ok_or_else(|| s3_error!(InternalError, "authorized target metadata snapshot is required"))?;
     validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
+    let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
+        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+    let snapshot_context = SnapshotReadContext {
+        metadata_backend,
+        bucket,
+        namespace,
+        table: &table_name,
+        entry: &current,
+    };
+    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
     request.requirements.push(metadata_digest_requirement(&target_metadata)?);
     if let Some(existing_commit) = existing_commit {
         if !crate::table_catalog::commit_log_matches_request(&existing_commit, &request, &current.table_id) {
@@ -5764,7 +5959,14 @@ where
         table: &table_name,
         entry: &current,
     };
-    validate_table_snapshot_commit_conflicts(req.as_deref_mut(), &snapshot_context, &expected_metadata, &request.updates).await?;
+    validate_table_snapshot_commit_conflicts(
+        req.as_deref_mut(),
+        &snapshot_context,
+        &expected_metadata,
+        &next_metadata,
+        &request.updates,
+    )
+    .await?;
     let (commit_id, metadata_file_token) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
     let next_generation = crate::table_catalog::next_table_catalog_generation(current.generation).map_err(catalog_store_error)?;
     let next_metadata_location = crate::table_catalog::table_metadata_file_path_for_entry(
@@ -5884,6 +6086,24 @@ where
             "commit retry updates do not match the original commit",
         ));
     }
+    let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
+        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+    let snapshot_context = SnapshotReadContext {
+        metadata_backend,
+        bucket,
+        namespace,
+        table: &table_name,
+        entry: current,
+    };
+    validate_table_snapshot_commit_conflicts(
+        req.as_deref_mut(),
+        &snapshot_context,
+        &previous_metadata,
+        &target_metadata,
+        &request.updates,
+    )
+    .await?;
+    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
     let operation = request
         .operation
         .clone()
@@ -6605,6 +6825,7 @@ where
         .map_err(catalog_store_error)?;
     let target_metadata = read_table_metadata_json(metadata_backend, bucket, &request.metadata_location).await?;
     sync_external_catalog_bridge_response_with_snapshot(
+        None,
         store,
         metadata_backend,
         bucket,
@@ -6626,6 +6847,7 @@ struct ExternalCatalogBridgeSyncSnapshot {
 }
 
 async fn sync_external_catalog_bridge_response_with_snapshot<B>(
+    mut req: Option<&mut S3Request<Body>>,
     store: &crate::table_catalog::ObjectTableCatalogStore<B>,
     metadata_backend: &B,
     bucket: &str,
@@ -6643,7 +6865,38 @@ where
     } = snapshot;
     validate_external_catalog_metadata_location(namespace, table, &request.metadata_location)?;
     validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
+    validate_supported_table_metadata(&target_metadata)?;
     let external_table_uuid = validate_external_catalog_metadata_uuid(request.external_table_uuid.as_deref(), &target_metadata)?;
+
+    let registration_entry = if current.is_none() {
+        let mut entry = table_entry_from_import_request(
+            bucket,
+            namespace,
+            table,
+            CatalogImportRequest {
+                metadata_location: request.metadata_location.clone(),
+                properties: request.properties.clone(),
+            },
+        )?;
+        adopt_registered_metadata_identity(&mut entry, &target_metadata)?;
+        Some(entry)
+    } else {
+        None
+    };
+    let graph_entry = current
+        .as_ref()
+        .or(registration_entry.as_ref())
+        .ok_or_else(|| s3_error!(InternalError, "external catalog sync table snapshot is missing"))?;
+    let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
+        .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+    let snapshot_context = SnapshotReadContext {
+        metadata_backend,
+        bucket,
+        namespace,
+        table: &table_name,
+        entry: graph_entry,
+    };
+    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
 
     let (action, table_response, table_id) = if let Some(current) = current {
         if request.expected_version_token.is_none() && request.expected_metadata_location.is_none() {
@@ -6730,16 +6983,8 @@ where
                 "external catalog sync cannot use expected table state when registering a missing table"
             ));
         }
-        let mut entry = table_entry_from_import_request(
-            bucket,
-            namespace,
-            table,
-            CatalogImportRequest {
-                metadata_location: request.metadata_location.clone(),
-                properties: request.properties.clone(),
-            },
-        )?;
-        adopt_registered_metadata_identity(&mut entry, &target_metadata)?;
+        let entry = registration_entry
+            .ok_or_else(|| s3_error!(InternalError, "external catalog sync registration snapshot is missing"))?;
         store.register_table(entry.clone()).await.map_err(catalog_store_error)?;
         let table_id = entry.table_id.clone();
         (
@@ -6779,11 +7024,24 @@ where
 {
     let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
     let metadata = read_table_metadata_json(metadata_backend, bucket, &metadata_location).await?;
-    catalog_import_response_with_metadata(store, bucket, namespace, table, request, metadata, table_bucket_enabled).await
+    catalog_import_response_with_metadata(
+        None,
+        store,
+        metadata_backend,
+        bucket,
+        namespace,
+        table,
+        request,
+        metadata,
+        table_bucket_enabled,
+    )
+    .await
 }
 
-async fn catalog_import_response_with_metadata<S>(
+async fn catalog_import_response_with_metadata<S, B>(
+    mut req: Option<&mut S3Request<Body>>,
     store: &S,
+    metadata_backend: &B,
     bucket: &str,
     namespace: &crate::table_catalog::Namespace,
     table: &str,
@@ -6793,6 +7051,7 @@ async fn catalog_import_response_with_metadata<S>(
 ) -> S3Result<RestLoadTableResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
+    B: crate::table_catalog::TableCatalogObjectBackend,
 {
     let started = Instant::now();
     let result = async {
@@ -6800,9 +7059,20 @@ where
         let mut entry = table_entry_from_import_request(bucket, namespace, table, request)?;
         validate_metadata_table_location_in_bucket(bucket, &metadata)?;
         adopt_registered_metadata_identity(&mut entry, &metadata)?;
+        validate_supported_table_metadata(&metadata)?;
         if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
             return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
         }
+        let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
+            .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+        let snapshot_context = SnapshotReadContext {
+            metadata_backend,
+            bucket,
+            namespace,
+            table: &table_name,
+            entry: &entry,
+        };
+        validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &metadata).await?;
         if let Some(existing) = store
             .load_table(bucket, &namespace.public_name(), table)
             .await
@@ -7209,7 +7479,17 @@ impl Operation for RestRegisterTableHandler {
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
         crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
-        let response = register_table_response(&store, &warehouse, &namespace, request, metadata, table_bucket_enabled).await?;
+        let response = register_table_response(
+            Some(&mut req),
+            &store,
+            &metadata_backend,
+            &warehouse,
+            &namespace,
+            request,
+            metadata,
+            table_bucket_enabled,
+        )
+        .await?;
         drop(metadata_guard);
         build_json_response(StatusCode::OK, &response)
     }
@@ -7611,6 +7891,7 @@ impl Operation for UpdateTableMetadataLocationHandler {
         )
         .await?;
         let response = update_table_metadata_location_response(
+            Some(&mut req),
             &store,
             &metadata_backend,
             &warehouse,
@@ -7875,7 +8156,9 @@ impl Operation for ImportTableCatalogHandler {
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
         crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
         let response = catalog_import_response_with_metadata(
+            Some(&mut req),
             &store,
+            &metadata_backend,
             &warehouse,
             &namespace,
             &table,
@@ -7957,6 +8240,7 @@ impl Operation for SyncExternalCatalogBridgeHandler {
             read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &request.metadata_location).await?;
         crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
         let response = sync_external_catalog_bridge_response_with_snapshot(
+            Some(&mut req),
             &store,
             &metadata_backend,
             &warehouse,
@@ -8078,6 +8362,29 @@ mod tests {
     use bytes::Bytes;
     use std::sync::Arc;
 
+    fn test_table_metadata_json(table_uuid: &str, location: &str) -> serde_json::Value {
+        serde_json::json!({
+            "format-version": 2,
+            "table-uuid": table_uuid,
+            "location": location,
+            "last-sequence-number": 0,
+            "last-updated-ms": 0,
+            "last-column-id": 0,
+            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
+            "current-schema-id": 0,
+            "partition-specs": [{"spec-id": 0, "fields": []}],
+            "default-spec-id": 0,
+            "last-partition-id": 999,
+            "sort-orders": [{"order-id": 0, "fields": []}],
+            "default-sort-order-id": 0,
+            "properties": {},
+            "snapshots": [],
+            "snapshot-log": [],
+            "metadata-log": [],
+            "refs": {}
+        })
+    }
+
     #[test]
     fn snapshot_read_budget_accepts_exact_limits_and_rejects_excess() {
         let mut budget = SnapshotReadBudget {
@@ -8172,6 +8479,65 @@ mod tests {
             .await
             .expect_err("a missing manifest object should still fail validation");
         assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[tokio::test]
+    async fn snapshot_graph_rejects_unknown_manifest_partition_spec() {
+        let backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let table = crate::table_catalog::IdentifierSegment::parse("events").expect("table should parse");
+        let entry = crate::table_catalog::TableEntry {
+            version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+            table_bucket: "warehouse".to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            table_id: "table-id".to_string(),
+            table_uuid: "table-uuid".to_string(),
+            format: "ICEBERG".to_string(),
+            format_version: 2,
+            warehouse_location: "s3://warehouse/tables/table-id".to_string(),
+            metadata_location: "tables/table-id/metadata/00001.metadata.json".to_string(),
+            version_token: "token-v1".to_string(),
+            generation: 1,
+            state: crate::table_catalog::TableCatalogEntryState::Active,
+            properties: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
+        };
+        let manifest_list = "s3://warehouse/tables/table-id/metadata/snap-1.avro";
+        let manifest = "s3://warehouse/tables/table-id/metadata/manifest-1.avro";
+        backend
+            .put_bytes(
+                "warehouse",
+                &test_snapshot_object_key("warehouse", manifest_list),
+                test_manifest_list_avro_entries_with_spec(&[(manifest, 9, 1, 1)]),
+            )
+            .await;
+        let mut metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        metadata["last-sequence-number"] = serde_json::Value::from(1);
+        metadata["snapshots"] = serde_json::json!([{
+            "snapshot-id": 1,
+            "sequence-number": 1,
+            "timestamp-ms": 1,
+            "manifest-list": manifest_list,
+            "summary": {"operation": "append"}
+        }]);
+        metadata["current-snapshot-id"] = serde_json::Value::from(1);
+        metadata["refs"] = serde_json::json!({"main": {"type": "branch", "snapshot-id": 1}});
+        let context = SnapshotReadContext {
+            metadata_backend: &backend,
+            bucket: "warehouse",
+            namespace: &namespace,
+            table: &table,
+            entry: &entry,
+        };
+
+        let error = validate_table_snapshot_graph(None, &context, &metadata)
+            .await
+            .expect_err("manifest-list partition spec must exist in table metadata");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(error.message(), Some("snapshot manifest references missing partition spec 9"));
     }
 
     #[test]
@@ -10177,7 +10543,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_requests_accept_legacy_empty_defaults_and_view_commit_ids() {
+    fn commit_requests_accept_legacy_empty_defaults_and_reject_view_commit_ids() {
         let table = serde_json::from_value::<RestCommitTableRequest>(serde_json::json!({}))
             .expect("legacy table commit should default omitted requirements and updates");
         assert!(table.requirements.is_empty());
@@ -10186,13 +10552,12 @@ mod tests {
             .expect("legacy view commit should default omitted requirements and updates");
         assert!(view.requirements.is_empty());
         assert!(view.updates.is_empty());
-        let view = serde_json::from_value::<RestCommitViewRequest>(serde_json::json!({
+        serde_json::from_value::<RestCommitViewRequest>(serde_json::json!({
             "commit-id": "non-standard-extension",
             "requirements": [],
             "updates": []
         }))
-        .expect("legacy view commit id should remain accepted");
-        assert_eq!(view.commit_id.as_deref(), Some("non-standard-extension"));
+        .expect_err("view commit-id must be rejected until view commits have durable idempotency records");
     }
 
     #[test]
@@ -10247,6 +10612,28 @@ mod tests {
                 .expect("supported format version should create metadata");
             assert_eq!(entry.format_version, version);
             assert_eq!(metadata["format-version"], version);
+            if version == 1 {
+                assert!(metadata["schema"].is_object());
+                assert!(metadata["partition-spec"].is_array());
+                for v2_field in [
+                    "schemas",
+                    "current-schema-id",
+                    "partition-specs",
+                    "default-spec-id",
+                    "last-partition-id",
+                    "sort-orders",
+                    "default-sort-order-id",
+                    "last-sequence-number",
+                ] {
+                    assert!(metadata.get(v2_field).is_none(), "Iceberg v1 metadata must omit {v2_field}");
+                }
+            } else {
+                assert!(metadata["schemas"].is_array());
+                assert!(metadata["partition-specs"].is_array());
+                assert!(metadata["sort-orders"].is_array());
+                assert!(metadata.get("schema").is_none());
+                assert!(metadata.get("partition-spec").is_none());
+            }
         }
 
         let request = serde_json::from_value(serde_json::json!({
@@ -10285,6 +10672,41 @@ mod tests {
             .expect_err("registered format version 3 is not implemented");
         assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
         assert_eq!(error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
+    }
+
+    #[test]
+    fn v1_table_metadata_upgrades_to_complete_v2_shape() {
+        let metadata = serde_json::json!({
+            "format-version": 1,
+            "table-uuid": "table-uuid",
+            "location": "s3://warehouse/tables/table-id",
+            "last-updated-ms": 1,
+            "last-column-id": 0,
+            "schema": {"type": "struct", "schema-id": 7, "fields": []},
+            "partition-spec": [],
+            "properties": {},
+            "snapshots": [],
+            "snapshot-log": [],
+            "metadata-log": []
+        });
+
+        let upgraded = apply_table_commit_updates_at(
+            metadata,
+            &[serde_json::json!({"action": "upgrade-format-version", "format-version": 2})],
+            "s3://warehouse/tables/table-id/metadata/v1.metadata.json",
+            2,
+        )
+        .expect("v1 metadata should upgrade to v2");
+
+        assert_eq!(upgraded["format-version"], 2);
+        assert_eq!(upgraded["current-schema-id"], 7);
+        assert_eq!(upgraded["schemas"][0]["schema-id"], 7);
+        assert_eq!(upgraded["default-spec-id"], 0);
+        assert_eq!(upgraded["default-sort-order-id"], 0);
+        assert_eq!(upgraded["last-sequence-number"], 0);
+        assert!(upgraded.get("schema").is_none());
+        assert!(upgraded.get("partition-spec").is_none());
+        validate_supported_table_metadata(&upgraded).expect("upgraded metadata should satisfy the v2 contract");
     }
 
     #[test]
@@ -11250,12 +11672,7 @@ mod tests {
             .put_json(
                 "warehouse",
                 current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "metadata-table-uuid",
-                    "location": "s3://warehouse/tables/table-id",
-                    "properties": {}
-                }),
+                test_table_metadata_json("metadata-table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 
@@ -11319,11 +11736,7 @@ mod tests {
             .put_json(
                 "warehouse",
                 current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "metadata-table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("metadata-table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
         let next_location = ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00002.metadata.json";
@@ -11331,16 +11744,12 @@ mod tests {
             .put_json(
                 "warehouse",
                 next_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "metadata-table-uuid",
-                    "location": "s3://warehouse/tables/table-id",
-                    "last-sequence-number": 2
-                }),
+                test_table_metadata_json("metadata-table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 
         let updated = update_table_metadata_location_response(
+            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -12036,11 +12445,7 @@ mod tests {
             .put_json(
                 bucket,
                 &metadata_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 
@@ -12117,11 +12522,7 @@ mod tests {
             .put_json(
                 bucket,
                 &metadata_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
         let bridge_path =
@@ -12181,30 +12582,12 @@ mod tests {
         let current_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
         let next_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
         seed_object_table_for_metadata_maintenance(&store, &backend, bucket, &namespace, &table, current_location.clone()).await;
-        backend
-            .put_json(
-                bucket,
-                &current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id",
-                    "last-sequence-number": 1
-                }),
-            )
-            .await;
-        backend
-            .put_json(
-                bucket,
-                &next_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id",
-                    "last-sequence-number": 2
-                }),
-            )
-            .await;
+        let mut current_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        current_metadata["last-sequence-number"] = serde_json::json!(1);
+        let mut next_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        next_metadata["last-sequence-number"] = serde_json::json!(2);
+        backend.put_json(bucket, &current_location, current_metadata).await;
+        backend.put_json(bucket, &next_location, next_metadata).await;
 
         let sync_request = || ExternalCatalogBridgeSyncRequest {
             catalog: "hive-metastore".to_string(),
@@ -12264,11 +12647,7 @@ mod tests {
         let current_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
         let next_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
         seed_object_table_for_metadata_maintenance(&store, &backend, bucket, &namespace, &table, current_location.clone()).await;
-        let target_metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "table-uuid",
-            "location": "s3://warehouse/tables/table-id"
-        });
+        let target_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
         backend.put_json(bucket, &next_location, target_metadata.clone()).await;
         let captured_current = store
             .load_table(bucket, "analytics", "events")
@@ -12281,6 +12660,7 @@ mod tests {
             .expect("concurrent table drop should succeed");
 
         let result = sync_external_catalog_bridge_response_with_snapshot(
+            None,
             &store,
             &backend,
             bucket,
@@ -12335,22 +12715,14 @@ mod tests {
             .put_json(
                 bucket,
                 &current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
         backend
             .put_json(
                 bucket,
                 &next_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "different-table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("different-table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 
@@ -12538,6 +12910,31 @@ mod tests {
         });
         validate_table_metadata_references(&metadata_without_current_snapshot)
             .expect("Iceberg null snapshot fields should represent a table without a current snapshot");
+    }
+
+    #[test]
+    fn table_metadata_validation_requires_complete_v2_core_fields() {
+        let metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        for required_field in [
+            "last-updated-ms",
+            "last-column-id",
+            "last-sequence-number",
+            "schemas",
+            "current-schema-id",
+            "partition-specs",
+            "default-spec-id",
+            "last-partition-id",
+            "sort-orders",
+            "default-sort-order-id",
+        ] {
+            let mut incomplete = metadata.clone();
+            incomplete
+                .as_object_mut()
+                .expect("metadata should be an object")
+                .remove(required_field);
+            validate_supported_table_metadata(&incomplete)
+                .expect_err("missing required Iceberg v2 metadata field must be rejected");
+        }
     }
 
     #[test]
@@ -12997,7 +13394,7 @@ mod tests {
             }
         })];
 
-        validate_table_snapshot_commit_conflicts(None, &context, &current_metadata, &updates)
+        validate_table_snapshot_commit_conflicts(None, &context, &current_metadata, &current_metadata, &updates)
             .await
             .expect("a branch commit should validate deletes against its declared parent snapshot");
     }
@@ -14242,13 +14639,21 @@ mod tests {
     #[test]
     fn metadata_id_assignment_rejects_exhausted_integer_space() {
         let metadata = serde_json::json!({
-            "schemas": [{"schema-id": i64::MAX}]
+            "schemas": [{"schema-id": i32::MAX}]
         });
 
         let error = next_array_object_i64(&metadata, "schemas", "schema-id")
             .expect_err("the next schema id must not reuse the maximum integer");
 
         assert_eq!(error.code(), &s3s::S3ErrorCode::InvalidRequest);
+
+        let metadata = serde_json::json!({
+            "schemas": [{"schema-id": i32::MAX - 1}]
+        });
+        assert_eq!(
+            next_array_object_i64(&metadata, "schemas", "schema-id").expect("the final signed 32-bit id should be assignable"),
+            i64::from(i32::MAX)
+        );
     }
 
     #[test]
@@ -14376,6 +14781,46 @@ mod tests {
 
         assert_eq!(request.name, "recent_events");
         assert_eq!(request.properties.get("comment").map(String::as_str), Some("recent event ids"));
+    }
+
+    #[test]
+    fn view_versions_resolve_minus_one_to_the_current_schema() {
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let request: CreateViewRequest = serde_json::from_value(serde_json::json!({
+            "name": "recent_events",
+            "schema": {"type": "struct", "schema-id": 3, "fields": []},
+            "view-version": {
+                "version-id": 1,
+                "schema-id": -1,
+                "summary": {"engine-name": "spark"},
+                "default-catalog": "warehouse",
+                "default-namespace": ["analytics"],
+                "representations": [{"type": "sql", "sql": "SELECT 1", "dialect": "spark"}]
+            }
+        }))
+        .expect("view request should parse");
+        let (_, metadata) = view_entry_from_create_view_request("warehouse", &namespace, request)
+            .expect("create should resolve the current schema placeholder");
+        assert_eq!(metadata["versions"][0]["schema-id"], 3);
+
+        let updated = apply_view_commit_updates_at(
+            metadata,
+            &[serde_json::json!({
+                "action": "add-view-version",
+                "view-version": {
+                    "version-id": 2,
+                    "schema-id": -1,
+                    "summary": {"engine-name": "spark"},
+                    "default-catalog": "warehouse",
+                    "default-namespace": ["analytics"],
+                    "representations": [{"type": "sql", "sql": "SELECT 2", "dialect": "spark"}]
+                }
+            })],
+            "s3://warehouse/views/view-id/metadata/v1.metadata.json",
+            2,
+        )
+        .expect("view commit should resolve the current schema placeholder");
+        assert_eq!(updated["versions"][1]["schema-id"], 3);
     }
 
     #[test]
@@ -15028,9 +15473,8 @@ mod tests {
     impl TableCredentialIssuer for UnavailableTableCredentialIssuer {
         async fn issue_table_credentials(
             &self,
-            request: TableCredentialIssueRequest<'_>,
+            _request: TableCredentialIssueRequest<'_>,
         ) -> S3Result<Option<IssuedTableCredentials>> {
-            assert_eq!(request.scope.scope_prefix, "s3://warehouse/tables/table-id/");
             Ok(None)
         }
     }
@@ -15071,11 +15515,8 @@ mod tests {
     impl TableCredentialIssuer for TestTableCredentialIssuer {
         async fn issue_table_credentials(
             &self,
-            request: TableCredentialIssueRequest<'_>,
+            _request: TableCredentialIssueRequest<'_>,
         ) -> S3Result<Option<IssuedTableCredentials>> {
-            assert_eq!(request.entry.table_bucket, "warehouse");
-            assert_eq!(request.scope.scope_prefix, "s3://warehouse/tables/table-id/");
-            assert_eq!(request.scope.object_prefix, "tables/table-id/");
             Ok(Some(IssuedTableCredentials {
                 access_key_id: "temporary-access-key".to_string(),
                 secret_access_key: "temporary-secret-key".to_string(),
@@ -15165,161 +15606,22 @@ mod tests {
         assert_eq!(response.headers.get(http::header::EXPIRES), Some(&HeaderValue::from_static("0")));
     }
 
-    #[test]
-    fn table_credentials_do_not_snapshot_parent_groups() {
+    #[tokio::test]
+    async fn iam_table_credentials_require_a_dedicated_signing_key() {
         let principal = rustfs_credentials::Credentials {
             access_key: "parent-access-key".to_string(),
-            groups: Some(vec!["analytics-writers".to_string()]),
             ..Default::default()
         };
-        let mut credential = rustfs_credentials::Credentials::default();
+        let issuer = IamTableCredentialIssuer { enabled: true };
+        let error = issuer
+            .issue_table_credentials(TableCredentialIssueRequest {
+                principal: Some(&principal),
+            })
+            .await
+            .expect_err("credential vending must not reuse the root S3 secret as a signing key");
 
-        bind_table_credential_parent(&mut credential, &principal);
-
-        assert_eq!(credential.parent_user, "parent-access-key");
-        assert!(credential.groups.is_none());
-    }
-
-    #[tokio::test]
-    async fn table_credential_session_policy_is_limited_to_table_prefix() {
-        let entry = table_entry_for_credentials();
-        let scope = table_credential_scope(&entry).expect("table credential scope should build");
-        let policy = table_credential_session_policy(&entry, &scope).expect("table credential policy should build");
-        let groups = None;
-        let conditions = std::collections::HashMap::new();
-        let claims = std::collections::HashMap::new();
-
-        assert!(
-            policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::S3Action(rustfs_policy::policy::action::S3Action::GetObjectAction),
-                    bucket: "warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "tables/table-id/data/file.parquet",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
-        assert!(
-            policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::S3Action(rustfs_policy::policy::action::S3Action::GetBucketLocationAction),
-                    bucket: "warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
-        assert!(
-            policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::AdminAction(rustfs_policy::policy::action::AdminAction::SetTableMetadataAction),
-                    bucket: "warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "namespaces/analytics/tables/events",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
-        assert!(
-            !policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::S3Action(rustfs_policy::policy::action::S3Action::GetObjectAction),
-                    bucket: "warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "tables/other/data/file.parquet",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
-        assert!(
-            !policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::S3Action(rustfs_policy::policy::action::S3Action::PutObjectAction),
-                    bucket: "other-warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "tables/table-id/data/file.parquet",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
-    }
-
-    #[tokio::test]
-    async fn table_credential_session_policy_includes_table_resource_actions() {
-        let entry = table_entry_for_credentials();
-        let scope = table_credential_scope(&entry).expect("table credential scope should build");
-        let policy = table_credential_session_policy(&entry, &scope).expect("table credential policy should build");
-        let groups = None;
-        let conditions = std::collections::HashMap::new();
-        let claims = std::collections::HashMap::new();
-
-        assert!(
-            policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::AdminAction(rustfs_policy::policy::action::AdminAction::GetTableMetadataAction),
-                    bucket: "warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "namespaces/analytics/tables/events",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
-        assert!(
-            !policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::AdminAction(rustfs_policy::policy::action::AdminAction::SetTableMetadataAction),
-                    bucket: "warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "namespaces/analytics/tables/orders",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
-        assert!(
-            !policy
-                .is_allowed(&rustfs_policy::policy::Args {
-                    account: "temporary-access-key",
-                    groups: &groups,
-                    action: Action::AdminAction(rustfs_policy::policy::action::AdminAction::CreateTableAction),
-                    bucket: "warehouse",
-                    conditions: &conditions,
-                    is_owner: false,
-                    object: "namespaces/analytics/tables/events",
-                    claims: &claims,
-                    deny_only: false,
-                })
-                .await
-        );
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
     }
 
     #[test]
@@ -15485,12 +15787,20 @@ mod tests {
     fn test_manifest_list_avro_bytes(manifest_paths: &[&str], sequence_number: i64, snapshot_id: i64) -> Vec<u8> {
         let manifests = manifest_paths
             .iter()
-            .map(|manifest_path| (*manifest_path, sequence_number, snapshot_id))
+            .map(|manifest_path| (*manifest_path, 0, sequence_number, snapshot_id))
             .collect::<Vec<_>>();
-        test_manifest_list_avro_entries(&manifests)
+        test_manifest_list_avro_entries_with_spec(&manifests)
     }
 
     fn test_manifest_list_avro_entries(manifests: &[(&str, i64, i64)]) -> Vec<u8> {
+        let manifests = manifests
+            .iter()
+            .map(|(manifest_path, sequence_number, snapshot_id)| (*manifest_path, 0, *sequence_number, *snapshot_id))
+            .collect::<Vec<_>>();
+        test_manifest_list_avro_entries_with_spec(&manifests)
+    }
+
+    fn test_manifest_list_avro_entries_with_spec(manifests: &[(&str, i32, i64, i64)]) -> Vec<u8> {
         let schema = apache_avro::Schema::parse_str(
             r#"
             {
@@ -15498,6 +15808,7 @@ mod tests {
               "name": "manifest_file",
               "fields": [
                 {"name": "manifest_path", "type": "string"},
+                {"name": "partition_spec_id", "type": "int"},
                 {"name": "sequence_number", "type": "long"},
                 {"name": "added_snapshot_id", "type": "long"}
               ]
@@ -15506,13 +15817,14 @@ mod tests {
         )
         .expect("manifest list avro schema should parse");
         let mut writer = apache_avro::Writer::new(&schema, Vec::new());
-        for (manifest_path, sequence_number, snapshot_id) in manifests {
+        for (manifest_path, partition_spec_id, sequence_number, snapshot_id) in manifests {
             writer
                 .append(apache_avro::types::Value::Record(vec![
                     (
                         "manifest_path".to_string(),
                         apache_avro::types::Value::String((*manifest_path).to_string()),
                     ),
+                    ("partition_spec_id".to_string(), apache_avro::types::Value::Int(*partition_spec_id)),
                     ("sequence_number".to_string(), apache_avro::types::Value::Long(*sequence_number)),
                     ("added_snapshot_id".to_string(), apache_avro::types::Value::Long(*snapshot_id)),
                 ]))
@@ -16694,16 +17006,14 @@ mod tests {
 
         let metadata_location =
             ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
-        let metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "table-uuid",
-            "location": "s3://warehouse/tables/table-id"
-        });
+        let metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
         metadata_backend
             .put_json("warehouse", metadata_location, metadata.clone())
             .await;
         let register = register_table_response(
+            None,
             &store,
+            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -16740,17 +17050,10 @@ mod tests {
             .expect("table should exist");
         let next_metadata_location =
             ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00002.metadata.json";
+        let mut next_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        next_metadata["last-sequence-number"] = serde_json::json!(2);
         metadata_backend
-            .put_json(
-                "warehouse",
-                next_metadata_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id",
-                    "last-sequence-number": 2
-                }),
-            )
+            .put_json("warehouse", next_metadata_location, next_metadata)
             .await;
         let commit = commit_table_response(
             &store,
@@ -16819,17 +17122,15 @@ mod tests {
         .expect("namespace should be created");
         let metadata_location =
             ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
-        let metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "metadata-table-uuid",
-            "location": "s3://warehouse/tables/table-id"
-        });
+        let metadata = test_table_metadata_json("metadata-table-uuid", "s3://warehouse/tables/table-id");
         metadata_backend
             .put_json("warehouse", metadata_location, metadata.clone())
             .await;
 
         register_table_response(
+            None,
             &store,
+            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -16871,17 +17172,15 @@ mod tests {
         .await
         .expect("namespace should be created");
         let metadata_location = "catalog-meta/events/00001.metadata.json";
-        let metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "existing-table-uuid",
-            "location": "s3://warehouse/tables/existing-table"
-        });
+        let metadata = test_table_metadata_json("existing-table-uuid", "s3://warehouse/tables/existing-table");
         metadata_backend
             .put_json("warehouse", metadata_location, metadata.clone())
             .await;
 
         let response = register_table_response(
+            None,
             &store,
+            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -16906,7 +17205,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn standard_commit_relocates_a_table_with_an_external_metadata_root() {
+    async fn standard_commit_rejects_warehouse_relocation() {
         let metadata_backend = TestTableCatalogObjectBackend::default();
         let store = crate::table_catalog::ObjectTableCatalogStore::new(metadata_backend.clone());
         let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
@@ -16925,16 +17224,14 @@ mod tests {
         .await
         .expect("namespace should be created");
         let metadata_location = "catalog-meta/events/00001.metadata.json";
-        let metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "existing-table-uuid",
-            "location": "s3://warehouse/tables/existing-table"
-        });
+        let metadata = test_table_metadata_json("existing-table-uuid", "s3://warehouse/tables/existing-table");
         metadata_backend
             .put_json("warehouse", metadata_location, metadata.clone())
             .await;
         register_table_response(
+            None,
             &store,
+            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -16957,17 +17254,17 @@ mod tests {
         }))
         .expect("set-location request should parse");
 
-        let response = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
+        let error = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
             .await
-            .expect("external metadata root relocation should commit");
-        assert!(response.metadata_location.starts_with("s3://warehouse/catalog-meta/events/"));
-        assert_eq!(metadata_backend.objects.lock().await.len(), object_count + 1);
-        let relocated = store
+            .expect_err("warehouse relocation must be rejected");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(metadata_backend.objects.lock().await.len(), object_count);
+        let unchanged = store
             .load_table("warehouse", "analytics", "events")
             .await
             .expect("table lookup should succeed")
             .expect("table should exist");
-        assert_eq!(relocated.warehouse_location, "s3://warehouse/tables/relocated-table");
+        assert_eq!(unchanged.warehouse_location, "s3://warehouse/tables/existing-table");
     }
 
     #[tokio::test]
@@ -17001,7 +17298,9 @@ mod tests {
 
         assert!(
             register_table_response(
+                None,
                 &store,
+                &metadata_backend,
                 "warehouse",
                 &namespace,
                 RegisterTableRequest {
@@ -17045,19 +17344,16 @@ mod tests {
         .expect("namespace should be created");
         let metadata_location =
             ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
-        let metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "metadata-table-uuid",
-            "location": "s3://warehouse/tables/table-id",
-            "schemas": [{"schema-id": 0, "type": "struct", "fields": []}],
-            "current-schema-id": 99
-        });
+        let mut metadata = test_table_metadata_json("metadata-table-uuid", "s3://warehouse/tables/table-id");
+        metadata["current-schema-id"] = serde_json::json!(99);
         metadata_backend
             .put_json("warehouse", metadata_location, metadata.clone())
             .await;
 
         let error = register_table_response(
+            None,
             &store,
+            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -17117,11 +17413,7 @@ mod tests {
             .put_json(
                 "warehouse",
                 current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": table_uuid,
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json(&table_uuid, "s3://warehouse/tables/table-id"),
             )
             .await;
         let current = get_table_metadata_location_response(&store, "warehouse", &namespace, "events")
@@ -17136,15 +17428,12 @@ mod tests {
             .put_json(
                 "warehouse",
                 next_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": table_uuid,
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json(&table_uuid, "s3://warehouse/tables/table-id"),
             )
             .await;
 
         let updated = update_table_metadata_location_response(
+            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17168,6 +17457,7 @@ mod tests {
         assert_ne!(updated.version_token, current.version_token);
 
         let replayed = update_table_metadata_location_response(
+            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17189,6 +17479,106 @@ mod tests {
         assert_eq!(replayed.metadata_location, updated.metadata_location);
         assert_eq!(replayed.version_token, updated.version_token);
         assert_eq!(replayed.generation, updated.generation);
+    }
+
+    #[tokio::test]
+    async fn metadata_location_api_revalidates_snapshot_objects_before_commit_and_replay() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let created = create_standard_events_table(&store, &metadata_backend, &namespace).await;
+        let current = store
+            .load_table("warehouse", "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+        let target_location = crate::table_catalog::table_metadata_file_path_for_entry(&current, "00002.metadata.json")
+            .expect("target metadata path should build");
+        let manifest_list = format!("{}/metadata/snap-10.avro", current.warehouse_location);
+        let data_file = format!("{}/data/part-10.parquet", current.warehouse_location);
+        let mut target_metadata = created.metadata;
+        target_metadata["last-sequence-number"] = serde_json::Value::from(1);
+        target_metadata["snapshots"] = serde_json::json!([{
+            "snapshot-id": 10,
+            "sequence-number": 1,
+            "timestamp-ms": 10,
+            "manifest-list": manifest_list,
+            "summary": {"operation": "append"}
+        }]);
+        target_metadata["current-snapshot-id"] = serde_json::Value::from(10);
+        target_metadata["refs"] = serde_json::json!({"main": {"type": "branch", "snapshot-id": 10}});
+        metadata_backend
+            .put_json("warehouse", &target_location, target_metadata.clone())
+            .await;
+        let request = || UpdateTableMetadataLocationRequest {
+            metadata_location: table_metadata_location_for_client("warehouse", &target_location),
+            version_token: current.version_token.clone(),
+            commit_id: None,
+            idempotency_key: Some("metadata-location-retry".to_string()),
+        };
+
+        let error = update_table_metadata_location_response(
+            None,
+            &store,
+            &metadata_backend,
+            "warehouse",
+            &namespace,
+            "events",
+            request(),
+            target_metadata.clone(),
+        )
+        .await
+        .expect_err("missing manifest-list must fail before pointer publication");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        let unchanged = store
+            .load_table("warehouse", "analytics", "events")
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should remain present");
+        assert_eq!(unchanged.metadata_location, current.metadata_location);
+
+        seed_test_snapshot_manifest(
+            &metadata_backend,
+            "warehouse",
+            target_metadata["snapshots"][0]["manifest-list"]
+                .as_str()
+                .expect("manifest-list should be a string"),
+            10,
+            1,
+            &[(&data_file, 0, 1, 10, 1)],
+        )
+        .await;
+        update_table_metadata_location_response(
+            None,
+            &store,
+            &metadata_backend,
+            "warehouse",
+            &namespace,
+            "events",
+            request(),
+            target_metadata.clone(),
+        )
+        .await
+        .expect("complete snapshot graph should commit");
+
+        metadata_backend
+            .delete_object("warehouse", &test_snapshot_object_key("warehouse", &data_file))
+            .await
+            .expect("referenced data file should be removed");
+        let error = update_table_metadata_location_response(
+            None,
+            &store,
+            &metadata_backend,
+            "warehouse",
+            &namespace,
+            "events",
+            request(),
+            target_metadata,
+        )
+        .await
+        .expect_err("idempotent replay must revalidate referenced objects");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(error.message(), Some("manifest referenced data file is missing"));
     }
 
     #[tokio::test]
@@ -17253,16 +17643,13 @@ mod tests {
             .put_json(
                 "warehouse",
                 invalid_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://other-warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://other-warehouse/tables/table-id"),
             )
             .await;
 
         assert!(
             update_table_metadata_location_response(
+                None,
                 &store,
                 &metadata_backend,
                 "warehouse",
@@ -17311,16 +17698,14 @@ mod tests {
         .await
         .expect("namespace should be created");
         let current_location = ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
-        let current_metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "table-uuid",
-            "location": "s3://warehouse/tables/table-id"
-        });
+        let current_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
         metadata_backend
             .put_json("warehouse", current_location, current_metadata.clone())
             .await;
         register_table_response(
+            None,
             &store,
+            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -17342,16 +17727,13 @@ mod tests {
             .put_json(
                 "warehouse",
                 mismatched_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "other-table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("other-table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 
         assert!(
             update_table_metadata_location_response(
+                None,
                 &store,
                 &metadata_backend,
                 "warehouse",
@@ -17406,11 +17788,7 @@ mod tests {
             .put_json(
                 bucket,
                 &imported_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 
@@ -17456,18 +17834,9 @@ mod tests {
         );
 
         let rollback_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
-        backend
-            .put_json(
-                bucket,
-                &rollback_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id",
-                    "last-sequence-number": 2
-                }),
-            )
-            .await;
+        let mut rollback_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        rollback_metadata["last-sequence-number"] = serde_json::Value::from(2);
+        backend.put_json(bucket, &rollback_location, rollback_metadata).await;
         let rollback = rollback_table_response(
             &store,
             &backend,
@@ -17540,11 +17909,7 @@ mod tests {
             .put_json(
                 bucket,
                 &current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
         catalog_import_response(
@@ -17572,11 +17937,7 @@ mod tests {
             .put_json(
                 bucket,
                 &invalid_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://other-warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://other-warehouse/tables/table-id"),
             )
             .await;
 
@@ -17636,11 +17997,7 @@ mod tests {
             .put_json(
                 bucket,
                 &current_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
         catalog_import_response(
@@ -17669,11 +18026,7 @@ mod tests {
             .put_json(
                 bucket,
                 &mismatched_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "other-table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("other-table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 
@@ -17726,16 +18079,14 @@ mod tests {
         .await
         .expect("namespace should be created");
         let current_location = ".rustfs-table/warehouses/default/namespaces/analytics/tables/events/metadata/00001.metadata.json";
-        let current_metadata = serde_json::json!({
-            "format-version": 2,
-            "table-uuid": "table-uuid",
-            "location": "s3://warehouse/tables/table-id"
-        });
+        let current_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
         metadata_backend
             .put_json("warehouse", current_location, current_metadata.clone())
             .await;
         register_table_response(
+            None,
             &store,
+            &metadata_backend,
             "warehouse",
             &namespace,
             RegisterTableRequest {
@@ -17759,11 +18110,7 @@ mod tests {
             .put_json(
                 "warehouse",
                 mismatched_location,
-                serde_json::json!({
-                    "format-version": 2,
-                    "table-uuid": "other-table-uuid",
-                    "location": "s3://warehouse/tables/table-id"
-                }),
+                test_table_metadata_json("other-table-uuid", "s3://warehouse/tables/table-id"),
             )
             .await;
 

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -32,14 +32,10 @@ use matchit::Params;
 use metrics::{counter, histogram};
 use percent_encoding::percent_decode_str;
 use rustfs_config::MAX_ADMIN_REQUEST_BODY_SIZE;
-#[cfg(test)]
-use rustfs_policy::policy::Policy;
 use rustfs_policy::policy::action::{Action, AdminAction, S3Action};
 use rustfs_utils::crypto::{base64_decode_url_safe_no_pad, base64_encode_url_safe_no_pad, hex_sha256};
 use s3s::{Body, S3Error, S3ErrorCode, S3Request, S3Response, S3Result, header::CONTENT_TYPE, s3_error};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-#[cfg(test)]
-use std::collections::HashMap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroUsize;
 use std::time::{Duration as StdDuration, Instant};
@@ -78,8 +74,6 @@ const REST_PAGE_SIZE_QUERY_PARAMETER: &str = "pageSize";
 const REST_NAMESPACE_SEPARATOR: char = '\u{1f}';
 const REST_NAMESPACE_SEPARATOR_UTF8: &str = "\u{1f}";
 const REST_NAMESPACE_SEPARATOR_URL_ENCODED: &str = "%1F";
-const TABLE_WAREHOUSE_READ_ACTIONS: &[S3Action] = &[S3Action::GetObjectAction];
-const TABLE_WAREHOUSE_WRITE_ACTIONS: &[S3Action] = &[S3Action::PutObjectAction, S3Action::DeleteObjectAction];
 const TABLE_COMMIT_MAX_MANIFESTS: usize = 10_000;
 const TABLE_COMMIT_MAX_AVRO_BYTES: usize = 512 * 1024 * 1024;
 const TABLE_COMMIT_MAX_FILE_REFERENCES: usize = 1_000_000;
@@ -1349,21 +1343,25 @@ async fn authorize_optional_table_catalog_object_read(
     }
 }
 
-fn table_catalog_prefix_authorization_probe(object_prefix: &str) -> String {
-    format!("{}/{}", object_prefix.trim_end_matches('/'), Uuid::new_v4())
-}
-
-async fn authorize_table_warehouse_s3_actions(
-    req: &mut S3Request<Body>,
+async fn authorize_table_warehouse_claim(
+    req: &S3Request<Body>,
+    principal: &TableCatalogRequestPrincipal,
     bucket: &str,
     warehouse_location: &str,
-    actions: &[S3Action],
 ) -> S3Result<()> {
     validate_table_location_in_bucket(bucket, warehouse_location)?;
     let warehouse_prefix = crate::table_catalog::table_catalog_object_key_from_location(bucket, warehouse_location)
         .ok_or_else(|| s3_error!(InvalidRequest, "table location must be inside the warehouse bucket"))?;
-    let authorization_probe = table_catalog_prefix_authorization_probe(&warehouse_prefix);
-    authorize_table_catalog_s3_actions(req, bucket, &authorization_probe, actions).await
+    validate_admin_request_with_bucket_object(
+        &req.headers,
+        &principal.credentials,
+        principal.owner,
+        false,
+        vec![Action::AdminAction(AdminAction::RegisterTableAction)],
+        req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
+        AdminResourceScope::bucket_object(bucket, warehouse_prefix.trim_end_matches('/')),
+    )
+    .await
 }
 
 async fn read_authorized_table_metadata_json(
@@ -1385,7 +1383,8 @@ async fn read_authorized_table_metadata_json(
         return Err(s3_error!(InvalidRequest, "table metadata object not found: {metadata_location}"));
     };
     let metadata = parse_table_metadata_json(&object.data)?;
-    authorize_table_warehouse_s3_actions(req, bucket, metadata_table_location(&metadata)?, TABLE_WAREHOUSE_WRITE_ACTIONS).await?;
+    let principal = table_catalog_request_principal(req).await?;
+    authorize_table_warehouse_claim(req, &principal, bucket, metadata_table_location(&metadata)?).await?;
     crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
     Ok((metadata, metadata_guard))
 }
@@ -3187,9 +3186,22 @@ fn validate_supported_table_metadata(metadata: &serde_json::Value) -> S3Result<(
                 return Err(s3_error!(InvalidRequest, "Iceberg v1 table metadata is missing schema"));
             }
             require_metadata_array(metadata, "partition-spec")?;
+            if let Some(snapshots) = metadata.get("snapshots").and_then(serde_json::Value::as_array) {
+                for snapshot in snapshots {
+                    if snapshot
+                        .get("sequence-number")
+                        .is_some_and(|sequence_number| sequence_number.as_i64() != Some(0))
+                    {
+                        return Err(s3_error!(InvalidRequest, "Iceberg v1 snapshot sequence-number must be zero when present"));
+                    }
+                }
+            }
         }
         2 => {
-            require_metadata_i64(metadata, "last-sequence-number")?;
+            let last_sequence_number = require_metadata_i64(metadata, "last-sequence-number")?;
+            if last_sequence_number < 0 {
+                return Err(s3_error!(InvalidRequest, "last-sequence-number must not be negative"));
+            }
             if require_metadata_array(metadata, "schemas")?.is_empty() {
                 return Err(s3_error!(InvalidRequest, "table metadata schemas must not be empty"));
             }
@@ -3203,6 +3215,20 @@ fn validate_supported_table_metadata(metadata: &serde_json::Value) -> S3Result<(
                 return Err(s3_error!(InvalidRequest, "table metadata sort-orders must not be empty"));
             }
             require_metadata_i32(metadata, "default-sort-order-id")?;
+            if let Some(snapshots) = metadata.get("snapshots").and_then(serde_json::Value::as_array) {
+                for snapshot in snapshots {
+                    let sequence_number = snapshot
+                        .get("sequence-number")
+                        .and_then(serde_json::Value::as_i64)
+                        .ok_or_else(|| s3_error!(InvalidRequest, "Iceberg v2 snapshot sequence-number must be an integer"))?;
+                    if sequence_number < 0 || sequence_number > last_sequence_number {
+                        return Err(s3_error!(
+                            InvalidRequest,
+                            "Iceberg v2 snapshot sequence-number must be between zero and last-sequence-number"
+                        ));
+                    }
+                }
+            }
         }
         _ => return Err(s3_error!(InvalidRequest, "unsupported Iceberg table format-version")),
     }
@@ -3620,6 +3646,18 @@ fn apply_upgrade_format_version_update(metadata: &mut serde_json::Value, update:
     if version < current {
         return Err(s3_error!(InvalidRequest, "format-version cannot be downgraded"));
     }
+    if current == 1
+        && version == 2
+        && let Some(snapshots) = metadata.get_mut("snapshots").and_then(serde_json::Value::as_array_mut)
+    {
+        for snapshot in snapshots {
+            snapshot
+                .as_object_mut()
+                .ok_or_else(|| s3_error!(InvalidRequest, "snapshot must be an object"))?
+                .entry("sequence-number".to_string())
+                .or_insert_with(|| serde_json::Value::from(0));
+        }
+    }
     metadata_object_mut(metadata)?.insert("format-version".to_string(), serde_json::Value::from(version));
     Ok(())
 }
@@ -3923,6 +3961,8 @@ struct SnapshotReadBudget {
     manifest_count: usize,
     avro_bytes: usize,
     file_reference_count: usize,
+    manifest_lists: BTreeMap<String, Vec<crate::table_catalog::ManifestListReference>>,
+    manifests: BTreeMap<String, Vec<crate::table_catalog::ManifestDataFileReference>>,
 }
 
 impl SnapshotReadBudget {
@@ -4003,7 +4043,6 @@ struct SnapshotFileIdentity {
 }
 
 async fn validate_table_snapshot_commit_conflicts<B>(
-    mut req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
     current_metadata: &serde_json::Value,
     next_metadata: &serde_json::Value,
@@ -4049,10 +4088,8 @@ where
         })
         .transpose()?;
     let mut read_budget = SnapshotReadBudget::default();
-    let parent_live_files =
-        load_snapshot_live_files(req.as_deref_mut(), context, current_metadata, parent_snapshot_id, &mut read_budget).await?;
+    let parent_live_files = load_snapshot_live_files(context, current_metadata, parent_snapshot_id, &mut read_budget).await?;
     let changes = load_snapshot_file_changes(
-        req,
         context,
         SnapshotChangeContext {
             metadata: next_metadata,
@@ -4109,11 +4146,7 @@ where
     Ok(())
 }
 
-async fn validate_table_snapshot_graph<B>(
-    mut req: Option<&mut S3Request<Body>>,
-    context: &SnapshotReadContext<'_, B>,
-    metadata: &serde_json::Value,
-) -> S3Result<()>
+async fn validate_table_snapshot_graph<B>(context: &SnapshotReadContext<'_, B>, metadata: &serde_json::Value) -> S3Result<()>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
@@ -4130,7 +4163,7 @@ where
             .get("snapshot-id")
             .and_then(serde_json::Value::as_i64)
             .ok_or_else(|| s3_error!(InvalidRequest, "snapshot-id must be an integer"))?;
-        load_snapshot_live_files(req.as_deref_mut(), context, metadata, Some(snapshot_id), &mut read_budget).await?;
+        load_snapshot_live_files(context, metadata, Some(snapshot_id), &mut read_budget).await?;
     }
     Ok(())
 }
@@ -4154,7 +4187,6 @@ fn added_snapshot_update(updates: &[serde_json::Value]) -> S3Result<Option<&serd
 }
 
 async fn load_snapshot_live_files<B>(
-    req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
     current_metadata: &serde_json::Value,
     snapshot_id: Option<i64>,
@@ -4178,7 +4210,7 @@ where
 
     let mut live_files = SnapshotLiveFiles::default();
     let mut seen_locations = BTreeSet::new();
-    for manifest in read_snapshot_manifest_references(req, context, current_metadata, snapshot, read_budget).await? {
+    for manifest in read_snapshot_manifest_references(context, current_metadata, snapshot, read_budget).await? {
         let SnapshotManifestLocation {
             manifest_path,
             partition_spec_id: _,
@@ -4224,7 +4256,6 @@ where
 }
 
 async fn load_snapshot_file_changes<B>(
-    req: Option<&mut S3Request<Body>>,
     read_context: &SnapshotReadContext<'_, B>,
     change_context: SnapshotChangeContext<'_>,
     read_budget: &mut SnapshotReadBudget,
@@ -4235,8 +4266,7 @@ where
     let mut changes = SnapshotFileChanges::default();
     let mut seen_locations = BTreeSet::new();
     for manifest in
-        read_snapshot_manifest_references(req, read_context, change_context.metadata, change_context.snapshot, read_budget)
-            .await?
+        read_snapshot_manifest_references(read_context, change_context.metadata, change_context.snapshot, read_budget).await?
     {
         for reference in &manifest.references {
             if !seen_locations.insert(reference.location.clone()) {
@@ -4362,7 +4392,6 @@ struct SnapshotManifestReferences {
 }
 
 async fn read_snapshot_manifest_references<B>(
-    mut req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
     metadata: &serde_json::Value,
     snapshot: &serde_json::Value,
@@ -4371,7 +4400,7 @@ async fn read_snapshot_manifest_references<B>(
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
-    let manifest_locations = snapshot_manifest_locations(req.as_deref_mut(), context, snapshot, read_budget).await?;
+    let manifest_locations = snapshot_manifest_locations(context, snapshot, read_budget).await?;
     let partition_spec_ids = table_metadata_partition_spec_ids(metadata)?;
     let format_version = metadata_format_version(metadata)?;
     let mut manifests = Vec::new();
@@ -4400,16 +4429,25 @@ where
             &manifest_location.manifest_path,
             crate::table_catalog::TableMetadataMaintenanceObjectKind::ManifestFile,
         )?;
-        authorize_optional_table_catalog_object_read(req.as_deref_mut(), context.bucket, &manifest_key).await?;
-        let manifest_object = context
-            .metadata_backend
-            .read_object_limited(context.bucket, &manifest_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
+        let file_references = if let Some(references) = read_budget.manifests.get(&manifest_key).cloned() {
+            references
+        } else {
+            let manifest_object = context
+                .metadata_backend
+                .read_object_limited(context.bucket, &manifest_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
+                .await
+                .map_err(catalog_store_error)?
+                .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest object is missing"))?;
+            read_budget.charge_avro_bytes(manifest_object.data.len())?;
+            let references = tokio::task::spawn_blocking(move || {
+                crate::table_catalog::data_file_references_from_manifest_avro(&manifest_object.data)
+            })
             .await
-            .map_err(catalog_store_error)?
-            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest object is missing"))?;
-        read_budget.charge_avro_bytes(manifest_object.data.len())?;
-        let file_references =
-            crate::table_catalog::data_file_references_from_manifest_avro(&manifest_object.data).map_err(catalog_store_error)?;
+            .map_err(|err| s3_error!(InternalError, "snapshot manifest parser task failed: {err}"))?
+            .map_err(catalog_store_error)?;
+            read_budget.manifests.insert(manifest_key, references.clone());
+            references
+        };
         read_budget.charge_file_references(file_references.len())?;
         let mut references = Vec::with_capacity(file_references.len());
         for mut reference in file_references {
@@ -4424,7 +4462,7 @@ where
             }
             references.push(reference);
         }
-        validate_manifest_data_file_references(req.as_deref_mut(), context, &references).await?;
+        validate_manifest_data_file_references(context, &references).await?;
         manifests.push(SnapshotManifestReferences {
             location: manifest_location,
             references,
@@ -4442,7 +4480,6 @@ struct SnapshotManifestLocation {
 }
 
 async fn snapshot_manifest_locations<B>(
-    req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
     snapshot: &serde_json::Value,
     read_budget: &mut SnapshotReadBudget,
@@ -4459,16 +4496,25 @@ where
             manifest_list_location,
             crate::table_catalog::TableMetadataMaintenanceObjectKind::ManifestList,
         )?;
-        authorize_optional_table_catalog_object_read(req, context.bucket, &manifest_list_key).await?;
-        let manifest_list_object = context
-            .metadata_backend
-            .read_object_limited(context.bucket, &manifest_list_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
+        let references = if let Some(references) = read_budget.manifest_lists.get(&manifest_list_key).cloned() {
+            references
+        } else {
+            let manifest_list_object = context
+                .metadata_backend
+                .read_object_limited(context.bucket, &manifest_list_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
+                .await
+                .map_err(catalog_store_error)?
+                .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest-list object is missing"))?;
+            read_budget.charge_avro_bytes(manifest_list_object.data.len())?;
+            let references = tokio::task::spawn_blocking(move || {
+                crate::table_catalog::manifest_list_references_from_manifest_list_avro(&manifest_list_object.data)
+            })
             .await
-            .map_err(catalog_store_error)?
-            .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest-list object is missing"))?;
-        read_budget.charge_avro_bytes(manifest_list_object.data.len())?;
-        let references = crate::table_catalog::manifest_list_references_from_manifest_list_avro(&manifest_list_object.data)
+            .map_err(|err| s3_error!(InternalError, "snapshot manifest-list parser task failed: {err}"))?
             .map_err(catalog_store_error)?;
+            read_budget.manifest_lists.insert(manifest_list_key, references.clone());
+            references
+        };
         if references.is_empty() {
             return Err(s3_error!(InvalidRequest, "snapshot manifest-list must reference at least one manifest"));
         }
@@ -4509,7 +4555,6 @@ where
 }
 
 async fn validate_manifest_data_file_references<B>(
-    mut req: Option<&mut S3Request<Body>>,
     context: &SnapshotReadContext<'_, B>,
     references: &[crate::table_catalog::ManifestDataFileReference],
 ) -> S3Result<()>
@@ -4527,8 +4572,9 @@ where
                 &reference.location,
                 reference.object_kind.clone(),
             )?;
-            authorize_optional_table_catalog_object_read(req.as_deref_mut(), context.bucket, &object_key).await?;
-            object_keys.push(object_key);
+            if reference.entry_status != Some(2) {
+                object_keys.push(object_key);
+            }
         }
 
         let metadata_backend = context.metadata_backend.clone();
@@ -5050,7 +5096,6 @@ fn table_identifier_from_request(
 }
 
 async fn register_table_response<S, B>(
-    req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &B,
     bucket: &str,
@@ -5080,7 +5125,7 @@ where
         table: &table,
         entry: &entry,
     };
-    validate_table_snapshot_graph(req, &snapshot_context, &metadata).await?;
+    validate_table_snapshot_graph(&snapshot_context, &metadata).await?;
     store
         .register_table(entry.clone())
         .await
@@ -5103,7 +5148,7 @@ where
     ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
     let metadata_data = serde_json::to_vec(&metadata)
         .map_err(|err| s3_error!(InternalError, "failed to serialize initial table metadata: {}", err))?;
-    let _metadata_guard = metadata_backend
+    let metadata_guard = metadata_backend
         .acquire_write_lock(bucket, &entry.metadata_location)
         .await
         .map_err(catalog_store_error)?;
@@ -5116,12 +5161,13 @@ where
         )
         .await
         .map_err(catalog_store_already_exists_error)?;
+    crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
     if let Err(err) = store
         .create_table(entry.clone())
         .await
         .map_err(catalog_store_already_exists_error)
     {
-        rollback_initial_metadata(metadata_backend, bucket, &entry.metadata_location, "table").await;
+        rollback_initial_metadata(metadata_backend, metadata_guard.as_ref(), bucket, &entry.metadata_location, "table").await;
         return Err(err);
     }
     Ok(load_table_response_from_entry(entry, metadata))
@@ -5142,7 +5188,7 @@ where
     ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
     let metadata_data = serde_json::to_vec(&metadata)
         .map_err(|err| s3_error!(InternalError, "failed to serialize initial view metadata: {}", err))?;
-    let _metadata_guard = metadata_backend
+    let metadata_guard = metadata_backend
         .acquire_write_lock(bucket, &entry.metadata_location)
         .await
         .map_err(catalog_store_error)?;
@@ -5155,12 +5201,13 @@ where
         )
         .await
         .map_err(catalog_store_already_exists_error)?;
+    crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
     if let Err(err) = store
         .create_view(entry.clone())
         .await
         .map_err(catalog_store_already_exists_error)
     {
-        rollback_initial_metadata(metadata_backend, bucket, &entry.metadata_location, "view").await;
+        rollback_initial_metadata(metadata_backend, metadata_guard.as_ref(), bucket, &entry.metadata_location, "view").await;
         return Err(err);
     }
     Ok(load_view_response_from_entry(entry, metadata))
@@ -5168,10 +5215,21 @@ where
 
 async fn rollback_initial_metadata(
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    metadata_guard: &dyn crate::table_catalog::TableCatalogObjectLockGuard,
     bucket: &str,
     metadata_location: &str,
     object_kind: &'static str,
 ) {
+    if let Err(err) = crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard) {
+        tracing::warn!(
+            bucket = %bucket,
+            metadata_location = %metadata_location,
+            object_kind,
+            error = %err,
+            "retaining initial catalog metadata after publication failure because its lock was lost"
+        );
+        return;
+    }
     if let Err(err) = metadata_backend.delete_object_unlocked(bucket, metadata_location).await {
         tracing::warn!(
             bucket = %bucket,
@@ -5573,7 +5631,6 @@ where
 }
 
 async fn update_table_metadata_location_response<S>(
-    mut req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
     bucket: &str,
@@ -5614,7 +5671,7 @@ where
         table: &table_name,
         entry: &current,
     };
-    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
+    validate_table_snapshot_graph(&snapshot_context, &target_metadata).await?;
     let (commit_id, _) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
     if let Some(replay) = published_api_commit_replay(
         store,
@@ -5840,7 +5897,7 @@ where
         table: &table_name,
         entry: &current,
     };
-    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
+    validate_table_snapshot_graph(&snapshot_context, &target_metadata).await?;
     request.requirements.push(metadata_digest_requirement(&target_metadata)?);
     if let Some(existing_commit) = existing_commit {
         if !crate::table_catalog::commit_log_matches_request(&existing_commit, &request, &current.table_id) {
@@ -5959,14 +6016,7 @@ where
         table: &table_name,
         entry: &current,
     };
-    validate_table_snapshot_commit_conflicts(
-        req.as_deref_mut(),
-        &snapshot_context,
-        &expected_metadata,
-        &next_metadata,
-        &request.updates,
-    )
-    .await?;
+    validate_table_snapshot_commit_conflicts(&snapshot_context, &expected_metadata, &next_metadata, &request.updates).await?;
     let (commit_id, metadata_file_token) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
     let next_generation = crate::table_catalog::next_table_catalog_generation(current.generation).map_err(catalog_store_error)?;
     let next_metadata_location = crate::table_catalog::table_metadata_file_path_for_entry(
@@ -6095,15 +6145,8 @@ where
         table: &table_name,
         entry: current,
     };
-    validate_table_snapshot_commit_conflicts(
-        req.as_deref_mut(),
-        &snapshot_context,
-        &previous_metadata,
-        &target_metadata,
-        &request.updates,
-    )
-    .await?;
-    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
+    validate_table_snapshot_commit_conflicts(&snapshot_context, &previous_metadata, &target_metadata, &request.updates).await?;
+    validate_table_snapshot_graph(&snapshot_context, &target_metadata).await?;
     let operation = request
         .operation
         .clone()
@@ -6825,7 +6868,6 @@ where
         .map_err(catalog_store_error)?;
     let target_metadata = read_table_metadata_json(metadata_backend, bucket, &request.metadata_location).await?;
     sync_external_catalog_bridge_response_with_snapshot(
-        None,
         store,
         metadata_backend,
         bucket,
@@ -6847,7 +6889,6 @@ struct ExternalCatalogBridgeSyncSnapshot {
 }
 
 async fn sync_external_catalog_bridge_response_with_snapshot<B>(
-    mut req: Option<&mut S3Request<Body>>,
     store: &crate::table_catalog::ObjectTableCatalogStore<B>,
     metadata_backend: &B,
     bucket: &str,
@@ -6896,9 +6937,9 @@ where
         table: &table_name,
         entry: graph_entry,
     };
-    validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &target_metadata).await?;
+    validate_table_snapshot_graph(&snapshot_context, &target_metadata).await?;
 
-    let (action, table_response, table_id) = if let Some(current) = current {
+    let (action, table_response, table_id, publish_bridge) = if let Some(current) = current {
         if request.expected_version_token.is_none() && request.expected_metadata_location.is_none() {
             if current.metadata_location != request.metadata_location
                 || current.table_uuid != metadata_table_uuid(&target_metadata)?
@@ -6914,6 +6955,7 @@ where
                 EXTERNAL_CATALOG_ACTION_REGISTERED.to_string(),
                 load_table_response_from_entry(current, target_metadata),
                 table_id,
+                true,
             )
         } else {
             let expected_version_token = request
@@ -6924,6 +6966,15 @@ where
                 .expected_metadata_location
                 .clone()
                 .ok_or_else(|| s3_error!(InvalidRequest, "external catalog sync requires expected-metadata-location"))?;
+            if current.metadata_location != request.metadata_location
+                && request.commit_id.is_none()
+                && request.idempotency_key.is_none()
+            {
+                return Err(s3_error!(
+                    InvalidRequest,
+                    "external catalog pointer sync requires commit-id or idempotency-key"
+                ));
+            }
             let (commit_id, _) = standard_commit_ids(request.commit_id.clone(), request.idempotency_key.as_deref());
             let result = if let Some(replay) = published_api_commit_replay(
                 store,
@@ -6969,11 +7020,27 @@ where
                     .await
                     .map_err(catalog_store_error)?
             };
+            let publish_bridge = result.table.metadata_location == request.metadata_location;
+            let response_metadata = if publish_bridge {
+                target_metadata
+            } else if !crate::table_catalog::is_valid_table_metadata_location_for_entry(
+                &result.table,
+                &result.table.metadata_location,
+            ) {
+                return Err(iceberg_rest_error(
+                    ICEBERG_ERROR_REST,
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "persisted table metadata location is outside the protected table metadata directory",
+                ));
+            } else {
+                read_table_metadata_json(metadata_backend, bucket, &result.table.metadata_location).await?
+            };
             let table_id = result.table.table_id.clone();
             (
                 EXTERNAL_CATALOG_ACTION_COMMITTED.to_string(),
-                load_table_response_from_entry(result.table, target_metadata),
+                load_table_response_from_entry(result.table, response_metadata),
                 table_id,
+                publish_bridge,
             )
         }
     } else {
@@ -6991,16 +7058,32 @@ where
             EXTERNAL_CATALOG_ACTION_REGISTERED.to_string(),
             load_table_response_from_entry(entry, target_metadata),
             table_id,
+            true,
         )
     };
 
-    let mut bridge_entry =
-        external_catalog_bridge_entry_from_sync_request(bucket, namespace, table, &request, external_table_uuid)?;
-    bridge_entry.table_id = table_id;
-    let bridge_entry = store
-        .put_external_catalog_bridge(bridge_entry)
-        .await
-        .map_err(catalog_store_error)?;
+    let bridge_entry = if publish_bridge {
+        let mut bridge_entry =
+            external_catalog_bridge_entry_from_sync_request(bucket, namespace, table, &request, external_table_uuid)?;
+        bridge_entry.table_id = table_id;
+        store
+            .put_external_catalog_bridge(bridge_entry)
+            .await
+            .map_err(catalog_store_error)?
+    } else {
+        store
+            .get_external_catalog_bridge(bucket, &namespace.public_name(), table)
+            .await
+            .map_err(catalog_store_error)?
+            .filter(|bridge| bridge.table_id == table_id)
+            .ok_or_else(|| {
+                iceberg_rest_error(
+                    ICEBERG_ERROR_COMMIT_FAILED,
+                    StatusCode::CONFLICT,
+                    "historical external catalog sync cannot reconstruct the current bridge state",
+                )
+            })?
+    };
     Ok(ExternalCatalogBridgeSyncResponse {
         action,
         table: table_response,
@@ -7025,12 +7108,13 @@ where
     let metadata_location = table_metadata_location_for_catalog(bucket, &request.metadata_location)?;
     let metadata = read_table_metadata_json(metadata_backend, bucket, &metadata_location).await?;
     catalog_import_response_with_metadata(
-        None,
         store,
         metadata_backend,
-        bucket,
-        namespace,
-        table,
+        RestTableRoute {
+            bucket,
+            namespace,
+            table,
+        },
         request,
         metadata,
         table_bucket_enabled,
@@ -7039,12 +7123,9 @@ where
 }
 
 async fn catalog_import_response_with_metadata<S, B>(
-    mut req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &B,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &str,
+    route: RestTableRoute<'_>,
     request: CatalogImportRequest,
     metadata: serde_json::Value,
     table_bucket_enabled: bool,
@@ -7053,6 +7134,11 @@ where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
+    let RestTableRoute {
+        bucket,
+        namespace,
+        table,
+    } = route;
     let started = Instant::now();
     let result = async {
         ensure_table_bucket_entry(store, bucket, table_bucket_enabled).await?;
@@ -7072,7 +7158,7 @@ where
             table: &table_name,
             entry: &entry,
         };
-        validate_table_snapshot_graph(req.as_deref_mut(), &snapshot_context, &metadata).await?;
+        validate_table_snapshot_graph(&snapshot_context, &metadata).await?;
         if let Some(existing) = store
             .load_table(bucket, &namespace.public_name(), table)
             .await
@@ -7140,7 +7226,8 @@ where
         .await?
         {
             let result = store.commit_table(replay).await.map_err(catalog_store_error)?;
-            return Ok(commit_table_response_from_result(result, target_metadata));
+            return commit_table_replay_response(None, metadata_backend, bucket, result, &metadata_location, target_metadata)
+                .await;
         }
         if !crate::table_catalog::is_valid_table_metadata_location_for_entry(&current, &metadata_location) {
             return Err(s3_error!(InvalidRequest, "metadata location must be inside the table metadata directory"));
@@ -7149,6 +7236,16 @@ where
         validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
         validate_metadata_table_location_in_bucket(bucket, &target_metadata)?;
         validate_metadata_matches_current_metadata(&current_metadata, &target_metadata)?;
+        let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
+            .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+        let snapshot_context = SnapshotReadContext {
+            metadata_backend,
+            bucket,
+            namespace,
+            table: &table_name,
+            entry: &current,
+        };
+        validate_table_snapshot_graph(&snapshot_context, &target_metadata).await?;
         let commit_request = crate::table_catalog::TableCommitRequest {
             table_bucket: bucket.to_string(),
             namespace: namespace.public_name(),
@@ -7450,7 +7547,7 @@ impl Operation for RestCreateTableHandler {
         let request = read_json_body::<CreateTableRequest>(input).await?;
         if let Some(location) = request.location.as_deref() {
             authorize_table_catalog_resource_for_principal(&req, &principal, &resource, AdminAction::RegisterTableAction).await?;
-            authorize_table_warehouse_s3_actions(&mut req, &warehouse, location, TABLE_WAREHOUSE_WRITE_ACTIONS).await?;
+            authorize_table_warehouse_claim(&req, &principal, &warehouse, location).await?;
         }
         let metadata_backend = table_catalog_backend()?;
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
@@ -7479,17 +7576,9 @@ impl Operation for RestRegisterTableHandler {
         let store = table_catalog_store_from_backend(metadata_backend.clone())?;
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
         crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
-        let response = register_table_response(
-            Some(&mut req),
-            &store,
-            &metadata_backend,
-            &warehouse,
-            &namespace,
-            request,
-            metadata,
-            table_bucket_enabled,
-        )
-        .await?;
+        let response =
+            register_table_response(&store, &metadata_backend, &warehouse, &namespace, request, metadata, table_bucket_enabled)
+                .await?;
         drop(metadata_guard);
         build_json_response(StatusCode::OK, &response)
     }
@@ -7603,11 +7692,7 @@ impl Operation for RestCommitTableHandler {
             .await
             .map_err(catalog_store_error)?
             .ok_or_else(|| iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"))?;
-        let warehouse_read_location =
-            table_commit_warehouse_read_location(Some(&mut req), &store, &metadata_backend, &warehouse, &current, &request)
-                .await?;
-        authorize_table_warehouse_s3_actions(&mut req, &warehouse, &warehouse_read_location, TABLE_WAREHOUSE_READ_ACTIONS)
-            .await?;
+        table_commit_warehouse_read_location(Some(&mut req), &store, &metadata_backend, &warehouse, &current, &request).await?;
         let target_metadata = if let Some(metadata_location) = request.new_metadata_location.as_deref() {
             let metadata_location = table_metadata_location_for_catalog(&warehouse, metadata_location)?;
             authorize_table_catalog_s3_actions(&mut req, &warehouse, &metadata_location, &[S3Action::GetObjectAction]).await?;
@@ -7620,28 +7705,9 @@ impl Operation for RestCommitTableHandler {
                 &metadata_location,
             )
             .await?;
-            authorize_table_warehouse_s3_actions(
-                &mut req,
-                &warehouse,
-                metadata_table_location(&metadata)?,
-                TABLE_WAREHOUSE_WRITE_ACTIONS,
-            )
-            .await?;
             request.new_metadata_location = Some(metadata_location);
             Some(metadata)
         } else {
-            if let Some(update) = request
-                .updates
-                .iter()
-                .rev()
-                .find(|update| update.get("action").and_then(serde_json::Value::as_str) == Some("set-location"))
-            {
-                let location = update
-                    .get("location")
-                    .and_then(serde_json::Value::as_str)
-                    .ok_or_else(|| s3_error!(InvalidRequest, "set-location requires location"))?;
-                authorize_table_warehouse_s3_actions(&mut req, &warehouse, location, TABLE_WAREHOUSE_WRITE_ACTIONS).await?;
-            }
             None
         };
         let response = commit_table_response_with_target_metadata(
@@ -7883,15 +7949,7 @@ impl Operation for UpdateTableMetadataLocationHandler {
             &request.metadata_location,
         )
         .await?;
-        authorize_table_warehouse_s3_actions(
-            &mut req,
-            &warehouse,
-            metadata_table_location(&target_metadata)?,
-            TABLE_WAREHOUSE_WRITE_ACTIONS,
-        )
-        .await?;
         let response = update_table_metadata_location_response(
-            Some(&mut req),
             &store,
             &metadata_backend,
             &warehouse,
@@ -8156,12 +8214,13 @@ impl Operation for ImportTableCatalogHandler {
         let table_bucket_enabled = table_bucket_enabled_from_metadata(&warehouse).await?;
         crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
         let response = catalog_import_response_with_metadata(
-            Some(&mut req),
             &store,
             &metadata_backend,
-            &warehouse,
-            &namespace,
-            &table,
+            RestTableRoute {
+                bucket: &warehouse,
+                namespace: &namespace,
+                table: &table,
+            },
             request,
             metadata,
             table_bucket_enabled,
@@ -8240,7 +8299,6 @@ impl Operation for SyncExternalCatalogBridgeHandler {
             read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &request.metadata_location).await?;
         crate::table_catalog::ensure_table_catalog_lock_held(metadata_guard.as_ref()).map_err(catalog_store_error)?;
         let response = sync_external_catalog_bridge_response_with_snapshot(
-            Some(&mut req),
             &store,
             &metadata_backend,
             &warehouse,
@@ -8342,13 +8400,6 @@ impl Operation for RollbackTableCatalogHandler {
             &request.metadata_location,
         )
         .await?;
-        authorize_table_warehouse_s3_actions(
-            &mut req,
-            &warehouse,
-            metadata_table_location(&target_metadata)?,
-            TABLE_WAREHOUSE_WRITE_ACTIONS,
-        )
-        .await?;
         let response =
             rollback_table_response(&store, &metadata_backend, &warehouse, &namespace, &table, request, target_metadata).await?;
         build_json_response(StatusCode::OK, &response)
@@ -8391,6 +8442,7 @@ mod tests {
             manifest_count: TABLE_COMMIT_MAX_MANIFESTS - 2,
             avro_bytes: TABLE_COMMIT_MAX_AVRO_BYTES - 3,
             file_reference_count: TABLE_COMMIT_MAX_FILE_REFERENCES - 4,
+            ..SnapshotReadBudget::default()
         };
 
         budget.charge_manifests(2).expect("exact manifest limit should be accepted");
@@ -8465,7 +8517,7 @@ mod tests {
             entry: &entry,
         };
 
-        validate_manifest_data_file_references(None, &context, &references)
+        validate_manifest_data_file_references(&context, &references)
             .await
             .expect("existing manifest objects should validate");
         assert!(backend.object_exists_max_in_flight() > 1);
@@ -8475,10 +8527,15 @@ mod tests {
             .delete_object("warehouse", &references[0].location)
             .await
             .expect("test object should be removed");
-        let error = validate_manifest_data_file_references(None, &context, &references)
+        let error = validate_manifest_data_file_references(&context, &references)
             .await
             .expect_err("a missing manifest object should still fail validation");
         assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+
+        references[0].entry_status = Some(2);
+        validate_manifest_data_file_references(&context, &references)
+            .await
+            .expect("a deleted manifest entry need not retain its physical file");
     }
 
     #[tokio::test]
@@ -8532,12 +8589,87 @@ mod tests {
             entry: &entry,
         };
 
-        let error = validate_table_snapshot_graph(None, &context, &metadata)
+        let error = validate_table_snapshot_graph(&context, &metadata)
             .await
             .expect_err("manifest-list partition spec must exist in table metadata");
 
         assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
         assert_eq!(error.message(), Some("snapshot manifest references missing partition spec 9"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_graph_reads_shared_manifest_objects_once() {
+        let backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        let table = crate::table_catalog::IdentifierSegment::parse("events").expect("table should parse");
+        let entry = crate::table_catalog::TableEntry {
+            version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+            table_bucket: "warehouse".to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            table_id: "table-id".to_string(),
+            table_uuid: "table-uuid".to_string(),
+            format: "ICEBERG".to_string(),
+            format_version: 2,
+            warehouse_location: "s3://warehouse/tables/table-id".to_string(),
+            metadata_location: "tables/table-id/metadata/00001.metadata.json".to_string(),
+            version_token: "token-v1".to_string(),
+            generation: 1,
+            state: crate::table_catalog::TableCatalogEntryState::Active,
+            properties: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
+        };
+        let manifest_list = "s3://warehouse/tables/table-id/metadata/snap-1.avro";
+        let data_file = "s3://warehouse/tables/table-id/data/part-1.parquet";
+        seed_test_snapshot_manifest(&backend, "warehouse", manifest_list, 1, 1, &[(data_file, 0, 1, 1, 1)]).await;
+        let mut metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        metadata["last-sequence-number"] = serde_json::Value::from(2);
+        metadata["snapshots"] = serde_json::json!([
+            {
+                "snapshot-id": 1,
+                "sequence-number": 1,
+                "timestamp-ms": 1,
+                "manifest-list": manifest_list,
+                "summary": {"operation": "append"}
+            },
+            {
+                "snapshot-id": 2,
+                "parent-snapshot-id": 1,
+                "sequence-number": 2,
+                "timestamp-ms": 2,
+                "manifest-list": manifest_list,
+                "summary": {"operation": "append"}
+            }
+        ]);
+        metadata["current-snapshot-id"] = serde_json::Value::from(2);
+        metadata["refs"] = serde_json::json!({"main": {"type": "branch", "snapshot-id": 2}});
+        let context = SnapshotReadContext {
+            metadata_backend: &backend,
+            bucket: "warehouse",
+            namespace: &namespace,
+            table: &table,
+            entry: &entry,
+        };
+
+        validate_table_snapshot_graph(&context, &metadata)
+            .await
+            .expect("shared snapshot graph should validate");
+
+        assert_eq!(backend.read_object_call_count(), 2);
+
+        let mut budget = SnapshotReadBudget {
+            file_reference_count: TABLE_COMMIT_MAX_FILE_REFERENCES - 1,
+            ..SnapshotReadBudget::default()
+        };
+        read_snapshot_manifest_references(&context, &metadata, &metadata["snapshots"][0], &mut budget)
+            .await
+            .expect("the first manifest traversal should reach the file reference limit");
+        let error = read_snapshot_manifest_references(&context, &metadata, &metadata["snapshots"][1], &mut budget)
+            .await
+            .err()
+            .expect("a cached manifest traversal must still consume the file reference budget");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
     }
 
     #[test]
@@ -9011,7 +9143,7 @@ mod tests {
         let create_table_block = operation_block(src, "RestCreateTableHandler");
         assert!(create_table_block.contains("request.location.as_deref()"));
         assert!(create_table_block.contains("AdminAction::RegisterTableAction"));
-        assert!(create_table_block.contains("authorize_table_warehouse_s3_actions"));
+        assert!(create_table_block.contains("authorize_table_warehouse_claim"));
 
         let register_table_block = operation_block(src, "RestRegisterTableHandler");
         assert!(register_table_block.contains("read_authorized_table_metadata_json"));
@@ -9020,17 +9152,15 @@ mod tests {
             !function_block(src, "async fn register_table_response").contains("read_table_metadata_json"),
             "register should persist the metadata snapshot used for authorization"
         );
-        let warehouse_auth_block = function_block(src, "async fn authorize_table_warehouse_s3_actions");
-        assert!(warehouse_auth_block.contains("table_catalog_prefix_authorization_probe"));
-        assert!(warehouse_auth_block.contains("actions"));
+        let warehouse_auth_block = function_block(src, "async fn authorize_table_warehouse_claim");
+        assert!(warehouse_auth_block.contains("AdminAction::RegisterTableAction"));
+        assert!(warehouse_auth_block.contains("AdminResourceScope::bucket_object"));
         let s3_auth_block = function_block(src, "async fn authorize_table_catalog_s3_actions");
         assert!(s3_auth_block.contains("table_catalog_request_principal(req).await?"));
         assert!(s3_auth_block.contains("ReqInfo"));
-        assert_eq!(TABLE_WAREHOUSE_READ_ACTIONS, &[S3Action::GetObjectAction]);
-        assert_eq!(TABLE_WAREHOUSE_WRITE_ACTIONS, &[S3Action::PutObjectAction, S3Action::DeleteObjectAction]);
         let metadata_auth_block = function_block(src, "async fn read_authorized_table_metadata_json");
         assert!(metadata_auth_block.contains("S3Action::GetObjectAction"));
-        assert!(metadata_auth_block.contains("authorize_table_warehouse_s3_actions"));
+        assert!(metadata_auth_block.contains("authorize_table_warehouse_claim"));
         assert!(metadata_auth_block.contains("acquire_read_lock"));
         assert!(metadata_auth_block.contains("ensure_table_catalog_lock_held"));
 
@@ -9095,29 +9225,17 @@ mod tests {
         assert!(import_block.contains("read_authorized_table_metadata_json"));
         assert!(import_block.contains("catalog_import_response_with_metadata"));
 
-        for handler in [
-            "RestCommitTableHandler",
-            "UpdateTableMetadataLocationHandler",
-            "RollbackTableCatalogHandler",
-        ] {
-            assert!(
-                operation_block(src, handler).contains("authorize_table_warehouse_s3_actions"),
-                "{handler} should authorize the warehouse prefix before publishing a relocated table"
-            );
-        }
-        assert!(
-            operation_block(src, "RestCommitTableHandler").contains("TABLE_WAREHOUSE_READ_ACTIONS"),
-            "table commits should require read access to manifest and data objects under the warehouse prefix"
-        );
+        let commit_block = operation_block(src, "RestCommitTableHandler");
+        assert!(commit_block.contains("authorize_table_catalog_s3_actions"));
+        assert!(commit_block.contains("S3Action::GetObjectAction"));
         for helper in [
-            "async fn table_commit_warehouse_read_location",
             "async fn read_snapshot_manifest_references",
             "async fn snapshot_manifest_locations",
-            "async fn validate_manifest_data_file_reference",
+            "async fn validate_manifest_data_file_references",
         ] {
             assert!(
-                function_block(src, helper).contains("authorize_optional_table_catalog_object_read"),
-                "{helper} should authorize every concrete object before reading it"
+                !function_block(src, helper).contains("authorize_optional_table_catalog_object_read"),
+                "{helper} should validate the catalog-owned metadata graph without per-object IAM fan-out"
             );
         }
 
@@ -9337,59 +9455,6 @@ mod tests {
             .or_else(|| block.find("\n#[cfg(test)]"))
             .unwrap_or(block.len());
         &block[..end]
-    }
-
-    #[test]
-    fn table_catalog_prefix_authorization_probe_is_an_unpredictable_descendant() {
-        let probe = table_catalog_prefix_authorization_probe("tables/existing/");
-        let suffix = probe
-            .strip_prefix("tables/existing/")
-            .expect("authorization probe should stay inside the warehouse prefix");
-        Uuid::parse_str(suffix).expect("authorization probe suffix should be a UUID");
-    }
-
-    #[tokio::test]
-    async fn table_catalog_prefix_authorization_probe_rejects_marker_only_policy() {
-        let marker_policy = Policy::parse_config(
-            br#"{
-                "Version": "2012-10-17",
-                "Statement": [{
-                    "Effect": "Allow",
-                    "Action": "s3:PutObject",
-                    "Resource": "arn:aws:s3:::warehouse/tables/existing/"
-                }]
-            }"#,
-        )
-        .expect("marker-only policy should parse");
-        let prefix_policy = Policy::parse_config(
-            br#"{
-                "Version": "2012-10-17",
-                "Statement": [{
-                    "Effect": "Allow",
-                    "Action": "s3:PutObject",
-                    "Resource": "arn:aws:s3:::warehouse/tables/existing/*"
-                }]
-            }"#,
-        )
-        .expect("prefix policy should parse");
-        let probe = table_catalog_prefix_authorization_probe("tables/existing/");
-        let groups = None;
-        let conditions = HashMap::new();
-        let claims = HashMap::new();
-        let args = rustfs_policy::policy::Args {
-            account: "testuser",
-            groups: &groups,
-            action: Action::S3Action(S3Action::PutObjectAction),
-            bucket: "warehouse",
-            conditions: &conditions,
-            is_owner: false,
-            object: &probe,
-            claims: &claims,
-            deny_only: false,
-        };
-
-        assert!(!marker_policy.is_allowed(&args).await);
-        assert!(prefix_policy.is_allowed(&args).await);
     }
 
     fn function_block<'a>(src: &'a str, signature: &str) -> &'a str {
@@ -10685,7 +10750,13 @@ mod tests {
             "schema": {"type": "struct", "schema-id": 7, "fields": []},
             "partition-spec": [],
             "properties": {},
-            "snapshots": [],
+            "snapshots": [{
+                "snapshot-id": 10,
+                "timestamp-ms": 1,
+                "manifests": ["s3://warehouse/tables/table-id/metadata/manifest.avro"],
+                "summary": {"operation": "append"}
+            }],
+            "current-snapshot-id": 10,
             "snapshot-log": [],
             "metadata-log": []
         });
@@ -10704,6 +10775,7 @@ mod tests {
         assert_eq!(upgraded["default-spec-id"], 0);
         assert_eq!(upgraded["default-sort-order-id"], 0);
         assert_eq!(upgraded["last-sequence-number"], 0);
+        assert_eq!(upgraded["snapshots"][0]["sequence-number"], 0);
         assert!(upgraded.get("schema").is_none());
         assert!(upgraded.get("partition-spec").is_none());
         validate_supported_table_metadata(&upgraded).expect("upgraded metadata should satisfy the v2 contract");
@@ -10849,6 +10921,96 @@ mod tests {
             .await
             .expect_err("missing namespace should reject view publication");
         assert!(metadata_backend.objects.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_table_response_rejects_lost_initial_metadata_lock_before_catalog_publish() {
+        let store = TestTableCatalogStore::default();
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(&store, "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            &store,
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        metadata_backend.lose_write_locks();
+        let request = serde_json::from_value(serde_json::json!({
+            "name": "events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            }
+        }))
+        .expect("create table request should parse");
+
+        create_table_response(&store, &metadata_backend, "warehouse", &namespace, request, true)
+            .await
+            .expect_err("a lost metadata lock must reject catalog publication");
+
+        assert!(store.tables.lock().await.is_empty());
+        assert_eq!(metadata_backend.objects.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn create_table_response_retains_initial_metadata_when_publish_fails_after_lock_loss() {
+        let pause = TestCatalogPublishPause::default();
+        let store = Arc::new(TestTableCatalogStore {
+            create_table_pause: Some(pause.clone()),
+            fail_create_table_after_pause: true,
+            ..Default::default()
+        });
+        let metadata_backend = TestTableCatalogObjectBackend::default();
+        let namespace = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
+        ensure_table_bucket_entry(store.as_ref(), "warehouse", true)
+            .await
+            .expect("table bucket entry should be seeded");
+        create_namespace_response(
+            store.as_ref(),
+            "warehouse",
+            CreateNamespaceRequest {
+                namespace: vec!["analytics".to_string()],
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("namespace should be created");
+        let request = serde_json::from_value(serde_json::json!({
+            "name": "events",
+            "schema": {
+                "type": "struct",
+                "schema-id": 0,
+                "fields": []
+            }
+        }))
+        .expect("create table request should parse");
+        let create_store = Arc::clone(&store);
+        let create_backend = metadata_backend.clone();
+        let create_namespace = namespace.clone();
+        let create = tokio::spawn(async move {
+            create_table_response(create_store.as_ref(), &create_backend, "warehouse", &create_namespace, request, true).await
+        });
+
+        pause.wait_started().await;
+        metadata_backend.lose_write_locks();
+        pause.release();
+        create
+            .await
+            .expect("create task should join")
+            .expect_err("injected catalog publication failure should be returned");
+
+        assert!(store.tables.lock().await.is_empty());
+        assert_eq!(metadata_backend.objects.lock().await.len(), 1);
     }
 
     #[tokio::test]
@@ -11374,8 +11536,10 @@ mod tests {
                 "writer": "test-client",
                 "requirements": [],
                 "updates": [{
-                    "action": "set-location",
-                    "location": "s3://warehouse/tables/relocated-events"
+                    "action": "set-properties",
+                    "updates": {
+                        "owner": "first"
+                    }
                 }]
             });
             standard_commit_table_response(
@@ -11387,7 +11551,7 @@ mod tests {
                 serde_json::from_value(first_request.clone()).expect("first commit request should parse"),
             )
             .await
-            .expect("first commit should relocate the table");
+            .expect("first commit should advance the table");
 
             let second = standard_commit_table_response(
                 &store,
@@ -11749,7 +11913,6 @@ mod tests {
             .await;
 
         let updated = update_table_metadata_location_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -12581,13 +12744,17 @@ mod tests {
         let table = crate::table_catalog::IdentifierSegment::parse("events").expect("table should parse");
         let current_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
         let next_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let later_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00003.metadata.json");
         seed_object_table_for_metadata_maintenance(&store, &backend, bucket, &namespace, &table, current_location.clone()).await;
         let mut current_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
         current_metadata["last-sequence-number"] = serde_json::json!(1);
         let mut next_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
         next_metadata["last-sequence-number"] = serde_json::json!(2);
+        let mut later_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        later_metadata["last-sequence-number"] = serde_json::json!(3);
         backend.put_json(bucket, &current_location, current_metadata).await;
         backend.put_json(bucket, &next_location, next_metadata).await;
+        backend.put_json(bucket, &later_location, later_metadata).await;
 
         let sync_request = || ExternalCatalogBridgeSyncRequest {
             catalog: "hive-metastore".to_string(),
@@ -12606,6 +12773,14 @@ mod tests {
             rollback_strategy: Some("retain-current-pointer".to_string()),
             properties: BTreeMap::new(),
         };
+        let mut non_idempotent_request = sync_request();
+        non_idempotent_request.idempotency_key = None;
+        let error =
+            sync_external_catalog_bridge_response(&store, &backend, bucket, &namespace, "events", non_idempotent_request, true)
+                .await
+                .expect_err("a pointer-changing external sync must carry a stable request identity");
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+
         let synced = sync_external_catalog_bridge_response(&store, &backend, bucket, &namespace, "events", sync_request(), true)
             .await
             .expect("external sync should commit existing table");
@@ -12635,6 +12810,48 @@ mod tests {
             .expect("table should exist");
         assert_eq!(replayed_current.version_token, current.version_token);
         assert_eq!(replayed_current.generation, current.generation);
+
+        let later = sync_external_catalog_bridge_response(
+            &store,
+            &backend,
+            bucket,
+            &namespace,
+            "events",
+            ExternalCatalogBridgeSyncRequest {
+                catalog: "hive-metastore".to_string(),
+                external_catalog_id: Some("hms-prod".to_string()),
+                external_namespace: "sales".to_string(),
+                external_table: "orders".to_string(),
+                external_table_uuid: Some("table-uuid".to_string()),
+                metadata_location: table_metadata_location_for_client(bucket, &later_location),
+                external_version_token: Some("hms-version-3".to_string()),
+                expected_version_token: Some(current.version_token.clone()),
+                expected_metadata_location: Some(table_metadata_location_for_client(bucket, &next_location)),
+                commit_id: None,
+                idempotency_key: Some("external-sync-idempotency-3".to_string()),
+                policy_mode: Some("rustfs-authoritative".to_string()),
+                credential_mode: Some("rustfs-table-credentials".to_string()),
+                rollback_strategy: Some("retain-current-pointer".to_string()),
+                properties: BTreeMap::new(),
+            },
+            true,
+        )
+        .await
+        .expect("a later external sync should commit");
+        assert_eq!(later.table.metadata_location, table_metadata_location_for_client(bucket, &later_location));
+
+        let historical =
+            sync_external_catalog_bridge_response(&store, &backend, bucket, &namespace, "events", sync_request(), true)
+                .await
+                .expect("a historical retry should return the latest published state");
+        assert_eq!(historical.table.metadata_location, later.table.metadata_location);
+        assert_eq!(historical.table.config, later.table.config);
+        let bridge = historical
+            .bridge
+            .bridge
+            .expect("historical retry should preserve the current bridge");
+        assert_eq!(bridge.last_synced_metadata_location.as_deref(), Some(later_location.as_str()));
+        assert_eq!(bridge.external_version_token.as_deref(), Some("hms-version-3"));
     }
 
     #[tokio::test]
@@ -12660,7 +12877,6 @@ mod tests {
             .expect("concurrent table drop should succeed");
 
         let result = sync_external_catalog_bridge_response_with_snapshot(
-            None,
             &store,
             &backend,
             bucket,
@@ -12935,6 +13151,24 @@ mod tests {
             validate_supported_table_metadata(&incomplete)
                 .expect_err("missing required Iceberg v2 metadata field must be rejected");
         }
+    }
+
+    #[test]
+    fn table_metadata_validation_bounds_snapshot_sequence_numbers() {
+        let mut metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        metadata["last-sequence-number"] = serde_json::Value::from(1);
+        metadata["snapshots"] = serde_json::json!([{
+            "snapshot-id": 10,
+            "sequence-number": 2,
+            "timestamp-ms": 1,
+            "manifest-list": "s3://warehouse/tables/table-id/metadata/snap-10.avro",
+            "summary": {"operation": "append"}
+        }]);
+
+        let error = validate_supported_table_metadata(&metadata)
+            .expect_err("snapshot sequence-number must not exceed last-sequence-number");
+
+        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
     }
 
     #[test]
@@ -13394,7 +13628,7 @@ mod tests {
             }
         })];
 
-        validate_table_snapshot_commit_conflicts(None, &context, &current_metadata, &current_metadata, &updates)
+        validate_table_snapshot_commit_conflicts(&context, &current_metadata, &current_metadata, &updates)
             .await
             .expect("a branch commit should validate deletes against its declared parent snapshot");
     }
@@ -15687,6 +15921,7 @@ mod tests {
         fail_put_table_bucket: tokio::sync::Mutex<bool>,
         create_table_pause: Option<TestCatalogPublishPause>,
         create_view_pause: Option<TestCatalogPublishPause>,
+        fail_create_table_after_pause: bool,
     }
 
     #[derive(Clone, Default)]
@@ -15717,6 +15952,18 @@ mod tests {
         object_exists_in_flight: Arc<std::sync::atomic::AtomicUsize>,
         object_exists_max_in_flight: Arc<std::sync::atomic::AtomicUsize>,
         locks: TestTableCatalogObjectLocks,
+        write_locks_lost: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    struct TestTableCatalogObjectLockGuard {
+        _guard: tokio::sync::OwnedMutexGuard<()>,
+        lost: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl crate::table_catalog::TableCatalogObjectLockGuard for TestTableCatalogObjectLockGuard {
+        fn is_lock_lost(&self) -> bool {
+            self.lost.load(std::sync::atomic::Ordering::Relaxed)
+        }
     }
 
     impl TestTableCatalogObjectBackend {
@@ -15736,6 +15983,10 @@ mod tests {
                 .get(&(bucket.to_string(), object.to_string()))
                 .cloned();
             lock.is_some_and(|lock| lock.try_lock_owned().is_err())
+        }
+
+        fn lose_write_locks(&self) {
+            self.write_locks_lost.store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
         async fn put_bytes(&self, bucket: &str, object: &str, data: Vec<u8>) {
@@ -16239,7 +16490,10 @@ mod tests {
                     .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
                     .clone()
             };
-            Ok(Box::new(lock.lock_owned().await))
+            Ok(Box::new(TestTableCatalogObjectLockGuard {
+                _guard: lock.lock_owned().await,
+                lost: Arc::clone(&self.write_locks_lost),
+            }))
         }
     }
 
@@ -16364,6 +16618,11 @@ mod tests {
             if let Some(pause) = &self.create_table_pause {
                 pause.started.notify_one();
                 pause.release.notified().await;
+            }
+            if self.fail_create_table_after_pause {
+                return Err(crate::table_catalog::TableCatalogStoreError::Internal(
+                    "injected table publication failure".to_string(),
+                ));
             }
             self.tables.lock().await.push(entry);
             Ok(())
@@ -17011,7 +17270,6 @@ mod tests {
             .put_json("warehouse", metadata_location, metadata.clone())
             .await;
         let register = register_table_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17128,7 +17386,6 @@ mod tests {
             .await;
 
         register_table_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17178,7 +17435,6 @@ mod tests {
             .await;
 
         let response = register_table_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17229,7 +17485,6 @@ mod tests {
             .put_json("warehouse", metadata_location, metadata.clone())
             .await;
         register_table_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17257,7 +17512,8 @@ mod tests {
         let error = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", request)
             .await
             .expect_err("warehouse relocation must be rejected");
-        assert_eq!(error.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_UNSUPPORTED_OPERATION.into()));
+        assert_eq!(error.status_code(), Some(StatusCode::NOT_ACCEPTABLE));
         assert_eq!(metadata_backend.objects.lock().await.len(), object_count);
         let unchanged = store
             .load_table("warehouse", "analytics", "events")
@@ -17298,7 +17554,6 @@ mod tests {
 
         assert!(
             register_table_response(
-                None,
                 &store,
                 &metadata_backend,
                 "warehouse",
@@ -17351,7 +17606,6 @@ mod tests {
             .await;
 
         let error = register_table_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17433,7 +17687,6 @@ mod tests {
             .await;
 
         let updated = update_table_metadata_location_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17457,7 +17710,6 @@ mod tests {
         assert_ne!(updated.version_token, current.version_token);
 
         let replayed = update_table_metadata_location_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17518,7 +17770,6 @@ mod tests {
         };
 
         let error = update_table_metadata_location_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17549,7 +17800,6 @@ mod tests {
         )
         .await;
         update_table_metadata_location_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17566,7 +17816,6 @@ mod tests {
             .await
             .expect("referenced data file should be removed");
         let error = update_table_metadata_location_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17649,7 +17898,6 @@ mod tests {
 
         assert!(
             update_table_metadata_location_response(
-                None,
                 &store,
                 &metadata_backend,
                 "warehouse",
@@ -17703,7 +17951,6 @@ mod tests {
             .put_json("warehouse", current_location, current_metadata.clone())
             .await;
         register_table_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",
@@ -17733,7 +17980,6 @@ mod tests {
 
         assert!(
             update_table_metadata_location_response(
-                None,
                 &store,
                 &metadata_backend,
                 "warehouse",
@@ -17867,7 +18113,7 @@ mod tests {
             "events",
             RollbackTableRequest {
                 metadata_location: table_metadata_location_for_client(bucket, &rollback_location),
-                version_token: current.version_token,
+                version_token: current.version_token.clone(),
                 commit_id: None,
                 idempotency_key: Some("rollback-request-1".to_string()),
             },
@@ -17881,6 +18127,52 @@ mod tests {
         assert_eq!(replayed.commit_id, rollback.commit_id);
         assert_eq!(replayed.version_token, rollback.version_token);
         assert_eq!(replayed.generation, rollback.generation);
+
+        let later_location = crate::table_catalog::default_table_metadata_file_path(&namespace, &table, "00003.metadata.json");
+        let mut later_metadata = test_table_metadata_json("table-uuid", "s3://warehouse/tables/table-id");
+        later_metadata["last-sequence-number"] = serde_json::Value::from(3);
+        backend.put_json(bucket, &later_location, later_metadata).await;
+        let later = rollback_table_response(
+            &store,
+            &backend,
+            bucket,
+            &namespace,
+            "events",
+            RollbackTableRequest {
+                metadata_location: table_metadata_location_for_client(bucket, &later_location),
+                version_token: rollback.version_token,
+                commit_id: None,
+                idempotency_key: Some("rollback-request-2".to_string()),
+            },
+            read_table_metadata_json(&backend, bucket, &later_location)
+                .await
+                .expect("later rollback metadata should load"),
+        )
+        .await
+        .expect("a later rollback should commit");
+
+        let historical = rollback_table_response(
+            &store,
+            &backend,
+            bucket,
+            &namespace,
+            "events",
+            RollbackTableRequest {
+                metadata_location: table_metadata_location_for_client(bucket, &rollback_location),
+                version_token: current.version_token,
+                commit_id: None,
+                idempotency_key: Some("rollback-request-1".to_string()),
+            },
+            read_table_metadata_json(&backend, bucket, &rollback_location)
+                .await
+                .expect("rollback metadata should load"),
+        )
+        .await
+        .expect("a historical rollback retry should return the current table state");
+
+        assert_eq!(historical.metadata_location, later.metadata_location);
+        assert_eq!(historical.version_token, later.version_token);
+        assert_eq!(historical.generation, later.generation);
     }
 
     #[tokio::test]
@@ -18084,7 +18376,6 @@ mod tests {
             .put_json("warehouse", current_location, current_metadata.clone())
             .await;
         register_table_response(
-            None,
             &store,
             &metadata_backend,
             "warehouse",

--- a/rustfs/src/admin/handlers/table_catalog.rs
+++ b/rustfs/src/admin/handlers/table_catalog.rs
@@ -69,12 +69,24 @@ const ICEBERG_ERROR_NO_SUCH_RESOURCE: &str = "NoSuchResourceException";
 const ICEBERG_ERROR_NO_SUCH_TABLE: &str = "NoSuchTableException";
 const ICEBERG_ERROR_NO_SUCH_VIEW: &str = "NoSuchViewException";
 const ICEBERG_ERROR_REST: &str = "RESTException";
+const ICEBERG_ERROR_UNPROCESSABLE_ENTITY: &str = "UnprocessableEntityException";
+const ICEBERG_ERROR_UNSUPPORTED_OPERATION: &str = "UnsupportedOperationException";
+const ICEBERG_VIEW_FORMAT_VERSION: i64 = 1;
+const IDEMPOTENCY_KEY_HEADER: &str = "idempotency-key";
 const REST_PAGE_TOKEN_VERSION: u8 = 1;
 const REST_PAGE_TOKEN_MAX_LENGTH: usize = 16 * 1024;
 const REST_DEFAULT_PAGE_SIZE: usize = 1000;
 const REST_MAX_PAGE_SIZE: usize = 1000;
 const REST_PAGE_TOKEN_QUERY_PARAMETER: &str = "pageToken";
 const REST_PAGE_SIZE_QUERY_PARAMETER: &str = "pageSize";
+const REST_NAMESPACE_SEPARATOR: char = '\u{1f}';
+const REST_NAMESPACE_SEPARATOR_UTF8: &str = "\u{1f}";
+const REST_NAMESPACE_SEPARATOR_URL_ENCODED: &str = "%1F";
+const TABLE_WAREHOUSE_READ_ACTIONS: &[S3Action] = &[S3Action::GetObjectAction];
+const TABLE_WAREHOUSE_WRITE_ACTIONS: &[S3Action] = &[S3Action::PutObjectAction, S3Action::DeleteObjectAction];
+const TABLE_COMMIT_MAX_MANIFESTS: usize = 10_000;
+const TABLE_COMMIT_MAX_AVRO_BYTES: usize = 512 * 1024 * 1024;
+const TABLE_COMMIT_MAX_FILE_REFERENCES: usize = 1_000_000;
 const CATALOG_ENDPOINT_PREFIX_CONFIG_KEY: &str = "rustfs.catalog-endpoint-prefix";
 const CATALOG_COMPAT_ENDPOINT_PREFIX_CONFIG_KEY: &str = "rustfs.catalog-compat-endpoint-prefix";
 const CATALOG_BACKING_CONFIG_KEY: &str = "rustfs.catalog-backing";
@@ -305,6 +317,8 @@ struct RestCommitTableRequest {
 struct RestCommitViewRequest {
     #[serde(default, rename = "identifier")]
     identifier: Option<RestTableIdentifier>,
+    #[serde(default, rename = "commit-id")]
+    commit_id: Option<String>,
     #[serde(default, rename = "expected-version-token")]
     expected_version_token: Option<String>,
     #[serde(default, rename = "expected-metadata-location")]
@@ -1350,6 +1364,14 @@ async fn authorize_table_catalog_s3_actions(
     object: &str,
     actions: &[S3Action],
 ) -> S3Result<()> {
+    if req.extensions.get::<ReqInfo>().is_none() {
+        let principal = table_catalog_request_principal(req).await?;
+        req.extensions.insert(ReqInfo {
+            cred: Some(principal.credentials),
+            is_owner: principal.owner,
+            ..Default::default()
+        });
+    }
     let original = {
         let req_info = req
             .extensions
@@ -1373,6 +1395,17 @@ async fn authorize_table_catalog_s3_actions(
         (req_info.bucket, req_info.object, req_info.version_id) = original;
     }
     result
+}
+
+async fn authorize_optional_table_catalog_object_read(
+    req: Option<&mut S3Request<Body>>,
+    bucket: &str,
+    object: &str,
+) -> S3Result<()> {
+    match req {
+        Some(req) => authorize_table_catalog_s3_actions(req, bucket, object, &[S3Action::GetObjectAction]).await,
+        None => Ok(()),
+    }
 }
 
 fn table_catalog_prefix_authorization_probe(object_prefix: &str) -> String {
@@ -1542,6 +1575,33 @@ fn warehouse_from_config_query(uri: &http::Uri) -> S3Result<Option<String>> {
     Ok(warehouse)
 }
 
+fn rest_purge_requested_from_query(uri: &http::Uri) -> S3Result<bool> {
+    let mut purge_requested = None;
+    if let Some(query) = uri.query() {
+        for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+            if key != "purgeRequested" {
+                continue;
+            }
+            if purge_requested.is_some() {
+                return Err(iceberg_rest_error(
+                    ICEBERG_ERROR_BAD_REQUEST,
+                    StatusCode::BAD_REQUEST,
+                    "purgeRequested query parameter must not be repeated",
+                ));
+            }
+            let value = value.parse::<bool>().map_err(|_| {
+                iceberg_rest_error(
+                    ICEBERG_ERROR_BAD_REQUEST,
+                    StatusCode::BAD_REQUEST,
+                    "purgeRequested query parameter must be true or false",
+                )
+            })?;
+            purge_requested = Some(value);
+        }
+    }
+    Ok(purge_requested.unwrap_or(false))
+}
+
 fn rest_pagination_from_query(uri: &http::Uri, context: RestPageContext<'_>) -> S3Result<RestPagination> {
     let mut page_token = None;
     let mut page_token_seen = false;
@@ -1676,6 +1736,67 @@ fn encode_rest_page_token(cursor: &str, context: &str) -> S3Result<String> {
         ));
     }
     Ok(encoded)
+}
+
+fn namespace_from_rest_value(
+    value: &str,
+) -> Result<crate::table_catalog::Namespace, crate::table_catalog::CatalogIdentifierError> {
+    let segments = value.split(REST_NAMESPACE_SEPARATOR).map(str::to_string).collect::<Vec<_>>();
+    crate::table_catalog::Namespace::from_segments(segments)
+}
+
+fn namespace_from_path_value(value: &str) -> S3Result<crate::table_catalog::Namespace> {
+    if value.contains('.') && !value.contains(REST_NAMESPACE_SEPARATOR) && !value.contains("%1F") && !value.contains("%1f") {
+        let decoded = percent_decode_str(value)
+            .decode_utf8()
+            .map_err(|_| s3_error!(InvalidRequest, "namespace path must be valid UTF-8"))?;
+        return crate::table_catalog::Namespace::parse(decoded.as_ref())
+            .map_err(|err| s3_error!(InvalidRequest, "invalid namespace: {}", err));
+    }
+    let normalized = value
+        .replace(REST_NAMESPACE_SEPARATOR_URL_ENCODED, REST_NAMESPACE_SEPARATOR_UTF8)
+        .replace("%1f", REST_NAMESPACE_SEPARATOR_UTF8);
+    let segments = normalized
+        .split(REST_NAMESPACE_SEPARATOR)
+        .map(|segment| {
+            percent_decode_str(segment)
+                .decode_utf8()
+                .map(std::borrow::Cow::into_owned)
+                .map_err(|_| s3_error!(InvalidRequest, "namespace path must be valid UTF-8"))
+        })
+        .collect::<S3Result<Vec<_>>>()?;
+    crate::table_catalog::Namespace::from_segments(segments)
+        .map_err(|err| s3_error!(InvalidRequest, "invalid namespace: {}", err))
+}
+
+fn rest_namespace_parent_from_query(uri: &http::Uri) -> S3Result<Option<crate::table_catalog::Namespace>> {
+    let mut parent = None;
+    let mut parent_seen = false;
+    if let Some(query) = uri.query() {
+        for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+            if key != "parent" {
+                continue;
+            }
+            if parent_seen {
+                return Err(iceberg_rest_error(
+                    ICEBERG_ERROR_BAD_REQUEST,
+                    StatusCode::BAD_REQUEST,
+                    "parent query parameter must not be repeated",
+                ));
+            }
+            parent_seen = true;
+            if !value.is_empty() {
+                parent = Some(namespace_from_rest_value(&value).map_err(|err| {
+                    iceberg_rest_error(
+                        ICEBERG_ERROR_BAD_REQUEST,
+                        StatusCode::BAD_REQUEST,
+                        format!("invalid parent namespace: {err}"),
+                    )
+                })?);
+            }
+        }
+    }
+    Ok(parent)
 }
 
 fn namespace_from_params(params: &Params<'_, '_>) -> S3Result<crate::table_catalog::Namespace> {
@@ -1869,24 +1990,6 @@ fn namespace_response_from_entry(entry: crate::table_catalog::NamespaceEntry) ->
     Ok(RestNamespaceResponse {
         namespace: namespace_segments(&namespace),
         properties: entry.properties,
-    })
-}
-
-fn list_namespaces_response_from_entries(
-    entries: Vec<crate::table_catalog::NamespaceEntry>,
-    next_page_token: Option<String>,
-) -> S3Result<RestListNamespacesResponse> {
-    let namespaces = entries
-        .into_iter()
-        .map(|entry| {
-            let namespace = crate::table_catalog::Namespace::parse(&entry.namespace)
-                .map_err(|err| s3_error!(InternalError, "persisted namespace entry is invalid: {}", err))?;
-            Ok(namespace_segments(&namespace))
-        })
-        .collect::<S3Result<Vec<_>>>()?;
-    Ok(RestListNamespacesResponse {
-        namespaces,
-        next_page_token,
     })
 }
 
@@ -2236,11 +2339,17 @@ fn table_commit_request_from_rest_request(
     let new_metadata_location = request
         .new_metadata_location
         .ok_or_else(|| s3_error!(InvalidRequest, "legacy commit requires new-metadata-location"))?;
+    let commit_id = request.commit_id.unwrap_or_else(|| {
+        request.idempotency_key.as_deref().map_or_else(
+            || Uuid::new_v4().to_string(),
+            |idempotency_key| format!("idempotency-{}", table_catalog_path_hash(idempotency_key)),
+        )
+    });
     Ok(crate::table_catalog::TableCommitRequest {
         table_bucket: bucket.to_string(),
         namespace: namespace.public_name(),
         table: table.to_string(),
-        commit_id: request.commit_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+        commit_id,
         idempotency_key: request.idempotency_key,
         operation: request.operation.unwrap_or_else(|| "commit".to_string()),
         expected_version_token: request
@@ -2701,7 +2810,9 @@ fn max_partition_field_id(value: &serde_json::Value) -> i64 {
     max_id
 }
 
-fn standard_commit_ids(commit_id: Option<String>) -> (String, String) {
+fn standard_commit_ids(commit_id: Option<String>, idempotency_key: Option<&str>) -> (String, String) {
+    let commit_id = commit_id
+        .or_else(|| idempotency_key.map(|idempotency_key| format!("idempotency-{}", table_catalog_path_hash(idempotency_key))));
     match commit_id {
         Some(commit_id) => match Uuid::parse_str(&commit_id) {
             Ok(uuid) => {
@@ -3647,11 +3758,18 @@ impl SnapshotFileChanges {
 }
 
 struct SnapshotChangeContext<'a> {
-    entry: &'a crate::table_catalog::TableEntry,
     snapshot: &'a serde_json::Value,
     current_live_files: &'a SnapshotLiveFiles,
     snapshot_id: i64,
     sequence_number: i64,
+}
+
+struct SnapshotReadContext<'a, B> {
+    metadata_backend: &'a B,
+    bucket: &'a str,
+    namespace: &'a crate::table_catalog::Namespace,
+    table: &'a crate::table_catalog::IdentifierSegment,
+    entry: &'a crate::table_catalog::TableEntry,
 }
 
 #[derive(PartialEq, Eq)]
@@ -3667,11 +3785,8 @@ struct SnapshotFileIdentity {
 }
 
 async fn validate_table_snapshot_commit_conflicts<B>(
-    metadata_backend: &B,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &crate::table_catalog::IdentifierSegment,
-    entry: &crate::table_catalog::TableEntry,
+    mut req: Option<&mut S3Request<Body>>,
+    context: &SnapshotReadContext<'_, B>,
     current_metadata: &serde_json::Value,
     updates: &[serde_json::Value],
 ) -> S3Result<()>
@@ -3697,15 +3812,11 @@ where
 
     let mut read_budget = SnapshotReadBudget::default();
     let current_live_files =
-        load_current_snapshot_live_files(metadata_backend, bucket, namespace, table, entry, current_metadata, &mut read_budget)
-            .await?;
+        load_current_snapshot_live_files(req.as_deref_mut(), context, current_metadata, &mut read_budget).await?;
     let changes = load_snapshot_file_changes(
-        metadata_backend,
-        bucket,
-        namespace,
-        table,
+        req,
+        context,
         SnapshotChangeContext {
-            entry,
             snapshot,
             current_live_files: &current_live_files,
             snapshot_id,
@@ -3779,11 +3890,8 @@ fn added_snapshot_update(updates: &[serde_json::Value]) -> S3Result<Option<&serd
 }
 
 async fn load_current_snapshot_live_files<B>(
-    metadata_backend: &B,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &crate::table_catalog::IdentifierSegment,
-    entry: &crate::table_catalog::TableEntry,
+    req: Option<&mut S3Request<Body>>,
+    context: &SnapshotReadContext<'_, B>,
     current_metadata: &serde_json::Value,
     read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<SnapshotLiveFiles>
@@ -3807,9 +3915,7 @@ where
         .ok_or_else(|| s3_error!(InvalidRequest, "current snapshot metadata is missing"))?;
 
     let mut live_files = SnapshotLiveFiles::default();
-    for manifest in
-        read_snapshot_manifest_references(metadata_backend, bucket, namespace, table, entry, snapshot, read_budget).await?
-    {
+    for manifest in read_snapshot_manifest_references(req, context, snapshot, read_budget).await? {
         let SnapshotManifestLocation {
             manifest_path,
             sequence_number,
@@ -3851,29 +3957,17 @@ where
 }
 
 async fn load_snapshot_file_changes<B>(
-    metadata_backend: &B,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &crate::table_catalog::IdentifierSegment,
-    context: SnapshotChangeContext<'_>,
+    req: Option<&mut S3Request<Body>>,
+    read_context: &SnapshotReadContext<'_, B>,
+    change_context: SnapshotChangeContext<'_>,
     read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<SnapshotFileChanges>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
     let mut changes = SnapshotFileChanges::default();
-    for manifest in read_snapshot_manifest_references(
-        metadata_backend,
-        bucket,
-        namespace,
-        table,
-        context.entry,
-        context.snapshot,
-        read_budget,
-    )
-    .await?
-    {
-        let inherited_identity = context
+    for manifest in read_snapshot_manifest_references(req, read_context, change_context.snapshot, read_budget).await? {
+        let inherited_identity = change_context
             .current_live_files
             .manifest_files
             .get(&manifest.location.manifest_path);
@@ -3896,14 +3990,14 @@ where
         if manifest
             .location
             .added_snapshot_id
-            .is_some_and(|added_snapshot_id| added_snapshot_id != context.snapshot_id)
+            .is_some_and(|added_snapshot_id| added_snapshot_id != change_context.snapshot_id)
         {
             return Err(s3_error!(InvalidRequest, "new manifest must belong to the committed snapshot"));
         }
         if manifest
             .location
             .sequence_number
-            .is_some_and(|sequence_number| sequence_number != context.sequence_number)
+            .is_some_and(|sequence_number| sequence_number != change_context.sequence_number)
         {
             return Err(s3_error!(InvalidRequest, "new manifest sequence must match the committed snapshot"));
         }
@@ -3912,7 +4006,7 @@ where
             let status = reference
                 .entry_status
                 .ok_or_else(|| s3_error!(InvalidRequest, "manifest entry status is required"))?;
-            if matches!(status, 1 | 2) && reference.snapshot_id != Some(context.snapshot_id) {
+            if matches!(status, 1 | 2) && reference.snapshot_id != Some(change_context.snapshot_id) {
                 return Err(s3_error!(
                     InvalidRequest,
                     "manifest changed entries must belong to the committed snapshot"
@@ -3926,7 +4020,7 @@ where
                 return Err(s3_error!(InvalidRequest, "added manifest entry sequence must match its manifest"));
             }
             if status == 2
-                && context
+                && change_context
                     .current_live_files
                     .identity(&reference.location, &reference.object_kind)
                     .is_some_and(|current_identity| {
@@ -3970,31 +4064,29 @@ struct SnapshotManifestReferences {
 }
 
 async fn read_snapshot_manifest_references<B>(
-    metadata_backend: &B,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &crate::table_catalog::IdentifierSegment,
-    entry: &crate::table_catalog::TableEntry,
+    mut req: Option<&mut S3Request<Body>>,
+    context: &SnapshotReadContext<'_, B>,
     snapshot: &serde_json::Value,
     read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<Vec<SnapshotManifestReferences>>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
-    let manifest_locations =
-        snapshot_manifest_locations(metadata_backend, bucket, namespace, table, entry, snapshot, read_budget).await?;
+    let manifest_locations = snapshot_manifest_locations(req.as_deref_mut(), context, snapshot, read_budget).await?;
     let mut manifests = Vec::new();
     for manifest_location in manifest_locations {
         let manifest_key = table_commit_object_key(
-            bucket,
-            namespace,
-            table,
-            entry,
+            context.bucket,
+            context.namespace,
+            context.table,
+            context.entry,
             &manifest_location.manifest_path,
             crate::table_catalog::TableMetadataMaintenanceObjectKind::ManifestFile,
         )?;
-        let manifest_object = metadata_backend
-            .read_object_limited(bucket, &manifest_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
+        authorize_optional_table_catalog_object_read(req.as_deref_mut(), context.bucket, &manifest_key).await?;
+        let manifest_object = context
+            .metadata_backend
+            .read_object_limited(context.bucket, &manifest_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
             .await
             .map_err(catalog_store_error)?
             .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest object is missing"))?;
@@ -4013,7 +4105,7 @@ where
             if reference.file_sequence_number.is_none() {
                 reference.file_sequence_number = manifest_location.sequence_number;
             }
-            validate_manifest_data_file_reference(metadata_backend, bucket, namespace, table, entry, &reference).await?;
+            validate_manifest_data_file_reference(req.as_deref_mut(), context, &reference).await?;
             references.push(reference);
         }
         manifests.push(SnapshotManifestReferences {
@@ -4032,11 +4124,8 @@ struct SnapshotManifestLocation {
 }
 
 async fn snapshot_manifest_locations<B>(
-    metadata_backend: &B,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &crate::table_catalog::IdentifierSegment,
-    entry: &crate::table_catalog::TableEntry,
+    req: Option<&mut S3Request<Body>>,
+    context: &SnapshotReadContext<'_, B>,
     snapshot: &serde_json::Value,
     read_budget: &mut SnapshotReadBudget,
 ) -> S3Result<Vec<SnapshotManifestLocation>>
@@ -4045,15 +4134,17 @@ where
 {
     if let Some(manifest_list_location) = snapshot.get("manifest-list").and_then(serde_json::Value::as_str) {
         let manifest_list_key = table_commit_object_key(
-            bucket,
-            namespace,
-            table,
-            entry,
+            context.bucket,
+            context.namespace,
+            context.table,
+            context.entry,
             manifest_list_location,
             crate::table_catalog::TableMetadataMaintenanceObjectKind::ManifestList,
         )?;
-        let manifest_list_object = metadata_backend
-            .read_object_limited(bucket, &manifest_list_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
+        authorize_optional_table_catalog_object_read(req, context.bucket, &manifest_list_key).await?;
+        let manifest_list_object = context
+            .metadata_backend
+            .read_object_limited(context.bucket, &manifest_list_key, crate::table_catalog::TABLE_MANIFEST_AVRO_MAX_SIZE)
             .await
             .map_err(catalog_store_error)?
             .ok_or_else(|| s3_error!(InvalidRequest, "snapshot manifest-list object is missing"))?;
@@ -4098,20 +4189,25 @@ where
 }
 
 async fn validate_manifest_data_file_reference<B>(
-    metadata_backend: &B,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &crate::table_catalog::IdentifierSegment,
-    entry: &crate::table_catalog::TableEntry,
+    req: Option<&mut S3Request<Body>>,
+    context: &SnapshotReadContext<'_, B>,
     reference: &crate::table_catalog::ManifestDataFileReference,
 ) -> S3Result<()>
 where
     B: crate::table_catalog::TableCatalogObjectBackend,
 {
-    let object_key =
-        table_commit_object_key(bucket, namespace, table, entry, &reference.location, reference.object_kind.clone())?;
-    if !metadata_backend
-        .object_exists(bucket, &object_key)
+    let object_key = table_commit_object_key(
+        context.bucket,
+        context.namespace,
+        context.table,
+        context.entry,
+        &reference.location,
+        reference.object_kind.clone(),
+    )?;
+    authorize_optional_table_catalog_object_read(req, context.bucket, &object_key).await?;
+    if !context
+        .metadata_backend
+        .object_exists(context.bucket, &object_key)
         .await
         .map_err(catalog_store_error)?
     {
@@ -4144,6 +4240,13 @@ fn apply_set_snapshot_ref_update(metadata: &mut serde_json::Value, update: &serd
         .get("snapshot-id")
         .and_then(serde_json::Value::as_i64)
         .ok_or_else(|| s3_error!(InvalidRequest, "set-snapshot-ref requires snapshot-id"))?;
+    let ref_type = update
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| s3_error!(InvalidRequest, "set-snapshot-ref requires type"))?;
+    if !matches!(ref_type, "branch" | "tag") {
+        return Err(s3_error!(InvalidRequest, "set-snapshot-ref type must be branch or tag"));
+    }
     let reference = update
         .as_object()
         .ok_or_else(|| s3_error!(InvalidRequest, "set-snapshot-ref must be a JSON object"))?
@@ -4396,28 +4499,84 @@ where
     namespace_response_from_entry(entry)
 }
 
-async fn list_namespaces_response<S>(store: &S, bucket: &str, uri: &http::Uri) -> S3Result<RestListNamespacesResponse>
+async fn list_namespaces_response<S>(
+    store: &S,
+    bucket: &str,
+    parent: Option<&crate::table_catalog::Namespace>,
+    uri: &http::Uri,
+) -> S3Result<RestListNamespacesResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    let entries = match parent {
+        Some(parent) => store
+            .list_namespaces_under(bucket, &parent.public_name())
+            .await
+            .map_err(catalog_store_error)?,
+        None => store.list_namespaces(bucket).await.map_err(catalog_store_error)?,
+    };
+    let parent_depth = parent.map_or(0, |parent| parent.segments().len());
+    let mut parent_exists = parent.is_none();
+    let mut direct_children = BTreeMap::new();
+    for entry in entries {
+        if entry.state != crate::table_catalog::TableCatalogEntryState::Active {
+            continue;
+        }
+        let namespace = crate::table_catalog::Namespace::parse(&entry.namespace).map_err(|err| {
+            iceberg_rest_error(
+                ICEBERG_ERROR_REST,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("catalog namespace is invalid: {err}"),
+            )
+        })?;
+        if let Some(parent) = parent {
+            if !namespace.segments().starts_with(parent.segments()) {
+                continue;
+            }
+            parent_exists = true;
+        }
+        if namespace.segments().len() <= parent_depth {
+            continue;
+        }
+        let child_segments = namespace.segments()[..=parent_depth]
+            .iter()
+            .map(|segment| segment.as_str().to_string())
+            .collect::<Vec<_>>();
+        direct_children.entry(child_segments.join(".")).or_insert(child_segments);
+    }
+    if !parent_exists {
+        let parent_name = parent.map(crate::table_catalog::Namespace::public_name).unwrap_or_default();
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_NO_SUCH_NAMESPACE,
+            StatusCode::NOT_FOUND,
+            format!("namespace not found: {bucket}/{parent_name}"),
+        ));
+    }
+
+    let parent_name = parent.map(crate::table_catalog::Namespace::public_name);
     let context = RestPageContext {
         resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
         warehouse: bucket,
-        namespace: None,
+        namespace: parent_name.as_deref(),
     };
     let pagination = rest_pagination_from_query(uri, context)?;
     let page = match pagination.page_request() {
-        Some((cursor, limit)) => store
-            .list_namespaces_page(bucket, cursor, limit)
-            .await
-            .map_err(catalog_store_error)?,
+        Some((cursor, limit)) => crate::table_catalog::catalog_list_page_from_entries(
+            direct_children.into_iter().collect(),
+            cursor,
+            limit,
+            |entry: &(String, Vec<String>)| entry.0.as_str(),
+        ),
         None => crate::table_catalog::TableCatalogListPage {
-            entries: store.list_namespaces(bucket).await.map_err(catalog_store_error)?,
+            entries: direct_children.into_iter().collect(),
             next_cursor: None,
         },
     };
     let next_page_token = pagination.next_page_token(page.next_cursor)?;
-    list_namespaces_response_from_entries(page.entries, next_page_token)
+    Ok(RestListNamespacesResponse {
+        namespaces: page.entries.into_iter().map(|(_, segments)| segments).collect(),
+        next_page_token,
+    })
 }
 
 async fn get_namespace_response<S>(
@@ -4657,6 +4816,18 @@ where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
     let namespace = namespace.public_name();
+    let namespace_is_active = store
+        .get_namespace(bucket, &namespace)
+        .await
+        .map_err(catalog_store_error)?
+        .is_some_and(|entry| entry.state == crate::table_catalog::TableCatalogEntryState::Active);
+    if !namespace_is_active {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_NO_SUCH_NAMESPACE,
+            StatusCode::NOT_FOUND,
+            format!("namespace not found: {bucket}/{namespace}"),
+        ));
+    }
     let context = RestPageContext {
         resource: TABLE_CATALOG_TABLE_RESOURCE_ROOT,
         warehouse: bucket,
@@ -4668,10 +4839,14 @@ where
             .list_tables_page(bucket, &namespace, cursor, limit)
             .await
             .map_err(catalog_store_error)?,
-        None => crate::table_catalog::TableCatalogListPage {
-            entries: store.list_tables(bucket, &namespace).await.map_err(catalog_store_error)?,
-            next_cursor: None,
-        },
+        None => {
+            let mut entries = store.list_tables(bucket, &namespace).await.map_err(catalog_store_error)?;
+            entries.retain(|entry| entry.state == crate::table_catalog::TableCatalogEntryState::Active);
+            crate::table_catalog::TableCatalogListPage {
+                entries,
+                next_cursor: None,
+            }
+        }
     };
     let next_page_token = pagination.next_page_token(page.next_cursor)?;
     list_tables_response_from_entries(page.entries, next_page_token)
@@ -4715,6 +4890,18 @@ where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
     let namespace = namespace.public_name();
+    let namespace_is_active = store
+        .get_namespace(bucket, &namespace)
+        .await
+        .map_err(catalog_store_error)?
+        .is_some_and(|entry| entry.state == crate::table_catalog::TableCatalogEntryState::Active);
+    if !namespace_is_active {
+        return Err(iceberg_rest_error(
+            ICEBERG_ERROR_NO_SUCH_NAMESPACE,
+            StatusCode::NOT_FOUND,
+            format!("namespace not found: {bucket}/{namespace}"),
+        ));
+    }
     let context = RestPageContext {
         resource: TABLE_CATALOG_VIEW_RESOURCE_ROOT,
         warehouse: bucket,
@@ -4726,10 +4913,14 @@ where
             .list_views_page(bucket, &namespace, cursor, limit)
             .await
             .map_err(catalog_store_error)?,
-        None => crate::table_catalog::TableCatalogListPage {
-            entries: store.list_views(bucket, &namespace).await.map_err(catalog_store_error)?,
-            next_cursor: None,
-        },
+        None => {
+            let mut entries = store.list_views(bucket, &namespace).await.map_err(catalog_store_error)?;
+            entries.retain(|entry| entry.state == crate::table_catalog::TableCatalogEntryState::Active);
+            crate::table_catalog::TableCatalogListPage {
+                entries,
+                next_cursor: None,
+            }
+        }
     };
     let next_page_token = pagination.next_page_token(page.next_cursor)?;
     list_views_response_from_entries(page.entries, next_page_token)
@@ -4829,7 +5020,7 @@ where
         )?;
         validate_metadata_view_location_in_bucket(bucket, &next_metadata)?;
         validate_metadata_matches_current_view_metadata(&current_metadata, &next_metadata)?;
-        let metadata_file_token = Uuid::new_v4().to_string();
+        let (_, metadata_file_token) = standard_commit_ids(request.commit_id.clone(), None);
         let next_generation = current.generation.saturating_add(1);
         let next_metadata_location = crate::table_catalog::default_view_metadata_file_path(
             namespace,
@@ -4999,6 +5190,13 @@ where
     Ok(table_metadata_location_response_from_entry(result.table))
 }
 
+#[derive(Clone, Copy)]
+struct RestTableRoute<'a> {
+    bucket: &'a str,
+    namespace: &'a crate::table_catalog::Namespace,
+    table: &'a str,
+}
+
 #[cfg(test)]
 async fn commit_table_response<S>(
     store: &S,
@@ -5020,7 +5218,19 @@ where
     } else {
         None
     };
-    commit_table_response_with_target_metadata(store, metadata_backend, bucket, namespace, table, request, target_metadata).await
+    commit_table_response_with_target_metadata(
+        None,
+        store,
+        metadata_backend,
+        RestTableRoute {
+            bucket,
+            namespace,
+            table,
+        },
+        request,
+        target_metadata,
+    )
+    .await
 }
 
 async fn table_commit_for_retry<S>(
@@ -5032,7 +5242,13 @@ async fn table_commit_for_retry<S>(
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
-    let by_commit_id = match request.commit_id.as_deref() {
+    let derived_commit_id = request.commit_id.clone().or_else(|| {
+        request
+            .idempotency_key
+            .as_deref()
+            .map(|idempotency_key| format!("idempotency-{}", table_catalog_path_hash(idempotency_key)))
+    });
+    let by_commit_id = match derived_commit_id.as_deref() {
         Some(commit_id) => store
             .get_commit_by_id(bucket, table_id, commit_id)
             .await
@@ -5059,6 +5275,7 @@ where
 }
 
 async fn table_commit_warehouse_read_location<S>(
+    req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
     bucket: &str,
@@ -5071,12 +5288,14 @@ where
     let Some(commit) = table_commit_for_retry(store, bucket, &current.table_id, request).await? else {
         return Ok(current.warehouse_location.clone());
     };
+    authorize_optional_table_catalog_object_read(req, bucket, &commit.previous_metadata_location).await?;
     let previous_metadata = read_table_metadata_json(metadata_backend, bucket, &commit.previous_metadata_location).await?;
     validate_metadata_table_location_in_bucket(bucket, &previous_metadata)?;
     Ok(metadata_table_location(&previous_metadata)?.to_string())
 }
 
 async fn commit_table_replay_response(
+    req: Option<&mut S3Request<Body>>,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
     bucket: &str,
     result: crate::table_catalog::TableCommitResult,
@@ -5092,26 +5311,31 @@ async fn commit_table_replay_response(
             "persisted table metadata location is outside the protected table metadata directory",
         ));
     } else {
+        authorize_optional_table_catalog_object_read(req, bucket, &result.table.metadata_location).await?;
         read_table_metadata_json(metadata_backend, bucket, &result.table.metadata_location).await?
     };
     Ok(commit_table_response_from_result(result, metadata))
 }
 
 async fn commit_table_response_with_target_metadata<S>(
+    mut req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &str,
+    route: RestTableRoute<'_>,
     request: RestCommitTableRequest,
     target_metadata: Option<serde_json::Value>,
 ) -> S3Result<RestCommitTableResponse>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    let RestTableRoute {
+        bucket,
+        namespace,
+        table,
+    } = route;
     validate_rest_commit_identifier(request.identifier.as_ref(), namespace, table)?;
     if request.new_metadata_location.is_none() {
-        return standard_commit_table_response(store, metadata_backend, bucket, namespace, table, request).await;
+        return standard_commit_table_response_inner(req, store, metadata_backend, route, request).await;
     }
 
     let Some(current) = store
@@ -5145,6 +5369,8 @@ where
                 "commit retry does not match the original request",
             ));
         }
+        authorize_optional_table_catalog_object_read(req.as_deref_mut(), bucket, &existing_commit.previous_metadata_location)
+            .await?;
         let previous_metadata =
             read_table_metadata_json(metadata_backend, bucket, &existing_commit.previous_metadata_location).await?;
         validate_metadata_table_location_in_bucket(bucket, &previous_metadata)?;
@@ -5152,10 +5378,18 @@ where
         validate_metadata_matches_current_metadata(&previous_metadata, &target_metadata)?;
         let committed_metadata_location = request.new_metadata_location.clone();
         let result = store.commit_table(request).await.map_err(catalog_store_error)?;
-        return commit_table_replay_response(metadata_backend, bucket, result, &committed_metadata_location, target_metadata)
-            .await;
+        return commit_table_replay_response(
+            req,
+            metadata_backend,
+            bucket,
+            result,
+            &committed_metadata_location,
+            target_metadata,
+        )
+        .await;
     }
 
+    authorize_optional_table_catalog_object_read(req, bucket, &current.metadata_location).await?;
     let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
     validate_metadata_table_location_in_bucket(bucket, &current_metadata)?;
     validate_table_commit_requirements(&current_metadata, &client_requirements)?;
@@ -5175,6 +5409,35 @@ async fn standard_commit_table_response<S>(
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    standard_commit_table_response_inner(
+        None,
+        store,
+        metadata_backend,
+        RestTableRoute {
+            bucket,
+            namespace,
+            table,
+        },
+        request,
+    )
+    .await
+}
+
+async fn standard_commit_table_response_inner<S>(
+    mut req: Option<&mut S3Request<Body>>,
+    store: &S,
+    metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
+    route: RestTableRoute<'_>,
+    request: RestCommitTableRequest,
+) -> S3Result<RestCommitTableResponse>
+where
+    S: crate::table_catalog::TableCatalogStore + ?Sized,
+{
+    let RestTableRoute {
+        bucket,
+        namespace,
+        table,
+    } = route;
     let Some(current) = store
         .load_table(bucket, &namespace.public_name(), table)
         .await
@@ -5183,12 +5446,13 @@ where
         return Err(iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"));
     };
     if let Some(response) =
-        replay_standard_table_commit(store, metadata_backend, bucket, namespace, table, &current, &request).await?
+        replay_standard_table_commit(req.as_deref_mut(), store, metadata_backend, route, &current, &request).await?
     {
         return Ok(response);
     }
     let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
         .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
+    authorize_optional_table_catalog_object_read(req.as_deref_mut(), bucket, &current.metadata_location).await?;
     let current_metadata = read_table_metadata_json(metadata_backend, bucket, &current.metadata_location).await?;
     validate_table_commit_requirements(&current_metadata, &request.requirements)?;
     let expected_metadata = current_metadata.clone();
@@ -5200,17 +5464,15 @@ where
     validate_metadata_matches_current_metadata(&expected_metadata, &next_metadata)?;
     crate::table_catalog::validate_table_warehouse_relocation(&current, metadata_table_location(&next_metadata)?)
         .map_err(catalog_store_error)?;
-    validate_table_snapshot_commit_conflicts(
+    let snapshot_context = SnapshotReadContext {
         metadata_backend,
         bucket,
         namespace,
-        &table_name,
-        &current,
-        &expected_metadata,
-        &request.updates,
-    )
-    .await?;
-    let (commit_id, metadata_file_token) = standard_commit_ids(request.commit_id);
+        table: &table_name,
+        entry: &current,
+    };
+    validate_table_snapshot_commit_conflicts(req.as_deref_mut(), &snapshot_context, &expected_metadata, &request.updates).await?;
+    let (commit_id, metadata_file_token) = standard_commit_ids(request.commit_id, request.idempotency_key.as_deref());
     let next_generation = current.generation.saturating_add(1);
     let next_metadata_location = crate::table_catalog::table_metadata_file_path_for_entry(
         &current,
@@ -5230,6 +5492,7 @@ where
     match put_result {
         Ok(()) => {}
         Err(crate::table_catalog::TableCatalogStoreError::Conflict(_)) => {
+            authorize_optional_table_catalog_object_read(req, bucket, &next_metadata_location).await?;
             let existing_metadata = read_table_metadata_json(metadata_backend, bucket, &next_metadata_location).await?;
             let persisted_timestamp = existing_metadata
                 .get("last-updated-ms")
@@ -5273,17 +5536,21 @@ where
 }
 
 async fn replay_standard_table_commit<S>(
+    mut req: Option<&mut S3Request<Body>>,
     store: &S,
     metadata_backend: &impl crate::table_catalog::TableCatalogObjectBackend,
-    bucket: &str,
-    namespace: &crate::table_catalog::Namespace,
-    table: &str,
+    route: RestTableRoute<'_>,
     current: &crate::table_catalog::TableEntry,
     request: &RestCommitTableRequest,
 ) -> S3Result<Option<RestCommitTableResponse>>
 where
     S: crate::table_catalog::TableCatalogStore + ?Sized,
 {
+    let RestTableRoute {
+        bucket,
+        namespace,
+        table,
+    } = route;
     let Some(commit) = table_commit_for_retry(store, bucket, &current.table_id, request).await? else {
         return Ok(None);
     };
@@ -5300,8 +5567,10 @@ where
             "commit retry does not match the original request",
         ));
     }
+    authorize_optional_table_catalog_object_read(req.as_deref_mut(), bucket, &commit.previous_metadata_location).await?;
     let previous_metadata = read_table_metadata_json(metadata_backend, bucket, &commit.previous_metadata_location).await?;
     validate_table_commit_requirements(&previous_metadata, &request.requirements)?;
+    authorize_optional_table_catalog_object_read(req.as_deref_mut(), bucket, &commit.new_metadata_location).await?;
     let target_metadata = read_table_metadata_json(metadata_backend, bucket, &commit.new_metadata_location).await?;
     let commit_timestamp_ms = target_metadata
         .get("last-updated-ms")
@@ -5348,7 +5617,8 @@ where
         .await
         .map_err(catalog_store_error)?;
     Ok(Some(
-        commit_table_replay_response(metadata_backend, bucket, result, &committed_metadata_location, target_metadata).await?,
+        commit_table_replay_response(req, metadata_backend, bucket, result, &committed_metadata_location, target_metadata)
+            .await?,
     ))
 }
 
@@ -5521,7 +5791,7 @@ where
     validate_metadata_table_location_in_bucket(bucket, &next_metadata)?;
     let table_name = crate::table_catalog::IdentifierSegment::parse(table.to_string())
         .map_err(|err| s3_error!(InvalidRequest, "invalid table name: {}", err))?;
-    let (commit_id, metadata_file_token) = standard_commit_ids(None);
+    let (commit_id, metadata_file_token) = standard_commit_ids(None, None);
     let next_generation = current.generation.saturating_add(1);
     let next_metadata_location = crate::table_catalog::default_table_metadata_file_path(
         namespace,
@@ -6352,17 +6622,8 @@ impl Operation for RestListNamespacesHandler {
         };
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableNamespaceAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let parent_name = parent.as_ref().map(crate::table_catalog::Namespace::public_name);
-        let pagination = rest_pagination_from_query(
-            &req.uri,
-            RestPageContext {
-                resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
-                warehouse: &warehouse,
-                namespace: parent_name.as_deref(),
-            },
-        )?;
         let store = table_catalog_store()?;
-        let response = list_namespaces_response(&store, &warehouse, &req.uri).await?;
+        let response = list_namespaces_response(&store, &warehouse, parent.as_ref(), &req.uri).await?;
         build_json_response(StatusCode::OK, &response)
     }
 }
@@ -6464,15 +6725,6 @@ impl Operation for RestListTablesHandler {
         let resource = TableCatalogResource::namespace(&warehouse, &namespace);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let namespace_name = namespace.public_name();
-        let pagination = rest_pagination_from_query(
-            &req.uri,
-            RestPageContext {
-                resource: TABLE_CATALOG_TABLE_RESOURCE_ROOT,
-                warehouse: &warehouse,
-                namespace: Some(&namespace_name),
-            },
-        )?;
         let store = table_catalog_store()?;
         let response = list_tables_response(&store, &warehouse, &namespace, &req.uri).await?;
         build_json_response(StatusCode::OK, &response)
@@ -6575,15 +6827,6 @@ impl Operation for RestListViewsHandler {
         let resource = TableCatalogResource::namespace(&warehouse, &namespace);
         authorize_table_catalog_resource_request(&req, &resource, AdminAction::GetTableMetadataAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
-        let namespace_name = namespace.public_name();
-        let pagination = rest_pagination_from_query(
-            &req.uri,
-            RestPageContext {
-                resource: TABLE_CATALOG_VIEW_RESOURCE_ROOT,
-                warehouse: &warehouse,
-                namespace: Some(&namespace_name),
-            },
-        )?;
         let store = table_catalog_store()?;
         let response = list_views_response(&store, &warehouse, &namespace, &req.uri).await?;
         build_json_response(StatusCode::OK, &response)
@@ -6683,7 +6926,8 @@ impl Operation for RestCommitTableHandler {
             .map_err(catalog_store_error)?
             .ok_or_else(|| iceberg_rest_error(ICEBERG_ERROR_NO_SUCH_TABLE, StatusCode::NOT_FOUND, "table not found"))?;
         let warehouse_read_location =
-            table_commit_warehouse_read_location(&store, &metadata_backend, &warehouse, &current, &request).await?;
+            table_commit_warehouse_read_location(Some(&mut req), &store, &metadata_backend, &warehouse, &current, &request)
+                .await?;
         authorize_table_warehouse_s3_actions(&mut req, &warehouse, &warehouse_read_location, TABLE_WAREHOUSE_READ_ACTIONS)
             .await?;
         let target_metadata = if let Some(metadata_location) = request.new_metadata_location.as_deref() {
@@ -6723,11 +6967,14 @@ impl Operation for RestCommitTableHandler {
             None
         };
         let response = commit_table_response_with_target_metadata(
+            Some(&mut req),
             &store,
             &metadata_backend,
-            &warehouse,
-            &namespace,
-            &table,
+            RestTableRoute {
+                bucket: &warehouse,
+                namespace: &namespace,
+                table: &table,
+            },
             request,
             target_metadata,
         )
@@ -6746,8 +6993,8 @@ impl Operation for RestDropTableHandler {
         let table = table_name_from_params(&params)?;
         if rest_purge_requested_from_query(&req.uri)? {
             return Err(iceberg_rest_error(
-                ICEBERG_ERROR_BAD_REQUEST,
-                StatusCode::BAD_REQUEST,
+                ICEBERG_ERROR_UNSUPPORTED_OPERATION,
+                StatusCode::NOT_ACCEPTABLE,
                 "purgeRequested=true is not supported",
             ));
         }
@@ -7264,6 +7511,7 @@ impl Operation for SyncExternalCatalogBridgeHandler {
         let resource = TableCatalogResource::table(&warehouse, &namespace, &table);
         let principal =
             authorize_table_catalog_resource_request(&req, &resource, AdminAction::SetTableMetadataLocationAction).await?;
+        authorize_table_catalog_resource_for_principal(&req, &principal, &resource, AdminAction::RegisterTableAction).await?;
         ensure_table_bucket_enabled(&warehouse).await?;
         let metadata_backend = table_catalog_backend()?;
         let store = table_catalog_object_store()?;
@@ -7283,9 +7531,6 @@ impl Operation for SyncExternalCatalogBridgeHandler {
             .map_err(catalog_store_error)?;
         let target_metadata =
             read_authorized_table_metadata_json(&mut req, &metadata_backend, &warehouse, &request.metadata_location).await?;
-        if current.is_none() {
-            authorize_table_catalog_resource_for_principal(&req, &principal, &resource, AdminAction::RegisterTableAction).await?;
-        }
         let response = sync_external_catalog_bridge_response_with_snapshot(
             &store,
             &metadata_backend,
@@ -7548,25 +7793,37 @@ mod tests {
         };
         let first_uri = "/iceberg/v1/analytics/namespaces?pageToken=&pageSize=2".parse().expect("URI");
         let first_pagination = rest_pagination_from_query(&first_uri, context).expect("first page query should parse");
-        let (first, next_page_token) = paginate_rest_entries(
+        let (cursor, limit) = first_pagination.page_request().expect("first page should be paginated");
+        let first = crate::table_catalog::catalog_list_page_from_entries(
             vec!["a".to_string(), "b".to_string(), "c".to_string()],
-            first_pagination,
-            context,
+            cursor,
+            limit,
             String::as_str,
-        )
-        .expect("first page should paginate");
-        assert_eq!(first, vec!["a".to_string(), "b".to_string()]);
-        let next_page_token = next_page_token.expect("first page should return a token");
+        );
+        assert_eq!(first.entries, vec!["a".to_string(), "b".to_string()]);
+        let next_page_token = first_pagination
+            .next_page_token(first.next_cursor)
+            .expect("first page token should encode")
+            .expect("first page should return a token");
 
         let exact_page_uri = "/iceberg/v1/analytics/namespaces?pageToken=&pageSize=2"
             .parse()
             .expect("exact page URI");
         let exact_page_pagination = rest_pagination_from_query(&exact_page_uri, context).expect("exact page query should parse");
-        let (exact_page, exact_page_token) =
-            paginate_rest_entries(vec!["a".to_string(), "b".to_string()], exact_page_pagination, context, String::as_str)
-                .expect("exact page should paginate");
-        assert_eq!(exact_page, vec!["a".to_string(), "b".to_string()]);
-        assert!(exact_page_token.is_none());
+        let (cursor, limit) = exact_page_pagination.page_request().expect("exact page should be paginated");
+        let exact_page = crate::table_catalog::catalog_list_page_from_entries(
+            vec!["a".to_string(), "b".to_string()],
+            cursor,
+            limit,
+            String::as_str,
+        );
+        assert_eq!(exact_page.entries, vec!["a".to_string(), "b".to_string()]);
+        assert!(
+            exact_page_pagination
+                .next_page_token(exact_page.next_cursor)
+                .expect("terminal token should encode")
+                .is_none()
+        );
 
         let query = url::form_urlencoded::Serializer::new(String::new())
             .append_pair("pageToken", &next_page_token)
@@ -7576,15 +7833,20 @@ mod tests {
             .parse()
             .expect("second page URI");
         let second_pagination = rest_pagination_from_query(&second_uri, context).expect("second page query should parse");
-        let (second, final_token) = paginate_rest_entries(
+        let (cursor, limit) = second_pagination.page_request().expect("second page should be paginated");
+        let second = crate::table_catalog::catalog_list_page_from_entries(
             vec!["aa".to_string(), "c".to_string(), "d".to_string()],
-            second_pagination,
-            context,
+            cursor,
+            limit,
             String::as_str,
-        )
-        .expect("second page should paginate after a deleted cursor");
-        assert_eq!(second, vec!["c".to_string(), "d".to_string()]);
-        assert!(final_token.is_none());
+        );
+        assert_eq!(second.entries, vec!["c".to_string(), "d".to_string()]);
+        assert!(
+            second_pagination
+                .next_page_token(second.next_cursor)
+                .expect("terminal token should encode")
+                .is_none()
+        );
     }
 
     #[test]
@@ -7612,7 +7874,8 @@ mod tests {
             warehouse: "analytics",
             namespace: Some("sales"),
         };
-        let table_token = encode_rest_page_token("orders", table_context).expect("table token should encode");
+        let table_token =
+            encode_rest_page_token("orders", &rest_page_context_fingerprint(table_context)).expect("table token should encode");
         let query = url::form_urlencoded::Serializer::new(String::new())
             .append_pair("pageToken", &table_token)
             .finish();
@@ -7628,9 +7891,10 @@ mod tests {
             warehouse: "archive",
             namespace: None,
         };
-        let warehouse_token = encode_rest_page_token("sales", namespace_context).expect("namespace page token should encode");
+        let warehouse_token = encode_rest_page_token("sales", &rest_page_context_fingerprint(namespace_context))
+            .expect("namespace page token should encode");
         assert!(
-            decode_rest_page_token(&warehouse_token, other_warehouse_context).is_err(),
+            decode_rest_page_token(&warehouse_token, &rest_page_context_fingerprint(other_warehouse_context)).is_err(),
             "namespace page tokens must remain warehouse-scoped"
         );
 
@@ -7640,75 +7904,44 @@ mod tests {
             namespace: Some("sales"),
         };
         assert!(
-            decode_rest_page_token(&table_token, namespace_resource_context).is_err(),
+            decode_rest_page_token(&table_token, &rest_page_context_fingerprint(namespace_resource_context)).is_err(),
             "page tokens must remain resource-scoped even when warehouse and namespace match"
         );
 
         let oversized = "a".repeat(REST_PAGE_TOKEN_MAX_LENGTH + 1);
-        assert!(decode_rest_page_token(&oversized, namespace_context).is_err());
+        let namespace_context_fingerprint = rest_page_context_fingerprint(namespace_context);
+        assert!(decode_rest_page_token(&oversized, &namespace_context_fingerprint).is_err());
 
         for token in [
             RestPageToken {
                 version: REST_PAGE_TOKEN_VERSION + 1,
-                context: rest_page_context_fingerprint(namespace_context),
-                after: "sales".to_string(),
+                context: namespace_context_fingerprint.clone(),
+                cursor: "sales".to_string(),
             },
             RestPageToken {
                 version: REST_PAGE_TOKEN_VERSION,
-                context: rest_page_context_fingerprint(namespace_context),
-                after: String::new(),
+                context: namespace_context_fingerprint.clone(),
+                cursor: String::new(),
             },
         ] {
             let encoded =
                 base64_encode_url_safe_no_pad(&serde_json::to_vec(&token).expect("invalid test token should serialize"));
-            assert!(decode_rest_page_token(&encoded, namespace_context).is_err());
+            assert!(decode_rest_page_token(&encoded, &namespace_context_fingerprint).is_err());
         }
 
         let invalid_json = base64_encode_url_safe_no_pad(b"not-json");
-        assert!(decode_rest_page_token(&invalid_json, namespace_context).is_err());
+        assert!(decode_rest_page_token(&invalid_json, &namespace_context_fingerprint).is_err());
 
         let unknown_field = base64_encode_url_safe_no_pad(
             &serde_json::to_vec(&serde_json::json!({
                 "version": REST_PAGE_TOKEN_VERSION,
-                "context": rest_page_context_fingerprint(namespace_context),
-                "after": "sales",
+                "context": namespace_context_fingerprint,
+                "cursor": "sales",
                 "unexpected": true
             }))
             .expect("unknown-field token should serialize"),
         );
-        assert!(decode_rest_page_token(&unknown_field, namespace_context).is_err());
-    }
-
-    #[test]
-    fn rest_pagination_requires_page_token_to_start_pagination() {
-        let context = RestPageContext {
-            resource: TABLE_CATALOG_TABLE_RESOURCE_ROOT,
-            warehouse: "analytics",
-            namespace: Some("sales"),
-        };
-        let uri = "/iceberg/v1/analytics/namespaces/sales/tables?pageToken=&pageSize=999999"
-            .parse()
-            .expect("URI");
-        let pagination = rest_pagination_from_query(&uri, context).expect("empty token should start pagination");
-        assert_eq!(pagination.after, None);
-        assert_eq!(pagination.limit, Some(REST_MAX_PAGE_SIZE));
-
-        let uri = "/iceberg/v1/analytics/namespaces/sales/tables?pageSize=2"
-            .parse()
-            .expect("URI");
-        let pagination = rest_pagination_from_query(&uri, context).expect("page size without a token should parse");
-        assert_eq!(pagination.after, None);
-        assert_eq!(pagination.limit, None);
-
-        let uri = "/iceberg/v1/analytics/namespaces/sales/tables".parse().expect("URI");
-        let pagination = rest_pagination_from_query(&uri, context).expect("request without pagination should parse");
-        let entries = (0..=REST_DEFAULT_PAGE_SIZE)
-            .map(|index| format!("table-{index:04}"))
-            .collect::<Vec<_>>();
-        let (page, next_page_token) = paginate_rest_entries(entries.clone(), pagination, context, String::as_str)
-            .expect("unpaginated request should preserve legacy behavior");
-        assert_eq!(page, entries);
-        assert!(next_page_token.is_none());
+        assert!(decode_rest_page_token(&unknown_field, &rest_page_context_fingerprint(namespace_context)).is_err());
     }
 
     #[test]
@@ -7744,16 +7977,6 @@ mod tests {
         let error = rest_namespace_parent_from_query(&uri).expect_err("repeated parent should fail");
         assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
         assert_eq!(error.status_code(), Some(StatusCode::BAD_REQUEST));
-    }
-
-    #[test]
-    fn list_responses_expose_null_next_page_token_at_end() {
-        let response = RestListNamespacesResponse {
-            namespaces: vec![vec!["sales".to_string()]],
-            next_page_token: None,
-        };
-        let value = serde_json::to_value(response).expect("list response should serialize");
-        assert_eq!(value["next-page-token"], serde_json::Value::Null);
     }
 
     #[test]
@@ -7940,6 +8163,9 @@ mod tests {
         let warehouse_auth_block = function_block(src, "async fn authorize_table_warehouse_s3_actions");
         assert!(warehouse_auth_block.contains("table_catalog_prefix_authorization_probe"));
         assert!(warehouse_auth_block.contains("actions"));
+        let s3_auth_block = function_block(src, "async fn authorize_table_catalog_s3_actions");
+        assert!(s3_auth_block.contains("table_catalog_request_principal(req).await?"));
+        assert!(s3_auth_block.contains("ReqInfo"));
         assert_eq!(TABLE_WAREHOUSE_READ_ACTIONS, &[S3Action::GetObjectAction]);
         assert_eq!(TABLE_WAREHOUSE_WRITE_ACTIONS, &[S3Action::PutObjectAction, S3Action::DeleteObjectAction]);
         let metadata_auth_block = function_block(src, "async fn read_authorized_table_metadata_json");
@@ -7954,7 +8180,17 @@ mod tests {
         assert!(sync_bridge_block.contains("read_authorized_table_metadata_json"));
         assert!(
             sync_bridge_block.contains(".load_table(&warehouse, &namespace.public_name(), &table)"),
-            "external catalog sync should branch authorization on current table existence"
+            "external catalog sync should load the current table snapshot after authorization"
+        );
+        let register_auth_position = sync_bridge_block
+            .find("AdminAction::RegisterTableAction")
+            .expect("external catalog sync should authorize registration");
+        let bucket_write_position = sync_bridge_block
+            .find("ensure_table_bucket_entry")
+            .expect("external catalog sync should materialize the table bucket entry");
+        assert!(
+            register_auth_position < bucket_write_position,
+            "external catalog sync must authorize registration before it can materialize catalog state"
         );
         assert!(
             sync_bridge_block.contains("sync_external_catalog_bridge_response_with_snapshot")
@@ -7981,6 +8217,17 @@ mod tests {
             operation_block(src, "RestCommitTableHandler").contains("TABLE_WAREHOUSE_READ_ACTIONS"),
             "table commits should require read access to manifest and data objects under the warehouse prefix"
         );
+        for helper in [
+            "async fn table_commit_warehouse_read_location",
+            "async fn read_snapshot_manifest_references",
+            "async fn snapshot_manifest_locations",
+            "async fn validate_manifest_data_file_reference",
+        ] {
+            assert!(
+                function_block(src, helper).contains("authorize_optional_table_catalog_object_read"),
+                "{helper} should authorize every concrete object before reading it"
+            );
+        }
 
         let migration_block = operation_block(src, "GetTableCatalogMigrationHandler");
         assert!(
@@ -8073,7 +8320,7 @@ mod tests {
         for (handler, helper_call) in [
             (
                 "RestListNamespacesHandler",
-                "list_namespaces_response(&store, &warehouse, &req.uri).await?",
+                "list_namespaces_response(&store, &warehouse, parent.as_ref(), &req.uri).await?",
             ),
             (
                 "RestListTablesHandler",
@@ -9044,7 +9291,7 @@ mod tests {
         }
 
         let first_uri = "/?pageSize=1".parse::<http::Uri>().expect("first page URI should parse");
-        let namespaces = list_namespaces_response(&store, "warehouse", &first_uri)
+        let namespaces = list_namespaces_response(&store, "warehouse", None, &first_uri)
             .await
             .expect("namespace first page should load");
         assert_eq!(namespaces.namespaces, vec![vec!["alpha".to_string()]]);
@@ -9052,11 +9299,22 @@ mod tests {
         let namespace_uri = format!("/?pageSize=1&pageToken={namespace_token}")
             .parse::<http::Uri>()
             .expect("namespace continuation URI should parse");
-        let namespaces = list_namespaces_response(&store, "warehouse", &namespace_uri)
+        let namespaces = list_namespaces_response(&store, "warehouse", None, &namespace_uri)
             .await
             .expect("namespace second page should load");
         assert_eq!(namespaces.namespaces, vec![vec!["beta".to_string()]]);
         assert!(namespaces.next_page_token.is_none());
+
+        store.namespaces.lock().await.push(crate::table_catalog::NamespaceEntry {
+            version: crate::table_catalog::TABLE_CATALOG_ENTRY_VERSION,
+            table_bucket: "warehouse".to_string(),
+            namespace: namespace.public_name(),
+            namespace_id: "analytics".to_string(),
+            state: crate::table_catalog::TableCatalogEntryState::Active,
+            properties: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
+        });
 
         let tables = list_tables_response(&store, "warehouse", &namespace, &first_uri)
             .await
@@ -9092,17 +9350,12 @@ mod tests {
 
         for uri in ["/", "/?pageSize=2"] {
             let uri = uri.parse::<http::Uri>().expect("list URI should parse");
-            let namespaces = list_namespaces_response(&store, "warehouse", &uri)
-                .await
-                .expect("namespace exact page should load");
             let tables = list_tables_response(&store, "warehouse", &namespace, &uri)
                 .await
                 .expect("table exact page should load");
             let views = list_views_response(&store, "warehouse", &namespace, &uri)
                 .await
                 .expect("view exact page should load");
-            assert_eq!(namespaces.namespaces.len(), 2);
-            assert!(namespaces.next_page_token.is_none());
             assert_eq!(tables.identifiers.len(), 2);
             assert!(tables.next_page_token.is_none());
             assert_eq!(views.identifiers.len(), 2);
@@ -9364,7 +9617,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_requests_accept_legacy_empty_defaults_and_reject_unsupported_view_commit_ids() {
+    fn commit_requests_accept_legacy_empty_defaults_and_view_commit_ids() {
         let table = serde_json::from_value::<RestCommitTableRequest>(serde_json::json!({}))
             .expect("legacy table commit should default omitted requirements and updates");
         assert!(table.requirements.is_empty());
@@ -9373,14 +9626,13 @@ mod tests {
             .expect("legacy view commit should default omitted requirements and updates");
         assert!(view.requirements.is_empty());
         assert!(view.updates.is_empty());
-        assert!(
-            serde_json::from_value::<RestCommitViewRequest>(serde_json::json!({
-                "commit-id": "non-standard-extension",
-                "requirements": [],
-                "updates": []
-            }))
-            .is_err()
-        );
+        let view = serde_json::from_value::<RestCommitViewRequest>(serde_json::json!({
+            "commit-id": "non-standard-extension",
+            "requirements": [],
+            "updates": []
+        }))
+        .expect("legacy view commit id should remain accepted");
+        assert_eq!(view.commit_id.as_deref(), Some("non-standard-extension"));
     }
 
     #[test]
@@ -9419,18 +9671,28 @@ mod tests {
     fn standard_commit_ids_use_uuid_for_metadata_file_when_provided() {
         let commit_id = "11111111-1111-4111-8111-111111111111";
         assert_eq!(
-            standard_commit_ids(Some(commit_id.to_string())),
+            standard_commit_ids(Some(commit_id.to_string()), None),
             (commit_id.to_string(), commit_id.to_string())
         );
     }
 
     #[test]
     fn standard_commit_ids_generate_metadata_hash_for_non_uuid_client_id() {
-        let (commit_id, metadata_file_token) = standard_commit_ids(Some("commit-1".to_string()));
+        let (commit_id, metadata_file_token) = standard_commit_ids(Some("commit-1".to_string()), None);
 
         assert_eq!(commit_id, "commit-1");
         assert_ne!(metadata_file_token, commit_id);
         assert_eq!(metadata_file_token, table_catalog_path_hash("commit-1"));
+    }
+
+    #[test]
+    fn standard_commit_ids_are_stable_for_idempotency_only_retries() {
+        let first = standard_commit_ids(None, Some("client-request"));
+        let second = standard_commit_ids(None, Some("client-request"));
+
+        assert_eq!(first, second);
+        assert!(first.0.starts_with("idempotency-"));
+        assert_eq!(first.1, table_catalog_path_hash(&first.0));
     }
 
     #[tokio::test]
@@ -10072,9 +10334,10 @@ mod tests {
                 .expect("current table should exist");
             let retry: RestCommitTableRequest = serde_json::from_value(first_request).expect("first commit retry should parse");
 
-            let read_location = table_commit_warehouse_read_location(&store, &metadata_backend, "warehouse", &current, &retry)
-                .await
-                .expect("retry read scope should resolve");
+            let read_location =
+                table_commit_warehouse_read_location(None, &store, &metadata_backend, "warehouse", &current, &retry)
+                    .await
+                    .expect("retry read scope should resolve");
             assert_eq!(read_location, original_warehouse_location, "{mode:?}");
 
             let replay = standard_commit_table_response(&store, &metadata_backend, "warehouse", &namespace, "events", retry)
@@ -14393,7 +14656,7 @@ mod tests {
             &self,
             bucket: &str,
             object: &str,
-        ) -> crate::table_catalog::TableCatalogStoreResult<Box<dyn Send>> {
+        ) -> crate::table_catalog::TableCatalogStoreResult<crate::table_catalog::TableCatalogObjectLock> {
             let lock = {
                 let mut locks = self.locks.lock().await;
                 locks
@@ -14833,7 +15096,7 @@ mod tests {
         assert_eq!(create.properties.get("owner").map(String::as_str), Some("lakehouse"));
 
         let unpaginated_uri = "/".parse::<http::Uri>().expect("list URI should parse");
-        let list = list_namespaces_response(&store, "warehouse", &unpaginated_uri)
+        let list = list_namespaces_response(&store, "warehouse", None, &unpaginated_uri)
             .await
             .expect("namespace list should load");
         assert_eq!(list.namespaces, vec![vec!["analytics".to_string()]]);
@@ -14862,7 +15125,7 @@ mod tests {
         drop_namespace_in_store(&store, "warehouse", "analytics")
             .await
             .expect("namespace should drop");
-        let list = list_namespaces_response(&store, "warehouse", &unpaginated_uri)
+        let list = list_namespaces_response(&store, "warehouse", None, &unpaginated_uri)
             .await
             .expect("namespace list should load after drop");
         assert!(list.namespaces.is_empty());
@@ -14894,46 +15157,30 @@ mod tests {
             .expect("namespace should be created");
         }
 
-        let top_level = list_namespaces_response(&store, "warehouse", None, RestPagination::default())
+        let unpaginated_uri = "/".parse::<http::Uri>().expect("list URI should parse");
+        let top_level = list_namespaces_response(&store, "warehouse", None, &unpaginated_uri)
             .await
             .expect("top-level namespaces should list");
         assert_eq!(top_level.namespaces, vec![vec!["analytics".to_string()], vec!["sales".to_string()]]);
 
         let analytics = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
-        let children = list_namespaces_response(
-            &store,
-            "warehouse",
-            Some(&analytics),
-            RestPagination {
-                after: None,
-                limit: Some(1),
-            },
-        )
-        .await
-        .expect("direct children should list");
+        let first_page_uri = "/?pageSize=1".parse::<http::Uri>().expect("first page URI should parse");
+        let children = list_namespaces_response(&store, "warehouse", Some(&analytics), &first_page_uri)
+            .await
+            .expect("direct children should list");
         assert_eq!(children.namespaces, vec![vec!["analytics".to_string(), "curated".to_string()]]);
         let next_page_token = children.next_page_token.expect("first child page should return a token");
-        let parent_context = RestPageContext {
-            resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
-            warehouse: "warehouse",
-            namespace: Some("analytics"),
-        };
-        let second_page = list_namespaces_response(
-            &store,
-            "warehouse",
-            Some(&analytics),
-            RestPagination {
-                after: Some(decode_rest_page_token(&next_page_token, parent_context).expect("parent token should decode")),
-                limit: Some(1),
-            },
-        )
-        .await
-        .expect("second child page should list");
+        let second_page_uri = format!("/?pageSize=1&pageToken={next_page_token}")
+            .parse::<http::Uri>()
+            .expect("second page URI should parse");
+        let second_page = list_namespaces_response(&store, "warehouse", Some(&analytics), &second_page_uri)
+            .await
+            .expect("second child page should list");
         assert_eq!(second_page.namespaces, vec![vec!["analytics".to_string(), "raw".to_string()]]);
         assert!(second_page.next_page_token.is_none());
 
         let missing = crate::table_catalog::Namespace::parse("missing").expect("namespace should parse");
-        let error = list_namespaces_response(&store, "warehouse", Some(&missing), RestPagination::default())
+        let error = list_namespaces_response(&store, "warehouse", Some(&missing), &unpaginated_uri)
             .await
             .expect_err("missing parent should fail");
         assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
@@ -14944,13 +15191,15 @@ mod tests {
             warehouse: "warehouse",
             namespace: Some("analytics"),
         };
-        let token = encode_rest_page_token("analytics.raw", parent_context).expect("parent token should encode");
+        let token = encode_rest_page_token("analytics.raw", &rest_page_context_fingerprint(parent_context))
+            .expect("parent token should encode");
         let wrong_parent_context = RestPageContext {
             resource: TABLE_CATALOG_NAMESPACE_RESOURCE_ROOT,
             warehouse: "warehouse",
             namespace: Some("sales"),
         };
-        let error = decode_rest_page_token(&token, wrong_parent_context).expect_err("token must stay parent-scoped");
+        let error = decode_rest_page_token(&token, &rest_page_context_fingerprint(wrong_parent_context))
+            .expect_err("token must stay parent-scoped");
         assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_BAD_REQUEST.into()));
     }
 
@@ -14982,13 +15231,14 @@ mod tests {
             .expect("archived namespace should exist")
             .state = crate::table_catalog::TableCatalogEntryState::Deleted;
 
-        let top_level = list_namespaces_response(&store, "warehouse", None, RestPagination::default())
+        let unpaginated_uri = "/".parse::<http::Uri>().expect("list URI should parse");
+        let top_level = list_namespaces_response(&store, "warehouse", None, &unpaginated_uri)
             .await
             .expect("top-level namespaces should list");
         assert_eq!(top_level.namespaces, vec![vec!["analytics".to_string()]]);
 
         let analytics = crate::table_catalog::Namespace::parse("analytics").expect("namespace should parse");
-        let children = list_namespaces_response(&store, "warehouse", Some(&analytics), RestPagination::default())
+        let children = list_namespaces_response(&store, "warehouse", Some(&analytics), &unpaginated_uri)
             .await
             .expect("synthesized namespace children should list");
         assert_eq!(children.namespaces, vec![vec!["analytics".to_string(), "raw".to_string()]]);
@@ -15010,7 +15260,8 @@ mod tests {
     async fn table_list_reports_missing_namespace() {
         let store = TestTableCatalogStore::default();
         let namespace = crate::table_catalog::Namespace::parse("missing").expect("namespace should parse");
-        let error = list_tables_response(&store, "warehouse", &namespace, RestPagination::default())
+        let uri = "/".parse::<http::Uri>().expect("list URI should parse");
+        let error = list_tables_response(&store, "warehouse", &namespace, &uri)
             .await
             .expect_err("missing namespace should fail");
         assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
@@ -15021,7 +15272,8 @@ mod tests {
     async fn view_list_reports_missing_namespace_and_paginates_active_entries() {
         let store = TestTableCatalogStore::default();
         let missing = crate::table_catalog::Namespace::parse("missing").expect("namespace should parse");
-        let error = list_views_response(&store, "warehouse", &missing, RestPagination::default())
+        let unpaginated_uri = "/".parse::<http::Uri>().expect("list URI should parse");
+        let error = list_views_response(&store, "warehouse", &missing, &unpaginated_uri)
             .await
             .expect_err("missing namespace should fail");
         assert_eq!(error.code(), &S3ErrorCode::Custom(ICEBERG_ERROR_NO_SUCH_NAMESPACE.into()));
@@ -15072,17 +15324,10 @@ mod tests {
             });
         }
 
-        let first = list_views_response(
-            &store,
-            "warehouse",
-            &namespace,
-            RestPagination {
-                after: None,
-                limit: Some(2),
-            },
-        )
-        .await
-        .expect("first view page should load");
+        let first_page_uri = "/?pageSize=2".parse::<http::Uri>().expect("first page URI should parse");
+        let first = list_views_response(&store, "warehouse", &namespace, &first_page_uri)
+            .await
+            .expect("first view page should load");
         assert_eq!(
             first
                 .identifiers
@@ -15092,22 +15337,12 @@ mod tests {
             vec!["alpha", "beta"]
         );
         let token = first.next_page_token.expect("first view page should return a token");
-        let context = RestPageContext {
-            resource: TABLE_CATALOG_VIEW_RESOURCE_ROOT,
-            warehouse: "warehouse",
-            namespace: Some("analytics"),
-        };
-        let second = list_views_response(
-            &store,
-            "warehouse",
-            &namespace,
-            RestPagination {
-                after: Some(decode_rest_page_token(&token, context).expect("view token should decode")),
-                limit: Some(2),
-            },
-        )
-        .await
-        .expect("second view page should load");
+        let second_page_uri = format!("/?pageSize=2&pageToken={token}")
+            .parse::<http::Uri>()
+            .expect("second page URI should parse");
+        let second = list_views_response(&store, "warehouse", &namespace, &second_page_uri)
+            .await
+            .expect("second view page should load");
         assert_eq!(
             second
                 .identifiers
@@ -15161,7 +15396,8 @@ mod tests {
             });
         }
 
-        let response = list_tables_response(&store, "warehouse", &namespace, RestPagination::default())
+        let uri = "/".parse::<http::Uri>().expect("list URI should parse");
+        let response = list_tables_response(&store, "warehouse", &namespace, &uri)
             .await
             .expect("table list should load");
         assert_eq!(

--- a/rustfs/src/admin/route_policy.rs
+++ b/rustfs/src/admin/route_policy.rs
@@ -90,6 +90,7 @@ const SET_TABLE_BUCKET: AdminActionRef = AdminActionRef::new("SetTableBucketActi
 const SET_TABLE_LIFECYCLE: AdminActionRef = AdminActionRef::new("SetTableLifecycleAction");
 const SET_TABLE_METADATA_LOCATION: AdminActionRef = AdminActionRef::new("SetTableMetadataLocationAction");
 const SET_TABLE_NAMESPACE: AdminActionRef = AdminActionRef::new("SetTableNamespaceAction");
+const UPDATE_TABLE_NAMESPACE_PROPERTIES: AdminActionRef = AdminActionRef::new("UpdateTableNamespacePropertiesAction");
 const SET_TIER: AdminActionRef = AdminActionRef::new("SetTierAction");
 const SITE_REPLICATION_ADD: AdminActionRef = AdminActionRef::new("SiteReplicationAddAction");
 const SITE_REPLICATION_INFO: AdminActionRef = AdminActionRef::new("SiteReplicationInfoAction");
@@ -912,11 +913,18 @@ pub const ADMIN_ROUTE_POLICY_SPECS: &[AdminRouteSpec] = &[
         RouteRiskLevel::Sensitive,
     ),
     admin(
+        HttpMethod::Post,
+        "/iceberg/v1/{warehouse}/namespaces/{namespace}/properties",
+        UPDATE_TABLE_NAMESPACE_PROPERTIES,
+        RouteRiskLevel::High,
+    ),
+    admin(
         HttpMethod::Delete,
         "/iceberg/v1/{warehouse}/namespaces/{namespace}",
         DELETE_TABLE_NAMESPACE,
         RouteRiskLevel::High,
     ),
+    admin(HttpMethod::Post, "/iceberg/v1/{warehouse}/tables/rename", SET_TABLE, RouteRiskLevel::High),
     admin(
         HttpMethod::Get,
         "/iceberg/v1/{warehouse}/namespaces/{namespace}/tables",
@@ -1189,9 +1197,21 @@ pub const ADMIN_ROUTE_POLICY_SPECS: &[AdminRouteSpec] = &[
         RouteRiskLevel::Sensitive,
     ),
     admin(
+        HttpMethod::Post,
+        "/_iceberg/v1/{warehouse}/namespaces/{namespace}/properties",
+        UPDATE_TABLE_NAMESPACE_PROPERTIES,
+        RouteRiskLevel::High,
+    ),
+    admin(
         HttpMethod::Delete,
         "/_iceberg/v1/{warehouse}/namespaces/{namespace}",
         DELETE_TABLE_NAMESPACE,
+        RouteRiskLevel::High,
+    ),
+    admin(
+        HttpMethod::Post,
+        "/_iceberg/v1/{warehouse}/tables/rename",
+        SET_TABLE,
         RouteRiskLevel::High,
     ),
     admin(
@@ -1641,13 +1661,25 @@ mod tests {
         let table_specs = ADMIN_ROUTE_POLICY_SPECS
             .iter()
             .filter(|spec| spec.path().starts_with("/iceberg/v1") || spec.path().starts_with("/_iceberg/v1"));
-        assert_eq!(table_specs.count(), 94);
+        assert_eq!(table_specs.count(), 98);
         assert_action(HttpMethod::Put, "/iceberg/v1/buckets/{warehouse}", SET_TABLE_BUCKET);
         assert_action(HttpMethod::Get, "/_iceberg/v1/buckets/{warehouse}", GET_TABLE_BUCKET);
         assert_action(HttpMethod::Get, "/iceberg/v1/{warehouse}/namespaces", GET_TABLE_NAMESPACE);
         assert_action(HttpMethod::Get, "/_iceberg/v1/{warehouse}/namespaces", GET_TABLE_NAMESPACE);
         assert_action(HttpMethod::Head, "/iceberg/v1/{warehouse}/namespaces/{namespace}", GET_TABLE_NAMESPACE);
         assert_action(HttpMethod::Head, "/_iceberg/v1/{warehouse}/namespaces/{namespace}", GET_TABLE_NAMESPACE);
+        assert_action(
+            HttpMethod::Post,
+            "/iceberg/v1/{warehouse}/namespaces/{namespace}/properties",
+            UPDATE_TABLE_NAMESPACE_PROPERTIES,
+        );
+        assert_action(
+            HttpMethod::Post,
+            "/_iceberg/v1/{warehouse}/namespaces/{namespace}/properties",
+            UPDATE_TABLE_NAMESPACE_PROPERTIES,
+        );
+        assert_action(HttpMethod::Post, "/iceberg/v1/{warehouse}/tables/rename", SET_TABLE);
+        assert_action(HttpMethod::Post, "/_iceberg/v1/{warehouse}/tables/rename", SET_TABLE);
         assert_action(HttpMethod::Post, "/iceberg/v1/{warehouse}/namespaces/{namespace}/tables", CREATE_TABLE);
         assert_action(HttpMethod::Post, "/_iceberg/v1/{warehouse}/namespaces/{namespace}/tables", CREATE_TABLE);
         assert_action(

--- a/rustfs/src/admin/route_registration_test.rs
+++ b/rustfs/src/admin/route_registration_test.rs
@@ -383,7 +383,13 @@ fn expected_admin_route_matrix() -> Vec<RouteMatrixEntry> {
         table_route_sample(Method::POST, "/{warehouse}/namespaces", "/analytics/namespaces"),
         table_route_sample(Method::GET, "/{warehouse}/namespaces/{namespace}", "/analytics/namespaces/sales"),
         table_route_sample(Method::HEAD, "/{warehouse}/namespaces/{namespace}", "/analytics/namespaces/sales"),
+        table_route_sample(
+            Method::POST,
+            "/{warehouse}/namespaces/{namespace}/properties",
+            "/analytics/namespaces/sales/properties",
+        ),
         table_route_sample(Method::DELETE, "/{warehouse}/namespaces/{namespace}", "/analytics/namespaces/sales"),
+        table_route_sample(Method::POST, "/{warehouse}/tables/rename", "/analytics/tables/rename"),
         table_route_sample(
             Method::GET,
             "/{warehouse}/namespaces/{namespace}/tables",
@@ -574,7 +580,13 @@ fn expected_admin_route_matrix() -> Vec<RouteMatrixEntry> {
         compat_table_route_sample(Method::POST, "/{warehouse}/namespaces", "/analytics/namespaces"),
         compat_table_route_sample(Method::GET, "/{warehouse}/namespaces/{namespace}", "/analytics/namespaces/sales"),
         compat_table_route_sample(Method::HEAD, "/{warehouse}/namespaces/{namespace}", "/analytics/namespaces/sales"),
+        compat_table_route_sample(
+            Method::POST,
+            "/{warehouse}/namespaces/{namespace}/properties",
+            "/analytics/namespaces/sales/properties",
+        ),
         compat_table_route_sample(Method::DELETE, "/{warehouse}/namespaces/{namespace}", "/analytics/namespaces/sales"),
+        compat_table_route_sample(Method::POST, "/{warehouse}/tables/rename", "/analytics/tables/rename"),
         compat_table_route_sample(
             Method::GET,
             "/{warehouse}/namespaces/{namespace}/tables",

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -926,6 +926,44 @@ fn table_data_plane_admin_action(action: Action) -> Option<AdminAction> {
     }
 }
 
+fn table_credential_claim_matches_resource(
+    action: Action,
+    bucket: &str,
+    claims: &HashMap<String, serde_json::Value>,
+    resource: Option<&crate::table_catalog::TableDataPlaneResource>,
+) -> bool {
+    let table_bucket_claim = claims.get(crate::table_catalog::TABLE_CREDENTIAL_BUCKET_CLAIM);
+    let table_id_claim = claims.get(crate::table_catalog::TABLE_CREDENTIAL_TABLE_ID_CLAIM);
+    let scope_prefix_claim = claims.get(crate::table_catalog::TABLE_CREDENTIAL_SCOPE_PREFIX_CLAIM);
+    if table_bucket_claim.is_none() && table_id_claim.is_none() && scope_prefix_claim.is_none() {
+        return true;
+    }
+    let (
+        Some(serde_json::Value::String(table_bucket)),
+        Some(serde_json::Value::String(table_id)),
+        Some(serde_json::Value::String(scope_prefix)),
+        Some(resource),
+    ) = (table_bucket_claim, table_id_claim, scope_prefix_claim, resource)
+    else {
+        return false;
+    };
+    let action_allowed = matches!(
+        action,
+        Action::S3Action(
+            S3Action::GetObjectAction
+                | S3Action::PutObjectAction
+                | S3Action::DeleteObjectAction
+                | S3Action::AbortMultipartUploadAction
+                | S3Action::ListMultipartUploadPartsAction
+        )
+    );
+    action_allowed
+        && table_bucket == bucket
+        && table_bucket == &resource.table_bucket
+        && table_id == &resource.table_id
+        && scope_prefix == &format!("s3://{}/{}", resource.table_bucket, resource.warehouse_object_prefix)
+}
+
 fn table_catalog_store_for_data_plane() -> S3Result<crate::table_catalog::EcStoreTableCatalogStore<ECStore>> {
     let store =
         runtime_sources::current_object_store_handle().ok_or_else(|| s3_error!(InternalError, "object store not initialized"))?;
@@ -982,7 +1020,11 @@ async fn authorize_table_data_plane_if_needed(
     let Some(admin_action) = table_data_plane_admin_action(action) else {
         return Ok(());
     };
-    let Some(resource) = table_data_plane_resource_for_request(bucket, object).await? else {
+    let resource = table_data_plane_resource_for_request(bucket, object).await?;
+    if !table_credential_claim_matches_resource(action, bucket, claims, resource.as_ref()) {
+        return Err(s3_error!(AccessDenied, "Access Denied"));
+    }
+    let Some(resource) = resource else {
         return Ok(());
     };
     let Ok(iam_store) = runtime_sources::current_ready_iam_handle() else {
@@ -2249,7 +2291,7 @@ mod tests {
         has_write_offset_bytes_header, legal_hold_write_requested, list_parts_authorize_action,
         load_bucket_policy_existing_object_tag_hint, merge_list_bucket_query_conditions, merge_request_object_tag_conditions,
         owner_can_bypass_policy_deny, post_object_authorize_action, put_bucket_policy_authorize_action, request_context_from_req,
-        retention_write_requested, secondary_tag_hint_action, table_data_plane_admin_action,
+        retention_write_requested, secondary_tag_hint_action, table_credential_claim_matches_resource, table_data_plane_admin_action,
         validate_post_object_success_controls, versioned_read_action,
     };
     use crate::error::ApiError;
@@ -2360,6 +2402,90 @@ mod tests {
             Some(rustfs_policy::policy::action::AdminAction::GetTableMetadataAction)
         );
         assert_eq!(table_data_plane_admin_action(Action::S3Action(S3Action::ListBucketAction)), None);
+    }
+
+    #[test]
+    fn table_vended_credential_is_bound_to_the_stable_table_identity() {
+        let get_object = Action::S3Action(S3Action::GetObjectAction);
+        let resource = crate::table_catalog::TableDataPlaneResource {
+            table_bucket: "warehouse".to_string(),
+            namespace: "analytics".to_string(),
+            table: "events".to_string(),
+            table_id: "table-id-v2".to_string(),
+            warehouse_object_prefix: "tables/table-id-v2/".to_string(),
+        };
+        let mut claims = HashMap::new();
+        assert!(table_credential_claim_matches_resource(get_object, "warehouse", &claims, Some(&resource)));
+        assert!(table_credential_claim_matches_resource(get_object, "warehouse", &claims, None));
+
+        claims.insert(
+            crate::table_catalog::TABLE_CREDENTIAL_BUCKET_CLAIM.to_string(),
+            serde_json::Value::String(resource.table_bucket.clone()),
+        );
+        claims.insert(
+            crate::table_catalog::TABLE_CREDENTIAL_SCOPE_PREFIX_CLAIM.to_string(),
+            serde_json::Value::String(format!("s3://{}/{}", resource.table_bucket, resource.warehouse_object_prefix)),
+        );
+        assert!(!table_credential_claim_matches_resource(
+            get_object,
+            "warehouse",
+            &claims,
+            Some(&resource)
+        ));
+        assert!(!table_credential_claim_matches_resource(get_object, "warehouse", &claims, None));
+
+        claims.insert(
+            crate::table_catalog::TABLE_CREDENTIAL_TABLE_ID_CLAIM.to_string(),
+            serde_json::Value::String(resource.table_id.clone()),
+        );
+        assert!(table_credential_claim_matches_resource(get_object, "warehouse", &claims, Some(&resource)));
+        assert!(!table_credential_claim_matches_resource(get_object, "warehouse", &claims, None));
+        assert!(!table_credential_claim_matches_resource(
+            get_object,
+            "other-warehouse",
+            &claims,
+            Some(&resource)
+        ));
+        assert!(!table_credential_claim_matches_resource(
+            Action::S3Action(S3Action::PutObjectTaggingAction),
+            "warehouse",
+            &claims,
+            Some(&resource)
+        ));
+
+        claims.insert(
+            crate::table_catalog::TABLE_CREDENTIAL_SCOPE_PREFIX_CLAIM.to_string(),
+            serde_json::Value::String("s3://warehouse/tables/old-table-id/".to_string()),
+        );
+        assert!(!table_credential_claim_matches_resource(
+            get_object,
+            "warehouse",
+            &claims,
+            Some(&resource)
+        ));
+        claims.insert(
+            crate::table_catalog::TABLE_CREDENTIAL_SCOPE_PREFIX_CLAIM.to_string(),
+            serde_json::Value::String(format!("s3://{}/{}", resource.table_bucket, resource.warehouse_object_prefix)),
+        );
+
+        claims.insert(
+            crate::table_catalog::TABLE_CREDENTIAL_TABLE_ID_CLAIM.to_string(),
+            serde_json::Value::String("dropped-table-id".to_string()),
+        );
+        assert!(!table_credential_claim_matches_resource(
+            get_object,
+            "warehouse",
+            &claims,
+            Some(&resource)
+        ));
+
+        claims.insert(crate::table_catalog::TABLE_CREDENTIAL_TABLE_ID_CLAIM.to_string(), serde_json::Value::Null);
+        assert!(!table_credential_claim_matches_resource(
+            get_object,
+            "warehouse",
+            &claims,
+            Some(&resource)
+        ));
     }
 
     #[test]

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -2291,8 +2291,8 @@ mod tests {
         has_write_offset_bytes_header, legal_hold_write_requested, list_parts_authorize_action,
         load_bucket_policy_existing_object_tag_hint, merge_list_bucket_query_conditions, merge_request_object_tag_conditions,
         owner_can_bypass_policy_deny, post_object_authorize_action, put_bucket_policy_authorize_action, request_context_from_req,
-        retention_write_requested, secondary_tag_hint_action, table_credential_claim_matches_resource, table_data_plane_admin_action,
-        validate_post_object_success_controls, versioned_read_action,
+        retention_write_requested, secondary_tag_hint_action, table_credential_claim_matches_resource,
+        table_data_plane_admin_action, validate_post_object_success_controls, versioned_read_action,
     };
     use crate::error::ApiError;
     use http::{Extensions, HeaderMap, HeaderValue, Method, Uri};

--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -1822,6 +1822,17 @@ pub(crate) fn table_warehouse_object_prefix(entry: &TableEntry) -> TableCatalogS
     table_warehouse_object_prefix_from_location(&entry.table_bucket, &entry.warehouse_location)
 }
 
+fn ensure_service_managed_table_warehouse(entry: &TableEntry) -> TableCatalogStoreResult<()> {
+    let warehouse_object_prefix = table_warehouse_object_prefix(entry)?;
+    let service_managed_prefix = format!("tables/{}/", entry.table_id);
+    if warehouse_object_prefix != service_managed_prefix {
+        return Err(TableCatalogStoreError::Unsupported(
+            "table maintenance requires a RustFS-managed warehouse location".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn table_warehouse_index_entry(entry: &TableEntry) -> TableCatalogStoreResult<TableWarehouseIndexEntry> {
     Ok(TableWarehouseIndexEntry {
         version: TABLE_CATALOG_ENTRY_VERSION,
@@ -3552,13 +3563,10 @@ where
         snapshot: StrongTableCatalogSnapshot,
         precondition: TableCatalogPutPrecondition,
     ) -> TableCatalogStoreResult<()> {
-        // Keep readers behind the state lock until durable publication finishes. Marking the
-        // cache stale first also makes cancellation at any persistence await recover by reload.
-        let mut state = self.state.lock().await;
-        state.hydrated = false;
-        let result = self.persist_snapshot(snapshot, precondition).await;
-        drop(state);
-        result
+        // A stale cache is recoverable from the durable snapshot after cancellation. Readers may
+        // continue from the previous snapshot while the conditional PUT is still in flight.
+        self.state.lock().await.hydrated = false;
+        self.persist_snapshot(snapshot, precondition).await
     }
 
     async fn materialize_bucket_snapshot(
@@ -5817,13 +5825,31 @@ where
         &self,
         entry: &TableEntry,
         reservation: WarehouseIndexReservation,
+        ownership_guard: Option<&dyn TableCatalogObjectLockGuard>,
         reason: &'static str,
     ) {
         if reservation != WarehouseIndexReservation::Created {
             return;
         }
         let warehouse_object_prefix = table_warehouse_object_prefix(entry).ok();
-        if let Err(err) = self.delete_table_warehouse_index(entry).await {
+        let result = if let Some(ownership_guard) = ownership_guard {
+            self.delete_created_table_warehouse_index_ownership_locked(entry, ownership_guard, reason)
+                .await
+        } else {
+            let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&entry.table_bucket);
+            match self
+                .backend
+                .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
+                .await
+            {
+                Ok(ownership_guard) => {
+                    self.delete_created_table_warehouse_index_ownership_locked(entry, ownership_guard.as_ref(), reason)
+                        .await
+                }
+                Err(err) => Err(err),
+            }
+        };
+        if let Err(err) = result {
             tracing::warn!(
                 table_bucket = %entry.table_bucket,
                 namespace = %entry.namespace,
@@ -5835,6 +5861,29 @@ where
                 "failed to roll back table warehouse index reservation"
             );
         }
+    }
+
+    async fn delete_created_table_warehouse_index_ownership_locked(
+        &self,
+        entry: &TableEntry,
+        ownership_guard: &dyn TableCatalogObjectLockGuard,
+        reason: &'static str,
+    ) -> TableCatalogStoreResult<()> {
+        ensure_table_catalog_lock_held(ownership_guard)?;
+        let index = table_warehouse_index_entry(entry)?;
+        if self.warehouse_index_entry_has_active_owner_unlocked(&index).await? {
+            return Ok(());
+        }
+        ensure_table_catalog_lock_held(ownership_guard)?;
+        self.delete_warehouse_index_object(
+            &self
+                .paths
+                .warehouse_index_entry_path(&index.table_bucket, &index.warehouse_object_prefix),
+            &index,
+            reason,
+        )
+        .await
+        .map(|_| ())
     }
 
     async fn delete_table_warehouse_index(&self, entry: &TableEntry) -> TableCatalogStoreResult<()> {
@@ -6159,7 +6208,13 @@ where
             ensure_table_catalog_lock_held(table_guard.as_ref())?;
             ensure_table_catalog_lock_held(view_guard.as_ref())?;
             self.write_entry_unlocked(self.catalog_bucket(), &table_path, &entry, precondition)
-                .await
+                .await?;
+            ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+            ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
+            ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+            ensure_table_catalog_lock_held(table_guard.as_ref())?;
+            ensure_table_catalog_lock_held(view_guard.as_ref())?;
+            Ok(())
         }
         .await;
         if result.is_err() {
@@ -6167,7 +6222,11 @@ where
                 self.rollback_materialized_namespace(&entry.table_bucket, &namespace, &namespace_path, namespace_guard.as_ref())
                     .await;
             }
-            self.delete_created_table_warehouse_index(&entry, reservation, "table entry write failed")
+            drop(view_guard);
+            drop(table_guard);
+            drop(namespace_guard);
+            drop(ownership_guard);
+            self.delete_created_table_warehouse_index(&entry, reservation, None, "table entry write failed")
                 .await;
         }
         result
@@ -6254,7 +6313,12 @@ where
             ensure_table_catalog_lock_held(table_guard.as_ref())?;
             ensure_table_catalog_lock_held(view_guard.as_ref())?;
             self.write_entry_unlocked(self.catalog_bucket(), &view_path, &entry, precondition)
-                .await
+                .await?;
+            ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+            ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+            ensure_table_catalog_lock_held(table_guard.as_ref())?;
+            ensure_table_catalog_lock_held(view_guard.as_ref())?;
+            Ok(())
         }
         .await;
         if result.is_err() && materialize_namespace {
@@ -6321,34 +6385,16 @@ where
         let identity_path = self
             .paths
             .external_catalog_bridge_identity_path(table_bucket, &namespace, &table);
-        let identity_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &identity_path).await?;
+        let identity_guard = self.backend.acquire_read_lock(self.catalog_bucket(), &identity_path).await?;
         let identity = self
             .read_entry_unlocked::<ExternalCatalogBridgeIdentityEntry>(self.catalog_bucket(), &identity_path)
             .await?
             .map(|(identity, _)| identity);
-        let identity = match identity {
-            Some(identity) => identity,
-            None => {
-                let identity = ExternalCatalogBridgeIdentityEntry {
-                    version: TABLE_EXTERNAL_CATALOG_BRIDGE_VERSION,
-                    table_bucket: table_bucket.to_string(),
-                    namespace: namespace.public_name(),
-                    table: table.as_str().to_string(),
-                    table_id: current.table_id.clone(),
-                };
-                ensure_table_catalog_lock_held(table_guard.as_ref())?;
-                ensure_table_catalog_lock_held(bridge_guard.as_ref())?;
-                ensure_table_catalog_lock_held(identity_guard.as_ref())?;
-                self.write_entry_unlocked(
-                    self.catalog_bucket(),
-                    &identity_path,
-                    &identity,
-                    TableCatalogPutPrecondition::IfAbsent,
-                )
-                .await?;
-                identity
-            }
-        };
+        let identity = identity.ok_or_else(|| {
+            TableCatalogStoreError::Conflict(
+                "external catalog bridge identity is missing; resync the bridge before use".to_string(),
+            )
+        })?;
         if bridge.version != TABLE_EXTERNAL_CATALOG_BRIDGE_VERSION
             || bridge.table_bucket != table_bucket
             || bridge.namespace != namespace.public_name()
@@ -6428,6 +6474,10 @@ where
         ensure_table_catalog_lock_held(identity_guard.as_ref())?;
         self.write_entry_unlocked(self.catalog_bucket(), &identity_path, &identity, TableCatalogPutPrecondition::Any)
             .await?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(table_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bridge_guard.as_ref())?;
+        ensure_table_catalog_lock_held(identity_guard.as_ref())?;
         Ok(entry)
     }
 
@@ -7890,6 +7940,7 @@ where
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
         }
+        ensure_service_managed_table_warehouse(&entry)?;
         self.backfill_table_warehouse_index(table_bucket).await?;
 
         let Some(current_metadata_object) = self.backend.read_object(table_bucket, &entry.metadata_location).await? else {
@@ -7942,6 +7993,7 @@ where
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
         }
+        ensure_service_managed_table_warehouse(&entry)?;
         self.backfill_table_warehouse_index(table_bucket).await?;
 
         let Some(current_metadata_object) = self.backend.read_object(table_bucket, &entry.metadata_location).await? else {
@@ -7986,6 +8038,7 @@ where
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
         }
+        ensure_service_managed_table_warehouse(&entry)?;
 
         let Some(current_metadata_object) = self.backend.read_object(table_bucket, &entry.metadata_location).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -8687,6 +8740,7 @@ where
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
         }
+        ensure_service_managed_table_warehouse(&entry)?;
         self.backfill_table_warehouse_index(table_bucket).await?;
         self.ensure_table_warehouse_prefix_available(&entry).await?;
         self.ensure_table_warehouse_index_owner(&entry).await?;
@@ -9466,7 +9520,10 @@ where
         ensure_table_catalog_lock_held(migration_guard.as_ref())?;
         ensure_table_catalog_lock_held(guard.as_ref())?;
         self.write_entry_unlocked(self.catalog_bucket(), &object, &entry, TableCatalogPutPrecondition::Any)
-            .await
+            .await?;
+        ensure_table_catalog_lock_held(registry_guard.as_ref())?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(guard.as_ref())
     }
 
     async fn create_namespace(&self, entry: NamespaceEntry) -> TableCatalogStoreResult<()> {
@@ -9496,7 +9553,10 @@ where
         ensure_table_catalog_lock_held(bucket_guard.as_ref())?;
         ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
         self.write_entry_unlocked(self.catalog_bucket(), &object, &entry, precondition)
-            .await
+            .await?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bucket_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())
     }
 
     async fn list_namespaces(&self, table_bucket: &str) -> TableCatalogStoreResult<Vec<NamespaceEntry>> {
@@ -9608,7 +9668,10 @@ where
         ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
         self.backend
             .delete_object_unlocked(self.catalog_bucket(), &namespace_path)
-            .await
+            .await?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bucket_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())
     }
 
     async fn create_table(&self, entry: TableEntry) -> TableCatalogStoreResult<()> {
@@ -10107,8 +10170,13 @@ where
             .await;
             if let Err(err) = staged_write_result {
                 if let Some(reservation) = reservation {
-                    self.delete_created_table_warehouse_index(&next, reservation, "commit staging failed")
-                        .await;
+                    self.delete_created_table_warehouse_index(
+                        &next,
+                        reservation,
+                        ownership_guard.as_deref(),
+                        "commit staging failed",
+                    )
+                    .await;
                 }
                 return table_commit_result(
                     &request.table_bucket,
@@ -10124,8 +10192,13 @@ where
             let cas_started = Instant::now();
             if let Err(err) = ensure_table_catalog_lock_held(table_guard.as_ref()) {
                 if let Some(reservation) = reservation {
-                    self.delete_created_table_warehouse_index(&next, reservation, "table lock lost before pointer CAS")
-                        .await;
+                    self.delete_created_table_warehouse_index(
+                        &next,
+                        reservation,
+                        ownership_guard.as_deref(),
+                        "table lock lost before pointer CAS",
+                    )
+                    .await;
                 }
                 return table_commit_result(
                     &request.table_bucket,
@@ -10139,8 +10212,13 @@ where
             }
             if let Err(err) = ensure_table_catalog_lock_held(metadata_guard.as_ref()) {
                 if let Some(reservation) = reservation {
-                    self.delete_created_table_warehouse_index(&next, reservation, "metadata lock lost before pointer CAS")
-                        .await;
+                    self.delete_created_table_warehouse_index(
+                        &next,
+                        reservation,
+                        ownership_guard.as_deref(),
+                        "metadata lock lost before pointer CAS",
+                    )
+                    .await;
                 }
                 return table_commit_result(
                     &request.table_bucket,
@@ -10156,8 +10234,13 @@ where
                 && let Err(err) = ensure_table_catalog_lock_held(current_metadata_guard)
             {
                 if let Some(reservation) = reservation {
-                    self.delete_created_table_warehouse_index(&next, reservation, "base metadata lock lost before pointer CAS")
-                        .await;
+                    self.delete_created_table_warehouse_index(
+                        &next,
+                        reservation,
+                        ownership_guard.as_deref(),
+                        "base metadata lock lost before pointer CAS",
+                    )
+                    .await;
                 }
                 return table_commit_result(
                     &request.table_bucket,
@@ -10171,8 +10254,13 @@ where
             }
             if let Err(err) = ensure_table_catalog_lock_held(migration_guard.as_ref()) {
                 if let Some(reservation) = reservation {
-                    self.delete_created_table_warehouse_index(&next, reservation, "catalog migration lock lost")
-                        .await;
+                    self.delete_created_table_warehouse_index(
+                        &next,
+                        reservation,
+                        ownership_guard.as_deref(),
+                        "catalog migration lock lost",
+                    )
+                    .await;
                 }
                 return table_commit_result(
                     &request.table_bucket,
@@ -10184,11 +10272,13 @@ where
                     Err(err),
                 );
             }
-            if let Some(ownership_guard) = ownership_guard.as_deref()
-                && let Err(err) = ensure_table_catalog_lock_held(ownership_guard)
-            {
+            let ownership_lock_error = ownership_guard
+                .as_deref()
+                .and_then(|ownership_guard| ensure_table_catalog_lock_held(ownership_guard).err());
+            if let Some(err) = ownership_lock_error {
+                drop(ownership_guard.take());
                 if let Some(reservation) = reservation {
-                    self.delete_created_table_warehouse_index(&next, reservation, "warehouse ownership lock lost")
+                    self.delete_created_table_warehouse_index(&next, reservation, None, "warehouse ownership lock lost")
                         .await;
                 }
                 return table_commit_result(
@@ -10212,9 +10302,34 @@ where
             record_table_commit_cas_result(&request.operation, cas_started, &cas_result);
             if let Err(err) = cas_result {
                 if let Some(reservation) = reservation {
-                    self.delete_created_table_warehouse_index(&next, reservation, "table pointer CAS failed")
-                        .await;
+                    self.delete_created_table_warehouse_index(
+                        &next,
+                        reservation,
+                        ownership_guard.as_deref(),
+                        "table pointer CAS failed",
+                    )
+                    .await;
                 }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            let post_cas_fence = ensure_table_catalog_lock_held(table_guard.as_ref())
+                .and_then(|_| ensure_table_catalog_lock_held(metadata_guard.as_ref()))
+                .and_then(|_| {
+                    current_metadata_guard
+                        .as_deref()
+                        .map_or(Ok(()), ensure_table_catalog_lock_held)
+                })
+                .and_then(|_| ensure_table_catalog_lock_held(migration_guard.as_ref()))
+                .and_then(|_| ownership_guard.as_deref().map_or(Ok(()), ensure_table_catalog_lock_held));
+            if let Err(err) = post_cas_fence {
                 return table_commit_result(
                     &request.table_bucket,
                     &request.namespace,
@@ -10283,44 +10398,78 @@ where
         ensure_table_catalog_lock_held(table_guard.as_ref())?;
         self.backend.delete_object_unlocked(self.catalog_bucket(), &object).await?;
         if let Err(err) = self.delete_table_warehouse_index(&entry).await {
+            ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+            ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
+            ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+            ensure_table_catalog_lock_held(table_guard.as_ref())?;
+            self.write_entry_unlocked(self.catalog_bucket(), &object, &entry, TableCatalogPutPrecondition::IfAbsent)
+                .await
+                .map_err(|restore_err| {
+                    TableCatalogStoreError::Internal(format!(
+                        "failed to delete table warehouse index ({err}) and failed to restore the table entry ({restore_err})"
+                    ))
+                })?;
+            return Err(err);
+        }
+        let bridge_cleanup = ensure_table_catalog_lock_held(bridge_guard.as_ref())
+            .and_then(|_| ensure_table_catalog_lock_held(migration_guard.as_ref()));
+        let bridge_deleted = match bridge_cleanup {
+            Ok(()) => match self.backend.delete_object_unlocked(self.catalog_bucket(), &bridge_path).await {
+                Ok(()) => true,
+                Err(err) => {
+                    tracing::warn!(
+                        table_bucket = %entry.table_bucket,
+                        namespace = %entry.namespace,
+                        table = %entry.table,
+                        table_id = %entry.table_id,
+                        object = %bridge_path,
+                        error = %err,
+                        "failed to clean up a stale external catalog bridge after dropping table"
+                    );
+                    false
+                }
+            },
+            Err(err) => {
+                tracing::warn!(
+                    table_bucket = %entry.table_bucket,
+                    namespace = %entry.namespace,
+                    table = %entry.table,
+                    table_id = %entry.table_id,
+                    object = %bridge_path,
+                    error = %err,
+                    "skipped stale external catalog bridge cleanup after dropping table"
+                );
+                false
+            }
+        };
+        if bridge_deleted
+            && let Err(err) = ensure_table_catalog_lock_held(identity_guard.as_ref())
+                .and_then(|_| ensure_table_catalog_lock_held(migration_guard.as_ref()))
+        {
             tracing::warn!(
                 table_bucket = %entry.table_bucket,
                 namespace = %entry.namespace,
                 table = %entry.table,
                 table_id = %entry.table_id,
+                object = %identity_path,
                 error = %err,
-                "failed to clean up stale table warehouse index after dropping table"
+                "skipped stale external catalog bridge identity cleanup after dropping table"
             );
-        }
-        for (path, guard) in [
-            (&bridge_path, bridge_guard.as_ref()),
-            (&identity_path, identity_guard.as_ref()),
-        ] {
-            if let Err(err) =
-                ensure_table_catalog_lock_held(guard).and_then(|_| ensure_table_catalog_lock_held(migration_guard.as_ref()))
-            {
-                tracing::warn!(
-                    table_bucket = %entry.table_bucket,
-                    namespace = %entry.namespace,
-                    table = %entry.table,
-                    table_id = %entry.table_id,
-                    object = %path,
-                    error = %err,
-                    "skipped stale external catalog bridge cleanup after dropping table"
-                );
-                continue;
-            }
-            if let Err(err) = self.backend.delete_object_unlocked(self.catalog_bucket(), path).await {
-                tracing::warn!(
-                    table_bucket = %entry.table_bucket,
-                    namespace = %entry.namespace,
-                    table = %entry.table,
-                    table_id = %entry.table_id,
-                    object = %path,
-                    error = %err,
-                    "failed to clean up a stale external catalog bridge after dropping table"
-                );
-            }
+        } else if bridge_deleted
+            && let Err(err) = self
+                .backend
+                .delete_object_unlocked(self.catalog_bucket(), &identity_path)
+                .await
+        {
+            tracing::warn!(
+                table_bucket = %entry.table_bucket,
+                namespace = %entry.namespace,
+                table = %entry.table,
+                table_id = %entry.table_id,
+                object = %identity_path,
+                error = %err,
+                "failed to clean up a stale external catalog bridge identity after dropping table"
+            );
         }
         Ok(())
     }
@@ -10473,6 +10622,10 @@ where
             TableCatalogPutPrecondition::IfMatch(current_etag),
         )
         .await?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+        ensure_table_catalog_lock_held(view_guard.as_ref())?;
+        ensure_table_catalog_lock_held(metadata_guard.as_ref())?;
         Ok(ViewCommitResult { view: next })
     }
 
@@ -10499,7 +10652,10 @@ where
         ensure_table_catalog_lock_held(migration_guard.as_ref())?;
         ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
         ensure_table_catalog_lock_held(view_guard.as_ref())?;
-        self.backend.delete_object_unlocked(self.catalog_bucket(), &object).await
+        self.backend.delete_object_unlocked(self.catalog_bucket(), &object).await?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+        ensure_table_catalog_lock_held(view_guard.as_ref())
     }
 
     async fn get_commit_by_id(
@@ -11127,10 +11283,11 @@ where
             .map_err(|_| TableCatalogStoreError::Internal("catalog list limit exceeds storage API range".to_string()))?;
 
         loop {
+            let previous_continuation = continuation.clone();
             let result = self
                 .store
                 .clone()
-                .list_objects_v2(bucket, prefix, continuation, None, max_keys, false, None, false)
+                .list_objects_v2(bucket, prefix, continuation.take(), None, max_keys, false, None, false)
                 .await
                 .map_err(|err| storage_error_to_catalog("list catalog objects", err))?;
 
@@ -11142,9 +11299,19 @@ where
                 break;
             }
 
-            let Some(next) = result.next_continuation_token else {
-                break;
-            };
+            let next = result
+                .next_continuation_token
+                .filter(|next| !next.is_empty())
+                .ok_or_else(|| {
+                    TableCatalogStoreError::Internal(
+                        "storage returned a truncated catalog listing without a continuation token".to_string(),
+                    )
+                })?;
+            if previous_continuation.as_deref() == Some(next.as_str()) {
+                return Err(TableCatalogStoreError::Internal(
+                    "storage repeated a catalog listing continuation token".to_string(),
+                ));
+            }
             continuation = Some(next);
         }
 
@@ -15036,8 +15203,10 @@ pub(crate) fn validate_table_warehouse_relocation(
     if next_warehouse_location == entry.warehouse_location {
         return Ok(());
     }
-    table_metadata_dir_path_for_entry(entry)?;
-    Ok(())
+    Err(TableCatalogStoreError::Invalid(
+        "table warehouse relocation is unsupported because retained snapshots may still reference the current warehouse"
+            .to_string(),
+    ))
 }
 
 pub(crate) fn is_valid_table_metadata_location_for_entry(entry: &TableEntry, metadata_location: &str) -> bool {
@@ -17103,6 +17272,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn table_maintenance_rejects_external_warehouse_locations() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend);
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        let mut entry = test_table_entry(bucket, &namespace, &table, current);
+        entry.warehouse_location = format!("s3://{bucket}/external/orders");
+        store.create_table(entry).await.unwrap();
+
+        let error = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect_err("background maintenance must not use internal authority for an external warehouse");
+
+        assert!(matches!(error, TableCatalogStoreError::Unsupported(_)));
+        assert!(error.to_string().contains("RustFS-managed warehouse"));
+    }
+
+    #[tokio::test]
     async fn maintenance_planning_rejects_missing_or_mismatched_table_uuid() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -17328,7 +17523,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn warehouse_relocation_reservation_denies_access_until_table_cas() {
+    async fn warehouse_relocation_is_rejected_before_index_reservation() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
         let bucket = "analytics";
@@ -17350,63 +17545,40 @@ mod tests {
                 .unwrap(),
             )
             .await;
-        let table_path = store.paths.table_entry_path(bucket, &namespace, &table);
         let relocated_index_path = store.paths.warehouse_index_entry_path(bucket, relocated_prefix);
-        let pause = backend.pause_next_put(RUSTFS_META_BUCKET, &table_path).await;
-        let commit_store = store.clone();
-        let namespace_name = namespace.public_name();
-        let table_name = table.as_str().to_string();
-        let current_for_commit = current.clone();
-        let next_for_commit = next.clone();
-        let commit = tokio::spawn(async move {
-            commit_store
-                .commit_table(TableCommitRequest {
-                    table_bucket: bucket.to_string(),
-                    namespace: namespace_name,
-                    table: table_name,
-                    commit_id: "relocate-commit".to_string(),
-                    idempotency_key: None,
-                    operation: "set-location".to_string(),
-                    expected_version_token: "token-v1".to_string(),
-                    expected_metadata_location: current_for_commit,
-                    new_metadata_location: next_for_commit,
-                    requirements: Vec::new(),
-                    writer: Some("test".to_string()),
-                })
-                .await
-        });
-        pause.wait_started().await;
-
-        assert!(
-            backend
-                .object_exists(RUSTFS_META_BUCKET, &relocated_index_path)
-                .await
-                .unwrap()
-        );
-        let pending_error =
-            table_data_plane_resource_for_object(&store, bucket, "tables/relocated-table-id/data/part-00001.parquet")
-                .await
-                .expect_err("a reservation without the matching table pointer must fail closed");
-        assert_matches!(
-            pending_error,
-            TableCatalogStoreError::Internal(message) if message.contains("different warehouse prefix")
-        );
-        assert!(
-            backend
-                .object_exists(RUSTFS_META_BUCKET, &relocated_index_path)
-                .await
-                .unwrap()
-        );
-
-        pause.release();
-        let committed = commit.await.unwrap().expect("relocation commit should complete");
-        assert_eq!(committed.table.metadata_location, next);
-        let resource = table_data_plane_resource_for_object(&store, bucket, "tables/relocated-table-id/data/part-00001.parquet")
+        let error = store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: "relocate-commit".to_string(),
+                idempotency_key: None,
+                operation: "set-location".to_string(),
+                expected_version_token: "token-v1".to_string(),
+                expected_metadata_location: current.clone(),
+                new_metadata_location: next,
+                requirements: Vec::new(),
+                writer: Some("test".to_string()),
+            })
             .await
-            .expect("committed relocation should resolve")
-            .expect("relocated object should have a table owner");
-        assert_eq!(resource.table_id, "table-id");
-        assert_eq!(resource.warehouse_object_prefix, relocated_prefix);
+            .expect_err("warehouse relocation must remain unsupported while retained snapshots use the old prefix");
+
+        assert_matches!(error, TableCatalogStoreError::Invalid(message) if message.contains("relocation is unsupported"));
+        assert!(
+            !backend
+                .object_exists(RUSTFS_META_BUCKET, &relocated_index_path)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .unwrap()
+                .unwrap()
+                .metadata_location,
+            current
+        );
     }
 
     #[tokio::test]
@@ -24985,7 +25157,7 @@ mod tests {
 
             let err = store.register_table(overlapping).await.unwrap_err();
 
-            assert_matches!(err, TableCatalogStoreError::Conflict(_));
+            assert_matches!(err, TableCatalogStoreError::Invalid(message) if message.contains("relocation is unsupported"));
             assert!(store.load_table(bucket, "sales", "customers").await.unwrap().is_none());
         }
     }
@@ -25261,7 +25433,7 @@ mod tests {
                 .await
                 .expect_err("external table warehouse relocation should be rejected");
 
-            assert_matches!(error, TableCatalogStoreError::Unsupported(_));
+            assert_matches!(error, TableCatalogStoreError::Invalid(message) if message.contains("relocation is unsupported"));
             let loaded = store
                 .load_table(bucket, &namespace.public_name(), table.as_str())
                 .await
@@ -25673,73 +25845,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn object_table_catalog_store_does_not_commit_after_warehouse_ownership_lock_loss() {
-        let backend = TestCatalogObjectBackend::default();
-        let store = ObjectTableCatalogStore::new(backend.clone());
-        let bucket = "analytics";
-        let namespace = Namespace::parse("sales").unwrap();
-        let table = IdentifierSegment::parse("orders").unwrap();
-        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
-        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
-
-        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
-        store
-            .create_namespace(test_namespace_entry(bucket, &namespace))
-            .await
-            .unwrap();
-        store
-            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
-            .await
-            .unwrap();
-        store.backfill_table_warehouse_index(bucket).await.unwrap();
-        backend
-            .seed_object(
-                bucket,
-                &new_metadata,
-                serde_json::to_vec(&serde_json::json!({
-                    "location": "s3://analytics/tables/relocated-table-id",
-                    "table-uuid": "table-uuid"
-                }))
-                .unwrap(),
-            )
-            .await;
-        backend
-            .lose_next_write_lock(store.catalog_bucket(), &store.paths.warehouse_index_ownership_lock_path(bucket))
-            .await;
-
-        let error = store
-            .commit_table(TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: table.as_str().to_string(),
-                commit_id: "commit-lock-loss".to_string(),
-                idempotency_key: None,
-                operation: "set-location".to_string(),
-                expected_version_token: "token-v1".to_string(),
-                expected_metadata_location: current_metadata.clone(),
-                new_metadata_location: new_metadata,
-                requirements: Vec::new(),
-                writer: Some("pyiceberg/test".to_string()),
-            })
-            .await
-            .expect_err("a lost warehouse ownership lock must prevent the table CAS");
-
-        assert_matches!(
-            error,
-            TableCatalogStoreError::Conflict(message) if message.contains("lock lease was lost")
-        );
-        let loaded = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
-        assert_eq!(loaded.metadata_location, current_metadata);
-        assert!(
-            store
-                .get_commit_by_id(bucket, "table-id", "commit-lock-loss")
-                .await
-                .unwrap()
-                .is_none()
-        );
-    }
-
-    #[tokio::test]
     async fn object_table_catalog_store_does_not_commit_after_migration_permit_loss() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -25885,152 +25990,6 @@ mod tests {
                 current_metadata
             );
         }
-    }
-
-    #[tokio::test]
-    async fn object_table_catalog_store_syncs_warehouse_location_from_committed_metadata() {
-        let backend = TestCatalogObjectBackend::default();
-        let store = ObjectTableCatalogStore::new(backend.clone());
-        let bucket = "analytics";
-        let namespace = Namespace::parse("sales").unwrap();
-        let table = IdentifierSegment::parse("orders").unwrap();
-        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
-        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
-
-        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
-        store
-            .create_namespace(test_namespace_entry(bucket, &namespace))
-            .await
-            .unwrap();
-        store
-            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
-            .await
-            .unwrap();
-        store.backfill_table_warehouse_index(bucket).await.unwrap();
-        backend.reset_call_counts().await;
-        backend
-            .seed_object(
-                bucket,
-                &new_metadata,
-                serde_json::to_vec(&serde_json::json!({
-                    "location": "s3://analytics/tables/relocated-table-id",
-                    "table-uuid": "table-uuid"
-                }))
-                .unwrap(),
-            )
-            .await;
-
-        let result = store
-            .commit_table(TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: table.as_str().to_string(),
-                commit_id: "commit-1".to_string(),
-                idempotency_key: None,
-                operation: "set-location".to_string(),
-                expected_version_token: "token-v1".to_string(),
-                expected_metadata_location: current_metadata,
-                new_metadata_location: new_metadata,
-                requirements: vec![serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"})],
-                writer: Some("pyiceberg/test".to_string()),
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(result.table.warehouse_location, "s3://analytics/tables/relocated-table-id");
-        backend.reset_call_counts().await;
-        let resource = table_data_plane_resource_for_object(&store, bucket, "tables/relocated-table-id/data/part-00001.parquet")
-            .await
-            .expect("data-plane resource lookup should succeed")
-            .expect("relocated table warehouse object should resolve to the table");
-        assert_eq!(resource.table, "orders");
-        assert_eq!(resource.warehouse_object_prefix, "tables/relocated-table-id/");
-        let old_resource = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/part-00001.parquet")
-            .await
-            .expect("old table warehouse lookup should succeed");
-        assert!(old_resource.is_none());
-        assert_eq!(backend.list_call_count().await, 0);
-    }
-
-    #[tokio::test]
-    async fn object_table_catalog_store_reuses_old_prefix_after_failed_relocation_index_delete() {
-        let backend = TestCatalogObjectBackend::default();
-        let store = ObjectTableCatalogStore::new(backend.clone());
-        let bucket = "analytics";
-        let namespace = Namespace::parse("sales").unwrap();
-        let table = IdentifierSegment::parse("orders").unwrap();
-        let next_table = IdentifierSegment::parse("returns").unwrap();
-        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
-        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
-        let old_index_path = store.paths.warehouse_index_entry_path(bucket, "tables/table-id/");
-
-        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
-        store
-            .create_namespace(test_namespace_entry(bucket, &namespace))
-            .await
-            .unwrap();
-        let old_entry = test_table_entry(bucket, &namespace, &table, current_metadata.clone());
-        store
-            .create_table(old_entry.clone())
-            .await
-            .expect("old table should be created");
-        backend
-            .seed_object(
-                bucket,
-                &new_metadata,
-                serde_json::to_vec(&serde_json::json!({
-                    "location": "s3://analytics/tables/relocated-table-id",
-                    "table-uuid": "table-uuid"
-                }))
-                .unwrap(),
-            )
-            .await;
-        backend.fail_delete_attempt(RUSTFS_META_BUCKET, &old_index_path, 1).await;
-
-        store
-            .commit_table(TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: table.as_str().to_string(),
-                commit_id: "commit-1".to_string(),
-                idempotency_key: None,
-                operation: "set-location".to_string(),
-                expected_version_token: "token-v1".to_string(),
-                expected_metadata_location: current_metadata.clone(),
-                new_metadata_location: new_metadata,
-                requirements: vec![serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"})],
-                writer: Some("pyiceberg/test".to_string()),
-            })
-            .await
-            .unwrap();
-
-        let next_table_metadata = default_table_metadata_file_path(&namespace, &next_table, "00001.metadata.json");
-        let mut next_entry = test_table_entry(bucket, &namespace, &next_table, next_table_metadata);
-        next_entry.table_id = "next-table-id".to_string();
-        next_entry.warehouse_location = format!("s3://{bucket}/tables/table-id");
-        store
-            .create_table(next_entry)
-            .await
-            .expect("stale old warehouse index should not block prefix reuse");
-
-        let (index, _) = store
-            .read_entry::<TableWarehouseIndexEntry>(store.catalog_bucket(), &old_index_path)
-            .await
-            .unwrap()
-            .expect("reused prefix index should exist");
-        assert_eq!(index.table, "returns");
-        assert_eq!(index.table_id, "next-table-id");
-
-        store
-            .delete_table_warehouse_index(&old_entry)
-            .await
-            .expect("old owner should not delete reused prefix index");
-        let reused_resource = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/part-00001.parquet")
-            .await
-            .expect("reused prefix lookup should succeed")
-            .expect("reused prefix should still resolve to the new table");
-        assert_eq!(reused_resource.table, "returns");
-        assert_eq!(reused_resource.table_id, "next-table-id");
     }
 
     #[tokio::test]

--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -50,10 +50,10 @@ use datafusion::{
 use http::HeaderMap;
 use metrics::{counter, histogram};
 use rustfs_filemeta::FileInfo;
-use rustfs_utils::crypto::hex_sha256;
+use rustfs_utils::crypto::{hex_sha256, is_sha256_checksum};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use time::{Duration, OffsetDateTime};
-use tokio::io::AsyncReadExt;
+use tokio::{io::AsyncReadExt, sync::Semaphore};
 use uuid::Uuid;
 
 use crate::storage_api::table::{
@@ -79,9 +79,14 @@ pub(crate) const TABLE_CATALOG_BACKING_DURABLE_STRONG: &str = "durable-strong";
 pub(crate) const TABLE_METADATA_FILE_NAME_MAX_LEN: usize = 128;
 pub(crate) const TABLE_METADATA_JSON_MAX_SIZE: usize = 50 * 1024 * 1024;
 pub(crate) const TABLE_MANIFEST_AVRO_MAX_SIZE: usize = 128 * 1024 * 1024;
+const TABLE_COMMIT_INTEGRITY_MAX_SIZE: usize = 4 * 1024;
 const TABLE_MANIFEST_AVRO_MAX_RECORDS: usize = 1_000_000;
 const TABLE_MANIFEST_AVRO_MAX_HEADER_ENTRIES: usize = 1_024;
 pub(crate) const TABLE_METADATA_DIGEST_REQUIREMENT_TYPE: &str = "assert-rustfs-metadata-sha256";
+pub(crate) const TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE: &str = "assert-rustfs-base-metadata-sha256";
+pub(crate) const TABLE_CREDENTIAL_BUCKET_CLAIM: &str = "rustfs:table-bucket";
+pub(crate) const TABLE_CREDENTIAL_TABLE_ID_CLAIM: &str = "rustfs:table-id";
+pub(crate) const TABLE_CREDENTIAL_SCOPE_PREFIX_CLAIM: &str = "rustfs:credential-scope-prefix";
 const NAMESPACE_PROPERTIES_MAX_ENTRIES: usize = 256;
 const NAMESPACE_PROPERTY_KEY_MAX_LEN: usize = 256;
 const NAMESPACE_PROPERTY_VALUE_MAX_LEN: usize = 4096;
@@ -106,12 +111,16 @@ const INTERNAL_CATALOG_ROOT: &str = BUCKET_TABLE_CATALOG_META_PREFIX;
 const TABLE_BUCKET_ROOT: &str = BUCKET_TABLE_CATALOG_TABLE_BUCKETS_PREFIX;
 const COMMIT_LOG_ROOT: &str = "commits";
 const COMMIT_IDEMPOTENCY_ROOT: &str = "commit-idempotency";
+const COMMIT_INTEGRITY_ROOT: &str = "commit-integrity";
 const WAREHOUSE_INDEX_ROOT: &str = "warehouse-index";
 const WAREHOUSE_INDEX_STATE_FILE: &str = "state.json";
 const WAREHOUSE_INDEX_OWNERSHIP_LOCK_FILE: &str = "ownership.lock";
 const WAREHOUSE_INDEX_MAX_PREFIX_DEPTH: usize = 64;
+const TABLE_CATALOG_CREATE_TASK_CONCURRENCY: usize = 64;
+static TABLE_CATALOG_CREATE_TASK_ADMISSION: Semaphore = Semaphore::const_new(TABLE_CATALOG_CREATE_TASK_CONCURRENCY);
 const EXTERNAL_CATALOG_ROOT: &str = "external-catalog";
 const EXTERNAL_CATALOG_BRIDGE_FILE: &str = "bridge.json";
+const EXTERNAL_CATALOG_IDENTITY_FILE: &str = "identity.json";
 const MAINTENANCE_ROOT: &str = "maintenance";
 const MAINTENANCE_CONFIG_FILE: &str = "config.json";
 const MAINTENANCE_JOB_ROOT: &str = "jobs";
@@ -511,6 +520,18 @@ pub(crate) struct CommitLogEntry {
     pub updated_at: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TableCommitIntegrityEntry {
+    version: u16,
+    table_bucket: String,
+    table_id: String,
+    commit_id: String,
+    request_sha256: Option<String>,
+    expected_metadata_sha256: Option<String>,
+    new_metadata_sha256: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TableCommitRequest {
@@ -542,6 +563,8 @@ pub(crate) struct ExternalCatalogBridgeEntry {
     pub table_bucket: String,
     pub namespace: String,
     pub table: String,
+    #[serde(skip)]
+    pub table_id: String,
     pub catalog: String,
     pub external_catalog_id: Option<String>,
     pub external_namespace: String,
@@ -559,6 +582,16 @@ pub(crate) struct ExternalCatalogBridgeEntry {
     pub properties: BTreeMap<String, String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExternalCatalogBridgeIdentityEntry {
+    version: u16,
+    table_bucket: String,
+    namespace: String,
+    table: String,
+    table_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1663,6 +1696,12 @@ impl std::error::Error for TableCatalogStoreError {}
 
 pub(crate) type TableCatalogStoreResult<T> = Result<T, TableCatalogStoreError>;
 
+pub(crate) fn next_table_catalog_generation(current: u64) -> TableCatalogStoreResult<u64> {
+    current
+        .checked_add(1)
+        .ok_or_else(|| TableCatalogStoreError::Invalid("table catalog generation is exhausted".to_string()))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TableCatalogBackingMode {
     ObjectBacked,
@@ -1826,28 +1865,45 @@ fn table_metadata_warehouse_location(
     metadata_warehouse_location(table_bucket, metadata_location, metadata_object, validate_table_warehouse_location)
 }
 
-fn validate_commit_metadata_digest(
-    request: &TableCommitRequest,
-    metadata_object: &TableCatalogObject,
-) -> TableCatalogStoreResult<()> {
+fn table_commit_metadata_digest<'a>(
+    request: &'a TableCommitRequest,
+    requirement_type: &str,
+    label: &str,
+) -> TableCatalogStoreResult<Option<&'a str>> {
+    table_commit_metadata_digest_from_requirements(&request.requirements, requirement_type, label)
+}
+
+fn table_commit_metadata_digest_from_requirements<'a>(
+    requirements: &'a [serde_json::Value],
+    requirement_type: &str,
+    label: &str,
+) -> TableCatalogStoreResult<Option<&'a str>> {
     let mut expected_digest = None;
-    for requirement in &request.requirements {
-        if requirement.get("type").and_then(serde_json::Value::as_str) != Some(TABLE_METADATA_DIGEST_REQUIREMENT_TYPE) {
+    for requirement in requirements {
+        if requirement.get("type").and_then(serde_json::Value::as_str) != Some(requirement_type) {
             continue;
         }
         if expected_digest.is_some() {
-            return Err(TableCatalogStoreError::Invalid(
-                "commit contains duplicate metadata digest requirements".to_string(),
-            ));
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "commit contains duplicate {label} metadata digest requirements"
+            )));
         }
         expected_digest = Some(
             requirement
                 .get("sha256")
                 .and_then(serde_json::Value::as_str)
-                .filter(|digest| digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
-                .ok_or_else(|| TableCatalogStoreError::Invalid("commit metadata digest is invalid".to_string()))?,
+                .filter(|digest| is_sha256_checksum(digest))
+                .ok_or_else(|| TableCatalogStoreError::Invalid(format!("commit {label} metadata digest is invalid")))?,
         );
     }
+    Ok(expected_digest)
+}
+
+fn validate_table_commit_metadata_object_digest(
+    expected_digest: Option<&str>,
+    metadata_object: &TableCatalogObject,
+    changed_message: &'static str,
+) -> TableCatalogStoreResult<()> {
     let Some(expected_digest) = expected_digest else {
         return Ok(());
     };
@@ -1857,8 +1913,186 @@ fn validate_commit_metadata_digest(
         .map_err(|err| TableCatalogStoreError::Internal(format!("failed to encode committed metadata: {err}")))?;
     let actual_digest = hex_sha256(&canonical, str::to_owned);
     if actual_digest != expected_digest {
+        return Err(TableCatalogStoreError::Conflict(changed_message.to_string()));
+    }
+    Ok(())
+}
+
+fn validate_commit_metadata_digest(
+    request: &TableCommitRequest,
+    metadata_object: &TableCatalogObject,
+) -> TableCatalogStoreResult<()> {
+    validate_table_commit_metadata_object_digest(
+        table_commit_metadata_digest(request, TABLE_METADATA_DIGEST_REQUIREMENT_TYPE, "new")?,
+        metadata_object,
+        "new metadata object changed after commit validation",
+    )
+}
+
+fn validate_commit_base_metadata_digest(
+    request: &TableCommitRequest,
+    metadata_object: &TableCatalogObject,
+) -> TableCatalogStoreResult<()> {
+    validate_table_commit_metadata_object_digest(
+        table_commit_metadata_digest(request, TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE, "base")?,
+        metadata_object,
+        "base metadata object changed after commit validation",
+    )
+}
+
+fn is_internal_commit_requirement(requirement: &serde_json::Value) -> bool {
+    matches!(
+        requirement.get("type").and_then(serde_json::Value::as_str),
+        Some(TABLE_METADATA_DIGEST_REQUIREMENT_TYPE) | Some(TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE)
+    )
+}
+
+fn client_commit_requirements(requirements: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    requirements
+        .iter()
+        .filter(|requirement| !is_internal_commit_requirement(requirement))
+        .cloned()
+        .collect()
+}
+
+fn table_commit_integrity_entry(
+    request: &TableCommitRequest,
+    table_id: &str,
+) -> TableCatalogStoreResult<Option<TableCommitIntegrityEntry>> {
+    let mut entry = table_commit_integrity_entry_from_requirements(
+        &request.table_bucket,
+        table_id,
+        &request.commit_id,
+        &request.requirements,
+    )?;
+    if let Some(entry) = entry.as_mut() {
+        entry.request_sha256 = Some(table_commit_replay_payload_sha256(request)?);
+    }
+    Ok(entry)
+}
+
+fn table_commit_replay_payload_sha256(request: &TableCommitRequest) -> TableCatalogStoreResult<String> {
+    #[derive(Serialize)]
+    struct ReplayPayload<'a> {
+        table_bucket: &'a str,
+        namespace: &'a str,
+        table: &'a str,
+        commit_id: &'a str,
+        idempotency_key: Option<&'a str>,
+        operation: &'a str,
+        expected_version_token: &'a str,
+        expected_metadata_location: &'a str,
+        new_metadata_location: &'a str,
+        requirements: Vec<&'a serde_json::Value>,
+        writer: Option<&'a str>,
+    }
+
+    let payload = ReplayPayload {
+        table_bucket: &request.table_bucket,
+        namespace: &request.namespace,
+        table: &request.table,
+        commit_id: &request.commit_id,
+        idempotency_key: request.idempotency_key.as_deref(),
+        operation: &request.operation,
+        expected_version_token: &request.expected_version_token,
+        expected_metadata_location: &request.expected_metadata_location,
+        new_metadata_location: &request.new_metadata_location,
+        requirements: request
+            .requirements
+            .iter()
+            .filter(|requirement| !is_internal_commit_requirement(requirement))
+            .collect(),
+        writer: request.writer.as_deref(),
+    };
+    let encoded = serde_json::to_vec(&payload)
+        .map_err(|err| TableCatalogStoreError::Internal(format!("failed to encode table commit replay payload: {err}")))?;
+    Ok(hex_sha256(&encoded, str::to_owned))
+}
+
+fn table_commit_integrity_entry_from_requirements(
+    table_bucket: &str,
+    table_id: &str,
+    commit_id: &str,
+    requirements: &[serde_json::Value],
+) -> TableCatalogStoreResult<Option<TableCommitIntegrityEntry>> {
+    let expected_metadata_sha256 =
+        table_commit_metadata_digest_from_requirements(requirements, TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE, "base")?
+            .map(str::to_owned);
+    let new_metadata_sha256 =
+        table_commit_metadata_digest_from_requirements(requirements, TABLE_METADATA_DIGEST_REQUIREMENT_TYPE, "new")?
+            .map(str::to_owned);
+    if expected_metadata_sha256.is_none() && new_metadata_sha256.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(TableCommitIntegrityEntry {
+        version: TABLE_CATALOG_ENTRY_VERSION,
+        table_bucket: table_bucket.to_string(),
+        table_id: table_id.to_string(),
+        commit_id: commit_id.to_string(),
+        request_sha256: None,
+        expected_metadata_sha256,
+        new_metadata_sha256,
+    }))
+}
+
+fn validate_table_commit_integrity_replay(
+    requested: Option<&TableCommitIntegrityEntry>,
+    persisted: Option<&TableCommitIntegrityEntry>,
+    legacy: Option<&TableCommitIntegrityEntry>,
+    allow_missing_requested_integrity: bool,
+) -> TableCatalogStoreResult<()> {
+    let Some(requested) = requested else {
+        if persisted.or(legacy).is_some() && !allow_missing_requested_integrity {
+            return Err(TableCatalogStoreError::Conflict(
+                "staged commit integrity must be included in the retry request".to_string(),
+            ));
+        }
+        return Ok(());
+    };
+    if persisted.or(legacy).is_some_and(|original| {
+        original.expected_metadata_sha256 != requested.expected_metadata_sha256
+            || original.new_metadata_sha256 != requested.new_metadata_sha256
+            || original
+                .request_sha256
+                .as_ref()
+                .zip(requested.request_sha256.as_ref())
+                .is_some_and(|(original, requested)| original != requested)
+    }) {
         return Err(TableCatalogStoreError::Conflict(
-            "new metadata object changed after commit validation".to_string(),
+            "commit integrity record does not match the original request".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_table_commit_integrity_identity(
+    entry: &TableCommitIntegrityEntry,
+    table_bucket: &str,
+    table_id: &str,
+    commit_id: &str,
+) -> TableCatalogStoreResult<()> {
+    if entry.version != TABLE_CATALOG_ENTRY_VERSION
+        || entry.table_bucket != table_bucket
+        || entry.table_id != table_id
+        || entry.commit_id != commit_id
+    {
+        return Err(TableCatalogStoreError::Invalid(
+            "table commit integrity entry does not match its catalog path".to_string(),
+        ));
+    }
+    if !entry.request_sha256.as_deref().is_some_and(is_sha256_checksum)
+        || entry
+            .expected_metadata_sha256
+            .as_deref()
+            .is_some_and(|digest| !is_sha256_checksum(digest))
+        || entry
+            .new_metadata_sha256
+            .as_deref()
+            .is_some_and(|digest| !is_sha256_checksum(digest))
+        || (entry.expected_metadata_sha256.is_none() && entry.new_metadata_sha256.is_none())
+    {
+        return Err(TableCatalogStoreError::Invalid(
+            "table commit integrity entry contains invalid digests".to_string(),
         ));
     }
     Ok(())
@@ -1871,7 +2105,7 @@ fn validate_view_metadata_digest(
     let Some(expected_digest) = expected_digest else {
         return Ok(());
     };
-    if expected_digest.len() != 64 || !expected_digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+    if !is_sha256_checksum(expected_digest) {
         return Err(TableCatalogStoreError::Invalid("view metadata digest is invalid".to_string()));
     }
     let metadata = serde_json::from_slice::<serde_json::Value>(&metadata_object.data)
@@ -2049,17 +2283,6 @@ pub(crate) trait TableCatalogStore: Send + Sync {
             .collect())
     }
 
-    async fn list_namespaces_page(
-        &self,
-        table_bucket: &str,
-        cursor: Option<&str>,
-        limit: NonZeroUsize,
-    ) -> TableCatalogStoreResult<TableCatalogListPage<NamespaceEntry>> {
-        let mut entries = self.list_namespaces(table_bucket).await?;
-        entries.retain(|entry| entry.state == TableCatalogEntryState::Active);
-        Ok(catalog_list_page_from_entries(entries, cursor, limit, |entry| &entry.namespace))
-    }
-
     async fn get_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Option<NamespaceEntry>>;
 
     async fn update_namespace_properties(
@@ -2202,9 +2425,16 @@ impl TableCatalogObjectLockGuard for tokio::sync::OwnedMutexGuard<()> {}
 
 pub(crate) type TableCatalogObjectLock = Box<dyn TableCatalogObjectLockGuard>;
 
-fn ensure_table_catalog_lock_held(guard: &dyn TableCatalogObjectLockGuard) -> TableCatalogStoreResult<()> {
+pub(crate) fn ensure_table_catalog_lock_held(guard: &dyn TableCatalogObjectLockGuard) -> TableCatalogStoreResult<()> {
     if guard.is_lock_lost() {
         return Err(TableCatalogStoreError::Conflict("table catalog lock lease was lost".to_string()));
+    }
+    Ok(())
+}
+
+fn ensure_table_catalog_locks_held(guards: &[TableCatalogObjectLock]) -> TableCatalogStoreResult<()> {
+    for guard in guards {
+        ensure_table_catalog_lock_held(guard.as_ref())?;
     }
     Ok(())
 }
@@ -2394,6 +2624,19 @@ impl TableCatalogObjectPaths {
         )
     }
 
+    pub fn external_catalog_bridge_identity_path(
+        &self,
+        table_bucket: &str,
+        namespace: &Namespace,
+        table: &IdentifierSegment,
+    ) -> String {
+        format!(
+            "{}{}/{EXTERNAL_CATALOG_ROOT}/{EXTERNAL_CATALOG_IDENTITY_FILE}",
+            self.table_entries_prefix(table_bucket, namespace),
+            table.as_str()
+        )
+    }
+
     pub fn view_entries_prefix(&self, table_bucket: &str, namespace: &Namespace) -> String {
         format!("{}{}/{}/", self.namespace_entries_prefix(table_bucket), namespace.storage_id(), VIEW_ROOT)
     }
@@ -2519,6 +2762,16 @@ impl TableCatalogObjectPaths {
             self.table_bucket_root_prefix(table_bucket),
             COMMIT_IDEMPOTENCY_ROOT,
             table_catalog_path_hash(table_id)
+        )
+    }
+
+    pub fn commit_integrity_entry_path(&self, table_bucket: &str, table_id: &str, commit_id: &str) -> String {
+        format!(
+            "{}{}/{}/{}.json",
+            self.table_bucket_root_prefix(table_bucket),
+            COMMIT_INTEGRITY_ROOT,
+            table_catalog_path_hash(table_id),
+            table_catalog_path_hash(commit_id)
         )
     }
 
@@ -2824,6 +3077,51 @@ where
         format!("{INTERNAL_CATALOG_ROOT}/{STRONG_TABLE_CATALOG_BACKING_ROOT}/{STRONG_TABLE_CATALOG_SNAPSHOT_FILE}")
     }
 
+    async fn read_commit_integrity_entry(&self, path: &str) -> TableCatalogStoreResult<Option<TableCommitIntegrityEntry>> {
+        let Some(object) = self
+            .object_backend
+            .read_object_limited(RUSTFS_META_BUCKET, path, TABLE_COMMIT_INTEGRITY_MAX_SIZE)
+            .await?
+        else {
+            return Ok(None);
+        };
+        serde_json::from_slice(&object.data)
+            .map(Some)
+            .map_err(|err| TableCatalogStoreError::Invalid(format!("failed to decode table commit integrity entry: {err}")))
+    }
+
+    async fn stage_commit_integrity_entry(
+        &self,
+        path: &str,
+        integrity: &TableCommitIntegrityEntry,
+    ) -> TableCatalogStoreResult<TableCatalogObjectLock> {
+        let guard = self.object_backend.acquire_write_lock(RUSTFS_META_BUCKET, path).await?;
+        let existing = self
+            .object_backend
+            .read_object_unlocked_limited(RUSTFS_META_BUCKET, path, TABLE_COMMIT_INTEGRITY_MAX_SIZE)
+            .await?;
+        if let Some(existing) = existing {
+            let existing = serde_json::from_slice::<TableCommitIntegrityEntry>(&existing.data).map_err(|err| {
+                TableCatalogStoreError::Invalid(format!("failed to decode table commit integrity entry: {err}"))
+            })?;
+            validate_table_commit_integrity_identity(
+                &existing,
+                &integrity.table_bucket,
+                &integrity.table_id,
+                &integrity.commit_id,
+            )?;
+            validate_table_commit_integrity_replay(Some(integrity), Some(&existing), None, false)?;
+            return Ok(guard);
+        }
+        let data = serde_json::to_vec(integrity)
+            .map_err(|err| TableCatalogStoreError::Internal(format!("failed to encode table commit integrity entry: {err}")))?;
+        ensure_table_catalog_lock_held(guard.as_ref())?;
+        self.object_backend
+            .put_object_unlocked(RUSTFS_META_BUCKET, path, data, TableCatalogPutPrecondition::IfAbsent)
+            .await?;
+        Ok(guard)
+    }
+
     fn snapshot_from_state_locked(state: &StrongTableCatalogState) -> StrongTableCatalogSnapshot {
         StrongTableCatalogSnapshot {
             version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
@@ -2959,12 +3257,19 @@ where
             if entry.state != TableCatalogEntryState::Active {
                 continue;
             }
-            let Ok(metadata_root) = table_metadata_dir_path_for_entry(entry) else {
-                continue;
-            };
-            let Ok(warehouse_object_prefix) = table_warehouse_object_prefix(entry) else {
-                continue;
-            };
+            let parsed_namespace = parse_namespace_for_store(namespace)?;
+            let parsed_table = parse_table_for_store(table)?;
+            validate_table_entry_path_identity(entry, table_bucket, &parsed_namespace, &parsed_table)?;
+            let metadata_root = table_metadata_dir_path_for_entry(entry).map_err(|err| {
+                TableCatalogStoreError::Invalid(format!(
+                    "active table {table_bucket}/{namespace}/{table} has an invalid metadata location: {err}"
+                ))
+            })?;
+            let warehouse_object_prefix = table_warehouse_object_prefix(entry).map_err(|err| {
+                TableCatalogStoreError::Invalid(format!(
+                    "active table {table_bucket}/{namespace}/{table} has an invalid warehouse location: {err}"
+                ))
+            })?;
             if !state
                 .table_buckets
                 .get(table_bucket)
@@ -3002,15 +3307,9 @@ where
             if entry.state != TableCatalogEntryState::Active {
                 continue;
             }
-            if state
-                .tables
-                .get(&(table_bucket.clone(), namespace.clone(), view.clone()))
-                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
-            {
-                return Err(TableCatalogStoreError::Invalid(format!(
-                    "active table and view share the same identifier: {table_bucket}/{namespace}/{view}"
-                )));
-            }
+            let parsed_namespace = parse_namespace_for_store(namespace)?;
+            let parsed_view = parse_table_for_store(view)?;
+            validate_view_entry_path_identity(entry, table_bucket, &parsed_namespace, &parsed_view)?;
             if !state
                 .table_buckets
                 .get(table_bucket)
@@ -3029,13 +3328,16 @@ where
                     "active view {table_bucket}/{namespace}/{view} has no active namespace"
                 )));
             }
-            if validate_view_warehouse_location(table_bucket, &entry.warehouse_location).is_err() {
-                continue;
-            }
-            let namespace = parse_namespace_for_store(namespace)?;
-            let view = parse_table_for_store(view)?;
-            if !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location) {
-                continue;
+            validate_view_warehouse_location(table_bucket, &entry.warehouse_location).map_err(|err| {
+                TableCatalogStoreError::Invalid(format!(
+                    "active view {table_bucket}/{namespace}/{view} has an invalid warehouse location: {err}"
+                ))
+            })?;
+            if !is_valid_view_metadata_location(&parsed_namespace, &parsed_view, &entry.metadata_location) {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "active view {table_bucket}/{}/{view} has an invalid metadata location",
+                    parsed_namespace.public_name()
+                )));
             }
         }
         state.warehouse_index = warehouse_index;
@@ -3250,22 +3552,13 @@ where
         snapshot: StrongTableCatalogSnapshot,
         precondition: TableCatalogPutPrecondition,
     ) -> TableCatalogStoreResult<()> {
-        match self.persist_snapshot(snapshot, precondition).await {
-            Ok(()) => {
-                if let Err(err) = self.reload_state_from_durable().await {
-                    self.state.lock().await.hydrated = false;
-                    tracing::warn!(
-                        error = %err,
-                        "durable strong catalog snapshot committed but local state reload failed"
-                    );
-                }
-                Ok(())
-            }
-            Err(err) => {
-                let _ = self.reload_state_from_durable().await;
-                Err(err)
-            }
-        }
+        // Keep readers behind the state lock until durable publication finishes. Marking the
+        // cache stale first also makes cancellation at any persistence await recover by reload.
+        let mut state = self.state.lock().await;
+        state.hydrated = false;
+        let result = self.persist_snapshot(snapshot, precondition).await;
+        drop(state);
+        result
     }
 
     async fn materialize_bucket_snapshot(
@@ -3574,7 +3867,7 @@ where
             new_version_token: format!("token-{}", Uuid::new_v4()),
             previous_metadata_location: current.metadata_location.clone(),
             new_metadata_location: request.new_metadata_location.clone(),
-            requirements: request.requirements.clone(),
+            requirements: client_commit_requirements(&request.requirements),
             status: CommitLogStatus::Committed,
             writer: request.writer.clone(),
             created_at: None,
@@ -3589,7 +3882,7 @@ where
         }
         Self::ensure_table_warehouse_prefix_available_locked(state, &next, &key)?;
         next.version_token = commit_log.new_version_token.clone();
-        next.generation = next.generation.saturating_add(1);
+        next.generation = next_table_catalog_generation(next.generation)?;
 
         let commit_key = Self::commit_key(&request.table_bucket, &next.table_id, &request.commit_id);
         state.commits.insert(commit_key, commit_log.clone());
@@ -3756,36 +4049,6 @@ where
         Ok(exact.into_iter().chain(descendants).collect())
     }
 
-    async fn list_namespaces_page(
-        &self,
-        table_bucket: &str,
-        cursor: Option<&str>,
-        limit: NonZeroUsize,
-    ) -> TableCatalogStoreResult<TableCatalogListPage<NamespaceEntry>> {
-        self.hydrate_state().await?;
-        let cursor = catalog_list_cursor(cursor, STRONG_CATALOG_LIST_CURSOR_PREFIX)?;
-        let cursor = cursor
-            .map(parse_namespace_for_store)
-            .transpose()?
-            .map(|namespace| namespace.public_name());
-        let start = match cursor {
-            Some(cursor) => Bound::Excluded((table_bucket.to_string(), cursor)),
-            None => Bound::Included((table_bucket.to_string(), String::new())),
-        };
-        let state = self.state.lock().await;
-        let entries = state
-            .namespaces
-            .range((start, Bound::Unbounded))
-            .take_while(|((bucket, _), _)| bucket == table_bucket)
-            .filter(|(_, entry)| entry.state == TableCatalogEntryState::Active)
-            .take(limit.get().saturating_add(1))
-            .map(|(_, entry)| entry.clone())
-            .collect();
-        Ok(finish_catalog_list_page(entries, limit, STRONG_CATALOG_LIST_CURSOR_PREFIX, |entry| {
-            &entry.namespace
-        }))
-    }
-
     async fn get_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Option<NamespaceEntry>> {
         self.hydrate_state().await?;
         let namespace = parse_namespace_for_store(namespace)?;
@@ -3915,7 +4178,15 @@ where
                     entry.table_bucket, entry.namespace
                 )));
             }
-            if state.tables.contains_key(&key) || state.views.contains_key(&key) {
+            if state
+                .tables
+                .get(&key)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+                || state
+                    .views
+                    .get(&key)
+                    .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
                 return Err(TableCatalogStoreError::Conflict(format!(
                     "catalog object already exists: table {}/{}/{}",
                     entry.table_bucket, entry.namespace, entry.table
@@ -3929,6 +4200,7 @@ where
                     .namespaces
                     .insert(namespace_key, synthetic_namespace_entry(&entry.table_bucket, &namespace));
             }
+            draft_state.views.remove(&key);
             draft_state.tables.insert(key, entry);
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition)
         };
@@ -4071,7 +4343,15 @@ where
                     destination_namespace.public_name()
                 )));
             }
-            if state.tables.contains_key(&destination_key) || state.views.contains_key(&destination_key) {
+            if state
+                .tables
+                .get(&destination_key)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+                || state
+                    .views
+                    .get(&destination_key)
+                    .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
                 return Err(TableCatalogStoreError::AlreadyExists(format!(
                     "destination table already exists: {table_bucket}/{}/{}",
                     destination_namespace.public_name(),
@@ -4116,7 +4396,9 @@ where
             return Ok(None);
         };
         if bucket_entry.state != TableCatalogEntryState::Active {
-            return Ok(None);
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "table bucket {table_bucket} catalog entry is not active"
+            )));
         }
 
         let Some(bucket_index) = state.warehouse_index.get(table_bucket) else {
@@ -4138,45 +4420,106 @@ where
     }
 
     async fn commit_table(&self, request: TableCommitRequest) -> TableCatalogStoreResult<TableCommitResult> {
-        let _write_guard = self.write_lock.lock().await;
-        self.hydrate_state().await?;
         let commit_started = Instant::now();
         record_table_commit_attempt(&request.operation);
         let namespace = parse_namespace_for_store(&request.namespace)?;
         let table = parse_table_for_store(&request.table)?;
         let key = Self::table_key(&request.table_bucket, &namespace, &table);
-
-        let committed_existing_result = {
-            let state = self.state.lock().await;
-            let current = Self::validate_new_table_commit_locked(&state, &key, &request);
-            match current {
-                Ok(current) => {
-                    let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
-                    Self::committed_existing_result_locked(&mut draft_state, &request, current).map(|result| {
+        let current = {
+            let _write_guard = self.write_lock.lock().await;
+            self.hydrate_state().await?;
+            let (current, committed_existing_result, existing_commit) = {
+                let state = self.state.lock().await;
+                let current = match Self::validate_new_table_commit_locked(&state, &key, &request) {
+                    Ok(current) => current,
+                    Err(error) => {
+                        return table_commit_result(
+                            &request.table_bucket,
+                            &request.namespace,
+                            &request.table,
+                            &request.commit_id,
+                            &request.operation,
+                            commit_started,
+                            Err(error),
+                        );
+                    }
+                };
+                let existing_commit = state
+                    .commits
+                    .get(&Self::commit_key(&request.table_bucket, &current.table_id, &request.commit_id))
+                    .cloned();
+                let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
+                let committed =
+                    Self::committed_existing_result_locked(&mut draft_state, &request, current.clone()).map(|result| {
                         Self::snapshot_from_mutated_state_locked(&mut draft_state)
                             .map(|snapshot| (result, snapshot, precondition))
-                    })
-                }
-                Err(error) => {
-                    return table_commit_result(
-                        &request.table_bucket,
-                        &request.namespace,
-                        &request.table,
-                        &request.commit_id,
-                        &request.operation,
-                        commit_started,
-                        Err(error),
-                    );
-                }
-            }
-        };
-        if let Some(prepared_result) = committed_existing_result {
-            let result = match prepared_result {
-                Ok((result, snapshot, precondition)) => {
-                    self.finalize_snapshot_write(snapshot, precondition).await.map(|_| result)
-                }
-                Err(err) => Err(err),
+                    });
+                (current, committed, existing_commit)
             };
+            let requested_integrity = table_commit_integrity_entry(&request, &current.table_id)?;
+            let integrity_path = TableCatalogObjectPaths::default().commit_integrity_entry_path(
+                &request.table_bucket,
+                &current.table_id,
+                &request.commit_id,
+            );
+            let persisted_integrity = self.read_commit_integrity_entry(&integrity_path).await?;
+            if let Some(persisted_integrity) = persisted_integrity.as_ref() {
+                validate_table_commit_integrity_identity(
+                    persisted_integrity,
+                    &request.table_bucket,
+                    &current.table_id,
+                    &request.commit_id,
+                )?;
+            }
+            let legacy_integrity = existing_commit
+                .as_ref()
+                .map(|commit| {
+                    table_commit_integrity_entry_from_requirements(
+                        &request.table_bucket,
+                        &current.table_id,
+                        &request.commit_id,
+                        &commit.requirements,
+                    )
+                })
+                .transpose()?
+                .flatten();
+            if let Err(error) = validate_table_commit_integrity_replay(
+                requested_integrity.as_ref(),
+                persisted_integrity.as_ref(),
+                legacy_integrity.as_ref(),
+                committed_existing_result.is_some(),
+            ) {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(error),
+                );
+            }
+            if let Some(prepared_result) = committed_existing_result {
+                let result = match prepared_result {
+                    Ok((result, snapshot, precondition)) => {
+                        self.finalize_snapshot_write(snapshot, precondition).await.map(|_| result)
+                    }
+                    Err(err) => Err(err),
+                };
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    result,
+                );
+            }
+            current
+        };
+
+        if request.new_metadata_location == current.metadata_location {
             return table_commit_result(
                 &request.table_bucket,
                 &request.namespace,
@@ -4184,11 +4527,41 @@ where
                 &request.commit_id,
                 &request.operation,
                 commit_started,
-                result,
+                Err(TableCatalogStoreError::Invalid(
+                    "new metadata location must differ from the current metadata location".to_string(),
+                )),
             );
         }
-
-        let _metadata_guard = self
+        let current_metadata_guard =
+            if table_commit_metadata_digest(&request, TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE, "base")?.is_some() {
+                let guard = self
+                    .object_backend
+                    .acquire_read_lock(&request.table_bucket, &current.metadata_location)
+                    .await?;
+                let Some(current_metadata_object) = self
+                    .object_backend
+                    .read_object_unlocked_limited(&request.table_bucket, &current.metadata_location, TABLE_METADATA_JSON_MAX_SIZE)
+                    .await?
+                else {
+                    return table_commit_result(
+                        &request.table_bucket,
+                        &request.namespace,
+                        &request.table,
+                        &request.commit_id,
+                        &request.operation,
+                        commit_started,
+                        Err(TableCatalogStoreError::NotFound(format!(
+                            "current metadata object {}",
+                            current.metadata_location
+                        ))),
+                    );
+                };
+                validate_commit_base_metadata_digest(&request, &current_metadata_object)?;
+                Some(guard)
+            } else {
+                None
+            };
+        let metadata_guard = self
             .object_backend
             .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
             .await?;
@@ -4213,7 +4586,19 @@ where
         validate_commit_metadata_digest(&request, &new_metadata_object)?;
         let next_warehouse_location =
             table_metadata_warehouse_location(&request.table_bucket, &request.new_metadata_location, &new_metadata_object)?;
+        let requested_integrity = table_commit_integrity_entry(&request, &current.table_id)?;
+        let integrity_path = TableCatalogObjectPaths::default().commit_integrity_entry_path(
+            &request.table_bucket,
+            &current.table_id,
+            &request.commit_id,
+        );
+        if let Some(integrity) = requested_integrity.as_ref() {
+            let integrity_guard = self.stage_commit_integrity_entry(&integrity_path, integrity).await?;
+            ensure_table_catalog_lock_held(integrity_guard.as_ref())?;
+        }
 
+        let _write_guard = self.write_lock.lock().await;
+        self.hydrate_state().await?;
         let cas_started = Instant::now();
         let prepared_result = {
             let state = self.state.lock().await;
@@ -4226,7 +4611,13 @@ where
             }
         };
         let result = match prepared_result {
-            Ok((result, snapshot, precondition)) => self.finalize_snapshot_write(snapshot, precondition).await.map(|_| result),
+            Ok((result, snapshot, precondition)) => {
+                if let Some(current_metadata_guard) = current_metadata_guard.as_deref() {
+                    ensure_table_catalog_lock_held(current_metadata_guard)?;
+                }
+                ensure_table_catalog_lock_held(metadata_guard.as_ref())?;
+                self.finalize_snapshot_write(snapshot, precondition).await.map(|_| result)
+            }
             Err(err) => Err(err),
         };
         let cas_result = result.as_ref().map(|_| ()).map_err(Clone::clone);
@@ -4302,7 +4693,15 @@ where
                     entry.table_bucket, entry.namespace
                 )));
             }
-            if state.views.contains_key(&key) || state.tables.contains_key(&key) {
+            if state
+                .views
+                .get(&key)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+                || state
+                    .tables
+                    .get(&key)
+                    .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
                 return Err(TableCatalogStoreError::Conflict(format!(
                     "catalog object already exists: view {}/{}/{}",
                     entry.table_bucket, entry.namespace, entry.view
@@ -4314,6 +4713,7 @@ where
                     .namespaces
                     .insert(namespace_key, synthetic_namespace_entry(&entry.table_bucket, &namespace));
             }
+            draft_state.tables.remove(&key);
             draft_state.views.insert(key, entry);
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition)
         };
@@ -4469,7 +4869,7 @@ where
                 next.warehouse_location = warehouse_location;
             }
             next.version_token = format!("token-{}", Uuid::new_v4());
-            next.generation = next.generation.saturating_add(1);
+            next.generation = next_table_catalog_generation(next.generation)?;
             let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
             draft_state.views.insert(key, next.clone());
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition, next)
@@ -4545,17 +4945,19 @@ where
         RUSTFS_META_BUCKET
     }
 
-    async fn list_entry_page<T, P>(
+    async fn list_entry_page<T, P, V>(
         &self,
         prefix: &str,
         entry_file: &str,
         cursor: Option<&str>,
         limit: NonZeroUsize,
         include: P,
+        validate: V,
     ) -> TableCatalogStoreResult<TableCatalogListPage<T>>
     where
         T: DeserializeOwned,
         P: Fn(&T) -> bool,
+        V: Fn(&str, &T) -> TableCatalogStoreResult<()>,
     {
         let cursor = catalog_list_cursor(cursor, OBJECT_CATALOG_LIST_CURSOR_PREFIX)?;
         if cursor.is_some_and(|cursor| !cursor.starts_with(prefix)) {
@@ -4590,6 +4992,7 @@ where
             let Some((entry, _)) = self.read_entry::<T>(self.catalog_bucket(), &object).await? else {
                 continue;
             };
+            validate(&object, &entry)?;
             if !include(&entry) {
                 continue;
             }
@@ -4622,11 +5025,11 @@ where
             if object == namespace_path || !object.ends_with(NAMESPACE_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await?
-                && entry.state == TableCatalogEntryState::Active
-                && namespace_is_descendant(&entry.namespace, &parent)
-            {
-                return Ok(true);
+            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await? {
+                validate_namespace_entry_object(&self.paths, &object, &entry)?;
+                if entry.state == TableCatalogEntryState::Active && namespace_is_descendant(&entry.namespace, &parent) {
+                    return Ok(true);
+                }
             }
         }
         Ok(false)
@@ -4689,6 +5092,7 @@ where
             let Some((existing, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &object).await? else {
                 continue;
             };
+            validate_table_entry_object(&self.paths, &object, &existing)?;
             if existing.state == TableCatalogEntryState::Active
                 && table_metadata_dir_path_for_entry(&existing).is_ok_and(|root| root == candidate_metadata_root)
             {
@@ -4867,6 +5271,7 @@ where
                         "table changed while preparing durable strong snapshot: {table_object}"
                     )));
                 };
+                validate_table_entry_object(&self.paths, table_object, &table_entry)?;
                 if table_entry.table_bucket != table_bucket || table_entry.namespace != namespace_entry.namespace {
                     return Err(TableCatalogStoreError::Invalid(format!(
                         "table {} does not match its catalog namespace",
@@ -4951,6 +5356,7 @@ where
                         "view changed while preparing durable strong snapshot: {view_object}"
                     )));
                 };
+                validate_view_entry_object(&self.paths, view_object, &view_entry)?;
                 if view_entry.table_bucket != table_bucket || view_entry.namespace != namespace_entry.namespace {
                     return Err(TableCatalogStoreError::Invalid(format!(
                         "view {} does not match its catalog namespace",
@@ -5227,6 +5633,7 @@ where
         else {
             return Ok(false);
         };
+        validate_table_entry_object(&self.paths, &table_path, &table)?;
         if table.state != TableCatalogEntryState::Active {
             return Ok(false);
         }
@@ -5350,18 +5757,6 @@ where
         }
     }
 
-    async fn delete_stale_table_warehouse_index(
-        &self,
-        object: &str,
-        index: &TableWarehouseIndexEntry,
-        reason: &'static str,
-    ) -> TableCatalogStoreResult<()> {
-        self.delete_warehouse_index_object(object, index, reason)
-            .await
-            .map(|_| ())
-            .map_err(|err| TableCatalogStoreError::Internal(format!("failed to delete stale warehouse index {object}: {err}")))
-    }
-
     async fn fail_closed_for_broken_warehouse_index(
         &self,
         object: &str,
@@ -5387,18 +5782,13 @@ where
                 .fail_closed_for_broken_warehouse_index(index_object, &index, "referenced table entry is missing")
                 .await;
         };
-        if table.state != TableCatalogEntryState::Active {
-            self.delete_stale_table_warehouse_index(index_object, &index, "referenced table is inactive")
-                .await?;
-            return Ok(None);
-        }
         let current_prefix = table_warehouse_object_prefix(&table).map_err(|err| {
             TableCatalogStoreError::Invalid(format!("warehouse index table entry has invalid location {index_object}: {err}"))
         })?;
         if current_prefix != index.warehouse_object_prefix {
-            self.delete_stale_table_warehouse_index(index_object, &index, "referenced table moved warehouse prefix")
-                .await?;
-            return Ok(None);
+            return self
+                .fail_closed_for_broken_warehouse_index(index_object, &index, "referenced table has a different warehouse prefix")
+                .await;
         }
         if table.table_id != index.table_id {
             return self
@@ -5513,39 +5903,6 @@ where
         Ok(None)
     }
 
-    async fn ensure_table_maintenance_object_owner(&self, entry: &TableEntry, object: &str) -> TableCatalogStoreResult<()> {
-        let warehouse_object_prefix = table_warehouse_object_prefix(entry)?;
-        if !object.starts_with(&warehouse_object_prefix) {
-            return Ok(());
-        }
-        for candidate_prefix in warehouse_index_candidate_prefixes(object) {
-            let index_object = self.paths.warehouse_index_entry_path(&entry.table_bucket, candidate_prefix);
-            let Some((index, _)) = self
-                .read_entry::<TableWarehouseIndexEntry>(self.catalog_bucket(), &index_object)
-                .await?
-            else {
-                continue;
-            };
-            if index.table_bucket != entry.table_bucket || index.warehouse_object_prefix != candidate_prefix {
-                return Err(TableCatalogStoreError::Invalid(format!(
-                    "warehouse index entry does not match indexed prefix: {index_object}"
-                )));
-            }
-            if index.state != TableCatalogEntryState::Active {
-                continue;
-            }
-            if index.table_id != entry.table_id {
-                return Err(TableCatalogStoreError::Conflict(format!(
-                    "maintenance object {object} is owned by another active table"
-                )));
-            }
-            return Ok(());
-        }
-        Err(TableCatalogStoreError::Internal(format!(
-            "maintenance object {object} has no active warehouse index owner"
-        )))
-    }
-
     async fn ensure_table_warehouse_index_owner(&self, entry: &TableEntry) -> TableCatalogStoreResult<()> {
         let expected = table_warehouse_index_entry(entry)?;
         let object = self
@@ -5641,6 +5998,7 @@ where
         let Some((entry, etag)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
             return Ok(None);
         };
+        validate_table_entry_object(&self.paths, &table_path, &entry)?;
         let Some(etag) = etag else {
             return Err(TableCatalogStoreError::Internal(format!("catalog table entry has no etag: {table_path}")));
         };
@@ -5660,6 +6018,7 @@ where
         else {
             return Ok(None);
         };
+        validate_table_entry_object(&self.paths, &table_path, &entry)?;
         let Some(etag) = etag else {
             return Err(TableCatalogStoreError::Internal(format!("catalog table entry has no etag: {table_path}")));
         };
@@ -5679,10 +6038,43 @@ where
         else {
             return Ok(None);
         };
+        validate_view_entry_object(&self.paths, &view_path, &entry)?;
         let Some(etag) = etag else {
             return Err(TableCatalogStoreError::Internal(format!("catalog view entry has no etag: {view_path}")));
         };
         Ok(Some((entry, etag)))
+    }
+
+    async fn rollback_materialized_namespace(
+        &self,
+        table_bucket: &str,
+        namespace: &Namespace,
+        namespace_path: &str,
+        namespace_guard: &dyn TableCatalogObjectLockGuard,
+    ) {
+        let result: TableCatalogStoreResult<()> = async {
+            ensure_table_catalog_lock_held(namespace_guard)?;
+            let expected = synthetic_namespace_entry(table_bucket, namespace);
+            let current = self
+                .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), namespace_path)
+                .await?
+                .map(|(entry, _)| entry);
+            if current.as_ref() == Some(&expected) {
+                self.backend
+                    .delete_object_unlocked(self.catalog_bucket(), namespace_path)
+                    .await?;
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(err) = result {
+            tracing::warn!(
+                table_bucket = %table_bucket,
+                namespace = %namespace.public_name(),
+                error = %err,
+                "failed to roll back a materialized table catalog namespace"
+            );
+        }
     }
 
     async fn write_table_entry(
@@ -5690,17 +6082,11 @@ where
         entry: TableEntry,
         precondition: TableCatalogPutPrecondition,
     ) -> TableCatalogStoreResult<()> {
-        validate_catalog_entry_version("table", entry.version)?;
         self.require_table_bucket(&entry.table_bucket).await?;
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let table = parse_table_for_store(&entry.table)?;
-        validate_table_warehouse_location(&entry.table_bucket, &entry.warehouse_location)?;
-        if !is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
-            return Err(TableCatalogStoreError::Invalid(
-                "object-backed table metadata location must be inside a protected table metadata directory".to_string(),
-            ));
-        }
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
+        validate_table_entry_identity(&entry, &entry.table_bucket, &namespace, &table)?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
         let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&entry.table_bucket);
         let ownership_guard = self
             .backend
@@ -5709,7 +6095,7 @@ where
         self.backfill_table_warehouse_index_ownership_locked(&entry.table_bucket, ownership_guard.as_ref())
             .await?;
         let namespace_path = self.paths.namespace_entry_path(&entry.table_bucket, &namespace);
-        let _namespace_guard = self
+        let namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
@@ -5725,24 +6111,40 @@ where
                 entry.table_bucket, entry.namespace
             )));
         }
+        let table_path = self.paths.table_entry_path(&entry.table_bucket, &namespace, &table);
+        let table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
         let view_path = self.paths.view_entry_path(&entry.table_bucket, &namespace, &table);
+        let view_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &view_path).await?;
         if self
             .read_entry_unlocked::<ViewEntry>(self.catalog_bucket(), &view_path)
             .await?
-            .is_some()
+            .is_some_and(|(entry, _)| entry.state == TableCatalogEntryState::Active)
         {
             return Err(TableCatalogStoreError::Conflict(format!(
                 "catalog object already exists: view {}/{}/{}",
                 entry.table_bucket, entry.namespace, entry.table
             )));
         }
-        let table_path = self.paths.table_entry_path(&entry.table_bucket, &namespace, &table);
-        let _table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
+        let precondition = match self
+            .read_table_with_etag_unlocked(&entry.table_bucket, &namespace, &table)
+            .await?
+        {
+            Some((current, _)) if current.state == TableCatalogEntryState::Active => {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "catalog object already exists: table {}/{}/{}",
+                    entry.table_bucket, entry.namespace, entry.table
+                )));
+            }
+            Some(_) => TableCatalogPutPrecondition::Any,
+            None => precondition,
+        };
         self.ensure_table_warehouse_prefix_available(&entry).await?;
         ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
         let reservation = self.reserve_table_warehouse_index(&entry).await?;
         let result = async {
             if materialize_namespace {
+                ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+                ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
                 self.write_entry_unlocked(
                     self.catalog_bucket(),
                     &namespace_path,
@@ -5751,32 +6153,48 @@ where
                 )
                 .await?;
             }
+            ensure_table_catalog_lock_held(migration_guard.as_ref())?;
             ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
+            ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+            ensure_table_catalog_lock_held(table_guard.as_ref())?;
+            ensure_table_catalog_lock_held(view_guard.as_ref())?;
             self.write_entry_unlocked(self.catalog_bucket(), &table_path, &entry, precondition)
                 .await
         }
         .await;
         if result.is_err() {
+            if materialize_namespace {
+                self.rollback_materialized_namespace(&entry.table_bucket, &namespace, &namespace_path, namespace_guard.as_ref())
+                    .await;
+            }
             self.delete_created_table_warehouse_index(&entry, reservation, "table entry write failed")
                 .await;
         }
         result
     }
 
+    async fn write_table_entry_cancellation_safe(&self, entry: TableEntry) -> TableCatalogStoreResult<()> {
+        let permit = TABLE_CATALOG_CREATE_TASK_ADMISSION
+            .acquire()
+            .await
+            .map_err(|_| TableCatalogStoreError::Internal("table catalog create admission is closed".to_string()))?;
+        let store = self.clone();
+        tokio::spawn(async move {
+            let _permit = permit;
+            store.write_table_entry(entry, TableCatalogPutPrecondition::IfAbsent).await
+        })
+        .await
+        .map_err(|err| TableCatalogStoreError::Internal(format!("table catalog create task failed: {err}")))?
+    }
+
     async fn write_view_entry(&self, entry: ViewEntry, precondition: TableCatalogPutPrecondition) -> TableCatalogStoreResult<()> {
-        validate_catalog_entry_version("view", entry.version)?;
         self.require_table_bucket(&entry.table_bucket).await?;
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let view = parse_table_for_store(&entry.view)?;
-        validate_view_warehouse_location(&entry.table_bucket, &entry.warehouse_location)?;
-        if !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location) {
-            return Err(TableCatalogStoreError::Invalid(
-                "object-backed view metadata location must match the view identifier".to_string(),
-            ));
-        }
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
+        validate_view_entry_identity(&entry, &entry.table_bucket, &namespace, &view)?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
         let namespace_path = self.paths.namespace_entry_path(&entry.table_bucket, &namespace);
-        let _namespace_guard = self
+        let namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
@@ -5793,29 +6211,71 @@ where
             )));
         }
         let table_path = self.paths.table_entry_path(&entry.table_bucket, &namespace, &view);
+        let table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
+        let view_path = self.paths.view_entry_path(&entry.table_bucket, &namespace, &view);
+        let view_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &view_path).await?;
         if self
             .read_entry_unlocked::<TableEntry>(self.catalog_bucket(), &table_path)
             .await?
-            .is_some()
+            .is_some_and(|(entry, _)| entry.state == TableCatalogEntryState::Active)
         {
             return Err(TableCatalogStoreError::Conflict(format!(
                 "catalog object already exists: table {}/{}/{}",
                 entry.table_bucket, entry.namespace, entry.view
             )));
         }
-        let view_path = self.paths.view_entry_path(&entry.table_bucket, &namespace, &view);
-        let _view_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &view_path).await?;
-        if materialize_namespace {
-            self.write_entry_unlocked(
-                self.catalog_bucket(),
-                &namespace_path,
-                &synthetic_namespace_entry(&entry.table_bucket, &namespace),
-                TableCatalogPutPrecondition::Any,
-            )
-            .await?;
+        let precondition = match self
+            .read_view_with_etag_unlocked(&entry.table_bucket, &namespace, &view)
+            .await?
+        {
+            Some((current, _)) if current.state == TableCatalogEntryState::Active => {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "catalog object already exists: view {}/{}/{}",
+                    entry.table_bucket, entry.namespace, entry.view
+                )));
+            }
+            Some(_) => TableCatalogPutPrecondition::Any,
+            None => precondition,
+        };
+        let result = async {
+            if materialize_namespace {
+                ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+                ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+                self.write_entry_unlocked(
+                    self.catalog_bucket(),
+                    &namespace_path,
+                    &synthetic_namespace_entry(&entry.table_bucket, &namespace),
+                    TableCatalogPutPrecondition::Any,
+                )
+                .await?;
+            }
+            ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+            ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+            ensure_table_catalog_lock_held(table_guard.as_ref())?;
+            ensure_table_catalog_lock_held(view_guard.as_ref())?;
+            self.write_entry_unlocked(self.catalog_bucket(), &view_path, &entry, precondition)
+                .await
         }
-        self.write_entry_unlocked(self.catalog_bucket(), &view_path, &entry, precondition)
+        .await;
+        if result.is_err() && materialize_namespace {
+            self.rollback_materialized_namespace(&entry.table_bucket, &namespace, &namespace_path, namespace_guard.as_ref())
+                .await;
+        }
+        result
+    }
+
+    async fn write_view_entry_cancellation_safe(&self, entry: ViewEntry) -> TableCatalogStoreResult<()> {
+        let permit = TABLE_CATALOG_CREATE_TASK_ADMISSION
+            .acquire()
             .await
+            .map_err(|_| TableCatalogStoreError::Internal("table catalog create admission is closed".to_string()))?;
+        let store = self.clone();
+        tokio::spawn(async move {
+            let _permit = permit;
+            store.write_view_entry(entry, TableCatalogPutPrecondition::IfAbsent).await
+        })
+        .await
+        .map_err(|err| TableCatalogStoreError::Internal(format!("table catalog view create task failed: {err}")))?
     }
 
     pub(crate) async fn get_external_catalog_bridge(
@@ -5834,31 +6294,139 @@ where
                 namespace.public_name()
             )));
         }
+        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
+        let table_guard = self.backend.acquire_read_lock(self.catalog_bucket(), &table_path).await?;
+        let current = self
+            .read_table_with_etag_unlocked(table_bucket, &namespace, &table)
+            .await?
+            .map(|(entry, _)| entry)
+            .filter(|entry| entry.state == TableCatalogEntryState::Active)
+            .ok_or_else(|| {
+                TableCatalogStoreError::TableNotFound(format!(
+                    "table {}/{}/{}",
+                    table_bucket,
+                    namespace.public_name(),
+                    table.as_str()
+                ))
+            })?;
         let bridge_path = self.paths.external_catalog_bridge_path(table_bucket, &namespace, &table);
-        self.read_entry::<ExternalCatalogBridgeEntry>(self.catalog_bucket(), &bridge_path)
-            .await
-            .map(|entry| entry.map(|(bridge, _)| bridge))
+        let bridge_guard = self.backend.acquire_read_lock(self.catalog_bucket(), &bridge_path).await?;
+        let bridge = self
+            .read_entry_unlocked::<ExternalCatalogBridgeEntry>(self.catalog_bucket(), &bridge_path)
+            .await?
+            .map(|(bridge, _)| bridge);
+        let Some(mut bridge) = bridge else {
+            return Ok(None);
+        };
+        let identity_path = self
+            .paths
+            .external_catalog_bridge_identity_path(table_bucket, &namespace, &table);
+        let identity_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &identity_path).await?;
+        let identity = self
+            .read_entry_unlocked::<ExternalCatalogBridgeIdentityEntry>(self.catalog_bucket(), &identity_path)
+            .await?
+            .map(|(identity, _)| identity);
+        let identity = match identity {
+            Some(identity) => identity,
+            None => {
+                let identity = ExternalCatalogBridgeIdentityEntry {
+                    version: TABLE_EXTERNAL_CATALOG_BRIDGE_VERSION,
+                    table_bucket: table_bucket.to_string(),
+                    namespace: namespace.public_name(),
+                    table: table.as_str().to_string(),
+                    table_id: current.table_id.clone(),
+                };
+                ensure_table_catalog_lock_held(table_guard.as_ref())?;
+                ensure_table_catalog_lock_held(bridge_guard.as_ref())?;
+                ensure_table_catalog_lock_held(identity_guard.as_ref())?;
+                self.write_entry_unlocked(
+                    self.catalog_bucket(),
+                    &identity_path,
+                    &identity,
+                    TableCatalogPutPrecondition::IfAbsent,
+                )
+                .await?;
+                identity
+            }
+        };
+        if bridge.version != TABLE_EXTERNAL_CATALOG_BRIDGE_VERSION
+            || bridge.table_bucket != table_bucket
+            || bridge.namespace != namespace.public_name()
+            || bridge.table != table.as_str()
+            || identity.version != TABLE_EXTERNAL_CATALOG_BRIDGE_VERSION
+            || identity.table_bucket != table_bucket
+            || identity.namespace != namespace.public_name()
+            || identity.table != table.as_str()
+            || identity.table_id != current.table_id
+        {
+            return Err(TableCatalogStoreError::Invalid(
+                "external catalog bridge identity does not match the active table".to_string(),
+            ));
+        }
+        ensure_table_catalog_lock_held(table_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bridge_guard.as_ref())?;
+        ensure_table_catalog_lock_held(identity_guard.as_ref())?;
+        bridge.table_id = current.table_id;
+        Ok(Some(bridge))
     }
 
     pub(crate) async fn put_external_catalog_bridge(
         &self,
-        entry: ExternalCatalogBridgeEntry,
+        mut entry: ExternalCatalogBridgeEntry,
     ) -> TableCatalogStoreResult<ExternalCatalogBridgeEntry> {
         validate_catalog_entry_version("external catalog bridge", entry.version)?;
         self.require_table_bucket(&entry.table_bucket).await?;
-        self.ensure_object_backed_writes_allowed(&entry.table_bucket).await?;
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let table = parse_table_for_store(&entry.table)?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
         if self.get_namespace(&entry.table_bucket, &entry.namespace).await?.is_none() {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "namespace {}/{}",
                 entry.table_bucket, entry.namespace
             )));
         }
+        let table_path = self.paths.table_entry_path(&entry.table_bucket, &namespace, &table);
+        let table_guard = self.backend.acquire_read_lock(self.catalog_bucket(), &table_path).await?;
+        let current = self
+            .read_table_with_etag_unlocked(&entry.table_bucket, &namespace, &table)
+            .await?
+            .map(|(entry, _)| entry)
+            .filter(|entry| entry.state == TableCatalogEntryState::Active)
+            .ok_or_else(|| {
+                TableCatalogStoreError::TableNotFound(format!("table {}/{}/{}", entry.table_bucket, entry.namespace, entry.table))
+            })?;
+        if !entry.table_id.is_empty() && entry.table_id != current.table_id {
+            return Err(TableCatalogStoreError::Conflict(
+                "external catalog bridge targets a different table identity".to_string(),
+            ));
+        }
+        entry.table_id = current.table_id;
         let bridge_path = self
             .paths
             .external_catalog_bridge_path(&entry.table_bucket, &namespace, &table);
-        self.write_entry(self.catalog_bucket(), &bridge_path, &entry, TableCatalogPutPrecondition::Any)
+        let identity_path = self
+            .paths
+            .external_catalog_bridge_identity_path(&entry.table_bucket, &namespace, &table);
+        let bridge_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &bridge_path).await?;
+        let identity_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &identity_path).await?;
+        let identity = ExternalCatalogBridgeIdentityEntry {
+            version: TABLE_EXTERNAL_CATALOG_BRIDGE_VERSION,
+            table_bucket: entry.table_bucket.clone(),
+            namespace: entry.namespace.clone(),
+            table: entry.table.clone(),
+            table_id: entry.table_id.clone(),
+        };
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(table_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bridge_guard.as_ref())?;
+        ensure_table_catalog_lock_held(identity_guard.as_ref())?;
+        self.write_entry_unlocked(self.catalog_bucket(), &bridge_path, &entry, TableCatalogPutPrecondition::Any)
+            .await?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(table_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bridge_guard.as_ref())?;
+        ensure_table_catalog_lock_held(identity_guard.as_ref())?;
+        self.write_entry_unlocked(self.catalog_bucket(), &identity_path, &identity, TableCatalogPutPrecondition::Any)
             .await?;
         Ok(entry)
     }
@@ -5953,8 +6521,7 @@ where
     ) -> TableCatalogStoreResult<TableCommitRecoveryReport> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -5973,9 +6540,9 @@ where
     ) -> TableCatalogStoreResult<TableCommitRecoveryReport> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
         let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
+        let table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
         let Some((entry, _)) = self.read_table_with_etag_unlocked(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
@@ -6007,6 +6574,8 @@ where
                 recovery_entry.recovery_state,
                 TableCommitRecoveryState::FinalizationRequired | TableCommitRecoveryState::IdempotencyIndexRepairRequired
             ) {
+                ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+                ensure_table_catalog_lock_held(table_guard.as_ref())?;
                 let mut committed = commit_log;
                 committed.status = CommitLogStatus::Committed;
                 self.finalize_commit_log(&commit_path, idempotency_path.as_deref(), &committed)
@@ -6026,8 +6595,7 @@ where
     ) -> TableCatalogStoreResult<TableMaintenanceConfig> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -6070,8 +6638,7 @@ where
     ) -> TableCatalogStoreResult<TableMaintenanceEffectiveConfig> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -6134,8 +6701,7 @@ where
         self.ensure_object_backed_writes_allowed(table_bucket).await?;
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -6156,6 +6722,21 @@ where
         &self,
         report: &TableMetadataMaintenanceReport,
     ) -> TableCatalogStoreResult<()> {
+        self.persist_table_metadata_maintenance_report(report, false).await
+    }
+
+    async fn put_table_metadata_maintenance_worker_report(
+        &self,
+        report: &TableMetadataMaintenanceReport,
+    ) -> TableCatalogStoreResult<()> {
+        self.persist_table_metadata_maintenance_report(report, true).await
+    }
+
+    async fn persist_table_metadata_maintenance_report(
+        &self,
+        report: &TableMetadataMaintenanceReport,
+        require_current_worker: bool,
+    ) -> TableCatalogStoreResult<()> {
         let report = table_maintenance_report_with_recommended_actions(report.clone());
         self.ensure_object_backed_writes_allowed(&report.job.table_bucket).await?;
         let namespace = parse_namespace_for_store(&report.job.namespace)?;
@@ -6173,11 +6754,44 @@ where
         let current_job_path =
             self.paths
                 .table_maintenance_current_job_path(&report.job.table_bucket, &namespace, &table, &report.job.table_id);
-        self.write_entry(self.catalog_bucket(), &job_path, &report, TableCatalogPutPrecondition::Any)
+        let current_job_guard = self
+            .backend
+            .acquire_write_lock(self.catalog_bucket(), &current_job_path)
             .await?;
-        self.write_entry(self.catalog_bucket(), &latest_job_path, &report, TableCatalogPutPrecondition::Any)
+        if require_current_worker {
+            let current = self
+                .read_entry_unlocked::<TableMetadataMaintenanceReport>(self.catalog_bucket(), &current_job_path)
+                .await?
+                .map(|(current, _)| current)
+                .ok_or_else(|| TableCatalogStoreError::Conflict("maintenance job is no longer current".to_string()))?;
+            ensure_current_maintenance_worker(&current.job, &report.job)?;
+        }
+        self.write_table_metadata_maintenance_report_locked(
+            &report,
+            &job_path,
+            &latest_job_path,
+            &current_job_path,
+            current_job_guard.as_ref(),
+        )
+        .await
+    }
+
+    async fn write_table_metadata_maintenance_report_locked(
+        &self,
+        report: &TableMetadataMaintenanceReport,
+        job_path: &str,
+        latest_job_path: &str,
+        current_job_path: &str,
+        current_job_guard: &dyn TableCatalogObjectLockGuard,
+    ) -> TableCatalogStoreResult<()> {
+        ensure_table_catalog_lock_held(current_job_guard)?;
+        self.write_entry(self.catalog_bucket(), job_path, report, TableCatalogPutPrecondition::Any)
             .await?;
-        self.write_entry(self.catalog_bucket(), &current_job_path, &report, TableCatalogPutPrecondition::Any)
+        ensure_table_catalog_lock_held(current_job_guard)?;
+        self.write_entry(self.catalog_bucket(), latest_job_path, report, TableCatalogPutPrecondition::Any)
+            .await?;
+        ensure_table_catalog_lock_held(current_job_guard)?;
+        self.write_entry_unlocked(self.catalog_bucket(), current_job_path, report, TableCatalogPutPrecondition::Any)
             .await
     }
 
@@ -6190,8 +6804,7 @@ where
     ) -> TableCatalogStoreResult<Option<TableMetadataMaintenanceReport>> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -6260,8 +6873,7 @@ where
     ) -> TableCatalogStoreResult<TableMaintenanceSchedulerReport> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -6931,6 +7543,28 @@ where
             .await?
         {
             if matches!(current.job.status, TableMetadataMaintenanceJobStatus::Running) {
+                if let Some(persisted) = self
+                    .get_table_metadata_maintenance_report_for_entry_unlocked(
+                        context.table_bucket,
+                        context.namespace,
+                        context.table,
+                        &context.entry.table_id,
+                        &current.job.job_id,
+                    )
+                    .await?
+                    .filter(|persisted| {
+                        matches!(
+                            persisted.job.status,
+                            TableMetadataMaintenanceJobStatus::Successful
+                                | TableMetadataMaintenanceJobStatus::Failed
+                                | TableMetadataMaintenanceJobStatus::Disabled
+                                | TableMetadataMaintenanceJobStatus::Paused
+                        )
+                    })
+                {
+                    self.put_table_metadata_maintenance_report(&persisted).await?;
+                    return Ok(TableMaintenanceWorkerPreflight::Complete(Box::new(persisted)));
+                }
                 if table_maintenance_job_lease_is_active(&current.job, effective.config.worker_lease_timeout_seconds, now) {
                     return Ok(TableMaintenanceWorkerPreflight::Complete(Box::new(current)));
                 }
@@ -7243,8 +7877,7 @@ where
         validate_table_snapshot_expiration_config(&config)?;
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -7296,8 +7929,7 @@ where
         validate_table_compaction_planning_config(&config)?;
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -7341,8 +7973,7 @@ where
         validate_table_compaction_planning_config(&config)?;
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -7395,8 +8026,8 @@ where
             .collect::<Vec<_>>();
 
         let now = OffsetDateTime::now_utc();
-        let snapshot_id = compaction_snapshot_id(&current_metadata, &entry, now);
-        let sequence_number = next_compaction_sequence_number(&current_metadata);
+        let snapshot_id = compaction_snapshot_id(&current_metadata, &entry, now)?;
+        let sequence_number = next_compaction_sequence_number(&current_metadata)?;
         let metadata_dir = table_metadata_dir_path_for_entry(&entry)?;
         let warehouse_object_prefix = table_warehouse_object_prefix(&entry)?;
         let compaction_id = Uuid::new_v4().to_string();
@@ -7544,10 +8175,8 @@ where
                 namespace.public_name()
             )));
         };
-        let Some((table_entry, _)) = self
-            .read_entry::<TableEntry>(self.catalog_bucket(), &self.paths.table_entry_path(table_bucket, &namespace, &table))
-            .await?
-        else {
+        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
+        let Some((table_entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -7555,6 +8184,7 @@ where
                 table.as_str()
             )));
         };
+        validate_table_entry_object_identity(&self.paths, &table_path, &table_entry)?;
         let commit_recovery = self.table_commit_recovery_report_for_entry(&table_entry, 0).await?;
         let backing_manifest = table_catalog_backing_manifest(&self.paths, &namespace, &table, &table_entry, &commit_recovery);
 
@@ -7724,11 +8354,11 @@ where
             }
         }
 
-        let _global_fence_guard = self
+        let global_fence_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &global_fence_lock_path)
             .await?;
-        let _fence_guard = self
+        let fence_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &fence_lock_path)
             .await?;
@@ -7762,6 +8392,9 @@ where
             )));
         }
 
+        ensure_table_catalog_lock_held(global_fence_guard.as_ref())?;
+        ensure_table_catalog_lock_held(fence_guard.as_ref())?;
+        ensure_table_catalog_locks_held(&source_guards)?;
         self.ensure_global_backing_migration_fence(&global_fence_path).await?;
         let (migration_id, target_bucket_existed) = if let Some((fence, _)) = existing_fence.as_ref() {
             (fence.migration_id.clone(), fence.target_bucket_existed)
@@ -7776,11 +8409,17 @@ where
                 source_fingerprint: None,
                 target_snapshot_etag: None,
             };
+            ensure_table_catalog_lock_held(global_fence_guard.as_ref())?;
+            ensure_table_catalog_lock_held(fence_guard.as_ref())?;
+            ensure_table_catalog_locks_held(&source_guards)?;
             self.write_entry(self.catalog_bucket(), &fence_path, &fence, TableCatalogPutPrecondition::IfAbsent)
                 .await?;
             (fence.migration_id, target_bucket_existed)
         };
 
+        ensure_table_catalog_lock_held(global_fence_guard.as_ref())?;
+        ensure_table_catalog_lock_held(fence_guard.as_ref())?;
+        ensure_table_catalog_locks_held(&source_guards)?;
         let (target_snapshot_etag, created) = strong_store.materialize_bucket_snapshot(source.clone()).await?;
         let completed_fence = TableCatalogBackingMigrationFence {
             version: TABLE_CATALOG_MIGRATION_VERSION,
@@ -7791,11 +8430,14 @@ where
             source_fingerprint: Some(source_fingerprint.clone()),
             target_snapshot_etag: Some(target_snapshot_etag.clone()),
         };
+        ensure_table_catalog_lock_held(global_fence_guard.as_ref())?;
+        ensure_table_catalog_lock_held(fence_guard.as_ref())?;
+        ensure_table_catalog_locks_held(&source_guards)?;
         self.write_entry(self.catalog_bucket(), &fence_path, &completed_fence, TableCatalogPutPrecondition::Any)
             .await?;
 
         drop(source_guards);
-        drop(_fence_guard);
+        drop(fence_guard);
         let ready_to_enable_durable_strong = self.all_table_buckets_materialized(&strong_store).await?;
         Ok(TableCatalogBackingMigrationExecutionReport {
             table_bucket: table_bucket.to_string(),
@@ -7826,11 +8468,11 @@ where
         let fence_lock_path = self.paths.backing_migration_fence_lock_path(table_bucket);
         let global_fence_path = self.paths.backing_migration_global_fence_path();
         let global_fence_lock_path = self.paths.backing_migration_global_fence_lock_path();
-        let _global_fence_guard = self
+        let global_fence_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &global_fence_lock_path)
             .await?;
-        let _fence_guard = self
+        let fence_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &fence_lock_path)
             .await?;
@@ -7864,19 +8506,28 @@ where
         }
 
         let strong_store = StrongTableCatalogStore::new(self.backend.clone());
+        let target_fingerprint = strong_store.bucket_snapshot_fingerprint(table_bucket).await?;
         if fence.status == TableCatalogBackingMigrationFenceStatus::Materialized
-            && strong_store.bucket_snapshot_fingerprint(table_bucket).await?.as_deref() != Some(&source_fingerprint)
+            && target_fingerprint.as_deref() != Some(&source_fingerprint)
+            && (fence.target_bucket_existed || target_fingerprint.is_some())
         {
             return Err(TableCatalogStoreError::Conflict(format!(
                 "durable strong catalog state changed after materializing table bucket {table_bucket}"
             )));
         }
-        if !fence.target_bucket_existed {
+        if !fence.target_bucket_existed && target_fingerprint.is_some() {
+            ensure_table_catalog_lock_held(global_fence_guard.as_ref())?;
+            ensure_table_catalog_lock_held(fence_guard.as_ref())?;
+            ensure_table_catalog_locks_held(&source_guards)?;
             strong_store
                 .remove_bucket_snapshot_if_unchanged(table_bucket, &source_fingerprint)
                 .await?;
         }
+        ensure_table_catalog_lock_held(global_fence_guard.as_ref())?;
+        ensure_table_catalog_lock_held(fence_guard.as_ref())?;
+        ensure_table_catalog_locks_held(&source_guards)?;
         self.backend.delete_object(self.catalog_bucket(), &fence_path).await?;
+        ensure_table_catalog_lock_held(global_fence_guard.as_ref())?;
         self.clear_global_backing_migration_fence_if_unused(&global_fence_path)
             .await?;
         Ok(TableCatalogBackingMigrationCancelReport {
@@ -8023,8 +8674,7 @@ where
     ) -> TableCatalogStoreResult<TableMetadataMaintenanceReport> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &table_path).await? else {
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -8037,6 +8687,9 @@ where
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
         }
+        self.backfill_table_warehouse_index(table_bucket).await?;
+        self.ensure_table_warehouse_prefix_available(&entry).await?;
+        self.ensure_table_warehouse_index_owner(&entry).await?;
 
         let Some(current_metadata_object) = self.backend.read_object(table_bucket, &entry.metadata_location).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -8124,7 +8777,7 @@ where
                 metadata_location.clone(),
                 TableMetadataMaintenanceReason::NoCurrentReachability,
             );
-            let Some(candidate_object) = self.backend.read_object(table_bucket, metadata_location).await? else {
+            let Some(candidate_object) = self.backend.object_metadata(table_bucket, metadata_location).await? else {
                 insert_metadata_maintenance_reason(
                     &mut maintenance_reasons,
                     metadata_location.clone(),
@@ -8150,7 +8803,7 @@ where
         let current_metadata_location = entry.metadata_location.clone();
         let retained_metadata_locations = retained.into_iter().collect::<Vec<_>>();
         let object_reports = metadata_maintenance_object_reports(maintenance_reasons);
-        let referenced_object_reports = metadata_maintenance_referenced_object_reports(
+        let referenced_object_scan = metadata_maintenance_referenced_object_reports(
             &self.backend,
             table_bucket,
             &namespace,
@@ -8160,6 +8813,7 @@ where
             &retained_metadata_locations,
         )
         .await?;
+        let referenced_object_reports = referenced_object_scan.reports;
         let reachability_graph =
             metadata_maintenance_reachability_graph_report(planned_metadata_file_count, &referenced_object_reports);
         let (planned_object_file_count, cleanup_object_candidate_locations, deletable_object_locations, object_cleanup_reports) =
@@ -8173,10 +8827,6 @@ where
                 now,
             )
             .await?;
-        for object_location in &cleanup_object_candidate_locations {
-            self.ensure_table_maintenance_object_owner(&entry, object_location).await?;
-        }
-
         let mut report = table_maintenance_report_with_recommended_actions(TableMetadataMaintenanceReport {
             job: TableMetadataMaintenanceJob {
                 job_id: Uuid::new_v4().to_string(),
@@ -8252,10 +8902,12 @@ where
         table: &str,
         retain_recent_metadata_files: usize,
     ) -> TableCatalogStoreResult<TableMetadataMaintenanceReport> {
-        let report = self
-            .plan_table_metadata_maintenance(table_bucket, namespace, table, retain_recent_metadata_files)
+        let mut effective = self
+            .get_effective_table_maintenance_config(table_bucket, namespace, table)
             .await?;
-        self.delete_table_metadata_maintenance_report(table_bucket, namespace, table, report)
+        effective.config.retain_recent_metadata_files = retain_recent_metadata_files;
+        effective.config.delete_enabled = true;
+        self.run_table_metadata_maintenance_with_config(table_bucket, namespace, table, true, None, effective)
             .await
     }
 
@@ -8367,13 +9019,13 @@ where
                 before_status,
                 before_quarantined_object_count,
             );
-            self.put_table_metadata_maintenance_report(&report).await?;
+            self.put_table_metadata_maintenance_worker_report(&report).await?;
             return Ok(report);
         }
 
         if delete {
             let running_report = report.clone();
-            let mut deleted = match self
+            let deleted = match self
                 .delete_table_metadata_maintenance_report(table_bucket, namespace, table, report)
                 .await
             {
@@ -8398,25 +9050,10 @@ where
                         before_status,
                         before_quarantined_object_count,
                     );
-                    self.put_table_metadata_maintenance_report(&failed).await?;
+                    self.put_table_metadata_maintenance_worker_report(&failed).await?;
                     return Err(err);
                 }
             };
-            let finished_at = OffsetDateTime::now_utc();
-            let before_status = Some(TableMetadataMaintenanceJobStatus::Running);
-            let before_quarantined_object_count = Some(0);
-            deleted.job.finished_at = Some(maintenance_timestamp(finished_at));
-            refresh_table_maintenance_report_recommended_actions(&mut deleted);
-            push_table_maintenance_audit_event(
-                &mut deleted,
-                finished_at,
-                TableMaintenanceAuditActor::Worker,
-                TableMaintenanceAuditAction::WorkerSucceeded,
-                None,
-                before_status,
-                before_quarantined_object_count,
-            );
-            self.put_table_metadata_maintenance_report(&deleted).await?;
             return Ok(deleted);
         }
 
@@ -8435,7 +9072,7 @@ where
             before_status,
             before_quarantined_object_count,
         );
-        self.put_table_metadata_maintenance_report(&report).await?;
+        self.put_table_metadata_maintenance_worker_report(&report).await?;
         Ok(report)
     }
 
@@ -8482,7 +9119,7 @@ where
             )));
         };
         let current_metadata_identity = TableCatalogObjectMetadata {
-            etag: current_metadata_object.etag.clone(),
+            etag: current_metadata_object.etag,
             mod_time: current_metadata_object.mod_time,
         };
         let current_metadata = serde_json::from_slice::<serde_json::Value>(&current_metadata_object.data).map_err(|err| {
@@ -8513,6 +9150,7 @@ where
         let cleanup_candidate_count = report.cleanup_candidate_locations.len();
         let planned_deletable_locations = report.deletable_metadata_locations.iter().cloned().collect::<BTreeSet<_>>();
         let mut cleanup_candidate_locations = BTreeMap::new();
+        let mut previously_deleted_metadata_locations = BTreeSet::new();
         let now = OffsetDateTime::now_utc();
         for metadata_location in &report.cleanup_candidate_locations {
             if !is_valid_table_metadata_location_for_entry(&entry, metadata_location) {
@@ -8525,8 +9163,10 @@ where
                     "cleanup candidate {metadata_location} is retained by current metadata"
                 )));
             }
-            self.ensure_table_maintenance_object_owner(&entry, metadata_location).await?;
             let Some(candidate_object) = self.backend.object_metadata(table_bucket, metadata_location).await? else {
+                if planned_deletable_locations.contains(metadata_location) {
+                    previously_deleted_metadata_locations.insert(metadata_location.clone());
+                }
                 continue;
             };
             if !planned_deletable_locations.contains(metadata_location.as_str()) {
@@ -8544,7 +9184,7 @@ where
             );
         }
 
-        let referenced_object_reports = metadata_maintenance_referenced_object_reports(
+        let referenced_object_scan = metadata_maintenance_referenced_object_reports(
             &self.backend,
             table_bucket,
             &namespace,
@@ -8554,6 +9194,8 @@ where
             &report.retained_metadata_locations,
         )
         .await?;
+        let referenced_object_reports = referenced_object_scan.reports;
+        let reference_source_objects = referenced_object_scan.source_objects;
         let referenced_object_locations = if referenced_object_reports
             .iter()
             .any(|report| report.state == TableMetadataMaintenanceObjectState::ManualReviewRequired)
@@ -8567,6 +9209,7 @@ where
         };
         let planned_deletable_object_locations = report.deletable_object_locations.iter().cloned().collect::<BTreeSet<_>>();
         let mut cleanup_object_candidate_locations = BTreeMap::new();
+        let mut previously_deleted_object_locations = BTreeSet::new();
         if !referenced_object_reports
             .iter()
             .any(|report| report.state == TableMetadataMaintenanceObjectState::ManualReviewRequired)
@@ -8577,13 +9220,15 @@ where
                         "cleanup object candidate {object_location} must be inside table metadata, data, or delete directories"
                     )));
                 }
-                self.ensure_table_maintenance_object_owner(&entry, object_location).await?;
                 if referenced_object_locations.contains(object_location.as_str()) {
                     return Err(TableCatalogStoreError::Conflict(format!(
                         "cleanup object candidate {object_location} is retained by current metadata"
                     )));
                 }
-                let Some(candidate_object) = self.backend.read_object(table_bucket, object_location).await? else {
+                let Some(candidate_object) = self.backend.object_metadata(table_bucket, object_location).await? else {
+                    if planned_deletable_object_locations.contains(object_location) {
+                        previously_deleted_object_locations.insert(object_location.clone());
+                    }
                     continue;
                 };
                 if !planned_deletable_object_locations.contains(object_location.as_str()) {
@@ -8592,16 +9237,18 @@ where
                 if !metadata_candidate_is_past_safety_window(candidate_object.mod_time, now) {
                     continue;
                 }
-                cleanup_object_candidate_locations.insert(
-                    object_location.clone(),
-                    TableCatalogObjectMetadata {
-                        etag: candidate_object.etag,
-                        mod_time: candidate_object.mod_time,
-                    },
-                );
+                cleanup_object_candidate_locations.insert(object_location.clone(), candidate_object);
             }
         }
 
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
+        let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(table_bucket);
+        let ownership_guard = self
+            .backend
+            .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
+            .await?;
+        self.backfill_table_warehouse_index_ownership_locked(table_bucket, ownership_guard.as_ref())
+            .await?;
         let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
         let table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
         let Some((current_entry, _)) = self.read_table_with_etag_unlocked(table_bucket, &namespace, &table).await? else {
@@ -8621,6 +9268,20 @@ where
                 "table identity or current metadata location changed before maintenance delete".to_string(),
             ));
         }
+        let current_job_path =
+            self.paths
+                .table_maintenance_current_job_path(table_bucket, &namespace, &table, &current_entry.table_id);
+        let current_job_guard = self
+            .backend
+            .acquire_write_lock(self.catalog_bucket(), &current_job_path)
+            .await?;
+        let current_job = self
+            .read_entry_unlocked::<TableMetadataMaintenanceReport>(self.catalog_bucket(), &current_job_path)
+            .await?
+            .map(|(current, _)| current)
+            .ok_or_else(|| TableCatalogStoreError::Conflict("maintenance job is no longer current".to_string()))?;
+        ensure_current_maintenance_worker(&current_job.job, &report.job)?;
+        self.ensure_table_warehouse_prefix_available(&current_entry).await?;
         self.ensure_table_warehouse_index_owner(&current_entry).await?;
         let current_metadata_guard = self
             .backend
@@ -8644,7 +9305,22 @@ where
             ));
         }
 
-        let mut deleted_metadata_locations = Vec::new();
+        let mut reference_source_guards = Vec::with_capacity(reference_source_objects.len());
+        for (object_location, expected) in reference_source_objects {
+            if object_location == current_entry.metadata_location {
+                continue;
+            }
+            let source_guard = self.backend.acquire_write_lock(table_bucket, &object_location).await?;
+            let source = self.backend.object_metadata_unlocked(table_bucket, &object_location).await?;
+            if source.as_ref() != Some(&expected) {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "referenced object {object_location} changed before maintenance delete"
+                )));
+            }
+            reference_source_guards.push(source_guard);
+        }
+
+        let mut deleted_metadata_locations = previously_deleted_metadata_locations.into_iter().collect::<Vec<_>>();
         for (metadata_location, expected) in cleanup_candidate_locations {
             let candidate_guard = self.backend.acquire_write_lock(table_bucket, &metadata_location).await?;
             let candidate = self
@@ -8656,12 +9332,19 @@ where
                     && candidate.mod_time == expected.mod_time
                     && metadata_candidate_is_past_safety_window(candidate.mod_time, OffsetDateTime::now_utc())
             }) {
+                ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+                ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
+                ensure_table_catalog_lock_held(table_guard.as_ref())?;
+                ensure_table_catalog_lock_held(current_job_guard.as_ref())?;
+                ensure_table_catalog_lock_held(current_metadata_guard.as_ref())?;
+                ensure_table_catalog_locks_held(&reference_source_guards)?;
+                ensure_table_catalog_lock_held(candidate_guard.as_ref())?;
                 self.backend.delete_object_unlocked(table_bucket, &metadata_location).await?;
                 deleted_metadata_locations.push(metadata_location);
             }
             drop(candidate_guard);
         }
-        let mut deleted_object_locations = Vec::new();
+        let mut deleted_object_locations = previously_deleted_object_locations.into_iter().collect::<Vec<_>>();
         for (object_location, expected) in cleanup_object_candidate_locations {
             let candidate_guard = self.backend.acquire_write_lock(table_bucket, &object_location).await?;
             let candidate = self.backend.object_metadata_unlocked(table_bucket, &object_location).await?;
@@ -8670,14 +9353,18 @@ where
                     && candidate.mod_time == expected.mod_time
                     && metadata_candidate_is_past_safety_window(candidate.mod_time, OffsetDateTime::now_utc())
             }) {
+                ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+                ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
+                ensure_table_catalog_lock_held(table_guard.as_ref())?;
+                ensure_table_catalog_lock_held(current_job_guard.as_ref())?;
+                ensure_table_catalog_lock_held(current_metadata_guard.as_ref())?;
+                ensure_table_catalog_locks_held(&reference_source_guards)?;
+                ensure_table_catalog_lock_held(candidate_guard.as_ref())?;
                 self.backend.delete_object_unlocked(table_bucket, &object_location).await?;
                 deleted_object_locations.push(object_location);
             }
             drop(candidate_guard);
         }
-        drop(current_metadata_guard);
-        drop(table_guard);
-
         let deleted_locations = deleted_metadata_locations.iter().cloned().collect::<BTreeSet<_>>();
         let deleted_object_location_set = deleted_object_locations.iter().cloned().collect::<BTreeSet<_>>();
         let retained_metadata_locations = protected.into_iter().collect::<Vec<_>>();
@@ -8697,7 +9384,7 @@ where
         let mut object_cleanup_reports = report.object_cleanup_reports;
         mark_deleted_object_cleanup_reports(&mut object_cleanup_reports, &deleted_object_location_set);
 
-        Ok(table_maintenance_report_with_recommended_actions(TableMetadataMaintenanceReport {
+        let mut deleted = table_maintenance_report_with_recommended_actions(TableMetadataMaintenanceReport {
             job,
             current_metadata_location: current_entry.metadata_location,
             retained_metadata_locations,
@@ -8712,7 +9399,43 @@ where
             snapshot_expiration: report.snapshot_expiration,
             compaction: report.compaction,
             audit_events: report.audit_events,
-        }))
+        });
+        let finished_at = OffsetDateTime::now_utc();
+        deleted.job.finished_at = Some(maintenance_timestamp(finished_at));
+        push_table_maintenance_audit_event(
+            &mut deleted,
+            finished_at,
+            TableMaintenanceAuditActor::Worker,
+            TableMaintenanceAuditAction::WorkerSucceeded,
+            None,
+            Some(TableMetadataMaintenanceJobStatus::Running),
+            Some(0),
+        );
+        let job_path =
+            self.paths
+                .table_maintenance_job_path(table_bucket, &namespace, &table, &current_entry.table_id, &deleted.job.job_id);
+        let latest_job_path =
+            self.paths
+                .table_maintenance_latest_job_path(table_bucket, &namespace, &table, &current_entry.table_id);
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
+        ensure_table_catalog_lock_held(table_guard.as_ref())?;
+        ensure_table_catalog_lock_held(current_job_guard.as_ref())?;
+        ensure_table_catalog_lock_held(current_metadata_guard.as_ref())?;
+        self.write_table_metadata_maintenance_report_locked(
+            &deleted,
+            &job_path,
+            &latest_job_path,
+            &current_job_path,
+            current_job_guard.as_ref(),
+        )
+        .await?;
+        drop(current_metadata_guard);
+        drop(current_job_guard);
+        drop(table_guard);
+        drop(ownership_guard);
+        drop(migration_guard);
+        Ok(deleted)
     }
 }
 
@@ -8735,10 +9458,13 @@ where
         if entry.catalog_type != TABLE_BUCKET_CATALOG_TYPE {
             return Err(TableCatalogStoreError::Invalid("unsupported table bucket catalog type".to_string()));
         }
-        let _registry_guard = self.acquire_table_bucket_registry_write_permit().await?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
+        let registry_guard = self.acquire_table_bucket_registry_write_permit().await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
         let object = self.paths.table_bucket_entry_path(&entry.table_bucket);
-        let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
+        let guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
+        ensure_table_catalog_lock_held(registry_guard.as_ref())?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(guard.as_ref())?;
         self.write_entry_unlocked(self.catalog_bucket(), &object, &entry, TableCatalogPutPrecondition::Any)
             .await
     }
@@ -8748,11 +9474,11 @@ where
         validate_namespace_properties(&entry.properties)?;
         self.require_table_bucket(&entry.table_bucket).await?;
         let namespace = parse_namespace_for_store(&entry.namespace)?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
         let bucket_path = self.paths.table_bucket_entry_path(&entry.table_bucket);
-        let _bucket_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &bucket_path).await?;
+        let bucket_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &bucket_path).await?;
         let object = self.paths.namespace_entry_path(&entry.table_bucket, &namespace);
-        let _namespace_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
+        let namespace_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
         let precondition = match self
             .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), &object)
             .await?
@@ -8766,6 +9492,9 @@ where
             Some(_) => TableCatalogPutPrecondition::Any,
             None => TableCatalogPutPrecondition::IfAbsent,
         };
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bucket_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
         self.write_entry_unlocked(self.catalog_bucket(), &object, &entry, precondition)
             .await
     }
@@ -8780,10 +9509,11 @@ where
             if !object.ends_with(NAMESPACE_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await?
-                && entry.state == TableCatalogEntryState::Active
-            {
-                entries.push(entry);
+            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await? {
+                validate_namespace_entry_object(&self.paths, &object, &entry)?;
+                if entry.state == TableCatalogEntryState::Active {
+                    entries.push(entry);
+                }
             }
         }
         entries.sort_by(|left, right| left.namespace.cmp(&right.namespace));
@@ -8798,38 +9528,27 @@ where
             if !object.ends_with(NAMESPACE_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await?
-                && entry.state == TableCatalogEntryState::Active
-            {
-                entries.push(entry);
+            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await? {
+                validate_namespace_entry_object(&self.paths, &object, &entry)?;
+                if entry.state == TableCatalogEntryState::Active {
+                    entries.push(entry);
+                }
             }
         }
         entries.sort_by(|left, right| left.namespace.cmp(&right.namespace));
         Ok(entries)
     }
 
-    async fn list_namespaces_page(
-        &self,
-        table_bucket: &str,
-        cursor: Option<&str>,
-        limit: NonZeroUsize,
-    ) -> TableCatalogStoreResult<TableCatalogListPage<NamespaceEntry>> {
-        self.list_entry_page(
-            &self.paths.namespace_entries_prefix(table_bucket),
-            NAMESPACE_ENTRY_FILE,
-            cursor,
-            limit,
-            |entry: &NamespaceEntry| entry.state == TableCatalogEntryState::Active,
-        )
-        .await
-    }
-
     async fn get_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Option<NamespaceEntry>> {
         let namespace = parse_namespace_for_store(namespace)?;
+        let namespace_path = self.paths.namespace_entry_path(table_bucket, &namespace);
         let exact = self
-            .read_entry::<NamespaceEntry>(self.catalog_bucket(), &self.paths.namespace_entry_path(table_bucket, &namespace))
+            .read_entry::<NamespaceEntry>(self.catalog_bucket(), &namespace_path)
             .await?
             .map(|(entry, _)| entry);
+        if let Some(entry) = exact.as_ref() {
+            validate_namespace_entry_object(&self.paths, &namespace_path, entry)?;
+        }
         if exact
             .as_ref()
             .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
@@ -8844,12 +9563,12 @@ where
 
     async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<()> {
         let namespace = parse_namespace_for_store(namespace)?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
         let bucket_path = self.paths.table_bucket_entry_path(table_bucket);
-        let _bucket_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &bucket_path).await?;
+        let bucket_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &bucket_path).await?;
         let namespace_path = self.paths.namespace_entry_path(table_bucket, &namespace);
         // Match create_namespace and migration lock order while draining table/view creation.
-        let _namespace_guard = self
+        let namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
@@ -8884,17 +9603,20 @@ where
                 namespace.public_name()
             )));
         }
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(bucket_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
         self.backend
             .delete_object_unlocked(self.catalog_bucket(), &namespace_path)
             .await
     }
 
     async fn create_table(&self, entry: TableEntry) -> TableCatalogStoreResult<()> {
-        self.write_table_entry(entry, TableCatalogPutPrecondition::IfAbsent).await
+        self.write_table_entry_cancellation_safe(entry).await
     }
 
     async fn register_table(&self, entry: TableEntry) -> TableCatalogStoreResult<()> {
-        self.write_table_entry(entry, TableCatalogPutPrecondition::IfAbsent).await
+        self.write_table_entry_cancellation_safe(entry).await
     }
 
     async fn list_tables(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Vec<TableEntry>> {
@@ -8908,10 +9630,11 @@ where
             if !object.ends_with(TABLE_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &object).await?
-                && entry.state == TableCatalogEntryState::Active
-            {
-                entries.push(entry);
+            if let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &object).await? {
+                validate_table_entry_object(&self.paths, &object, &entry)?;
+                if entry.state == TableCatalogEntryState::Active {
+                    entries.push(entry);
+                }
             }
         }
         entries.sort_by(|left, right| left.table.cmp(&right.table));
@@ -8932,6 +9655,7 @@ where
             cursor,
             limit,
             |entry: &TableEntry| entry.state == TableCatalogEntryState::Active,
+            |object, entry: &TableEntry| validate_table_entry_object(&self.paths, object, entry),
         )
         .await
     }
@@ -8946,19 +9670,16 @@ where
         {
             return Ok(None);
         }
+        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
         let entry = self
-            .read_entry::<TableEntry>(self.catalog_bucket(), &self.paths.table_entry_path(table_bucket, &namespace, &table))
+            .read_entry::<TableEntry>(self.catalog_bucket(), &table_path)
             .await?
-            .map(|(table, _)| table)
-            .filter(|entry| entry.state == TableCatalogEntryState::Active);
-        if let Some(entry) = entry.as_ref()
-            && !is_valid_table_metadata_location_for_entry(entry, &entry.metadata_location)
-        {
-            return Err(TableCatalogStoreError::Invalid(
-                "object-backed table metadata location must be inside a protected table metadata directory".to_string(),
-            ));
-        }
-        Ok(entry)
+            .map(|(table, _)| table);
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
+        validate_table_entry_object(&self.paths, &table_path, &entry)?;
+        Ok((entry.state == TableCatalogEntryState::Active).then_some(entry))
     }
 
     async fn resolve_table_data_plane_resource(
@@ -8973,24 +9694,31 @@ where
             return Ok(None);
         };
         if table_bucket_entry.state != TableCatalogEntryState::Active {
-            return Ok(None);
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "table bucket {table_bucket} catalog entry is not active"
+            )));
         }
 
         if self.warehouse_index_ready(table_bucket).await? {
-            return self.resolve_table_data_plane_resource_from_index(table_bucket, object).await;
+            if let Some(resource) = self
+                .resolve_table_data_plane_resource_from_index(table_bucket, object)
+                .await?
+            {
+                return Ok(Some(resource));
+            }
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "table bucket {table_bucket} warehouse index does not cover the requested object"
+            )));
         }
 
-        match self.backfill_table_warehouse_index(table_bucket).await {
-            Ok(()) => self.resolve_table_data_plane_resource_from_index(table_bucket, object).await,
-            Err(err) => {
-                tracing::warn!(
-                    table_bucket = %table_bucket,
-                    error = %err,
-                    "failed to backfill table warehouse index; falling back to catalog scan"
-                );
-                scan_table_data_plane_resource_for_object(self, table_bucket, object).await
-            }
+        self.backfill_table_warehouse_index(table_bucket).await?;
+        if let Some(resource) = self
+            .resolve_table_data_plane_resource_from_index(table_bucket, object)
+            .await?
+        {
+            return Ok(Some(resource));
         }
+        Ok(None)
     }
 
     async fn commit_table(&self, request: TableCommitRequest) -> TableCatalogStoreResult<TableCommitResult> {
@@ -8998,50 +9726,17 @@ where
         record_table_commit_attempt(&request.operation);
         let namespace = parse_namespace_for_store(&request.namespace)?;
         let table = parse_table_for_store(&request.table)?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(&request.table_bucket).await?;
-        let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&request.table_bucket);
-        let ownership_guard = self
-            .backend
-            .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
-            .await?;
-        self.backfill_table_warehouse_index_ownership_locked(&request.table_bucket, ownership_guard.as_ref())
-            .await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(&request.table_bucket).await?;
         let table_path = self.paths.table_entry_path(&request.table_bucket, &namespace, &table);
-        let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
+        let mut ownership_guard = None;
 
-        let Some((current, current_etag)) = self
-            .read_table_with_etag_unlocked(&request.table_bucket, &namespace, &table)
-            .await?
-        else {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(TableCatalogStoreError::TableNotFound(format!(
-                    "table {}/{}/{}",
-                    request.table_bucket, request.namespace, request.table
-                ))),
-            );
-        };
+        loop {
+            let table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
 
-        let commit_path = self
-            .paths
-            .commit_log_entry_path(&request.table_bucket, &current.table_id, &request.commit_id);
-        let existing_commit = self.read_commit_by_path(&commit_path).await?;
-        let idempotency_path = request.idempotency_key.as_deref().map(|idempotency_key| {
-            self.paths
-                .commit_idempotency_entry_path(&request.table_bucket, &current.table_id, idempotency_key)
-        });
-        let existing_idempotency_commit = match idempotency_path.as_deref() {
-            Some(idempotency_path) => self.read_commit_by_path(idempotency_path).await?,
-            None => None,
-        };
-
-        if let Some(existing) = existing_commit.as_ref() {
-            if !commit_log_matches_request(existing, &request, &current.table_id) {
+            let Some((current, current_etag)) = self
+                .read_table_with_etag_unlocked(&request.table_bucket, &namespace, &table)
+                .await?
+            else {
                 return table_commit_result(
                     &request.table_bucket,
                     &request.namespace,
@@ -9049,13 +9744,53 @@ where
                     &request.commit_id,
                     &request.operation,
                     commit_started,
-                    Err(TableCatalogStoreError::Conflict(format!(
-                        "commit id already exists: {}",
-                        request.commit_id
+                    Err(TableCatalogStoreError::TableNotFound(format!(
+                        "table {}/{}/{}",
+                        request.table_bucket, request.namespace, request.table
                     ))),
                 );
+            };
+
+            let commit_path = self
+                .paths
+                .commit_log_entry_path(&request.table_bucket, &current.table_id, &request.commit_id);
+            let integrity_path =
+                self.paths
+                    .commit_integrity_entry_path(&request.table_bucket, &current.table_id, &request.commit_id);
+            let requested_integrity = table_commit_integrity_entry(&request, &current.table_id)?;
+            let existing_integrity = self
+                .read_entry::<TableCommitIntegrityEntry>(self.catalog_bucket(), &integrity_path)
+                .await?
+                .map(|(entry, _)| entry);
+            if let Some(existing_integrity) = existing_integrity.as_ref() {
+                validate_table_commit_integrity_identity(
+                    existing_integrity,
+                    &request.table_bucket,
+                    &current.table_id,
+                    &request.commit_id,
+                )?;
             }
-            if matches!(existing.status, CommitLogStatus::Committed) && table_matches_staged_base(&current, existing) {
+            let existing_commit = self.read_commit_by_path(&commit_path).await?;
+            let legacy_integrity = existing_commit
+                .as_ref()
+                .map(|commit| {
+                    table_commit_integrity_entry_from_requirements(
+                        &request.table_bucket,
+                        &current.table_id,
+                        &request.commit_id,
+                        &commit.requirements,
+                    )
+                })
+                .transpose()?
+                .flatten();
+            if let Err(err) = validate_table_commit_integrity_replay(
+                requested_integrity.as_ref(),
+                existing_integrity.as_ref(),
+                legacy_integrity.as_ref(),
+                existing_commit.as_ref().is_some_and(|existing| {
+                    matches!(existing.status, CommitLogStatus::Committed) || table_matches_committed_log(&current, existing)
+                }),
+            ) {
                 return table_commit_result(
                     &request.table_bucket,
                     &request.namespace,
@@ -9063,245 +9798,443 @@ where
                     &request.commit_id,
                     &request.operation,
                     commit_started,
-                    Err(TableCatalogStoreError::Conflict(
-                        "committed record still matches the pre-commit table state".to_string(),
-                    )),
+                    Err(err),
                 );
             }
-            if matches!(existing.status, CommitLogStatus::Committed) || table_matches_committed_log(&current, existing) {
-                let mut committed = existing.clone();
-                committed.status = CommitLogStatus::Committed;
-                let _ = self
-                    .finalize_commit_log(&commit_path, idempotency_path.as_deref(), &committed)
-                    .await;
-                return table_commit_result(
-                    &request.table_bucket,
-                    &request.namespace,
-                    &request.table,
-                    &request.commit_id,
-                    &request.operation,
-                    commit_started,
-                    Ok(TableCommitResult {
-                        table: current,
-                        commit_log: committed,
-                    }),
-                );
+            let idempotency_path = request.idempotency_key.as_deref().map(|idempotency_key| {
+                self.paths
+                    .commit_idempotency_entry_path(&request.table_bucket, &current.table_id, idempotency_key)
+            });
+            let existing_idempotency_commit = match idempotency_path.as_deref() {
+                Some(idempotency_path) => self.read_commit_by_path(idempotency_path).await?,
+                None => None,
+            };
+
+            if let Some(existing) = existing_commit.as_ref() {
+                if !commit_log_matches_request(existing, &request, &current.table_id) {
+                    return table_commit_result(
+                        &request.table_bucket,
+                        &request.namespace,
+                        &request.table,
+                        &request.commit_id,
+                        &request.operation,
+                        commit_started,
+                        Err(TableCatalogStoreError::Conflict(format!(
+                            "commit id already exists: {}",
+                            request.commit_id
+                        ))),
+                    );
+                }
+                if matches!(existing.status, CommitLogStatus::Committed) && table_matches_staged_base(&current, existing) {
+                    return table_commit_result(
+                        &request.table_bucket,
+                        &request.namespace,
+                        &request.table,
+                        &request.commit_id,
+                        &request.operation,
+                        commit_started,
+                        Err(TableCatalogStoreError::Conflict(
+                            "committed record still matches the pre-commit table state".to_string(),
+                        )),
+                    );
+                }
+                if matches!(existing.status, CommitLogStatus::Committed) || table_matches_committed_log(&current, existing) {
+                    let mut committed = existing.clone();
+                    committed.status = CommitLogStatus::Committed;
+                    let _ = self
+                        .finalize_commit_log(&commit_path, idempotency_path.as_deref(), &committed)
+                        .await;
+                    return table_commit_result(
+                        &request.table_bucket,
+                        &request.namespace,
+                        &request.table,
+                        &request.commit_id,
+                        &request.operation,
+                        commit_started,
+                        Ok(TableCommitResult {
+                            table: current,
+                            commit_log: committed,
+                        }),
+                    );
+                }
+                if !matches!(existing.status, CommitLogStatus::Staged) || !table_matches_staged_base(&current, existing) {
+                    return table_commit_result(
+                        &request.table_bucket,
+                        &request.namespace,
+                        &request.table,
+                        &request.commit_id,
+                        &request.operation,
+                        commit_started,
+                        Err(TableCatalogStoreError::Conflict(
+                            "existing commit record does not match current table state".to_string(),
+                        )),
+                    );
+                }
             }
-            if !matches!(existing.status, CommitLogStatus::Staged) || !table_matches_staged_base(&current, existing) {
-                return table_commit_result(
-                    &request.table_bucket,
-                    &request.namespace,
-                    &request.table,
-                    &request.commit_id,
-                    &request.operation,
-                    commit_started,
-                    Err(TableCatalogStoreError::Conflict(
-                        "existing commit record does not match current table state".to_string(),
-                    )),
-                );
-            }
-        }
-        if let Some(existing) = existing_idempotency_commit.as_ref()
-            && !commit_log_matches_request(existing, &request, &current.table_id)
-        {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(TableCatalogStoreError::Conflict("idempotency key already exists".to_string())),
-            );
-        }
-        if existing_commit.is_none() && existing_idempotency_commit.is_some() {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(TableCatalogStoreError::Conflict(
-                    "idempotency key exists without a recoverable commit record".to_string(),
-                )),
-            );
-        }
-
-        if current.version_token != request.expected_version_token {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(TableCatalogStoreError::Conflict(
-                    "current table version token does not match expected token".to_string(),
-                )),
-            );
-        }
-        if current.metadata_location != request.expected_metadata_location {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(TableCatalogStoreError::Conflict(
-                    "current table metadata location does not match expected location".to_string(),
-                )),
-            );
-        }
-        if !is_valid_table_metadata_location_for_entry(&current, &request.new_metadata_location) {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(TableCatalogStoreError::Invalid(
-                    "new metadata location must be inside the table metadata directory".to_string(),
-                )),
-            );
-        }
-        let _metadata_guard = self
-            .backend
-            .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
-            .await?;
-        let Some(new_metadata_object) = self
-            .backend
-            .read_object_unlocked_limited(&request.table_bucket, &request.new_metadata_location, TABLE_METADATA_JSON_MAX_SIZE)
-            .await?
-        else {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(TableCatalogStoreError::NotFound(format!(
-                    "new metadata object {}",
-                    request.new_metadata_location
-                ))),
-            );
-        };
-        validate_commit_metadata_digest(&request, &new_metadata_object)?;
-        let next_warehouse_location =
-            table_metadata_warehouse_location(&request.table_bucket, &request.new_metadata_location, &new_metadata_object)?;
-
-        let has_existing_commit = existing_commit.is_some();
-        let mut staged_commit_log = existing_commit.unwrap_or_else(|| CommitLogEntry {
-            version: TABLE_CATALOG_ENTRY_VERSION,
-            commit_id: request.commit_id.clone(),
-            idempotency_key: request.idempotency_key.clone(),
-            table_id: current.table_id.clone(),
-            operation: request.operation.clone(),
-            expected_version_token: request.expected_version_token.clone(),
-            new_version_token: format!("token-{}", Uuid::new_v4()),
-            previous_metadata_location: current.metadata_location.clone(),
-            new_metadata_location: request.new_metadata_location.clone(),
-            requirements: request.requirements.clone(),
-            status: CommitLogStatus::Staged,
-            writer: request.writer.clone(),
-            created_at: None,
-            updated_at: None,
-        });
-        staged_commit_log.status = CommitLogStatus::Staged;
-
-        if let Some(warehouse_location) = next_warehouse_location.as_deref()
-            && let Err(err) = validate_table_warehouse_relocation(&current, warehouse_location)
-        {
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(err),
-            );
-        }
-        let mut next = current.clone();
-        next.metadata_location = staged_commit_log.new_metadata_location.clone();
-        if let Some(warehouse_location) = next_warehouse_location {
-            next.warehouse_location = warehouse_location;
-        }
-        next.version_token = staged_commit_log.new_version_token.clone();
-        next.generation = current.generation.saturating_add(1);
-        if next.warehouse_location != current.warehouse_location {
-            self.ensure_table_warehouse_prefix_available(&next).await?;
-        }
-        ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
-        let reservation = self.reserve_table_warehouse_index(&next).await?;
-
-        let staged_write_result = async {
-            if !has_existing_commit {
-                self.write_entry(
-                    self.catalog_bucket(),
-                    &commit_path,
-                    &staged_commit_log,
-                    TableCatalogPutPrecondition::IfAbsent,
-                )
-                .await?;
-            }
-            if let Some(idempotency_path) = idempotency_path.as_deref()
-                && existing_idempotency_commit.is_none()
+            if let Some(existing) = existing_idempotency_commit.as_ref()
+                && !commit_log_matches_request(existing, &request, &current.table_id)
             {
-                self.write_entry(
-                    self.catalog_bucket(),
-                    idempotency_path,
-                    &staged_commit_log,
-                    TableCatalogPutPrecondition::IfAbsent,
-                )
-                .await?;
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::Conflict("idempotency key already exists".to_string())),
+                );
             }
-            Ok(())
-        }
-        .await;
-        if let Err(err) = staged_write_result {
-            self.delete_created_table_warehouse_index(&next, reservation, "commit staging failed")
-                .await;
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(err),
-            );
-        }
+            if existing_commit.is_none() && existing_idempotency_commit.is_some() {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::Conflict(
+                        "idempotency key exists without a recoverable commit record".to_string(),
+                    )),
+                );
+            }
 
-        let cas_started = Instant::now();
-        if let Err(err) = ensure_table_catalog_lock_held(ownership_guard.as_ref()) {
-            self.delete_created_table_warehouse_index(&next, reservation, "warehouse ownership lock lost")
-                .await;
-            return table_commit_result(
-                &request.table_bucket,
-                &request.namespace,
-                &request.table,
-                &request.commit_id,
-                &request.operation,
-                commit_started,
-                Err(err),
-            );
-        }
-        let cas_result = self
-            .write_entry_unlocked(
-                self.catalog_bucket(),
-                &table_path,
-                &next,
-                TableCatalogPutPrecondition::IfMatch(current_etag),
-            )
+            if current.version_token != request.expected_version_token {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::Conflict(
+                        "current table version token does not match expected token".to_string(),
+                    )),
+                );
+            }
+            if current.metadata_location != request.expected_metadata_location {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::Conflict(
+                        "current table metadata location does not match expected location".to_string(),
+                    )),
+                );
+            }
+            if !is_valid_table_metadata_location_for_entry(&current, &request.new_metadata_location) {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::Invalid(
+                        "new metadata location must be inside the table metadata directory".to_string(),
+                    )),
+                );
+            }
+            if request.new_metadata_location == current.metadata_location {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::Invalid(
+                        "new metadata location must differ from the current metadata location".to_string(),
+                    )),
+                );
+            }
+            let current_metadata_guard =
+                if table_commit_metadata_digest(&request, TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE, "base")?.is_some() {
+                    let guard = self
+                        .backend
+                        .acquire_read_lock(&request.table_bucket, &current.metadata_location)
+                        .await?;
+                    let Some(current_metadata_object) = self
+                        .backend
+                        .read_object_unlocked_limited(
+                            &request.table_bucket,
+                            &current.metadata_location,
+                            TABLE_METADATA_JSON_MAX_SIZE,
+                        )
+                        .await?
+                    else {
+                        return table_commit_result(
+                            &request.table_bucket,
+                            &request.namespace,
+                            &request.table,
+                            &request.commit_id,
+                            &request.operation,
+                            commit_started,
+                            Err(TableCatalogStoreError::NotFound(format!(
+                                "current metadata object {}",
+                                current.metadata_location
+                            ))),
+                        );
+                    };
+                    validate_commit_base_metadata_digest(&request, &current_metadata_object)?;
+                    Some(guard)
+                } else {
+                    None
+                };
+            let metadata_guard = self
+                .backend
+                .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
+                .await?;
+            let Some(new_metadata_object) = self
+                .backend
+                .read_object_unlocked_limited(&request.table_bucket, &request.new_metadata_location, TABLE_METADATA_JSON_MAX_SIZE)
+                .await?
+            else {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::NotFound(format!(
+                        "new metadata object {}",
+                        request.new_metadata_location
+                    ))),
+                );
+            };
+            validate_commit_metadata_digest(&request, &new_metadata_object)?;
+            let next_warehouse_location =
+                table_metadata_warehouse_location(&request.table_bucket, &request.new_metadata_location, &new_metadata_object)?;
+
+            let has_existing_commit = existing_commit.is_some();
+            let mut staged_commit_log = existing_commit.unwrap_or_else(|| CommitLogEntry {
+                version: TABLE_CATALOG_ENTRY_VERSION,
+                commit_id: request.commit_id.clone(),
+                idempotency_key: request.idempotency_key.clone(),
+                table_id: current.table_id.clone(),
+                operation: request.operation.clone(),
+                expected_version_token: request.expected_version_token.clone(),
+                new_version_token: format!("token-{}", Uuid::new_v4()),
+                previous_metadata_location: current.metadata_location.clone(),
+                new_metadata_location: request.new_metadata_location.clone(),
+                requirements: client_commit_requirements(&request.requirements),
+                status: CommitLogStatus::Staged,
+                writer: request.writer.clone(),
+                created_at: None,
+                updated_at: None,
+            });
+            staged_commit_log.status = CommitLogStatus::Staged;
+
+            if let Some(warehouse_location) = next_warehouse_location.as_deref()
+                && let Err(err) = validate_table_warehouse_relocation(&current, warehouse_location)
+            {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            let mut next = current.clone();
+            next.metadata_location = staged_commit_log.new_metadata_location.clone();
+            if let Some(warehouse_location) = next_warehouse_location {
+                next.warehouse_location = warehouse_location;
+            }
+            next.version_token = staged_commit_log.new_version_token.clone();
+            next.generation = next_table_catalog_generation(current.generation)?;
+            let warehouse_changed = next.warehouse_location != current.warehouse_location;
+            if warehouse_changed && ownership_guard.is_none() {
+                drop(current_metadata_guard);
+                drop(metadata_guard);
+                drop(table_guard);
+                let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&request.table_bucket);
+                let guard = self
+                    .backend
+                    .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
+                    .await?;
+                self.backfill_table_warehouse_index_ownership_locked(&request.table_bucket, guard.as_ref())
+                    .await?;
+                ownership_guard = Some(guard);
+                continue;
+            }
+            let reservation = if warehouse_changed {
+                let ownership_guard = ownership_guard.as_deref().ok_or_else(|| {
+                    TableCatalogStoreError::Internal("warehouse relocation is missing its ownership lock".to_string())
+                })?;
+                ensure_table_catalog_lock_held(ownership_guard)?;
+                self.ensure_table_warehouse_prefix_available(&next).await?;
+                Some(self.reserve_table_warehouse_index(&next).await?)
+            } else {
+                None
+            };
+
+            let staged_write_result = async {
+                if !has_existing_commit
+                    && existing_integrity.is_none()
+                    && let Some(integrity) = requested_integrity.as_ref()
+                {
+                    self.write_entry(self.catalog_bucket(), &integrity_path, integrity, TableCatalogPutPrecondition::IfAbsent)
+                        .await?;
+                }
+                if !has_existing_commit {
+                    self.write_entry(
+                        self.catalog_bucket(),
+                        &commit_path,
+                        &staged_commit_log,
+                        TableCatalogPutPrecondition::IfAbsent,
+                    )
+                    .await?;
+                }
+                if let Some(idempotency_path) = idempotency_path.as_deref()
+                    && existing_idempotency_commit.is_none()
+                {
+                    self.write_entry(
+                        self.catalog_bucket(),
+                        idempotency_path,
+                        &staged_commit_log,
+                        TableCatalogPutPrecondition::IfAbsent,
+                    )
+                    .await?;
+                }
+                Ok(())
+            }
             .await;
-        record_table_commit_cas_result(&request.operation, cas_started, &cas_result);
-        if let Err(err) = cas_result {
-            self.delete_created_table_warehouse_index(&next, reservation, "table pointer CAS failed")
+            if let Err(err) = staged_write_result {
+                if let Some(reservation) = reservation {
+                    self.delete_created_table_warehouse_index(&next, reservation, "commit staging failed")
+                        .await;
+                }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+
+            let cas_started = Instant::now();
+            if let Err(err) = ensure_table_catalog_lock_held(table_guard.as_ref()) {
+                if let Some(reservation) = reservation {
+                    self.delete_created_table_warehouse_index(&next, reservation, "table lock lost before pointer CAS")
+                        .await;
+                }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            if let Err(err) = ensure_table_catalog_lock_held(metadata_guard.as_ref()) {
+                if let Some(reservation) = reservation {
+                    self.delete_created_table_warehouse_index(&next, reservation, "metadata lock lost before pointer CAS")
+                        .await;
+                }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            if let Some(current_metadata_guard) = current_metadata_guard.as_deref()
+                && let Err(err) = ensure_table_catalog_lock_held(current_metadata_guard)
+            {
+                if let Some(reservation) = reservation {
+                    self.delete_created_table_warehouse_index(&next, reservation, "base metadata lock lost before pointer CAS")
+                        .await;
+                }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            if let Err(err) = ensure_table_catalog_lock_held(migration_guard.as_ref()) {
+                if let Some(reservation) = reservation {
+                    self.delete_created_table_warehouse_index(&next, reservation, "catalog migration lock lost")
+                        .await;
+                }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            if let Some(ownership_guard) = ownership_guard.as_deref()
+                && let Err(err) = ensure_table_catalog_lock_held(ownership_guard)
+            {
+                if let Some(reservation) = reservation {
+                    self.delete_created_table_warehouse_index(&next, reservation, "warehouse ownership lock lost")
+                        .await;
+                }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            let cas_result = self
+                .write_entry_unlocked(
+                    self.catalog_bucket(),
+                    &table_path,
+                    &next,
+                    TableCatalogPutPrecondition::IfMatch(current_etag),
+                )
                 .await;
+            record_table_commit_cas_result(&request.operation, cas_started, &cas_result);
+            if let Err(err) = cas_result {
+                if let Some(reservation) = reservation {
+                    self.delete_created_table_warehouse_index(&next, reservation, "table pointer CAS failed")
+                        .await;
+                }
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
+            self.delete_table_warehouse_index_if_changed(&current, &next).await;
+
+            let mut commit_log = staged_commit_log;
+            commit_log.status = CommitLogStatus::Committed;
+            // After the table CAS succeeds, the staged record is the durable recovery source.
+            // A finalization failure must not turn an externally committed pointer into a failed commit response.
+            let _ = self
+                .finalize_commit_log(&commit_path, idempotency_path.as_deref(), &commit_log)
+                .await;
+
             return table_commit_result(
                 &request.table_bucket,
                 &request.namespace,
@@ -9309,46 +10242,27 @@ where
                 &request.commit_id,
                 &request.operation,
                 commit_started,
-                Err(err),
+                Ok(TableCommitResult { table: next, commit_log }),
             );
         }
-        self.delete_table_warehouse_index_if_changed(&current, &next).await;
-
-        let mut commit_log = staged_commit_log;
-        commit_log.status = CommitLogStatus::Committed;
-        // After the table CAS succeeds, the staged record is the durable recovery source.
-        // A finalization failure must not turn an externally committed pointer into a failed commit response.
-        let _ = self
-            .finalize_commit_log(&commit_path, idempotency_path.as_deref(), &commit_log)
-            .await;
-
-        table_commit_result(
-            &request.table_bucket,
-            &request.namespace,
-            &request.table,
-            &request.commit_id,
-            &request.operation,
-            commit_started,
-            Ok(TableCommitResult { table: next, commit_log }),
-        )
     }
 
     async fn drop_table(&self, table_bucket: &str, namespace: &str, table: &str) -> TableCatalogStoreResult<()> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
         let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(table_bucket);
         let ownership_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
             .await?;
         let namespace_path = self.paths.namespace_entry_path(table_bucket, &namespace);
-        let _namespace_guard = self
+        let namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
         let object = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
+        let table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
         let Some((entry, _)) = self.read_table_with_etag_unlocked(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::TableNotFound(format!(
                 "table {}/{}/{}",
@@ -9357,37 +10271,62 @@ where
                 table.as_str()
             )));
         };
+        let bridge_path = self.paths.external_catalog_bridge_path(table_bucket, &namespace, &table);
+        let identity_path = self
+            .paths
+            .external_catalog_bridge_identity_path(table_bucket, &namespace, &table);
+        let bridge_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &bridge_path).await?;
+        let identity_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &identity_path).await?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
         ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+        ensure_table_catalog_lock_held(table_guard.as_ref())?;
         self.backend.delete_object_unlocked(self.catalog_bucket(), &object).await?;
         if let Err(err) = self.delete_table_warehouse_index(&entry).await {
-            if let Err(restore_err) = self
-                .write_entry_unlocked(self.catalog_bucket(), &object, &entry, TableCatalogPutPrecondition::IfAbsent)
-                .await
-            {
-                tracing::warn!(
-                    table_bucket = %entry.table_bucket,
-                    namespace = %entry.namespace,
-                    table = %entry.table,
-                    table_id = %entry.table_id,
-                    error = %restore_err,
-                    "failed to restore table entry after warehouse index delete failure"
-                );
-            }
             tracing::warn!(
                 table_bucket = %entry.table_bucket,
                 namespace = %entry.namespace,
                 table = %entry.table,
                 table_id = %entry.table_id,
                 error = %err,
-                "failed to delete table warehouse index after dropping table"
+                "failed to clean up stale table warehouse index after dropping table"
             );
-            return Err(err);
+        }
+        for (path, guard) in [
+            (&bridge_path, bridge_guard.as_ref()),
+            (&identity_path, identity_guard.as_ref()),
+        ] {
+            if let Err(err) =
+                ensure_table_catalog_lock_held(guard).and_then(|_| ensure_table_catalog_lock_held(migration_guard.as_ref()))
+            {
+                tracing::warn!(
+                    table_bucket = %entry.table_bucket,
+                    namespace = %entry.namespace,
+                    table = %entry.table,
+                    table_id = %entry.table_id,
+                    object = %path,
+                    error = %err,
+                    "skipped stale external catalog bridge cleanup after dropping table"
+                );
+                continue;
+            }
+            if let Err(err) = self.backend.delete_object_unlocked(self.catalog_bucket(), path).await {
+                tracing::warn!(
+                    table_bucket = %entry.table_bucket,
+                    namespace = %entry.namespace,
+                    table = %entry.table,
+                    table_id = %entry.table_id,
+                    object = %path,
+                    error = %err,
+                    "failed to clean up a stale external catalog bridge after dropping table"
+                );
+            }
         }
         Ok(())
     }
 
     async fn create_view(&self, entry: ViewEntry) -> TableCatalogStoreResult<()> {
-        self.write_view_entry(entry, TableCatalogPutPrecondition::IfAbsent).await
+        self.write_view_entry_cancellation_safe(entry).await
     }
 
     async fn list_views(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Vec<ViewEntry>> {
@@ -9401,10 +10340,11 @@ where
             if !object.ends_with(VIEW_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<ViewEntry>(self.catalog_bucket(), &object).await?
-                && entry.state == TableCatalogEntryState::Active
-            {
-                entries.push(entry);
+            if let Some((entry, _)) = self.read_entry::<ViewEntry>(self.catalog_bucket(), &object).await? {
+                validate_view_entry_object(&self.paths, &object, &entry)?;
+                if entry.state == TableCatalogEntryState::Active {
+                    entries.push(entry);
+                }
             }
         }
         entries.sort_by(|left, right| left.view.cmp(&right.view));
@@ -9425,6 +10365,7 @@ where
             cursor,
             limit,
             |entry: &ViewEntry| entry.state == TableCatalogEntryState::Active,
+            |object, entry: &ViewEntry| validate_view_entry_object(&self.paths, object, entry),
         )
         .await
     }
@@ -9439,27 +10380,24 @@ where
         {
             return Ok(None);
         }
+        let view_path = self.paths.view_entry_path(table_bucket, &namespace, &view);
         let entry = self
-            .read_entry::<ViewEntry>(self.catalog_bucket(), &self.paths.view_entry_path(table_bucket, &namespace, &view))
+            .read_entry::<ViewEntry>(self.catalog_bucket(), &view_path)
             .await?
-            .map(|(view, _)| view)
-            .filter(|entry| entry.state == TableCatalogEntryState::Active);
-        if let Some(entry) = entry.as_ref()
-            && !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location)
-        {
-            return Err(TableCatalogStoreError::Invalid(
-                "object-backed view metadata location must match the view identifier".to_string(),
-            ));
-        }
-        Ok(entry)
+            .map(|(view, _)| view);
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
+        validate_view_entry_object(&self.paths, &view_path, &entry)?;
+        Ok((entry.state == TableCatalogEntryState::Active).then_some(entry))
     }
 
     async fn replace_view(&self, request: ViewCommitRequest) -> TableCatalogStoreResult<ViewCommitResult> {
         let namespace = parse_namespace_for_store(&request.namespace)?;
         let view = parse_table_for_store(&request.view)?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(&request.table_bucket).await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(&request.table_bucket).await?;
         let namespace_path = self.paths.namespace_entry_path(&request.table_bucket, &namespace);
-        let _namespace_guard = self
+        let namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
@@ -9468,7 +10406,7 @@ where
             .await?
             .is_some_and(|(entry, _)| entry.state == TableCatalogEntryState::Active);
         let view_path = self.paths.view_entry_path(&request.table_bucket, &namespace, &view);
-        let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &view_path).await?;
+        let view_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &view_path).await?;
         let Some((current, current_etag)) = self
             .read_view_with_etag_unlocked(&request.table_bucket, &namespace, &view)
             .await?
@@ -9499,7 +10437,7 @@ where
                 "new metadata location must be inside the view metadata directory".to_string(),
             ));
         }
-        let _metadata_guard = self
+        let metadata_guard = self
             .backend
             .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
             .await?;
@@ -9523,7 +10461,11 @@ where
             next.warehouse_location = warehouse_location;
         }
         next.version_token = format!("token-{}", Uuid::new_v4());
-        next.generation = next.generation.saturating_add(1);
+        next.generation = next_table_catalog_generation(next.generation)?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+        ensure_table_catalog_lock_held(view_guard.as_ref())?;
+        ensure_table_catalog_lock_held(metadata_guard.as_ref())?;
         self.write_entry_unlocked(
             self.catalog_bucket(),
             &view_path,
@@ -9537,26 +10479,26 @@ where
     async fn drop_view(&self, table_bucket: &str, namespace: &str, view: &str) -> TableCatalogStoreResult<()> {
         let namespace = parse_namespace_for_store(namespace)?;
         let view = parse_table_for_store(view)?;
-        let _migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
+        let migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
         let namespace_path = self.paths.namespace_entry_path(table_bucket, &namespace);
-        let _namespace_guard = self
+        let namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
         let object = self.paths.view_entry_path(table_bucket, &namespace, &view);
-        let _view_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
-        if self
-            .read_entry_unlocked::<ViewEntry>(self.catalog_bucket(), &object)
-            .await?
-            .is_none()
-        {
+        let view_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
+        let Some((entry, _)) = self.read_entry_unlocked::<ViewEntry>(self.catalog_bucket(), &object).await? else {
             return Err(TableCatalogStoreError::ViewNotFound(format!(
                 "view {}/{}/{}",
                 table_bucket,
                 namespace.public_name(),
                 view.as_str()
             )));
-        }
+        };
+        validate_view_entry_object(&self.paths, &object, &entry)?;
+        ensure_table_catalog_lock_held(migration_guard.as_ref())?;
+        ensure_table_catalog_lock_held(namespace_guard.as_ref())?;
+        ensure_table_catalog_lock_held(view_guard.as_ref())?;
         self.backend.delete_object_unlocked(self.catalog_bucket(), &object).await
     }
 
@@ -9620,18 +10562,6 @@ where
         match self {
             Self::ObjectBacked(store) => store.list_namespaces_under(table_bucket, parent).await,
             Self::DurableStrong(store) => store.list_namespaces_under(table_bucket, parent).await,
-        }
-    }
-
-    async fn list_namespaces_page(
-        &self,
-        table_bucket: &str,
-        cursor: Option<&str>,
-        limit: NonZeroUsize,
-    ) -> TableCatalogStoreResult<TableCatalogListPage<NamespaceEntry>> {
-        match self {
-            Self::ObjectBacked(store) => store.list_namespaces_page(table_bucket, cursor, limit).await,
-            Self::DurableStrong(store) => store.list_namespaces_page(table_bucket, cursor, limit).await,
         }
     }
 
@@ -10395,6 +11325,25 @@ struct TableMetadataMaintenanceReferencedObjectAccumulator {
     reasons: BTreeSet<TableMetadataMaintenanceReason>,
 }
 
+struct TableMetadataMaintenanceReferenceScan {
+    reports: Vec<TableMetadataMaintenanceReferencedObjectReport>,
+    source_objects: BTreeMap<String, TableCatalogObjectMetadata>,
+}
+
+struct TableMetadataMaintenanceReferenceContext<'a, B> {
+    backend: &'a B,
+    table_bucket: &'a str,
+    namespace: &'a Namespace,
+    table: &'a IdentifierSegment,
+    entry: &'a TableEntry,
+}
+
+#[derive(Default)]
+struct TableMetadataMaintenanceReferenceState {
+    reports: BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
+    source_objects: BTreeMap<String, TableCatalogObjectMetadata>,
+}
+
 fn insert_referenced_object_report(
     reports: &mut BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
     object_location: String,
@@ -10423,26 +11372,24 @@ async fn metadata_maintenance_referenced_object_reports<B>(
     entry: &TableEntry,
     current_metadata: &serde_json::Value,
     retained_metadata_locations: &[String],
-) -> TableCatalogStoreResult<Vec<TableMetadataMaintenanceReferencedObjectReport>>
+) -> TableCatalogStoreResult<TableMetadataMaintenanceReferenceScan>
 where
     B: TableCatalogObjectBackend,
 {
-    let mut reports = BTreeMap::<String, TableMetadataMaintenanceReferencedObjectAccumulator>::new();
-    metadata_maintenance_referenced_object_reports_for_metadata(
+    let context = TableMetadataMaintenanceReferenceContext {
         backend,
         table_bucket,
         namespace,
         table,
         entry,
-        current_metadata,
-        &mut reports,
-    )
-    .await?;
+    };
+    let mut state = TableMetadataMaintenanceReferenceState::default();
+    metadata_maintenance_referenced_object_reports_for_metadata(&context, current_metadata, &mut state).await?;
 
     for metadata_location in retained_metadata_locations {
-        let Some(metadata_object) = backend.read_object(table_bucket, metadata_location).await? else {
+        let Some(metadata_object) = context.backend.read_object(context.table_bucket, metadata_location).await? else {
             insert_referenced_object_report(
-                &mut reports,
+                &mut state.reports,
                 metadata_location.clone(),
                 TableMetadataMaintenanceObjectKind::MetadataFile,
                 TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10450,9 +11397,10 @@ where
             );
             continue;
         };
+        record_maintenance_reference_source(&mut state.source_objects, metadata_location, &metadata_object)?;
         let Ok(metadata) = serde_json::from_slice::<serde_json::Value>(&metadata_object.data) else {
             insert_referenced_object_report(
-                &mut reports,
+                &mut state.reports,
                 metadata_location.clone(),
                 TableMetadataMaintenanceObjectKind::MetadataFile,
                 TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10462,7 +11410,7 @@ where
         };
         if !metadata.is_object() {
             insert_referenced_object_report(
-                &mut reports,
+                &mut state.reports,
                 metadata_location.clone(),
                 TableMetadataMaintenanceObjectKind::MetadataFile,
                 TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10470,37 +11418,51 @@ where
             );
             continue;
         }
-        metadata_maintenance_referenced_object_reports_for_metadata(
-            backend,
-            table_bucket,
-            namespace,
-            table,
-            entry,
-            &metadata,
-            &mut reports,
-        )
-        .await?;
+        metadata_maintenance_referenced_object_reports_for_metadata(&context, &metadata, &mut state).await?;
     }
 
-    Ok(reports
-        .into_iter()
-        .map(|(object_location, report)| TableMetadataMaintenanceReferencedObjectReport {
-            object_location,
-            object_kind: report.object_kind,
-            state: report.state,
-            reasons: report.reasons.into_iter().collect(),
-        })
-        .collect())
+    Ok(TableMetadataMaintenanceReferenceScan {
+        reports: state
+            .reports
+            .into_iter()
+            .map(|(object_location, report)| TableMetadataMaintenanceReferencedObjectReport {
+                object_location,
+                object_kind: report.object_kind,
+                state: report.state,
+                reasons: report.reasons.into_iter().collect(),
+            })
+            .collect(),
+        source_objects: state.source_objects,
+    })
+}
+
+fn record_maintenance_reference_source(
+    source_objects: &mut BTreeMap<String, TableCatalogObjectMetadata>,
+    object_location: &str,
+    object: &TableCatalogObject,
+) -> TableCatalogStoreResult<()> {
+    let identity = TableCatalogObjectMetadata {
+        etag: object.etag.clone(),
+        mod_time: object.mod_time,
+    };
+    match source_objects.entry(object_location.to_string()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(identity);
+        }
+        std::collections::btree_map::Entry::Occupied(entry) if entry.get() != &identity => {
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "referenced object {object_location} changed during maintenance planning"
+            )));
+        }
+        std::collections::btree_map::Entry::Occupied(_) => {}
+    }
+    Ok(())
 }
 
 async fn metadata_maintenance_referenced_object_reports_for_metadata<B>(
-    backend: &B,
-    table_bucket: &str,
-    namespace: &Namespace,
-    table: &IdentifierSegment,
-    entry: &TableEntry,
+    context: &TableMetadataMaintenanceReferenceContext<'_, B>,
     metadata: &serde_json::Value,
-    reports: &mut BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
+    state: &mut TableMetadataMaintenanceReferenceState,
 ) -> TableCatalogStoreResult<()>
 where
     B: TableCatalogObjectBackend,
@@ -10511,7 +11473,7 @@ where
         None if current_snapshot_id.is_none() => return Ok(()),
         _ => {
             insert_referenced_object_report(
-                reports,
+                &mut state.reports,
                 "snapshots".to_string(),
                 TableMetadataMaintenanceObjectKind::MetadataFile,
                 TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10526,7 +11488,7 @@ where
             .any(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64) == Some(current_snapshot_id))
     }) {
         insert_referenced_object_report(
-            reports,
+            &mut state.reports,
             "current-snapshot-id".to_string(),
             TableMetadataMaintenanceObjectKind::MetadataFile,
             TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10536,16 +11498,7 @@ where
 
     for snapshot in snapshots {
         if let Some(manifest_list_location) = snapshot.get("manifest-list").and_then(serde_json::Value::as_str) {
-            metadata_maintenance_referenced_manifest_list(
-                backend,
-                table_bucket,
-                namespace,
-                table,
-                entry,
-                manifest_list_location,
-                reports,
-            )
-            .await?;
+            metadata_maintenance_referenced_manifest_list(context, manifest_list_location, state).await?;
             continue;
         }
 
@@ -10555,7 +11508,7 @@ where
                 .and_then(serde_json::Value::as_i64)
                 .map_or_else(|| "snapshots[]".to_string(), |snapshot_id| format!("snapshots[{snapshot_id}]"));
             insert_referenced_object_report(
-                reports,
+                &mut state.reports,
                 snapshot_id,
                 TableMetadataMaintenanceObjectKind::MetadataFile,
                 TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10566,7 +11519,7 @@ where
         for manifest in manifests {
             let Some(manifest_location) = manifest.as_str() else {
                 insert_referenced_object_report(
-                    reports,
+                    &mut state.reports,
                     "snapshots[].manifests".to_string(),
                     TableMetadataMaintenanceObjectKind::ManifestFile,
                     TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10574,16 +11527,7 @@ where
                 );
                 continue;
             };
-            metadata_maintenance_referenced_manifest_file(
-                backend,
-                table_bucket,
-                namespace,
-                table,
-                entry,
-                manifest_location,
-                reports,
-            )
-            .await?;
+            metadata_maintenance_referenced_manifest_file(context, manifest_location, state).await?;
         }
     }
 
@@ -10591,26 +11535,22 @@ where
 }
 
 async fn metadata_maintenance_referenced_manifest_list<B>(
-    backend: &B,
-    table_bucket: &str,
-    namespace: &Namespace,
-    table: &IdentifierSegment,
-    entry: &TableEntry,
+    context: &TableMetadataMaintenanceReferenceContext<'_, B>,
     manifest_list_location: &str,
-    reports: &mut BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
+    state: &mut TableMetadataMaintenanceReferenceState,
 ) -> TableCatalogStoreResult<()>
 where
     B: TableCatalogObjectBackend,
 {
     let Some(manifest_list_key) = table_reference_object_key(
-        namespace,
-        table,
-        entry,
+        context.namespace,
+        context.table,
+        context.entry,
         manifest_list_location,
         TableMetadataMaintenanceObjectKind::ManifestList,
     ) else {
         insert_referenced_object_report(
-            reports,
+            &mut state.reports,
             manifest_list_location.to_string(),
             TableMetadataMaintenanceObjectKind::ManifestList,
             TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10619,69 +11559,61 @@ where
         return Ok(());
     };
     insert_referenced_object_report(
-        reports,
+        &mut state.reports,
         manifest_list_key.clone(),
         TableMetadataMaintenanceObjectKind::ManifestList,
         TableMetadataMaintenanceObjectState::Retained,
         TableMetadataMaintenanceReason::ManifestList,
     );
+    if state.source_objects.contains_key(&manifest_list_key) {
+        return Ok(());
+    }
 
-    let Some(manifest_list_object) = backend
-        .read_object_limited(table_bucket, &manifest_list_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+    let Some(manifest_list_object) = context
+        .backend
+        .read_object_limited(context.table_bucket, &manifest_list_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
         .await?
     else {
         mark_referenced_object_manual_review(
-            reports,
+            &mut state.reports,
             &manifest_list_key,
             TableMetadataMaintenanceReason::UnsupportedManifestAvro,
         );
         return Ok(());
     };
+    record_maintenance_reference_source(&mut state.source_objects, &manifest_list_key, &manifest_list_object)?;
     let Ok(manifest_paths) = manifest_paths_from_manifest_list_avro(&manifest_list_object.data) else {
         mark_referenced_object_manual_review(
-            reports,
+            &mut state.reports,
             &manifest_list_key,
             TableMetadataMaintenanceReason::UnsupportedManifestAvro,
         );
         return Ok(());
     };
     for manifest_location in manifest_paths {
-        metadata_maintenance_referenced_manifest_file(
-            backend,
-            table_bucket,
-            namespace,
-            table,
-            entry,
-            &manifest_location,
-            reports,
-        )
-        .await?;
+        metadata_maintenance_referenced_manifest_file(context, &manifest_location, state).await?;
     }
 
     Ok(())
 }
 
 async fn metadata_maintenance_referenced_manifest_file<B>(
-    backend: &B,
-    table_bucket: &str,
-    namespace: &Namespace,
-    table: &IdentifierSegment,
-    entry: &TableEntry,
+    context: &TableMetadataMaintenanceReferenceContext<'_, B>,
     manifest_location: &str,
-    reports: &mut BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
+    state: &mut TableMetadataMaintenanceReferenceState,
 ) -> TableCatalogStoreResult<()>
 where
     B: TableCatalogObjectBackend,
 {
     let Some(manifest_key) = table_reference_object_key(
-        namespace,
-        table,
-        entry,
+        context.namespace,
+        context.table,
+        context.entry,
         manifest_location,
         TableMetadataMaintenanceObjectKind::ManifestFile,
     ) else {
         insert_referenced_object_report(
-            reports,
+            &mut state.reports,
             manifest_location.to_string(),
             TableMetadataMaintenanceObjectKind::ManifestFile,
             TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10690,28 +11622,43 @@ where
         return Ok(());
     };
     insert_referenced_object_report(
-        reports,
+        &mut state.reports,
         manifest_key.clone(),
         TableMetadataMaintenanceObjectKind::ManifestFile,
         TableMetadataMaintenanceObjectState::Retained,
         TableMetadataMaintenanceReason::ManifestFile,
     );
+    if state.source_objects.contains_key(&manifest_key) {
+        return Ok(());
+    }
 
-    let Some(manifest_object) = backend
-        .read_object_limited(table_bucket, &manifest_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+    let Some(manifest_object) = context
+        .backend
+        .read_object_limited(context.table_bucket, &manifest_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
         .await?
     else {
-        mark_referenced_object_manual_review(reports, &manifest_key, TableMetadataMaintenanceReason::UnsupportedManifestAvro);
+        mark_referenced_object_manual_review(
+            &mut state.reports,
+            &manifest_key,
+            TableMetadataMaintenanceReason::UnsupportedManifestAvro,
+        );
         return Ok(());
     };
+    record_maintenance_reference_source(&mut state.source_objects, &manifest_key, &manifest_object)?;
     let Ok(file_references) = file_references_from_manifest_avro(&manifest_object.data) else {
-        mark_referenced_object_manual_review(reports, &manifest_key, TableMetadataMaintenanceReason::UnsupportedManifestAvro);
+        mark_referenced_object_manual_review(
+            &mut state.reports,
+            &manifest_key,
+            TableMetadataMaintenanceReason::UnsupportedManifestAvro,
+        );
         return Ok(());
     };
     for (file_location, object_kind) in file_references {
-        let Some(file_key) = table_reference_object_key(namespace, table, entry, &file_location, object_kind.clone()) else {
+        let Some(file_key) =
+            table_reference_object_key(context.namespace, context.table, context.entry, &file_location, object_kind.clone())
+        else {
             insert_referenced_object_report(
-                reports,
+                &mut state.reports,
                 file_location,
                 object_kind,
                 TableMetadataMaintenanceObjectState::ManualReviewRequired,
@@ -10720,7 +11667,7 @@ where
             continue;
         };
         insert_referenced_object_report(
-            reports,
+            &mut state.reports,
             file_key,
             object_kind.clone(),
             TableMetadataMaintenanceObjectState::Retained,
@@ -10896,14 +11843,49 @@ fn validate_uncompressed_avro_container(data: &[u8]) -> TableCatalogStoreResult<
             ));
         }
     }
-    offset
+    let marker_end = offset
         .checked_add(16)
         .filter(|end| *end <= data.len())
         .ok_or_else(|| TableCatalogStoreError::Invalid("Avro container is missing its sync marker".to_string()))?;
+    let sync_marker: [u8; 16] = data[offset..marker_end]
+        .try_into()
+        .map_err(|_| TableCatalogStoreError::Invalid("Avro container has an invalid sync marker".to_string()))?;
+    offset = marker_end;
     if codec.is_some_and(|codec| codec != b"null") {
         return Err(TableCatalogStoreError::Invalid(
             "compressed Avro codecs are not supported for table commit validation".to_string(),
         ));
+    }
+
+    let mut record_count = 0usize;
+    while offset < data.len() {
+        let block_count = read_avro_long(data, &mut offset)?;
+        let block_count = usize::try_from(block_count)
+            .ok()
+            .filter(|count| *count > 0)
+            .ok_or_else(|| TableCatalogStoreError::Invalid("Avro data block count is invalid".to_string()))?;
+        record_count = record_count
+            .checked_add(block_count)
+            .filter(|count| *count <= TABLE_MANIFEST_AVRO_MAX_RECORDS)
+            .ok_or_else(|| {
+                TableCatalogStoreError::Invalid(format!(
+                    "Avro container exceeds the maximum record count of {TABLE_MANIFEST_AVRO_MAX_RECORDS}"
+                ))
+            })?;
+        let block_size = read_avro_long(data, &mut offset)?;
+        let block_size = usize::try_from(block_size)
+            .map_err(|_| TableCatalogStoreError::Invalid("Avro data block size is invalid".to_string()))?;
+        let block_end = offset
+            .checked_add(block_size)
+            .ok_or_else(|| TableCatalogStoreError::Invalid("Avro data block exceeds the object size".to_string()))?;
+        let block_marker_end = block_end
+            .checked_add(16)
+            .filter(|marker_end| *marker_end <= data.len())
+            .ok_or_else(|| TableCatalogStoreError::Invalid("Avro data block exceeds the object size".to_string()))?;
+        if data[block_end..block_marker_end] != sync_marker {
+            return Err(TableCatalogStoreError::Invalid("Avro data block has an invalid sync marker".to_string()));
+        }
+        offset = block_marker_end;
     }
     Ok(())
 }
@@ -12589,6 +13571,12 @@ fn compacted_manifest_avro_bytes(data_files: &[CompactedDataFile]) -> TableCatal
     let schema = compacted_manifest_avro_schema(data_files)?;
     let mut writer = apache_avro::Writer::new(&schema, Vec::new());
     for data_file in data_files {
+        let record_count = i64::try_from(data_file.record_count).map_err(|_| {
+            TableCatalogStoreError::Invalid("compacted data file record count exceeds the Iceberg long range".to_string())
+        })?;
+        let file_size_bytes = i64::try_from(data_file.file_size_bytes).map_err(|_| {
+            TableCatalogStoreError::Invalid("compacted data file size exceeds the Iceberg long range".to_string())
+        })?;
         let sort_order_id = match data_file.sort_order_id {
             Some(sort_order_id) => apache_avro::types::Value::Union(1, Box::new(apache_avro::types::Value::Int(sort_order_id))),
             None => apache_avro::types::Value::Union(0, Box::new(apache_avro::types::Value::Null)),
@@ -12609,14 +13597,8 @@ fn compacted_manifest_avro_bytes(data_files: &[CompactedDataFile]) -> TableCatal
                         ("file_path".to_string(), apache_avro::types::Value::String(data_file.file_path.clone())),
                         ("file_format".to_string(), apache_avro::types::Value::String("PARQUET".to_string())),
                         ("partition".to_string(), apache_avro::types::Value::Record(data_file.partition.clone())),
-                        (
-                            "record_count".to_string(),
-                            apache_avro::types::Value::Long(i64::try_from(data_file.record_count).unwrap_or(i64::MAX)),
-                        ),
-                        (
-                            "file_size_in_bytes".to_string(),
-                            apache_avro::types::Value::Long(i64::try_from(data_file.file_size_bytes).unwrap_or(i64::MAX)),
-                        ),
+                        ("record_count".to_string(), apache_avro::types::Value::Long(record_count)),
+                        ("file_size_in_bytes".to_string(), apache_avro::types::Value::Long(file_size_bytes)),
                         (
                             "column_sizes".to_string(),
                             apache_avro::types::Value::Union(0, Box::new(apache_avro::types::Value::Null)),
@@ -12664,9 +13646,17 @@ fn compacted_manifest_avro_bytes(data_files: &[CompactedDataFile]) -> TableCatal
         .map_err(|err| TableCatalogStoreError::Internal(format!("failed to flush compaction manifest: {err}")))
 }
 
-fn compaction_snapshot_id(current_metadata: &serde_json::Value, entry: &TableEntry, now: OffsetDateTime) -> i64 {
-    let generation = i64::try_from(entry.generation).unwrap_or(i64::MAX);
-    let mut snapshot_id = unix_timestamp_millis(now).saturating_mul(1000).saturating_add(generation);
+fn compaction_snapshot_id(
+    current_metadata: &serde_json::Value,
+    entry: &TableEntry,
+    now: OffsetDateTime,
+) -> TableCatalogStoreResult<i64> {
+    let generation = i64::try_from(entry.generation)
+        .map_err(|_| TableCatalogStoreError::Invalid("table generation exceeds the snapshot id range".to_string()))?;
+    let mut snapshot_id = unix_timestamp_millis(now)
+        .checked_mul(1000)
+        .and_then(|timestamp| timestamp.checked_add(generation))
+        .ok_or_else(|| TableCatalogStoreError::Invalid("compaction snapshot id overflows".to_string()))?;
     let existing_snapshot_ids = current_metadata
         .get("snapshots")
         .and_then(serde_json::Value::as_array)
@@ -12675,17 +13665,20 @@ fn compaction_snapshot_id(current_metadata: &serde_json::Value, entry: &TableEnt
         .filter_map(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64))
         .collect::<BTreeSet<_>>();
     while existing_snapshot_ids.contains(&snapshot_id) {
-        snapshot_id = snapshot_id.saturating_add(1);
+        snapshot_id = snapshot_id
+            .checked_add(1)
+            .ok_or_else(|| TableCatalogStoreError::Invalid("compaction snapshot id space is exhausted".to_string()))?;
     }
-    snapshot_id
+    Ok(snapshot_id)
 }
 
-fn next_compaction_sequence_number(current_metadata: &serde_json::Value) -> i64 {
+fn next_compaction_sequence_number(current_metadata: &serde_json::Value) -> TableCatalogStoreResult<i64> {
     current_metadata
         .get("last-sequence-number")
         .and_then(serde_json::Value::as_i64)
-        .unwrap_or(0)
-        .saturating_add(1)
+        .ok_or_else(|| TableCatalogStoreError::Invalid("table metadata is missing last-sequence-number".to_string()))?
+        .checked_add(1)
+        .ok_or_else(|| TableCatalogStoreError::Invalid("table sequence number is exhausted".to_string()))
 }
 
 fn compaction_metadata_json(
@@ -13108,6 +14101,24 @@ fn table_maintenance_job_lease_is_active(
     heartbeat_at.saturating_add(Duration::seconds(timeout_seconds)) > now
 }
 
+fn ensure_current_maintenance_worker(
+    current: &TableMetadataMaintenanceJob,
+    expected: &TableMetadataMaintenanceJob,
+) -> TableCatalogStoreResult<()> {
+    if !matches!(current.status, TableMetadataMaintenanceJobStatus::Running)
+        || current.job_id != expected.job_id
+        || current.table_id != expected.table_id
+        || current.lease_id.is_empty()
+        || current.lease_id != expected.lease_id
+        || current.worker_id != expected.worker_id
+    {
+        return Err(TableCatalogStoreError::Conflict(
+            "maintenance worker lease changed before publication".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn table_maintenance_job_retry_is_pending(job: &TableMetadataMaintenanceJob, now: OffsetDateTime) -> bool {
     if !matches!(job.status, TableMetadataMaintenanceJobStatus::Failed) {
         return false;
@@ -13121,6 +14132,139 @@ fn table_maintenance_job_retry_is_pending(job: &TableMetadataMaintenanceJob, now
 fn validate_catalog_entry_version(kind: &str, version: u16) -> TableCatalogStoreResult<()> {
     if version != TABLE_CATALOG_ENTRY_VERSION {
         return Err(TableCatalogStoreError::Invalid(format!("unsupported {kind} entry version")));
+    }
+    Ok(())
+}
+
+fn validate_namespace_entry_object(
+    paths: &TableCatalogObjectPaths,
+    object: &str,
+    entry: &NamespaceEntry,
+) -> TableCatalogStoreResult<()> {
+    validate_catalog_entry_version("namespace", entry.version)?;
+    validate_namespace_properties(&entry.properties)?;
+    let namespace = parse_namespace_for_store(&entry.namespace)?;
+    if paths.namespace_entry_path(&entry.table_bucket, &namespace) != object {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog namespace entry identity does not match its object path".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_table_entry_identity(
+    entry: &TableEntry,
+    table_bucket: &str,
+    namespace: &Namespace,
+    table: &IdentifierSegment,
+) -> TableCatalogStoreResult<()> {
+    validate_table_entry_path_identity(entry, table_bucket, namespace, table)?;
+    validate_table_warehouse_location(table_bucket, &entry.warehouse_location)?;
+    if !is_valid_table_metadata_location_for_entry(entry, &entry.metadata_location) {
+        return Err(TableCatalogStoreError::Invalid(
+            "object-backed table metadata location must be inside a protected table metadata directory".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_table_entry_path_identity(
+    entry: &TableEntry,
+    table_bucket: &str,
+    namespace: &Namespace,
+    table: &IdentifierSegment,
+) -> TableCatalogStoreResult<()> {
+    validate_catalog_entry_version("table", entry.version)?;
+    if entry.table_bucket != table_bucket || entry.namespace != namespace.public_name() || entry.table != table.as_str() {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog table entry identity does not match its object path".to_string(),
+        ));
+    }
+    if entry.table_id.is_empty() || entry.table_uuid.is_empty() {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog table entry has an empty stable identity".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_table_entry_object_identity(
+    paths: &TableCatalogObjectPaths,
+    object: &str,
+    entry: &TableEntry,
+) -> TableCatalogStoreResult<()> {
+    let namespace = parse_namespace_for_store(&entry.namespace)?;
+    let table = parse_table_for_store(&entry.table)?;
+    validate_table_entry_path_identity(entry, &entry.table_bucket, &namespace, &table)?;
+    if paths.table_entry_path(&entry.table_bucket, &namespace, &table) != object {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog table entry identity does not match its object path".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_table_entry_object(paths: &TableCatalogObjectPaths, object: &str, entry: &TableEntry) -> TableCatalogStoreResult<()> {
+    validate_table_entry_object_identity(paths, object, entry)?;
+    validate_table_warehouse_location(&entry.table_bucket, &entry.warehouse_location)?;
+    if !is_valid_table_metadata_location_for_entry(entry, &entry.metadata_location) {
+        return Err(TableCatalogStoreError::Invalid(
+            "object-backed table metadata location must be inside a protected table metadata directory".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_view_entry_identity(
+    entry: &ViewEntry,
+    table_bucket: &str,
+    namespace: &Namespace,
+    view: &IdentifierSegment,
+) -> TableCatalogStoreResult<()> {
+    validate_view_entry_path_identity(entry, table_bucket, namespace, view)?;
+    validate_view_warehouse_location(table_bucket, &entry.warehouse_location)?;
+    if !is_valid_view_metadata_location(namespace, view, &entry.metadata_location) {
+        return Err(TableCatalogStoreError::Invalid(
+            "object-backed view metadata location must match the view identifier".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_view_entry_path_identity(
+    entry: &ViewEntry,
+    table_bucket: &str,
+    namespace: &Namespace,
+    view: &IdentifierSegment,
+) -> TableCatalogStoreResult<()> {
+    validate_catalog_entry_version("view", entry.version)?;
+    if entry.table_bucket != table_bucket || entry.namespace != namespace.public_name() || entry.view != view.as_str() {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog view entry identity does not match its object path".to_string(),
+        ));
+    }
+    if entry.view_id.is_empty() || entry.view_uuid.is_empty() {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog view entry has an empty stable identity".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_view_entry_object(paths: &TableCatalogObjectPaths, object: &str, entry: &ViewEntry) -> TableCatalogStoreResult<()> {
+    let namespace = parse_namespace_for_store(&entry.namespace)?;
+    let view = parse_table_for_store(&entry.view)?;
+    validate_view_entry_path_identity(entry, &entry.table_bucket, &namespace, &view)?;
+    if paths.view_entry_path(&entry.table_bucket, &namespace, &view) != object {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog view entry identity does not match its object path".to_string(),
+        ));
+    }
+    validate_view_warehouse_location(&entry.table_bucket, &entry.warehouse_location)?;
+    if !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location) {
+        return Err(TableCatalogStoreError::Invalid(
+            "object-backed view metadata location must match the view identifier".to_string(),
+        ));
     }
     Ok(())
 }
@@ -13240,19 +14384,12 @@ pub(crate) fn commit_log_matches_request(commit_log: &CommitLogEntry, request: &
         && commit_log.expected_version_token == request.expected_version_token
         && commit_log.previous_metadata_location == request.expected_metadata_location
         && commit_log.new_metadata_location == request.new_metadata_location
-        && commit_requirements_match(&commit_log.requirements, &request.requirements)
+        && client_commit_requirements(&commit_log.requirements) == client_commit_requirements(&request.requirements)
         && commit_log.writer == request.writer
 }
 
-fn commit_requirements_match(persisted: &[serde_json::Value], requested: &[serde_json::Value]) -> bool {
-    if persisted == requested {
-        return true;
-    }
-    let Some((internal_digest, client_requirements)) = requested.split_last() else {
-        return false;
-    };
-    persisted == client_requirements
-        && internal_digest.get("type").and_then(serde_json::Value::as_str) == Some(TABLE_METADATA_DIGEST_REQUIREMENT_TYPE)
+fn committed_requirements_match(left: &[serde_json::Value], right: &[serde_json::Value]) -> bool {
+    client_commit_requirements(left) == client_commit_requirements(right)
 }
 
 fn table_matches_committed_log(table: &TableEntry, commit_log: &CommitLogEntry) -> bool {
@@ -13314,7 +14451,7 @@ fn commit_logs_share_recovery_payload(left: &CommitLogEntry, right: &CommitLogEn
         && left.new_version_token == right.new_version_token
         && left.previous_metadata_location == right.previous_metadata_location
         && left.new_metadata_location == right.new_metadata_location
-        && left.requirements == right.requirements
+        && committed_requirements_match(&left.requirements, &right.requirements)
         && left.writer == right.writer
 }
 
@@ -13899,13 +15036,7 @@ pub(crate) fn validate_table_warehouse_relocation(
     if next_warehouse_location == entry.warehouse_location {
         return Ok(());
     }
-    let object_key = table_catalog_object_key_from_location(&entry.table_bucket, &entry.metadata_location)
-        .ok_or_else(|| TableCatalogStoreError::Invalid("current metadata location is invalid".to_string()))?;
-    if table_metadata_dir_from_object_key(&object_key).is_none() {
-        return Err(TableCatalogStoreError::Unsupported(
-            "warehouse relocation is unsupported for tables registered outside the managed catalog metadata root".to_string(),
-        ));
-    }
+    table_metadata_dir_path_for_entry(entry)?;
     Ok(())
 }
 
@@ -13941,23 +15072,23 @@ fn table_metadata_dir_path_for_entry(entry: &TableEntry) -> TableCatalogStoreRes
     if let Some(metadata_dir) = table_metadata_dir_from_object_key(&object_key) {
         return Ok(metadata_dir);
     }
-    let warehouse_prefix = table_warehouse_object_prefix(entry)?;
-    let metadata_dir = format!("{warehouse_prefix}{METADATA_DIR}");
-    object_key
-        .strip_prefix(&format!("{metadata_dir}/"))
-        .filter(|file_name| is_valid_table_metadata_file_name(file_name))
-        .map(|_| metadata_dir)
-        .ok_or_else(|| {
-            TableCatalogStoreError::Invalid(
-                "current metadata location must be inside a protected table metadata directory".to_string(),
-            )
-        })
+    let (metadata_dir, file_name) = object_key.rsplit_once('/').ok_or_else(|| {
+        TableCatalogStoreError::Invalid("current metadata location must include a protected metadata directory".to_string())
+    })?;
+    if metadata_dir.is_empty() || !is_valid_table_metadata_file_name(file_name) {
+        return Err(TableCatalogStoreError::Invalid(
+            "current metadata location must be inside a protected table metadata directory".to_string(),
+        ));
+    }
+    Ok(metadata_dir.to_string())
 }
 
 fn table_object_root_prefix_for_entry(entry: &TableEntry) -> Option<String> {
-    table_metadata_dir_path_for_entry(entry)
-        .ok()
-        .and_then(|metadata_dir| metadata_dir.strip_suffix(METADATA_DIR).map(str::to_string))
+    table_metadata_dir_path_for_entry(entry).ok().and_then(|metadata_dir| {
+        metadata_dir
+            .strip_suffix(&format!("/{METADATA_DIR}"))
+            .map(|root| format!("{root}/"))
+    })
 }
 
 pub(crate) fn is_valid_table_metadata_location(
@@ -14123,6 +15254,15 @@ mod tests {
         assert_eq!(marker["catalog_type"], TABLE_BUCKET_CATALOG_TYPE);
         assert_eq!(marker["reserved_prefix"], TABLE_RESERVED_PREFIX);
         assert!(!table_bucket_marker_json().unwrap().is_empty());
+    }
+
+    #[test]
+    fn table_catalog_generation_rejects_exhausted_counter() {
+        assert_eq!(next_table_catalog_generation(41).unwrap(), 42);
+        assert_matches!(
+            next_table_catalog_generation(u64::MAX),
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("generation is exhausted")
+        );
     }
 
     #[test]
@@ -15445,6 +16585,22 @@ mod tests {
         store.backend.reset_call_counts().await;
     }
 
+    async fn claim_table_metadata_maintenance_report(
+        store: &ObjectTableCatalogStore<TestCatalogObjectBackend>,
+        mut report: TableMetadataMaintenanceReport,
+    ) -> TableMetadataMaintenanceReport {
+        report.job.operation = TableMetadataMaintenanceOperation::Delete;
+        report.job.status = TableMetadataMaintenanceJobStatus::Running;
+        report.job.worker_id = Some("test-worker".to_string());
+        report.job.lease_id = Uuid::new_v4().to_string();
+        report.job.heartbeat_at = Some(maintenance_timestamp(OffsetDateTime::now_utc()));
+        store
+            .put_table_metadata_maintenance_report(&report)
+            .await
+            .expect("maintenance report should be claimed");
+        report
+    }
+
     async fn seed_quarantined_table_maintenance(
         store: &ObjectTableCatalogStore<TestCatalogObjectBackend>,
         backend: &TestCatalogObjectBackend,
@@ -15572,6 +16728,263 @@ mod tests {
             .await
             .expect_err("object over the size limit should be rejected");
         assert_matches!(err, TableCatalogStoreError::Invalid(message) if message.contains("maximum size"));
+    }
+
+    #[tokio::test]
+    async fn object_catalog_rejects_namespace_payloads_at_the_wrong_paths() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let parent = Namespace::parse("sales").expect("parent namespace should parse");
+        let child = Namespace::parse("sales.daily").expect("child namespace should parse");
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &parent))
+            .await
+            .expect("parent namespace should be created");
+
+        let mut misplaced_parent = test_namespace_entry(bucket, &parent);
+        misplaced_parent.namespace = "marketing".to_string();
+        misplaced_parent.namespace_id = Namespace::parse("marketing").expect("namespace should parse").storage_id();
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store.paths.namespace_entry_path(bucket, &parent),
+                serde_json::to_vec(&misplaced_parent).expect("namespace should serialize"),
+            )
+            .await;
+        assert_matches!(
+            store.get_namespace(bucket, &parent.public_name()).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+        assert_matches!(
+            store.list_namespaces(bucket).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store.paths.namespace_entry_path(bucket, &parent),
+                serde_json::to_vec(&test_namespace_entry(bucket, &parent)).expect("namespace should serialize"),
+            )
+            .await;
+        let mut misplaced_child = test_namespace_entry(bucket, &child);
+        misplaced_child.namespace = "sales.monthly".to_string();
+        misplaced_child.namespace_id = Namespace::parse("sales.monthly")
+            .expect("namespace should parse")
+            .storage_id();
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store.paths.namespace_entry_path(bucket, &child),
+                serde_json::to_vec(&misplaced_child).expect("namespace should serialize"),
+            )
+            .await;
+
+        assert_matches!(
+            store.list_namespaces_under(bucket, &parent.public_name()).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+    }
+
+    #[tokio::test]
+    async fn object_catalog_rejects_table_and_view_payloads_at_the_wrong_paths() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let view = IdentifierSegment::parse("recent_orders").expect("view should parse");
+        let table_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let view_metadata = default_view_metadata_file_path(&namespace, &view, "00001.metadata.json");
+
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        let table_entry = test_table_entry(bucket, &namespace, &table, table_metadata);
+        store.create_table(table_entry.clone()).await.unwrap();
+        let view_entry = test_view_entry(bucket, &namespace, &view, view_metadata);
+        store.create_view(view_entry.clone()).await.unwrap();
+
+        let mut misplaced_table = table_entry;
+        misplaced_table.table = "returns".to_string();
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store.paths.table_entry_path(bucket, &namespace, &table),
+                serde_json::to_vec(&misplaced_table).unwrap(),
+            )
+            .await;
+        let table_error = store
+            .load_table(bucket, &namespace.public_name(), table.as_str())
+            .await
+            .expect_err("a table payload must match its catalog object path");
+        assert_matches!(
+            table_error,
+            TableCatalogStoreError::Invalid(message) if message.contains("identity does not match its object path")
+        );
+        assert_matches!(
+            store.list_tables(bucket, &namespace.public_name()).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+        assert_matches!(
+            store.export_table_catalog_entry(bucket, &namespace.public_name(), table.as_str()).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+        assert_matches!(
+            store
+                .list_tables_page(
+                    bucket,
+                    &namespace.public_name(),
+                    None,
+                    NonZeroUsize::new(1).expect("page size should be non-zero"),
+                )
+                .await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+        assert_matches!(
+            store.drop_table(bucket, &namespace.public_name(), table.as_str()).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+        assert!(
+            backend
+                .object_exists(RUSTFS_META_BUCKET, &store.paths.table_entry_path(bucket, &namespace, &table),)
+                .await
+                .expect("misplaced table object existence should be readable")
+        );
+
+        let mut misplaced_view = view_entry;
+        misplaced_view.view = "daily_orders".to_string();
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store.paths.view_entry_path(bucket, &namespace, &view),
+                serde_json::to_vec(&misplaced_view).unwrap(),
+            )
+            .await;
+        let view_error = store
+            .load_view(bucket, &namespace.public_name(), view.as_str())
+            .await
+            .expect_err("a view payload must match its catalog object path");
+        assert_matches!(
+            view_error,
+            TableCatalogStoreError::Invalid(message) if message.contains("identity does not match its object path")
+        );
+        assert_matches!(
+            store.list_views(bucket, &namespace.public_name()).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+        assert_matches!(
+            store.drop_view(bucket, &namespace.public_name(), view.as_str()).await,
+            Err(TableCatalogStoreError::Invalid(message)) if message.contains("identity does not match its object path")
+        );
+        assert!(
+            backend
+                .object_exists(RUSTFS_META_BUCKET, &store.paths.view_entry_path(bucket, &namespace, &view),)
+                .await
+                .expect("misplaced view object existence should be readable")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_catalog_bridge_does_not_follow_a_recreated_table_name() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let metadata_location = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        store
+            .create_table(test_table_entry(bucket, &namespace, &table, metadata_location.clone()))
+            .await
+            .unwrap();
+        let mut configured = store
+            .put_external_catalog_bridge(ExternalCatalogBridgeEntry {
+                version: TABLE_EXTERNAL_CATALOG_BRIDGE_VERSION,
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                table_id: String::new(),
+                catalog: "polaris".to_string(),
+                external_catalog_id: Some("catalog-1".to_string()),
+                external_namespace: "sales".to_string(),
+                external_table: "orders".to_string(),
+                external_table_uuid: Some("external-table-uuid".to_string()),
+                metadata_location: Some(metadata_location.clone()),
+                external_version_token: Some("external-v1".to_string()),
+                policy_mode: "read-only".to_string(),
+                credential_mode: "vended".to_string(),
+                sync_mode: "manual".to_string(),
+                rollback_strategy: "manual".to_string(),
+                last_sync_status: Some("successful".to_string()),
+                last_synced_metadata_location: Some(metadata_location.clone()),
+                properties: BTreeMap::new(),
+                created_at: None,
+                updated_at: None,
+            })
+            .await
+            .expect("bridge should bind to the active table");
+        assert_eq!(configured.table_id, "table-id");
+
+        let bridge_path = store.paths.external_catalog_bridge_path(bucket, &namespace, &table);
+        let identity_path = store.paths.external_catalog_bridge_identity_path(bucket, &namespace, &table);
+        let persisted_bridge = backend
+            .read_object(RUSTFS_META_BUCKET, &bridge_path)
+            .await
+            .expect("bridge lookup should succeed")
+            .expect("bridge should be persisted");
+        let persisted_bridge: serde_json::Value =
+            serde_json::from_slice(&persisted_bridge.data).expect("bridge should remain compatible JSON");
+        assert!(persisted_bridge.get("table_id").is_none());
+        backend.fail_delete_attempt(RUSTFS_META_BUCKET, &bridge_path, 1).await;
+        backend.fail_delete_attempt(RUSTFS_META_BUCKET, &identity_path, 1).await;
+
+        store
+            .drop_table(bucket, &namespace.public_name(), table.as_str())
+            .await
+            .expect("original table should be dropped");
+        let mut recreated = test_table_entry(bucket, &namespace, &table, metadata_location);
+        recreated.table_id = "table-id-2".to_string();
+        recreated.table_uuid = "table-uuid-2".to_string();
+        recreated.warehouse_location = format!("s3://{bucket}/tables/table-id-2");
+        store
+            .create_table(recreated)
+            .await
+            .expect("same table name should be reusable");
+
+        let error = store
+            .get_external_catalog_bridge(bucket, &namespace.public_name(), table.as_str())
+            .await
+            .expect_err("the old bridge must not attach to a different stable table identity");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Invalid(message) if message.contains("identity does not match the active table")
+        );
+
+        configured.table_id.clear();
+        configured.catalog = "nessie".to_string();
+        backend.fail_next_put(RUSTFS_META_BUCKET, &bridge_path).await;
+        store
+            .put_external_catalog_bridge(configured)
+            .await
+            .expect_err("a bridge publication failure must not publish the replacement table identity");
+        let error = store
+            .get_external_catalog_bridge(bucket, &namespace.public_name(), table.as_str())
+            .await
+            .expect_err("a failed bridge replacement must leave the stale identity fenced");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Invalid(message) if message.contains("identity does not match the active table")
+        );
     }
 
     #[tokio::test]
@@ -15744,6 +17157,7 @@ mod tests {
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
             .await
             .expect("maintenance report should be planned");
+        let report = claim_table_metadata_maintenance_report(&store, report).await;
         backend
             .seed_object(bucket, &current, br#"{"table-uuid":"other-table-uuid","metadata-log":[]}"#.to_vec())
             .await;
@@ -15804,7 +17218,7 @@ mod tests {
             .expect("data-plane resource lookup should succeed");
 
         assert!(resource.is_none());
-        assert_eq!(backend.list_call_count().await, 0);
+        assert!(backend.list_call_count().await > 0);
     }
 
     #[tokio::test]
@@ -15876,7 +17290,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn table_data_plane_resource_skips_stale_deeper_index_and_matches_parent() {
+    async fn table_data_plane_resource_fails_closed_for_a_stale_deeper_index() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
         let bucket = "analytics";
@@ -15895,24 +17309,104 @@ mod tests {
             warehouse_object_prefix: stale_prefix.to_string(),
             state: TableCatalogEntryState::Active,
         };
+        let stale_index_path = store.paths.warehouse_index_entry_path(bucket, stale_prefix);
         store
-            .write_entry(
-                store.catalog_bucket(),
-                &store.paths.warehouse_index_entry_path(bucket, stale_prefix),
-                &stale_index,
-                TableCatalogPutPrecondition::Any,
-            )
+            .write_entry(store.catalog_bucket(), &stale_index_path, &stale_index, TableCatalogPutPrecondition::Any)
             .await
             .unwrap();
 
-        let resource = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/child/data/part-00001.parquet")
+        let error = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/child/data/part-00001.parquet")
             .await
-            .expect("stale deeper index should not fail lookup")
-            .expect("parent table should still protect the object");
+            .expect_err("an active index that disagrees with its table must deny resolution");
 
-        assert_eq!(resource.table, "orders");
-        assert_eq!(resource.warehouse_object_prefix, "tables/table-id/");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Internal(message) if message.contains("different warehouse prefix")
+        );
+        assert!(backend.object_exists(RUSTFS_META_BUCKET, &stale_index_path).await.unwrap());
         assert_eq!(backend.list_call_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn warehouse_relocation_reservation_denies_access_until_table_cas() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let next = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let relocated_prefix = "tables/relocated-table-id/";
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend
+            .seed_object(
+                bucket,
+                &next,
+                serde_json::to_vec(&serde_json::json!({
+                    "location": "s3://analytics/tables/relocated-table-id",
+                    "table-uuid": "table-uuid"
+                }))
+                .unwrap(),
+            )
+            .await;
+        let table_path = store.paths.table_entry_path(bucket, &namespace, &table);
+        let relocated_index_path = store.paths.warehouse_index_entry_path(bucket, relocated_prefix);
+        let pause = backend.pause_next_put(RUSTFS_META_BUCKET, &table_path).await;
+        let commit_store = store.clone();
+        let namespace_name = namespace.public_name();
+        let table_name = table.as_str().to_string();
+        let current_for_commit = current.clone();
+        let next_for_commit = next.clone();
+        let commit = tokio::spawn(async move {
+            commit_store
+                .commit_table(TableCommitRequest {
+                    table_bucket: bucket.to_string(),
+                    namespace: namespace_name,
+                    table: table_name,
+                    commit_id: "relocate-commit".to_string(),
+                    idempotency_key: None,
+                    operation: "set-location".to_string(),
+                    expected_version_token: "token-v1".to_string(),
+                    expected_metadata_location: current_for_commit,
+                    new_metadata_location: next_for_commit,
+                    requirements: Vec::new(),
+                    writer: Some("test".to_string()),
+                })
+                .await
+        });
+        pause.wait_started().await;
+
+        assert!(
+            backend
+                .object_exists(RUSTFS_META_BUCKET, &relocated_index_path)
+                .await
+                .unwrap()
+        );
+        let pending_error =
+            table_data_plane_resource_for_object(&store, bucket, "tables/relocated-table-id/data/part-00001.parquet")
+                .await
+                .expect_err("a reservation without the matching table pointer must fail closed");
+        assert_matches!(
+            pending_error,
+            TableCatalogStoreError::Internal(message) if message.contains("different warehouse prefix")
+        );
+        assert!(
+            backend
+                .object_exists(RUSTFS_META_BUCKET, &relocated_index_path)
+                .await
+                .unwrap()
+        );
+
+        pause.release();
+        let committed = commit.await.unwrap().expect("relocation commit should complete");
+        assert_eq!(committed.table.metadata_location, next);
+        let resource = table_data_plane_resource_for_object(&store, bucket, "tables/relocated-table-id/data/part-00001.parquet")
+            .await
+            .expect("committed relocation should resolve")
+            .expect("relocated object should have a table owner");
+        assert_eq!(resource.table_id, "table-id");
+        assert_eq!(resource.warehouse_object_prefix, relocated_prefix);
     }
 
     #[tokio::test]
@@ -16025,7 +17519,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn table_data_plane_resource_falls_back_to_scan_without_index_state() {
+    async fn table_data_plane_resource_backfills_missing_index_state() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
         let bucket = "analytics";
@@ -16066,7 +17560,7 @@ mod tests {
 
         let resource = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/part-00001.parquet")
             .await
-            .expect("legacy catalog lookup should fall back to scanning")
+            .expect("legacy catalog lookup should backfill the index")
             .expect("legacy table entry should resolve");
 
         assert_eq!(resource.table, "orders");
@@ -16082,6 +17576,40 @@ mod tests {
         assert_eq!(indexed_resource.table, "orders");
         assert_eq!(backend.list_call_count().await, 0);
         assert!(backend.read_call_count().await <= WAREHOUSE_INDEX_MAX_PREFIX_DEPTH + 3);
+    }
+
+    #[tokio::test]
+    async fn table_data_plane_resource_fails_closed_when_a_ready_index_entry_is_missing() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current).await;
+        let entry = store
+            .load_table(bucket, "sales", "orders")
+            .await
+            .unwrap()
+            .expect("table should exist");
+        let index = table_warehouse_index_entry(&entry).expect("warehouse index should validate");
+        let index_path = store.paths.warehouse_index_entry_path(bucket, &index.warehouse_object_prefix);
+        backend
+            .delete_object(RUSTFS_META_BUCKET, &index_path)
+            .await
+            .expect("warehouse index entry should be removed");
+        backend.reset_call_counts().await;
+
+        let error = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/part-00001.parquet")
+            .await
+            .expect_err("a missing ready index entry must fail closed");
+
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message) if message.contains("warehouse index does not cover")
+        );
+        assert_eq!(backend.list_call_count().await, 0);
     }
 
     #[tokio::test]
@@ -16220,24 +17748,6 @@ mod tests {
 
         seed_catalog_list_entries(&store, bucket, &namespace).await;
 
-        let namespace_page = store
-            .list_namespaces_page(bucket, None, one)
-            .await
-            .expect("first namespace page should load");
-        assert_eq!(namespace_page.entries[0].namespace, "analytics");
-        assert!(
-            namespace_page
-                .next_cursor
-                .as_deref()
-                .is_some_and(|cursor| cursor.starts_with(OBJECT_CATALOG_LIST_CURSOR_PREFIX))
-        );
-        let namespace_page = store
-            .list_namespaces_page(bucket, namespace_page.next_cursor.as_deref(), one)
-            .await
-            .expect("second namespace page should load");
-        assert_eq!(namespace_page.entries[0].namespace, "sales");
-        assert!(namespace_page.next_cursor.is_none());
-
         backend.reset_call_counts().await;
         let table_page = store
             .list_tables_page(bucket, &namespace_name, None, one)
@@ -16276,50 +17786,6 @@ mod tests {
                 .await,
             Err(TableCatalogStoreError::Invalid(_))
         ));
-    }
-
-    #[tokio::test]
-    async fn object_catalog_pagination_bounds_sparse_namespace_scans() {
-        let backend = TestCatalogObjectBackend::default();
-        let store = ObjectTableCatalogStore::new(backend.clone());
-        let bucket = "analytics";
-        let namespace = Namespace::parse("sales").expect("namespace should parse");
-        let prefix = store.paths.namespace_entries_prefix(bucket);
-
-        store
-            .put_table_bucket(test_bucket_entry(bucket))
-            .await
-            .expect("table bucket should be created");
-        store
-            .create_namespace(test_namespace_entry(bucket, &namespace))
-            .await
-            .expect("namespace should be created");
-        for index in 0..TABLE_CATALOG_LIST_MAX_KEYS {
-            backend
-                .seed_object(RUSTFS_META_BUCKET, &format!("{prefix}0000-spacer/{index:04}.json"), Vec::new())
-                .await;
-        }
-        backend.reset_call_counts().await;
-
-        let one = NonZeroUsize::new(1).expect("page size should be non-zero");
-        let first = store
-            .list_namespaces_page(bucket, None, one)
-            .await
-            .expect("sparse first page should load");
-        assert!(first.entries.is_empty());
-        assert_eq!(backend.list_call_count().await, 1);
-        let cursor = first.next_cursor.expect("truncated sparse page should have a cursor");
-        assert!(cursor.starts_with(OBJECT_CATALOG_LIST_CURSOR_PREFIX));
-        assert!(!cursor.ends_with(NAMESPACE_ENTRY_FILE));
-
-        let second = store
-            .list_namespaces_page(bucket, Some(&cursor), one)
-            .await
-            .expect("sparse continuation page should load");
-        assert_eq!(second.entries.len(), 1);
-        assert_eq!(second.entries[0].namespace, namespace.public_name());
-        assert!(second.next_cursor.is_none());
-        assert_eq!(backend.list_call_count().await, 2);
     }
 
     #[tokio::test]
@@ -16607,7 +18073,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn table_data_plane_resource_skips_invalid_warehouse_locations() {
+    async fn table_data_plane_resource_fails_closed_for_invalid_active_warehouse_locations() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend);
         let bucket = "analytics";
@@ -16646,18 +18112,16 @@ mod tests {
             .await
             .unwrap();
 
-        let unrelated = table_data_plane_resource_for_object(&store, bucket, "ordinary/object.parquet")
+        let unrelated_error = table_data_plane_resource_for_object(&store, bucket, "ordinary/object.parquet")
             .await
-            .expect("invalid table warehouse location should not deny unrelated object lookup");
-        assert!(unrelated.is_none());
+            .expect_err("an invalid active table must keep the table bucket fail closed");
+        assert_matches!(unrelated_error, TableCatalogStoreError::Invalid(_));
 
-        let resource = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/part-00001.parquet")
+        let valid_prefix_error = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/part-00001.parquet")
             .await
-            .expect("invalid table warehouse location should not block a later valid match")
-            .expect("valid table warehouse object should resolve to the table");
-        assert_eq!(resource.table, "orders");
-        assert_eq!(resource.table_id, "table-id");
-        assert_eq!(resource.warehouse_object_prefix, "tables/table-id/");
+            .expect_err("a valid sibling must not bypass a corrupt active catalog entry");
+        assert_matches!(valid_prefix_error, TableCatalogStoreError::Invalid(_));
+        assert!(!store.warehouse_index_ready(bucket).await.unwrap());
     }
 
     #[tokio::test]
@@ -18400,6 +19864,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maintenance_worker_repairs_stale_running_alias_from_terminal_job() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let now = OffsetDateTime::UNIX_EPOCH + Duration::seconds(100);
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
+        store
+            .put_table_maintenance_config(
+                bucket,
+                "sales",
+                "orders",
+                TableMaintenanceConfig {
+                    version: TABLE_MAINTENANCE_CONFIG_VERSION,
+                    background_enabled: true,
+                    worker_lease_timeout_seconds: 60,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("background maintenance config should persist");
+        let mut running = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("maintenance report should be planned");
+        running.job.status = TableMetadataMaintenanceJobStatus::Running;
+        running.job.worker_id = Some("worker-a".to_string());
+        running.job.lease_id = "lease-a".to_string();
+        running.job.heartbeat_at = Some(maintenance_timestamp(now - Duration::seconds(120)));
+        store
+            .put_table_metadata_maintenance_report(&running)
+            .await
+            .expect("running aliases should be seeded");
+        let mut terminal = running.clone();
+        terminal.job.status = TableMetadataMaintenanceJobStatus::Successful;
+        terminal.job.finished_at = Some(maintenance_timestamp(now - Duration::seconds(60)));
+        let job_path =
+            store
+                .paths
+                .table_maintenance_job_path(bucket, &namespace, &table, &terminal.job.table_id, &terminal.job.job_id);
+        store
+            .write_entry(RUSTFS_META_BUCKET, &job_path, &terminal, TableCatalogPutPrecondition::Any)
+            .await
+            .expect("terminal per-job record should be seeded without updating aliases");
+
+        let recovered = store
+            .run_table_metadata_maintenance_worker_once_at(bucket, "sales", "orders", "worker-b".to_string(), now)
+            .await
+            .expect("worker should recover the terminal per-job record");
+
+        assert_eq!(recovered.job.job_id, terminal.job.job_id);
+        assert_eq!(recovered.job.status, TableMetadataMaintenanceJobStatus::Successful);
+        let current_alias = store
+            .get_table_metadata_maintenance_report(bucket, "sales", "orders", MAINTENANCE_JOB_ALIAS_CURRENT)
+            .await
+            .expect("current alias lookup should succeed")
+            .expect("current alias should exist");
+        let latest_alias = store
+            .get_table_metadata_maintenance_report(bucket, "sales", "orders", MAINTENANCE_JOB_ALIAS_LATEST)
+            .await
+            .expect("latest alias lookup should succeed")
+            .expect("latest alias should exist");
+        assert_eq!(current_alias.job.status, TableMetadataMaintenanceJobStatus::Successful);
+        assert_eq!(latest_alias.job.status, TableMetadataMaintenanceJobStatus::Successful);
+        assert_eq!(current_alias.job.job_id, terminal.job.job_id);
+        assert_eq!(latest_alias.job.job_id, terminal.job.job_id);
+    }
+
+    #[tokio::test]
     async fn maintenance_worker_run_recovers_expired_running_job() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -18959,25 +20497,142 @@ mod tests {
     }
 
     #[test]
-    fn commit_requirements_accept_legacy_logs_without_internal_metadata_digest() {
+    fn table_commit_manifest_readers_reject_oversized_declared_avro_blocks() {
+        let mut malformed = b"Obj\x01".to_vec();
+        malformed.push(0);
+        malformed.extend_from_slice(&[7; 16]);
+        malformed.push(2);
+        let mut encoded_size = 2_000_000u64;
+        loop {
+            let byte = u8::try_from(encoded_size & 0x7f).expect("Avro long byte should fit");
+            encoded_size >>= 7;
+            if encoded_size == 0 {
+                malformed.push(byte);
+                break;
+            }
+            malformed.push(byte | 0x80);
+        }
+
+        let error = validate_uncompressed_avro_container(&malformed)
+            .expect_err("a declared block larger than the container must fail before Avro decoding");
+
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Invalid(message) if message.contains("data block exceeds the object size")
+        );
+    }
+
+    #[test]
+    fn committed_requirements_ignore_internal_metadata_digests() {
         let client_requirement = serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"});
         let internal_digest = serde_json::json!({
             "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
             "sha256": "digest"
         });
 
-        assert!(commit_requirements_match(
+        assert!(committed_requirements_match(
             std::slice::from_ref(&client_requirement),
             &[client_requirement.clone(), internal_digest.clone()],
         ));
-        assert!(commit_requirements_match(
+        assert!(committed_requirements_match(
             &[client_requirement.clone(), internal_digest.clone()],
             &[client_requirement.clone(), internal_digest.clone()],
         ));
-        assert!(!commit_requirements_match(
+        assert!(committed_requirements_match(
             std::slice::from_ref(&client_requirement),
             &[internal_digest, client_requirement.clone()],
         ));
+    }
+
+    #[test]
+    fn commit_integrity_digests_are_stored_outside_compatible_commit_logs() {
+        let client_requirement = serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"});
+        let base_digest = serde_json::json!({
+            "type": TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE,
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+        });
+        let new_digest = serde_json::json!({
+            "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        });
+        let request = TableCommitRequest {
+            table_bucket: "analytics".to_string(),
+            namespace: "sales".to_string(),
+            table: "orders".to_string(),
+            commit_id: "commit-1".to_string(),
+            idempotency_key: Some("request-1".to_string()),
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            expected_metadata_location: "tables/table-id/metadata/00001.metadata.json".to_string(),
+            new_metadata_location: "tables/table-id/metadata/00002.metadata.json".to_string(),
+            requirements: vec![client_requirement.clone(), base_digest, new_digest],
+            writer: Some("pyiceberg/test".to_string()),
+        };
+        let log = CommitLogEntry {
+            version: TABLE_CATALOG_ENTRY_VERSION,
+            commit_id: request.commit_id.clone(),
+            idempotency_key: request.idempotency_key.clone(),
+            table_id: "table-id".to_string(),
+            operation: request.operation.clone(),
+            expected_version_token: request.expected_version_token.clone(),
+            new_version_token: "token-v2".to_string(),
+            previous_metadata_location: request.expected_metadata_location.clone(),
+            new_metadata_location: request.new_metadata_location.clone(),
+            requirements: vec![client_requirement.clone()],
+            status: CommitLogStatus::Staged,
+            writer: request.writer.clone(),
+            created_at: None,
+            updated_at: None,
+        };
+
+        assert!(commit_log_matches_request(&log, &request, "table-id"));
+        let mut staged_index = log.clone();
+        staged_index.status = CommitLogStatus::Staged;
+        staged_index.requirements = request.requirements.clone();
+        assert!(commit_logs_share_recovery_payload(&log, &staged_index));
+        assert_eq!(log.requirements, vec![client_requirement]);
+
+        let integrity = table_commit_integrity_entry(&request, "table-id")
+            .expect("commit integrity should be valid")
+            .expect("digest requirements should produce a sidecar");
+        assert!(integrity.request_sha256.is_some());
+        assert_eq!(
+            integrity.expected_metadata_sha256.as_deref(),
+            Some("0000000000000000000000000000000000000000000000000000000000000000")
+        );
+        assert_eq!(
+            integrity.new_metadata_sha256.as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+
+        let mut changed_digest_request = request.clone();
+        changed_digest_request
+            .requirements
+            .last_mut()
+            .expect("internal digest should exist")["sha256"] =
+            serde_json::Value::String("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string());
+        assert!(commit_log_matches_request(&staged_index, &changed_digest_request, "table-id"));
+        assert_ne!(
+            table_commit_integrity_entry(&request, "table-id").unwrap(),
+            table_commit_integrity_entry(&changed_digest_request, "table-id").unwrap()
+        );
+
+        let mut changed_payload_request = request;
+        changed_payload_request.operation = "overwrite".to_string();
+        let changed_payload_integrity = table_commit_integrity_entry(&changed_payload_request, "table-id")
+            .expect("changed commit integrity should be valid")
+            .expect("digest requirements should produce a sidecar");
+        assert_ne!(integrity.request_sha256, changed_payload_integrity.request_sha256);
+        assert_matches!(
+            validate_table_commit_integrity_replay(Some(&changed_payload_integrity), Some(&integrity), None, true),
+            Err(TableCatalogStoreError::Conflict(message)) if message.contains("original request")
+        );
+        assert_matches!(
+            validate_table_commit_integrity_replay(None, Some(&integrity), None, false),
+            Err(TableCatalogStoreError::Conflict(message)) if message.contains("must be included")
+        );
+        validate_table_commit_integrity_replay(None, Some(&integrity), None, true)
+            .expect("an older client may replay an existing commit without internal digest requirements");
     }
 
     #[tokio::test]
@@ -19234,6 +20889,72 @@ mod tests {
         assert!(backend.object_exists(bucket, &data_file).await.unwrap());
         assert!(!backend.object_exists(bucket, &orphan_manifest).await.unwrap());
         assert!(!backend.object_exists(bucket, &orphan_data).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn maintenance_delete_rejects_referenced_manifest_rewritten_after_planning() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let metadata_dir = default_table_metadata_dir_path(&namespace, &table);
+        let table_root = format!("{}{}/", default_table_root_prefix(&namespace), table.as_str());
+        let manifest_list = format!("{metadata_dir}/snap-10.avro");
+        let manifest = format!("{metadata_dir}/manifest-10.avro");
+        let data_file = format!("{table_root}data/part-00001.parquet");
+        let orphan_data = format!("{table_root}data/orphan.parquet");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend
+            .seed_object(bucket, &manifest_list, manifest_list_avro_bytes(&[&manifest]))
+            .await;
+        backend
+            .seed_object(bucket, &manifest, manifest_avro_bytes(&[(&data_file, 0)]))
+            .await;
+        backend.seed_object(bucket, &data_file, b"data".to_vec()).await;
+        backend.seed_object(bucket, &orphan_data, b"orphan-data".to_vec()).await;
+        backend
+            .seed_object(
+                bucket,
+                &current,
+                serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
+                    "metadata-log": [],
+                    "snapshots": [{"snapshot-id": 10, "manifest-list": manifest_list}],
+                    "refs": {"main": {"snapshot-id": 10, "type": "branch"}}
+                }))
+                .expect("metadata should serialize"),
+            )
+            .await;
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("maintenance report should be planned");
+        assert_eq!(report.deletable_object_locations, vec![orphan_data.clone()]);
+        let report = claim_table_metadata_maintenance_report(&store, report).await;
+        backend
+            .replace_on_write_lock_acquisition(
+                bucket,
+                &manifest,
+                1,
+                manifest_avro_bytes(&[(&data_file, 0), (&orphan_data, 0)]),
+                false,
+                true,
+            )
+            .await;
+
+        let error = store
+            .delete_table_metadata_maintenance_report(bucket, "sales", "orders", report)
+            .await
+            .expect_err("manifest replacement must invalidate the destructive plan");
+
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message) if message.contains("referenced object") && message.contains("changed")
+        );
+        assert!(backend.object_exists(bucket, &orphan_data).await.unwrap());
     }
 
     #[tokio::test]
@@ -19811,6 +21532,47 @@ mod tests {
                 .reasons
                 .contains(&TableCompactionPlanningReason::MissingCurrentSnapshot)
         );
+    }
+
+    #[test]
+    fn compaction_identifiers_fail_when_the_numeric_space_is_exhausted() {
+        let namespace = Namespace::parse("analytics").expect("namespace should parse");
+        let table = IdentifierSegment::parse("events").expect("table should parse");
+        let mut entry = test_table_entry(
+            "warehouse",
+            &namespace,
+            &table,
+            default_table_metadata_file_path(&namespace, &table, "00001.metadata.json"),
+        );
+        entry.generation = u64::try_from(i64::MAX).expect("i64::MAX should fit in u64");
+        let metadata = serde_json::json!({
+            "snapshots": [{"snapshot-id": i64::MAX}],
+            "last-sequence-number": i64::MAX
+        });
+
+        let snapshot_error = compaction_snapshot_id(&metadata, &entry, OffsetDateTime::UNIX_EPOCH)
+            .expect_err("snapshot id exhaustion must fail instead of looping");
+        assert_matches!(snapshot_error, TableCatalogStoreError::Invalid(_));
+        let sequence_error =
+            next_compaction_sequence_number(&metadata).expect_err("sequence number exhaustion must fail instead of saturating");
+        assert_matches!(sequence_error, TableCatalogStoreError::Invalid(_));
+
+        let data_file = CompactedDataFile {
+            object_key: "data.parquet".to_string(),
+            file_path: "s3://warehouse/data.parquet".to_string(),
+            file_size_bytes: 1,
+            record_count: u64::try_from(i64::MAX).expect("i64::MAX should fit in u64") + 1,
+            partition_spec_id: 0,
+            partition: Vec::new(),
+            sort_order_id: None,
+            status: 1,
+            snapshot_id: 1,
+            sequence_number: 1,
+            file_sequence_number: 1,
+        };
+        let manifest_error =
+            compacted_manifest_avro_bytes(&[data_file]).expect_err("manifest counters outside the Iceberg long range must fail");
+        assert_matches!(manifest_error, TableCatalogStoreError::Invalid(_));
     }
 
     #[tokio::test]
@@ -20621,6 +22383,7 @@ mod tests {
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
             .await
             .unwrap();
+        let report = claim_table_metadata_maintenance_report(&store, report).await;
         assert_eq!(report.cleanup_candidate_locations, vec![old.clone(), fresh.clone()]);
         assert_eq!(report.deletable_metadata_locations, vec![old.clone()]);
 
@@ -20648,6 +22411,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maintenance_delete_retry_records_candidates_deleted_before_report_persistence() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let candidate = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend.seed_object(bucket, &candidate, b"{}".to_vec()).await;
+        backend
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("maintenance report should be planned");
+        let report = claim_table_metadata_maintenance_report(&store, report).await;
+        backend
+            .delete_object(bucket, &candidate)
+            .await
+            .expect("the first delete attempt should remove the candidate");
+
+        let recovered = store
+            .delete_table_metadata_maintenance_report(bucket, "sales", "orders", report)
+            .await
+            .expect("the retry should reconcile an already deleted candidate");
+
+        assert_eq!(recovered.job.status, TableMetadataMaintenanceJobStatus::Successful);
+        assert_eq!(recovered.job.deleted_metadata_file_count, 1);
+        assert_eq!(recovered.cleanup_candidate_locations, vec![candidate.clone()]);
+        assert_eq!(recovered.deletable_metadata_locations, vec![candidate.clone()]);
+        assert_eq!(
+            maintenance_object_report(&recovered, &candidate).state,
+            TableMetadataMaintenanceObjectState::Deleted
+        );
+        assert!(!backend.object_exists(bucket, &candidate).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn maintenance_delete_preserves_candidates_replaced_before_lock_acquisition() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -20668,6 +22472,7 @@ mod tests {
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
             .await
             .expect("maintenance report should be planned");
+        let report = claim_table_metadata_maintenance_report(&store, report).await;
         backend
             .replace_on_write_lock_acquisition(bucket, &first, 1, b"new-etag".to_vec(), false, true)
             .await;
@@ -20704,6 +22509,137 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maintenance_delete_rejects_a_worker_after_lease_replacement() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let candidate = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend.seed_object(bucket, &candidate, b"{}".to_vec()).await;
+        backend
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("maintenance report should be planned");
+        let stale = claim_table_metadata_maintenance_report(&store, report).await;
+        let mut replacement = stale.clone();
+        replacement.job.job_id = Uuid::new_v4().to_string();
+        replacement.job.worker_id = Some("replacement-worker".to_string());
+        replacement.job.lease_id = Uuid::new_v4().to_string();
+        store
+            .put_table_metadata_maintenance_report(&replacement)
+            .await
+            .expect("replacement worker should become current");
+
+        let error = store
+            .delete_table_metadata_maintenance_report(bucket, "sales", "orders", stale)
+            .await
+            .expect_err("a replaced worker lease must not retain delete authority");
+
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message) if message.contains("worker lease changed")
+        );
+        assert!(backend.object_exists(bucket, &candidate).await.unwrap());
+        let current_report = store
+            .get_table_metadata_maintenance_report(bucket, "sales", "orders", MAINTENANCE_JOB_ALIAS_CURRENT)
+            .await
+            .unwrap()
+            .expect("replacement worker should remain current");
+        assert_eq!(current_report.job.job_id, replacement.job.job_id);
+    }
+
+    #[tokio::test]
+    async fn maintenance_delete_stops_when_any_protecting_lock_is_lost() {
+        for lock_target in [
+            "migration",
+            "ownership",
+            "table",
+            "current-job",
+            "current-metadata",
+            "reference-source",
+            "candidate",
+        ] {
+            let backend = TestCatalogObjectBackend::default();
+            let store = ObjectTableCatalogStore::new(backend.clone());
+            let bucket = "analytics";
+            let namespace = Namespace::parse("sales").expect("namespace should parse");
+            let table = IdentifierSegment::parse("orders").expect("table should parse");
+            let candidate = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+            let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+            let metadata_dir = default_table_metadata_dir_path(&namespace, &table);
+            let manifest_list = format!("{metadata_dir}/snap-10.avro");
+            let manifest = format!("{metadata_dir}/manifest-10.avro");
+            let data_file = format!("{}/part-10.parquet", default_table_data_dir_path(&namespace, &table));
+
+            seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+            backend.seed_object(bucket, &candidate, b"{}".to_vec()).await;
+            backend
+                .seed_object(bucket, &manifest_list, manifest_list_avro_bytes(&[&manifest]))
+                .await;
+            backend
+                .seed_object(bucket, &manifest, manifest_avro_bytes(&[(&data_file, 0)]))
+                .await;
+            backend.seed_object(bucket, &data_file, b"data".to_vec()).await;
+            backend
+                .seed_object(
+                    bucket,
+                    &current,
+                    serde_json::to_vec(&serde_json::json!({
+                        "table-uuid": "table-uuid",
+                        "metadata-log": [],
+                        "snapshots": [{"snapshot-id": 10, "manifest-list": manifest_list}],
+                        "refs": {"main": {"snapshot-id": 10, "type": "branch"}}
+                    }))
+                    .expect("metadata should serialize"),
+                )
+                .await;
+            let report = store
+                .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+                .await
+                .expect("maintenance report should be planned");
+            let report = claim_table_metadata_maintenance_report(&store, report).await;
+            assert_eq!(report.deletable_metadata_locations, vec![candidate.clone()]);
+
+            let table_path = store.paths.table_entry_path(bucket, &namespace, &table);
+            let migration_path = store.paths.backing_migration_fence_lock_path(bucket);
+            let ownership_path = store.paths.warehouse_index_ownership_lock_path(bucket);
+            let current_job_path =
+                store
+                    .paths
+                    .table_maintenance_current_job_path(bucket, &namespace, &table, &report.job.table_id);
+            let (lock_bucket, lock_object) = match lock_target {
+                "migration" => (RUSTFS_META_BUCKET, migration_path.as_str()),
+                "ownership" => (RUSTFS_META_BUCKET, ownership_path.as_str()),
+                "table" => (RUSTFS_META_BUCKET, table_path.as_str()),
+                "current-job" => (RUSTFS_META_BUCKET, current_job_path.as_str()),
+                "current-metadata" => (bucket, current.as_str()),
+                "reference-source" => (bucket, manifest.as_str()),
+                "candidate" => (bucket, candidate.as_str()),
+                _ => unreachable!(),
+            };
+            backend.lose_next_write_lock(lock_bucket, lock_object).await;
+
+            let error = store
+                .delete_table_metadata_maintenance_report(bucket, "sales", "orders", report)
+                .await
+                .expect_err("maintenance must not delete after losing a protecting lock");
+
+            assert_matches!(
+                error,
+                TableCatalogStoreError::Conflict(message) if message.contains("lock lease was lost")
+            );
+            assert!(backend.object_exists(bucket, &candidate).await.unwrap());
+        }
+    }
+
+    #[tokio::test]
     async fn maintenance_delete_conflicts_when_current_pointer_changes_before_delete() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -20724,6 +22660,7 @@ mod tests {
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
             .await
             .unwrap();
+        let report = claim_table_metadata_maintenance_report(&store, report).await;
         assert_eq!(report.cleanup_candidate_locations, vec![old.clone()]);
 
         backend
@@ -20777,6 +22714,7 @@ mod tests {
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
             .await
             .unwrap();
+        let report = claim_table_metadata_maintenance_report(&store, report).await;
         assert!(report.deletable_object_locations.contains(&reassigned_object.to_string()));
 
         let mut child = test_table_entry(bucket, &namespace, &child_table, child_metadata);
@@ -21304,6 +23242,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn durable_strong_migration_cancel_retries_after_target_removal() {
+        let backend = TestCatalogObjectBackend::default();
+        let object_store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        seed_table_for_metadata_maintenance(&object_store, bucket, &namespace, &table, current_metadata).await;
+        object_store
+            .materialize_durable_strong_backing_migration(bucket)
+            .await
+            .expect("migration snapshot should materialize");
+        let fence_path = object_store.paths.backing_migration_fence_path(bucket);
+        backend.fail_delete_attempt(RUSTFS_META_BUCKET, &fence_path, 1).await;
+
+        object_store
+            .cancel_durable_strong_backing_migration(bucket)
+            .await
+            .expect_err("injected fence deletion failure should interrupt cancellation");
+        assert!(
+            StrongTableCatalogStore::new(backend.clone())
+                .load_table(bucket, "sales", "orders")
+                .await
+                .expect("strong table lookup should succeed")
+                .is_none(),
+            "the newly materialized target should already be removed"
+        );
+        assert!(backend.object_exists(RUSTFS_META_BUCKET, &fence_path).await.unwrap());
+
+        let retry = object_store
+            .cancel_durable_strong_backing_migration(bucket)
+            .await
+            .expect("cancellation retry should release the remaining fence");
+
+        assert_eq!(retry.status, TableCatalogBackingMigrationCancelStatus::FenceReleased);
+        assert!(!retry.object_backed_writes_fenced);
+        assert!(!backend.object_exists(RUSTFS_META_BUCKET, &fence_path).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn durable_strong_migration_waits_for_in_flight_catalog_writes() {
         let backend = TestCatalogObjectBackend::default();
         let object_store = ObjectTableCatalogStore::new(backend.clone());
@@ -21586,40 +23564,50 @@ mod tests {
             .await
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        let client_requirement = serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"});
+        let metadata_digest = hex_sha256(b"{}", str::to_owned);
+        let expected_requirements = vec![
+            client_requirement.clone(),
+            serde_json::json!({
+                "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+                "sha256": metadata_digest.clone()
+            }),
+        ];
+        let request = TableCommitRequest {
+            table_bucket: bucket.to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            commit_id: "commit-1".to_string(),
+            idempotency_key: Some("client-request".to_string()),
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            expected_metadata_location: current_metadata,
+            new_metadata_location: new_metadata.clone(),
+            requirements: expected_requirements,
+            writer: Some("pyiceberg/test".to_string()),
+        };
 
-        let result = store
-            .commit_table(TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: table.as_str().to_string(),
-                commit_id: "commit-1".to_string(),
-                idempotency_key: Some("client-request".to_string()),
-                operation: "append".to_string(),
-                expected_version_token: "token-v1".to_string(),
-                expected_metadata_location: current_metadata,
-                new_metadata_location: new_metadata.clone(),
-                requirements: Vec::new(),
-                writer: Some("pyiceberg/test".to_string()),
-            })
-            .await
-            .unwrap();
+        let result = store.commit_table(request.clone()).await.unwrap();
 
         assert_eq!(result.table.metadata_location, new_metadata);
         assert_eq!(result.table.generation, 2);
         assert_eq!(result.commit_log.status, CommitLogStatus::Committed);
+        assert_eq!(result.commit_log.requirements, vec![client_requirement.clone()]);
 
         let loaded = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
         assert_eq!(loaded.metadata_location, result.table.metadata_location);
         assert_eq!(loaded.version_token, result.table.version_token);
-        assert_eq!(
-            store
-                .get_commit_by_id(bucket, "table-id", "commit-1")
-                .await
-                .unwrap()
-                .unwrap()
-                .status,
-            CommitLogStatus::Committed
-        );
+        let stored_commit = store.get_commit_by_id(bucket, "table-id", "commit-1").await.unwrap().unwrap();
+        assert_eq!(stored_commit.status, CommitLogStatus::Committed);
+        assert_eq!(stored_commit.requirements, result.commit_log.requirements);
+        let integrity_path = TableCatalogObjectPaths::default().commit_integrity_entry_path(bucket, "table-id", "commit-1");
+        let integrity = store
+            .read_commit_integrity_entry(&integrity_path)
+            .await
+            .expect("commit integrity lookup should succeed")
+            .expect("commit integrity should be persisted");
+        assert!(integrity.request_sha256.is_some());
+        assert_eq!(integrity.new_metadata_sha256.as_deref(), Some(metadata_digest.as_str()));
         assert_eq!(
             store
                 .get_commit_by_idempotency_key(bucket, "table-id", "client-request")
@@ -21630,11 +23618,91 @@ mod tests {
             CommitLogStatus::Committed
         );
 
+        let mut legacy_retry = request;
+        legacy_retry.requirements = vec![client_requirement];
+        let replay = store
+            .commit_table(legacy_retry)
+            .await
+            .expect("an older client should replay the committed result without internal digest requirements");
+        assert_eq!(replay.table.version_token, result.table.version_token);
+
         let recovery = store.plan_table_commit_recovery(bucket, "sales", "orders").await.unwrap();
         assert_eq!(recovery.staged_before_table_update_count, 0);
         assert_eq!(recovery.finalization_required_count, 0);
         assert_eq!(recovery.idempotency_repair_required_count, 0);
         assert_eq!(recovery.manual_review_count, 0);
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_commit_integrity_sidecar_fences_retry_after_snapshot_failure() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        store
+            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
+            .await
+            .unwrap();
+        backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        let request = TableCommitRequest {
+            table_bucket: bucket.to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            commit_id: "commit-sidecar-retry".to_string(),
+            idempotency_key: None,
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            expected_metadata_location: current_metadata.clone(),
+            new_metadata_location: new_metadata.clone(),
+            requirements: vec![serde_json::json!({
+                "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+                "sha256": hex_sha256(b"{}", str::to_owned)
+            })],
+            writer: Some("pyiceberg/test".to_string()),
+        };
+        let snapshot_path = StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path();
+        backend.fail_next_put(RUSTFS_META_BUCKET, &snapshot_path).await;
+
+        let error = store
+            .commit_table(request.clone())
+            .await
+            .expect_err("snapshot publication should fail after staging commit integrity");
+        assert_matches!(error, TableCatalogStoreError::Internal(_));
+        assert_eq!(
+            store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .unwrap()
+                .unwrap()
+                .metadata_location,
+            current_metadata
+        );
+
+        let mut takeover = request.clone();
+        takeover.operation = "overwrite".to_string();
+        let error = store
+            .commit_table(takeover)
+            .await
+            .expect_err("a different payload must not take over the staged commit id");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message) if message.contains("original request")
+        );
+
+        let result = store
+            .commit_table(request)
+            .await
+            .expect("the original payload should recover after snapshot publication failure");
+        assert_eq!(result.table.metadata_location, new_metadata);
     }
 
     #[tokio::test]
@@ -21647,18 +23715,6 @@ mod tests {
         let one = NonZeroUsize::new(1).expect("page size should be non-zero");
 
         seed_catalog_list_entries(&store, bucket, &namespace).await;
-
-        let first = store
-            .list_namespaces_page(bucket, None, one)
-            .await
-            .expect("first strong namespace page should load");
-        assert_eq!(first.entries[0].namespace, "analytics");
-        let second = store
-            .list_namespaces_page(bucket, first.next_cursor.as_deref(), one)
-            .await
-            .expect("second strong namespace page should load");
-        assert_eq!(second.entries[0].namespace, "sales");
-        assert!(second.next_cursor.is_none());
 
         let first = store
             .list_tables_page(bucket, &namespace_name, None, one)
@@ -21686,14 +23742,6 @@ mod tests {
         assert!(second.next_cursor.is_none());
 
         let exact = NonZeroUsize::new(2).expect("exact page size should be non-zero");
-        assert!(
-            store
-                .list_namespaces_page(bucket, None, exact)
-                .await
-                .expect("exact strong namespace page should load")
-                .next_cursor
-                .is_none()
-        );
         assert!(
             store
                 .list_tables_page(bucket, &namespace_name, None, exact)
@@ -22322,6 +24370,23 @@ mod tests {
         };
         assert_matches!(invalid, TableCatalogStoreError::Invalid(message) if message.contains("protected"));
 
+        let mut invalid_warehouse = test_table_entry(
+            bucket,
+            &namespace,
+            &orders,
+            default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json"),
+        );
+        invalid_warehouse.warehouse_location = "s3://analytics/tables/../orders".to_string();
+        let Err(invalid_warehouse) =
+            StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(snapshot(vec![invalid_warehouse]), None)
+        else {
+            panic!("an invalid active table warehouse must fail closed");
+        };
+        assert_matches!(
+            invalid_warehouse,
+            TableCatalogStoreError::Invalid(message) if message.contains("invalid warehouse location")
+        );
+
         let orphan = test_table_entry(
             bucket,
             &namespace,
@@ -22366,6 +24431,19 @@ mod tests {
         };
         assert_matches!(orphan_view, TableCatalogStoreError::Invalid(message) if message.contains("no active namespace"));
 
+        let mut invalid_view_warehouse = view_entry.clone();
+        invalid_view_warehouse.warehouse_location = "s3://analytics/views/../summary".to_string();
+        let Err(invalid_view_warehouse) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            view_snapshot(vec![test_namespace_entry(bucket, &namespace)], vec![invalid_view_warehouse]),
+            None,
+        ) else {
+            panic!("an invalid active view warehouse must fail closed");
+        };
+        assert_matches!(
+            invalid_view_warehouse,
+            TableCatalogStoreError::Invalid(message) if message.contains("invalid warehouse location")
+        );
+
         let mut invalid_view = view_entry;
         invalid_view.metadata_location = default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json");
         let Err(invalid_view) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
@@ -22375,6 +24453,38 @@ mod tests {
             panic!("active view with an invalid metadata location should fail closed");
         };
         assert_matches!(invalid_view, TableCatalogStoreError::Invalid(message) if message.contains("invalid metadata location"));
+    }
+
+    #[test]
+    fn strong_catalog_snapshot_loads_legacy_same_name_table_and_view() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let name = IdentifierSegment::parse("orders").expect("identifier should parse");
+        let snapshot = StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces: vec![test_namespace_entry(bucket, &namespace)],
+            tables: vec![test_table_entry(
+                bucket,
+                &namespace,
+                &name,
+                default_table_metadata_file_path(&namespace, &name, "00001.metadata.json"),
+            )],
+            views: vec![test_view_entry(
+                bucket,
+                &namespace,
+                &name,
+                default_view_metadata_file_path(&namespace, &name, "00001.metadata.json"),
+            )],
+            commits: Vec::new(),
+            idempotency: Vec::new(),
+        };
+
+        let state = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(snapshot, None)
+            .expect("legacy same-name table and view should remain readable after upgrade");
+
+        assert_eq!(state.tables.len(), 1);
+        assert_eq!(state.views.len(), 1);
     }
 
     #[test]
@@ -23372,39 +25482,59 @@ mod tests {
         store.backfill_table_warehouse_index(bucket).await.unwrap();
         backend.reset_call_counts().await;
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        let client_requirement = serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"});
+        let metadata_digest = hex_sha256(b"{}", str::to_owned);
+        let expected_requirements = vec![
+            client_requirement.clone(),
+            serde_json::json!({
+                "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+                "sha256": metadata_digest.clone()
+            }),
+        ];
+        let ownership_lock_path = store.paths.warehouse_index_ownership_lock_path(bucket);
+        let ownership_lock_acquisitions = backend
+            .write_lock_acquisition_count(store.catalog_bucket(), &ownership_lock_path)
+            .await;
 
-        let result = store
-            .commit_table(TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: table.as_str().to_string(),
-                commit_id: "commit-1".to_string(),
-                idempotency_key: Some("client/%2f\nrequest".to_string()),
-                operation: "append".to_string(),
-                expected_version_token: "token-v1".to_string(),
-                expected_metadata_location: current_metadata,
-                new_metadata_location: new_metadata.clone(),
-                requirements: vec![serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"})],
-                writer: Some("pyiceberg/test".to_string()),
-            })
-            .await
-            .unwrap();
+        let request = TableCommitRequest {
+            table_bucket: bucket.to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            commit_id: "commit-1".to_string(),
+            idempotency_key: Some("client/%2f\nrequest".to_string()),
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            expected_metadata_location: current_metadata,
+            new_metadata_location: new_metadata.clone(),
+            requirements: expected_requirements,
+            writer: Some("pyiceberg/test".to_string()),
+        };
+        let result = store.commit_table(request.clone()).await.unwrap();
 
         assert_eq!(result.table.metadata_location, new_metadata);
         assert_ne!(result.table.version_token, "token-v1");
         assert_eq!(result.table.generation, 2);
         assert_eq!(result.commit_log.status, CommitLogStatus::Committed);
+        assert_eq!(result.commit_log.requirements, vec![client_requirement.clone()]);
 
         let loaded = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
         assert_eq!(loaded.metadata_location, result.table.metadata_location);
         assert_eq!(loaded.version_token, result.table.version_token);
-        assert!(
-            store
-                .get_commit_by_id(bucket, "table-id", "commit-1")
-                .await
-                .unwrap()
-                .is_some()
-        );
+        let stored_commit = store
+            .get_commit_by_id(bucket, "table-id", "commit-1")
+            .await
+            .unwrap()
+            .expect("commit log should exist");
+        assert_eq!(stored_commit.requirements, result.commit_log.requirements);
+        let integrity_path = store.paths.commit_integrity_entry_path(bucket, "table-id", "commit-1");
+        let integrity = store
+            .read_entry::<TableCommitIntegrityEntry>(RUSTFS_META_BUCKET, &integrity_path)
+            .await
+            .expect("commit integrity lookup should succeed")
+            .map(|(entry, _)| entry)
+            .expect("commit integrity should be persisted");
+        assert!(integrity.request_sha256.is_some());
+        assert_eq!(integrity.new_metadata_sha256.as_deref(), Some(metadata_digest.as_str()));
         assert!(
             store
                 .get_commit_by_idempotency_key(bucket, "table-id", "client/%2f\nrequest")
@@ -23412,7 +25542,134 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+        let mut legacy_retry = request;
+        legacy_retry.requirements = vec![client_requirement];
+        let replay = store
+            .commit_table(legacy_retry)
+            .await
+            .expect("an older client should replay the committed result without internal digest requirements");
+        assert_eq!(replay.table.version_token, result.table.version_token);
         assert_eq!(backend.list_call_count().await, 0);
+        assert_eq!(
+            backend
+                .write_lock_acquisition_count(store.catalog_bucket(), &ownership_lock_path)
+                .await,
+            ownership_lock_acquisitions,
+            "pointer-only commits must not serialize on the bucket ownership lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn object_catalog_commit_integrity_sidecar_fences_retry_after_log_failure() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        store
+            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
+            .await
+            .unwrap();
+        store.backfill_table_warehouse_index(bucket).await.unwrap();
+        backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        let request = TableCommitRequest {
+            table_bucket: bucket.to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            commit_id: "commit-sidecar-retry".to_string(),
+            idempotency_key: None,
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            expected_metadata_location: current_metadata.clone(),
+            new_metadata_location: new_metadata.clone(),
+            requirements: vec![serde_json::json!({
+                "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+                "sha256": hex_sha256(b"{}", str::to_owned)
+            })],
+            writer: Some("pyiceberg/test".to_string()),
+        };
+        let commit_path = store.paths.commit_log_entry_path(bucket, "table-id", "commit-sidecar-retry");
+        backend.fail_next_put(store.catalog_bucket(), &commit_path).await;
+
+        let error = store
+            .commit_table(request.clone())
+            .await
+            .expect_err("commit log publication should fail after staging commit integrity");
+        assert_matches!(error, TableCatalogStoreError::Internal(_));
+        assert_eq!(
+            store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .unwrap()
+                .unwrap()
+                .metadata_location,
+            current_metadata
+        );
+        assert!(
+            store
+                .get_commit_by_id(bucket, "table-id", "commit-sidecar-retry")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let integrity_path = store
+            .paths
+            .commit_integrity_entry_path(bucket, "table-id", "commit-sidecar-retry");
+        let (integrity, _) = store
+            .read_entry::<TableCommitIntegrityEntry>(store.catalog_bucket(), &integrity_path)
+            .await
+            .expect("commit integrity lookup should succeed")
+            .expect("commit integrity should be staged before the commit log");
+
+        let mut takeover = request.clone();
+        takeover.operation = "overwrite".to_string();
+        let error = store
+            .commit_table(takeover)
+            .await
+            .expect_err("a different payload must not take over the staged commit id");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message) if message.contains("original request")
+        );
+
+        let mut corrupt_integrity = integrity.clone();
+        corrupt_integrity.request_sha256 = None;
+        backend
+            .seed_object(
+                store.catalog_bucket(),
+                &integrity_path,
+                serde_json::to_vec(&corrupt_integrity).expect("corrupt integrity entry should encode"),
+            )
+            .await;
+        let error = store
+            .commit_table(request.clone())
+            .await
+            .expect_err("a persisted integrity entry without a request digest must fail closed");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Invalid(message) if message.contains("invalid digests")
+        );
+        backend
+            .seed_object(
+                store.catalog_bucket(),
+                &integrity_path,
+                serde_json::to_vec(&integrity).expect("integrity entry should encode"),
+            )
+            .await;
+
+        let result = store
+            .commit_table(request)
+            .await
+            .expect("the original payload should recover after commit log failure");
+        assert_eq!(result.table.metadata_location, new_metadata);
     }
 
     #[tokio::test]
@@ -23435,7 +25692,17 @@ mod tests {
             .await
             .unwrap();
         store.backfill_table_warehouse_index(bucket).await.unwrap();
-        backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        backend
+            .seed_object(
+                bucket,
+                &new_metadata,
+                serde_json::to_vec(&serde_json::json!({
+                    "location": "s3://analytics/tables/relocated-table-id",
+                    "table-uuid": "table-uuid"
+                }))
+                .unwrap(),
+            )
+            .await;
         backend
             .lose_next_write_lock(store.catalog_bucket(), &store.paths.warehouse_index_ownership_lock_path(bucket))
             .await;
@@ -23447,7 +25714,7 @@ mod tests {
                 table: table.as_str().to_string(),
                 commit_id: "commit-lock-loss".to_string(),
                 idempotency_key: None,
-                operation: "append".to_string(),
+                operation: "set-location".to_string(),
                 expected_version_token: "token-v1".to_string(),
                 expected_metadata_location: current_metadata.clone(),
                 new_metadata_location: new_metadata,
@@ -23470,6 +25737,154 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn object_table_catalog_store_does_not_commit_after_migration_permit_loss() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        store
+            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
+            .await
+            .unwrap();
+        backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        backend
+            .lose_next_write_lock(store.catalog_bucket(), &store.paths.backing_migration_fence_lock_path(bucket))
+            .await;
+
+        let error = store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: "commit-migration-lock-loss".to_string(),
+                idempotency_key: None,
+                operation: "append".to_string(),
+                expected_version_token: "token-v1".to_string(),
+                expected_metadata_location: current_metadata.clone(),
+                new_metadata_location: new_metadata,
+                requirements: Vec::new(),
+                writer: Some("test".to_string()),
+            })
+            .await
+            .expect_err("a lost migration permit must prevent the table CAS");
+
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message) if message.contains("lock lease was lost")
+        );
+        let current = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
+        assert_eq!(current.metadata_location, current_metadata);
+        let staged = store
+            .get_commit_by_id(bucket, "table-id", "commit-migration-lock-loss")
+            .await
+            .unwrap()
+            .expect("the staged record should remain available for recovery");
+        assert_eq!(staged.status, CommitLogStatus::Staged);
+    }
+
+    #[tokio::test]
+    async fn object_table_catalog_store_does_not_commit_after_metadata_lock_loss() {
+        for lock_target in ["base", "new"] {
+            let backend = TestCatalogObjectBackend::default();
+            let store = ObjectTableCatalogStore::new(backend.clone());
+            let bucket = "analytics";
+            let namespace = Namespace::parse("sales").expect("namespace should parse");
+            let table = IdentifierSegment::parse("orders").expect("table should parse");
+            let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+            let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+            store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .unwrap();
+            store
+                .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
+                .await
+                .unwrap();
+            backend.seed_object(bucket, &current_metadata, b"{}".to_vec()).await;
+            backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+            let locked_metadata = if lock_target == "base" {
+                &current_metadata
+            } else {
+                &new_metadata
+            };
+            backend.lose_next_write_lock(bucket, locked_metadata).await;
+            let commit_id = format!("commit-{lock_target}-metadata-lock-loss");
+            let metadata_digest = hex_sha256(b"{}", str::to_owned);
+
+            let request = TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: commit_id.clone(),
+                idempotency_key: None,
+                operation: "append".to_string(),
+                expected_version_token: "token-v1".to_string(),
+                expected_metadata_location: current_metadata.clone(),
+                new_metadata_location: new_metadata,
+                requirements: vec![
+                    serde_json::json!({
+                        "type": TABLE_BASE_METADATA_DIGEST_REQUIREMENT_TYPE,
+                        "sha256": metadata_digest
+                    }),
+                    serde_json::json!({
+                        "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+                        "sha256": hex_sha256(b"{}", str::to_owned)
+                    }),
+                ],
+                writer: Some("test".to_string()),
+            };
+            let error = store
+                .commit_table(request.clone())
+                .await
+                .expect_err("a lost metadata lock must prevent the table CAS");
+
+            assert_matches!(
+                error,
+                TableCatalogStoreError::Conflict(message) if message.contains("lock lease was lost")
+            );
+            let current = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
+            assert_eq!(current.metadata_location, current_metadata);
+            let staged = store
+                .get_commit_by_id(bucket, "table-id", &commit_id)
+                .await
+                .unwrap()
+                .expect("the staged record should remain available for recovery");
+            assert_eq!(staged.status, CommitLogStatus::Staged);
+
+            let mut retry_without_integrity = request;
+            retry_without_integrity.requirements.clear();
+            let error = store
+                .commit_table(retry_without_integrity)
+                .await
+                .expect_err("a staged commit must not be resumed without its integrity requirements");
+            assert_matches!(
+                error,
+                TableCatalogStoreError::Conflict(message) if message.contains("must be included")
+            );
+            assert_eq!(
+                store
+                    .load_table(bucket, "sales", "orders")
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .metadata_location,
+                current_metadata
+            );
+        }
     }
 
     #[tokio::test]
@@ -24765,6 +27180,135 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn object_catalog_finishes_table_and_view_creation_after_caller_cancellation() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let view = IdentifierSegment::parse("summary").expect("view should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be created");
+
+        let table_path = store.paths.table_entry_path(bucket, &namespace, &table);
+        let table_pause = backend.pause_next_put(RUSTFS_META_BUCKET, &table_path).await;
+        let table_store = store.clone();
+        let table_entry = test_table_entry(
+            bucket,
+            &namespace,
+            &table,
+            default_table_metadata_file_path(&namespace, &table, "00001.metadata.json"),
+        );
+        let table_create = tokio::spawn(async move { table_store.create_table(table_entry).await });
+        table_pause.wait_started().await;
+        table_create.abort();
+        assert!(
+            table_create
+                .await
+                .expect_err("table caller should be cancelled")
+                .is_cancelled()
+        );
+        table_pause.release();
+        assert!(
+            store
+                .load_table(bucket, &namespace.public_name(), table.as_str())
+                .await
+                .expect("table lookup should succeed")
+                .is_some(),
+            "detached table publication must finish after caller cancellation"
+        );
+
+        let view_path = store.paths.view_entry_path(bucket, &namespace, &view);
+        let view_pause = backend.pause_next_put(RUSTFS_META_BUCKET, &view_path).await;
+        let view_store = store.clone();
+        let view_entry = test_view_entry(
+            bucket,
+            &namespace,
+            &view,
+            default_view_metadata_file_path(&namespace, &view, "00001.metadata.json"),
+        );
+        let view_create = tokio::spawn(async move { view_store.create_view(view_entry).await });
+        view_pause.wait_started().await;
+        view_create.abort();
+        assert!(view_create.await.expect_err("view caller should be cancelled").is_cancelled());
+        view_pause.release();
+        assert!(
+            store
+                .load_view(bucket, &namespace.public_name(), view.as_str())
+                .await
+                .expect("view lookup should succeed")
+                .is_some(),
+            "detached view publication must finish after caller cancellation"
+        );
+    }
+
+    #[tokio::test]
+    async fn object_catalog_rolls_back_materialized_parent_after_child_write_failure() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let parent = Namespace::parse("sales").expect("parent namespace should parse");
+        let child = Namespace::parse("sales.daily").expect("child namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let view_parent = Namespace::parse("reporting").expect("view parent should parse");
+        let view_child = Namespace::parse("reporting.daily").expect("view child should parse");
+        let view = IdentifierSegment::parse("summary").expect("view should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &child))
+            .await
+            .expect("table child namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &view_child))
+            .await
+            .expect("view child namespace should be created");
+
+        let table_entry = test_table_entry(
+            bucket,
+            &parent,
+            &table,
+            default_table_metadata_file_path(&parent, &table, "00001.metadata.json"),
+        );
+        let table_path = store.paths.table_entry_path(bucket, &parent, &table);
+        backend.fail_next_put(RUSTFS_META_BUCKET, &table_path).await;
+        store
+            .create_table(table_entry.clone())
+            .await
+            .expect_err("table write failure should abort parent materialization");
+        let parent_path = store.paths.namespace_entry_path(bucket, &parent);
+        let index = table_warehouse_index_entry(&table_entry).expect("table warehouse index should validate");
+        let index_path = store.paths.warehouse_index_entry_path(bucket, &index.warehouse_object_prefix);
+        assert!(!backend.object_exists(RUSTFS_META_BUCKET, &parent_path).await.unwrap());
+        assert!(!backend.object_exists(RUSTFS_META_BUCKET, &table_path).await.unwrap());
+        assert!(!backend.object_exists(RUSTFS_META_BUCKET, &index_path).await.unwrap());
+
+        let view_entry = test_view_entry(
+            bucket,
+            &view_parent,
+            &view,
+            default_view_metadata_file_path(&view_parent, &view, "00001.metadata.json"),
+        );
+        let view_path = store.paths.view_entry_path(bucket, &view_parent, &view);
+        backend.fail_next_put(RUSTFS_META_BUCKET, &view_path).await;
+        store
+            .create_view(view_entry)
+            .await
+            .expect_err("view write failure should abort parent materialization");
+        let view_parent_path = store.paths.namespace_entry_path(bucket, &view_parent);
+        assert!(!backend.object_exists(RUSTFS_META_BUCKET, &view_parent_path).await.unwrap());
+        assert!(!backend.object_exists(RUSTFS_META_BUCKET, &view_path).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn catalog_backings_page_tables_and_views_at_exact_boundaries() {
         let bucket = "analytics";
         let namespace = Namespace::parse("sales").expect("namespace should parse");
@@ -25064,6 +27608,76 @@ mod tests {
                 .await
                 .expect_err("table should conflict with a same-name view");
             assert_matches!(error, TableCatalogStoreError::Conflict(_));
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_reuse_identifiers_after_deleted_cross_kind_entries() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let name = IdentifierSegment::parse("orders").expect("identifier should parse");
+
+        for mode in [TableCatalogBackingMode::ObjectBacked, TableCatalogBackingMode::DurableStrong] {
+            let store = ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), mode);
+            store
+                .put_table_bucket(test_bucket_entry(bucket))
+                .await
+                .expect("table bucket should be created");
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .expect("namespace should be created");
+            store
+                .create_table(test_table_entry(
+                    bucket,
+                    &namespace,
+                    &name,
+                    default_table_metadata_file_path(&namespace, &name, "00001.metadata.json"),
+                ))
+                .await
+                .expect("table should be created");
+            store
+                .drop_table(bucket, &namespace.public_name(), name.as_str())
+                .await
+                .expect("table should be dropped");
+
+            store
+                .create_view(test_view_entry(
+                    bucket,
+                    &namespace,
+                    &name,
+                    default_view_metadata_file_path(&namespace, &name, "00001.metadata.json"),
+                ))
+                .await
+                .expect("a view should reuse a deleted table identifier");
+            assert!(store.load_table(bucket, "sales", "orders").await.unwrap().is_none());
+            assert!(store.load_view(bucket, "sales", "orders").await.unwrap().is_some());
+            store
+                .drop_view(bucket, &namespace.public_name(), name.as_str())
+                .await
+                .expect("view should be dropped");
+
+            let mut recreated = test_table_entry(
+                bucket,
+                &namespace,
+                &name,
+                default_table_metadata_file_path(&namespace, &name, "00002.metadata.json"),
+            );
+            recreated.table_id = "replacement-table-id".to_string();
+            recreated.table_uuid = "replacement-table-uuid".to_string();
+            recreated.warehouse_location = format!("s3://{bucket}/tables/replacement-table-id");
+            store
+                .create_table(recreated.clone())
+                .await
+                .expect("a table should reuse a deleted view identifier");
+
+            assert!(store.load_view(bucket, "sales", "orders").await.unwrap().is_none());
+            let loaded = store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .expect("table lookup should succeed")
+                .expect("replacement table should exist");
+            assert_eq!(loaded.table_id, recreated.table_id);
         }
     }
 

--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -80,6 +80,7 @@ pub(crate) const TABLE_METADATA_FILE_NAME_MAX_LEN: usize = 128;
 pub(crate) const TABLE_METADATA_JSON_MAX_SIZE: usize = 50 * 1024 * 1024;
 pub(crate) const TABLE_MANIFEST_AVRO_MAX_SIZE: usize = 128 * 1024 * 1024;
 const TABLE_MANIFEST_AVRO_MAX_RECORDS: usize = 1_000_000;
+const TABLE_MANIFEST_AVRO_MAX_HEADER_ENTRIES: usize = 1_024;
 pub(crate) const TABLE_METADATA_DIGEST_REQUIREMENT_TYPE: &str = "assert-rustfs-metadata-sha256";
 const NAMESPACE_PROPERTIES_MAX_ENTRIES: usize = 256;
 const NAMESPACE_PROPERTY_KEY_MAX_LEN: usize = 256;
@@ -2000,7 +2001,7 @@ where
     TableCatalogListPage { entries, next_cursor }
 }
 
-fn catalog_list_page_from_entries<T, F>(
+pub(crate) fn catalog_list_page_from_entries<T, F>(
     mut entries: Vec<T>,
     cursor: Option<&str>,
     limit: NonZeroUsize,
@@ -2038,18 +2039,25 @@ pub(crate) trait TableCatalogStore: Send + Sync {
 
     async fn list_namespaces(&self, table_bucket: &str) -> TableCatalogStoreResult<Vec<NamespaceEntry>>;
 
+    async fn list_namespaces_under(&self, table_bucket: &str, parent: &str) -> TableCatalogStoreResult<Vec<NamespaceEntry>> {
+        let parent = parse_namespace_for_store(parent)?.public_name();
+        Ok(self
+            .list_namespaces(table_bucket)
+            .await?
+            .into_iter()
+            .filter(|entry| entry.namespace == parent || namespace_is_descendant(&entry.namespace, &parent))
+            .collect())
+    }
+
     async fn list_namespaces_page(
         &self,
         table_bucket: &str,
         cursor: Option<&str>,
         limit: NonZeroUsize,
     ) -> TableCatalogStoreResult<TableCatalogListPage<NamespaceEntry>> {
-        Ok(catalog_list_page_from_entries(
-            self.list_namespaces(table_bucket).await?,
-            cursor,
-            limit,
-            |entry| &entry.namespace,
-        ))
+        let mut entries = self.list_namespaces(table_bucket).await?;
+        entries.retain(|entry| entry.state == TableCatalogEntryState::Active);
+        Ok(catalog_list_page_from_entries(entries, cursor, limit, |entry| &entry.namespace))
     }
 
     async fn get_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Option<NamespaceEntry>>;
@@ -2081,12 +2089,9 @@ pub(crate) trait TableCatalogStore: Send + Sync {
         cursor: Option<&str>,
         limit: NonZeroUsize,
     ) -> TableCatalogStoreResult<TableCatalogListPage<TableEntry>> {
-        Ok(catalog_list_page_from_entries(
-            self.list_tables(table_bucket, namespace).await?,
-            cursor,
-            limit,
-            |entry| &entry.table,
-        ))
+        let mut entries = self.list_tables(table_bucket, namespace).await?;
+        entries.retain(|entry| entry.state == TableCatalogEntryState::Active);
+        Ok(catalog_list_page_from_entries(entries, cursor, limit, |entry| &entry.table))
     }
 
     async fn load_table(&self, table_bucket: &str, namespace: &str, table: &str) -> TableCatalogStoreResult<Option<TableEntry>>;
@@ -2128,12 +2133,9 @@ pub(crate) trait TableCatalogStore: Send + Sync {
         cursor: Option<&str>,
         limit: NonZeroUsize,
     ) -> TableCatalogStoreResult<TableCatalogListPage<ViewEntry>> {
-        Ok(catalog_list_page_from_entries(
-            self.list_views(table_bucket, namespace).await?,
-            cursor,
-            limit,
-            |entry| &entry.view,
-        ))
+        let mut entries = self.list_views(table_bucket, namespace).await?;
+        entries.retain(|entry| entry.state == TableCatalogEntryState::Active);
+        Ok(catalog_list_page_from_entries(entries, cursor, limit, |entry| &entry.view))
     }
 
     async fn load_view(&self, table_bucket: &str, namespace: &str, view: &str) -> TableCatalogStoreResult<Option<ViewEntry>>;
@@ -2155,32 +2157,6 @@ pub(crate) trait TableCatalogStore: Send + Sync {
         table_id: &str,
         idempotency_key: &str,
     ) -> TableCatalogStoreResult<Option<CommitLogEntry>>;
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TableCatalogPage<T> {
-    pub entries: Vec<T>,
-    pub has_more: bool,
-}
-
-fn catalog_page<T, F>(entries: Vec<T>, after: Option<&str>, limit: usize, key: F) -> TableCatalogStoreResult<TableCatalogPage<T>>
-where
-    F: Fn(&T) -> &str,
-{
-    if limit == 0 {
-        return Err(TableCatalogStoreError::Invalid(
-            "catalog page limit must be greater than zero".to_string(),
-        ));
-    }
-    let start = after.map_or(0, |after| entries.partition_point(|entry| key(entry) <= after));
-    let mut entries = entries
-        .into_iter()
-        .skip(start)
-        .take(limit.saturating_add(1))
-        .collect::<Vec<_>>();
-    let has_more = entries.len() > limit;
-    entries.truncate(limit);
-    Ok(TableCatalogPage { entries, has_more })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2209,6 +2185,30 @@ pub(crate) enum TableCatalogPutPrecondition {
     IfMatch(String),
 }
 
+pub(crate) trait TableCatalogObjectLockGuard: Send + Sync {
+    fn is_lock_lost(&self) -> bool {
+        false
+    }
+}
+
+impl TableCatalogObjectLockGuard for rustfs_lock::NamespaceLockGuard {
+    fn is_lock_lost(&self) -> bool {
+        rustfs_lock::NamespaceLockGuard::is_lock_lost(self)
+    }
+}
+
+#[cfg(test)]
+impl TableCatalogObjectLockGuard for tokio::sync::OwnedMutexGuard<()> {}
+
+pub(crate) type TableCatalogObjectLock = Box<dyn TableCatalogObjectLockGuard>;
+
+fn ensure_table_catalog_lock_held(guard: &dyn TableCatalogObjectLockGuard) -> TableCatalogStoreResult<()> {
+    if guard.is_lock_lost() {
+        return Err(TableCatalogStoreError::Conflict("table catalog lock lease was lost".to_string()));
+    }
+    Ok(())
+}
+
 #[async_trait::async_trait]
 pub(crate) trait TableCatalogObjectBackend: Clone + Send + Sync + 'static {
     async fn read_object(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObject>>;
@@ -2232,9 +2232,38 @@ pub(crate) trait TableCatalogObjectBackend: Clone + Send + Sync + 'static {
         self.read_object(bucket, object).await
     }
 
+    async fn read_object_unlocked_limited(
+        &self,
+        bucket: &str,
+        object: &str,
+        max_size: usize,
+    ) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
+        let result = self.read_object_unlocked(bucket, object).await?;
+        if result.as_ref().is_some_and(|object| object.data.len() > max_size) {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "catalog object {bucket}/{object} exceeds the maximum size of {max_size} bytes"
+            )));
+        }
+        Ok(result)
+    }
+
     async fn object_metadata(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObjectMetadata>> {
         Ok(self
             .read_object(bucket, object)
+            .await?
+            .map(|object| TableCatalogObjectMetadata {
+                etag: object.etag,
+                mod_time: object.mod_time,
+            }))
+    }
+
+    async fn object_metadata_unlocked(
+        &self,
+        bucket: &str,
+        object: &str,
+    ) -> TableCatalogStoreResult<Option<TableCatalogObjectMetadata>> {
+        Ok(self
+            .read_object_unlocked(bucket, object)
             .await?
             .map(|object| TableCatalogObjectMetadata {
                 etag: object.etag,
@@ -2290,11 +2319,11 @@ pub(crate) trait TableCatalogObjectBackend: Clone + Send + Sync + 'static {
         Ok(TableCatalogObjectListPage { objects, is_truncated })
     }
 
-    async fn acquire_read_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Box<dyn Send>> {
+    async fn acquire_read_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<TableCatalogObjectLock> {
         self.acquire_write_lock(bucket, object).await
     }
 
-    async fn acquire_write_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Box<dyn Send>>;
+    async fn acquire_write_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<TableCatalogObjectLock>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2930,8 +2959,12 @@ where
             if entry.state != TableCatalogEntryState::Active {
                 continue;
             }
-            let metadata_root = table_metadata_dir_path_for_entry(entry)?;
-            let warehouse_object_prefix = table_warehouse_object_prefix(entry)?;
+            let Ok(metadata_root) = table_metadata_dir_path_for_entry(entry) else {
+                continue;
+            };
+            let Ok(warehouse_object_prefix) = table_warehouse_object_prefix(entry) else {
+                continue;
+            };
             if !state
                 .table_buckets
                 .get(table_bucket)
@@ -2969,6 +3002,15 @@ where
             if entry.state != TableCatalogEntryState::Active {
                 continue;
             }
+            if state
+                .tables
+                .get(&(table_bucket.clone(), namespace.clone(), view.clone()))
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "active table and view share the same identifier: {table_bucket}/{namespace}/{view}"
+                )));
+            }
             if !state
                 .table_buckets
                 .get(table_bucket)
@@ -2987,15 +3029,13 @@ where
                     "active view {table_bucket}/{namespace}/{view} has no active namespace"
                 )));
             }
-            validate_view_warehouse_location(table_bucket, &entry.warehouse_location)?;
+            if validate_view_warehouse_location(table_bucket, &entry.warehouse_location).is_err() {
+                continue;
+            }
             let namespace = parse_namespace_for_store(namespace)?;
             let view = parse_table_for_store(view)?;
             if !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location) {
-                return Err(TableCatalogStoreError::Invalid(format!(
-                    "active view {table_bucket}/{}/{} has an invalid metadata location",
-                    namespace.public_name(),
-                    view.as_str()
-                )));
+                continue;
             }
         }
         state.warehouse_index = warehouse_index;
@@ -3419,7 +3459,7 @@ where
         request: &TableCommitRequest,
     ) -> TableCatalogStoreResult<TableEntry> {
         let Some(current) = state.tables.get(key).cloned() else {
-            return Err(TableCatalogStoreError::NotFound(format!(
+            return Err(TableCatalogStoreError::TableNotFound(format!(
                 "table {}/{}/{}",
                 request.table_bucket, request.namespace, request.table
             )));
@@ -3666,7 +3706,11 @@ where
         let (snapshot, precondition) = {
             let state = self.state.lock().await;
             Self::require_table_bucket_in_state(&state, &entry.table_bucket)?;
-            if state.namespaces.contains_key(&key) {
+            if state
+                .namespaces
+                .get(&key)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
                 return Err(TableCatalogStoreError::Conflict(format!(
                     "catalog object already exists: namespace {}/{}",
                     entry.table_bucket, entry.namespace
@@ -3685,11 +3729,31 @@ where
         let mut entries = state
             .namespaces
             .iter()
-            .filter(|((bucket, _), _)| bucket == table_bucket)
+            .filter(|((bucket, _), entry)| bucket == table_bucket && entry.state == TableCatalogEntryState::Active)
             .map(|(_, entry)| entry.clone())
             .collect::<Vec<_>>();
         entries.sort_by(|left, right| left.namespace.cmp(&right.namespace));
         Ok(entries)
+    }
+
+    async fn list_namespaces_under(&self, table_bucket: &str, parent: &str) -> TableCatalogStoreResult<Vec<NamespaceEntry>> {
+        self.hydrate_state().await?;
+        let parent = parse_namespace_for_store(parent)?.public_name();
+        let state = self.state.lock().await;
+        let exact = state
+            .namespaces
+            .get(&(table_bucket.to_string(), parent.clone()))
+            .filter(|entry| entry.state == TableCatalogEntryState::Active)
+            .cloned();
+        let descendant_start = (table_bucket.to_string(), format!("{parent}."));
+        let descendants = state
+            .namespaces
+            .range(descendant_start..)
+            .take_while(|((bucket, namespace), _)| bucket == table_bucket && namespace_is_descendant(namespace, &parent))
+            .filter(|(_, entry)| entry.state == TableCatalogEntryState::Active)
+            .map(|(_, entry)| entry.clone())
+            .collect::<Vec<_>>();
+        Ok(exact.into_iter().chain(descendants).collect())
     }
 
     async fn list_namespaces_page(
@@ -3713,6 +3777,7 @@ where
             .namespaces
             .range((start, Bound::Unbounded))
             .take_while(|((bucket, _), _)| bucket == table_bucket)
+            .filter(|(_, entry)| entry.state == TableCatalogEntryState::Active)
             .take(limit.get().saturating_add(1))
             .map(|(_, entry)| entry.clone())
             .collect();
@@ -3736,7 +3801,7 @@ where
         if Self::has_active_namespace_descendant_locked(&state, table_bucket, &parent) {
             return Ok(Some(synthetic_namespace_entry(table_bucket, &namespace)));
         }
-        Ok(exact)
+        Ok(None)
     }
 
     async fn update_namespace_properties(
@@ -3789,22 +3854,26 @@ where
                     "namespace {table_bucket}/{parent} has child namespaces"
                 )));
             }
-            if !state.namespaces.contains_key(&key) {
+            if !state
+                .namespaces
+                .get(&key)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
                 return Err(TableCatalogStoreError::NamespaceNotFound(format!(
                     "namespace {}/{}",
                     table_bucket,
                     namespace.public_name()
                 )));
             }
-            if state
-                .tables
-                .keys()
-                .any(|(bucket, namespace_name, _)| bucket == table_bucket && namespace_name == &namespace.public_name())
-                || state
-                    .views
-                    .keys()
-                    .any(|(bucket, namespace_name, _)| bucket == table_bucket && namespace_name == &namespace.public_name())
-            {
+            if state.tables.iter().any(|((bucket, namespace_name, _), entry)| {
+                bucket == table_bucket
+                    && namespace_name == &namespace.public_name()
+                    && entry.state == TableCatalogEntryState::Active
+            }) || state.views.iter().any(|((bucket, namespace_name, _), entry)| {
+                bucket == table_bucket
+                    && namespace_name == &namespace.public_name()
+                    && entry.state == TableCatalogEntryState::Active
+            }) {
                 return Err(TableCatalogStoreError::Conflict(format!(
                     "namespace {}/{} is not empty",
                     table_bucket,
@@ -3910,10 +3979,21 @@ where
             None => Bound::Included((table_bucket.to_string(), namespace.clone(), String::new())),
         };
         let state = self.state.lock().await;
+        if !state
+            .namespaces
+            .get(&(table_bucket.to_string(), namespace.clone()))
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(TableCatalogListPage {
+                entries: Vec::new(),
+                next_cursor: None,
+            });
+        }
         let entries = state
             .tables
             .range((start, Bound::Unbounded))
             .take_while(|((bucket, entry_namespace, _), _)| bucket == table_bucket && entry_namespace == &namespace)
+            .filter(|(_, entry)| entry.state == TableCatalogEntryState::Active)
             .take(limit.get().saturating_add(1))
             .map(|(_, entry)| entry.clone())
             .collect();
@@ -4114,7 +4194,7 @@ where
             .await?;
         let Some(new_metadata_object) = self
             .object_backend
-            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked_limited(&request.table_bucket, &request.new_metadata_location, TABLE_METADATA_JSON_MAX_SIZE)
             .await?
         else {
             return table_commit_result(
@@ -4284,10 +4364,21 @@ where
             None => Bound::Included((table_bucket.to_string(), namespace.clone(), String::new())),
         };
         let state = self.state.lock().await;
+        if !state
+            .namespaces
+            .get(&(table_bucket.to_string(), namespace.clone()))
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(TableCatalogListPage {
+                entries: Vec::new(),
+                next_cursor: None,
+            });
+        }
         let entries = state
             .views
             .range((start, Bound::Unbounded))
             .take_while(|((bucket, entry_namespace, _), _)| bucket == table_bucket && entry_namespace == &namespace)
+            .filter(|(_, entry)| entry.state == TableCatalogEntryState::Active)
             .take(limit.get().saturating_add(1))
             .map(|(_, entry)| entry.clone())
             .collect();
@@ -4331,10 +4422,10 @@ where
             .await?;
         let Some(new_metadata_object) = self
             .object_backend
-            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked_limited(&request.table_bucket, &request.new_metadata_location, TABLE_METADATA_JSON_MAX_SIZE)
             .await?
         else {
-            return Err(TableCatalogStoreError::NotFound(format!(
+            return Err(TableCatalogStoreError::TableNotFound(format!(
                 "new view metadata object {}",
                 request.new_metadata_location
             )));
@@ -4454,15 +4545,17 @@ where
         RUSTFS_META_BUCKET
     }
 
-    async fn list_entry_page<T>(
+    async fn list_entry_page<T, P>(
         &self,
         prefix: &str,
         entry_file: &str,
         cursor: Option<&str>,
         limit: NonZeroUsize,
+        include: P,
     ) -> TableCatalogStoreResult<TableCatalogListPage<T>>
     where
         T: DeserializeOwned,
+        P: Fn(&T) -> bool,
     {
         let cursor = catalog_list_cursor(cursor, OBJECT_CATALOG_LIST_CURSOR_PREFIX)?;
         if cursor.is_some_and(|cursor| !cursor.starts_with(prefix)) {
@@ -4475,7 +4568,6 @@ where
             .ok_or_else(|| TableCatalogStoreError::Internal("catalog object scan limit must be positive".to_string()))?;
         let mut entries = Vec::with_capacity(limit.get());
         let mut last_entry_path = None;
-
         let page = self
             .backend
             .list_objects_page(self.catalog_bucket(), prefix, cursor, scan_limit)
@@ -4495,6 +4587,12 @@ where
             if !object.ends_with(entry_file) {
                 continue;
             }
+            let Some((entry, _)) = self.read_entry::<T>(self.catalog_bucket(), &object).await? else {
+                continue;
+            };
+            if !include(&entry) {
+                continue;
+            }
             if entries.len() == limit.get() {
                 let last_entry_path = last_entry_path.ok_or_else(|| {
                     TableCatalogStoreError::Internal("catalog page cursor is missing its last entry".to_string())
@@ -4504,9 +4602,6 @@ where
                     next_cursor: Some(format!("{OBJECT_CATALOG_LIST_CURSOR_PREFIX}{last_entry_path}")),
                 });
             }
-            let Some((entry, _)) = self.read_entry::<T>(self.catalog_bucket(), &object).await? else {
-                continue;
-            };
             last_entry_path = Some(object);
             entries.push(entry);
         }
@@ -4519,6 +4614,92 @@ where
         Ok(TableCatalogListPage { entries, next_cursor })
     }
 
+    async fn has_active_namespace_descendant(&self, table_bucket: &str, namespace: &Namespace) -> TableCatalogStoreResult<bool> {
+        let parent = namespace.public_name();
+        let namespace_path = self.paths.namespace_entry_path(table_bucket, namespace);
+        let descendant_prefix = format!("{}{}/", self.paths.namespace_entries_prefix(table_bucket), namespace.storage_id());
+        for object in self.backend.list_objects(self.catalog_bucket(), &descendant_prefix).await? {
+            if object == namespace_path || !object.ends_with(NAMESPACE_ENTRY_FILE) {
+                continue;
+            }
+            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await?
+                && entry.state == TableCatalogEntryState::Active
+                && namespace_is_descendant(&entry.namespace, &parent)
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    async fn ensure_table_warehouse_prefix_available(&self, candidate: &TableEntry) -> TableCatalogStoreResult<()> {
+        if candidate.state != TableCatalogEntryState::Active {
+            return Ok(());
+        }
+        let candidate_namespace = parse_namespace_for_store(&candidate.namespace)?;
+        let candidate_table = parse_table_for_store(&candidate.table)?;
+        let candidate_path = self
+            .paths
+            .table_entry_path(&candidate.table_bucket, &candidate_namespace, &candidate_table);
+        let candidate_prefix = table_warehouse_object_prefix(candidate)?;
+        let candidate_metadata_root = table_metadata_dir_path_for_entry(candidate)?;
+        for object in self
+            .backend
+            .list_objects(self.catalog_bucket(), &self.paths.warehouse_index_entries_prefix(&candidate.table_bucket))
+            .await?
+        {
+            if object == self.paths.warehouse_index_state_path(&candidate.table_bucket) || !object.ends_with(".json") {
+                continue;
+            }
+            let Some((existing, _)) = self
+                .read_entry::<TableWarehouseIndexEntry>(self.catalog_bucket(), &object)
+                .await?
+            else {
+                continue;
+            };
+            if existing.table_bucket != candidate.table_bucket
+                || self
+                    .paths
+                    .warehouse_index_entry_path(&existing.table_bucket, &existing.warehouse_object_prefix)
+                    != object
+            {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "warehouse index entry does not match its catalog object path: {object}"
+                )));
+            }
+            if existing.namespace == candidate.namespace && existing.table == candidate.table {
+                continue;
+            }
+            if warehouse_object_prefixes_overlap(&existing.warehouse_object_prefix, &candidate_prefix)
+                && self.warehouse_index_entry_has_active_owner_unlocked(&existing).await?
+            {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "table warehouse location overlaps an active table: {candidate_prefix}"
+                )));
+            }
+        }
+        for object in self
+            .backend
+            .list_objects(self.catalog_bucket(), &self.paths.namespace_entries_prefix(&candidate.table_bucket))
+            .await?
+        {
+            if object == candidate_path || !object.ends_with(TABLE_ENTRY_FILE) {
+                continue;
+            }
+            let Some((existing, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &object).await? else {
+                continue;
+            };
+            if existing.state == TableCatalogEntryState::Active
+                && table_metadata_dir_path_for_entry(&existing).is_ok_and(|root| root == candidate_metadata_root)
+            {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "table metadata directory is already registered: {candidate_metadata_root}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     async fn read_backing_migration_fence(
         &self,
         table_bucket: &str,
@@ -4527,7 +4708,7 @@ where
             .await
     }
 
-    async fn acquire_table_bucket_registry_write_permit(&self) -> TableCatalogStoreResult<Box<dyn Send>> {
+    async fn acquire_table_bucket_registry_write_permit(&self) -> TableCatalogStoreResult<TableCatalogObjectLock> {
         let fence_path = self.paths.backing_migration_global_fence_path();
         let lock_path = self.paths.backing_migration_global_fence_lock_path();
         let guard = self.backend.acquire_read_lock(self.catalog_bucket(), &lock_path).await?;
@@ -4543,7 +4724,10 @@ where
         Ok(guard)
     }
 
-    async fn acquire_object_backed_catalog_write_permit(&self, table_bucket: &str) -> TableCatalogStoreResult<Box<dyn Send>> {
+    async fn acquire_object_backed_catalog_write_permit(
+        &self,
+        table_bucket: &str,
+    ) -> TableCatalogStoreResult<TableCatalogObjectLock> {
         let lock_path = self.paths.backing_migration_fence_lock_path(table_bucket);
         let guard = self.backend.acquire_read_lock(self.catalog_bucket(), &lock_path).await?;
         if self.read_backing_migration_fence(table_bucket).await?.is_some() {
@@ -4608,7 +4792,7 @@ where
     async fn collect_bucket_snapshot_with_locks(
         &self,
         table_bucket: &str,
-        guards: &mut Vec<Box<dyn Send>>,
+        guards: &mut Vec<TableCatalogObjectLock>,
     ) -> TableCatalogStoreResult<StrongTableCatalogBucketSnapshot> {
         let bucket_path = self.paths.table_bucket_entry_path(table_bucket);
         guards.push(self.backend.acquire_write_lock(self.catalog_bucket(), &bucket_path).await?);
@@ -4688,6 +4872,10 @@ where
                         "table {} does not match its catalog namespace",
                         table_entry.table
                     )));
+                }
+                if namespace_entry.state != TableCatalogEntryState::Active || table_entry.state != TableCatalogEntryState::Active
+                {
+                    continue;
                 }
 
                 for commit_object in self
@@ -4769,9 +4957,13 @@ where
                         view_entry.view
                     )));
                 }
-                views.push(view_entry);
+                if namespace_entry.state == TableCatalogEntryState::Active && view_entry.state == TableCatalogEntryState::Active {
+                    views.push(view_entry);
+                }
             }
-            namespaces.push(namespace_entry);
+            if namespace_entry.state == TableCatalogEntryState::Active {
+                namespaces.push(namespace_entry);
+            }
         }
         if let Some(object) = unmatched_table_objects.first() {
             return Err(TableCatalogStoreError::Invalid(format!(
@@ -5018,11 +5210,21 @@ where
             && state.state == TableCatalogEntryState::Active)
     }
 
-    async fn warehouse_index_entry_has_active_owner(&self, index: &TableWarehouseIndexEntry) -> TableCatalogStoreResult<bool> {
+    async fn warehouse_index_entry_has_active_owner_unlocked(
+        &self,
+        index: &TableWarehouseIndexEntry,
+    ) -> TableCatalogStoreResult<bool> {
         if index.state != TableCatalogEntryState::Active {
             return Ok(false);
         }
-        let Some(table) = self.load_table(&index.table_bucket, &index.namespace, &index.table).await? else {
+        // The bucket ownership lock is already held; reacquiring namespace/table locks here would invert the catalog lock order.
+        let namespace = parse_namespace_for_store(&index.namespace)?;
+        let table = parse_table_for_store(&index.table)?;
+        let table_path = self.paths.table_entry_path(&index.table_bucket, &namespace, &table);
+        let Some((table, _)) = self
+            .read_entry_unlocked::<TableEntry>(self.catalog_bucket(), &table_path)
+            .await?
+        else {
             return Ok(false);
         };
         if table.state != TableCatalogEntryState::Active {
@@ -5129,7 +5331,7 @@ where
                     }
                     if existing.table_bucket != index.table_bucket
                         || existing.warehouse_object_prefix != index.warehouse_object_prefix
-                        || self.warehouse_index_entry_has_active_owner(&existing).await?
+                        || self.warehouse_index_entry_has_active_owner_unlocked(&existing).await?
                     {
                         return Err(TableCatalogStoreError::Conflict(format!(
                             "table warehouse location is already registered: {}",
@@ -5370,6 +5572,7 @@ where
         table_bucket: &str,
         namespace: &str,
         table: &str,
+        ownership_guard: &dyn TableCatalogObjectLockGuard,
     ) -> TableCatalogStoreResult<()> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
@@ -5381,19 +5584,25 @@ where
         if current.state != TableCatalogEntryState::Active {
             return Ok(());
         }
+        ensure_table_catalog_lock_held(ownership_guard)?;
         self.reserve_table_warehouse_index(&current).await.map(|_| ())
     }
 
     async fn backfill_table_warehouse_index(&self, table_bucket: &str) -> TableCatalogStoreResult<()> {
         let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(table_bucket);
-        let _ownership_guard = self
+        let ownership_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
             .await?;
-        self.backfill_table_warehouse_index_ownership_locked(table_bucket).await
+        self.backfill_table_warehouse_index_ownership_locked(table_bucket, ownership_guard.as_ref())
+            .await
     }
 
-    async fn backfill_table_warehouse_index_ownership_locked(&self, table_bucket: &str) -> TableCatalogStoreResult<()> {
+    async fn backfill_table_warehouse_index_ownership_locked(
+        &self,
+        table_bucket: &str,
+        ownership_guard: &dyn TableCatalogObjectLockGuard,
+    ) -> TableCatalogStoreResult<()> {
         let state_object = self.paths.warehouse_index_state_path(table_bucket);
         let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &state_object).await?;
         if self.read_warehouse_index_state_unlocked(table_bucket).await? {
@@ -5407,10 +5616,11 @@ where
                 if table.state != TableCatalogEntryState::Active {
                     continue;
                 }
-                self.backfill_active_table_warehouse_index(&table.table_bucket, &table.namespace, &table.table)
+                self.backfill_active_table_warehouse_index(&table.table_bucket, &table.namespace, &table.table, ownership_guard)
                     .await?;
             }
         }
+        ensure_table_catalog_lock_held(ownership_guard)?;
         self.write_warehouse_index_state_unlocked(table_bucket).await
     }
 
@@ -5492,11 +5702,11 @@ where
         }
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
         let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&entry.table_bucket);
-        let _ownership_guard = self
+        let ownership_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
             .await?;
-        self.backfill_table_warehouse_index_ownership_locked(&entry.table_bucket)
+        self.backfill_table_warehouse_index_ownership_locked(&entry.table_bucket, ownership_guard.as_ref())
             .await?;
         let namespace_path = self.paths.namespace_entry_path(&entry.table_bucket, &namespace);
         let _namespace_guard = self
@@ -5529,6 +5739,7 @@ where
         let table_path = self.paths.table_entry_path(&entry.table_bucket, &namespace, &table);
         let _table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
         self.ensure_table_warehouse_prefix_available(&entry).await?;
+        ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
         let reservation = self.reserve_table_warehouse_index(&entry).await?;
         let result = async {
             if materialize_namespace {
@@ -5540,6 +5751,7 @@ where
                 )
                 .await?;
             }
+            ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
             self.write_entry_unlocked(self.catalog_bucket(), &table_path, &entry, precondition)
                 .await
         }
@@ -8314,7 +8526,7 @@ where
                 )));
             }
             self.ensure_table_maintenance_object_owner(&entry, metadata_location).await?;
-            let Some(candidate_object) = self.backend.read_object(table_bucket, metadata_location).await? else {
+            let Some(candidate_object) = self.backend.object_metadata(table_bucket, metadata_location).await? else {
                 continue;
             };
             if !planned_deletable_locations.contains(metadata_location.as_str()) {
@@ -8416,7 +8628,7 @@ where
             .await?;
         let Some(locked_current_metadata) = self
             .backend
-            .read_object_unlocked(table_bucket, &current_entry.metadata_location)
+            .object_metadata_unlocked(table_bucket, &current_entry.metadata_location)
             .await?
         else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -8435,7 +8647,10 @@ where
         let mut deleted_metadata_locations = Vec::new();
         for (metadata_location, expected) in cleanup_candidate_locations {
             let candidate_guard = self.backend.acquire_write_lock(table_bucket, &metadata_location).await?;
-            let candidate = self.backend.read_object_unlocked(table_bucket, &metadata_location).await?;
+            let candidate = self
+                .backend
+                .object_metadata_unlocked(table_bucket, &metadata_location)
+                .await?;
             if candidate.as_ref().is_some_and(|candidate| {
                 candidate.etag == expected.etag
                     && candidate.mod_time == expected.mod_time
@@ -8449,7 +8664,7 @@ where
         let mut deleted_object_locations = Vec::new();
         for (object_location, expected) in cleanup_object_candidate_locations {
             let candidate_guard = self.backend.acquire_write_lock(table_bucket, &object_location).await?;
-            let candidate = self.backend.read_object_unlocked(table_bucket, &object_location).await?;
+            let candidate = self.backend.object_metadata_unlocked(table_bucket, &object_location).await?;
             if candidate.as_ref().is_some_and(|candidate| {
                 candidate.etag == expected.etag
                     && candidate.mod_time == expected.mod_time
@@ -8537,7 +8752,21 @@ where
         let bucket_path = self.paths.table_bucket_entry_path(&entry.table_bucket);
         let _bucket_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &bucket_path).await?;
         let object = self.paths.namespace_entry_path(&entry.table_bucket, &namespace);
-        self.write_entry(self.catalog_bucket(), &object, &entry, TableCatalogPutPrecondition::IfAbsent)
+        let _namespace_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
+        let precondition = match self
+            .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), &object)
+            .await?
+        {
+            Some((current, _)) if current.state == TableCatalogEntryState::Active => {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "catalog object already exists: namespace {}/{}",
+                    entry.table_bucket, entry.namespace
+                )));
+            }
+            Some(_) => TableCatalogPutPrecondition::Any,
+            None => TableCatalogPutPrecondition::IfAbsent,
+        };
+        self.write_entry_unlocked(self.catalog_bucket(), &object, &entry, precondition)
             .await
     }
 
@@ -8551,7 +8780,27 @@ where
             if !object.ends_with(NAMESPACE_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await? {
+            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await?
+                && entry.state == TableCatalogEntryState::Active
+            {
+                entries.push(entry);
+            }
+        }
+        entries.sort_by(|left, right| left.namespace.cmp(&right.namespace));
+        Ok(entries)
+    }
+
+    async fn list_namespaces_under(&self, table_bucket: &str, parent: &str) -> TableCatalogStoreResult<Vec<NamespaceEntry>> {
+        let parent = parse_namespace_for_store(parent)?;
+        let prefix = format!("{}{}/", self.paths.namespace_entries_prefix(table_bucket), parent.storage_id());
+        let mut entries = Vec::new();
+        for object in self.backend.list_objects(self.catalog_bucket(), &prefix).await? {
+            if !object.ends_with(NAMESPACE_ENTRY_FILE) {
+                continue;
+            }
+            if let Some((entry, _)) = self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &object).await?
+                && entry.state == TableCatalogEntryState::Active
+            {
                 entries.push(entry);
             }
         }
@@ -8565,8 +8814,14 @@ where
         cursor: Option<&str>,
         limit: NonZeroUsize,
     ) -> TableCatalogStoreResult<TableCatalogListPage<NamespaceEntry>> {
-        self.list_entry_page(&self.paths.namespace_entries_prefix(table_bucket), NAMESPACE_ENTRY_FILE, cursor, limit)
-            .await
+        self.list_entry_page(
+            &self.paths.namespace_entries_prefix(table_bucket),
+            NAMESPACE_ENTRY_FILE,
+            cursor,
+            limit,
+            |entry: &NamespaceEntry| entry.state == TableCatalogEntryState::Active,
+        )
+        .await
     }
 
     async fn get_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Option<NamespaceEntry>> {
@@ -8584,7 +8839,7 @@ where
         if self.has_active_namespace_descendant(table_bucket, &namespace).await? {
             return Ok(Some(synthetic_namespace_entry(table_bucket, &namespace)));
         }
-        Ok(exact)
+        Ok(None)
     }
 
     async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<()> {
@@ -8604,10 +8859,10 @@ where
                 "namespace {table_bucket}/{parent} has child namespaces"
             )));
         }
-        if self
+        if !self
             .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), &namespace_path)
             .await?
-            .is_none()
+            .is_some_and(|(entry, _)| entry.state == TableCatalogEntryState::Active)
         {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "namespace {}/{}",
@@ -8676,6 +8931,7 @@ where
             TABLE_ENTRY_FILE,
             cursor,
             limit,
+            |entry: &TableEntry| entry.state == TableCatalogEntryState::Active,
         )
         .await
     }
@@ -8744,11 +9000,11 @@ where
         let table = parse_table_for_store(&request.table)?;
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(&request.table_bucket).await?;
         let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&request.table_bucket);
-        let _ownership_guard = self
+        let ownership_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
             .await?;
-        self.backfill_table_warehouse_index_ownership_locked(&request.table_bucket)
+        self.backfill_table_warehouse_index_ownership_locked(&request.table_bucket, ownership_guard.as_ref())
             .await?;
         let table_path = self.paths.table_entry_path(&request.table_bucket, &namespace, &table);
         let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
@@ -8764,7 +9020,7 @@ where
                 &request.commit_id,
                 &request.operation,
                 commit_started,
-                Err(TableCatalogStoreError::NotFound(format!(
+                Err(TableCatalogStoreError::TableNotFound(format!(
                     "table {}/{}/{}",
                     request.table_bucket, request.namespace, request.table
                 ))),
@@ -8917,7 +9173,7 @@ where
             .await?;
         let Some(new_metadata_object) = self
             .backend
-            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked_limited(&request.table_bucket, &request.new_metadata_location, TABLE_METADATA_JSON_MAX_SIZE)
             .await?
         else {
             return table_commit_result(
@@ -8979,6 +9235,7 @@ where
         if next.warehouse_location != current.warehouse_location {
             self.ensure_table_warehouse_prefix_available(&next).await?;
         }
+        ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
         let reservation = self.reserve_table_warehouse_index(&next).await?;
 
         let staged_write_result = async {
@@ -9020,6 +9277,19 @@ where
         }
 
         let cas_started = Instant::now();
+        if let Err(err) = ensure_table_catalog_lock_held(ownership_guard.as_ref()) {
+            self.delete_created_table_warehouse_index(&next, reservation, "warehouse ownership lock lost")
+                .await;
+            return table_commit_result(
+                &request.table_bucket,
+                &request.namespace,
+                &request.table,
+                &request.commit_id,
+                &request.operation,
+                commit_started,
+                Err(err),
+            );
+        }
         let cas_result = self
             .write_entry_unlocked(
                 self.catalog_bucket(),
@@ -9068,7 +9338,7 @@ where
         let table = parse_table_for_store(table)?;
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
         let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(table_bucket);
-        let _ownership_guard = self
+        let ownership_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
             .await?;
@@ -9087,6 +9357,7 @@ where
                 table.as_str()
             )));
         };
+        ensure_table_catalog_lock_held(ownership_guard.as_ref())?;
         self.backend.delete_object_unlocked(self.catalog_bucket(), &object).await?;
         if let Err(err) = self.delete_table_warehouse_index(&entry).await {
             if let Err(restore_err) = self
@@ -9148,8 +9419,14 @@ where
         limit: NonZeroUsize,
     ) -> TableCatalogStoreResult<TableCatalogListPage<ViewEntry>> {
         let namespace = parse_namespace_for_store(namespace)?;
-        self.list_entry_page(&self.paths.view_entries_prefix(table_bucket, &namespace), VIEW_ENTRY_FILE, cursor, limit)
-            .await
+        self.list_entry_page(
+            &self.paths.view_entries_prefix(table_bucket, &namespace),
+            VIEW_ENTRY_FILE,
+            cursor,
+            limit,
+            |entry: &ViewEntry| entry.state == TableCatalogEntryState::Active,
+        )
+        .await
     }
 
     async fn load_view(&self, table_bucket: &str, namespace: &str, view: &str) -> TableCatalogStoreResult<Option<ViewEntry>> {
@@ -9228,7 +9505,7 @@ where
             .await?;
         let Some(new_metadata_object) = self
             .backend
-            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked_limited(&request.table_bucket, &request.new_metadata_location, TABLE_METADATA_JSON_MAX_SIZE)
             .await?
         else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -9336,6 +9613,13 @@ where
         match self {
             Self::ObjectBacked(store) => store.list_namespaces(table_bucket).await,
             Self::DurableStrong(store) => store.list_namespaces(table_bucket).await,
+        }
+    }
+
+    async fn list_namespaces_under(&self, table_bucket: &str, parent: &str) -> TableCatalogStoreResult<Vec<NamespaceEntry>> {
+        match self {
+            Self::ObjectBacked(store) => store.list_namespaces_under(table_bucket, parent).await,
+            Self::DurableStrong(store) => store.list_namespaces_under(table_bucket, parent).await,
         }
     }
 
@@ -9803,8 +10087,45 @@ where
         .await
     }
 
+    async fn read_object_unlocked_limited(
+        &self,
+        bucket: &str,
+        object: &str,
+        max_size: usize,
+    ) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
+        self.read_object_with_options(
+            bucket,
+            object,
+            ObjectOptions {
+                no_lock: true,
+                ..Default::default()
+            },
+            Some(max_size),
+        )
+        .await
+    }
+
     async fn object_metadata(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObjectMetadata>> {
         match self.store.get_object_info(bucket, object, &ObjectOptions::default()).await {
+            Ok(info) => Ok(Some(TableCatalogObjectMetadata {
+                etag: info.etag,
+                mod_time: info.mod_time,
+            })),
+            Err(err) if is_missing_storage_error(&err) => Ok(None),
+            Err(err) => Err(storage_error_to_catalog("stat catalog object", err)),
+        }
+    }
+
+    async fn object_metadata_unlocked(
+        &self,
+        bucket: &str,
+        object: &str,
+    ) -> TableCatalogStoreResult<Option<TableCatalogObjectMetadata>> {
+        let opts = ObjectOptions {
+            no_lock: true,
+            ..Default::default()
+        };
+        match self.store.get_object_info(bucket, object, &opts).await {
             Ok(info) => Ok(Some(TableCatalogObjectMetadata {
                 etag: info.etag,
                 mod_time: info.mod_time,
@@ -9923,7 +10244,7 @@ where
         })
     }
 
-    async fn acquire_write_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Box<dyn Send>> {
+    async fn acquire_write_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<TableCatalogObjectLock> {
         let lock = self
             .store
             .new_ns_lock(bucket, object)
@@ -9936,7 +10257,7 @@ where
         Ok(Box::new(guard))
     }
 
-    async fn acquire_read_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Box<dyn Send>> {
+    async fn acquire_read_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<TableCatalogObjectLock> {
         let lock = self
             .store
             .new_ns_lock(bucket, object)
@@ -10436,6 +10757,7 @@ pub(crate) fn manifest_list_references_from_manifest_list_avro(
             "manifest list exceeds the maximum size of {TABLE_MANIFEST_AVRO_MAX_SIZE} bytes"
         )));
     }
+    validate_uncompressed_avro_container(data)?;
     let reader = apache_avro::Reader::new(data)
         .map_err(|err| TableCatalogStoreError::Invalid(format!("failed to read manifest list Avro: {err}")))?;
     let mut manifest_paths = Vec::new();
@@ -10473,6 +10795,7 @@ pub(crate) fn data_file_references_from_manifest_avro(data: &[u8]) -> TableCatal
             "manifest exceeds the maximum size of {TABLE_MANIFEST_AVRO_MAX_SIZE} bytes"
         )));
     }
+    validate_uncompressed_avro_container(data)?;
     let reader = apache_avro::Reader::new(data)
         .map_err(|err| TableCatalogStoreError::Invalid(format!("failed to read manifest Avro: {err}")))?;
     let mut files = Vec::new();
@@ -10524,6 +10847,101 @@ pub(crate) fn data_file_references_from_manifest_avro(data: &[u8]) -> TableCatal
         });
     }
     Ok(files)
+}
+
+fn validate_uncompressed_avro_container(data: &[u8]) -> TableCatalogStoreResult<()> {
+    if !data.starts_with(b"Obj\x01") {
+        return Err(TableCatalogStoreError::Invalid("Avro container has invalid header magic".to_string()));
+    }
+    let mut offset = 4;
+    let mut entry_count = 0usize;
+    let mut codec = None;
+    loop {
+        let block_count = read_avro_long(data, &mut offset)?;
+        if block_count == 0 {
+            break;
+        }
+        let (block_count, expected_end) = if block_count < 0 {
+            let block_count = block_count
+                .checked_neg()
+                .and_then(|count| usize::try_from(count).ok())
+                .ok_or_else(|| TableCatalogStoreError::Invalid("Avro header block count is invalid".to_string()))?;
+            let block_size = read_avro_long(data, &mut offset)?;
+            let block_size = usize::try_from(block_size)
+                .map_err(|_| TableCatalogStoreError::Invalid("Avro header block size is invalid".to_string()))?;
+            let expected_end = offset
+                .checked_add(block_size)
+                .filter(|end| *end <= data.len())
+                .ok_or_else(|| TableCatalogStoreError::Invalid("Avro header block exceeds the object size".to_string()))?;
+            (block_count, Some(expected_end))
+        } else {
+            let block_count = usize::try_from(block_count)
+                .map_err(|_| TableCatalogStoreError::Invalid("Avro header block count is invalid".to_string()))?;
+            (block_count, None)
+        };
+        entry_count = entry_count
+            .checked_add(block_count)
+            .filter(|count| *count <= TABLE_MANIFEST_AVRO_MAX_HEADER_ENTRIES)
+            .ok_or_else(|| TableCatalogStoreError::Invalid("Avro header has too many metadata entries".to_string()))?;
+        for _ in 0..block_count {
+            let key = read_avro_bytes(data, &mut offset)?;
+            let value = read_avro_bytes(data, &mut offset)?;
+            if key == b"avro.codec" {
+                codec = Some(value);
+            }
+        }
+        if expected_end.is_some_and(|expected_end| offset != expected_end) {
+            return Err(TableCatalogStoreError::Invalid(
+                "Avro header block size does not match its contents".to_string(),
+            ));
+        }
+    }
+    offset
+        .checked_add(16)
+        .filter(|end| *end <= data.len())
+        .ok_or_else(|| TableCatalogStoreError::Invalid("Avro container is missing its sync marker".to_string()))?;
+    if codec.is_some_and(|codec| codec != b"null") {
+        return Err(TableCatalogStoreError::Invalid(
+            "compressed Avro codecs are not supported for table commit validation".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_avro_long(data: &[u8], offset: &mut usize) -> TableCatalogStoreResult<i64> {
+    let mut raw = 0u64;
+    for shift in (0..=63).step_by(7) {
+        let byte = *data
+            .get(*offset)
+            .ok_or_else(|| TableCatalogStoreError::Invalid("Avro header is truncated".to_string()))?;
+        *offset = offset
+            .checked_add(1)
+            .ok_or_else(|| TableCatalogStoreError::Invalid("Avro header offset overflowed".to_string()))?;
+        if shift == 63 && byte & 0xfe != 0 {
+            return Err(TableCatalogStoreError::Invalid("Avro long is out of range".to_string()));
+        }
+        raw |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            let magnitude =
+                i64::try_from(raw >> 1).map_err(|_| TableCatalogStoreError::Invalid("Avro long is out of range".to_string()))?;
+            let sign = if raw & 1 == 0 { 0 } else { -1 };
+            return Ok(magnitude ^ sign);
+        }
+    }
+    Err(TableCatalogStoreError::Invalid("Avro long is out of range".to_string()))
+}
+
+fn read_avro_bytes<'a>(data: &'a [u8], offset: &mut usize) -> TableCatalogStoreResult<&'a [u8]> {
+    let length = read_avro_long(data, offset)?;
+    let length = usize::try_from(length)
+        .map_err(|_| TableCatalogStoreError::Invalid("Avro header byte string length is invalid".to_string()))?;
+    let end = offset
+        .checked_add(length)
+        .filter(|end| *end <= data.len())
+        .ok_or_else(|| TableCatalogStoreError::Invalid("Avro header byte string is truncated".to_string()))?;
+    let value = &data[*offset..end];
+    *offset = end;
+    Ok(value)
 }
 
 fn avro_record_field<'a>(value: &'a apache_avro::types::Value, name: &str) -> Option<&'a apache_avro::types::Value> {
@@ -12822,8 +13240,19 @@ pub(crate) fn commit_log_matches_request(commit_log: &CommitLogEntry, request: &
         && commit_log.expected_version_token == request.expected_version_token
         && commit_log.previous_metadata_location == request.expected_metadata_location
         && commit_log.new_metadata_location == request.new_metadata_location
-        && commit_log.requirements == request.requirements
+        && commit_requirements_match(&commit_log.requirements, &request.requirements)
         && commit_log.writer == request.writer
+}
+
+fn commit_requirements_match(persisted: &[serde_json::Value], requested: &[serde_json::Value]) -> bool {
+    if persisted == requested {
+        return true;
+    }
+    let Some((internal_digest, client_requirements)) = requested.split_last() else {
+        return false;
+    };
+    persisted == client_requirements
+        && internal_digest.get("type").and_then(serde_json::Value::as_str) == Some(TABLE_METADATA_DIGEST_REQUIREMENT_TYPE)
 }
 
 fn table_matches_committed_log(table: &TableEntry, commit_log: &CommitLogEntry) -> bool {
@@ -13228,6 +13657,9 @@ impl Namespace {
     pub const MAX_LEN: usize = 512;
 
     pub fn parse(value: &str) -> Result<Self, CatalogIdentifierError> {
+        if value.len() > Self::MAX_LEN {
+            return Err(CatalogIdentifierError::NamespaceTooLong { max: Self::MAX_LEN });
+        }
         let segments = value.split('.').map(str::to_string).collect::<Vec<_>>();
         Self::from_segments(segments)
     }
@@ -13236,7 +13668,11 @@ impl Namespace {
         if values.is_empty() {
             return Err(CatalogIdentifierError::Empty);
         }
-        if value.len() > Self::MAX_LEN {
+        let value_len = values
+            .iter()
+            .try_fold(values.len().saturating_sub(1), |length, value| length.checked_add(value.len()))
+            .ok_or(CatalogIdentifierError::NamespaceTooLong { max: Self::MAX_LEN })?;
+        if value_len > Self::MAX_LEN {
             return Err(CatalogIdentifierError::NamespaceTooLong { max: Self::MAX_LEN });
         }
 
@@ -14082,6 +14518,17 @@ mod tests {
     type TestCatalogObjectLocks = Arc<tokio::sync::Mutex<BTreeMap<TestCatalogObjectLockKey, TestCatalogObjectLock>>>;
     type TestCatalogObjectReplacements = BTreeMap<TestCatalogObjectLockKey, BTreeMap<usize, TestCatalogObjectReplacement>>;
 
+    struct TestCatalogObjectLockGuard {
+        _guard: tokio::sync::OwnedMutexGuard<()>,
+        lost: bool,
+    }
+
+    impl TableCatalogObjectLockGuard for TestCatalogObjectLockGuard {
+        fn is_lock_lost(&self) -> bool {
+            self.lost
+        }
+    }
+
     struct TestCatalogObjectReplacement {
         data: Vec<u8>,
         preserve_etag: bool,
@@ -14114,6 +14561,7 @@ mod tests {
         pause_put_attempts: BTreeMap<(String, String), BTreeMap<usize, TestCatalogObjectPause>>,
         fail_delete_attempts: BTreeMap<(String, String), BTreeSet<usize>>,
         replace_on_write_lock_acquisitions: TestCatalogObjectReplacements,
+        lost_write_lock_acquisitions: BTreeMap<TestCatalogObjectLockKey, BTreeSet<usize>>,
         put_attempts: BTreeMap<(String, String), usize>,
         delete_attempts: BTreeMap<(String, String), usize>,
         write_lock_acquisitions: BTreeMap<(String, String), usize>,
@@ -14121,7 +14569,6 @@ mod tests {
         metadata_calls: usize,
         list_calls: usize,
         list_prefixes: Vec<(String, String)>,
-        list_page_limits: Vec<i32>,
         next_etag: u64,
     }
 
@@ -14189,16 +14636,19 @@ mod tests {
                 );
         }
 
+        async fn lose_next_write_lock(&self, bucket: &str, object: &str) {
+            let mut state = self.state.lock().await;
+            let key = (bucket.to_string(), object.to_string());
+            let attempt = state.write_lock_acquisitions.get(&key).copied().unwrap_or_default() + 1;
+            state.lost_write_lock_acquisitions.entry(key).or_default().insert(attempt);
+        }
+
         async fn list_call_count(&self) -> usize {
             self.state.lock().await.list_calls
         }
 
         async fn list_prefixes(&self) -> Vec<(String, String)> {
             self.state.lock().await.list_prefixes.clone()
-        }
-
-        async fn list_page_limits(&self) -> Vec<i32> {
-            self.state.lock().await.list_page_limits.clone()
         }
 
         async fn read_call_count(&self) -> usize {
@@ -14215,7 +14665,6 @@ mod tests {
             state.metadata_calls = 0;
             state.list_calls = 0;
             state.list_prefixes.clear();
-            state.list_page_limits.clear();
         }
 
         async fn write_lock_acquisition_count(&self, bucket: &str, object: &str) -> usize {
@@ -14328,6 +14777,10 @@ mod tests {
     }
 
     fn manifest_list_avro_bytes(manifest_paths: &[&str]) -> Vec<u8> {
+        manifest_list_avro_bytes_with_codec(manifest_paths, apache_avro::Codec::Null)
+    }
+
+    fn manifest_list_avro_bytes_with_codec(manifest_paths: &[&str], codec: apache_avro::Codec) -> Vec<u8> {
         let schema = apache_avro::Schema::parse_str(
             r#"
             {
@@ -14343,7 +14796,7 @@ mod tests {
             "#,
         )
         .expect("manifest list avro schema should parse");
-        let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+        let mut writer = apache_avro::Writer::with_codec(&schema, Vec::new(), codec);
         for manifest_path in manifest_paths {
             writer
                 .append(apache_avro::types::Value::Record(vec![
@@ -14416,6 +14869,10 @@ mod tests {
     }
 
     fn manifest_avro_bytes_with_status(files: &[(&str, i32, i32)]) -> Vec<u8> {
+        manifest_avro_bytes_with_status_and_codec(files, apache_avro::Codec::Null)
+    }
+
+    fn manifest_avro_bytes_with_status_and_codec(files: &[(&str, i32, i32)], codec: apache_avro::Codec) -> Vec<u8> {
         let schema = apache_avro::Schema::parse_str(
             r#"
             {
@@ -14444,7 +14901,7 @@ mod tests {
             "#,
         )
         .expect("manifest avro schema should parse");
-        let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+        let mut writer = apache_avro::Writer::with_codec(&schema, Vec::new(), codec);
         for (file_path, content, status) in files {
             writer
                 .append(apache_avro::types::Value::Record(vec![
@@ -14789,37 +15246,29 @@ mod tests {
             &self,
             bucket: &str,
             prefix: &str,
-            after: Option<&str>,
-            limit: i32,
-        ) -> TableCatalogStoreResult<TableCatalogPage<String>> {
-            if limit <= 0 {
-                return Err(TableCatalogStoreError::Invalid(
-                    "catalog object page limit must be greater than zero".to_string(),
-                ));
-            }
-            let limit = usize::try_from(limit)
-                .map_err(|_| TableCatalogStoreError::Invalid("catalog object page limit is too large".to_string()))?;
+            start_after: Option<&str>,
+            limit: NonZeroUsize,
+        ) -> TableCatalogStoreResult<TableCatalogObjectListPage> {
+            let limit = limit.get();
             let mut state = self.state.lock().await;
             state.list_calls += 1;
-            state.list_page_limits.push(i32::try_from(limit).unwrap_or(i32::MAX));
             let mut objects = state
                 .objects
                 .keys()
                 .filter(|(entry_bucket, object)| {
-                    entry_bucket == bucket && object.starts_with(prefix) && after.is_none_or(|after| object.as_str() > after)
+                    entry_bucket == bucket
+                        && object.starts_with(prefix)
+                        && start_after.is_none_or(|start_after| object.as_str() > start_after)
                 })
                 .map(|(_, object)| object.clone())
                 .take(limit.saturating_add(1))
                 .collect::<Vec<_>>();
-            let has_more = objects.len() > limit;
+            let is_truncated = objects.len() > limit;
             objects.truncate(limit);
-            Ok(TableCatalogPage {
-                entries: objects,
-                has_more,
-            })
+            Ok(TableCatalogObjectListPage { objects, is_truncated })
         }
 
-        async fn acquire_write_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Box<dyn Send>> {
+        async fn acquire_write_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<TableCatalogObjectLock> {
             let attempt = {
                 let mut state = self.state.lock().await;
                 let acquisitions = state
@@ -14839,6 +15288,10 @@ mod tests {
             };
             let guard = lock.lock_owned().await;
             let mut state = self.state.lock().await;
+            let lost = state
+                .lost_write_lock_acquisitions
+                .get(&key)
+                .is_some_and(|attempts| attempts.contains(&attempt));
             let replacement = state
                 .replace_on_write_lock_acquisitions
                 .get_mut(&key)
@@ -14866,7 +15319,7 @@ mod tests {
                 state.objects.insert(key, TestCatalogObjectRecord { data, etag, mod_time });
             }
             drop(state);
-            Ok(Box::new(guard))
+            Ok(Box::new(TestCatalogObjectLockGuard { _guard: guard, lost }))
         }
     }
 
@@ -14956,15 +15409,18 @@ mod tests {
                 .expect("namespace should be created");
         }
         for name in ["alpha", "beta"] {
-            let identifier = IdentifierSegment::parse(name).expect("table and view name should parse");
-            let metadata_location = default_table_metadata_file_path(namespace, &identifier, "00001.metadata.json");
-            let mut table = test_table_entry(bucket, namespace, &identifier, metadata_location.clone());
+            let table_identifier = IdentifierSegment::parse(name).expect("table name should parse");
+            let table_metadata_location = default_table_metadata_file_path(namespace, &table_identifier, "00001.metadata.json");
+            let mut table = test_table_entry(bucket, namespace, &table_identifier, table_metadata_location);
             table.table_id = format!("table-{name}");
             table.table_uuid = format!("table-uuid-{name}");
             table.warehouse_location = format!("s3://{bucket}/tables/table-{name}");
             store.create_table(table).await.expect("table should be created");
 
-            let mut view = test_view_entry(bucket, namespace, &identifier, metadata_location);
+            let view_name = format!("view_{name}");
+            let view_identifier = IdentifierSegment::parse(&view_name).expect("view name should parse");
+            let view_metadata_location = default_view_metadata_file_path(namespace, &view_identifier, "00001.metadata.json");
+            let mut view = test_view_entry(bucket, namespace, &view_identifier, view_metadata_location);
             view.view_id = format!("view-{name}");
             view.view_uuid = format!("view-uuid-{name}");
             view.warehouse_location = format!("s3://{bucket}/views/view-{name}");
@@ -15727,10 +16183,19 @@ mod tests {
             .delete_object(RUSTFS_META_BUCKET, &table_path)
             .await
             .expect("listed table entry should be deleted before backfill");
+        let ownership_guard = backend
+            .acquire_write_lock(store.catalog_bucket(), &store.paths.warehouse_index_ownership_lock_path(bucket))
+            .await
+            .expect("warehouse ownership lock should be acquired");
 
         for table in listed {
             store
-                .backfill_active_table_warehouse_index(&table.table_bucket, &table.namespace, &table.table)
+                .backfill_active_table_warehouse_index(
+                    &table.table_bucket,
+                    &table.namespace,
+                    &table.table,
+                    ownership_guard.as_ref(),
+                )
                 .await
                 .expect("backfill should skip a table deleted after listing");
         }
@@ -15779,7 +16244,7 @@ mod tests {
             .await
             .expect("first table page should load");
         assert_eq!(table_page.entries[0].table, "alpha");
-        assert_eq!(backend.read_call_count().await, 1);
+        assert_eq!(backend.read_call_count().await, 2);
         let table_page = store
             .list_tables_page(bucket, &namespace_name, table_page.next_cursor.as_deref(), one)
             .await
@@ -15791,12 +16256,12 @@ mod tests {
             .list_views_page(bucket, &namespace_name, None, one)
             .await
             .expect("first view page should load");
-        assert_eq!(view_page.entries[0].view, "alpha");
+        assert_eq!(view_page.entries[0].view, "view_alpha");
         let view_page = store
             .list_views_page(bucket, &namespace_name, view_page.next_cursor.as_deref(), one)
             .await
             .expect("second view page should load");
-        assert_eq!(view_page.entries[0].view, "beta");
+        assert_eq!(view_page.entries[0].view, "view_beta");
         assert!(view_page.next_cursor.is_none());
 
         let exact_page = store
@@ -15855,6 +16320,61 @@ mod tests {
         assert_eq!(second.entries[0].namespace, namespace.public_name());
         assert!(second.next_cursor.is_none());
         assert_eq!(backend.list_call_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn object_catalog_pagination_does_not_emit_token_for_trailing_inactive_entry() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let alpha = IdentifierSegment::parse("alpha").expect("table should parse");
+        let beta = IdentifierSegment::parse("beta").expect("table should parse");
+        let mut active = test_table_entry(
+            bucket,
+            &namespace,
+            &alpha,
+            default_table_metadata_file_path(&namespace, &alpha, "00001.metadata.json"),
+        );
+        active.table_id = "alpha-id".to_string();
+        active.warehouse_location = format!("s3://{bucket}/tables/alpha-id");
+        let mut inactive = test_table_entry(
+            bucket,
+            &namespace,
+            &beta,
+            default_table_metadata_file_path(&namespace, &beta, "00001.metadata.json"),
+        );
+        inactive.table_id = "beta-id".to_string();
+        inactive.warehouse_location = format!("s3://{bucket}/tables/beta-id");
+        inactive.state = TableCatalogEntryState::Deleted;
+
+        for entry in [&active, &inactive] {
+            let table = IdentifierSegment::parse(entry.table.clone()).expect("table should parse");
+            store
+                .write_entry(
+                    store.catalog_bucket(),
+                    &store.paths.table_entry_path(bucket, &namespace, &table),
+                    entry,
+                    TableCatalogPutPrecondition::Any,
+                )
+                .await
+                .expect("table entry should be seeded");
+        }
+        backend.reset_call_counts().await;
+
+        let page = store
+            .list_tables_page(
+                bucket,
+                &namespace.public_name(),
+                None,
+                NonZeroUsize::new(1).expect("page size should be non-zero"),
+            )
+            .await
+            .expect("table page should load");
+
+        assert_eq!(page.entries, vec![active]);
+        assert!(page.next_cursor.is_none());
+        assert_eq!(backend.read_call_count().await, 2);
     }
 
     #[tokio::test]
@@ -18418,6 +18938,46 @@ mod tests {
             error,
             TableCatalogStoreError::Invalid(message) if message.contains("content must be an int")
         );
+    }
+
+    #[test]
+    fn table_commit_manifest_readers_reject_compressed_avro() {
+        let codec = apache_avro::Codec::Deflate(apache_avro::DeflateSettings::default());
+        let manifest_list = manifest_list_avro_bytes_with_codec(&["metadata/manifest.avro"], codec);
+        let manifest = manifest_avro_bytes_with_status_and_codec(&[("data/part.parquet", 0, 1)], codec);
+
+        for result in [
+            manifest_list_references_from_manifest_list_avro(&manifest_list).map(|_| ()),
+            data_file_references_from_manifest_avro(&manifest).map(|_| ()),
+        ] {
+            assert_matches!(
+                result,
+                Err(TableCatalogStoreError::Invalid(message))
+                    if message.contains("compressed Avro codecs are not supported")
+            );
+        }
+    }
+
+    #[test]
+    fn commit_requirements_accept_legacy_logs_without_internal_metadata_digest() {
+        let client_requirement = serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"});
+        let internal_digest = serde_json::json!({
+            "type": TABLE_METADATA_DIGEST_REQUIREMENT_TYPE,
+            "sha256": "digest"
+        });
+
+        assert!(commit_requirements_match(
+            std::slice::from_ref(&client_requirement),
+            &[client_requirement.clone(), internal_digest.clone()],
+        ));
+        assert!(commit_requirements_match(
+            &[client_requirement.clone(), internal_digest.clone()],
+            &[client_requirement.clone(), internal_digest.clone()],
+        ));
+        assert!(!commit_requirements_match(
+            std::slice::from_ref(&client_requirement),
+            &[internal_digest, client_requirement.clone()],
+        ));
     }
 
     #[tokio::test]
@@ -21117,12 +21677,12 @@ mod tests {
             .list_views_page(bucket, &namespace_name, None, one)
             .await
             .expect("first strong view page should load");
-        assert_eq!(first.entries[0].view, "alpha");
+        assert_eq!(first.entries[0].view, "view_alpha");
         let second = store
             .list_views_page(bucket, &namespace_name, first.next_cursor.as_deref(), one)
             .await
             .expect("second strong view page should load");
-        assert_eq!(second.entries[0].view, "beta");
+        assert_eq!(second.entries[0].view, "view_beta");
         assert!(second.next_cursor.is_none());
 
         let exact = NonZeroUsize::new(2).expect("exact page size should be non-zero");
@@ -22856,6 +23416,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn object_table_catalog_store_does_not_commit_after_warehouse_ownership_lock_loss() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").unwrap();
+        let table = IdentifierSegment::parse("orders").unwrap();
+        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        store
+            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
+            .await
+            .unwrap();
+        store.backfill_table_warehouse_index(bucket).await.unwrap();
+        backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        backend
+            .lose_next_write_lock(store.catalog_bucket(), &store.paths.warehouse_index_ownership_lock_path(bucket))
+            .await;
+
+        let error = store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: "commit-lock-loss".to_string(),
+                idempotency_key: None,
+                operation: "append".to_string(),
+                expected_version_token: "token-v1".to_string(),
+                expected_metadata_location: current_metadata.clone(),
+                new_metadata_location: new_metadata,
+                requirements: Vec::new(),
+                writer: Some("pyiceberg/test".to_string()),
+            })
+            .await
+            .expect_err("a lost warehouse ownership lock must prevent the table CAS");
+
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message) if message.contains("lock lease was lost")
+        );
+        let loaded = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
+        assert_eq!(loaded.metadata_location, current_metadata);
+        assert!(
+            store
+                .get_commit_by_id(bucket, "table-id", "commit-lock-loss")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
     async fn object_table_catalog_store_syncs_warehouse_location_from_committed_metadata() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -24190,10 +24807,11 @@ mod tests {
                 view.warehouse_location = format!("s3://{bucket}/views/{view_name}-id");
                 store.create_view(view).await.expect("view should be created");
             }
-            backend.reset_call_counts().await;
+            let one = NonZeroUsize::new(1).expect("one is non-zero");
+            let two = NonZeroUsize::new(2).expect("two is non-zero");
 
             let table_page = store
-                .list_tables_page(bucket, "sales", None, 2)
+                .list_tables_page(bucket, "sales", None, two)
                 .await
                 .expect("table page should load");
             assert_eq!(
@@ -24204,9 +24822,15 @@ mod tests {
                     .collect::<Vec<_>>(),
                 vec!["alpha", "beta"]
             );
-            assert!(table_page.has_more);
+            assert!(table_page.next_cursor.is_some());
+            let table_cursor = store
+                .list_tables_page(bucket, "sales", None, one)
+                .await
+                .expect("single table page should load")
+                .next_cursor
+                .expect("single table page should return a cursor");
             let exact_table_page = store
-                .list_tables_page(bucket, "sales", Some("alpha"), 2)
+                .list_tables_page(bucket, "sales", Some(&table_cursor), two)
                 .await
                 .expect("exact table page should load");
             assert_eq!(
@@ -24217,19 +24841,25 @@ mod tests {
                     .collect::<Vec<_>>(),
                 vec!["beta", "gamma"]
             );
-            assert!(!exact_table_page.has_more);
+            assert!(exact_table_page.next_cursor.is_none());
 
             let view_page = store
-                .list_views_page(bucket, "sales", None, 2)
+                .list_views_page(bucket, "sales", None, two)
                 .await
                 .expect("view page should load");
             assert_eq!(
                 view_page.entries.iter().map(|entry| entry.view.as_str()).collect::<Vec<_>>(),
                 vec!["view_alpha", "view_beta"]
             );
-            assert!(view_page.has_more);
+            assert!(view_page.next_cursor.is_some());
+            let view_cursor = store
+                .list_views_page(bucket, "sales", None, one)
+                .await
+                .expect("single view page should load")
+                .next_cursor
+                .expect("single view page should return a cursor");
             let exact_view_page = store
-                .list_views_page(bucket, "sales", Some("view_alpha"), 2)
+                .list_views_page(bucket, "sales", Some(&view_cursor), two)
                 .await
                 .expect("exact view page should load");
             assert_eq!(
@@ -24240,15 +24870,7 @@ mod tests {
                     .collect::<Vec<_>>(),
                 vec!["view_beta", "view_gamma"]
             );
-            assert!(!exact_view_page.has_more);
-            assert_eq!(
-                backend.list_page_limits().await,
-                if mode == TableCatalogBackingMode::ObjectBacked {
-                    vec![3, 3, 3, 3]
-                } else {
-                    Vec::new()
-                }
-            );
+            assert!(exact_view_page.next_cursor.is_none());
         }
     }
 

--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -110,6 +110,8 @@ const VIEW_ENTRY_FILE: &str = "view-entry.json";
 const INTERNAL_CATALOG_ROOT: &str = BUCKET_TABLE_CATALOG_META_PREFIX;
 const TABLE_BUCKET_ROOT: &str = BUCKET_TABLE_CATALOG_TABLE_BUCKETS_PREFIX;
 const COMMIT_LOG_ROOT: &str = "commits";
+const COMMIT_HEAD_ROOT: &str = "commit-heads";
+const COMMIT_HEAD_FILE: &str = "head.json";
 const COMMIT_IDEMPOTENCY_ROOT: &str = "commit-idempotency";
 const COMMIT_INTEGRITY_ROOT: &str = "commit-integrity";
 const WAREHOUSE_INDEX_ROOT: &str = "warehouse-index";
@@ -2757,6 +2759,16 @@ impl TableCatalogObjectPaths {
         )
     }
 
+    pub fn commit_head_path(&self, table_bucket: &str, table_id: &str) -> String {
+        format!(
+            "{}{}/{}/{}",
+            self.table_bucket_root_prefix(table_bucket),
+            COMMIT_HEAD_ROOT,
+            table_catalog_path_hash(table_id),
+            COMMIT_HEAD_FILE
+        )
+    }
+
     pub fn commit_idempotency_entry_path(&self, table_bucket: &str, table_id: &str, idempotency_key: &str) -> String {
         format!(
             "{}{}/{}/{}.json",
@@ -2961,6 +2973,7 @@ type StrongWarehouseIndex = BTreeMap<String, BTreeMap<String, StrongResourceKey>
 #[derive(Clone, Default)]
 struct StrongTableCatalogState {
     hydrated: bool,
+    hydration_generation: u64,
     snapshot_etag: Option<String>,
     table_buckets: BTreeMap<String, TableBucketEntry>,
     namespaces: BTreeMap<StrongNamespaceKey, NamespaceEntry>,
@@ -3520,13 +3533,13 @@ where
         loop {
             let observed_state = {
                 let state = self.state.lock().await;
-                (state.hydrated, state.snapshot_etag.clone())
+                (state.hydrated, state.snapshot_etag.clone(), state.hydration_generation)
             };
             let snapshot_object = self
                 .object_backend
                 .read_object(RUSTFS_META_BUCKET, &Self::snapshot_object_path())
                 .await?;
-            let loaded_state = if let Some(snapshot_object) = snapshot_object {
+            let mut loaded_state = if let Some(snapshot_object) = snapshot_object {
                 let snapshot = serde_json::from_slice::<StrongTableCatalogSnapshot>(&snapshot_object.data).map_err(|err| {
                     TableCatalogStoreError::Internal(format!("failed to decode strong catalog snapshot: {err}"))
                 })?;
@@ -3537,8 +3550,9 @@ where
                     ..StrongTableCatalogState::default()
                 }
             };
+            loaded_state.hydration_generation = observed_state.2;
             let mut state = self.state.lock().await;
-            if (state.hydrated, state.snapshot_etag.clone()) != observed_state {
+            if (state.hydrated, state.snapshot_etag.clone(), state.hydration_generation) != observed_state {
                 continue;
             }
             *state = loaded_state;
@@ -3563,10 +3577,24 @@ where
         snapshot: StrongTableCatalogSnapshot,
         precondition: TableCatalogPutPrecondition,
     ) -> TableCatalogStoreResult<()> {
-        // A stale cache is recoverable from the durable snapshot after cancellation. Readers may
-        // continue from the previous snapshot while the conditional PUT is still in flight.
-        self.state.lock().await.hydrated = false;
-        self.persist_snapshot(snapshot, precondition).await
+        let completed_generation = {
+            let mut state = self.state.lock().await;
+            let writing_generation = state
+                .hydration_generation
+                .checked_add(1)
+                .ok_or_else(|| TableCatalogStoreError::Internal("strong catalog cache generation is exhausted".to_string()))?;
+            let completed_generation = writing_generation
+                .checked_add(1)
+                .ok_or_else(|| TableCatalogStoreError::Internal("strong catalog cache generation is exhausted".to_string()))?;
+            state.hydrated = false;
+            state.hydration_generation = writing_generation;
+            completed_generation
+        };
+        let result = self.persist_snapshot(snapshot, precondition).await;
+        let mut state = self.state.lock().await;
+        state.hydrated = false;
+        state.hydration_generation = completed_generation;
+        result
     }
 
     async fn materialize_bucket_snapshot(
@@ -3821,10 +3849,10 @@ where
     }
 
     fn committed_existing_result_locked(
-        state: &mut StrongTableCatalogState,
+        state: &StrongTableCatalogState,
         request: &TableCommitRequest,
         current: TableEntry,
-    ) -> Option<TableCommitResult> {
+    ) -> Option<(TableCommitResult, bool)> {
         let commit_key = Self::commit_key(&request.table_bucket, &current.table_id, &request.commit_id);
         let existing = state.commits.get(&commit_key)?;
         if !commit_log_matches_request(existing, request, &current.table_id) {
@@ -3839,17 +3867,39 @@ where
 
         let mut committed = existing.clone();
         committed.status = CommitLogStatus::Committed;
-        state.commits.insert(commit_key, committed.clone());
-        if let Some(idempotency_key) = committed.idempotency_key.as_deref() {
+        let idempotency_key = committed
+            .idempotency_key
+            .as_deref()
+            .map(|idempotency_key| Self::idempotency_key(&request.table_bucket, &current.table_id, idempotency_key));
+        let requires_persist = !matches!(existing.status, CommitLogStatus::Committed)
+            || idempotency_key
+                .as_ref()
+                .is_some_and(|idempotency_key| state.idempotency.get(idempotency_key) != Some(&committed));
+        Some((
+            TableCommitResult {
+                table: current,
+                commit_log: committed,
+            },
+            requires_persist,
+        ))
+    }
+
+    fn persist_committed_existing_result_locked(
+        state: &mut StrongTableCatalogState,
+        request: &TableCommitRequest,
+        result: &TableCommitResult,
+    ) {
+        let table_id = &result.table.table_id;
+        state.commits.insert(
+            Self::commit_key(&request.table_bucket, table_id, &request.commit_id),
+            result.commit_log.clone(),
+        );
+        if let Some(idempotency_key) = result.commit_log.idempotency_key.as_deref() {
             state.idempotency.insert(
-                Self::idempotency_key(&request.table_bucket, &current.table_id, idempotency_key),
-                committed.clone(),
+                Self::idempotency_key(&request.table_bucket, table_id, idempotency_key),
+                result.commit_log.clone(),
             );
         }
-        Some(TableCommitResult {
-            table: current,
-            commit_log: committed,
-        })
     }
 
     fn apply_commit_locked(
@@ -3858,11 +3908,14 @@ where
         namespace: &Namespace,
         table: &IdentifierSegment,
         next_warehouse_location: Option<String>,
-    ) -> TableCatalogStoreResult<TableCommitResult> {
+    ) -> TableCatalogStoreResult<(TableCommitResult, bool)> {
         let key = Self::table_key(&request.table_bucket, namespace, table);
         let current = Self::validate_new_table_commit_locked(state, &key, request)?;
-        if let Some(result) = Self::committed_existing_result_locked(state, request, current.clone()) {
-            return Ok(result);
+        if let Some((result, requires_persist)) = Self::committed_existing_result_locked(state, request, current.clone()) {
+            if requires_persist {
+                Self::persist_committed_existing_result_locked(state, request, &result);
+            }
+            return Ok((result, requires_persist));
         }
 
         let commit_log = CommitLogEntry {
@@ -3902,7 +3955,7 @@ where
         }
         state.tables.insert(key, next.clone());
 
-        Ok(TableCommitResult { table: next, commit_log })
+        Ok((TableCommitResult { table: next, commit_log }, true))
     }
 
     pub(crate) async fn plan_table_commit_recovery(
@@ -4456,11 +4509,16 @@ where
                     .commits
                     .get(&Self::commit_key(&request.table_bucket, &current.table_id, &request.commit_id))
                     .cloned();
-                let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
                 let committed =
-                    Self::committed_existing_result_locked(&mut draft_state, &request, current.clone()).map(|result| {
-                        Self::snapshot_from_mutated_state_locked(&mut draft_state)
-                            .map(|snapshot| (result, snapshot, precondition))
+                    Self::committed_existing_result_locked(&state, &request, current.clone()).map(|(result, changed)| {
+                        if changed {
+                            let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
+                            Self::persist_committed_existing_result_locked(&mut draft_state, &request, &result);
+                            Self::snapshot_from_mutated_state_locked(&mut draft_state)
+                                .map(|snapshot| (result, Some(snapshot), precondition))
+                        } else {
+                            Ok((result, None, Self::snapshot_write_precondition_locked(&state)))
+                        }
                     });
                 (current, committed, existing_commit)
             };
@@ -4509,9 +4567,10 @@ where
             }
             if let Some(prepared_result) = committed_existing_result {
                 let result = match prepared_result {
-                    Ok((result, snapshot, precondition)) => {
+                    Ok((result, Some(snapshot), precondition)) => {
                         self.finalize_snapshot_write(snapshot, precondition).await.map(|_| result)
                     }
+                    Ok((result, None, _)) => Ok(result),
                     Err(err) => Err(err),
                 };
                 return table_commit_result(
@@ -4612,20 +4671,21 @@ where
             let state = self.state.lock().await;
             let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
             match Self::apply_commit_locked(&mut draft_state, &request, &namespace, &table, next_warehouse_location) {
-                Ok(result) => {
-                    Self::snapshot_from_mutated_state_locked(&mut draft_state).map(|snapshot| (result, snapshot, precondition))
-                }
+                Ok((result, true)) => Self::snapshot_from_mutated_state_locked(&mut draft_state)
+                    .map(|snapshot| (result, Some(snapshot), precondition)),
+                Ok((result, false)) => Ok((result, None, precondition)),
                 Err(err) => Err(err),
             }
         };
         let result = match prepared_result {
-            Ok((result, snapshot, precondition)) => {
+            Ok((result, Some(snapshot), precondition)) => {
                 if let Some(current_metadata_guard) = current_metadata_guard.as_deref() {
                     ensure_table_catalog_lock_held(current_metadata_guard)?;
                 }
                 ensure_table_catalog_lock_held(metadata_guard.as_ref())?;
                 self.finalize_snapshot_write(snapshot, precondition).await.map(|_| result)
             }
+            Ok((result, None, _)) => Ok(result),
             Err(err) => Err(err),
         };
         let cas_result = result.as_ref().map(|_| ()).map_err(Clone::clone);
@@ -4824,7 +4884,7 @@ where
                 "new metadata location must be inside the view metadata directory".to_string(),
             ));
         }
-        let _metadata_guard = self
+        let metadata_guard = self
             .object_backend
             .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
             .await?;
@@ -4882,6 +4942,7 @@ where
             draft_state.views.insert(key, next.clone());
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition, next)
         };
+        ensure_table_catalog_lock_held(metadata_guard.as_ref())?;
         self.finalize_snapshot_write(snapshot, precondition).await?;
         Ok(ViewCommitResult { view: next })
     }
@@ -5655,7 +5716,7 @@ where
         index: &TableWarehouseIndexEntry,
         reason: &'static str,
     ) -> TableCatalogStoreResult<bool> {
-        let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), object).await?;
+        let guard = self.backend.acquire_write_lock(self.catalog_bucket(), object).await?;
         let Some((current, _)) = self
             .read_entry_unlocked::<TableWarehouseIndexEntry>(self.catalog_bucket(), object)
             .await?
@@ -5677,6 +5738,7 @@ where
             );
             return Ok(false);
         }
+        ensure_table_catalog_lock_held(guard.as_ref())?;
         self.delete_warehouse_index_object_unlocked(object, index, reason).await?;
         Ok(true)
     }
@@ -6498,6 +6560,93 @@ where
         if let Some(idempotency_path) = idempotency_path {
             self.write_entry(self.catalog_bucket(), idempotency_path, commit_log, TableCatalogPutPrecondition::Any)
                 .await?;
+        }
+        Ok(())
+    }
+
+    async fn finalize_commit_head(
+        &self,
+        entry: &TableEntry,
+        commit_log: &CommitLogEntry,
+    ) -> TableCatalogStoreResult<CommitLogEntry> {
+        let commit_path = self
+            .paths
+            .commit_log_entry_path(&entry.table_bucket, &entry.table_id, &commit_log.commit_id);
+        let idempotency_path = commit_log.idempotency_key.as_deref().map(|idempotency_key| {
+            self.paths
+                .commit_idempotency_entry_path(&entry.table_bucket, &entry.table_id, idempotency_key)
+        });
+        let mut committed = commit_log.clone();
+        committed.status = CommitLogStatus::Committed;
+        self.finalize_commit_log(&commit_path, idempotency_path.as_deref(), &committed)
+            .await?;
+        self.write_entry(
+            self.catalog_bucket(),
+            &self.paths.commit_head_path(&entry.table_bucket, &entry.table_id),
+            &committed,
+            TableCatalogPutPrecondition::Any,
+        )
+        .await?;
+        Ok(committed)
+    }
+
+    async fn current_commit_log(&self, entry: &TableEntry) -> TableCatalogStoreResult<Option<CommitLogEntry>> {
+        let mut current = None;
+        for object in self
+            .backend
+            .list_objects(
+                self.catalog_bucket(),
+                &self.paths.commit_log_entries_prefix(&entry.table_bucket, &entry.table_id),
+            )
+            .await?
+        {
+            if !object.ends_with(".json") {
+                continue;
+            }
+            let Some(commit) = self.read_commit_by_path(&object).await? else {
+                continue;
+            };
+            if commit.table_id != entry.table_id || !table_matches_committed_log(entry, &commit) {
+                continue;
+            }
+            if current.is_some() {
+                return Err(TableCatalogStoreError::Conflict(
+                    "multiple commit records match the current table pointer".to_string(),
+                ));
+            }
+            current = Some(commit);
+        }
+        Ok(current)
+    }
+
+    async fn reconcile_commit_head(&self, entry: &TableEntry) -> TableCatalogStoreResult<()> {
+        let head_path = self.paths.commit_head_path(&entry.table_bucket, &entry.table_id);
+        let head = self.read_commit_by_path(&head_path).await?;
+        if let Some(head) = head.as_ref() {
+            if head.table_id != entry.table_id {
+                return Err(TableCatalogStoreError::Conflict(
+                    "commit head belongs to a different table identity".to_string(),
+                ));
+            }
+            if table_matches_committed_log(entry, head) {
+                if matches!(head.status, CommitLogStatus::Staged) {
+                    self.finalize_commit_head(entry, head).await?;
+                }
+                return Ok(());
+            }
+            if matches!(head.status, CommitLogStatus::Staged) && table_matches_staged_base(entry, head) {
+                return Ok(());
+            }
+        }
+
+        if let Some(commit) = self.current_commit_log(entry).await? {
+            self.finalize_commit_head(entry, &commit).await?;
+            return Ok(());
+        }
+        if head.is_some() {
+            return Err(TableCatalogStoreError::Conflict(
+                "commit head does not match the current or pre-commit table state".to_string(),
+            ));
         }
         Ok(())
     }
@@ -9339,7 +9488,7 @@ where
         self.ensure_table_warehouse_index_owner(&current_entry).await?;
         let current_metadata_guard = self
             .backend
-            .acquire_write_lock(table_bucket, &current_entry.metadata_location)
+            .acquire_read_lock(table_bucket, &current_entry.metadata_location)
             .await?;
         let Some(locked_current_metadata) = self
             .backend
@@ -9364,7 +9513,7 @@ where
             if object_location == current_entry.metadata_location {
                 continue;
             }
-            let source_guard = self.backend.acquire_write_lock(table_bucket, &object_location).await?;
+            let source_guard = self.backend.acquire_read_lock(table_bucket, &object_location).await?;
             let source = self.backend.object_metadata_unlocked(table_bucket, &object_location).await?;
             if source.as_ref() != Some(&expected) {
                 return Err(TableCatalogStoreError::Conflict(format!(
@@ -9813,10 +9962,22 @@ where
                     ))),
                 );
             };
+            if let Err(err) = self.reconcile_commit_head(&current).await {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(err),
+                );
+            }
 
             let commit_path = self
                 .paths
                 .commit_log_entry_path(&request.table_bucket, &current.table_id, &request.commit_id);
+            let commit_head_path = self.paths.commit_head_path(&request.table_bucket, &current.table_id);
             let integrity_path =
                 self.paths
                     .commit_integrity_entry_path(&request.table_bucket, &current.table_id, &request.commit_id);
@@ -10165,6 +10326,13 @@ where
                     )
                     .await?;
                 }
+                self.write_entry(
+                    self.catalog_bucket(),
+                    &commit_head_path,
+                    &staged_commit_log,
+                    TableCatalogPutPrecondition::Any,
+                )
+                .await?;
                 Ok(())
             }
             .await;
@@ -10329,26 +10497,25 @@ where
                 })
                 .and_then(|_| ensure_table_catalog_lock_held(migration_guard.as_ref()))
                 .and_then(|_| ownership_guard.as_deref().map_or(Ok(()), ensure_table_catalog_lock_held));
-            if let Err(err) = post_cas_fence {
-                return table_commit_result(
-                    &request.table_bucket,
-                    &request.namespace,
-                    &request.table,
-                    &request.commit_id,
-                    &request.operation,
-                    commit_started,
-                    Err(err),
-                );
-            }
             self.delete_table_warehouse_index_if_changed(&current, &next).await;
 
             let mut commit_log = staged_commit_log;
             commit_log.status = CommitLogStatus::Committed;
-            // After the table CAS succeeds, the staged record is the durable recovery source.
-            // A finalization failure must not turn an externally committed pointer into a failed commit response.
-            let _ = self
-                .finalize_commit_log(&commit_path, idempotency_path.as_deref(), &commit_log)
-                .await;
+            let finalization_result = match post_cas_fence {
+                Ok(()) => self.finalize_commit_head(&next, &commit_log).await,
+                Err(err) => Err(err),
+            };
+            if let Err(err) = finalization_result {
+                tracing::warn!(
+                    table_bucket = %request.table_bucket,
+                    namespace = %request.namespace,
+                    table = %request.table,
+                    table_id = %next.table_id,
+                    commit_id = %request.commit_id,
+                    error = %err,
+                    "table commit pointer advanced with pending commit record finalization"
+                );
+            }
 
             return table_commit_result(
                 &request.table_bucket,
@@ -15203,7 +15370,7 @@ pub(crate) fn validate_table_warehouse_relocation(
     if next_warehouse_location == entry.warehouse_location {
         return Ok(());
     }
-    Err(TableCatalogStoreError::Invalid(
+    Err(TableCatalogStoreError::Unsupported(
         "table warehouse relocation is unsupported because retained snapshots may still reference the current warehouse"
             .to_string(),
     ))
@@ -15790,6 +15957,7 @@ mod tests {
         );
 
         let commit_path = paths.commit_log_entry_path("table/../bucket", "table/../id", "commit/%2f\nid");
+        let commit_head_path = paths.commit_head_path("table/../bucket", "table/../id");
         let idempotency_path = paths.commit_idempotency_entry_path("table/../bucket", "table/../id", "client/%2f\nrequest");
         let warehouse_index_path = paths.warehouse_index_entry_path("table/../bucket", "tables/table/../id/data\nprefix/");
         let warehouse_index_state_path = paths.warehouse_index_state_path("table/../bucket");
@@ -15799,6 +15967,7 @@ mod tests {
 
         for path in [
             commit_path,
+            commit_head_path,
             idempotency_path,
             warehouse_index_path,
             warehouse_index_state_path,
@@ -15830,11 +15999,16 @@ mod tests {
     struct TestCatalogObjectLockGuard {
         _guard: tokio::sync::OwnedMutexGuard<()>,
         lost: bool,
+        lost_after_checks: Option<usize>,
+        held_checks: std::sync::atomic::AtomicUsize,
     }
 
     impl TableCatalogObjectLockGuard for TestCatalogObjectLockGuard {
         fn is_lock_lost(&self) -> bool {
             self.lost
+                || self.lost_after_checks.is_some_and(|lost_after_checks| {
+                    self.held_checks.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1 >= lost_after_checks
+                })
         }
     }
 
@@ -15871,6 +16045,7 @@ mod tests {
         fail_delete_attempts: BTreeMap<(String, String), BTreeSet<usize>>,
         replace_on_write_lock_acquisitions: TestCatalogObjectReplacements,
         lost_write_lock_acquisitions: BTreeMap<TestCatalogObjectLockKey, BTreeSet<usize>>,
+        lost_write_lock_after_checks: BTreeMap<TestCatalogObjectLockKey, BTreeMap<usize, usize>>,
         put_attempts: BTreeMap<(String, String), usize>,
         delete_attempts: BTreeMap<(String, String), usize>,
         write_lock_acquisitions: BTreeMap<(String, String), usize>,
@@ -15950,6 +16125,17 @@ mod tests {
             let key = (bucket.to_string(), object.to_string());
             let attempt = state.write_lock_acquisitions.get(&key).copied().unwrap_or_default() + 1;
             state.lost_write_lock_acquisitions.entry(key).or_default().insert(attempt);
+        }
+
+        async fn lose_next_write_lock_after_checks(&self, bucket: &str, object: &str, checks: usize) {
+            let mut state = self.state.lock().await;
+            let key = (bucket.to_string(), object.to_string());
+            let attempt = state.write_lock_acquisitions.get(&key).copied().unwrap_or_default() + 1;
+            state
+                .lost_write_lock_after_checks
+                .entry(key)
+                .or_default()
+                .insert(attempt, checks);
         }
 
         async fn list_call_count(&self) -> usize {
@@ -16601,6 +16787,10 @@ mod tests {
                 .lost_write_lock_acquisitions
                 .get(&key)
                 .is_some_and(|attempts| attempts.contains(&attempt));
+            let lost_after_checks = state
+                .lost_write_lock_after_checks
+                .get_mut(&key)
+                .and_then(|acquisitions| acquisitions.remove(&attempt));
             let replacement = state
                 .replace_on_write_lock_acquisitions
                 .get_mut(&key)
@@ -16628,7 +16818,12 @@ mod tests {
                 state.objects.insert(key, TestCatalogObjectRecord { data, etag, mod_time });
             }
             drop(state);
-            Ok(Box::new(TestCatalogObjectLockGuard { _guard: guard, lost }))
+            Ok(Box::new(TestCatalogObjectLockGuard {
+                _guard: guard,
+                lost,
+                lost_after_checks,
+                held_checks: std::sync::atomic::AtomicUsize::new(0),
+            }))
         }
     }
 
@@ -17563,7 +17758,7 @@ mod tests {
             .await
             .expect_err("warehouse relocation must remain unsupported while retained snapshots use the old prefix");
 
-        assert_matches!(error, TableCatalogStoreError::Invalid(message) if message.contains("relocation is unsupported"));
+        assert_matches!(error, TableCatalogStoreError::Unsupported(message) if message.contains("relocation is unsupported"));
         assert!(
             !backend
                 .object_exists(RUSTFS_META_BUCKET, &relocated_index_path)
@@ -18054,8 +18249,8 @@ mod tests {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
         let bucket = "analytics";
-        let namespace = Namespace::parse("sales").unwrap();
-        let table = IdentifierSegment::parse("orders").unwrap();
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
         let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
         let index_path = store.paths.warehouse_index_entry_path(bucket, "tables/table-id/");
 
@@ -18079,6 +18274,38 @@ mod tests {
             .expect("restored table data-plane lookup should succeed")
             .expect("restored table should keep data-plane protection");
         assert_eq!(resource.table, "orders");
+    }
+
+    #[tokio::test]
+    async fn object_table_catalog_store_keeps_warehouse_index_after_lock_loss() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let index_path = store.paths.warehouse_index_entry_path(bucket, "tables/table-id/");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current).await;
+        let entry = store
+            .load_table(bucket, &namespace.public_name(), table.as_str())
+            .await
+            .expect("table lookup should succeed")
+            .expect("table should exist");
+        backend.lose_next_write_lock(RUSTFS_META_BUCKET, &index_path).await;
+
+        let error = store
+            .delete_table_warehouse_index(&entry)
+            .await
+            .expect_err("warehouse index deletion must stop after lock loss");
+
+        assert_matches!(error, TableCatalogStoreError::Conflict(_));
+        assert!(
+            backend
+                .object_exists(RUSTFS_META_BUCKET, &index_path)
+                .await
+                .expect("warehouse index lookup should succeed")
+        );
     }
 
     #[tokio::test]
@@ -23726,15 +23953,18 @@ mod tests {
         let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
         let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
 
-        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
         store
             .create_namespace(test_namespace_entry(bucket, &namespace))
             .await
-            .unwrap();
+            .expect("namespace should be created");
         store
             .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
             .await
-            .unwrap();
+            .expect("table should be created");
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
         let client_requirement = serde_json::json!({"type": "assert-table-uuid", "uuid": "table-uuid"});
         let metadata_digest = hex_sha256(b"{}", str::to_owned);
@@ -23962,23 +24192,21 @@ mod tests {
             .await
             .expect("table should be created");
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        let request = TableCommitRequest {
+            table_bucket: bucket.to_string(),
+            namespace: namespace.public_name(),
+            table: table.as_str().to_string(),
+            commit_id: "commit-1".to_string(),
+            idempotency_key: Some("client-request".to_string()),
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            expected_metadata_location: current_metadata,
+            new_metadata_location: new_metadata.clone(),
+            requirements: Vec::new(),
+            writer: Some("pyiceberg/test".to_string()),
+        };
 
-        let result = store
-            .commit_table(TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: table.as_str().to_string(),
-                commit_id: "commit-1".to_string(),
-                idempotency_key: Some("client-request".to_string()),
-                operation: "append".to_string(),
-                expected_version_token: "token-v1".to_string(),
-                expected_metadata_location: current_metadata,
-                new_metadata_location: new_metadata.clone(),
-                requirements: Vec::new(),
-                writer: Some("pyiceberg/test".to_string()),
-            })
-            .await
-            .expect("commit should succeed");
+        let result = store.commit_table(request.clone()).await.expect("commit should succeed");
 
         let restarted = StrongTableCatalogStore::new(backend.clone());
         let loaded = restarted
@@ -24015,6 +24243,24 @@ mod tests {
         assert_eq!(recovery.finalization_required_count, 0);
         assert_eq!(recovery.idempotency_repair_required_count, 0);
         assert_eq!(recovery.manual_review_count, 0);
+
+        backend
+            .fail_next_put(
+                RUSTFS_META_BUCKET,
+                &StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path(),
+            )
+            .await;
+        let replay = restarted
+            .commit_table(request)
+            .await
+            .expect("a clean replay should not rewrite the durable snapshot");
+        assert_eq!(replay.table.version_token, result.table.version_token);
+
+        let error = restarted
+            .put_table_bucket(test_bucket_entry("later-bucket"))
+            .await
+            .expect_err("the injected snapshot write failure should remain pending after replay");
+        assert_matches!(error, TableCatalogStoreError::Internal(_));
     }
 
     #[tokio::test]
@@ -24388,6 +24634,10 @@ mod tests {
             .await
             .expect("create task should join")
             .expect("table should be created");
+        assert!(
+            !store.state.lock().await.hydrated,
+            "a reload of the previous snapshot must remain invalidated after the durable write"
+        );
 
         let resource = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/data/file.parquet")
             .await
@@ -24398,6 +24648,67 @@ mod tests {
         assert_eq!(resource.table, table.as_str());
         assert_eq!(resource.table_id, "table-id");
         assert_eq!(resource.warehouse_object_prefix, "tables/table-id/");
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_view_replace_rejects_lost_metadata_lock() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let view = IdentifierSegment::parse("recent_orders").expect("view should parse");
+        let current_metadata = default_view_metadata_file_path(&namespace, &view, "00001.metadata.json");
+        let next_metadata = default_view_metadata_file_path(&namespace, &view, "00002.metadata.json");
+
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be created");
+        store
+            .create_view(test_view_entry(bucket, &namespace, &view, current_metadata.clone()))
+            .await
+            .expect("view should be created");
+        backend
+            .seed_object(
+                bucket,
+                &next_metadata,
+                serde_json::to_vec(&serde_json::json!({
+                    "format-version": 1,
+                    "view-uuid": "view-uuid",
+                    "location": format!("s3://{bucket}/views/view-id")
+                }))
+                .expect("view metadata should serialize"),
+            )
+            .await;
+        backend.lose_next_write_lock(bucket, &next_metadata).await;
+
+        let error = store
+            .replace_view(ViewCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                view: view.as_str().to_string(),
+                expected_version_token: "token-v1".to_string(),
+                expected_metadata_location: current_metadata.clone(),
+                new_metadata_location: next_metadata,
+                new_metadata_sha256: None,
+            })
+            .await
+            .expect_err("view replacement must stop after metadata lock loss");
+
+        assert_matches!(error, TableCatalogStoreError::Conflict(_));
+        let restarted = StrongTableCatalogStore::new(backend);
+        let loaded = restarted
+            .load_view(bucket, &namespace.public_name(), view.as_str())
+            .await
+            .expect("view lookup should succeed")
+            .expect("view should still exist");
+        assert_eq!(loaded.metadata_location, current_metadata);
+        assert_eq!(loaded.version_token, "token-v1");
+        assert_eq!(loaded.generation, 1);
     }
 
     #[tokio::test]
@@ -25433,7 +25744,7 @@ mod tests {
                 .await
                 .expect_err("external table warehouse relocation should be rejected");
 
-            assert_matches!(error, TableCatalogStoreError::Invalid(message) if message.contains("relocation is unsupported"));
+            assert_matches!(error, TableCatalogStoreError::Unsupported(message) if message.contains("relocation is unsupported"));
             let loaded = store
                 .load_table(bucket, &namespace.public_name(), table.as_str())
                 .await
@@ -25721,7 +26032,11 @@ mod tests {
             .await
             .expect("an older client should replay the committed result without internal digest requirements");
         assert_eq!(replay.table.version_token, result.table.version_token);
-        assert_eq!(backend.list_call_count().await, 0);
+        assert_eq!(
+            backend.list_call_count().await,
+            1,
+            "the first post-upgrade commit should scan once before establishing the durable commit head"
+        );
         assert_eq!(
             backend
                 .write_lock_acquisition_count(store.catalog_bucket(), &ownership_lock_path)
@@ -26038,7 +26353,11 @@ mod tests {
         let loaded = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
         assert_eq!(loaded.metadata_location, current_metadata);
         assert_eq!(loaded.version_token, "token-v1");
-        let staged = store.get_commit_by_id(bucket, "table-id", "commit-1").await.unwrap().unwrap();
+        let staged = store
+            .get_commit_by_id(bucket, "table-id", "commit-1")
+            .await
+            .expect("commit lookup should succeed")
+            .expect("staged commit should exist");
         assert_eq!(staged.status, CommitLogStatus::Staged);
     }
 
@@ -26051,6 +26370,7 @@ mod tests {
         let table = IdentifierSegment::parse("orders").unwrap();
         let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
         let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let later_metadata = default_table_metadata_file_path(&namespace, &table, "00003.metadata.json");
         let commit_path = TableCatalogObjectPaths::default().commit_log_entry_path(bucket, "table-id", "commit-1");
 
         store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
@@ -26063,6 +26383,7 @@ mod tests {
             .await
             .unwrap();
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        backend.seed_object(bucket, &later_metadata, b"{}".to_vec()).await;
         backend.fail_put_attempt(RUSTFS_META_BUCKET, &commit_path, 2).await;
 
         let request = TableCommitRequest {
@@ -26088,11 +26409,115 @@ mod tests {
         let staged = store.get_commit_by_id(bucket, "table-id", "commit-1").await.unwrap().unwrap();
         assert_eq!(staged.status, CommitLogStatus::Staged);
 
-        let retry = store.commit_table(request).await.unwrap();
-        assert_eq!(retry.table.version_token, result.table.version_token);
-        assert_eq!(retry.commit_log.status, CommitLogStatus::Committed);
+        let later = store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: "commit-2".to_string(),
+                idempotency_key: None,
+                operation: "append".to_string(),
+                expected_version_token: result.table.version_token.clone(),
+                expected_metadata_location: new_metadata,
+                new_metadata_location: later_metadata.clone(),
+                requirements: Vec::new(),
+                writer: None,
+            })
+            .await
+            .expect("a later commit should finalize the prior recovery head before advancing");
+        assert_eq!(later.table.metadata_location, later_metadata);
         let committed = store.get_commit_by_id(bucket, "table-id", "commit-1").await.unwrap().unwrap();
         assert_eq!(committed.status, CommitLogStatus::Committed);
+
+        let retry = store
+            .commit_table(request)
+            .await
+            .expect("a historical retry should return the current committed table state");
+        assert_eq!(retry.table.version_token, later.table.version_token);
+        assert_eq!(retry.commit_log.status, CommitLogStatus::Committed);
+        assert_eq!(retry.table.metadata_location, later_metadata);
+    }
+
+    #[tokio::test]
+    async fn object_table_catalog_store_returns_committed_result_when_lock_is_lost_after_cas() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let later_metadata = default_table_metadata_file_path(&namespace, &table, "00003.metadata.json");
+
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be created");
+        store
+            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
+            .await
+            .expect("table should be created");
+        backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        backend.seed_object(bucket, &later_metadata, b"{}".to_vec()).await;
+        let table_path = store.paths.table_entry_path(bucket, &namespace, &table);
+        backend
+            .lose_next_write_lock_after_checks(store.catalog_bucket(), &table_path, 2)
+            .await;
+
+        let committed = store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: "commit-1".to_string(),
+                idempotency_key: None,
+                operation: "append".to_string(),
+                expected_version_token: "token-v1".to_string(),
+                expected_metadata_location: current_metadata,
+                new_metadata_location: new_metadata.clone(),
+                requirements: Vec::new(),
+                writer: None,
+            })
+            .await
+            .expect("a successful pointer CAS must remain externally committed after lock loss");
+
+        assert_eq!(committed.table.metadata_location, new_metadata);
+        assert_eq!(committed.commit_log.status, CommitLogStatus::Committed);
+        let staged = store
+            .get_commit_by_id(bucket, "table-id", "commit-1")
+            .await
+            .expect("commit lookup should succeed")
+            .expect("staged commit should exist");
+        assert_eq!(staged.status, CommitLogStatus::Staged);
+
+        let later = store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: "commit-2".to_string(),
+                idempotency_key: None,
+                operation: "append".to_string(),
+                expected_version_token: committed.table.version_token,
+                expected_metadata_location: new_metadata,
+                new_metadata_location: later_metadata.clone(),
+                requirements: Vec::new(),
+                writer: None,
+            })
+            .await
+            .expect("a later commit should recover the staged record before advancing");
+
+        assert_eq!(later.table.metadata_location, later_metadata);
+        let recovered = store
+            .get_commit_by_id(bucket, "table-id", "commit-1")
+            .await
+            .expect("commit lookup should succeed")
+            .expect("recovered commit should exist");
+        assert_eq!(recovered.status, CommitLogStatus::Committed);
     }
 
     #[tokio::test]

--- a/rustfs/src/table_catalog.rs
+++ b/rustfs/src/table_catalog.rs
@@ -50,8 +50,8 @@ use datafusion::{
 use http::HeaderMap;
 use metrics::{counter, histogram};
 use rustfs_filemeta::FileInfo;
+use rustfs_utils::crypto::hex_sha256;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use sha2::{Digest, Sha256};
 use time::{Duration, OffsetDateTime};
 use tokio::io::AsyncReadExt;
 use uuid::Uuid;
@@ -77,6 +77,14 @@ pub(crate) const ENV_TABLE_CATALOG_BACKING: &str = "RUSTFS_TABLE_CATALOG_BACKING
 pub(crate) const TABLE_CATALOG_BACKING_OBJECT: &str = "object";
 pub(crate) const TABLE_CATALOG_BACKING_DURABLE_STRONG: &str = "durable-strong";
 pub(crate) const TABLE_METADATA_FILE_NAME_MAX_LEN: usize = 128;
+pub(crate) const TABLE_METADATA_JSON_MAX_SIZE: usize = 50 * 1024 * 1024;
+pub(crate) const TABLE_MANIFEST_AVRO_MAX_SIZE: usize = 128 * 1024 * 1024;
+const TABLE_MANIFEST_AVRO_MAX_RECORDS: usize = 1_000_000;
+pub(crate) const TABLE_METADATA_DIGEST_REQUIREMENT_TYPE: &str = "assert-rustfs-metadata-sha256";
+const NAMESPACE_PROPERTIES_MAX_ENTRIES: usize = 256;
+const NAMESPACE_PROPERTY_KEY_MAX_LEN: usize = 256;
+const NAMESPACE_PROPERTY_VALUE_MAX_LEN: usize = 4096;
+const NAMESPACE_PROPERTIES_MAX_TOTAL_BYTES: usize = 64 * 1024;
 pub const TABLE_RESERVED_PREFIX: &str = BUCKET_TABLE_RESERVED_PREFIX;
 const WAREHOUSE_ROOT: &str = "warehouses";
 const NAMESPACE_ROOT: &str = "namespaces";
@@ -99,6 +107,7 @@ const COMMIT_LOG_ROOT: &str = "commits";
 const COMMIT_IDEMPOTENCY_ROOT: &str = "commit-idempotency";
 const WAREHOUSE_INDEX_ROOT: &str = "warehouse-index";
 const WAREHOUSE_INDEX_STATE_FILE: &str = "state.json";
+const WAREHOUSE_INDEX_OWNERSHIP_LOCK_FILE: &str = "ownership.lock";
 const WAREHOUSE_INDEX_MAX_PREFIX_DEPTH: usize = 64;
 const EXTERNAL_CATALOG_ROOT: &str = "external-catalog";
 const EXTERNAL_CATALOG_BRIDGE_FILE: &str = "bridge.json";
@@ -296,6 +305,113 @@ pub(crate) struct NamespaceEntry {
     pub updated_at: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NamespacePropertiesUpdate {
+    removals: Vec<String>,
+    updates: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NamespacePropertiesUpdateError {
+    DuplicateRemoval(String),
+    Overlap(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct NamespacePropertiesUpdateResult {
+    pub updated: Vec<String>,
+    pub removed: Vec<String>,
+    pub missing: Vec<String>,
+}
+
+impl NamespacePropertiesUpdate {
+    pub(crate) fn try_new(
+        removals: Vec<String>,
+        updates: BTreeMap<String, String>,
+    ) -> Result<Self, NamespacePropertiesUpdateError> {
+        let mut removal_keys = BTreeSet::new();
+        for key in &removals {
+            if !removal_keys.insert(key.as_str()) {
+                return Err(NamespacePropertiesUpdateError::DuplicateRemoval(key.clone()));
+            }
+            if updates.contains_key(key) {
+                return Err(NamespacePropertiesUpdateError::Overlap(key.clone()));
+            }
+        }
+        Ok(Self { removals, updates })
+    }
+
+    pub(crate) fn apply_to(self, entry: &mut NamespaceEntry) -> NamespacePropertiesUpdateResult {
+        let updated = self.updates.keys().cloned().collect::<Vec<_>>();
+        for (key, value) in self.updates {
+            entry.properties.insert(key, value);
+        }
+
+        let mut removed = Vec::new();
+        let mut missing = Vec::new();
+        for key in self.removals {
+            if entry.properties.remove(&key).is_some() {
+                removed.push(key);
+            } else {
+                missing.push(key);
+            }
+        }
+
+        NamespacePropertiesUpdateResult {
+            updated,
+            removed,
+            missing,
+        }
+    }
+}
+
+fn validate_namespace_properties(properties: &BTreeMap<String, String>) -> TableCatalogStoreResult<()> {
+    if properties.len() > NAMESPACE_PROPERTIES_MAX_ENTRIES {
+        return Err(TableCatalogStoreError::Invalid(format!(
+            "namespace properties exceed the maximum of {NAMESPACE_PROPERTIES_MAX_ENTRIES} entries"
+        )));
+    }
+
+    let mut total_bytes = 0usize;
+    for (key, value) in properties {
+        if key.is_empty() || key.len() > NAMESPACE_PROPERTY_KEY_MAX_LEN {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "namespace property key length must be between 1 and {NAMESPACE_PROPERTY_KEY_MAX_LEN} bytes"
+            )));
+        }
+        if value.len() > NAMESPACE_PROPERTY_VALUE_MAX_LEN {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "namespace property value exceeds {NAMESPACE_PROPERTY_VALUE_MAX_LEN} bytes"
+            )));
+        }
+        total_bytes += key.len() + value.len();
+        if total_bytes > NAMESPACE_PROPERTIES_MAX_TOTAL_BYTES {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "namespace properties exceed {NAMESPACE_PROPERTIES_MAX_TOTAL_BYTES} bytes"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn namespace_is_descendant(candidate: &str, parent: &str) -> bool {
+    candidate.strip_prefix(parent).is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+fn synthetic_namespace_entry(table_bucket: &str, namespace: &Namespace) -> NamespaceEntry {
+    let namespace = namespace.public_name();
+    NamespaceEntry {
+        version: TABLE_CATALOG_ENTRY_VERSION,
+        table_bucket: table_bucket.to_string(),
+        namespace: namespace.clone(),
+        namespace_id: namespace,
+        state: TableCatalogEntryState::Active,
+        properties: BTreeMap::new(),
+        created_at: None,
+        updated_at: None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TableEntry {
@@ -453,6 +569,7 @@ pub(crate) struct ViewCommitRequest {
     pub expected_version_token: String,
     pub expected_metadata_location: String,
     pub new_metadata_location: String,
+    pub new_metadata_sha256: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1515,8 +1632,13 @@ pub(crate) struct TableCommitRecoveryReport {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TableCatalogStoreError {
     NotFound(String),
+    NamespaceNotFound(String),
+    TableNotFound(String),
+    ViewNotFound(String),
+    AlreadyExists(String),
     Conflict(String),
     Invalid(String),
+    Unsupported(String),
     Internal(String),
 }
 
@@ -1524,8 +1646,13 @@ impl fmt::Display for TableCatalogStoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotFound(message) => write!(f, "table catalog entry not found: {message}"),
+            Self::NamespaceNotFound(message) => write!(f, "table catalog namespace not found: {message}"),
+            Self::TableNotFound(message) => write!(f, "table catalog table not found: {message}"),
+            Self::ViewNotFound(message) => write!(f, "table catalog view not found: {message}"),
+            Self::AlreadyExists(message) => write!(f, "table catalog entry already exists: {message}"),
             Self::Conflict(message) => write!(f, "table catalog conflict: {message}"),
             Self::Invalid(message) => write!(f, "invalid table catalog entry: {message}"),
+            Self::Unsupported(message) => write!(f, "unsupported table catalog operation: {message}"),
             Self::Internal(message) => write!(f, "table catalog store error: {message}"),
         }
     }
@@ -1577,9 +1704,19 @@ fn normalize_warehouse_object_prefix(object_prefix: &str, max_prefix_depth: Opti
             "table warehouse location must include an object prefix".to_string(),
         ));
     }
+    if is_reserved_table_object_key(object_prefix) {
+        return Err(TableCatalogStoreError::Invalid(
+            "table warehouse location must not use the reserved table prefix".to_string(),
+        ));
+    }
     if object_prefix.contains('\\') {
         return Err(TableCatalogStoreError::Invalid(
             "table warehouse location contains an invalid path separator".to_string(),
+        ));
+    }
+    if object_prefix.contains(['*', '?']) {
+        return Err(TableCatalogStoreError::Invalid(
+            "table warehouse location contains an IAM wildcard".to_string(),
         ));
     }
     let mut segment_count = 0;
@@ -1627,6 +1764,10 @@ fn table_warehouse_object_prefix_from_location(table_bucket: &str, warehouse_loc
 
 fn view_warehouse_object_prefix_from_location(table_bucket: &str, warehouse_location: &str) -> TableCatalogStoreResult<String> {
     warehouse_object_prefix_from_location(table_bucket, warehouse_location, None)
+}
+
+fn warehouse_object_prefixes_overlap(left: &str, right: &str) -> bool {
+    left.starts_with(right) || right.starts_with(left)
 }
 
 pub(crate) fn validate_table_warehouse_location(table_bucket: &str, warehouse_location: &str) -> TableCatalogStoreResult<()> {
@@ -1682,6 +1823,67 @@ fn table_metadata_warehouse_location(
     metadata_object: &TableCatalogObject,
 ) -> TableCatalogStoreResult<Option<String>> {
     metadata_warehouse_location(table_bucket, metadata_location, metadata_object, validate_table_warehouse_location)
+}
+
+fn validate_commit_metadata_digest(
+    request: &TableCommitRequest,
+    metadata_object: &TableCatalogObject,
+) -> TableCatalogStoreResult<()> {
+    let mut expected_digest = None;
+    for requirement in &request.requirements {
+        if requirement.get("type").and_then(serde_json::Value::as_str) != Some(TABLE_METADATA_DIGEST_REQUIREMENT_TYPE) {
+            continue;
+        }
+        if expected_digest.is_some() {
+            return Err(TableCatalogStoreError::Invalid(
+                "commit contains duplicate metadata digest requirements".to_string(),
+            ));
+        }
+        expected_digest = Some(
+            requirement
+                .get("sha256")
+                .and_then(serde_json::Value::as_str)
+                .filter(|digest| digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
+                .ok_or_else(|| TableCatalogStoreError::Invalid("commit metadata digest is invalid".to_string()))?,
+        );
+    }
+    let Some(expected_digest) = expected_digest else {
+        return Ok(());
+    };
+    let metadata = serde_json::from_slice::<serde_json::Value>(&metadata_object.data)
+        .map_err(|err| TableCatalogStoreError::Invalid(format!("failed to parse committed metadata: {err}")))?;
+    let canonical = serde_json::to_vec(&metadata)
+        .map_err(|err| TableCatalogStoreError::Internal(format!("failed to encode committed metadata: {err}")))?;
+    let actual_digest = hex_sha256(&canonical, str::to_owned);
+    if actual_digest != expected_digest {
+        return Err(TableCatalogStoreError::Conflict(
+            "new metadata object changed after commit validation".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_view_metadata_digest(
+    expected_digest: Option<&str>,
+    metadata_object: &TableCatalogObject,
+) -> TableCatalogStoreResult<()> {
+    let Some(expected_digest) = expected_digest else {
+        return Ok(());
+    };
+    if expected_digest.len() != 64 || !expected_digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(TableCatalogStoreError::Invalid("view metadata digest is invalid".to_string()));
+    }
+    let metadata = serde_json::from_slice::<serde_json::Value>(&metadata_object.data)
+        .map_err(|err| TableCatalogStoreError::Invalid(format!("failed to parse committed view metadata: {err}")))?;
+    let canonical = serde_json::to_vec(&metadata)
+        .map_err(|err| TableCatalogStoreError::Internal(format!("failed to encode committed view metadata: {err}")))?;
+    let actual_digest = hex_sha256(&canonical, str::to_owned);
+    if actual_digest != expected_digest {
+        return Err(TableCatalogStoreError::Conflict(
+            "new view metadata object changed after commit validation".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn view_metadata_warehouse_location(
@@ -1852,6 +2054,18 @@ pub(crate) trait TableCatalogStore: Send + Sync {
 
     async fn get_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Option<NamespaceEntry>>;
 
+    async fn update_namespace_properties(
+        &self,
+        table_bucket: &str,
+        namespace: &str,
+        update: NamespacePropertiesUpdate,
+    ) -> TableCatalogStoreResult<NamespacePropertiesUpdateResult> {
+        let _ = (table_bucket, namespace, update);
+        Err(TableCatalogStoreError::Unsupported(
+            "namespace property updates are not supported by this catalog store".to_string(),
+        ))
+    }
+
     async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<()>;
 
     async fn create_table(&self, entry: TableEntry) -> TableCatalogStoreResult<()>;
@@ -1876,6 +2090,20 @@ pub(crate) trait TableCatalogStore: Send + Sync {
     }
 
     async fn load_table(&self, table_bucket: &str, namespace: &str, table: &str) -> TableCatalogStoreResult<Option<TableEntry>>;
+
+    async fn rename_table(
+        &self,
+        table_bucket: &str,
+        source_namespace: &str,
+        source_table: &str,
+        destination_namespace: &str,
+        destination_table: &str,
+    ) -> TableCatalogStoreResult<()> {
+        let _ = (table_bucket, source_namespace, source_table, destination_namespace, destination_table);
+        Err(TableCatalogStoreError::Unsupported(
+            "table rename is not supported by this catalog store".to_string(),
+        ))
+    }
 
     async fn resolve_table_data_plane_resource(
         &self,
@@ -1930,6 +2158,32 @@ pub(crate) trait TableCatalogStore: Send + Sync {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableCatalogPage<T> {
+    pub entries: Vec<T>,
+    pub has_more: bool,
+}
+
+fn catalog_page<T, F>(entries: Vec<T>, after: Option<&str>, limit: usize, key: F) -> TableCatalogStoreResult<TableCatalogPage<T>>
+where
+    F: Fn(&T) -> &str,
+{
+    if limit == 0 {
+        return Err(TableCatalogStoreError::Invalid(
+            "catalog page limit must be greater than zero".to_string(),
+        ));
+    }
+    let start = after.map_or(0, |after| entries.partition_point(|entry| key(entry) <= after));
+    let mut entries = entries
+        .into_iter()
+        .skip(start)
+        .take(limit.saturating_add(1))
+        .collect::<Vec<_>>();
+    let has_more = entries.len() > limit;
+    entries.truncate(limit);
+    Ok(TableCatalogPage { entries, has_more })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TableCatalogObject {
     pub data: Vec<u8>,
     pub etag: Option<String>,
@@ -1958,6 +2212,21 @@ pub(crate) enum TableCatalogPutPrecondition {
 #[async_trait::async_trait]
 pub(crate) trait TableCatalogObjectBackend: Clone + Send + Sync + 'static {
     async fn read_object(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObject>>;
+
+    async fn read_object_limited(
+        &self,
+        bucket: &str,
+        object: &str,
+        max_size: usize,
+    ) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
+        let result = self.read_object(bucket, object).await?;
+        if result.as_ref().is_some_and(|object| object.data.len() > max_size) {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "catalog object {bucket}/{object} exceeds the maximum size of {max_size} bytes"
+            )));
+        }
+        Ok(result)
+    }
 
     async fn read_object_unlocked(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
         self.read_object(bucket, object).await
@@ -2233,6 +2502,19 @@ impl TableCatalogObjectPaths {
         )
     }
 
+    pub fn warehouse_index_ownership_lock_path(&self, table_bucket: &str) -> String {
+        format!(
+            "{}{}/{}",
+            self.table_bucket_root_prefix(table_bucket),
+            WAREHOUSE_INDEX_ROOT,
+            WAREHOUSE_INDEX_OWNERSHIP_LOCK_FILE
+        )
+    }
+
+    pub fn warehouse_index_entries_prefix(&self, table_bucket: &str) -> String {
+        format!("{}{}/", self.table_bucket_root_prefix(table_bucket), WAREHOUSE_INDEX_ROOT)
+    }
+
     pub fn warehouse_index_entry_path(&self, table_bucket: &str, warehouse_object_prefix: &str) -> String {
         format!(
             "{}{}/{}.json",
@@ -2454,7 +2736,7 @@ struct TableCatalogBackingMigrationFence {
 fn table_catalog_bucket_snapshot_fingerprint(snapshot: &StrongTableCatalogBucketSnapshot) -> TableCatalogStoreResult<String> {
     let data = serde_json::to_vec(snapshot)
         .map_err(|err| TableCatalogStoreError::Internal(format!("failed to encode catalog migration snapshot: {err}")))?;
-    Ok(hex_simd::encode_to_string(Sha256::digest(data), hex_simd::AsciiCase::Lower))
+    Ok(hex_sha256(&data, str::to_owned))
 }
 
 #[derive(Clone)]
@@ -2486,6 +2768,15 @@ where
 
     fn namespace_key(table_bucket: &str, namespace: &Namespace) -> StrongNamespaceKey {
         (table_bucket.to_string(), namespace.public_name())
+    }
+
+    fn has_active_namespace_descendant_locked(state: &StrongTableCatalogState, table_bucket: &str, parent: &str) -> bool {
+        let range_start = (table_bucket.to_string(), format!("{parent}."));
+        state
+            .namespaces
+            .range(range_start..)
+            .take_while(|((bucket, candidate), _)| bucket == table_bucket && namespace_is_descendant(candidate, parent))
+            .any(|(_, entry)| entry.state == TableCatalogEntryState::Active)
     }
 
     fn table_key(table_bucket: &str, namespace: &Namespace, table: &IdentifierSegment) -> StrongResourceKey {
@@ -2634,7 +2925,47 @@ where
 
     fn rebuild_warehouse_index_locked(state: &mut StrongTableCatalogState) -> TableCatalogStoreResult<()> {
         let mut warehouse_index: StrongWarehouseIndex = BTreeMap::new();
+        let mut metadata_roots = BTreeMap::<(String, String), StrongResourceKey>::new();
         for ((table_bucket, namespace, table), entry) in &state.tables {
+            if entry.state != TableCatalogEntryState::Active {
+                continue;
+            }
+            let metadata_root = table_metadata_dir_path_for_entry(entry)?;
+            let warehouse_object_prefix = table_warehouse_object_prefix(entry)?;
+            if !state
+                .table_buckets
+                .get(table_bucket)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "active table {table_bucket}/{namespace}/{table} has no active table bucket"
+                )));
+            }
+            if !state
+                .namespaces
+                .get(&(table_bucket.clone(), namespace.clone()))
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "active table {table_bucket}/{namespace}/{table} has no active namespace"
+                )));
+            }
+            let table_key = (table_bucket.clone(), namespace.clone(), table.clone());
+            if let Some(existing_key) = metadata_roots.insert((table_bucket.clone(), metadata_root.clone()), table_key.clone()) {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "duplicate active table metadata root in strong catalog snapshot: {metadata_root} is owned by {}/{}/{} and {}/{}/{}",
+                    existing_key.0, existing_key.1, existing_key.2, table_key.0, table_key.1, table_key.2
+                )));
+            }
+            let bucket_index = warehouse_index.entry(table_bucket.clone()).or_default();
+            if let Some(existing_key) = bucket_index.insert(warehouse_object_prefix.clone(), table_key.clone()) {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "duplicate active table warehouse location in strong catalog snapshot: {warehouse_object_prefix} is owned by {}/{}/{} and {}/{}/{}",
+                    existing_key.0, existing_key.1, existing_key.2, table_key.0, table_key.1, table_key.2
+                )));
+            }
+        }
+        for ((table_bucket, namespace, view), entry) in &state.views {
             if entry.state != TableCatalogEntryState::Active {
                 continue;
             }
@@ -2643,27 +2974,27 @@ where
                 .get(table_bucket)
                 .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
             {
-                continue;
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "active view {table_bucket}/{namespace}/{view} has no active table bucket"
+                )));
             }
             if !state
                 .namespaces
                 .get(&(table_bucket.clone(), namespace.clone()))
                 .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
             {
-                continue;
-            }
-            let Ok(warehouse_object_prefix) = table_warehouse_object_prefix(entry) else {
-                continue;
-            };
-            let table_key = (table_bucket.clone(), namespace.clone(), table.clone());
-            if let Some(existing_key) = warehouse_index
-                .entry(table_bucket.clone())
-                .or_default()
-                .insert(warehouse_object_prefix.clone(), table_key.clone())
-            {
                 return Err(TableCatalogStoreError::Invalid(format!(
-                    "duplicate active table warehouse location in strong catalog snapshot: {warehouse_object_prefix} is owned by {}/{}/{} and {}/{}/{}",
-                    existing_key.0, existing_key.1, existing_key.2, table_key.0, table_key.1, table_key.2
+                    "active view {table_bucket}/{namespace}/{view} has no active namespace"
+                )));
+            }
+            validate_view_warehouse_location(table_bucket, &entry.warehouse_location)?;
+            let namespace = parse_namespace_for_store(namespace)?;
+            let view = parse_table_for_store(view)?;
+            if !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location) {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "active view {table_bucket}/{}/{} has an invalid metadata location",
+                    namespace.public_name(),
+                    view.as_str()
                 )));
             }
         }
@@ -2695,39 +3026,102 @@ where
             ..StrongTableCatalogState::default()
         };
         for entry in snapshot.table_buckets {
-            state.table_buckets.insert(entry.table_bucket.clone(), entry);
+            let table_bucket = entry.table_bucket.clone();
+            if state.table_buckets.insert(table_bucket.clone(), entry).is_some() {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "strong catalog snapshot contains duplicate table bucket {table_bucket}"
+                )));
+            }
         }
         for entry in snapshot.namespaces {
             let namespace = parse_namespace_for_store(&entry.namespace)?;
-            state
-                .namespaces
-                .insert(Self::namespace_key(&entry.table_bucket, &namespace), entry);
+            let key = Self::namespace_key(&entry.table_bucket, &namespace);
+            if state.namespaces.insert(key, entry).is_some() {
+                return Err(TableCatalogStoreError::Invalid(
+                    "strong catalog snapshot contains duplicate namespace".to_string(),
+                ));
+            }
         }
+        let mut table_ids = BTreeSet::new();
         for entry in snapshot.tables {
             let namespace = parse_namespace_for_store(&entry.namespace)?;
             let table = parse_table_for_store(&entry.table)?;
-            state
-                .tables
-                .insert(Self::table_key(&entry.table_bucket, &namespace, &table), entry);
+            let key = Self::table_key(&entry.table_bucket, &namespace, &table);
+            if !table_ids.insert((entry.table_bucket.clone(), entry.table_id.clone())) {
+                return Err(TableCatalogStoreError::Invalid(
+                    "strong catalog snapshot contains duplicate table ids".to_string(),
+                ));
+            }
+            if state.tables.insert(key, entry).is_some() {
+                return Err(TableCatalogStoreError::Invalid(
+                    "strong catalog snapshot contains duplicate table identifiers".to_string(),
+                ));
+            }
         }
         for entry in snapshot.views {
             let namespace = parse_namespace_for_store(&entry.namespace)?;
             let view = parse_table_for_store(&entry.view)?;
-            state
-                .views
-                .insert(Self::table_key(&entry.table_bucket, &namespace, &view), entry);
+            let key = Self::table_key(&entry.table_bucket, &namespace, &view);
+            if state.views.insert(key, entry).is_some() {
+                return Err(TableCatalogStoreError::Invalid(
+                    "strong catalog snapshot contains duplicate view identifiers".to_string(),
+                ));
+            }
         }
         for record in snapshot.commits {
-            state.commits.insert(
-                Self::commit_key(&record.table_bucket, &record.table_id, &record.lookup_key),
-                record.commit,
-            );
+            if record.commit.table_id != record.table_id || record.commit.commit_id != record.lookup_key {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "strong catalog commit {} does not match its snapshot owner",
+                    record.lookup_key
+                )));
+            }
+            if !table_ids.contains(&(record.table_bucket.clone(), record.table_id.clone())) {
+                continue;
+            }
+            let key = Self::commit_key(&record.table_bucket, &record.table_id, &record.lookup_key);
+            if state.commits.insert(key, record.commit).is_some() {
+                return Err(TableCatalogStoreError::Invalid(
+                    "strong catalog snapshot contains duplicate commit lookup keys".to_string(),
+                ));
+            }
         }
         for record in snapshot.idempotency {
-            state.idempotency.insert(
-                Self::idempotency_key(&record.table_bucket, &record.table_id, &record.lookup_key),
-                record.commit,
-            );
+            if record.commit.table_id != record.table_id
+                || record.commit.idempotency_key.as_deref() != Some(record.lookup_key.as_str())
+            {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "strong catalog idempotency index {} does not match its snapshot owner",
+                    record.lookup_key
+                )));
+            }
+            if !table_ids.contains(&(record.table_bucket.clone(), record.table_id.clone())) {
+                continue;
+            }
+            let commit_key = Self::commit_key(&record.table_bucket, &record.table_id, &record.commit.commit_id);
+            if state.commits.get(&commit_key) != Some(&record.commit) {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "strong catalog idempotency index {} has no matching commit",
+                    record.lookup_key
+                )));
+            }
+            let key = Self::idempotency_key(&record.table_bucket, &record.table_id, &record.lookup_key);
+            if state.idempotency.insert(key, record.commit).is_some() {
+                return Err(TableCatalogStoreError::Invalid(
+                    "strong catalog snapshot contains duplicate idempotency lookup keys".to_string(),
+                ));
+            }
+        }
+        for ((table_bucket, table_id, _), commit) in &state.commits {
+            let Some(idempotency_key) = commit.idempotency_key.as_deref() else {
+                continue;
+            };
+            let index_key = Self::idempotency_key(table_bucket, table_id, idempotency_key);
+            if state.idempotency.get(&index_key) != Some(commit) {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "strong catalog commit {} has no matching idempotency index",
+                    commit.commit_id
+                )));
+            }
         }
         Self::rebuild_warehouse_index_locked(&mut state)?;
         Ok(state)
@@ -2770,22 +3164,33 @@ where
     }
 
     async fn reload_state_from_durable(&self) -> TableCatalogStoreResult<()> {
-        let snapshot_object = self
-            .object_backend
-            .read_object(RUSTFS_META_BUCKET, &Self::snapshot_object_path())
-            .await?;
-        let mut state = self.state.lock().await;
-        if let Some(snapshot_object) = snapshot_object {
-            let snapshot = serde_json::from_slice::<StrongTableCatalogSnapshot>(&snapshot_object.data)
-                .map_err(|err| TableCatalogStoreError::Internal(format!("failed to decode strong catalog snapshot: {err}")))?;
-            *state = Self::state_from_snapshot(snapshot, snapshot_object.etag)?;
-        } else {
-            *state = StrongTableCatalogState {
-                hydrated: true,
-                ..StrongTableCatalogState::default()
+        loop {
+            let observed_state = {
+                let state = self.state.lock().await;
+                (state.hydrated, state.snapshot_etag.clone())
             };
+            let snapshot_object = self
+                .object_backend
+                .read_object(RUSTFS_META_BUCKET, &Self::snapshot_object_path())
+                .await?;
+            let loaded_state = if let Some(snapshot_object) = snapshot_object {
+                let snapshot = serde_json::from_slice::<StrongTableCatalogSnapshot>(&snapshot_object.data).map_err(|err| {
+                    TableCatalogStoreError::Internal(format!("failed to decode strong catalog snapshot: {err}"))
+                })?;
+                Self::state_from_snapshot(snapshot, snapshot_object.etag)?
+            } else {
+                StrongTableCatalogState {
+                    hydrated: true,
+                    ..StrongTableCatalogState::default()
+                }
+            };
+            let mut state = self.state.lock().await;
+            if (state.hydrated, state.snapshot_etag.clone()) != observed_state {
+                continue;
+            }
+            *state = loaded_state;
+            return Ok(());
         }
-        Ok(())
     }
 
     async fn persist_snapshot(
@@ -2806,7 +3211,16 @@ where
         precondition: TableCatalogPutPrecondition,
     ) -> TableCatalogStoreResult<()> {
         match self.persist_snapshot(snapshot, precondition).await {
-            Ok(()) => self.reload_state_from_durable().await,
+            Ok(()) => {
+                if let Err(err) = self.reload_state_from_durable().await {
+                    self.state.lock().await.hydrated = false;
+                    tracing::warn!(
+                        error = %err,
+                        "durable strong catalog snapshot committed but local state reload failed"
+                    );
+                }
+                Ok(())
+            }
             Err(err) => {
                 let _ = self.reload_state_from_durable().await;
                 Err(err)
@@ -2840,6 +3254,7 @@ where
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition)
         };
         self.finalize_snapshot_write(snapshot, precondition).await?;
+        self.hydrate_state().await?;
         let state = self.state.lock().await;
         let snapshot_etag = state
             .snapshot_etag
@@ -2907,9 +3322,34 @@ where
             let Ok(existing_prefix) = table_warehouse_object_prefix(existing) else {
                 continue;
             };
-            if existing_prefix == candidate_prefix {
+            if warehouse_object_prefixes_overlap(&existing_prefix, &candidate_prefix) {
                 return Err(TableCatalogStoreError::Conflict(format!(
-                    "table warehouse location is already registered: {candidate_prefix}"
+                    "table warehouse location overlaps an active table: {candidate_prefix}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_table_metadata_root_available_locked(
+        state: &StrongTableCatalogState,
+        candidate: &TableEntry,
+        candidate_key: &StrongResourceKey,
+    ) -> TableCatalogStoreResult<()> {
+        if candidate.state != TableCatalogEntryState::Active {
+            return Ok(());
+        }
+        let candidate_root = table_metadata_dir_path_for_entry(candidate)?;
+        for (existing_key, existing) in &state.tables {
+            if existing_key == candidate_key
+                || existing.table_bucket != candidate.table_bucket
+                || existing.state != TableCatalogEntryState::Active
+            {
+                continue;
+            }
+            if table_metadata_dir_path_for_entry(existing)? == candidate_root {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "table metadata directory is already registered: {candidate_root}"
                 )));
             }
         }
@@ -2977,8 +3417,6 @@ where
         state: &StrongTableCatalogState,
         key: &StrongResourceKey,
         request: &TableCommitRequest,
-        namespace: &Namespace,
-        table: &IdentifierSegment,
     ) -> TableCatalogStoreResult<TableEntry> {
         let Some(current) = state.tables.get(key).cloned() else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -3000,6 +3438,11 @@ where
                     "commit id already exists: {}",
                     request.commit_id
                 )));
+            }
+            if matches!(existing.status, CommitLogStatus::Committed) && table_matches_staged_base(&current, existing) {
+                return Err(TableCatalogStoreError::Conflict(
+                    "committed record still matches the pre-commit table state".to_string(),
+                ));
             }
             if matches!(existing.status, CommitLogStatus::Committed) || table_matches_committed_log(&current, existing) {
                 return Ok(current);
@@ -3028,7 +3471,7 @@ where
                 "current table metadata location does not match expected location".to_string(),
             ));
         }
-        if !is_valid_table_metadata_location(namespace, table, &request.new_metadata_location) {
+        if !is_valid_table_metadata_location_for_entry(&current, &request.new_metadata_location) {
             return Err(TableCatalogStoreError::Invalid(
                 "new metadata location must be inside the table metadata directory".to_string(),
             ));
@@ -3044,6 +3487,9 @@ where
         let commit_key = Self::commit_key(&request.table_bucket, &current.table_id, &request.commit_id);
         let existing = state.commits.get(&commit_key)?;
         if !commit_log_matches_request(existing, request, &current.table_id) {
+            return None;
+        }
+        if matches!(existing.status, CommitLogStatus::Committed) && table_matches_staged_base(&current, existing) {
             return None;
         }
         if !matches!(existing.status, CommitLogStatus::Committed) && !table_matches_committed_log(&current, existing) {
@@ -3073,7 +3519,7 @@ where
         next_warehouse_location: Option<String>,
     ) -> TableCatalogStoreResult<TableCommitResult> {
         let key = Self::table_key(&request.table_bucket, namespace, table);
-        let current = Self::validate_new_table_commit_locked(state, &key, request, namespace, table)?;
+        let current = Self::validate_new_table_commit_locked(state, &key, request)?;
         if let Some(result) = Self::committed_existing_result_locked(state, request, current.clone()) {
             return Ok(result);
         }
@@ -3098,6 +3544,7 @@ where
         let mut next = current;
         next.metadata_location = commit_log.new_metadata_location.clone();
         if let Some(warehouse_location) = next_warehouse_location {
+            validate_table_warehouse_relocation(&next, &warehouse_location)?;
             next.warehouse_location = warehouse_location;
         }
         Self::ensure_table_warehouse_prefix_available_locked(state, &next, &key)?;
@@ -3213,6 +3660,7 @@ where
         let _write_guard = self.write_lock.lock().await;
         self.hydrate_state().await?;
         validate_catalog_entry_version("namespace", entry.version)?;
+        validate_namespace_properties(&entry.properties)?;
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let key = Self::namespace_key(&entry.table_bucket, &namespace);
         let (snapshot, precondition) = {
@@ -3277,7 +3725,55 @@ where
         self.hydrate_state().await?;
         let namespace = parse_namespace_for_store(namespace)?;
         let state = self.state.lock().await;
-        Ok(state.namespaces.get(&Self::namespace_key(table_bucket, &namespace)).cloned())
+        let exact = state.namespaces.get(&Self::namespace_key(table_bucket, &namespace)).cloned();
+        if exact
+            .as_ref()
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(exact);
+        }
+        let parent = namespace.public_name();
+        if Self::has_active_namespace_descendant_locked(&state, table_bucket, &parent) {
+            return Ok(Some(synthetic_namespace_entry(table_bucket, &namespace)));
+        }
+        Ok(exact)
+    }
+
+    async fn update_namespace_properties(
+        &self,
+        table_bucket: &str,
+        namespace: &str,
+        update: NamespacePropertiesUpdate,
+    ) -> TableCatalogStoreResult<NamespacePropertiesUpdateResult> {
+        let _write_guard = self.write_lock.lock().await;
+        self.hydrate_state().await?;
+        let namespace = parse_namespace_for_store(namespace)?;
+        let key = Self::namespace_key(table_bucket, &namespace);
+        let (snapshot, precondition, result) = {
+            let state = self.state.lock().await;
+            let parent = namespace.public_name();
+            let current = state
+                .namespaces
+                .get(&key)
+                .filter(|entry| entry.state == TableCatalogEntryState::Active)
+                .cloned()
+                .or_else(|| {
+                    Self::has_active_namespace_descendant_locked(&state, table_bucket, &parent)
+                        .then(|| synthetic_namespace_entry(table_bucket, &namespace))
+                })
+                .ok_or_else(|| TableCatalogStoreError::NamespaceNotFound(format!("{table_bucket}/{parent}")))?;
+            let mut next = current.clone();
+            let result = update.apply_to(&mut next);
+            validate_namespace_properties(&next.properties)?;
+            if next == current {
+                return Ok(result);
+            }
+            let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
+            draft_state.namespaces.insert(key, next);
+            (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition, result)
+        };
+        self.finalize_snapshot_write(snapshot, precondition).await?;
+        Ok(result)
     }
 
     async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<()> {
@@ -3287,8 +3783,14 @@ where
         let key = Self::namespace_key(table_bucket, &namespace);
         let (snapshot, precondition) = {
             let state = self.state.lock().await;
+            let parent = namespace.public_name();
+            if Self::has_active_namespace_descendant_locked(&state, table_bucket, &parent) {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "namespace {table_bucket}/{parent} has child namespaces"
+                )));
+            }
             if !state.namespaces.contains_key(&key) {
-                return Err(TableCatalogStoreError::NotFound(format!(
+                return Err(TableCatalogStoreError::NamespaceNotFound(format!(
                     "namespace {}/{}",
                     table_bucket,
                     namespace.public_name()
@@ -3331,23 +3833,33 @@ where
         let (snapshot, precondition) = {
             let state = self.state.lock().await;
             Self::require_table_bucket_in_state(&state, &entry.table_bucket)?;
-            if !state
+            let namespace_key = Self::namespace_key(&entry.table_bucket, &namespace);
+            let namespace_is_explicit = state
                 .namespaces
-                .contains_key(&Self::namespace_key(&entry.table_bucket, &namespace))
+                .get(&namespace_key)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active);
+            if !namespace_is_explicit
+                && !Self::has_active_namespace_descendant_locked(&state, &entry.table_bucket, &namespace.public_name())
             {
-                return Err(TableCatalogStoreError::NotFound(format!(
+                return Err(TableCatalogStoreError::NamespaceNotFound(format!(
                     "namespace {}/{}",
                     entry.table_bucket, entry.namespace
                 )));
             }
-            if state.tables.contains_key(&key) {
+            if state.tables.contains_key(&key) || state.views.contains_key(&key) {
                 return Err(TableCatalogStoreError::Conflict(format!(
                     "catalog object already exists: table {}/{}/{}",
                     entry.table_bucket, entry.namespace, entry.table
                 )));
             }
             Self::ensure_table_warehouse_prefix_available_locked(&state, &entry, &key)?;
+            Self::ensure_table_metadata_root_available_locked(&state, &entry, &key)?;
             let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
+            if !namespace_is_explicit {
+                draft_state
+                    .namespaces
+                    .insert(namespace_key, synthetic_namespace_entry(&entry.table_bucket, &namespace));
+            }
             draft_state.tables.insert(key, entry);
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition)
         };
@@ -3358,10 +3870,21 @@ where
         self.hydrate_state().await?;
         let namespace = parse_namespace_for_store(namespace)?;
         let state = self.state.lock().await;
+        if !state
+            .namespaces
+            .get(&Self::namespace_key(table_bucket, &namespace))
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(Vec::new());
+        }
         let mut entries = state
             .tables
             .iter()
-            .filter(|((bucket, namespace_name, _), _)| bucket == table_bucket && namespace_name == &namespace.public_name())
+            .filter(|((bucket, namespace_name, _), entry)| {
+                bucket == table_bucket
+                    && namespace_name == &namespace.public_name()
+                    && entry.state == TableCatalogEntryState::Active
+            })
             .map(|(_, entry)| entry.clone())
             .collect::<Vec<_>>();
         entries.sort_by(|left, right| left.table.cmp(&right.table));
@@ -3404,7 +3927,98 @@ where
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
         let state = self.state.lock().await;
-        Ok(state.tables.get(&Self::table_key(table_bucket, &namespace, &table)).cloned())
+        if !state
+            .namespaces
+            .get(&Self::namespace_key(table_bucket, &namespace))
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(None);
+        }
+        Ok(state
+            .tables
+            .get(&Self::table_key(table_bucket, &namespace, &table))
+            .filter(|entry| entry.state == TableCatalogEntryState::Active)
+            .cloned())
+    }
+
+    async fn rename_table(
+        &self,
+        table_bucket: &str,
+        source_namespace: &str,
+        source_table: &str,
+        destination_namespace: &str,
+        destination_table: &str,
+    ) -> TableCatalogStoreResult<()> {
+        let _write_guard = self.write_lock.lock().await;
+        self.hydrate_state().await?;
+        let source_namespace = parse_namespace_for_store(source_namespace)?;
+        let source_table = parse_table_for_store(source_table)?;
+        let destination_namespace = parse_namespace_for_store(destination_namespace)?;
+        let destination_table = parse_table_for_store(destination_table)?;
+        let source_key = Self::table_key(table_bucket, &source_namespace, &source_table);
+        let destination_key = Self::table_key(table_bucket, &destination_namespace, &destination_table);
+
+        let (snapshot, precondition) = {
+            let state = self.state.lock().await;
+            let Some(source) = state.tables.get(&source_key).cloned() else {
+                return Err(TableCatalogStoreError::TableNotFound(format!(
+                    "{table_bucket}/{}/{}",
+                    source_namespace.public_name(),
+                    source_table.as_str()
+                )));
+            };
+            if source.state != TableCatalogEntryState::Active
+                || !state
+                    .namespaces
+                    .get(&Self::namespace_key(table_bucket, &source_namespace))
+                    .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            {
+                return Err(TableCatalogStoreError::TableNotFound(format!(
+                    "{table_bucket}/{}/{}",
+                    source_namespace.public_name(),
+                    source_table.as_str()
+                )));
+            }
+            let destination_namespace_is_explicit = state
+                .namespaces
+                .get(&Self::namespace_key(table_bucket, &destination_namespace))
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active);
+            if !destination_namespace_is_explicit
+                && !Self::has_active_namespace_descendant_locked(&state, table_bucket, &destination_namespace.public_name())
+            {
+                return Err(TableCatalogStoreError::NamespaceNotFound(format!(
+                    "{table_bucket}/{}",
+                    destination_namespace.public_name()
+                )));
+            }
+            if state.tables.contains_key(&destination_key) || state.views.contains_key(&destination_key) {
+                return Err(TableCatalogStoreError::AlreadyExists(format!(
+                    "destination table already exists: {table_bucket}/{}/{}",
+                    destination_namespace.public_name(),
+                    destination_table.as_str()
+                )));
+            }
+            if !is_valid_table_metadata_location_for_entry(&source, &source.metadata_location) {
+                return Err(TableCatalogStoreError::Invalid(
+                    "current metadata location must be inside the table metadata directory".to_string(),
+                ));
+            }
+
+            let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
+            draft_state.tables.remove(&source_key);
+            if !destination_namespace_is_explicit {
+                draft_state.namespaces.insert(
+                    Self::namespace_key(table_bucket, &destination_namespace),
+                    synthetic_namespace_entry(table_bucket, &destination_namespace),
+                );
+            }
+            let mut destination = source;
+            destination.namespace = destination_namespace.public_name();
+            destination.table = destination_table.as_str().to_string();
+            draft_state.tables.insert(destination_key, destination);
+            (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition)
+        };
+        self.finalize_snapshot_write(snapshot, precondition).await
     }
 
     async fn resolve_table_data_plane_resource(
@@ -3454,7 +4068,7 @@ where
 
         let committed_existing_result = {
             let state = self.state.lock().await;
-            let current = Self::validate_new_table_commit_locked(&state, &key, &request, &namespace, &table);
+            let current = Self::validate_new_table_commit_locked(&state, &key, &request);
             match current {
                 Ok(current) => {
                     let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
@@ -3494,9 +4108,13 @@ where
             );
         }
 
+        let _metadata_guard = self
+            .object_backend
+            .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
+            .await?;
         let Some(new_metadata_object) = self
             .object_backend
-            .read_object(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
             .await?
         else {
             return table_commit_result(
@@ -3512,6 +4130,7 @@ where
                 ))),
             );
         };
+        validate_commit_metadata_digest(&request, &new_metadata_object)?;
         let next_warehouse_location =
             table_metadata_warehouse_location(&request.table_bucket, &request.new_metadata_location, &new_metadata_object)?;
 
@@ -3552,7 +4171,7 @@ where
         let (snapshot, precondition) = {
             let state = self.state.lock().await;
             if !state.tables.contains_key(&key) {
-                return Err(TableCatalogStoreError::NotFound(format!(
+                return Err(TableCatalogStoreError::TableNotFound(format!(
                     "table {}/{}/{}",
                     table_bucket,
                     namespace.public_name(),
@@ -3560,7 +4179,15 @@ where
                 )));
             }
             let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
-            draft_state.tables.remove(&key);
+            let removed = draft_state.tables.remove(&key).ok_or_else(|| {
+                TableCatalogStoreError::Internal("table disappeared while preparing the strong catalog snapshot".to_string())
+            })?;
+            draft_state
+                .commits
+                .retain(|(entry_bucket, table_id, _), _| entry_bucket != table_bucket || table_id != &removed.table_id);
+            draft_state
+                .idempotency
+                .retain(|(entry_bucket, table_id, _), _| entry_bucket != table_bucket || table_id != &removed.table_id);
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition)
         };
         self.finalize_snapshot_write(snapshot, precondition).await
@@ -3573,26 +4200,40 @@ where
         validate_view_warehouse_location(&entry.table_bucket, &entry.warehouse_location)?;
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let view = parse_table_for_store(&entry.view)?;
+        if !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location) {
+            return Err(TableCatalogStoreError::Invalid(
+                "view metadata location must match the view identifier".to_string(),
+            ));
+        }
         let key = Self::table_key(&entry.table_bucket, &namespace, &view);
         let (snapshot, precondition) = {
             let state = self.state.lock().await;
             Self::require_table_bucket_in_state(&state, &entry.table_bucket)?;
-            if !state
+            let namespace_key = Self::namespace_key(&entry.table_bucket, &namespace);
+            let namespace_is_explicit = state
                 .namespaces
-                .contains_key(&Self::namespace_key(&entry.table_bucket, &namespace))
+                .get(&namespace_key)
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active);
+            if !namespace_is_explicit
+                && !Self::has_active_namespace_descendant_locked(&state, &entry.table_bucket, &namespace.public_name())
             {
-                return Err(TableCatalogStoreError::NotFound(format!(
+                return Err(TableCatalogStoreError::NamespaceNotFound(format!(
                     "namespace {}/{}",
                     entry.table_bucket, entry.namespace
                 )));
             }
-            if state.views.contains_key(&key) {
+            if state.views.contains_key(&key) || state.tables.contains_key(&key) {
                 return Err(TableCatalogStoreError::Conflict(format!(
                     "catalog object already exists: view {}/{}/{}",
                     entry.table_bucket, entry.namespace, entry.view
                 )));
             }
             let (precondition, mut draft_state) = Self::snapshot_draft_context_locked(&state);
+            if !namespace_is_explicit {
+                draft_state
+                    .namespaces
+                    .insert(namespace_key, synthetic_namespace_entry(&entry.table_bucket, &namespace));
+            }
             draft_state.views.insert(key, entry);
             (Self::snapshot_from_mutated_state_locked(&mut draft_state)?, precondition)
         };
@@ -3603,10 +4244,21 @@ where
         self.hydrate_state().await?;
         let namespace = parse_namespace_for_store(namespace)?;
         let state = self.state.lock().await;
+        if !state
+            .namespaces
+            .get(&Self::namespace_key(table_bucket, &namespace))
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(Vec::new());
+        }
         let mut entries = state
             .views
             .iter()
-            .filter(|((bucket, namespace_name, _), _)| bucket == table_bucket && namespace_name == &namespace.public_name())
+            .filter(|((bucket, namespace_name, _), entry)| {
+                bucket == table_bucket
+                    && namespace_name == &namespace.public_name()
+                    && entry.state == TableCatalogEntryState::Active
+            })
             .map(|(_, entry)| entry.clone())
             .collect::<Vec<_>>();
         entries.sort_by(|left, right| left.view.cmp(&right.view));
@@ -3649,7 +4301,18 @@ where
         let namespace = parse_namespace_for_store(namespace)?;
         let view = parse_table_for_store(view)?;
         let state = self.state.lock().await;
-        Ok(state.views.get(&Self::table_key(table_bucket, &namespace, &view)).cloned())
+        if !state
+            .namespaces
+            .get(&Self::namespace_key(table_bucket, &namespace))
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(None);
+        }
+        Ok(state
+            .views
+            .get(&Self::table_key(table_bucket, &namespace, &view))
+            .filter(|entry| entry.state == TableCatalogEntryState::Active)
+            .cloned())
     }
 
     async fn replace_view(&self, request: ViewCommitRequest) -> TableCatalogStoreResult<ViewCommitResult> {
@@ -3662,9 +4325,13 @@ where
                 "new metadata location must be inside the view metadata directory".to_string(),
             ));
         }
+        let _metadata_guard = self
+            .object_backend
+            .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
+            .await?;
         let Some(new_metadata_object) = self
             .object_backend
-            .read_object(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
             .await?
         else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -3672,14 +4339,24 @@ where
                 request.new_metadata_location
             )));
         };
+        validate_view_metadata_digest(request.new_metadata_sha256.as_deref(), &new_metadata_object)?;
         let next_warehouse_location =
             view_metadata_warehouse_location(&request.table_bucket, &request.new_metadata_location, &new_metadata_object)?;
 
         let key = Self::table_key(&request.table_bucket, &namespace, &view);
         let (snapshot, precondition, next) = {
             let state = self.state.lock().await;
-            let Some(current) = state.views.get(&key).cloned() else {
-                return Err(TableCatalogStoreError::NotFound(format!(
+            let namespace_is_active = state
+                .namespaces
+                .get(&Self::namespace_key(&request.table_bucket, &namespace))
+                .is_some_and(|entry| entry.state == TableCatalogEntryState::Active);
+            let Some(current) = state
+                .views
+                .get(&key)
+                .filter(|entry| namespace_is_active && entry.state == TableCatalogEntryState::Active)
+                .cloned()
+            else {
+                return Err(TableCatalogStoreError::ViewNotFound(format!(
                     "view {}/{}/{}",
                     request.table_bucket, request.namespace, request.view
                 )));
@@ -3719,7 +4396,7 @@ where
         let (snapshot, precondition) = {
             let state = self.state.lock().await;
             if !state.views.contains_key(&key) {
-                return Err(TableCatalogStoreError::NotFound(format!(
+                return Err(TableCatalogStoreError::ViewNotFound(format!(
                     "view {}/{}/{}",
                     table_bucket,
                     namespace.public_name(),
@@ -4634,6 +5311,60 @@ where
         Ok(None)
     }
 
+    async fn ensure_table_maintenance_object_owner(&self, entry: &TableEntry, object: &str) -> TableCatalogStoreResult<()> {
+        let warehouse_object_prefix = table_warehouse_object_prefix(entry)?;
+        if !object.starts_with(&warehouse_object_prefix) {
+            return Ok(());
+        }
+        for candidate_prefix in warehouse_index_candidate_prefixes(object) {
+            let index_object = self.paths.warehouse_index_entry_path(&entry.table_bucket, candidate_prefix);
+            let Some((index, _)) = self
+                .read_entry::<TableWarehouseIndexEntry>(self.catalog_bucket(), &index_object)
+                .await?
+            else {
+                continue;
+            };
+            if index.table_bucket != entry.table_bucket || index.warehouse_object_prefix != candidate_prefix {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "warehouse index entry does not match indexed prefix: {index_object}"
+                )));
+            }
+            if index.state != TableCatalogEntryState::Active {
+                continue;
+            }
+            if index.table_id != entry.table_id {
+                return Err(TableCatalogStoreError::Conflict(format!(
+                    "maintenance object {object} is owned by another active table"
+                )));
+            }
+            return Ok(());
+        }
+        Err(TableCatalogStoreError::Internal(format!(
+            "maintenance object {object} has no active warehouse index owner"
+        )))
+    }
+
+    async fn ensure_table_warehouse_index_owner(&self, entry: &TableEntry) -> TableCatalogStoreResult<()> {
+        let expected = table_warehouse_index_entry(entry)?;
+        let object = self
+            .paths
+            .warehouse_index_entry_path(&entry.table_bucket, &expected.warehouse_object_prefix);
+        let Some((current, _)) = self
+            .read_entry::<TableWarehouseIndexEntry>(self.catalog_bucket(), &object)
+            .await?
+        else {
+            return Err(TableCatalogStoreError::Internal(format!(
+                "active table has no warehouse index owner: {object}"
+            )));
+        };
+        if current != expected {
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "active table warehouse index owner changed: {object}"
+            )));
+        }
+        Ok(())
+    }
+
     async fn backfill_active_table_warehouse_index(
         &self,
         table_bucket: &str,
@@ -4654,6 +5385,15 @@ where
     }
 
     async fn backfill_table_warehouse_index(&self, table_bucket: &str) -> TableCatalogStoreResult<()> {
+        let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(table_bucket);
+        let _ownership_guard = self
+            .backend
+            .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
+            .await?;
+        self.backfill_table_warehouse_index_ownership_locked(table_bucket).await
+    }
+
+    async fn backfill_table_warehouse_index_ownership_locked(&self, table_bucket: &str) -> TableCatalogStoreResult<()> {
         let state_object = self.paths.warehouse_index_state_path(table_bucket);
         let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &state_object).await?;
         if self.read_warehouse_index_state_unlocked(table_bucket).await? {
@@ -4667,23 +5407,8 @@ where
                 if table.state != TableCatalogEntryState::Active {
                     continue;
                 }
-                if let Err(err) = self
-                    .backfill_active_table_warehouse_index(&table.table_bucket, &table.namespace, &table.table)
-                    .await
-                {
-                    if matches!(&err, TableCatalogStoreError::Invalid(_)) {
-                        tracing::warn!(
-                            table_bucket = %table.table_bucket,
-                            namespace = %table.namespace,
-                            table = %table.table,
-                            table_id = %table.table_id,
-                            error = %err,
-                            "skipping invalid table warehouse location while backfilling warehouse index"
-                        );
-                        continue;
-                    }
-                    return Err(err);
-                }
+                self.backfill_active_table_warehouse_index(&table.table_bucket, &table.namespace, &table.table)
+                    .await?;
             }
         }
         self.write_warehouse_index_state_unlocked(table_bucket).await
@@ -4760,28 +5485,65 @@ where
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let table = parse_table_for_store(&entry.table)?;
         validate_table_warehouse_location(&entry.table_bucket, &entry.warehouse_location)?;
+        if !is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
+            return Err(TableCatalogStoreError::Invalid(
+                "object-backed table metadata location must be inside a protected table metadata directory".to_string(),
+            ));
+        }
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
+        let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&entry.table_bucket);
+        let _ownership_guard = self
+            .backend
+            .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
+            .await?;
+        self.backfill_table_warehouse_index_ownership_locked(&entry.table_bucket)
+            .await?;
         let namespace_path = self.paths.namespace_entry_path(&entry.table_bucket, &namespace);
         let _namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
-        if self
+        let namespace_is_active = self
             .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), &namespace_path)
             .await?
-            .is_none()
-        {
-            return Err(TableCatalogStoreError::NotFound(format!(
+            .is_some_and(|(entry, _)| entry.state == TableCatalogEntryState::Active);
+        let materialize_namespace =
+            !namespace_is_active && self.has_active_namespace_descendant(&entry.table_bucket, &namespace).await?;
+        if !namespace_is_active && !materialize_namespace {
+            return Err(TableCatalogStoreError::NamespaceNotFound(format!(
                 "namespace {}/{}",
                 entry.table_bucket, entry.namespace
             )));
         }
+        let view_path = self.paths.view_entry_path(&entry.table_bucket, &namespace, &table);
+        if self
+            .read_entry_unlocked::<ViewEntry>(self.catalog_bucket(), &view_path)
+            .await?
+            .is_some()
+        {
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "catalog object already exists: view {}/{}/{}",
+                entry.table_bucket, entry.namespace, entry.table
+            )));
+        }
         let table_path = self.paths.table_entry_path(&entry.table_bucket, &namespace, &table);
         let _table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
+        self.ensure_table_warehouse_prefix_available(&entry).await?;
         let reservation = self.reserve_table_warehouse_index(&entry).await?;
-        let result = self
-            .write_entry_unlocked(self.catalog_bucket(), &table_path, &entry, precondition)
-            .await;
+        let result = async {
+            if materialize_namespace {
+                self.write_entry_unlocked(
+                    self.catalog_bucket(),
+                    &namespace_path,
+                    &synthetic_namespace_entry(&entry.table_bucket, &namespace),
+                    TableCatalogPutPrecondition::Any,
+                )
+                .await?;
+            }
+            self.write_entry_unlocked(self.catalog_bucket(), &table_path, &entry, precondition)
+                .await
+        }
+        .await;
         if result.is_err() {
             self.delete_created_table_warehouse_index(&entry, reservation, "table entry write failed")
                 .await;
@@ -4795,24 +5557,51 @@ where
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let view = parse_table_for_store(&entry.view)?;
         validate_view_warehouse_location(&entry.table_bucket, &entry.warehouse_location)?;
+        if !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location) {
+            return Err(TableCatalogStoreError::Invalid(
+                "object-backed view metadata location must match the view identifier".to_string(),
+            ));
+        }
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
         let namespace_path = self.paths.namespace_entry_path(&entry.table_bucket, &namespace);
         let _namespace_guard = self
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
-        if self
+        let namespace_is_active = self
             .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), &namespace_path)
             .await?
-            .is_none()
-        {
-            return Err(TableCatalogStoreError::NotFound(format!(
+            .is_some_and(|(entry, _)| entry.state == TableCatalogEntryState::Active);
+        let materialize_namespace =
+            !namespace_is_active && self.has_active_namespace_descendant(&entry.table_bucket, &namespace).await?;
+        if !namespace_is_active && !materialize_namespace {
+            return Err(TableCatalogStoreError::NamespaceNotFound(format!(
                 "namespace {}/{}",
                 entry.table_bucket, entry.namespace
             )));
         }
+        let table_path = self.paths.table_entry_path(&entry.table_bucket, &namespace, &view);
+        if self
+            .read_entry_unlocked::<TableEntry>(self.catalog_bucket(), &table_path)
+            .await?
+            .is_some()
+        {
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "catalog object already exists: table {}/{}/{}",
+                entry.table_bucket, entry.namespace, entry.view
+            )));
+        }
         let view_path = self.paths.view_entry_path(&entry.table_bucket, &namespace, &view);
         let _view_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &view_path).await?;
+        if materialize_namespace {
+            self.write_entry_unlocked(
+                self.catalog_bucket(),
+                &namespace_path,
+                &synthetic_namespace_entry(&entry.table_bucket, &namespace),
+                TableCatalogPutPrecondition::Any,
+            )
+            .await?;
+        }
         self.write_entry_unlocked(self.catalog_bucket(), &view_path, &entry, precondition)
             .await
     }
@@ -6251,11 +7040,12 @@ where
                 table.as_str()
             )));
         };
-        if !is_valid_table_metadata_location(&namespace, &table, &entry.metadata_location) {
+        if !is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
             return Err(TableCatalogStoreError::Invalid(
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
         }
+        self.backfill_table_warehouse_index(table_bucket).await?;
 
         let Some(current_metadata_object) = self.backend.read_object(table_bucket, &entry.metadata_location).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -6303,11 +7093,12 @@ where
                 table.as_str()
             )));
         };
-        if !is_valid_table_metadata_location(&namespace, &table, &entry.metadata_location) {
+        if !is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
             return Err(TableCatalogStoreError::Invalid(
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
         }
+        self.backfill_table_warehouse_index(table_bucket).await?;
 
         let Some(current_metadata_object) = self.backend.read_object(table_bucket, &entry.metadata_location).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -6347,7 +7138,7 @@ where
                 table.as_str()
             )));
         };
-        if !is_valid_table_metadata_location(&namespace, &table, &entry.metadata_location) {
+        if !is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
             return Err(TableCatalogStoreError::Invalid(
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
@@ -6394,7 +7185,7 @@ where
         let now = OffsetDateTime::now_utc();
         let snapshot_id = compaction_snapshot_id(&current_metadata, &entry, now);
         let sequence_number = next_compaction_sequence_number(&current_metadata);
-        let metadata_dir = default_table_metadata_dir_path(&namespace, &table);
+        let metadata_dir = table_metadata_dir_path_for_entry(&entry)?;
         let warehouse_object_prefix = table_warehouse_object_prefix(&entry)?;
         let compaction_id = Uuid::new_v4().to_string();
         let mut compacted_files = Vec::with_capacity(report.rewrite_groups.len());
@@ -6440,8 +7231,7 @@ where
 
         let new_manifest = format!("{metadata_dir}/manifest-compaction-{compaction_id}.avro");
         let new_manifest_list = format!("{metadata_dir}/snap-{snapshot_id}-compaction-{compaction_id}.avro");
-        let new_metadata =
-            default_table_metadata_file_path(&namespace, &table, &format!("compaction-{compaction_id}.metadata.json"));
+        let new_metadata = table_metadata_file_path_for_entry(&entry, &format!("compaction-{compaction_id}.metadata.json"))?;
         let manifest_data = compacted_manifest_avro_bytes(&manifest_data_files)?;
         let manifest_length = u64::try_from(manifest_data.len()).unwrap_or(u64::MAX);
         self.backend
@@ -6944,32 +7734,32 @@ where
 
         let mut retained = BTreeSet::new();
         let mut current_metadata_for_refs = None;
-        let current_metadata_status =
-            if is_valid_table_metadata_location(&parsed_namespace, &parsed_table, &current_metadata_location) {
-                retained.insert(current_metadata_location.clone());
-                match self.backend.read_object(table_bucket, &current_metadata_location).await? {
-                    Some(current_metadata_object) => {
-                        match serde_json::from_slice::<serde_json::Value>(&current_metadata_object.data) {
-                            Ok(current_metadata) if current_metadata.is_object() => {
-                                retained.extend(metadata_log_locations(&current_metadata, &parsed_namespace, &parsed_table));
-                                current_metadata_for_refs = Some(current_metadata);
-                                TableMetadataPointerStatus::Valid
-                            }
-                            Ok(_) | Err(_) => TableMetadataPointerStatus::InvalidJson,
+        let current_metadata_status = if is_valid_table_metadata_location_for_entry(&catalog.table, &current_metadata_location) {
+            retained.insert(current_metadata_location.clone());
+            match self.backend.read_object(table_bucket, &current_metadata_location).await? {
+                Some(current_metadata_object) => {
+                    match serde_json::from_slice::<serde_json::Value>(&current_metadata_object.data) {
+                        Ok(current_metadata) if current_metadata.is_object() => {
+                            retained.extend(metadata_log_locations(&current_metadata, &catalog.table));
+                            current_metadata_for_refs = Some(current_metadata);
+                            TableMetadataPointerStatus::Valid
                         }
+                        Ok(_) | Err(_) => TableMetadataPointerStatus::InvalidJson,
                     }
-                    None => TableMetadataPointerStatus::MissingObject,
                 }
-            } else {
-                TableMetadataPointerStatus::InvalidLocation
-            };
+                None => TableMetadataPointerStatus::MissingObject,
+            }
+        } else {
+            TableMetadataPointerStatus::InvalidLocation
+        };
 
         let mut metadata_locations = Vec::new();
-        let metadata_prefix = format!("{}/", default_table_metadata_dir_path(&parsed_namespace, &parsed_table));
-        for object in self.backend.list_objects(table_bucket, &metadata_prefix).await? {
-            if let Some(metadata_location) = metadata_location_from_metadata_file_path(&parsed_namespace, &parsed_table, &object)
-            {
-                metadata_locations.push(metadata_location);
+        if let Ok(metadata_dir) = table_metadata_dir_path_for_entry(&catalog.table) {
+            let metadata_prefix = format!("{metadata_dir}/");
+            for object in self.backend.list_objects(table_bucket, &metadata_prefix).await? {
+                if is_valid_table_metadata_location_for_entry(&catalog.table, &object) {
+                    metadata_locations.push(object);
+                }
             }
         }
         metadata_locations.sort();
@@ -6983,8 +7773,7 @@ where
                 metadata_locations_for_protected_snapshot_refs(
                     &self.backend,
                     table_bucket,
-                    &parsed_namespace,
-                    &parsed_table,
+                    &catalog.table,
                     current_metadata,
                     &metadata_locations,
                 )
@@ -7031,7 +7820,7 @@ where
                 table.as_str()
             )));
         };
-        if !is_valid_table_metadata_location(&namespace, &table, &entry.metadata_location) {
+        if !is_valid_table_metadata_location_for_entry(&entry, &entry.metadata_location) {
             return Err(TableCatalogStoreError::Invalid(
                 "current metadata location must be inside the table metadata directory".to_string(),
             ));
@@ -7052,10 +7841,11 @@ where
                 entry.metadata_location
             )));
         }
+        validate_table_metadata_identity_for_maintenance(&entry, &current_metadata)?;
 
         let mut retained = BTreeSet::new();
         let mut maintenance_reasons = BTreeMap::<String, BTreeSet<TableMetadataMaintenanceReason>>::new();
-        for metadata_location in metadata_log_locations(&current_metadata, &namespace, &table) {
+        for metadata_location in metadata_log_locations(&current_metadata, &entry) {
             retained.insert(metadata_location.clone());
             insert_metadata_maintenance_reason(
                 &mut maintenance_reasons,
@@ -7071,10 +7861,10 @@ where
         );
 
         let mut metadata_locations = Vec::new();
-        let metadata_prefix = format!("{}/", default_table_metadata_dir_path(&namespace, &table));
+        let metadata_prefix = format!("{}/", table_metadata_dir_path_for_entry(&entry)?);
         for object in self.backend.list_objects(table_bucket, &metadata_prefix).await? {
-            if let Some(metadata_location) = metadata_location_from_metadata_file_path(&namespace, &table, &object) {
-                metadata_locations.push(metadata_location);
+            if is_valid_table_metadata_location_for_entry(&entry, &object) {
+                metadata_locations.push(object);
             }
         }
         metadata_locations.sort();
@@ -7094,8 +7884,7 @@ where
         for metadata_location in metadata_locations_for_protected_snapshot_refs(
             &self.backend,
             table_bucket,
-            &namespace,
-            &table,
+            &entry,
             &current_metadata,
             &metadata_locations,
         )
@@ -7146,8 +7935,7 @@ where
                 );
             }
         }
-        let warehouse_object_prefix = table_warehouse_object_prefix(&entry).ok();
-        let current_metadata_location = entry.metadata_location;
+        let current_metadata_location = entry.metadata_location.clone();
         let retained_metadata_locations = retained.into_iter().collect::<Vec<_>>();
         let object_reports = metadata_maintenance_object_reports(maintenance_reasons);
         let referenced_object_reports = metadata_maintenance_referenced_object_reports(
@@ -7155,7 +7943,7 @@ where
             table_bucket,
             &namespace,
             &table,
-            warehouse_object_prefix.as_deref(),
+            &entry,
             &current_metadata,
             &retained_metadata_locations,
         )
@@ -7168,11 +7956,14 @@ where
                 table_bucket,
                 &namespace,
                 &table,
-                warehouse_object_prefix.as_deref(),
+                &entry,
                 &referenced_object_reports,
                 now,
             )
             .await?;
+        for object_location in &cleanup_object_candidate_locations {
+            self.ensure_table_maintenance_object_owner(&entry, object_location).await?;
+        }
 
         let mut report = table_maintenance_report_with_recommended_actions(TableMetadataMaintenanceReport {
             job: TableMetadataMaintenanceJob {
@@ -7445,15 +8236,8 @@ where
     ) -> TableCatalogStoreResult<TableMetadataMaintenanceReport> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        if !is_valid_table_metadata_location(&namespace, &table, &report.current_metadata_location) {
-            return Err(TableCatalogStoreError::Invalid(
-                "maintenance report current metadata location must be inside the table metadata directory".to_string(),
-            ));
-        }
-
-        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
-        let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
-        let Some((entry, _)) = self.read_table_with_etag_unlocked(table_bucket, &namespace, &table).await? else {
+        self.backfill_table_warehouse_index(table_bucket).await?;
+        let Some((entry, _)) = self.read_table_with_etag(table_bucket, &namespace, &table).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
@@ -7461,18 +8245,33 @@ where
                 table.as_str()
             )));
         };
+        if entry.state != TableCatalogEntryState::Active {
+            return Err(TableCatalogStoreError::NotFound(format!(
+                "table {}/{}/{}",
+                table_bucket,
+                namespace.public_name(),
+                table.as_str()
+            )));
+        }
         if entry.metadata_location != report.current_metadata_location {
             return Err(TableCatalogStoreError::Conflict(
                 "current metadata location changed before maintenance delete".to_string(),
             ));
         }
-        let warehouse_object_prefix = table_warehouse_object_prefix(&entry).ok();
-
+        if !is_valid_table_metadata_location_for_entry(&entry, &report.current_metadata_location) {
+            return Err(TableCatalogStoreError::Invalid(
+                "maintenance report current metadata location must be inside the table metadata directory".to_string(),
+            ));
+        }
         let Some(current_metadata_object) = self.backend.read_object(table_bucket, &entry.metadata_location).await? else {
             return Err(TableCatalogStoreError::NotFound(format!(
                 "current metadata object {}",
                 entry.metadata_location
             )));
+        };
+        let current_metadata_identity = TableCatalogObjectMetadata {
+            etag: current_metadata_object.etag.clone(),
+            mod_time: current_metadata_object.mod_time,
         };
         let current_metadata = serde_json::from_slice::<serde_json::Value>(&current_metadata_object.data).map_err(|err| {
             TableCatalogStoreError::Invalid(format!("failed to parse current metadata {}: {err}", entry.metadata_location))
@@ -7483,16 +8282,16 @@ where
                 entry.metadata_location
             )));
         }
+        validate_table_metadata_identity_for_maintenance(&entry, &current_metadata)?;
 
-        let mut protected = metadata_log_locations(&current_metadata, &namespace, &table);
+        let mut protected = metadata_log_locations(&current_metadata, &entry);
         protected.insert(entry.metadata_location.clone());
         protected.extend(report.retained_metadata_locations.iter().cloned());
         protected.extend(
             metadata_locations_for_protected_snapshot_refs(
                 &self.backend,
                 table_bucket,
-                &namespace,
-                &table,
+                &entry,
                 &current_metadata,
                 &report.cleanup_candidate_locations,
             )
@@ -7501,10 +8300,10 @@ where
 
         let cleanup_candidate_count = report.cleanup_candidate_locations.len();
         let planned_deletable_locations = report.deletable_metadata_locations.iter().cloned().collect::<BTreeSet<_>>();
-        let mut cleanup_candidate_locations = BTreeSet::new();
+        let mut cleanup_candidate_locations = BTreeMap::new();
         let now = OffsetDateTime::now_utc();
         for metadata_location in &report.cleanup_candidate_locations {
-            if !is_valid_table_metadata_location(&namespace, &table, metadata_location) {
+            if !is_valid_table_metadata_location_for_entry(&entry, metadata_location) {
                 return Err(TableCatalogStoreError::Invalid(format!(
                     "cleanup candidate {metadata_location} must be inside the table metadata directory"
                 )));
@@ -7514,6 +8313,7 @@ where
                     "cleanup candidate {metadata_location} is retained by current metadata"
                 )));
             }
+            self.ensure_table_maintenance_object_owner(&entry, metadata_location).await?;
             let Some(candidate_object) = self.backend.read_object(table_bucket, metadata_location).await? else {
                 continue;
             };
@@ -7523,13 +8323,13 @@ where
             if !metadata_candidate_is_past_safety_window(candidate_object.mod_time, now) {
                 continue;
             }
-            cleanup_candidate_locations.insert(metadata_location.clone());
-        }
-
-        let cleanup_candidate_locations = cleanup_candidate_locations.into_iter().collect::<Vec<_>>();
-        let deleted_locations = cleanup_candidate_locations.iter().cloned().collect::<BTreeSet<_>>();
-        for metadata_location in &cleanup_candidate_locations {
-            self.backend.delete_object(table_bucket, metadata_location).await?;
+            cleanup_candidate_locations.insert(
+                metadata_location.clone(),
+                TableCatalogObjectMetadata {
+                    etag: candidate_object.etag,
+                    mod_time: candidate_object.mod_time,
+                },
+            );
         }
 
         let referenced_object_reports = metadata_maintenance_referenced_object_reports(
@@ -7537,7 +8337,7 @@ where
             table_bucket,
             &namespace,
             &table,
-            warehouse_object_prefix.as_deref(),
+            &entry,
             &current_metadata,
             &report.retained_metadata_locations,
         )
@@ -7554,19 +8354,18 @@ where
                 .collect::<BTreeSet<_>>()
         };
         let planned_deletable_object_locations = report.deletable_object_locations.iter().cloned().collect::<BTreeSet<_>>();
-        let mut cleanup_object_candidate_locations = BTreeSet::new();
+        let mut cleanup_object_candidate_locations = BTreeMap::new();
         if !referenced_object_reports
             .iter()
             .any(|report| report.state == TableMetadataMaintenanceObjectState::ManualReviewRequired)
         {
             for object_location in &report.cleanup_object_candidate_locations {
-                if table_maintenance_object_kind(&namespace, &table, warehouse_object_prefix.as_deref(), object_location)
-                    .is_none()
-                {
+                if table_maintenance_object_kind_for_entry(&namespace, &table, &entry, object_location).is_none() {
                     return Err(TableCatalogStoreError::Invalid(format!(
                         "cleanup object candidate {object_location} must be inside table metadata, data, or delete directories"
                     )));
                 }
+                self.ensure_table_maintenance_object_owner(&entry, object_location).await?;
                 if referenced_object_locations.contains(object_location.as_str()) {
                     return Err(TableCatalogStoreError::Conflict(format!(
                         "cleanup object candidate {object_location} is retained by current metadata"
@@ -7581,16 +8380,91 @@ where
                 if !metadata_candidate_is_past_safety_window(candidate_object.mod_time, now) {
                     continue;
                 }
-                cleanup_object_candidate_locations.insert(object_location.clone());
+                cleanup_object_candidate_locations.insert(
+                    object_location.clone(),
+                    TableCatalogObjectMetadata {
+                        etag: candidate_object.etag,
+                        mod_time: candidate_object.mod_time,
+                    },
+                );
             }
         }
 
-        let cleanup_object_candidate_locations = cleanup_object_candidate_locations.into_iter().collect::<Vec<_>>();
-        let deleted_object_locations = cleanup_object_candidate_locations.iter().cloned().collect::<BTreeSet<_>>();
-        for object_location in &cleanup_object_candidate_locations {
-            self.backend.delete_object(table_bucket, object_location).await?;
+        let table_path = self.paths.table_entry_path(table_bucket, &namespace, &table);
+        let table_guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
+        let Some((current_entry, _)) = self.read_table_with_etag_unlocked(table_bucket, &namespace, &table).await? else {
+            return Err(TableCatalogStoreError::NotFound(format!(
+                "table {}/{}/{}",
+                table_bucket,
+                namespace.public_name(),
+                table.as_str()
+            )));
+        };
+        if current_entry.state != TableCatalogEntryState::Active
+            || current_entry.table_id != entry.table_id
+            || current_entry.metadata_location != entry.metadata_location
+            || current_entry.warehouse_location != entry.warehouse_location
+        {
+            return Err(TableCatalogStoreError::Conflict(
+                "table identity or current metadata location changed before maintenance delete".to_string(),
+            ));
+        }
+        self.ensure_table_warehouse_index_owner(&current_entry).await?;
+        let current_metadata_guard = self
+            .backend
+            .acquire_write_lock(table_bucket, &current_entry.metadata_location)
+            .await?;
+        let Some(locked_current_metadata) = self
+            .backend
+            .read_object_unlocked(table_bucket, &current_entry.metadata_location)
+            .await?
+        else {
+            return Err(TableCatalogStoreError::NotFound(format!(
+                "current metadata object {}",
+                current_entry.metadata_location
+            )));
+        };
+        if locked_current_metadata.etag != current_metadata_identity.etag
+            || locked_current_metadata.mod_time != current_metadata_identity.mod_time
+        {
+            return Err(TableCatalogStoreError::Conflict(
+                "current metadata object changed before maintenance delete".to_string(),
+            ));
         }
 
+        let mut deleted_metadata_locations = Vec::new();
+        for (metadata_location, expected) in cleanup_candidate_locations {
+            let candidate_guard = self.backend.acquire_write_lock(table_bucket, &metadata_location).await?;
+            let candidate = self.backend.read_object_unlocked(table_bucket, &metadata_location).await?;
+            if candidate.as_ref().is_some_and(|candidate| {
+                candidate.etag == expected.etag
+                    && candidate.mod_time == expected.mod_time
+                    && metadata_candidate_is_past_safety_window(candidate.mod_time, OffsetDateTime::now_utc())
+            }) {
+                self.backend.delete_object_unlocked(table_bucket, &metadata_location).await?;
+                deleted_metadata_locations.push(metadata_location);
+            }
+            drop(candidate_guard);
+        }
+        let mut deleted_object_locations = Vec::new();
+        for (object_location, expected) in cleanup_object_candidate_locations {
+            let candidate_guard = self.backend.acquire_write_lock(table_bucket, &object_location).await?;
+            let candidate = self.backend.read_object_unlocked(table_bucket, &object_location).await?;
+            if candidate.as_ref().is_some_and(|candidate| {
+                candidate.etag == expected.etag
+                    && candidate.mod_time == expected.mod_time
+                    && metadata_candidate_is_past_safety_window(candidate.mod_time, OffsetDateTime::now_utc())
+            }) {
+                self.backend.delete_object_unlocked(table_bucket, &object_location).await?;
+                deleted_object_locations.push(object_location);
+            }
+            drop(candidate_guard);
+        }
+        drop(current_metadata_guard);
+        drop(table_guard);
+
+        let deleted_locations = deleted_metadata_locations.iter().cloned().collect::<BTreeSet<_>>();
+        let deleted_object_location_set = deleted_object_locations.iter().cloned().collect::<BTreeSet<_>>();
         let retained_metadata_locations = protected.into_iter().collect::<Vec<_>>();
         let mut job = report.job;
         job.operation = TableMetadataMaintenanceOperation::Delete;
@@ -7599,23 +8473,23 @@ where
         job.retained_metadata_file_count = retained_metadata_locations.len();
         job.cleanup_candidate_count = cleanup_candidate_count;
         job.deletable_metadata_file_count = planned_deletable_locations.len();
-        job.deleted_metadata_file_count = cleanup_candidate_locations.len();
+        job.deleted_metadata_file_count = deleted_metadata_locations.len();
         job.cleanup_candidate_object_count = report.cleanup_object_candidate_locations.len();
         job.deletable_object_count = planned_deletable_object_locations.len();
-        job.deleted_object_count = cleanup_object_candidate_locations.len();
+        job.deleted_object_count = deleted_object_locations.len();
         let mut object_reports = report.object_reports;
         mark_deleted_metadata_object_reports(&mut object_reports, &deleted_locations);
         let mut object_cleanup_reports = report.object_cleanup_reports;
-        mark_deleted_object_cleanup_reports(&mut object_cleanup_reports, &deleted_object_locations);
+        mark_deleted_object_cleanup_reports(&mut object_cleanup_reports, &deleted_object_location_set);
 
         Ok(table_maintenance_report_with_recommended_actions(TableMetadataMaintenanceReport {
             job,
-            current_metadata_location: entry.metadata_location,
+            current_metadata_location: current_entry.metadata_location,
             retained_metadata_locations,
-            cleanup_candidate_locations: cleanup_candidate_locations.clone(),
-            deletable_metadata_locations: cleanup_candidate_locations,
-            cleanup_object_candidate_locations: cleanup_object_candidate_locations.clone(),
-            deletable_object_locations: cleanup_object_candidate_locations,
+            cleanup_candidate_locations: deleted_metadata_locations.clone(),
+            deletable_metadata_locations: deleted_metadata_locations,
+            cleanup_object_candidate_locations: deleted_object_locations.clone(),
+            deletable_object_locations: deleted_object_locations,
             object_reports,
             object_cleanup_reports,
             referenced_object_reports,
@@ -7656,6 +8530,7 @@ where
 
     async fn create_namespace(&self, entry: NamespaceEntry) -> TableCatalogStoreResult<()> {
         validate_catalog_entry_version("namespace", entry.version)?;
+        validate_namespace_properties(&entry.properties)?;
         self.require_table_bucket(&entry.table_bucket).await?;
         let namespace = parse_namespace_for_store(&entry.namespace)?;
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(&entry.table_bucket).await?;
@@ -7696,9 +8571,20 @@ where
 
     async fn get_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<Option<NamespaceEntry>> {
         let namespace = parse_namespace_for_store(namespace)?;
-        self.read_entry::<NamespaceEntry>(self.catalog_bucket(), &self.paths.namespace_entry_path(table_bucket, &namespace))
-            .await
-            .map(|entry| entry.map(|(namespace, _)| namespace))
+        let exact = self
+            .read_entry::<NamespaceEntry>(self.catalog_bucket(), &self.paths.namespace_entry_path(table_bucket, &namespace))
+            .await?
+            .map(|(entry, _)| entry);
+        if exact
+            .as_ref()
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(exact);
+        }
+        if self.has_active_namespace_descendant(table_bucket, &namespace).await? {
+            return Ok(Some(synthetic_namespace_entry(table_bucket, &namespace)));
+        }
+        Ok(exact)
     }
 
     async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<()> {
@@ -7712,6 +8598,12 @@ where
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
+        let parent = namespace.public_name();
+        if self.has_active_namespace_descendant(table_bucket, &namespace).await? {
+            return Err(TableCatalogStoreError::Conflict(format!(
+                "namespace {table_bucket}/{parent} has child namespaces"
+            )));
+        }
         if self
             .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), &namespace_path)
             .await?
@@ -7761,7 +8653,9 @@ where
             if !object.ends_with(TABLE_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &object).await? {
+            if let Some((entry, _)) = self.read_entry::<TableEntry>(self.catalog_bucket(), &object).await?
+                && entry.state == TableCatalogEntryState::Active
+            {
                 entries.push(entry);
             }
         }
@@ -7789,9 +8683,26 @@ where
     async fn load_table(&self, table_bucket: &str, namespace: &str, table: &str) -> TableCatalogStoreResult<Option<TableEntry>> {
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
-        self.read_entry::<TableEntry>(self.catalog_bucket(), &self.paths.table_entry_path(table_bucket, &namespace, &table))
-            .await
-            .map(|entry| entry.map(|(table, _)| table))
+        if !self
+            .get_namespace(table_bucket, &namespace.public_name())
+            .await?
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(None);
+        }
+        let entry = self
+            .read_entry::<TableEntry>(self.catalog_bucket(), &self.paths.table_entry_path(table_bucket, &namespace, &table))
+            .await?
+            .map(|(table, _)| table)
+            .filter(|entry| entry.state == TableCatalogEntryState::Active);
+        if let Some(entry) = entry.as_ref()
+            && !is_valid_table_metadata_location_for_entry(entry, &entry.metadata_location)
+        {
+            return Err(TableCatalogStoreError::Invalid(
+                "object-backed table metadata location must be inside a protected table metadata directory".to_string(),
+            ));
+        }
+        Ok(entry)
     }
 
     async fn resolve_table_data_plane_resource(
@@ -7832,6 +8743,13 @@ where
         let namespace = parse_namespace_for_store(&request.namespace)?;
         let table = parse_table_for_store(&request.table)?;
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(&request.table_bucket).await?;
+        let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(&request.table_bucket);
+        let _ownership_guard = self
+            .backend
+            .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
+            .await?;
+        self.backfill_table_warehouse_index_ownership_locked(&request.table_bucket)
+            .await?;
         let table_path = self.paths.table_entry_path(&request.table_bucket, &namespace, &table);
         let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &table_path).await?;
 
@@ -7879,6 +8797,19 @@ where
                         "commit id already exists: {}",
                         request.commit_id
                     ))),
+                );
+            }
+            if matches!(existing.status, CommitLogStatus::Committed) && table_matches_staged_base(&current, existing) {
+                return table_commit_result(
+                    &request.table_bucket,
+                    &request.namespace,
+                    &request.table,
+                    &request.commit_id,
+                    &request.operation,
+                    commit_started,
+                    Err(TableCatalogStoreError::Conflict(
+                        "committed record still matches the pre-commit table state".to_string(),
+                    )),
                 );
             }
             if matches!(existing.status, CommitLogStatus::Committed) || table_matches_committed_log(&current, existing) {
@@ -7967,7 +8898,7 @@ where
                 )),
             );
         }
-        if !is_valid_table_metadata_location(&namespace, &table, &request.new_metadata_location) {
+        if !is_valid_table_metadata_location_for_entry(&current, &request.new_metadata_location) {
             return table_commit_result(
                 &request.table_bucket,
                 &request.namespace,
@@ -7980,9 +8911,13 @@ where
                 )),
             );
         }
+        let _metadata_guard = self
+            .backend
+            .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
+            .await?;
         let Some(new_metadata_object) = self
             .backend
-            .read_object(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
             .await?
         else {
             return table_commit_result(
@@ -7998,6 +8933,7 @@ where
                 ))),
             );
         };
+        validate_commit_metadata_digest(&request, &new_metadata_object)?;
         let next_warehouse_location =
             table_metadata_warehouse_location(&request.table_bucket, &request.new_metadata_location, &new_metadata_object)?;
 
@@ -8020,6 +8956,19 @@ where
         });
         staged_commit_log.status = CommitLogStatus::Staged;
 
+        if let Some(warehouse_location) = next_warehouse_location.as_deref()
+            && let Err(err) = validate_table_warehouse_relocation(&current, warehouse_location)
+        {
+            return table_commit_result(
+                &request.table_bucket,
+                &request.namespace,
+                &request.table,
+                &request.commit_id,
+                &request.operation,
+                commit_started,
+                Err(err),
+            );
+        }
         let mut next = current.clone();
         next.metadata_location = staged_commit_log.new_metadata_location.clone();
         if let Some(warehouse_location) = next_warehouse_location {
@@ -8027,6 +8976,9 @@ where
         }
         next.version_token = staged_commit_log.new_version_token.clone();
         next.generation = current.generation.saturating_add(1);
+        if next.warehouse_location != current.warehouse_location {
+            self.ensure_table_warehouse_prefix_available(&next).await?;
+        }
         let reservation = self.reserve_table_warehouse_index(&next).await?;
 
         let staged_write_result = async {
@@ -8115,6 +9067,11 @@ where
         let namespace = parse_namespace_for_store(namespace)?;
         let table = parse_table_for_store(table)?;
         let _migration_guard = self.acquire_object_backed_catalog_write_permit(table_bucket).await?;
+        let ownership_lock_path = self.paths.warehouse_index_ownership_lock_path(table_bucket);
+        let _ownership_guard = self
+            .backend
+            .acquire_write_lock(self.catalog_bucket(), &ownership_lock_path)
+            .await?;
         let namespace_path = self.paths.namespace_entry_path(table_bucket, &namespace);
         let _namespace_guard = self
             .backend
@@ -8123,7 +9080,7 @@ where
         let object = self.paths.table_entry_path(table_bucket, &namespace, &table);
         let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &object).await?;
         let Some((entry, _)) = self.read_table_with_etag_unlocked(table_bucket, &namespace, &table).await? else {
-            return Err(TableCatalogStoreError::NotFound(format!(
+            return Err(TableCatalogStoreError::TableNotFound(format!(
                 "table {}/{}/{}",
                 table_bucket,
                 namespace.public_name(),
@@ -8173,7 +9130,9 @@ where
             if !object.ends_with(VIEW_ENTRY_FILE) {
                 continue;
             }
-            if let Some((entry, _)) = self.read_entry::<ViewEntry>(self.catalog_bucket(), &object).await? {
+            if let Some((entry, _)) = self.read_entry::<ViewEntry>(self.catalog_bucket(), &object).await?
+                && entry.state == TableCatalogEntryState::Active
+            {
                 entries.push(entry);
             }
         }
@@ -8196,9 +9155,26 @@ where
     async fn load_view(&self, table_bucket: &str, namespace: &str, view: &str) -> TableCatalogStoreResult<Option<ViewEntry>> {
         let namespace = parse_namespace_for_store(namespace)?;
         let view = parse_table_for_store(view)?;
-        self.read_entry::<ViewEntry>(self.catalog_bucket(), &self.paths.view_entry_path(table_bucket, &namespace, &view))
-            .await
-            .map(|entry| entry.map(|(view, _)| view))
+        if !self
+            .get_namespace(table_bucket, &namespace.public_name())
+            .await?
+            .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+        {
+            return Ok(None);
+        }
+        let entry = self
+            .read_entry::<ViewEntry>(self.catalog_bucket(), &self.paths.view_entry_path(table_bucket, &namespace, &view))
+            .await?
+            .map(|(view, _)| view)
+            .filter(|entry| entry.state == TableCatalogEntryState::Active);
+        if let Some(entry) = entry.as_ref()
+            && !is_valid_view_metadata_location(&namespace, &view, &entry.metadata_location)
+        {
+            return Err(TableCatalogStoreError::Invalid(
+                "object-backed view metadata location must match the view identifier".to_string(),
+            ));
+        }
+        Ok(entry)
     }
 
     async fn replace_view(&self, request: ViewCommitRequest) -> TableCatalogStoreResult<ViewCommitResult> {
@@ -8210,17 +9186,27 @@ where
             .backend
             .acquire_write_lock(self.catalog_bucket(), &namespace_path)
             .await?;
+        let namespace_is_active = self
+            .read_entry_unlocked::<NamespaceEntry>(self.catalog_bucket(), &namespace_path)
+            .await?
+            .is_some_and(|(entry, _)| entry.state == TableCatalogEntryState::Active);
         let view_path = self.paths.view_entry_path(&request.table_bucket, &namespace, &view);
         let _guard = self.backend.acquire_write_lock(self.catalog_bucket(), &view_path).await?;
         let Some((current, current_etag)) = self
             .read_view_with_etag_unlocked(&request.table_bucket, &namespace, &view)
             .await?
+            .filter(|(entry, _)| namespace_is_active && entry.state == TableCatalogEntryState::Active)
         else {
-            return Err(TableCatalogStoreError::NotFound(format!(
+            return Err(TableCatalogStoreError::ViewNotFound(format!(
                 "view {}/{}/{}",
                 request.table_bucket, request.namespace, request.view
             )));
         };
+        if !is_valid_view_metadata_location(&namespace, &view, &current.metadata_location) {
+            return Err(TableCatalogStoreError::Invalid(
+                "object-backed view metadata location must match the view identifier".to_string(),
+            ));
+        }
         if current.version_token != request.expected_version_token {
             return Err(TableCatalogStoreError::Conflict(
                 "current view version token does not match expected token".to_string(),
@@ -8236,9 +9222,13 @@ where
                 "new metadata location must be inside the view metadata directory".to_string(),
             ));
         }
+        let _metadata_guard = self
+            .backend
+            .acquire_read_lock(&request.table_bucket, &request.new_metadata_location)
+            .await?;
         let Some(new_metadata_object) = self
             .backend
-            .read_object(&request.table_bucket, &request.new_metadata_location)
+            .read_object_unlocked(&request.table_bucket, &request.new_metadata_location)
             .await?
         else {
             return Err(TableCatalogStoreError::NotFound(format!(
@@ -8246,6 +9236,7 @@ where
                 request.new_metadata_location
             )));
         };
+        validate_view_metadata_digest(request.new_metadata_sha256.as_deref(), &new_metadata_object)?;
         let next_warehouse_location =
             view_metadata_warehouse_location(&request.table_bucket, &request.new_metadata_location, &new_metadata_object)?;
 
@@ -8282,7 +9273,7 @@ where
             .await?
             .is_none()
         {
-            return Err(TableCatalogStoreError::NotFound(format!(
+            return Err(TableCatalogStoreError::ViewNotFound(format!(
                 "view {}/{}/{}",
                 table_bucket,
                 namespace.public_name(),
@@ -8367,6 +9358,20 @@ where
         }
     }
 
+    async fn update_namespace_properties(
+        &self,
+        table_bucket: &str,
+        namespace: &str,
+        update: NamespacePropertiesUpdate,
+    ) -> TableCatalogStoreResult<NamespacePropertiesUpdateResult> {
+        match self {
+            Self::ObjectBacked(_) => Err(TableCatalogStoreError::Unsupported(
+                "namespace property updates require durable-strong catalog backing".to_string(),
+            )),
+            Self::DurableStrong(store) => store.update_namespace_properties(table_bucket, namespace, update).await,
+        }
+    }
+
     async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<()> {
         match self {
             Self::ObjectBacked(store) => store.drop_namespace(table_bucket, namespace).await,
@@ -8412,6 +9417,26 @@ where
         match self {
             Self::ObjectBacked(store) => store.load_table(table_bucket, namespace, table).await,
             Self::DurableStrong(store) => store.load_table(table_bucket, namespace, table).await,
+        }
+    }
+
+    async fn rename_table(
+        &self,
+        table_bucket: &str,
+        source_namespace: &str,
+        source_table: &str,
+        destination_namespace: &str,
+        destination_table: &str,
+    ) -> TableCatalogStoreResult<()> {
+        match self {
+            Self::ObjectBacked(_) => Err(TableCatalogStoreError::Unsupported(
+                "table rename requires durable-strong catalog backing".to_string(),
+            )),
+            Self::DurableStrong(store) => {
+                store
+                    .rename_table(table_bucket, source_namespace, source_table, destination_namespace, destination_table)
+                    .await
+            }
         }
     }
 
@@ -8751,7 +9776,18 @@ where
     S: TableCatalogStorage,
 {
     async fn read_object(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
-        self.read_object_with_options(bucket, object, ObjectOptions::default()).await
+        self.read_object_with_options(bucket, object, ObjectOptions::default(), None)
+            .await
+    }
+
+    async fn read_object_limited(
+        &self,
+        bucket: &str,
+        object: &str,
+        max_size: usize,
+    ) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
+        self.read_object_with_options(bucket, object, ObjectOptions::default(), Some(max_size))
+            .await
     }
 
     async fn read_object_unlocked(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
@@ -8762,6 +9798,7 @@ where
                 no_lock: true,
                 ..Default::default()
             },
+            None,
         )
         .await
     }
@@ -8922,12 +9959,21 @@ where
         bucket: &str,
         object: &str,
         opts: ObjectOptions,
+        max_size: Option<usize>,
     ) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
         let info = match self.store.get_object_info(bucket, object, &opts).await {
             Ok(info) => info,
             Err(err) if is_missing_storage_error(&err) => return Ok(None),
             Err(err) => return Err(storage_error_to_catalog("read catalog object info", err)),
         };
+        if let Some(max_size) = max_size {
+            let max_size_i64 = i64::try_from(max_size).unwrap_or(i64::MAX);
+            if info.size > max_size_i64 {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "catalog object {bucket}/{object} exceeds the maximum size of {max_size} bytes"
+                )));
+            }
+        }
         let mut reader = match self
             .store
             .get_object_reader(bucket, object, None, HeaderMap::new(), &opts)
@@ -8938,11 +9984,21 @@ where
             Err(err) => return Err(storage_error_to_catalog("read catalog object", err)),
         };
         let mut data = Vec::new();
-        reader
-            .stream
-            .read_to_end(&mut data)
-            .await
-            .map_err(|err| TableCatalogStoreError::Internal(format!("failed to read catalog object {bucket}/{object}: {err}")))?;
+        if let Some(max_size) = max_size {
+            let read_limit = u64::try_from(max_size.saturating_add(1)).unwrap_or(u64::MAX);
+            reader.stream.take(read_limit).read_to_end(&mut data).await.map_err(|err| {
+                TableCatalogStoreError::Internal(format!("failed to read catalog object {bucket}/{object}: {err}"))
+            })?;
+            if data.len() > max_size {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "catalog object {bucket}/{object} exceeds the maximum size of {max_size} bytes"
+                )));
+            }
+        } else {
+            reader.stream.read_to_end(&mut data).await.map_err(|err| {
+                TableCatalogStoreError::Internal(format!("failed to read catalog object {bucket}/{object}: {err}"))
+            })?;
+        }
         Ok(Some(TableCatalogObject {
             data,
             etag: info.etag,
@@ -9043,7 +10099,7 @@ async fn metadata_maintenance_referenced_object_reports<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
     current_metadata: &serde_json::Value,
     retained_metadata_locations: &[String],
 ) -> TableCatalogStoreResult<Vec<TableMetadataMaintenanceReferencedObjectReport>>
@@ -9056,7 +10112,7 @@ where
         table_bucket,
         namespace,
         table,
-        warehouse_object_prefix,
+        entry,
         current_metadata,
         &mut reports,
     )
@@ -9098,7 +10154,7 @@ where
             table_bucket,
             namespace,
             table,
-            warehouse_object_prefix,
+            entry,
             &metadata,
             &mut reports,
         )
@@ -9121,16 +10177,41 @@ async fn metadata_maintenance_referenced_object_reports_for_metadata<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
     metadata: &serde_json::Value,
     reports: &mut BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
 ) -> TableCatalogStoreResult<()>
 where
     B: TableCatalogObjectBackend,
 {
-    let Some(snapshots) = metadata.get("snapshots").and_then(serde_json::Value::as_array) else {
-        return Ok(());
+    let current_snapshot_id = metadata.get("current-snapshot-id").and_then(serde_json::Value::as_i64);
+    let snapshots = match metadata.get("snapshots") {
+        Some(serde_json::Value::Array(snapshots)) => snapshots,
+        None if current_snapshot_id.is_none() => return Ok(()),
+        _ => {
+            insert_referenced_object_report(
+                reports,
+                "snapshots".to_string(),
+                TableMetadataMaintenanceObjectKind::MetadataFile,
+                TableMetadataMaintenanceObjectState::ManualReviewRequired,
+                TableMetadataMaintenanceReason::UnreadableMetadata,
+            );
+            return Ok(());
+        }
     };
+    if current_snapshot_id.is_some_and(|current_snapshot_id| {
+        !snapshots
+            .iter()
+            .any(|snapshot| snapshot.get("snapshot-id").and_then(serde_json::Value::as_i64) == Some(current_snapshot_id))
+    }) {
+        insert_referenced_object_report(
+            reports,
+            "current-snapshot-id".to_string(),
+            TableMetadataMaintenanceObjectKind::MetadataFile,
+            TableMetadataMaintenanceObjectState::ManualReviewRequired,
+            TableMetadataMaintenanceReason::UnreadableMetadata,
+        );
+    }
 
     for snapshot in snapshots {
         if let Some(manifest_list_location) = snapshot.get("manifest-list").and_then(serde_json::Value::as_str) {
@@ -9139,7 +10220,7 @@ where
                 table_bucket,
                 namespace,
                 table,
-                warehouse_object_prefix,
+                entry,
                 manifest_list_location,
                 reports,
             )
@@ -9148,6 +10229,17 @@ where
         }
 
         let Some(manifests) = snapshot.get("manifests").and_then(serde_json::Value::as_array) else {
+            let snapshot_id = snapshot
+                .get("snapshot-id")
+                .and_then(serde_json::Value::as_i64)
+                .map_or_else(|| "snapshots[]".to_string(), |snapshot_id| format!("snapshots[{snapshot_id}]"));
+            insert_referenced_object_report(
+                reports,
+                snapshot_id,
+                TableMetadataMaintenanceObjectKind::MetadataFile,
+                TableMetadataMaintenanceObjectState::ManualReviewRequired,
+                TableMetadataMaintenanceReason::UnreadableMetadata,
+            );
             continue;
         };
         for manifest in manifests {
@@ -9166,7 +10258,7 @@ where
                 table_bucket,
                 namespace,
                 table,
-                warehouse_object_prefix,
+                entry,
                 manifest_location,
                 reports,
             )
@@ -9182,14 +10274,20 @@ async fn metadata_maintenance_referenced_manifest_list<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
     manifest_list_location: &str,
     reports: &mut BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
 ) -> TableCatalogStoreResult<()>
 where
     B: TableCatalogObjectBackend,
 {
-    let Some(manifest_list_key) = table_catalog_object_key_from_location(table_bucket, manifest_list_location) else {
+    let Some(manifest_list_key) = table_reference_object_key(
+        namespace,
+        table,
+        entry,
+        manifest_list_location,
+        TableMetadataMaintenanceObjectKind::ManifestList,
+    ) else {
         insert_referenced_object_report(
             reports,
             manifest_list_location.to_string(),
@@ -9199,18 +10297,6 @@ where
         );
         return Ok(());
     };
-    if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &manifest_list_key)
-        != Some(TableMetadataMaintenanceObjectKind::ManifestList)
-    {
-        insert_referenced_object_report(
-            reports,
-            manifest_list_key,
-            TableMetadataMaintenanceObjectKind::ManifestList,
-            TableMetadataMaintenanceObjectState::ManualReviewRequired,
-            TableMetadataMaintenanceReason::UnsupportedManifestAvro,
-        );
-        return Ok(());
-    }
     insert_referenced_object_report(
         reports,
         manifest_list_key.clone(),
@@ -9219,7 +10305,10 @@ where
         TableMetadataMaintenanceReason::ManifestList,
     );
 
-    let Some(manifest_list_object) = backend.read_object(table_bucket, &manifest_list_key).await? else {
+    let Some(manifest_list_object) = backend
+        .read_object_limited(table_bucket, &manifest_list_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+        .await?
+    else {
         mark_referenced_object_manual_review(
             reports,
             &manifest_list_key,
@@ -9241,7 +10330,7 @@ where
             table_bucket,
             namespace,
             table,
-            warehouse_object_prefix,
+            entry,
             &manifest_location,
             reports,
         )
@@ -9256,14 +10345,20 @@ async fn metadata_maintenance_referenced_manifest_file<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
     manifest_location: &str,
     reports: &mut BTreeMap<String, TableMetadataMaintenanceReferencedObjectAccumulator>,
 ) -> TableCatalogStoreResult<()>
 where
     B: TableCatalogObjectBackend,
 {
-    let Some(manifest_key) = table_catalog_object_key_from_location(table_bucket, manifest_location) else {
+    let Some(manifest_key) = table_reference_object_key(
+        namespace,
+        table,
+        entry,
+        manifest_location,
+        TableMetadataMaintenanceObjectKind::ManifestFile,
+    ) else {
         insert_referenced_object_report(
             reports,
             manifest_location.to_string(),
@@ -9273,18 +10368,6 @@ where
         );
         return Ok(());
     };
-    if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &manifest_key)
-        != Some(TableMetadataMaintenanceObjectKind::ManifestFile)
-    {
-        insert_referenced_object_report(
-            reports,
-            manifest_key,
-            TableMetadataMaintenanceObjectKind::ManifestFile,
-            TableMetadataMaintenanceObjectState::ManualReviewRequired,
-            TableMetadataMaintenanceReason::UnsupportedManifestAvro,
-        );
-        return Ok(());
-    }
     insert_referenced_object_report(
         reports,
         manifest_key.clone(),
@@ -9293,7 +10376,10 @@ where
         TableMetadataMaintenanceReason::ManifestFile,
     );
 
-    let Some(manifest_object) = backend.read_object(table_bucket, &manifest_key).await? else {
+    let Some(manifest_object) = backend
+        .read_object_limited(table_bucket, &manifest_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+        .await?
+    else {
         mark_referenced_object_manual_review(reports, &manifest_key, TableMetadataMaintenanceReason::UnsupportedManifestAvro);
         return Ok(());
     };
@@ -9302,7 +10388,7 @@ where
         return Ok(());
     };
     for (file_location, object_kind) in file_references {
-        let Some(file_key) = table_catalog_object_key_from_location(table_bucket, &file_location) else {
+        let Some(file_key) = table_reference_object_key(namespace, table, entry, &file_location, object_kind.clone()) else {
             insert_referenced_object_report(
                 reports,
                 file_location,
@@ -9312,16 +10398,6 @@ where
             );
             continue;
         };
-        if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &file_key) != Some(object_kind.clone()) {
-            insert_referenced_object_report(
-                reports,
-                file_key,
-                object_kind,
-                TableMetadataMaintenanceObjectState::ManualReviewRequired,
-                TableMetadataMaintenanceReason::UnsupportedManifestAvro,
-            );
-            continue;
-        }
         insert_referenced_object_report(
             reports,
             file_key,
@@ -9355,10 +10431,20 @@ fn manifest_paths_from_manifest_list_avro(data: &[u8]) -> TableCatalogStoreResul
 pub(crate) fn manifest_list_references_from_manifest_list_avro(
     data: &[u8],
 ) -> TableCatalogStoreResult<Vec<ManifestListReference>> {
+    if data.len() > TABLE_MANIFEST_AVRO_MAX_SIZE {
+        return Err(TableCatalogStoreError::Invalid(format!(
+            "manifest list exceeds the maximum size of {TABLE_MANIFEST_AVRO_MAX_SIZE} bytes"
+        )));
+    }
     let reader = apache_avro::Reader::new(data)
         .map_err(|err| TableCatalogStoreError::Invalid(format!("failed to read manifest list Avro: {err}")))?;
     let mut manifest_paths = Vec::new();
     for value in reader {
+        if manifest_paths.len() >= TABLE_MANIFEST_AVRO_MAX_RECORDS {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "manifest list exceeds the maximum record count of {TABLE_MANIFEST_AVRO_MAX_RECORDS}"
+            )));
+        }
         let value =
             value.map_err(|err| TableCatalogStoreError::Invalid(format!("failed to read manifest list record: {err}")))?;
         let manifest_path = avro_record_field(&value, "manifest_path")
@@ -9382,24 +10468,40 @@ fn file_references_from_manifest_avro(data: &[u8]) -> TableCatalogStoreResult<Ve
 }
 
 pub(crate) fn data_file_references_from_manifest_avro(data: &[u8]) -> TableCatalogStoreResult<Vec<ManifestDataFileReference>> {
+    if data.len() > TABLE_MANIFEST_AVRO_MAX_SIZE {
+        return Err(TableCatalogStoreError::Invalid(format!(
+            "manifest exceeds the maximum size of {TABLE_MANIFEST_AVRO_MAX_SIZE} bytes"
+        )));
+    }
     let reader = apache_avro::Reader::new(data)
         .map_err(|err| TableCatalogStoreError::Invalid(format!("failed to read manifest Avro: {err}")))?;
     let mut files = Vec::new();
     for value in reader {
+        if files.len() >= TABLE_MANIFEST_AVRO_MAX_RECORDS {
+            return Err(TableCatalogStoreError::Invalid(format!(
+                "manifest exceeds the maximum record count of {TABLE_MANIFEST_AVRO_MAX_RECORDS}"
+            )));
+        }
         let value = value.map_err(|err| TableCatalogStoreError::Invalid(format!("failed to read manifest record: {err}")))?;
         let data_file = avro_record_field(&value, "data_file")
             .ok_or_else(|| TableCatalogStoreError::Invalid("manifest entry missing data_file".to_string()))?;
         let file_path = avro_record_field(data_file, "file_path")
             .and_then(avro_string_value)
             .ok_or_else(|| TableCatalogStoreError::Invalid("manifest data file missing file_path".to_string()))?;
-        let content = avro_record_field(data_file, "content")
-            .and_then(avro_i32_value)
-            .ok_or_else(|| TableCatalogStoreError::Invalid("manifest data file missing content".to_string()))?;
+        let content = match avro_record_field(data_file, "content") {
+            Some(content) => avro_i32_value(content)
+                .ok_or_else(|| TableCatalogStoreError::Invalid("manifest data file content must be an int".to_string()))?,
+            None => 0,
+        };
         let (content, object_kind) = match content {
             0 => (ManifestDataFileContent::Data, TableMetadataMaintenanceObjectKind::DataFile),
             1 => (ManifestDataFileContent::PositionDelete, TableMetadataMaintenanceObjectKind::DeleteFile),
             2 => (ManifestDataFileContent::EqualityDelete, TableMetadataMaintenanceObjectKind::DeleteFile),
-            _ => continue,
+            _ => {
+                return Err(TableCatalogStoreError::Invalid(format!(
+                    "manifest data file has unsupported content value {content}"
+                )));
+            }
         };
         files.push(ManifestDataFileReference {
             location: file_path.to_string(),
@@ -9498,64 +10600,93 @@ pub(crate) fn table_catalog_object_key_from_location(table_bucket: &str, locatio
     Some(object.to_string())
 }
 
+pub(crate) fn table_reference_object_key(
+    namespace: &Namespace,
+    table: &IdentifierSegment,
+    entry: &TableEntry,
+    location: &str,
+    expected_kind: TableMetadataMaintenanceObjectKind,
+) -> Option<String> {
+    let object_key = table_catalog_object_key_from_location(&entry.table_bucket, location)?;
+    let matches_expected_kind = |candidate: &str| {
+        if expected_kind == TableMetadataMaintenanceObjectKind::MetadataFile {
+            is_valid_table_metadata_location_for_entry(entry, candidate)
+        } else {
+            table_maintenance_object_kind_for_entry(namespace, table, entry, candidate).as_ref() == Some(&expected_kind)
+        }
+    };
+    if matches_expected_kind(&object_key) {
+        return Some(object_key);
+    }
+    if location.starts_with("s3://") {
+        return None;
+    }
+    let warehouse_prefix = table_warehouse_object_prefix(entry).ok()?;
+    let resolved = format!("{warehouse_prefix}{object_key}");
+    matches_expected_kind(&resolved).then_some(resolved)
+}
+
 pub(crate) fn table_maintenance_object_kind(
     namespace: &Namespace,
     table: &IdentifierSegment,
     warehouse_object_prefix: Option<&str>,
     object_location: &str,
 ) -> Option<TableMetadataMaintenanceObjectKind> {
-    let metadata_prefix = format!("{}/", default_table_metadata_dir_path(namespace, table));
-    if let Some(kind) = table_maintenance_metadata_object_kind(&metadata_prefix, object_location) {
+    let table_root_prefix = format!("{}{}/", default_table_root_prefix(namespace), table.as_str());
+    if let Some(kind) = table_maintenance_object_kind_in_root(&table_root_prefix, object_location) {
+        return Some(kind);
+    }
+    warehouse_object_prefix.and_then(|prefix| table_maintenance_object_kind_in_root(prefix, object_location))
+}
+
+fn table_maintenance_object_kind_in_root(
+    table_root_prefix: &str,
+    object_location: &str,
+) -> Option<TableMetadataMaintenanceObjectKind> {
+    let relative = object_location.strip_prefix(table_root_prefix)?;
+    if let Some(file_name) = relative.strip_prefix("metadata/")
+        && let Some(kind) = table_maintenance_metadata_file_kind(file_name)
+    {
         return Some(kind);
     }
 
-    let data_prefix = format!("{}/", default_table_data_dir_path(namespace, table));
-    if object_location
-        .strip_prefix(&data_prefix)
+    if relative
+        .strip_prefix("data/")
         .is_some_and(is_valid_table_maintenance_nested_object)
     {
         return Some(TableMetadataMaintenanceObjectKind::DataFile);
     }
 
-    let delete_prefix = format!("{}/", default_table_delete_dir_path(namespace, table));
-    if object_location
-        .strip_prefix(&delete_prefix)
+    if relative
+        .strip_prefix("delete/")
         .is_some_and(is_valid_table_maintenance_nested_object)
     {
         return Some(TableMetadataMaintenanceObjectKind::DeleteFile);
     }
 
-    if let Some(warehouse_object_prefix) = warehouse_object_prefix {
-        let metadata_prefix = format!("{warehouse_object_prefix}{METADATA_DIR}/");
-        if let Some(kind) = table_maintenance_metadata_object_kind(&metadata_prefix, object_location) {
-            return Some(kind);
-        }
-
-        let data_prefix = format!("{warehouse_object_prefix}{DATA_DIR}/");
-        if object_location
-            .strip_prefix(&data_prefix)
-            .is_some_and(is_valid_table_maintenance_nested_object)
-        {
-            return Some(TableMetadataMaintenanceObjectKind::DataFile);
-        }
-
-        let delete_prefix = format!("{warehouse_object_prefix}{DELETE_DIR}/");
-        if object_location
-            .strip_prefix(&delete_prefix)
-            .is_some_and(is_valid_table_maintenance_nested_object)
-        {
-            return Some(TableMetadataMaintenanceObjectKind::DeleteFile);
-        }
-    }
-
     None
 }
 
-fn table_maintenance_metadata_object_kind(
-    metadata_prefix: &str,
+pub(crate) fn table_maintenance_object_kind_for_entry(
+    namespace: &Namespace,
+    table: &IdentifierSegment,
+    entry: &TableEntry,
     object_location: &str,
 ) -> Option<TableMetadataMaintenanceObjectKind> {
-    let file_name = object_location.strip_prefix(metadata_prefix)?;
+    if let Some(table_root_prefix) = table_object_root_prefix_for_entry(entry).as_deref()
+        && let Some(kind) = table_maintenance_object_kind_in_root(table_root_prefix, object_location)
+    {
+        return Some(kind);
+    }
+    if let Some(kind) = table_maintenance_object_kind(namespace, table, None, object_location) {
+        return Some(kind);
+    }
+    table_warehouse_object_prefix(entry)
+        .ok()
+        .and_then(|prefix| table_maintenance_object_kind_in_root(&prefix, object_location))
+}
+
+fn table_maintenance_metadata_file_kind(file_name: &str) -> Option<TableMetadataMaintenanceObjectKind> {
     if file_name.is_empty()
         || file_name.contains('/')
         || file_name.contains('\\')
@@ -9648,15 +10779,14 @@ async fn metadata_maintenance_object_cleanup_reports<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
     referenced_object_reports: &[TableMetadataMaintenanceReferencedObjectReport],
     now: OffsetDateTime,
 ) -> TableCatalogStoreResult<(usize, Vec<String>, Vec<String>, Vec<TableMetadataMaintenanceObjectCleanupReport>)>
 where
     B: TableCatalogObjectBackend,
 {
-    let scanned_objects =
-        table_maintenance_cleanup_objects(backend, table_bucket, namespace, table, warehouse_object_prefix).await?;
+    let scanned_objects = table_maintenance_cleanup_objects(backend, table_bucket, namespace, table, entry).await?;
     if referenced_object_reports
         .iter()
         .any(|report| report.state == TableMetadataMaintenanceObjectState::ManualReviewRequired)
@@ -9714,16 +10844,23 @@ async fn table_maintenance_cleanup_objects<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
 ) -> TableCatalogStoreResult<BTreeMap<String, TableMetadataMaintenanceObjectKind>>
 where
     B: TableCatalogObjectBackend,
 {
     let mut objects = BTreeMap::new();
+    let stable_table_root_prefix = table_object_root_prefix_for_entry(entry);
+    let warehouse_object_prefix = table_warehouse_object_prefix(entry).ok();
     let mut metadata_prefixes = vec![format!("{}/", default_table_metadata_dir_path(namespace, table))];
     let mut data_prefixes = vec![format!("{}/", default_table_data_dir_path(namespace, table))];
     let mut delete_prefixes = vec![format!("{}/", default_table_delete_dir_path(namespace, table))];
-    if let Some(warehouse_object_prefix) = warehouse_object_prefix {
+    if let Some(stable_table_root_prefix) = stable_table_root_prefix.as_deref() {
+        metadata_prefixes.push(format!("{stable_table_root_prefix}{METADATA_DIR}/"));
+        data_prefixes.push(format!("{stable_table_root_prefix}{DATA_DIR}/"));
+        delete_prefixes.push(format!("{stable_table_root_prefix}{DELETE_DIR}/"));
+    }
+    if let Some(warehouse_object_prefix) = warehouse_object_prefix.as_deref() {
         metadata_prefixes.push(format!("{warehouse_object_prefix}{METADATA_DIR}/"));
         data_prefixes.push(format!("{warehouse_object_prefix}{DATA_DIR}/"));
         delete_prefixes.push(format!("{warehouse_object_prefix}{DELETE_DIR}/"));
@@ -9737,7 +10874,7 @@ where
 
     for metadata_prefix in metadata_prefixes {
         for object in backend.list_objects(table_bucket, &metadata_prefix).await? {
-            if let Some(kind) = table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &object)
+            if let Some(kind) = table_maintenance_object_kind_for_entry(namespace, table, entry, &object)
                 && matches!(
                     kind,
                     TableMetadataMaintenanceObjectKind::ManifestList | TableMetadataMaintenanceObjectKind::ManifestFile
@@ -9750,7 +10887,7 @@ where
 
     for data_prefix in data_prefixes {
         for object in backend.list_objects(table_bucket, &data_prefix).await? {
-            if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &object)
+            if table_maintenance_object_kind_for_entry(namespace, table, entry, &object)
                 == Some(TableMetadataMaintenanceObjectKind::DataFile)
             {
                 objects.insert(object, TableMetadataMaintenanceObjectKind::DataFile);
@@ -9760,7 +10897,7 @@ where
 
     for delete_prefix in delete_prefixes {
         for object in backend.list_objects(table_bucket, &delete_prefix).await? {
-            if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &object)
+            if table_maintenance_object_kind_for_entry(namespace, table, entry, &object)
                 == Some(TableMetadataMaintenanceObjectKind::DeleteFile)
             {
                 objects.insert(object, TableMetadataMaintenanceObjectKind::DeleteFile);
@@ -9811,22 +10948,47 @@ fn mark_deleted_object_cleanup_reports(
     }
 }
 
-fn metadata_log_locations(
-    current_metadata: &serde_json::Value,
-    namespace: &Namespace,
-    table: &IdentifierSegment,
-) -> BTreeSet<String> {
+fn validate_table_metadata_identity_for_maintenance(
+    entry: &TableEntry,
+    metadata: &serde_json::Value,
+) -> TableCatalogStoreResult<()> {
+    let metadata_table_uuid = metadata
+        .get("table-uuid")
+        .and_then(serde_json::Value::as_str)
+        .filter(|uuid| !uuid.is_empty())
+        .ok_or_else(|| TableCatalogStoreError::Invalid("current table metadata is missing table-uuid".to_string()))?;
+    if metadata_table_uuid != entry.table_uuid {
+        return Err(TableCatalogStoreError::Invalid(
+            "current table metadata table-uuid does not match the catalog table".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn metadata_log_locations(current_metadata: &serde_json::Value, entry: &TableEntry) -> BTreeSet<String> {
     let mut locations = BTreeSet::new();
+    let Ok(namespace) = parse_namespace_for_store(&entry.namespace) else {
+        return locations;
+    };
+    let Ok(table) = parse_table_for_store(&entry.table) else {
+        return locations;
+    };
     let Some(metadata_log) = current_metadata.get("metadata-log").and_then(serde_json::Value::as_array) else {
         return locations;
     };
 
-    for entry in metadata_log {
-        let Some(metadata_location) = entry.get("metadata-file").and_then(serde_json::Value::as_str) else {
+    for log_entry in metadata_log {
+        let Some(metadata_location) = log_entry.get("metadata-file").and_then(serde_json::Value::as_str) else {
             continue;
         };
-        if is_valid_table_metadata_location(namespace, table, metadata_location) {
-            locations.insert(metadata_location.to_string());
+        if let Some(metadata_location) = table_reference_object_key(
+            &namespace,
+            &table,
+            entry,
+            metadata_location,
+            TableMetadataMaintenanceObjectKind::MetadataFile,
+        ) {
+            locations.insert(metadata_location);
         }
     }
 
@@ -9836,8 +10998,7 @@ fn metadata_log_locations(
 async fn metadata_locations_for_protected_snapshot_refs<B>(
     backend: &B,
     table_bucket: &str,
-    namespace: &Namespace,
-    table: &IdentifierSegment,
+    entry: &TableEntry,
     current_metadata: &serde_json::Value,
     metadata_locations: &[String],
 ) -> TableCatalogStoreResult<BTreeSet<String>>
@@ -9851,7 +11012,7 @@ where
 
     let mut retained = BTreeSet::new();
     for metadata_location in metadata_locations {
-        if !is_valid_table_metadata_location(namespace, table, metadata_location) {
+        if !is_valid_table_metadata_location_for_entry(entry, metadata_location) {
             continue;
         }
         let Some(metadata_object) = backend.read_object(table_bucket, metadata_location).await? else {
@@ -10114,7 +11275,6 @@ where
     let current_snapshot_id = current_metadata
         .get("current-snapshot-id")
         .and_then(serde_json::Value::as_i64);
-    let warehouse_object_prefix = table_warehouse_object_prefix(entry).ok();
     let mut snapshot_reports = Vec::new();
     let mut candidates = Vec::new();
     let mut rewrite_groups = Vec::new();
@@ -10145,7 +11305,7 @@ where
                             table_bucket,
                             namespace,
                             table,
-                            warehouse_object_prefix.as_deref(),
+                            entry,
                             manifest_list,
                             &config,
                         )
@@ -10258,44 +11418,45 @@ async fn compaction_data_file_candidates<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
     manifest_list: &str,
     config: &TableCompactionPlanningConfig,
 ) -> TableCatalogStoreResult<CompactionManifestPlanning>
 where
     B: TableCatalogObjectBackend,
 {
-    let Some(manifest_list_key) = table_catalog_object_key_from_location(table_bucket, manifest_list) else {
-        return Err(TableCatalogStoreError::Invalid(
-            "compaction manifest list must be inside the table bucket".to_string(),
-        ));
-    };
-    if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &manifest_list_key)
-        != Some(TableMetadataMaintenanceObjectKind::ManifestList)
-    {
+    let warehouse_object_prefix = table_warehouse_object_prefix(entry).ok();
+    let Some(manifest_list_key) =
+        table_reference_object_key(namespace, table, entry, manifest_list, TableMetadataMaintenanceObjectKind::ManifestList)
+    else {
         return Err(TableCatalogStoreError::Invalid(
             "compaction manifest list must be inside the table metadata directory".to_string(),
         ));
-    }
-    let Some(manifest_list_object) = backend.read_object(table_bucket, &manifest_list_key).await? else {
+    };
+    let Some(manifest_list_object) = backend
+        .read_object_limited(table_bucket, &manifest_list_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+        .await?
+    else {
         return Err(TableCatalogStoreError::NotFound(format!("compaction manifest list {manifest_list_key}")));
     };
     let manifest_paths = manifest_paths_from_manifest_list_avro(&manifest_list_object.data)?;
     let mut planning = CompactionManifestPlanning::default();
     for manifest_location in manifest_paths {
-        let Some(manifest_key) = table_catalog_object_key_from_location(table_bucket, &manifest_location) else {
-            return Err(TableCatalogStoreError::Invalid(
-                "compaction manifest must be inside the table bucket".to_string(),
-            ));
-        };
-        if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &manifest_key)
-            != Some(TableMetadataMaintenanceObjectKind::ManifestFile)
-        {
+        let Some(manifest_key) = table_reference_object_key(
+            namespace,
+            table,
+            entry,
+            &manifest_location,
+            TableMetadataMaintenanceObjectKind::ManifestFile,
+        ) else {
             return Err(TableCatalogStoreError::Invalid(
                 "compaction manifest must be inside the table metadata directory".to_string(),
             ));
-        }
-        let Some(manifest_object) = backend.read_object(table_bucket, &manifest_key).await? else {
+        };
+        let Some(manifest_object) = backend
+            .read_object_limited(table_bucket, &manifest_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+            .await?
+        else {
             return Err(TableCatalogStoreError::NotFound(format!("compaction manifest {manifest_key}")));
         };
         for reference in data_file_references_from_manifest_avro(&manifest_object.data)? {
@@ -10305,7 +11466,7 @@ where
                     table_bucket,
                     namespace,
                     table,
-                    warehouse_object_prefix,
+                    entry,
                     &mut planning.row_level_planning,
                     &reference,
                 )
@@ -10313,26 +11474,30 @@ where
                 continue;
             }
             validate_compaction_manifest_entry_status(reference.entry_status)?;
-            let Some(data_key) = table_catalog_object_key_from_location(table_bucket, &reference.location) else {
-                return Err(TableCatalogStoreError::Invalid(
-                    "compaction data file must be inside the table bucket".to_string(),
-                ));
-            };
-            if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &data_key)
-                != Some(TableMetadataMaintenanceObjectKind::DataFile)
-            {
+            let Some(data_key) = table_reference_object_key(
+                namespace,
+                table,
+                entry,
+                &reference.location,
+                TableMetadataMaintenanceObjectKind::DataFile,
+            ) else {
                 return Err(TableCatalogStoreError::Invalid(
                     "compaction data file must be inside the table data directory".to_string(),
                 ));
-            }
+            };
             let Some(data_object) = backend.read_object(table_bucket, &data_key).await? else {
                 return Err(TableCatalogStoreError::NotFound(format!("compaction data file {data_key}")));
             };
             let size_bytes = u64::try_from(data_object.data.len()).unwrap_or(u64::MAX);
             if size_bytes <= config.small_file_threshold_bytes {
                 planning.candidates.push(TableCompactionDataFileCandidate {
-                    rewrite_prefix: compaction_data_file_rewrite_prefix(namespace, table, warehouse_object_prefix, &data_key)
-                        .unwrap_or_else(|| data_key.clone()),
+                    rewrite_prefix: compaction_data_file_rewrite_prefix(
+                        namespace,
+                        table,
+                        warehouse_object_prefix.as_deref(),
+                        &data_key,
+                    )
+                    .unwrap_or_else(|| data_key.clone()),
                     location: data_key,
                     size_bytes,
                     sort_order_id: reference.sort_order_id,
@@ -10348,7 +11513,7 @@ async fn record_compaction_row_level_delete_file<B>(
     table_bucket: &str,
     namespace: &Namespace,
     table: &IdentifierSegment,
-    warehouse_object_prefix: Option<&str>,
+    entry: &TableEntry,
     planning: &mut TableRowLevelMaintenancePlanningReport,
     reference: &ManifestDataFileReference,
 ) -> TableCatalogStoreResult<()>
@@ -10358,18 +11523,17 @@ where
     let Some(content) = row_level_delete_file_content(reference.content) else {
         return Ok(());
     };
-    let Some(delete_key) = table_catalog_object_key_from_location(table_bucket, &reference.location) else {
-        return Err(TableCatalogStoreError::Invalid(
-            "compaction delete file must be inside the table bucket".to_string(),
-        ));
-    };
-    if table_maintenance_object_kind(namespace, table, warehouse_object_prefix, &delete_key)
-        != Some(TableMetadataMaintenanceObjectKind::DeleteFile)
-    {
+    let Some(delete_key) = table_reference_object_key(
+        namespace,
+        table,
+        entry,
+        &reference.location,
+        TableMetadataMaintenanceObjectKind::DeleteFile,
+    ) else {
         return Err(TableCatalogStoreError::Invalid(
             "compaction delete file must be inside the table delete directory".to_string(),
         ));
-    }
+    };
 
     let object_exists = backend.read_object(table_bucket, &delete_key).await?.is_some();
     planning.status = TableRowLevelMaintenancePlanningStatus::ManualReviewRequired;
@@ -10468,38 +11632,37 @@ where
         .and_then(serde_json::Value::as_str)
         .ok_or_else(|| TableCatalogStoreError::Invalid("compaction requires current snapshot manifest list".to_string()))?;
 
-    let warehouse_object_prefix = table_warehouse_object_prefix(entry).ok();
-    let Some(manifest_list_key) = table_catalog_object_key_from_location(table_bucket, manifest_list) else {
-        return Err(TableCatalogStoreError::Invalid(
-            "compaction manifest list must be inside the table bucket".to_string(),
-        ));
-    };
-    if table_maintenance_object_kind(namespace, table, warehouse_object_prefix.as_deref(), &manifest_list_key)
-        != Some(TableMetadataMaintenanceObjectKind::ManifestList)
-    {
+    let Some(manifest_list_key) =
+        table_reference_object_key(namespace, table, entry, manifest_list, TableMetadataMaintenanceObjectKind::ManifestList)
+    else {
         return Err(TableCatalogStoreError::Invalid(
             "compaction manifest list must be inside the table metadata directory".to_string(),
         ));
-    }
-    let Some(manifest_list_object) = backend.read_object(table_bucket, &manifest_list_key).await? else {
+    };
+    let Some(manifest_list_object) = backend
+        .read_object_limited(table_bucket, &manifest_list_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+        .await?
+    else {
         return Err(TableCatalogStoreError::NotFound(format!("compaction manifest list {manifest_list_key}")));
     };
 
     let mut data_files = Vec::new();
     for manifest_reference in manifest_list_references_from_manifest_list_avro(&manifest_list_object.data)? {
-        let Some(manifest_key) = table_catalog_object_key_from_location(table_bucket, &manifest_reference.manifest_path) else {
-            return Err(TableCatalogStoreError::Invalid(
-                "compaction manifest must be inside the table bucket".to_string(),
-            ));
-        };
-        if table_maintenance_object_kind(namespace, table, warehouse_object_prefix.as_deref(), &manifest_key)
-            != Some(TableMetadataMaintenanceObjectKind::ManifestFile)
-        {
+        let Some(manifest_key) = table_reference_object_key(
+            namespace,
+            table,
+            entry,
+            &manifest_reference.manifest_path,
+            TableMetadataMaintenanceObjectKind::ManifestFile,
+        ) else {
             return Err(TableCatalogStoreError::Invalid(
                 "compaction manifest must be inside the table metadata directory".to_string(),
             ));
-        }
-        let Some(manifest_object) = backend.read_object(table_bucket, &manifest_key).await? else {
+        };
+        let Some(manifest_object) = backend
+            .read_object_limited(table_bucket, &manifest_key, TABLE_MANIFEST_AVRO_MAX_SIZE)
+            .await?
+        else {
             return Err(TableCatalogStoreError::NotFound(format!("compaction manifest {manifest_key}")));
         };
         for reference in data_file_references_from_manifest_avro(&manifest_object.data)? {
@@ -10509,18 +11672,17 @@ where
                 ));
             }
             validate_compaction_manifest_entry_status(reference.entry_status)?;
-            let Some(data_key) = table_catalog_object_key_from_location(table_bucket, &reference.location) else {
-                return Err(TableCatalogStoreError::Invalid(
-                    "compaction data file must be inside the table bucket".to_string(),
-                ));
-            };
-            if table_maintenance_object_kind(namespace, table, warehouse_object_prefix.as_deref(), &data_key)
-                != Some(TableMetadataMaintenanceObjectKind::DataFile)
-            {
+            let Some(data_key) = table_reference_object_key(
+                namespace,
+                table,
+                entry,
+                &reference.location,
+                TableMetadataMaintenanceObjectKind::DataFile,
+            ) else {
                 return Err(TableCatalogStoreError::Invalid(
                     "compaction data file must be inside the table data directory".to_string(),
                 ));
-            }
+            };
             let Some(data_object) = backend.read_object(table_bucket, &data_key).await? else {
                 return Err(TableCatalogStoreError::NotFound(format!("compaction data file {data_key}")));
             };
@@ -11651,7 +12813,7 @@ fn validate_table_compaction_planning_config(config: &TableCompactionPlanningCon
     Ok(())
 }
 
-fn commit_log_matches_request(commit_log: &CommitLogEntry, request: &TableCommitRequest, table_id: &str) -> bool {
+pub(crate) fn commit_log_matches_request(commit_log: &CommitLogEntry, request: &TableCommitRequest, table_id: &str) -> bool {
     commit_log.version == TABLE_CATALOG_ENTRY_VERSION
         && commit_log.commit_id == request.commit_id
         && commit_log.idempotency_key == request.idempotency_key
@@ -11830,9 +12992,15 @@ fn record_table_commit_attempt(operation: &str) {
 fn table_catalog_store_result_label<T>(result: &TableCatalogStoreResult<T>) -> &'static str {
     match result {
         Ok(_) => "success",
-        Err(TableCatalogStoreError::Conflict(_)) => "conflict",
+        Err(TableCatalogStoreError::AlreadyExists(_) | TableCatalogStoreError::Conflict(_)) => "conflict",
         Err(TableCatalogStoreError::Invalid(_)) => "invalid",
-        Err(TableCatalogStoreError::NotFound(_)) => "not_found",
+        Err(
+            TableCatalogStoreError::NotFound(_)
+            | TableCatalogStoreError::NamespaceNotFound(_)
+            | TableCatalogStoreError::TableNotFound(_)
+            | TableCatalogStoreError::ViewNotFound(_),
+        ) => "not_found",
+        Err(TableCatalogStoreError::Unsupported(_)) => "unsupported",
         Err(TableCatalogStoreError::Internal(_)) => "failure",
     }
 }
@@ -12060,17 +13228,22 @@ impl Namespace {
     pub const MAX_LEN: usize = 512;
 
     pub fn parse(value: &str) -> Result<Self, CatalogIdentifierError> {
-        if value.is_empty() {
+        let segments = value.split('.').map(str::to_string).collect::<Vec<_>>();
+        Self::from_segments(segments)
+    }
+
+    pub(crate) fn from_segments(values: Vec<String>) -> Result<Self, CatalogIdentifierError> {
+        if values.is_empty() {
             return Err(CatalogIdentifierError::Empty);
         }
         if value.len() > Self::MAX_LEN {
             return Err(CatalogIdentifierError::NamespaceTooLong { max: Self::MAX_LEN });
         }
 
-        let mut segments = Vec::new();
-        for segment in value.split('.') {
-            segments.push(IdentifierSegment::parse(segment.to_string())?);
-        }
+        let segments = values
+            .into_iter()
+            .map(IdentifierSegment::parse)
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self { segments })
     }
@@ -12268,6 +13441,87 @@ pub(crate) fn metadata_location_from_metadata_file_path(
         .strip_prefix(prefix.as_str())
         .filter(|value| is_valid_table_metadata_file_name(value))
         .map(|_| object_key.to_string())
+}
+
+fn table_metadata_dir_from_object_key(object_key: &str) -> Option<String> {
+    let namespace_root = default_namespace_root_prefix();
+    let relative = object_key.strip_prefix(&namespace_root)?;
+    let (namespace_storage_id, table_path) = relative.rsplit_once(&format!("/{TABLE_ROOT}/"))?;
+    Namespace::from_segments(namespace_storage_id.split('/').map(str::to_string).collect()).ok()?;
+    let (table_name, metadata_file_name) = table_path.split_once(&format!("/{METADATA_DIR}/"))?;
+    IdentifierSegment::parse(table_name).ok()?;
+    if !is_valid_table_metadata_file_name(metadata_file_name) {
+        return None;
+    }
+    Some(format!("{namespace_root}{namespace_storage_id}/{TABLE_ROOT}/{table_name}/{METADATA_DIR}"))
+}
+
+pub(crate) fn validate_table_warehouse_relocation(
+    entry: &TableEntry,
+    next_warehouse_location: &str,
+) -> TableCatalogStoreResult<()> {
+    if next_warehouse_location == entry.warehouse_location {
+        return Ok(());
+    }
+    let object_key = table_catalog_object_key_from_location(&entry.table_bucket, &entry.metadata_location)
+        .ok_or_else(|| TableCatalogStoreError::Invalid("current metadata location is invalid".to_string()))?;
+    if table_metadata_dir_from_object_key(&object_key).is_none() {
+        return Err(TableCatalogStoreError::Unsupported(
+            "warehouse relocation is unsupported for tables registered outside the managed catalog metadata root".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn is_valid_table_metadata_location_for_entry(entry: &TableEntry, metadata_location: &str) -> bool {
+    let Ok(metadata_dir) = table_metadata_dir_path_for_entry(entry) else {
+        return false;
+    };
+    let Some(object_key) = table_catalog_object_key_from_location(&entry.table_bucket, metadata_location) else {
+        return false;
+    };
+    object_key
+        .strip_prefix(&format!("{metadata_dir}/"))
+        .is_some_and(is_valid_table_metadata_file_name)
+}
+
+pub(crate) fn table_metadata_file_path_for_entry(
+    entry: &TableEntry,
+    metadata_file_name: &str,
+) -> TableCatalogStoreResult<String> {
+    if !is_valid_table_metadata_file_name(metadata_file_name) {
+        return Err(TableCatalogStoreError::Invalid("invalid table metadata file name".to_string()));
+    }
+    let metadata_dir = table_metadata_dir_path_for_entry(entry)?;
+    Ok(format!("{metadata_dir}/{metadata_file_name}"))
+}
+
+fn table_metadata_dir_path_for_entry(entry: &TableEntry) -> TableCatalogStoreResult<String> {
+    let object_key = table_catalog_object_key_from_location(&entry.table_bucket, &entry.metadata_location).ok_or_else(|| {
+        TableCatalogStoreError::Invalid(
+            "current metadata location must be inside a protected table metadata directory".to_string(),
+        )
+    })?;
+    if let Some(metadata_dir) = table_metadata_dir_from_object_key(&object_key) {
+        return Ok(metadata_dir);
+    }
+    let warehouse_prefix = table_warehouse_object_prefix(entry)?;
+    let metadata_dir = format!("{warehouse_prefix}{METADATA_DIR}");
+    object_key
+        .strip_prefix(&format!("{metadata_dir}/"))
+        .filter(|file_name| is_valid_table_metadata_file_name(file_name))
+        .map(|_| metadata_dir)
+        .ok_or_else(|| {
+            TableCatalogStoreError::Invalid(
+                "current metadata location must be inside a protected table metadata directory".to_string(),
+            )
+        })
+}
+
+fn table_object_root_prefix_for_entry(entry: &TableEntry) -> Option<String> {
+    table_metadata_dir_path_for_entry(entry)
+        .ok()
+        .and_then(|metadata_dir| metadata_dir.strip_suffix(METADATA_DIR).map(str::to_string))
 }
 
 pub(crate) fn is_valid_table_metadata_location(
@@ -12826,14 +14080,21 @@ mod tests {
     type TestCatalogObjectLockKey = (String, String);
     type TestCatalogObjectLock = Arc<tokio::sync::Mutex<()>>;
     type TestCatalogObjectLocks = Arc<tokio::sync::Mutex<BTreeMap<TestCatalogObjectLockKey, TestCatalogObjectLock>>>;
+    type TestCatalogObjectReplacements = BTreeMap<TestCatalogObjectLockKey, BTreeMap<usize, TestCatalogObjectReplacement>>;
+
+    struct TestCatalogObjectReplacement {
+        data: Vec<u8>,
+        preserve_etag: bool,
+        preserve_mod_time: bool,
+    }
 
     #[derive(Clone, Default)]
-    struct TestCatalogObjectPutPause {
+    struct TestCatalogObjectPause {
         started: Arc<tokio::sync::Notify>,
         release: Arc<tokio::sync::Notify>,
     }
 
-    impl TestCatalogObjectPutPause {
+    impl TestCatalogObjectPause {
         async fn wait_started(&self) {
             self.started.notified().await;
         }
@@ -12847,16 +14108,20 @@ mod tests {
     struct TestCatalogObjectState {
         objects: BTreeMap<(String, String), TestCatalogObjectRecord>,
         fail_read_attempts: BTreeMap<(String, String), BTreeSet<usize>>,
+        pause_read_attempts: BTreeMap<(String, String), BTreeMap<usize, TestCatalogObjectPause>>,
         read_attempts: BTreeMap<(String, String), usize>,
         fail_put_attempts: BTreeMap<(String, String), BTreeSet<usize>>,
-        pause_put_attempts: BTreeMap<(String, String), BTreeMap<usize, TestCatalogObjectPutPause>>,
+        pause_put_attempts: BTreeMap<(String, String), BTreeMap<usize, TestCatalogObjectPause>>,
         fail_delete_attempts: BTreeMap<(String, String), BTreeSet<usize>>,
+        replace_on_write_lock_acquisitions: TestCatalogObjectReplacements,
         put_attempts: BTreeMap<(String, String), usize>,
         delete_attempts: BTreeMap<(String, String), usize>,
         write_lock_acquisitions: BTreeMap<(String, String), usize>,
         read_calls: usize,
         metadata_calls: usize,
         list_calls: usize,
+        list_prefixes: Vec<(String, String)>,
+        list_page_limits: Vec<i32>,
         next_etag: u64,
     }
 
@@ -12899,8 +14164,41 @@ mod tests {
                 .insert(attempt);
         }
 
+        async fn replace_on_write_lock_acquisition(
+            &self,
+            bucket: &str,
+            object: &str,
+            attempt: usize,
+            data: Vec<u8>,
+            preserve_etag: bool,
+            preserve_mod_time: bool,
+        ) {
+            self.state
+                .lock()
+                .await
+                .replace_on_write_lock_acquisitions
+                .entry((bucket.to_string(), object.to_string()))
+                .or_default()
+                .insert(
+                    attempt,
+                    TestCatalogObjectReplacement {
+                        data,
+                        preserve_etag,
+                        preserve_mod_time,
+                    },
+                );
+        }
+
         async fn list_call_count(&self) -> usize {
             self.state.lock().await.list_calls
+        }
+
+        async fn list_prefixes(&self) -> Vec<(String, String)> {
+            self.state.lock().await.list_prefixes.clone()
+        }
+
+        async fn list_page_limits(&self) -> Vec<i32> {
+            self.state.lock().await.list_page_limits.clone()
         }
 
         async fn read_call_count(&self) -> usize {
@@ -12916,6 +14214,8 @@ mod tests {
             state.read_calls = 0;
             state.metadata_calls = 0;
             state.list_calls = 0;
+            state.list_prefixes.clear();
+            state.list_page_limits.clear();
         }
 
         async fn write_lock_acquisition_count(&self, bucket: &str, object: &str) -> usize {
@@ -12928,11 +14228,34 @@ mod tests {
                 .unwrap_or_default()
         }
 
+        async fn write_lock_is_held(&self, bucket: &str, object: &str) -> bool {
+            let lock = self
+                .locks
+                .lock()
+                .await
+                .get(&(bucket.to_string(), object.to_string()))
+                .cloned();
+            lock.is_some_and(|lock| lock.try_lock_owned().is_err())
+        }
+
         async fn fail_next_read(&self, bucket: &str, object: &str) {
             let mut state = self.state.lock().await;
             let key = (bucket.to_string(), object.to_string());
             let next_attempt = state.read_attempts.get(&key).copied().unwrap_or_default() + 1;
             state.fail_read_attempts.entry(key).or_default().insert(next_attempt);
+        }
+
+        async fn pause_next_read(&self, bucket: &str, object: &str) -> TestCatalogObjectPause {
+            let mut state = self.state.lock().await;
+            let key = (bucket.to_string(), object.to_string());
+            let next_attempt = state.read_attempts.get(&key).copied().unwrap_or_default() + 1;
+            let pause = TestCatalogObjectPause::default();
+            state
+                .pause_read_attempts
+                .entry(key)
+                .or_default()
+                .insert(next_attempt, pause.clone());
+            pause
         }
 
         async fn fail_next_put(&self, bucket: &str, object: &str) {
@@ -12942,11 +14265,11 @@ mod tests {
             state.fail_put_attempts.entry(key).or_default().insert(next_attempt);
         }
 
-        async fn pause_next_put(&self, bucket: &str, object: &str) -> TestCatalogObjectPutPause {
+        async fn pause_next_put(&self, bucket: &str, object: &str) -> TestCatalogObjectPause {
             let mut state = self.state.lock().await;
             let key = (bucket.to_string(), object.to_string());
             let next_attempt = state.put_attempts.get(&key).copied().unwrap_or_default() + 1;
-            let pause = TestCatalogObjectPutPause::default();
+            let pause = TestCatalogObjectPause::default();
             state
                 .pause_put_attempts
                 .entry(key)
@@ -13044,6 +14367,52 @@ mod tests {
                 .map(|(file_path, content)| (*file_path, *content, 1))
                 .collect::<Vec<_>>(),
         )
+    }
+
+    fn manifest_v1_avro_bytes(file_paths: &[&str]) -> Vec<u8> {
+        let schema = apache_avro::Schema::parse_str(
+            r#"
+            {
+              "type": "record",
+              "name": "manifest_entry_v1",
+              "fields": [
+                {"name": "status", "type": "int"},
+                {"name": "snapshot_id", "type": "long"},
+                {
+                  "name": "data_file",
+                  "type": {
+                    "type": "record",
+                    "name": "data_file_v1",
+                    "fields": [
+                      {"name": "file_path", "type": "string"},
+                      {"name": "record_count", "type": "long"},
+                      {"name": "file_size_in_bytes", "type": "long"}
+                    ]
+                  }
+                }
+              ]
+            }
+            "#,
+        )
+        .expect("v1 manifest avro schema should parse");
+        let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+        for file_path in file_paths {
+            writer
+                .append(apache_avro::types::Value::Record(vec![
+                    ("status".to_string(), apache_avro::types::Value::Int(1)),
+                    ("snapshot_id".to_string(), apache_avro::types::Value::Long(20)),
+                    (
+                        "data_file".to_string(),
+                        apache_avro::types::Value::Record(vec![
+                            ("file_path".to_string(), apache_avro::types::Value::String((*file_path).to_string())),
+                            ("record_count".to_string(), apache_avro::types::Value::Long(1)),
+                            ("file_size_in_bytes".to_string(), apache_avro::types::Value::Long(1)),
+                        ]),
+                    ),
+                ]))
+                .expect("v1 manifest record should append");
+        }
+        writer.into_inner().expect("v1 manifest avro bytes should flush")
     }
 
     fn manifest_avro_bytes_with_status(files: &[(&str, i32, i32)]) -> Vec<u8> {
@@ -13264,28 +14633,40 @@ mod tests {
     #[async_trait::async_trait]
     impl TableCatalogObjectBackend for TestCatalogObjectBackend {
         async fn read_object(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Option<TableCatalogObject>> {
-            let mut state = self.state.lock().await;
-            state.read_calls += 1;
             let key = (bucket.to_string(), object.to_string());
-            let attempt = {
-                let attempts = state.read_attempts.entry(key.clone()).or_default();
-                *attempts += 1;
-                *attempts
+            let (result, pause) = {
+                let mut state = self.state.lock().await;
+                state.read_calls += 1;
+                let attempt = {
+                    let attempts = state.read_attempts.entry(key.clone()).or_default();
+                    *attempts += 1;
+                    *attempts
+                };
+                if state
+                    .fail_read_attempts
+                    .get(&key)
+                    .is_some_and(|attempts| attempts.contains(&attempt))
+                {
+                    return Err(TableCatalogStoreError::Internal(format!(
+                        "injected read failure for {object} attempt {attempt}"
+                    )));
+                }
+                let result = state.objects.get(&key).map(|record| TableCatalogObject {
+                    data: record.data.clone(),
+                    etag: Some(record.etag.clone()),
+                    mod_time: record.mod_time,
+                });
+                let pause = state
+                    .pause_read_attempts
+                    .get_mut(&key)
+                    .and_then(|attempts| attempts.remove(&attempt));
+                (result, pause)
             };
-            if state
-                .fail_read_attempts
-                .get(&key)
-                .is_some_and(|attempts| attempts.contains(&attempt))
-            {
-                return Err(TableCatalogStoreError::Internal(format!(
-                    "injected read failure for {object} attempt {attempt}"
-                )));
+            if let Some(pause) = pause {
+                pause.started.notify_one();
+                pause.release.notified().await;
             }
-            Ok(state.objects.get(&key).map(|record| TableCatalogObject {
-                data: record.data.clone(),
-                etag: Some(record.etag.clone()),
-                mod_time: record.mod_time,
-            }))
+            Ok(result)
         }
 
         async fn object_metadata(
@@ -13395,6 +14776,7 @@ mod tests {
         async fn list_objects(&self, bucket: &str, prefix: &str) -> TableCatalogStoreResult<Vec<String>> {
             let mut state = self.state.lock().await;
             state.list_calls += 1;
+            state.list_prefixes.push((bucket.to_string(), prefix.to_string()));
             Ok(state
                 .objects
                 .keys()
@@ -13403,22 +14785,88 @@ mod tests {
                 .collect())
         }
 
+        async fn list_objects_page(
+            &self,
+            bucket: &str,
+            prefix: &str,
+            after: Option<&str>,
+            limit: i32,
+        ) -> TableCatalogStoreResult<TableCatalogPage<String>> {
+            if limit <= 0 {
+                return Err(TableCatalogStoreError::Invalid(
+                    "catalog object page limit must be greater than zero".to_string(),
+                ));
+            }
+            let limit = usize::try_from(limit)
+                .map_err(|_| TableCatalogStoreError::Invalid("catalog object page limit is too large".to_string()))?;
+            let mut state = self.state.lock().await;
+            state.list_calls += 1;
+            state.list_page_limits.push(i32::try_from(limit).unwrap_or(i32::MAX));
+            let mut objects = state
+                .objects
+                .keys()
+                .filter(|(entry_bucket, object)| {
+                    entry_bucket == bucket && object.starts_with(prefix) && after.is_none_or(|after| object.as_str() > after)
+                })
+                .map(|(_, object)| object.clone())
+                .take(limit.saturating_add(1))
+                .collect::<Vec<_>>();
+            let has_more = objects.len() > limit;
+            objects.truncate(limit);
+            Ok(TableCatalogPage {
+                entries: objects,
+                has_more,
+            })
+        }
+
         async fn acquire_write_lock(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<Box<dyn Send>> {
-            {
+            let attempt = {
                 let mut state = self.state.lock().await;
-                *state
+                let acquisitions = state
                     .write_lock_acquisitions
                     .entry((bucket.to_string(), object.to_string()))
-                    .or_default() += 1;
-            }
+                    .or_default();
+                *acquisitions += 1;
+                *acquisitions
+            };
+            let key = (bucket.to_string(), object.to_string());
             let lock = {
                 let mut locks = self.locks.lock().await;
                 locks
-                    .entry((bucket.to_string(), object.to_string()))
+                    .entry(key.clone())
                     .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
                     .clone()
             };
-            Ok(Box::new(lock.lock_owned().await))
+            let guard = lock.lock_owned().await;
+            let mut state = self.state.lock().await;
+            let replacement = state
+                .replace_on_write_lock_acquisitions
+                .get_mut(&key)
+                .and_then(|acquisitions| acquisitions.remove(&attempt));
+            if let Some(TestCatalogObjectReplacement {
+                data,
+                preserve_etag,
+                preserve_mod_time,
+            }) = replacement
+            {
+                let previous = state.objects.get(&key).cloned();
+                let etag = if preserve_etag {
+                    previous
+                        .as_ref()
+                        .map(|record| record.etag.clone())
+                        .unwrap_or_else(|| state.next_etag())
+                } else {
+                    state.next_etag()
+                };
+                let mod_time = if preserve_mod_time {
+                    previous.and_then(|record| record.mod_time)
+                } else {
+                    Some(OffsetDateTime::now_utc())
+                };
+                state.objects.insert(key, TestCatalogObjectRecord { data, etag, mod_time });
+            }
+            drop(state);
+            Ok(Box::new(guard))
         }
     }
 
@@ -13554,7 +15002,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -13610,6 +15058,64 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(object_buckets, BTreeSet::from([RUSTFS_META_BUCKET]));
+    }
+
+    #[tokio::test]
+    async fn object_table_catalog_store_scopes_parent_namespace_listing() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let parent = Namespace::parse("sales").expect("parent namespace should parse");
+        let child = Namespace::parse("sales.daily").expect("child namespace should parse");
+        let sibling = Namespace::parse("finance").expect("sibling namespace should parse");
+
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+        for namespace in [&parent, &child, &sibling] {
+            store
+                .create_namespace(test_namespace_entry(bucket, namespace))
+                .await
+                .expect("namespace should be created");
+        }
+        backend.reset_call_counts().await;
+
+        let entries = store
+            .list_namespaces_under(bucket, &parent.public_name())
+            .await
+            .expect("parent namespace listing should succeed");
+
+        assert_eq!(
+            entries.into_iter().map(|entry| entry.namespace).collect::<Vec<_>>(),
+            vec!["sales".to_string(), "sales.daily".to_string()]
+        );
+        assert_eq!(
+            backend.list_prefixes().await,
+            vec![(
+                RUSTFS_META_BUCKET.to_string(),
+                format!("{}{}/", store.paths.namespace_entries_prefix(bucket), parent.storage_id())
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_object_backend_rejects_reads_over_the_requested_limit() {
+        let backend = TestCatalogObjectBackend::default();
+        backend.seed_object("analytics", "metadata.json", vec![0; 3]).await;
+
+        let object = backend
+            .read_object_limited("analytics", "metadata.json", 3)
+            .await
+            .expect("object at the size limit should load")
+            .expect("object should exist");
+        assert_eq!(object.data.len(), 3);
+
+        let err = backend
+            .read_object_limited("analytics", "metadata.json", 2)
+            .await
+            .expect_err("object over the size limit should be rejected");
+        assert_matches!(err, TableCatalogStoreError::Invalid(message) if message.contains("maximum size"));
     }
 
     #[tokio::test]
@@ -13681,6 +15187,7 @@ mod tests {
                 expected_version_token: "token-v1".to_string(),
                 expected_metadata_location: current_metadata,
                 new_metadata_location: next_metadata.clone(),
+                new_metadata_sha256: None,
             })
             .await
             .unwrap();
@@ -13712,7 +15219,7 @@ mod tests {
         backend.seed_object(bucket, &v1, b"{}".to_vec()).await;
         backend.seed_object(bucket, &v2, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
 
         let report = store
@@ -13724,6 +15231,79 @@ mod tests {
         assert!(report.retained_metadata_locations.contains(&report.current_metadata_location));
         assert!(!report.cleanup_candidate_locations.contains(&report.current_metadata_location));
         assert_eq!(report.cleanup_candidate_locations, vec![v1, v2]);
+    }
+
+    #[tokio::test]
+    async fn maintenance_planning_rejects_missing_or_mismatched_table_uuid() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let old = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend.seed_object(bucket, &old, b"{}".to_vec()).await;
+
+        for metadata in [
+            serde_json::json!({"metadata-log": []}),
+            serde_json::json!({"table-uuid": "other-table-uuid", "metadata-log": []}),
+        ] {
+            backend
+                .seed_object(bucket, &current, serde_json::to_vec(&metadata).expect("metadata should encode"))
+                .await;
+
+            let error = store
+                .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+                .await
+                .expect_err("maintenance must reject metadata for an unknown table identity");
+
+            assert_matches!(error, TableCatalogStoreError::Invalid(_));
+            assert!(
+                backend
+                    .object_exists(bucket, &old)
+                    .await
+                    .expect("old metadata lookup should succeed")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn maintenance_delete_revalidates_current_table_uuid() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let old = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend.seed_object(bucket, &old, b"{}".to_vec()).await;
+        backend
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("maintenance report should be planned");
+        backend
+            .seed_object(bucket, &current, br#"{"table-uuid":"other-table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
+
+        let error = store
+            .delete_table_metadata_maintenance_report(bucket, "sales", "orders", report)
+            .await
+            .expect_err("maintenance must revalidate current metadata identity before deleting");
+
+        assert_matches!(error, TableCatalogStoreError::Invalid(_));
+        assert!(
+            backend
+                .object_exists(bucket, &old)
+                .await
+                .expect("old metadata lookup should succeed")
+        );
     }
 
     #[tokio::test]
@@ -13772,31 +15352,71 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn table_data_plane_resource_prefers_longest_registered_warehouse_prefix() {
+    async fn table_data_plane_resource_rejects_overlapping_registered_warehouse_prefix() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
         let bucket = "analytics";
         let namespace = Namespace::parse("sales").unwrap();
         let parent_table = IdentifierSegment::parse("orders").unwrap();
         let child_table = IdentifierSegment::parse("orders_child").unwrap();
-        let current = default_table_metadata_file_path(&namespace, &parent_table, "00001.metadata.json");
+        let parent_metadata = default_table_metadata_file_path(&namespace, &parent_table, "00001.metadata.json");
+        let child_metadata = default_table_metadata_file_path(&namespace, &child_table, "00001.metadata.json");
 
-        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &parent_table, current.clone()).await;
-        let mut child_entry = test_table_entry(bucket, &namespace, &child_table, current);
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &parent_table, parent_metadata).await;
+        let mut child_entry = test_table_entry(bucket, &namespace, &child_table, child_metadata);
         child_entry.table_id = "table-id-child".to_string();
         child_entry.warehouse_location = format!("s3://{bucket}/tables/table-id/child");
-        store.create_table(child_entry).await.unwrap();
+        let error = store.create_table(child_entry).await.unwrap_err();
+        assert_matches!(error, TableCatalogStoreError::Conflict(_));
+        backend.reset_call_counts().await;
 
         let resource = table_data_plane_resource_for_object(&store, bucket, "tables/table-id/child/data/part-00001.parquet")
             .await
             .expect("data-plane resource lookup should succeed")
-            .expect("object should resolve to the child table");
+            .expect("object should remain owned by the parent table");
 
-        assert_eq!(resource.table, "orders_child");
-        assert_eq!(resource.table_id, "table-id-child");
-        assert_eq!(resource.warehouse_object_prefix, "tables/table-id/child/");
-        assert_eq!(resource.catalog_resource_object(), "namespaces/sales/tables/orders_child");
+        assert_eq!(resource.table, "orders");
+        assert_eq!(resource.table_id, "table-id");
+        assert_eq!(resource.warehouse_object_prefix, "tables/table-id/");
+        assert_eq!(resource.catalog_resource_object(), "namespaces/sales/tables/orders");
         assert_eq!(backend.list_call_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn object_table_catalog_store_scopes_warehouse_uniqueness_scans() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").unwrap();
+        let first_table = IdentifierSegment::parse("orders").unwrap();
+        let second_table = IdentifierSegment::parse("customers").unwrap();
+        let first_metadata = default_table_metadata_file_path(&namespace, &first_table, "00001.metadata.json");
+        let second_metadata = default_table_metadata_file_path(&namespace, &second_table, "00001.metadata.json");
+
+        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        store
+            .create_table(test_table_entry(bucket, &namespace, &first_table, first_metadata))
+            .await
+            .unwrap();
+        backend.reset_call_counts().await;
+
+        let mut second = test_table_entry(bucket, &namespace, &second_table, second_metadata);
+        second.table_id = "customer-table-id".to_string();
+        second.table_uuid = "customer-table-uuid".to_string();
+        second.warehouse_location = format!("s3://{bucket}/tables/customer-table-id");
+        store.create_table(second).await.unwrap();
+
+        assert_eq!(
+            backend.list_prefixes().await,
+            vec![
+                (RUSTFS_META_BUCKET.to_string(), store.paths.warehouse_index_entries_prefix(bucket)),
+                (RUSTFS_META_BUCKET.to_string(), store.paths.namespace_entries_prefix(bucket)),
+            ]
+        );
     }
 
     #[tokio::test]
@@ -13847,10 +15467,11 @@ mod tests {
         let namespace = Namespace::parse("sales").unwrap();
         let first_table = IdentifierSegment::parse("orders").unwrap();
         let second_table = IdentifierSegment::parse("returns").unwrap();
-        let current = default_table_metadata_file_path(&namespace, &first_table, "00001.metadata.json");
+        let first_metadata = default_table_metadata_file_path(&namespace, &first_table, "00001.metadata.json");
+        let second_metadata = default_table_metadata_file_path(&namespace, &second_table, "00001.metadata.json");
 
-        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &first_table, current.clone()).await;
-        let mut second_entry = test_table_entry(bucket, &namespace, &second_table, current);
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &first_table, first_metadata).await;
+        let mut second_entry = test_table_entry(bucket, &namespace, &second_table, second_metadata);
         second_entry.table_id = "second-table-id".to_string();
         second_entry.warehouse_location = format!("s3://{bucket}/tables/table-id");
 
@@ -13858,7 +15479,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            TableCatalogStoreError::Conflict(message) if message.contains("warehouse location is already registered")
+            TableCatalogStoreError::Conflict(message) if message.contains("warehouse location overlaps an active table")
         ));
     }
 
@@ -14004,7 +15625,60 @@ mod tests {
 
         assert_eq!(indexed_resource.table, "orders");
         assert_eq!(backend.list_call_count().await, 0);
-        assert!(backend.read_call_count().await <= 5);
+        assert!(backend.read_call_count().await <= WAREHOUSE_INDEX_MAX_PREFIX_DEPTH + 3);
+    }
+
+    #[tokio::test]
+    async fn warehouse_index_backfill_fails_closed_for_invalid_active_table() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend);
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let metadata_location = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let mut invalid_table = test_table_entry(bucket, &namespace, &table, metadata_location);
+        invalid_table.warehouse_location = format!("s3://{bucket}/tables/*/warehouse");
+
+        store
+            .write_entry(
+                store.catalog_bucket(),
+                &store.paths.table_bucket_entry_path(bucket),
+                &test_bucket_entry(bucket),
+                TableCatalogPutPrecondition::Any,
+            )
+            .await
+            .expect("legacy table bucket entry should be seeded");
+        store
+            .write_entry(
+                store.catalog_bucket(),
+                &store.paths.namespace_entry_path(bucket, &namespace),
+                &test_namespace_entry(bucket, &namespace),
+                TableCatalogPutPrecondition::Any,
+            )
+            .await
+            .expect("legacy namespace entry should be seeded");
+        store
+            .write_entry(
+                store.catalog_bucket(),
+                &store.paths.table_entry_path(bucket, &namespace, &table),
+                &invalid_table,
+                TableCatalogPutPrecondition::Any,
+            )
+            .await
+            .expect("legacy invalid table entry should be seeded");
+
+        let error = store
+            .backfill_table_warehouse_index(bucket)
+            .await
+            .expect_err("an invalid active table must keep the ownership index incomplete");
+
+        assert_matches!(error, TableCatalogStoreError::Invalid(_));
+        assert!(
+            !store
+                .warehouse_index_ready(bucket)
+                .await
+                .expect("index state lookup should succeed")
+        );
     }
 
     #[tokio::test]
@@ -14191,7 +15865,8 @@ mod tests {
         let namespace = Namespace::parse("sales").unwrap();
         let failed_table = IdentifierSegment::parse("failed_orders").unwrap();
         let next_table = IdentifierSegment::parse("orders").unwrap();
-        let current = default_table_metadata_file_path(&namespace, &failed_table, "00001.metadata.json");
+        let failed_metadata = default_table_metadata_file_path(&namespace, &failed_table, "00001.metadata.json");
+        let next_metadata = default_table_metadata_file_path(&namespace, &next_table, "00001.metadata.json");
         let failed_table_path = store.paths.table_entry_path(bucket, &namespace, &failed_table);
 
         store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
@@ -14201,13 +15876,13 @@ mod tests {
             .unwrap();
         backend.fail_put_attempt(RUSTFS_META_BUCKET, &failed_table_path, 1).await;
 
-        let mut failed_entry = test_table_entry(bucket, &namespace, &failed_table, current.clone());
+        let mut failed_entry = test_table_entry(bucket, &namespace, &failed_table, failed_metadata);
         failed_entry.table_id = "failed-table-id".to_string();
         failed_entry.warehouse_location = format!("s3://{bucket}/tables/shared-table");
         let error = store.create_table(failed_entry).await.unwrap_err();
         assert!(matches!(error, TableCatalogStoreError::Internal(_)));
 
-        let mut next_entry = test_table_entry(bucket, &namespace, &next_table, current);
+        let mut next_entry = test_table_entry(bucket, &namespace, &next_table, next_metadata);
         next_entry.table_id = "next-table-id".to_string();
         next_entry.warehouse_location = format!("s3://{bucket}/tables/shared-table");
         store
@@ -14403,6 +16078,7 @@ mod tests {
                 expected_version_token: "token-v1".to_string(),
                 expected_metadata_location: current,
                 new_metadata_location: next,
+                new_metadata_sha256: None,
             })
             .await
             .expect("view metadata location should not inherit table index depth limits");
@@ -14439,8 +16115,14 @@ mod tests {
             )
             .await
             .unwrap();
+        let valid_entry = test_table_entry(bucket, &namespace, &valid_table, current);
         store
-            .create_table(test_table_entry(bucket, &namespace, &valid_table, current))
+            .write_entry(
+                store.catalog_bucket(),
+                &store.paths.table_entry_path(bucket, &namespace, &valid_table),
+                &valid_entry,
+                TableCatalogPutPrecondition::IfAbsent,
+            )
             .await
             .unwrap();
 
@@ -14472,7 +16154,7 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         backend
             .seed_object_with_mod_time(bucket, &fresh, b"{}".to_vec(), Some(OffsetDateTime::now_utc()))
@@ -14523,6 +16205,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [
                         {
                             "timestamp-ms": 1,
@@ -14592,7 +16275,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         let mut report = store
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
@@ -14663,7 +16346,7 @@ mod tests {
             .await
             .unwrap();
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         let report = store
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
@@ -14997,7 +16680,7 @@ mod tests {
             .expect("bucket default maintenance config should persist");
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
 
         let report = store
@@ -15064,7 +16747,7 @@ mod tests {
             .expect("table maintenance override should persist");
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
 
         let report = store
@@ -15119,7 +16802,7 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         let before_worker_run = backend.write_lock_acquisition_count(RUSTFS_META_BUCKET, &table_path).await;
 
@@ -15155,7 +16838,7 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15201,7 +16884,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15241,7 +16924,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
 
         let report = store
@@ -15278,7 +16961,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15327,7 +17010,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
 
         let result = store
@@ -15368,7 +17051,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15418,7 +17101,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15500,6 +17183,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [],
                     "snapshots": [
                         {
@@ -15582,7 +17266,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15648,7 +17332,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15705,7 +17389,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -15981,7 +17665,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -16040,7 +17724,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         let mut running = store
             .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
@@ -16091,7 +17775,7 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -16150,7 +17834,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -16209,7 +17893,7 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         store
             .put_table_maintenance_config(
@@ -16293,7 +17977,7 @@ mod tests {
             .seed_object(
                 bucket,
                 &default_table_metadata_file_path(&namespace, &table, "00002.metadata.json"),
-                br#"{"metadata-log":[]}"#.to_vec(),
+                br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec(),
             )
             .await;
         let mut running = store
@@ -16349,6 +18033,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [],
                     "schemas": [],
                     "partition-specs": [],
@@ -16440,6 +18125,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [],
                     "snapshots": [
                         {
@@ -16508,7 +18194,7 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &manifest, manifest_avro_bytes(&[(&data_file, 0)]))
+            .seed_object(bucket, &manifest, manifest_v1_avro_bytes(&[&data_file]))
             .await;
         backend.seed_object(bucket, &data_file, b"data".to_vec()).await;
         backend
@@ -16516,6 +18202,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [],
                     "snapshots": [
                         {
@@ -16581,6 +18268,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [],
                     "snapshots": [
                         {
@@ -16618,6 +18306,121 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maintenance_reachability_resolves_relative_table_references() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let manifest_list = "tables/table-id/metadata/snap-10.avro".to_string();
+        let manifest = "tables/table-id/metadata/manifest-10.avro".to_string();
+        let data_file = "tables/table-id/data/part-00001.parquet".to_string();
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend
+            .seed_object(bucket, &manifest_list, manifest_list_avro_bytes(&["metadata/manifest-10.avro"]))
+            .await;
+        backend
+            .seed_object(bucket, &manifest, manifest_avro_bytes(&[("data/part-00001.parquet", 0)]))
+            .await;
+        backend.seed_object(bucket, &data_file, b"data".to_vec()).await;
+        backend
+            .seed_object(
+                bucket,
+                &current,
+                serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
+                    "format-version": 4,
+                    "metadata-log": [],
+                    "current-snapshot-id": 10,
+                    "snapshots": [
+                        {
+                            "snapshot-id": 10,
+                            "manifest-list": "metadata/snap-10.avro"
+                        }
+                    ]
+                }))
+                .expect("metadata should serialize"),
+            )
+            .await;
+
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("relative references should be resolved against the table warehouse");
+
+        assert_eq!(report.reachability_graph.status, TableMaintenanceReachabilityGraphStatus::Complete);
+        for location in [&manifest_list, &manifest, &data_file] {
+            assert!(report.referenced_object_reports.iter().any(|object| {
+                object.object_location == *location && object.state == TableMetadataMaintenanceObjectState::Retained
+            }));
+        }
+    }
+
+    #[test]
+    fn manifest_reader_rejects_unknown_data_file_content() {
+        let manifest = manifest_avro_bytes(&[("data/part-00001.parquet", 3)]);
+        let error = data_file_references_from_manifest_avro(&manifest).expect_err("unknown manifest content must fail closed");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Invalid(message)
+                if message.contains("unsupported content value 3")
+        );
+    }
+
+    #[test]
+    fn manifest_reader_rejects_non_int_data_file_content() {
+        let schema = apache_avro::Schema::parse_str(
+            r#"
+            {
+              "type": "record",
+              "name": "manifest_entry_with_invalid_content",
+              "fields": [
+                {"name": "status", "type": "int"},
+                {
+                  "name": "data_file",
+                  "type": {
+                    "type": "record",
+                    "name": "data_file_with_invalid_content",
+                    "fields": [
+                      {"name": "content", "type": "long"},
+                      {"name": "file_path", "type": "string"}
+                    ]
+                  }
+                }
+              ]
+            }
+            "#,
+        )
+        .expect("manifest schema should parse");
+        let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+        writer
+            .append(apache_avro::types::Value::Record(vec![
+                ("status".to_string(), apache_avro::types::Value::Int(1)),
+                (
+                    "data_file".to_string(),
+                    apache_avro::types::Value::Record(vec![
+                        ("content".to_string(), apache_avro::types::Value::Long(0)),
+                        (
+                            "file_path".to_string(),
+                            apache_avro::types::Value::String("data/part-00001.parquet".to_string()),
+                        ),
+                    ]),
+                ),
+            ]))
+            .expect("manifest record should append");
+        let manifest = writer.into_inner().expect("manifest avro bytes should flush");
+
+        let error = data_file_references_from_manifest_avro(&manifest).expect_err("non-int manifest content must fail closed");
+
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Invalid(message) if message.contains("content must be an int")
+        );
+    }
+
+    #[tokio::test]
     async fn maintenance_reachability_fails_closed_when_retained_metadata_is_unreadable() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -16636,6 +18439,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [
                         {
                             "timestamp-ms": 1,
@@ -16674,6 +18478,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maintenance_reachability_fails_closed_when_current_snapshot_has_no_manifests() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let orphan_data = format!("{}/orphan.parquet", default_table_data_dir_path(&namespace, &table));
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend.seed_object(bucket, &orphan_data, b"orphan".to_vec()).await;
+        backend
+            .seed_object(
+                bucket,
+                &current,
+                serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
+                    "metadata-log": [],
+                    "current-snapshot-id": 10,
+                    "snapshots": [
+                        {
+                            "snapshot-id": 10
+                        }
+                    ]
+                }))
+                .expect("metadata should serialize"),
+            )
+            .await;
+
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("metadata maintenance dry-run should succeed");
+
+        assert_eq!(
+            report.reachability_graph.status,
+            TableMaintenanceReachabilityGraphStatus::ManualReviewRequired
+        );
+        assert!(report.cleanup_object_candidate_locations.is_empty());
+        assert!(report.deletable_object_locations.is_empty());
+        assert!(report.referenced_object_reports.iter().any(|object| {
+            object.state == TableMetadataMaintenanceObjectState::ManualReviewRequired
+                && object.reasons.contains(&TableMetadataMaintenanceReason::UnreadableMetadata)
+        }));
+        assert!(
+            backend
+                .object_exists(bucket, &orphan_data)
+                .await
+                .expect("orphan lookup should succeed")
+        );
+    }
+
+    #[tokio::test]
     async fn maintenance_dry_run_reports_unreachable_manifest_data_and_delete_candidates() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -16706,6 +18563,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [],
                     "snapshots": [
                         {
@@ -16783,6 +18641,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [],
                     "snapshots": [
                         {
@@ -16838,6 +18697,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [
                         {
                             "timestamp-ms": 1,
@@ -16898,6 +18758,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "current-snapshot-id": 30,
                     "metadata-log": [],
                     "refs": {
@@ -18074,7 +19935,7 @@ mod tests {
             backend.seed_object(bucket, metadata, b"{}".to_vec()).await;
         }
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         backend.seed_object(bucket, &manifest, b"manifest".to_vec()).await;
 
@@ -18109,6 +19970,7 @@ mod tests {
                 bucket,
                 &current,
                 serde_json::to_vec(&serde_json::json!({
+                    "table-uuid": "table-uuid",
                     "metadata-log": [
                         {
                             "timestamp-ms": 1,
@@ -18154,10 +20016,15 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         backend
-            .seed_object_with_mod_time(bucket, &fresh, br#"{"metadata-log":[]}"#.to_vec(), Some(OffsetDateTime::now_utc()))
+            .seed_object_with_mod_time(
+                bucket,
+                &fresh,
+                br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec(),
+                Some(OffsetDateTime::now_utc()),
+            )
             .await;
 
         let report = store
@@ -18184,7 +20051,7 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         backend
             .seed_object_with_mod_time(bucket, &fresh, b"{}".to_vec(), Some(OffsetDateTime::now_utc()))
@@ -18221,6 +20088,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maintenance_delete_preserves_candidates_replaced_before_lock_acquisition() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let first = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let second = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let current = default_table_metadata_file_path(&namespace, &table, "00003.metadata.json");
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend.seed_object(bucket, &first, b"first".to_vec()).await;
+        backend.seed_object(bucket, &second, b"second".to_vec()).await;
+        backend
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .expect("maintenance report should be planned");
+        backend
+            .replace_on_write_lock_acquisition(bucket, &first, 1, b"new-etag".to_vec(), false, true)
+            .await;
+        backend
+            .replace_on_write_lock_acquisition(bucket, &second, 1, b"new-mod-time".to_vec(), true, false)
+            .await;
+
+        let deleted = store
+            .delete_table_metadata_maintenance_report(bucket, "sales", "orders", report)
+            .await
+            .expect("replaced cleanup candidates should be skipped");
+
+        assert_eq!(deleted.job.status, TableMetadataMaintenanceJobStatus::Successful);
+        assert_eq!(deleted.job.deleted_metadata_file_count, 0);
+        assert!(deleted.cleanup_candidate_locations.is_empty());
+        assert_eq!(
+            backend
+                .read_object(bucket, &first)
+                .await
+                .expect("first replacement lookup should succeed")
+                .expect("first replacement should remain")
+                .data,
+            b"new-etag"
+        );
+        assert_eq!(
+            backend
+                .read_object(bucket, &second)
+                .await
+                .expect("second replacement lookup should succeed")
+                .expect("second replacement should remain")
+                .data,
+            b"new-mod-time"
+        );
+    }
+
+    #[tokio::test]
     async fn maintenance_delete_conflicts_when_current_pointer_changes_before_delete() {
         let backend = TestCatalogObjectBackend::default();
         let store = ObjectTableCatalogStore::new(backend.clone());
@@ -18234,7 +20157,7 @@ mod tests {
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend.seed_object(bucket, &old, b"{}".to_vec()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
 
         let report = store
@@ -18243,7 +20166,9 @@ mod tests {
             .unwrap();
         assert_eq!(report.cleanup_candidate_locations, vec![old.clone()]);
 
-        backend.seed_object(bucket, &next, br#"{"metadata-log":[]}"#.to_vec()).await;
+        backend
+            .seed_object(bucket, &next, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
         store
             .commit_table(TableCommitRequest {
                 table_bucket: bucket.to_string(),
@@ -18268,6 +20193,61 @@ mod tests {
 
         assert_matches!(err, TableCatalogStoreError::Conflict(_));
         assert!(backend.object_exists(bucket, &old).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn maintenance_delete_rejects_candidate_reassigned_to_nested_table_warehouse() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ObjectTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").unwrap();
+        let table = IdentifierSegment::parse("orders").unwrap();
+        let child_table = IdentifierSegment::parse("orders_child").unwrap();
+        let current = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+        let child_metadata = default_table_metadata_file_path(&namespace, &child_table, "00001.metadata.json");
+        let reassigned_object = "tables/table-id/data/child/data/part-00001.parquet";
+
+        seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
+        backend
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
+            .await;
+        backend.seed_object(bucket, reassigned_object, b"data".to_vec()).await;
+
+        let report = store
+            .plan_table_metadata_maintenance(bucket, "sales", "orders", 0)
+            .await
+            .unwrap();
+        assert!(report.deletable_object_locations.contains(&reassigned_object.to_string()));
+
+        let mut child = test_table_entry(bucket, &namespace, &child_table, child_metadata);
+        child.table_id = "child-table-id".to_string();
+        child.table_uuid = "child-table-uuid".to_string();
+        child.warehouse_location = format!("s3://{bucket}/tables/table-id/data/child");
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store.paths.table_entry_path(bucket, &namespace, &child_table),
+                serde_json::to_vec(&child).unwrap(),
+            )
+            .await;
+        let child_index = table_warehouse_index_entry(&child).unwrap();
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store
+                    .paths
+                    .warehouse_index_entry_path(bucket, &child_index.warehouse_object_prefix),
+                serde_json::to_vec(&child_index).unwrap(),
+            )
+            .await;
+
+        let err = store
+            .delete_table_metadata_maintenance_report(bucket, "sales", "orders", report)
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, TableCatalogStoreError::Conflict(_));
+        assert!(backend.object_exists(bucket, reassigned_object).await.unwrap());
     }
 
     #[tokio::test]
@@ -18464,7 +20444,7 @@ mod tests {
                 .load_table(bucket, &namespace.public_name(), table.as_str())
                 .await
                 .unwrap()
-                .is_some()
+                .is_none()
         );
 
         let error = object_store
@@ -18512,7 +20492,7 @@ mod tests {
                 .load_view(bucket, &namespace.public_name(), view.as_str())
                 .await
                 .unwrap()
-                .is_some()
+                .is_none()
         );
 
         let error = object_store
@@ -19258,6 +21238,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn strong_catalog_drop_removes_commit_indexes_before_restart() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let new_metadata = default_table_metadata_file_path(&namespace, &table, "00002.metadata.json");
+
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be created");
+        store
+            .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
+            .await
+            .expect("table should be created");
+        backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
+        store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: namespace.public_name(),
+                table: table.as_str().to_string(),
+                commit_id: "commit-1".to_string(),
+                idempotency_key: Some("client-request".to_string()),
+                operation: "append".to_string(),
+                expected_version_token: "token-v1".to_string(),
+                expected_metadata_location: current_metadata,
+                new_metadata_location: new_metadata,
+                requirements: Vec::new(),
+                writer: Some("pyiceberg/test".to_string()),
+            })
+            .await
+            .expect("commit should succeed");
+
+        store
+            .drop_table(bucket, &namespace.public_name(), table.as_str())
+            .await
+            .expect("table should be dropped");
+
+        let restarted = StrongTableCatalogStore::new(backend);
+        assert!(
+            restarted
+                .load_table(bucket, &namespace.public_name(), table.as_str())
+                .await
+                .expect("snapshot should hydrate after table drop")
+                .is_none()
+        );
+        assert!(
+            restarted
+                .get_commit_by_id(bucket, "table-id", "commit-1")
+                .await
+                .expect("commit lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            restarted
+                .get_commit_by_idempotency_key(bucket, "table-id", "client-request")
+                .await
+                .expect("idempotency lookup should succeed")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
     async fn strong_catalog_backing_rejects_stale_snapshot_cas_after_concurrent_restart() {
         let backend = TestCatalogObjectBackend::default();
         let store = StrongTableCatalogStore::new(backend.clone());
@@ -19404,6 +21453,50 @@ mod tests {
             .expect("table should still exist");
         assert_eq!(loaded_after_commit.metadata_location, result.table.metadata_location);
         assert_eq!(loaded_after_commit.version_token, result.table.version_token);
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_backing_does_not_install_stale_concurrent_reload() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let snapshot_path = StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path();
+
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+
+        let pause = backend.pause_next_read(RUSTFS_META_BUCKET, &snapshot_path).await;
+        let stale_store = store.clone();
+        let stale_reload = tokio::spawn(async move { stale_store.reload_state_from_durable().await });
+        pause.wait_started().await;
+
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be durably created while stale reload is paused");
+
+        pause.release();
+        stale_reload
+            .await
+            .expect("stale reload task should join")
+            .expect("stale reload should retry against the current snapshot");
+
+        assert!(
+            store
+                .get_namespace(bucket, "sales")
+                .await
+                .expect("namespace lookup should succeed")
+                .is_some()
+        );
+        let durable = backend
+            .read_object(RUSTFS_META_BUCKET, &snapshot_path)
+            .await
+            .expect("durable snapshot read should succeed")
+            .expect("durable snapshot should exist");
+        assert_eq!(store.state.lock().await.snapshot_etag, durable.etag);
     }
 
     #[tokio::test]
@@ -19578,6 +21671,448 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn strong_catalog_backing_hydrates_legacy_nested_warehouse_prefixes() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let parent = IdentifierSegment::parse("orders").expect("table should parse");
+        let child = IdentifierSegment::parse("orders_child").expect("table should parse");
+        let parent_entry = test_table_entry(
+            bucket,
+            &namespace,
+            &parent,
+            default_table_metadata_file_path(&namespace, &parent, "00001.metadata.json"),
+        );
+        let mut child_entry = test_table_entry(
+            bucket,
+            &namespace,
+            &child,
+            default_table_metadata_file_path(&namespace, &child, "00001.metadata.json"),
+        );
+        child_entry.table_id = "child-table-id".to_string();
+        child_entry.table_uuid = "child-table-uuid".to_string();
+        child_entry.warehouse_location = format!("s3://{bucket}/tables/table-id/child");
+        let snapshot = StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces: vec![test_namespace_entry(bucket, &namespace)],
+            tables: vec![parent_entry, child_entry],
+            views: Vec::new(),
+            commits: Vec::new(),
+            idempotency: Vec::new(),
+        };
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path(),
+                serde_json::to_vec(&snapshot).expect("strong snapshot should encode"),
+            )
+            .await;
+
+        store
+            .get_table_bucket(bucket)
+            .await
+            .expect("legacy nested warehouse prefixes should hydrate")
+            .expect("table bucket should exist");
+        let resource = store
+            .resolve_table_data_plane_resource(bucket, "tables/table-id/child/data/part.parquet")
+            .await
+            .expect("nested resource should resolve")
+            .expect("nested resource should have an owner");
+        assert_eq!(resource.table, child.as_str());
+    }
+
+    #[test]
+    fn strong_catalog_snapshot_rejects_duplicate_or_invalid_metadata_roots() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let orders = IdentifierSegment::parse("orders").expect("table should parse");
+        let returns = IdentifierSegment::parse("returns").expect("table should parse");
+        let metadata_location = default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json");
+        let orders_entry = test_table_entry(bucket, &namespace, &orders, metadata_location.clone());
+        let mut returns_entry = test_table_entry(bucket, &namespace, &returns, metadata_location);
+        returns_entry.table_id = "table-id-2".to_string();
+        returns_entry.table_uuid = "table-uuid-2".to_string();
+        returns_entry.warehouse_location = "s3://analytics/tables/table-id-2".to_string();
+        let snapshot = |tables| StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces: vec![test_namespace_entry(bucket, &namespace)],
+            tables,
+            views: Vec::new(),
+            commits: Vec::new(),
+            idempotency: Vec::new(),
+        };
+
+        let Err(duplicate) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(vec![orders_entry.clone(), returns_entry]),
+            None,
+        ) else {
+            panic!("duplicate metadata root should fail closed");
+        };
+        assert_matches!(duplicate, TableCatalogStoreError::Invalid(message) if message.contains("duplicate active table metadata root"));
+
+        let mut invalid_entry = orders_entry;
+        invalid_entry.metadata_location = "tables/table-id/data/part.parquet".to_string();
+        let Err(invalid) =
+            StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(snapshot(vec![invalid_entry]), None)
+        else {
+            panic!("metadata pointer outside a protected metadata directory should fail closed");
+        };
+        assert_matches!(invalid, TableCatalogStoreError::Invalid(message) if message.contains("protected"));
+
+        let orphan = test_table_entry(
+            bucket,
+            &namespace,
+            &orders,
+            default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json"),
+        );
+        let orphan_snapshot = StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces: Vec::new(),
+            tables: vec![orphan],
+            views: Vec::new(),
+            commits: Vec::new(),
+            idempotency: Vec::new(),
+        };
+        let Err(orphan) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(orphan_snapshot, None) else {
+            panic!("active table without an active namespace should fail closed");
+        };
+        assert_matches!(orphan, TableCatalogStoreError::Invalid(message) if message.contains("no active namespace"));
+
+        let view = IdentifierSegment::parse("summary").expect("view should parse");
+        let view_entry = test_view_entry(
+            bucket,
+            &namespace,
+            &view,
+            default_view_metadata_file_path(&namespace, &view, "00001.metadata.json"),
+        );
+        let view_snapshot = |namespaces, views| StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces,
+            tables: Vec::new(),
+            views,
+            commits: Vec::new(),
+            idempotency: Vec::new(),
+        };
+        let Err(orphan_view) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            view_snapshot(Vec::new(), vec![view_entry.clone()]),
+            None,
+        ) else {
+            panic!("active view without an active namespace should fail closed");
+        };
+        assert_matches!(orphan_view, TableCatalogStoreError::Invalid(message) if message.contains("no active namespace"));
+
+        let mut invalid_view = view_entry;
+        invalid_view.metadata_location = default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json");
+        let Err(invalid_view) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            view_snapshot(vec![test_namespace_entry(bucket, &namespace)], vec![invalid_view]),
+            None,
+        ) else {
+            panic!("active view with an invalid metadata location should fail closed");
+        };
+        assert_matches!(invalid_view, TableCatalogStoreError::Invalid(message) if message.contains("invalid metadata location"));
+    }
+
+    #[test]
+    fn strong_catalog_snapshot_rejects_duplicate_catalog_keys() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let orders = IdentifierSegment::parse("orders").expect("table should parse");
+        let returns = IdentifierSegment::parse("returns").expect("table should parse");
+        let view = IdentifierSegment::parse("summary").expect("view should parse");
+        let orders_entry = test_table_entry(
+            bucket,
+            &namespace,
+            &orders,
+            default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json"),
+        );
+        let mut returns_entry = test_table_entry(
+            bucket,
+            &namespace,
+            &returns,
+            default_table_metadata_file_path(&namespace, &returns, "00001.metadata.json"),
+        );
+        returns_entry.table_id = "table-id-2".to_string();
+        returns_entry.table_uuid = "table-uuid-2".to_string();
+        returns_entry.warehouse_location = "s3://analytics/tables/table-id-2".to_string();
+        let view_entry = test_view_entry(
+            bucket,
+            &namespace,
+            &view,
+            default_view_metadata_file_path(&namespace, &view, "00001.metadata.json"),
+        );
+        let snapshot = |table_buckets, namespaces, tables, views| StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets,
+            namespaces,
+            tables,
+            views,
+            commits: Vec::new(),
+            idempotency: Vec::new(),
+        };
+
+        let table_bucket = test_bucket_entry(bucket);
+        let Err(duplicate_bucket) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![table_bucket.clone(), table_bucket],
+                vec![test_namespace_entry(bucket, &namespace)],
+                Vec::new(),
+                Vec::new(),
+            ),
+            None,
+        ) else {
+            panic!("duplicate table bucket should fail closed");
+        };
+        assert_matches!(
+            duplicate_bucket,
+            TableCatalogStoreError::Invalid(message) if message.contains("duplicate table bucket")
+        );
+
+        let namespace_entry = test_namespace_entry(bucket, &namespace);
+        let Err(duplicate_namespace) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![test_bucket_entry(bucket)],
+                vec![namespace_entry.clone(), namespace_entry],
+                Vec::new(),
+                Vec::new(),
+            ),
+            None,
+        ) else {
+            panic!("duplicate namespace should fail closed");
+        };
+        assert_matches!(
+            duplicate_namespace,
+            TableCatalogStoreError::Invalid(message) if message.contains("duplicate namespace")
+        );
+
+        let mut duplicate_table_id = returns_entry.clone();
+        duplicate_table_id.table_id = orders_entry.table_id.clone();
+        let Err(duplicate_table_id) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![test_bucket_entry(bucket)],
+                vec![test_namespace_entry(bucket, &namespace)],
+                vec![orders_entry.clone(), duplicate_table_id],
+                Vec::new(),
+            ),
+            None,
+        ) else {
+            panic!("duplicate table id should fail closed");
+        };
+        assert_matches!(
+            duplicate_table_id,
+            TableCatalogStoreError::Invalid(message) if message.contains("duplicate table ids")
+        );
+
+        let mut duplicate_table_identifier = orders_entry.clone();
+        duplicate_table_identifier.table_id = "table-id-3".to_string();
+        duplicate_table_identifier.table_uuid = "table-uuid-3".to_string();
+        duplicate_table_identifier.warehouse_location = "s3://analytics/tables/table-id-3".to_string();
+        let Err(duplicate_table_identifier) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![test_bucket_entry(bucket)],
+                vec![test_namespace_entry(bucket, &namespace)],
+                vec![orders_entry, duplicate_table_identifier],
+                Vec::new(),
+            ),
+            None,
+        ) else {
+            panic!("duplicate table identifier should fail closed");
+        };
+        assert_matches!(
+            duplicate_table_identifier,
+            TableCatalogStoreError::Invalid(message) if message.contains("duplicate table identifiers")
+        );
+
+        let mut duplicate_view_identifier = view_entry.clone();
+        duplicate_view_identifier.view_id = "view-id-2".to_string();
+        duplicate_view_identifier.view_uuid = "view-uuid-2".to_string();
+        duplicate_view_identifier.warehouse_location = "s3://analytics/views/view-id-2".to_string();
+        let Err(duplicate_view_identifier) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![test_bucket_entry(bucket)],
+                vec![test_namespace_entry(bucket, &namespace)],
+                vec![returns_entry],
+                vec![view_entry, duplicate_view_identifier],
+            ),
+            None,
+        ) else {
+            panic!("duplicate view identifier should fail closed");
+        };
+        assert_matches!(
+            duplicate_view_identifier,
+            TableCatalogStoreError::Invalid(message) if message.contains("duplicate view identifiers")
+        );
+    }
+
+    #[test]
+    fn strong_catalog_snapshot_rejects_mismatched_commit_indexes() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let table_entry = test_table_entry(
+            bucket,
+            &namespace,
+            &table,
+            default_table_metadata_file_path(&namespace, &table, "00001.metadata.json"),
+        );
+        let commit = CommitLogEntry {
+            version: TABLE_CATALOG_ENTRY_VERSION,
+            commit_id: "commit-1".to_string(),
+            idempotency_key: Some("request-1".to_string()),
+            table_id: table_entry.table_id.clone(),
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            new_version_token: "token-v2".to_string(),
+            previous_metadata_location: table_entry.metadata_location.clone(),
+            new_metadata_location: default_table_metadata_file_path(&namespace, &table, "00002.metadata.json"),
+            requirements: Vec::new(),
+            status: CommitLogStatus::Committed,
+            writer: Some("pyiceberg/test".to_string()),
+            created_at: None,
+            updated_at: None,
+        };
+        let record = |lookup_key: &str, commit: CommitLogEntry| StrongCommitSnapshotRecord {
+            table_bucket: bucket.to_string(),
+            table_id: table_entry.table_id.clone(),
+            lookup_key: lookup_key.to_string(),
+            commit,
+        };
+        let snapshot = |commits, idempotency| StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces: vec![test_namespace_entry(bucket, &namespace)],
+            tables: vec![table_entry.clone()],
+            views: Vec::new(),
+            commits,
+            idempotency,
+        };
+
+        let Err(mismatched_commit) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(vec![record("different-commit", commit.clone())], Vec::new()),
+            None,
+        ) else {
+            panic!("commit lookup key mismatch should fail closed");
+        };
+        assert_matches!(
+            mismatched_commit,
+            TableCatalogStoreError::Invalid(message) if message.contains("does not match its snapshot owner")
+        );
+
+        let Err(missing_idempotency) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(vec![record("commit-1", commit.clone())], Vec::new()),
+            None,
+        ) else {
+            panic!("commit without its idempotency index should fail closed");
+        };
+        assert_matches!(
+            missing_idempotency,
+            TableCatalogStoreError::Invalid(message) if message.contains("has no matching idempotency index")
+        );
+
+        let Err(duplicate_commit) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(vec![record("commit-1", commit.clone()), record("commit-1", commit.clone())], Vec::new()),
+            None,
+        ) else {
+            panic!("duplicate commit lookup key should fail closed");
+        };
+        assert_matches!(
+            duplicate_commit,
+            TableCatalogStoreError::Invalid(message) if message.contains("duplicate commit lookup keys")
+        );
+
+        let Err(mismatched_idempotency) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![record("commit-1", commit.clone())],
+                vec![record("different-request", commit.clone())],
+            ),
+            None,
+        ) else {
+            panic!("idempotency lookup key mismatch should fail closed");
+        };
+        assert_matches!(
+            mismatched_idempotency,
+            TableCatalogStoreError::Invalid(message) if message.contains("does not match its snapshot owner")
+        );
+
+        let mut mismatched_commit_payload = commit.clone();
+        mismatched_commit_payload.new_version_token = "token-v3".to_string();
+        let Err(mismatched_idempotency_commit) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![record("commit-1", commit.clone())],
+                vec![record("request-1", mismatched_commit_payload)],
+            ),
+            None,
+        ) else {
+            panic!("idempotency payload mismatch should fail closed");
+        };
+        assert_matches!(
+            mismatched_idempotency_commit,
+            TableCatalogStoreError::Invalid(message) if message.contains("has no matching commit")
+        );
+
+        let Err(duplicate_idempotency) = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(
+            snapshot(
+                vec![record("commit-1", commit.clone())],
+                vec![record("request-1", commit.clone()), record("request-1", commit)],
+            ),
+            None,
+        ) else {
+            panic!("duplicate idempotency lookup key should fail closed");
+        };
+        assert_matches!(
+            duplicate_idempotency,
+            TableCatalogStoreError::Invalid(message) if message.contains("duplicate idempotency lookup keys")
+        );
+    }
+
+    #[test]
+    fn strong_catalog_snapshot_discards_legacy_dropped_table_commit_indexes() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let commit = CommitLogEntry {
+            version: TABLE_CATALOG_ENTRY_VERSION,
+            commit_id: "commit-1".to_string(),
+            idempotency_key: Some("request-1".to_string()),
+            table_id: "dropped-table-id".to_string(),
+            operation: "append".to_string(),
+            expected_version_token: "token-v1".to_string(),
+            new_version_token: "token-v2".to_string(),
+            previous_metadata_location: "tables/dropped-table-id/metadata/00001.metadata.json".to_string(),
+            new_metadata_location: "tables/dropped-table-id/metadata/00002.metadata.json".to_string(),
+            requirements: Vec::new(),
+            status: CommitLogStatus::Committed,
+            writer: Some("pyiceberg/test".to_string()),
+            created_at: None,
+            updated_at: None,
+        };
+        let record = |lookup_key: &str, commit: CommitLogEntry| StrongCommitSnapshotRecord {
+            table_bucket: bucket.to_string(),
+            table_id: "dropped-table-id".to_string(),
+            lookup_key: lookup_key.to_string(),
+            commit,
+        };
+        let snapshot = StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces: vec![test_namespace_entry(bucket, &namespace)],
+            tables: Vec::new(),
+            views: Vec::new(),
+            commits: vec![record("commit-1", commit.clone())],
+            idempotency: vec![record("request-1", commit)],
+        };
+
+        let state = StrongTableCatalogStore::<TestCatalogObjectBackend>::state_from_snapshot(snapshot, None)
+            .expect("legacy dropped-table commit indexes should not make the catalog unreadable");
+
+        assert!(state.commits.is_empty());
+        assert!(state.idempotency.is_empty());
+    }
+
+    #[tokio::test]
     async fn strong_catalog_backing_does_not_publish_draft_when_persist_and_reload_fail() {
         let backend = TestCatalogObjectBackend::default();
         let store = StrongTableCatalogStore::new(backend.clone());
@@ -19613,6 +22148,43 @@ mod tests {
                 .expect("durable state should reload after transient failure")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_materialization_reloads_etag_after_transient_reload_failure() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let snapshot_path = StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path();
+        assert!(
+            store
+                .get_table_bucket(bucket)
+                .await
+                .expect("empty durable snapshot should hydrate")
+                .is_none()
+        );
+        backend.fail_next_read(RUSTFS_META_BUCKET, &snapshot_path).await;
+
+        let (snapshot_etag, created) = store
+            .materialize_bucket_snapshot(StrongTableCatalogBucketSnapshot {
+                table_bucket: test_bucket_entry(bucket),
+                namespaces: Vec::new(),
+                tables: Vec::new(),
+                views: Vec::new(),
+                commits: Vec::new(),
+                idempotency: Vec::new(),
+            })
+            .await
+            .expect("materialization should recover the committed snapshot etag");
+
+        assert!(created);
+        let durable = backend
+            .read_object(RUSTFS_META_BUCKET, &snapshot_path)
+            .await
+            .expect("durable snapshot read should succeed")
+            .expect("durable snapshot should exist");
+        assert_eq!(snapshot_etag, durable.etag.expect("durable snapshot should have an etag"));
+        assert!(store.state.lock().await.hydrated);
     }
 
     #[tokio::test]
@@ -19696,10 +22268,28 @@ mod tests {
         assert!(store.load_table(bucket, "sales", "orders").await.unwrap().is_none());
     }
 
+    #[test]
+    fn table_warehouse_location_rejects_reserved_catalog_prefix_only() {
+        assert_matches!(
+            validate_table_warehouse_location("analytics", "s3://analytics/.rustfs-table/warehouse"),
+            Err(TableCatalogStoreError::Invalid(_))
+        );
+        validate_table_warehouse_location("analytics", "s3://analytics/.rustfs-table-other/warehouse")
+            .expect("a non-reserved lookalike prefix should remain valid");
+    }
+
+    #[test]
+    fn table_warehouse_location_rejects_iam_wildcards() {
+        for location in ["s3://analytics/tables/*/warehouse", "s3://analytics/tables/?/warehouse"] {
+            assert_matches!(
+                validate_table_warehouse_location("analytics", location),
+                Err(TableCatalogStoreError::Invalid(message)) if message.contains("IAM wildcard")
+            );
+        }
+    }
+
     #[tokio::test]
-    async fn strong_catalog_backing_rejects_duplicate_table_warehouse_location_on_register() {
-        let backend = TestCatalogObjectBackend::default();
-        let store = StrongTableCatalogStore::new(backend);
+    async fn catalog_backings_reject_overlapping_table_warehouse_location_on_register() {
         let bucket = "analytics";
         let namespace = Namespace::parse("sales").unwrap();
         let orders = IdentifierSegment::parse("orders").unwrap();
@@ -19707,30 +22297,178 @@ mod tests {
         let orders_metadata = default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json");
         let customers_metadata = default_table_metadata_file_path(&namespace, &customers, "00001.metadata.json");
 
-        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
-        store
-            .create_namespace(test_namespace_entry(bucket, &namespace))
-            .await
-            .unwrap();
-        store
-            .create_table(test_table_entry(bucket, &namespace, &orders, orders_metadata))
-            .await
-            .unwrap();
-        let mut duplicate = test_table_entry(bucket, &namespace, &customers, customers_metadata);
-        duplicate.table_id = "table-id-2".to_string();
-        duplicate.table_uuid = "table-uuid-2".to_string();
-        duplicate.warehouse_location = format!("s3://{bucket}/tables/table-id");
+        for mode in [TableCatalogBackingMode::ObjectBacked, TableCatalogBackingMode::DurableStrong] {
+            let store = ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), mode);
+            store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .unwrap();
+            store
+                .create_table(test_table_entry(bucket, &namespace, &orders, orders_metadata.clone()))
+                .await
+                .unwrap();
+            let mut overlapping = test_table_entry(bucket, &namespace, &customers, customers_metadata.clone());
+            overlapping.table_id = "table-id-2".to_string();
+            overlapping.table_uuid = "table-uuid-2".to_string();
+            overlapping.warehouse_location = format!("s3://{bucket}/tables/table-id/nested");
 
-        let err = store.register_table(duplicate).await.unwrap_err();
+            let err = store.register_table(overlapping).await.unwrap_err();
 
-        assert_matches!(err, TableCatalogStoreError::Conflict(_));
-        assert!(store.load_table(bucket, "sales", "customers").await.unwrap().is_none());
+            assert_matches!(err, TableCatalogStoreError::Conflict(_));
+            assert!(store.load_table(bucket, "sales", "customers").await.unwrap().is_none());
+        }
     }
 
     #[tokio::test]
-    async fn strong_catalog_backing_rejects_duplicate_table_warehouse_location_on_commit_relocation() {
-        let backend = TestCatalogObjectBackend::default();
-        let store = StrongTableCatalogStore::new(backend.clone());
+    async fn catalog_backings_reject_duplicate_table_metadata_root_on_register() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").unwrap();
+        let orders = IdentifierSegment::parse("orders").unwrap();
+        let customers = IdentifierSegment::parse("customers").unwrap();
+        let metadata_location = default_table_metadata_file_path(&namespace, &orders, "00001.metadata.json");
+
+        for mode in [TableCatalogBackingMode::ObjectBacked, TableCatalogBackingMode::DurableStrong] {
+            let store = ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), mode);
+            store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .unwrap();
+            store
+                .create_table(test_table_entry(bucket, &namespace, &orders, metadata_location.clone()))
+                .await
+                .unwrap();
+            let mut duplicate_root = test_table_entry(bucket, &namespace, &customers, metadata_location.clone());
+            duplicate_root.table_id = "table-id-2".to_string();
+            duplicate_root.table_uuid = "table-uuid-2".to_string();
+            duplicate_root.warehouse_location = format!("s3://{bucket}/tables/table-id-2");
+
+            let err = store.register_table(duplicate_root).await.unwrap_err();
+
+            assert_matches!(err, TableCatalogStoreError::Conflict(_) | TableCatalogStoreError::Invalid(_));
+            assert!(store.load_table(bucket, "sales", "customers").await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_hide_inactive_tables_and_orphaned_object_entries() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").unwrap();
+        let table = IdentifierSegment::parse("orders").unwrap();
+        let view = IdentifierSegment::parse("summary").unwrap();
+        let metadata_location = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let view_metadata_location = default_view_metadata_file_path(&namespace, &view, "00001.metadata.json");
+
+        let object_backend = TestCatalogObjectBackend::default();
+        let object_store = ObjectTableCatalogStore::new(object_backend.clone());
+        object_store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+        object_store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .unwrap();
+        let table_entry = test_table_entry(bucket, &namespace, &table, metadata_location.clone());
+        object_store.create_table(table_entry.clone()).await.unwrap();
+        let view_entry = test_view_entry(bucket, &namespace, &view, view_metadata_location);
+        object_store.create_view(view_entry.clone()).await.unwrap();
+
+        let mut deleted_namespace = test_namespace_entry(bucket, &namespace);
+        deleted_namespace.state = TableCatalogEntryState::Deleted;
+        object_backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &object_store.paths.namespace_entry_path(bucket, &namespace),
+                serde_json::to_vec(&deleted_namespace).unwrap(),
+            )
+            .await;
+        assert!(object_store.load_table(bucket, "sales", "orders").await.unwrap().is_none());
+        assert!(object_store.load_view(bucket, "sales", "summary").await.unwrap().is_none());
+
+        object_backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &object_store.paths.namespace_entry_path(bucket, &namespace),
+                serde_json::to_vec(&test_namespace_entry(bucket, &namespace)).unwrap(),
+            )
+            .await;
+        let mut deleted_table = table_entry;
+        deleted_table.state = TableCatalogEntryState::Deleted;
+        let mut deleted_view = view_entry;
+        deleted_view.state = TableCatalogEntryState::Deleted;
+        object_backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &object_store.paths.table_entry_path(bucket, &namespace, &table),
+                serde_json::to_vec(&deleted_table).unwrap(),
+            )
+            .await;
+        object_backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &object_store.paths.view_entry_path(bucket, &namespace, &view),
+                serde_json::to_vec(&deleted_view).unwrap(),
+            )
+            .await;
+        assert!(object_store.load_table(bucket, "sales", "orders").await.unwrap().is_none());
+        assert!(object_store.load_view(bucket, "sales", "summary").await.unwrap().is_none());
+        assert!(object_store.list_tables(bucket, "sales").await.unwrap().is_empty());
+        assert!(object_store.list_views(bucket, "sales").await.unwrap().is_empty());
+
+        let strong_backend = TestCatalogObjectBackend::default();
+        let strong_store = StrongTableCatalogStore::new(strong_backend.clone());
+        let strong_snapshot = StrongTableCatalogSnapshot {
+            version: STRONG_TABLE_CATALOG_SNAPSHOT_VERSION,
+            table_buckets: vec![test_bucket_entry(bucket)],
+            namespaces: vec![test_namespace_entry(bucket, &namespace)],
+            tables: vec![deleted_table],
+            views: vec![deleted_view],
+            commits: Vec::new(),
+            idempotency: Vec::new(),
+        };
+        strong_backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path(),
+                serde_json::to_vec(&strong_snapshot).unwrap(),
+            )
+            .await;
+        assert!(strong_store.load_table(bucket, "sales", "orders").await.unwrap().is_none());
+        assert!(strong_store.load_view(bucket, "sales", "summary").await.unwrap().is_none());
+        assert!(strong_store.list_tables(bucket, "sales").await.unwrap().is_empty());
+        assert!(strong_store.list_views(bucket, "sales").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_reject_view_metadata_outside_identifier() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let view = IdentifierSegment::parse("summary").expect("view should parse");
+        let invalid_metadata = default_view_metadata_file_path(
+            &namespace,
+            &IdentifierSegment::parse("other").expect("other view should parse"),
+            "00001.metadata.json",
+        );
+
+        for mode in [TableCatalogBackingMode::ObjectBacked, TableCatalogBackingMode::DurableStrong] {
+            let store = ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), mode);
+            store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .unwrap();
+
+            let error = store
+                .create_view(test_view_entry(bucket, &namespace, &view, invalid_metadata.clone()))
+                .await
+                .expect_err("view metadata path must match the view identifier");
+
+            assert_matches!(error, TableCatalogStoreError::Invalid(_));
+            assert!(store.load_view(bucket, "sales", "summary").await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_reject_overlapping_table_warehouse_location_on_commit_relocation() {
         let bucket = "analytics";
         let namespace = Namespace::parse("sales").unwrap();
         let orders = IdentifierSegment::parse("orders").unwrap();
@@ -19739,60 +22477,136 @@ mod tests {
         let relocated_metadata = default_table_metadata_file_path(&namespace, &orders, "00002.metadata.json");
         let customers_metadata = default_table_metadata_file_path(&namespace, &customers, "00001.metadata.json");
 
-        store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
-        store
-            .create_namespace(test_namespace_entry(bucket, &namespace))
-            .await
-            .unwrap();
-        store
-            .create_table(test_table_entry(bucket, &namespace, &orders, orders_metadata.clone()))
-            .await
-            .unwrap();
-        let mut customers_entry = test_table_entry(bucket, &namespace, &customers, customers_metadata);
-        customers_entry.table_id = "table-id-2".to_string();
-        customers_entry.table_uuid = "table-uuid-2".to_string();
-        customers_entry.warehouse_location = format!("s3://{bucket}/tables/customer-id");
-        store.create_table(customers_entry).await.unwrap();
-        backend
-            .seed_object(
-                bucket,
-                &relocated_metadata,
-                serde_json::to_vec(&serde_json::json!({
-                    "location": "s3://analytics/tables/customer-id",
-                    "table-uuid": "table-uuid"
-                }))
-                .unwrap(),
-            )
-            .await;
-
-        let err = store
-            .commit_table(TableCommitRequest {
-                table_bucket: bucket.to_string(),
-                namespace: namespace.public_name(),
-                table: orders.as_str().to_string(),
-                commit_id: "commit-1".to_string(),
-                idempotency_key: Some("client-request".to_string()),
-                operation: "set-location".to_string(),
-                expected_version_token: "token-v1".to_string(),
-                expected_metadata_location: orders_metadata.clone(),
-                new_metadata_location: relocated_metadata,
-                requirements: Vec::new(),
-                writer: Some("pyiceberg/test".to_string()),
-            })
-            .await
-            .unwrap_err();
-
-        assert_matches!(err, TableCatalogStoreError::Conflict(_));
-        let loaded = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
-        assert_eq!(loaded.metadata_location, orders_metadata);
-        assert_eq!(loaded.warehouse_location, format!("s3://{bucket}/tables/table-id"));
-        assert!(
+        for mode in [TableCatalogBackingMode::ObjectBacked, TableCatalogBackingMode::DurableStrong] {
+            let backend = TestCatalogObjectBackend::default();
+            let store = ConfiguredTableCatalogStore::new(backend.clone(), mode);
+            store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
             store
-                .get_commit_by_id(bucket, "table-id", "commit-1")
+                .create_namespace(test_namespace_entry(bucket, &namespace))
                 .await
-                .unwrap()
-                .is_none()
-        );
+                .unwrap();
+            store
+                .create_table(test_table_entry(bucket, &namespace, &orders, orders_metadata.clone()))
+                .await
+                .unwrap();
+            let mut customers_entry = test_table_entry(bucket, &namespace, &customers, customers_metadata.clone());
+            customers_entry.table_id = "table-id-2".to_string();
+            customers_entry.table_uuid = "table-uuid-2".to_string();
+            customers_entry.warehouse_location = format!("s3://{bucket}/tables/customer-id");
+            store.create_table(customers_entry).await.unwrap();
+            backend
+                .seed_object(
+                    bucket,
+                    &relocated_metadata,
+                    serde_json::to_vec(&serde_json::json!({
+                        "location": "s3://analytics/tables/customer-id/nested",
+                        "table-uuid": "table-uuid"
+                    }))
+                    .unwrap(),
+                )
+                .await;
+
+            let err = store
+                .commit_table(TableCommitRequest {
+                    table_bucket: bucket.to_string(),
+                    namespace: namespace.public_name(),
+                    table: orders.as_str().to_string(),
+                    commit_id: "commit-1".to_string(),
+                    idempotency_key: Some("client-request".to_string()),
+                    operation: "set-location".to_string(),
+                    expected_version_token: "token-v1".to_string(),
+                    expected_metadata_location: orders_metadata.clone(),
+                    new_metadata_location: relocated_metadata.clone(),
+                    requirements: Vec::new(),
+                    writer: Some("pyiceberg/test".to_string()),
+                })
+                .await
+                .unwrap_err();
+
+            assert_matches!(err, TableCatalogStoreError::Conflict(_));
+            let loaded = store.load_table(bucket, "sales", "orders").await.unwrap().unwrap();
+            assert_eq!(loaded.metadata_location, orders_metadata);
+            assert_eq!(loaded.warehouse_location, format!("s3://{bucket}/tables/table-id"));
+            assert!(
+                store
+                    .get_commit_by_id(bucket, "table-id", "commit-1")
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_reject_external_table_warehouse_relocation() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let current_metadata = "tables/external/metadata/00001.metadata.json";
+        let next_metadata = "tables/external/metadata/00002.metadata.json";
+
+        for mode in [TableCatalogBackingMode::ObjectBacked, TableCatalogBackingMode::DurableStrong] {
+            let backend = TestCatalogObjectBackend::default();
+            let store = ConfiguredTableCatalogStore::new(backend.clone(), mode);
+            store
+                .put_table_bucket(test_bucket_entry(bucket))
+                .await
+                .expect("table bucket should be created");
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .expect("namespace should be created");
+            let mut entry = test_table_entry(bucket, &namespace, &table, current_metadata.to_string());
+            entry.warehouse_location = "s3://analytics/tables/external".to_string();
+            store
+                .register_table(entry)
+                .await
+                .expect("external table should be registered");
+            backend
+                .seed_object(
+                    bucket,
+                    next_metadata,
+                    serde_json::to_vec(&serde_json::json!({
+                        "location": "s3://analytics/tables/relocated",
+                        "table-uuid": "table-uuid"
+                    }))
+                    .expect("metadata should encode"),
+                )
+                .await;
+
+            let error = store
+                .commit_table(TableCommitRequest {
+                    table_bucket: bucket.to_string(),
+                    namespace: namespace.public_name(),
+                    table: table.as_str().to_string(),
+                    commit_id: "commit-1".to_string(),
+                    idempotency_key: Some("request-1".to_string()),
+                    operation: "set-location".to_string(),
+                    expected_version_token: "token-v1".to_string(),
+                    expected_metadata_location: current_metadata.to_string(),
+                    new_metadata_location: next_metadata.to_string(),
+                    requirements: Vec::new(),
+                    writer: Some("pyiceberg/test".to_string()),
+                })
+                .await
+                .expect_err("external table warehouse relocation should be rejected");
+
+            assert_matches!(error, TableCatalogStoreError::Unsupported(_));
+            let loaded = store
+                .load_table(bucket, &namespace.public_name(), table.as_str())
+                .await
+                .expect("table load should succeed")
+                .expect("table should remain registered");
+            assert_eq!(loaded.metadata_location, current_metadata);
+            assert_eq!(loaded.warehouse_location, "s3://analytics/tables/external");
+            assert!(
+                store
+                    .get_commit_by_id(bucket, "table-id", "commit-1")
+                    .await
+                    .expect("commit lookup should succeed")
+                    .is_none()
+            );
+        }
     }
 
     #[tokio::test]
@@ -19874,21 +22688,28 @@ mod tests {
     #[tokio::test]
     async fn consistency_check_reports_invalid_metadata_location() {
         let backend = TestCatalogObjectBackend::default();
-        let store = ObjectTableCatalogStore::new(backend);
+        let store = ObjectTableCatalogStore::new(backend.clone());
         let bucket = "analytics";
         let namespace = Namespace::parse("sales").unwrap();
         let table = IdentifierSegment::parse("orders").unwrap();
-        let invalid_metadata = ".rustfs-table/warehouses/default/namespaces/sales/tables/other/metadata/00001.metadata.json";
+        let valid_metadata = default_table_metadata_file_path(&namespace, &table, "00001.metadata.json");
+        let invalid_metadata = "outside/00001.metadata.json";
 
         store.put_table_bucket(test_bucket_entry(bucket)).await.unwrap();
         store
             .create_namespace(test_namespace_entry(bucket, &namespace))
             .await
             .unwrap();
-        store
-            .create_table(test_table_entry(bucket, &namespace, &table, invalid_metadata.to_string()))
-            .await
-            .unwrap();
+        let mut corrupted_entry = test_table_entry(bucket, &namespace, &table, valid_metadata);
+        store.create_table(corrupted_entry.clone()).await.unwrap();
+        corrupted_entry.metadata_location = invalid_metadata.to_string();
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &store.paths.table_entry_path(bucket, &namespace, &table),
+                serde_json::to_vec(&corrupted_entry).unwrap(),
+            )
+            .await;
 
         let report = store.diagnose_table_catalog(bucket, "sales", "orders", 0).await.unwrap();
 
@@ -19909,10 +22730,10 @@ mod tests {
 
         seed_table_for_metadata_maintenance(&store, bucket, &namespace, &table, current.clone()).await;
         backend
-            .seed_object(bucket, &current, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &current, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
         backend
-            .seed_object(bucket, &uncommitted, br#"{"metadata-log":[]}"#.to_vec())
+            .seed_object(bucket, &uncommitted, br#"{"table-uuid":"table-uuid","metadata-log":[]}"#.to_vec())
             .await;
 
         let report = store.diagnose_table_catalog(bucket, "sales", "orders", 0).await.unwrap();
@@ -19988,6 +22809,8 @@ mod tests {
             .create_table(test_table_entry(bucket, &namespace, &table, current_metadata.clone()))
             .await
             .unwrap();
+        store.backfill_table_warehouse_index(bucket).await.unwrap();
+        backend.reset_call_counts().await;
         backend.seed_object(bucket, &new_metadata, b"{}".to_vec()).await;
 
         let result = store
@@ -20029,6 +22852,7 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+        assert_eq!(backend.list_call_count().await, 0);
     }
 
     #[tokio::test]
@@ -20082,6 +22906,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.table.warehouse_location, "s3://analytics/tables/relocated-table-id");
+        backend.reset_call_counts().await;
         let resource = table_data_plane_resource_for_object(&store, bucket, "tables/relocated-table-id/data/part-00001.parquet")
             .await
             .expect("data-plane resource lookup should succeed")
@@ -20147,7 +22972,8 @@ mod tests {
             .await
             .unwrap();
 
-        let mut next_entry = test_table_entry(bucket, &namespace, &next_table, current_metadata);
+        let next_table_metadata = default_table_metadata_file_path(&namespace, &next_table, "00001.metadata.json");
+        let mut next_entry = test_table_entry(bucket, &namespace, &next_table, next_table_metadata);
         next_entry.table_id = "next-table-id".to_string();
         next_entry.warehouse_location = format!("s3://{bucket}/tables/table-id");
         store
@@ -20878,6 +23704,1179 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[tokio::test]
+    async fn configured_object_catalog_rejects_namespace_property_update_without_mutation() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = ConfiguredTableCatalogStore::new(backend, TableCatalogBackingMode::ObjectBacked);
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let mut entry = test_namespace_entry(bucket, &namespace);
+        entry.properties = BTreeMap::from([("owner".to_string(), "lakehouse".to_string())]);
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store.create_namespace(entry).await.expect("namespace should be created");
+
+        let result = store
+            .update_namespace_properties(
+                bucket,
+                "sales",
+                NamespacePropertiesUpdate::try_new(Vec::new(), BTreeMap::from([("owner".to_string(), "platform".to_string())]))
+                    .expect("namespace update should validate"),
+            )
+            .await
+            .expect_err("object-backed namespace property update should be unsupported");
+        assert_matches!(result, TableCatalogStoreError::Unsupported(_));
+        let stored = store
+            .get_namespace(bucket, "sales")
+            .await
+            .expect("namespace lookup should succeed")
+            .expect("namespace should remain");
+        assert_eq!(stored.properties.get("owner").map(String::as_str), Some("lakehouse"));
+    }
+
+    #[test]
+    fn namespace_property_update_rejects_overlap_and_duplicate_removals() {
+        let overlap = NamespacePropertiesUpdate::try_new(
+            vec!["owner".to_string()],
+            BTreeMap::from([("owner".to_string(), "platform".to_string())]),
+        )
+        .expect_err("overlapping update should fail");
+        assert_matches!(overlap, NamespacePropertiesUpdateError::Overlap(key) if key == "owner");
+
+        let duplicate = NamespacePropertiesUpdate::try_new(vec!["owner".to_string(), "owner".to_string()], BTreeMap::new())
+            .expect_err("duplicate removal should fail");
+        assert_matches!(duplicate, NamespacePropertiesUpdateError::DuplicateRemoval(key) if key == "owner");
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_namespace_property_update_survives_restart() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be created");
+
+        store
+            .update_namespace_properties(
+                bucket,
+                "sales",
+                NamespacePropertiesUpdate::try_new(
+                    vec!["absent".to_string()],
+                    BTreeMap::from([("owner".to_string(), "platform".to_string())]),
+                )
+                .expect("namespace update should validate"),
+            )
+            .await
+            .expect("namespace properties should update");
+
+        let restarted = StrongTableCatalogStore::new(backend);
+        let stored = restarted
+            .get_namespace(bucket, "sales")
+            .await
+            .expect("namespace lookup after restart should succeed")
+            .expect("namespace should survive restart");
+        assert_eq!(stored.properties.get("owner").map(String::as_str), Some("platform"));
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_namespace_property_update_does_not_publish_failed_snapshot() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        let mut entry = test_namespace_entry(bucket, &namespace);
+        entry.properties.insert("owner".to_string(), "lakehouse".to_string());
+        store.create_namespace(entry).await.expect("namespace should be created");
+        backend
+            .fail_next_put(
+                RUSTFS_META_BUCKET,
+                &StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path(),
+            )
+            .await;
+
+        let error = store
+            .update_namespace_properties(
+                bucket,
+                "sales",
+                NamespacePropertiesUpdate::try_new(Vec::new(), BTreeMap::from([("owner".to_string(), "platform".to_string())]))
+                    .expect("namespace update should validate"),
+            )
+            .await
+            .expect_err("failed snapshot write should fail namespace update");
+        assert_matches!(error, TableCatalogStoreError::Internal(_));
+
+        let stored = store
+            .get_namespace(bucket, "sales")
+            .await
+            .expect("namespace lookup should succeed")
+            .expect("namespace should remain");
+        assert_eq!(stored.properties.get("owner").map(String::as_str), Some("lakehouse"));
+        let restarted = StrongTableCatalogStore::new(backend);
+        let stored = restarted
+            .get_namespace(bucket, "sales")
+            .await
+            .expect("namespace lookup after restart should succeed")
+            .expect("namespace should survive restart");
+        assert_eq!(stored.properties.get("owner").map(String::as_str), Some("lakehouse"));
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_namespace_property_update_rejects_inactive_namespace() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend);
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be created");
+        let namespace_key = StrongTableCatalogStore::<TestCatalogObjectBackend>::namespace_key(bucket, &namespace);
+        store
+            .state
+            .lock()
+            .await
+            .namespaces
+            .get_mut(&namespace_key)
+            .expect("namespace should exist")
+            .state = TableCatalogEntryState::Deleting;
+
+        let error = store
+            .update_namespace_properties(
+                bucket,
+                "sales",
+                NamespacePropertiesUpdate::try_new(Vec::new(), BTreeMap::from([("owner".to_string(), "platform".to_string())]))
+                    .expect("namespace update should validate"),
+            )
+            .await
+            .expect_err("inactive namespace should not accept property updates");
+        assert_matches!(error, TableCatalogStoreError::NamespaceNotFound(_));
+    }
+
+    #[tokio::test]
+    async fn namespace_properties_load_legacy_values_but_reject_oversized_writes() {
+        let backend = TestCatalogObjectBackend::default();
+        let object_store = ObjectTableCatalogStore::new(backend.clone());
+        let strong_store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        object_store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("object-backed bucket should be created");
+        strong_store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("strong bucket should be created");
+
+        let mut oversized = test_namespace_entry(bucket, &namespace);
+        oversized
+            .properties
+            .insert("owner".to_string(), "x".repeat(NAMESPACE_PROPERTY_VALUE_MAX_LEN + 1));
+        let object_error = object_store
+            .create_namespace(oversized.clone())
+            .await
+            .expect_err("object-backed namespace creation must reject oversized properties");
+        assert_matches!(object_error, TableCatalogStoreError::Invalid(_));
+        let strong_error = strong_store
+            .create_namespace(oversized.clone())
+            .await
+            .expect_err("strong namespace creation must reject oversized properties");
+        assert_matches!(strong_error, TableCatalogStoreError::Invalid(_));
+
+        backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &object_store.paths.namespace_entry_path(bucket, &namespace),
+                serde_json::to_vec(&oversized).expect("legacy namespace should serialize"),
+            )
+            .await;
+        let legacy = object_store
+            .get_namespace(bucket, "sales")
+            .await
+            .expect("legacy namespace lookup should succeed")
+            .expect("legacy namespace should remain readable");
+        assert_eq!(
+            legacy.properties.get("owner").map(String::len),
+            Some(NAMESPACE_PROPERTY_VALUE_MAX_LEN + 1)
+        );
+
+        strong_store
+            .create_namespace(test_namespace_entry(bucket, &namespace))
+            .await
+            .expect("namespace should be created");
+        let error = strong_store
+            .update_namespace_properties(
+                bucket,
+                "sales",
+                NamespacePropertiesUpdate::try_new(Vec::new(), oversized.properties)
+                    .expect("property update request should validate structurally"),
+            )
+            .await
+            .expect_err("oversized property update should be rejected");
+        assert_matches!(error, TableCatalogStoreError::Invalid(_));
+        let stored = strong_store
+            .get_namespace(bucket, "sales")
+            .await
+            .expect("namespace lookup should succeed")
+            .expect("namespace should remain");
+        assert!(stored.properties.is_empty());
+    }
+
+    #[test]
+    fn namespace_property_validation_covers_exact_and_exceeded_limits() {
+        let mut exact_total = BTreeMap::new();
+        for index in 0..15 {
+            exact_total.insert(format!("k{index:02}"), "v".repeat(NAMESPACE_PROPERTY_VALUE_MAX_LEN));
+        }
+        let used = exact_total.iter().map(|(key, value)| key.len() + value.len()).sum::<usize>();
+        let final_key = "k15".to_string();
+        exact_total.insert(
+            final_key.clone(),
+            "v".repeat(NAMESPACE_PROPERTIES_MAX_TOTAL_BYTES - used - final_key.len()),
+        );
+        assert_eq!(
+            exact_total.iter().map(|(key, value)| key.len() + value.len()).sum::<usize>(),
+            NAMESPACE_PROPERTIES_MAX_TOTAL_BYTES
+        );
+        assert!(validate_namespace_properties(&exact_total).is_ok());
+
+        let mut exceeded_total = exact_total;
+        exceeded_total
+            .get_mut(&final_key)
+            .expect("final property should exist")
+            .push('v');
+        assert_matches!(validate_namespace_properties(&exceeded_total), Err(TableCatalogStoreError::Invalid(_)));
+        assert_matches!(
+            validate_namespace_properties(&BTreeMap::from([(String::new(), "value".to_string())])),
+            Err(TableCatalogStoreError::Invalid(_))
+        );
+        assert_matches!(
+            validate_namespace_properties(&BTreeMap::from([(
+                "owner".to_string(),
+                "v".repeat(NAMESPACE_PROPERTY_VALUE_MAX_LEN + 1),
+            )])),
+            Err(TableCatalogStoreError::Invalid(_))
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_expose_implicit_parents_and_reject_dropping_them() {
+        let bucket = "analytics";
+        let parent = Namespace::parse("sales").expect("parent namespace should parse");
+        let child = Namespace::parse("sales.daily").expect("child namespace should parse");
+
+        let object_backend = TestCatalogObjectBackend::default();
+        let object_store = ObjectTableCatalogStore::new(object_backend.clone());
+        object_store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("object-backed bucket should be created");
+        object_store
+            .create_namespace(test_namespace_entry(bucket, &child))
+            .await
+            .expect("object-backed child namespace should be created");
+        let mut inactive_parent = test_namespace_entry(bucket, &parent);
+        inactive_parent.state = TableCatalogEntryState::Deleted;
+        object_backend
+            .seed_object(
+                RUSTFS_META_BUCKET,
+                &object_store.paths.namespace_entry_path(bucket, &parent),
+                serde_json::to_vec(&inactive_parent).expect("inactive parent should serialize"),
+            )
+            .await;
+        assert_eq!(
+            object_store
+                .get_namespace(bucket, &parent.public_name())
+                .await
+                .expect("object-backed parent lookup should succeed")
+                .expect("implicit object-backed parent should exist")
+                .namespace,
+            parent.public_name()
+        );
+        let error = object_store
+            .drop_namespace(bucket, &parent.public_name())
+            .await
+            .expect_err("object-backed parent with a child should not drop");
+        assert_matches!(error, TableCatalogStoreError::Conflict(_));
+
+        let strong_store = StrongTableCatalogStore::new(TestCatalogObjectBackend::default());
+        strong_store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("strong bucket should be created");
+        strong_store
+            .create_namespace(test_namespace_entry(bucket, &parent))
+            .await
+            .expect("strong parent namespace should be created");
+        strong_store
+            .create_namespace(test_namespace_entry(bucket, &child))
+            .await
+            .expect("strong child namespace should be created");
+        strong_store
+            .state
+            .lock()
+            .await
+            .namespaces
+            .get_mut(&StrongTableCatalogStore::<TestCatalogObjectBackend>::namespace_key(bucket, &parent))
+            .expect("strong parent should exist")
+            .state = TableCatalogEntryState::Deleted;
+        assert_eq!(
+            strong_store
+                .get_namespace(bucket, &parent.public_name())
+                .await
+                .expect("strong parent lookup should succeed")
+                .expect("implicit strong parent should exist")
+                .namespace,
+            parent.public_name()
+        );
+        strong_store
+            .update_namespace_properties(
+                bucket,
+                &parent.public_name(),
+                NamespacePropertiesUpdate::try_new(Vec::new(), BTreeMap::from([("owner".to_string(), "platform".to_string())]))
+                    .expect("namespace update should validate"),
+            )
+            .await
+            .expect("implicit strong parent should materialize on property update");
+        let materialized_parent = strong_store
+            .get_namespace(bucket, &parent.public_name())
+            .await
+            .expect("materialized parent lookup should succeed")
+            .expect("materialized parent should exist");
+        assert_eq!(materialized_parent.properties.get("owner").map(String::as_str), Some("platform"));
+        let error = strong_store
+            .drop_namespace(bucket, &parent.public_name())
+            .await
+            .expect_err("strong parent with a child should not drop");
+        assert_matches!(error, TableCatalogStoreError::Conflict(_));
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_materialize_implicit_parents_for_tables_and_views() {
+        let bucket = "analytics";
+        let table_parent = Namespace::parse("sales").expect("table parent should parse");
+        let table_child = Namespace::parse("sales.daily").expect("table child should parse");
+        let view_parent = Namespace::parse("reporting").expect("view parent should parse");
+        let view_child = Namespace::parse("reporting.daily").expect("view child should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        let view = IdentifierSegment::parse("summary").expect("view should parse");
+
+        for store in [
+            ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), TableCatalogBackingMode::ObjectBacked),
+            ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), TableCatalogBackingMode::DurableStrong),
+        ] {
+            store
+                .put_table_bucket(test_bucket_entry(bucket))
+                .await
+                .expect("table bucket should be created");
+            store
+                .create_namespace(test_namespace_entry(bucket, &table_child))
+                .await
+                .expect("table child namespace should be created");
+            store
+                .create_namespace(test_namespace_entry(bucket, &view_child))
+                .await
+                .expect("view child namespace should be created");
+
+            store
+                .create_table(test_table_entry(
+                    bucket,
+                    &table_parent,
+                    &table,
+                    default_table_metadata_file_path(&table_parent, &table, "00001.metadata.json"),
+                ))
+                .await
+                .expect("implicit table parent should accept table creation");
+            store
+                .create_view(test_view_entry(
+                    bucket,
+                    &view_parent,
+                    &view,
+                    default_view_metadata_file_path(&view_parent, &view, "00001.metadata.json"),
+                ))
+                .await
+                .expect("implicit view parent should accept view creation");
+
+            assert!(
+                store
+                    .get_namespace(bucket, &table_parent.public_name())
+                    .await
+                    .expect("table parent lookup should succeed")
+                    .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            );
+            assert!(
+                store
+                    .get_namespace(bucket, &view_parent.public_name())
+                    .await
+                    .expect("view parent lookup should succeed")
+                    .is_some_and(|entry| entry.state == TableCatalogEntryState::Active)
+            );
+            assert!(
+                store
+                    .load_table(bucket, &table_parent.public_name(), table.as_str())
+                    .await
+                    .expect("table lookup should succeed")
+                    .is_some()
+            );
+            assert!(
+                store
+                    .load_view(bucket, &view_parent.public_name(), view.as_str())
+                    .await
+                    .expect("view lookup should succeed")
+                    .is_some()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_backings_page_tables_and_views_at_exact_boundaries() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+
+        for mode in [TableCatalogBackingMode::ObjectBacked, TableCatalogBackingMode::DurableStrong] {
+            let backend = TestCatalogObjectBackend::default();
+            let store = ConfiguredTableCatalogStore::new(backend.clone(), mode);
+            store
+                .put_table_bucket(test_bucket_entry(bucket))
+                .await
+                .expect("table bucket should be created");
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .expect("namespace should be created");
+
+            for name in ["alpha", "beta", "gamma"] {
+                let identifier = IdentifierSegment::parse(name).expect("identifier should parse");
+                let mut table = test_table_entry(
+                    bucket,
+                    &namespace,
+                    &identifier,
+                    default_table_metadata_file_path(&namespace, &identifier, "00001.metadata.json"),
+                );
+                table.table_id = format!("{name}-table-id");
+                table.table_uuid = format!("{name}-table-uuid");
+                table.warehouse_location = format!("s3://{bucket}/tables/{name}-table-id");
+                store.create_table(table).await.expect("table should be created");
+
+                let view_name = format!("view_{name}");
+                let view_identifier = IdentifierSegment::parse(&view_name).expect("view identifier should parse");
+                let mut view = test_view_entry(
+                    bucket,
+                    &namespace,
+                    &view_identifier,
+                    default_view_metadata_file_path(&namespace, &view_identifier, "00001.metadata.json"),
+                );
+                view.view_id = format!("{view_name}-id");
+                view.view_uuid = format!("{view_name}-uuid");
+                view.warehouse_location = format!("s3://{bucket}/views/{view_name}-id");
+                store.create_view(view).await.expect("view should be created");
+            }
+            backend.reset_call_counts().await;
+
+            let table_page = store
+                .list_tables_page(bucket, "sales", None, 2)
+                .await
+                .expect("table page should load");
+            assert_eq!(
+                table_page
+                    .entries
+                    .iter()
+                    .map(|entry| entry.table.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["alpha", "beta"]
+            );
+            assert!(table_page.has_more);
+            let exact_table_page = store
+                .list_tables_page(bucket, "sales", Some("alpha"), 2)
+                .await
+                .expect("exact table page should load");
+            assert_eq!(
+                exact_table_page
+                    .entries
+                    .iter()
+                    .map(|entry| entry.table.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["beta", "gamma"]
+            );
+            assert!(!exact_table_page.has_more);
+
+            let view_page = store
+                .list_views_page(bucket, "sales", None, 2)
+                .await
+                .expect("view page should load");
+            assert_eq!(
+                view_page.entries.iter().map(|entry| entry.view.as_str()).collect::<Vec<_>>(),
+                vec!["view_alpha", "view_beta"]
+            );
+            assert!(view_page.has_more);
+            let exact_view_page = store
+                .list_views_page(bucket, "sales", Some("view_alpha"), 2)
+                .await
+                .expect("exact view page should load");
+            assert_eq!(
+                exact_view_page
+                    .entries
+                    .iter()
+                    .map(|entry| entry.view.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["view_beta", "view_gamma"]
+            );
+            assert!(!exact_view_page.has_more);
+            assert_eq!(
+                backend.list_page_limits().await,
+                if mode == TableCatalogBackingMode::ObjectBacked {
+                    vec![3, 3, 3, 3]
+                } else {
+                    Vec::new()
+                }
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_ignores_inactive_only_namespace_descendants() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend);
+        let bucket = "analytics";
+        let source_namespace = Namespace::parse("sales").expect("source namespace should parse");
+        let parent = Namespace::parse("curated").expect("parent namespace should parse");
+        let child = Namespace::parse("curated.daily").expect("child namespace should parse");
+        let table = IdentifierSegment::parse("orders").expect("table should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &source_namespace))
+            .await
+            .expect("source namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &child))
+            .await
+            .expect("child namespace should be created");
+        store
+            .create_table(test_table_entry(
+                bucket,
+                &source_namespace,
+                &table,
+                default_table_metadata_file_path(&source_namespace, &table, "00001.metadata.json"),
+            ))
+            .await
+            .expect("source table should be created");
+        store
+            .state
+            .lock()
+            .await
+            .namespaces
+            .get_mut(&StrongTableCatalogStore::<TestCatalogObjectBackend>::namespace_key(bucket, &child))
+            .expect("child namespace should exist")
+            .state = TableCatalogEntryState::Deleted;
+
+        assert!(
+            store
+                .get_namespace(bucket, &parent.public_name())
+                .await
+                .expect("parent lookup should succeed")
+                .is_none()
+        );
+        let update_error = store
+            .update_namespace_properties(
+                bucket,
+                &parent.public_name(),
+                NamespacePropertiesUpdate::try_new(Vec::new(), BTreeMap::from([("owner".to_string(), "platform".to_string())]))
+                    .expect("namespace update should validate"),
+            )
+            .await
+            .expect_err("inactive descendants must not materialize a parent");
+        assert_matches!(update_error, TableCatalogStoreError::NamespaceNotFound(_));
+        let rename_error = store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect_err("inactive descendants must not authorize a rename destination");
+        assert_matches!(rename_error, TableCatalogStoreError::NamespaceNotFound(_));
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_table_rename_materializes_implicit_destination_namespace() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend);
+        let bucket = "analytics";
+        let source_namespace = Namespace::parse("sales").expect("source namespace should parse");
+        let destination_namespace = Namespace::parse("curated").expect("destination namespace should parse");
+        let destination_child = Namespace::parse("curated.daily").expect("destination child should parse");
+        let source_table = IdentifierSegment::parse("orders").expect("source table should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &source_namespace))
+            .await
+            .expect("source namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &destination_namespace))
+            .await
+            .expect("destination parent should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &destination_child))
+            .await
+            .expect("destination child should be created");
+        let destination_key = StrongTableCatalogStore::<TestCatalogObjectBackend>::namespace_key(bucket, &destination_namespace);
+        store
+            .state
+            .lock()
+            .await
+            .namespaces
+            .get_mut(&destination_key)
+            .expect("destination parent should exist")
+            .state = TableCatalogEntryState::Deleted;
+        store
+            .create_table(test_table_entry(
+                bucket,
+                &source_namespace,
+                &source_table,
+                default_table_metadata_file_path(&source_namespace, &source_table, "00001.metadata.json"),
+            ))
+            .await
+            .expect("source table should be created");
+
+        store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect("implicit destination namespace should accept rename");
+
+        assert!(
+            store
+                .load_table(bucket, "curated", "orders_v2")
+                .await
+                .expect("destination table lookup should succeed")
+                .is_some()
+        );
+        assert_eq!(
+            store
+                .state
+                .lock()
+                .await
+                .namespaces
+                .get(&destination_key)
+                .expect("destination parent should be materialized")
+                .state,
+            TableCatalogEntryState::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn table_and_view_names_share_one_namespace_identifier_space() {
+        let bucket = "analytics";
+        let namespace = Namespace::parse("sales").expect("namespace should parse");
+        let table_name = IdentifierSegment::parse("orders").expect("table should parse");
+        let view_name = IdentifierSegment::parse("summary").expect("view should parse");
+
+        for store in [
+            ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), TableCatalogBackingMode::ObjectBacked),
+            ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), TableCatalogBackingMode::DurableStrong),
+        ] {
+            store
+                .put_table_bucket(test_bucket_entry(bucket))
+                .await
+                .expect("table bucket should be created");
+            store
+                .create_namespace(test_namespace_entry(bucket, &namespace))
+                .await
+                .expect("namespace should be created");
+            store
+                .create_table(test_table_entry(
+                    bucket,
+                    &namespace,
+                    &table_name,
+                    default_table_metadata_file_path(&namespace, &table_name, "00001.metadata.json"),
+                ))
+                .await
+                .expect("table should be created");
+            let error = store
+                .create_view(test_view_entry(
+                    bucket,
+                    &namespace,
+                    &table_name,
+                    default_view_metadata_file_path(&namespace, &table_name, "00001.metadata.json"),
+                ))
+                .await
+                .expect_err("view should conflict with a same-name table");
+            assert_matches!(error, TableCatalogStoreError::Conflict(_));
+
+            store
+                .create_view(test_view_entry(
+                    bucket,
+                    &namespace,
+                    &view_name,
+                    default_view_metadata_file_path(&namespace, &view_name, "00001.metadata.json"),
+                ))
+                .await
+                .expect("view should be created");
+            let error = store
+                .create_table(test_table_entry(
+                    bucket,
+                    &namespace,
+                    &view_name,
+                    default_table_metadata_file_path(&namespace, &view_name, "00001.metadata.json"),
+                ))
+                .await
+                .expect_err("table should conflict with a same-name view");
+            assert_matches!(error, TableCatalogStoreError::Conflict(_));
+        }
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_table_rename_is_atomic_and_survives_restart() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let source_namespace = Namespace::parse("sales").expect("source namespace should parse");
+        let destination_namespace = Namespace::parse("curated").expect("destination namespace should parse");
+        let source_table = IdentifierSegment::parse("orders").expect("source table should parse");
+        let metadata_location = default_table_metadata_file_path(&source_namespace, &source_table, "00001.metadata.json");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &source_namespace))
+            .await
+            .expect("source namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &destination_namespace))
+            .await
+            .expect("destination namespace should be created");
+        let source = test_table_entry(bucket, &source_namespace, &source_table, metadata_location);
+        store
+            .create_table(source.clone())
+            .await
+            .expect("source table should be created");
+        let snapshot_path = StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path();
+        let pre_rename_snapshot = backend
+            .read_object(RUSTFS_META_BUCKET, &snapshot_path)
+            .await
+            .expect("pre-rename snapshot read should succeed")
+            .expect("pre-rename snapshot should exist");
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&pre_rename_snapshot.data)
+                .expect("pre-rename snapshot should be valid JSON")["version"],
+            serde_json::Value::from(STRONG_TABLE_CATALOG_SNAPSHOT_VERSION)
+        );
+        store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect("table should rename");
+
+        let snapshot_data = backend
+            .read_object(RUSTFS_META_BUCKET, &snapshot_path)
+            .await
+            .expect("durable snapshot read should succeed")
+            .expect("durable snapshot should exist")
+            .data;
+        let snapshot_json =
+            serde_json::from_slice::<serde_json::Value>(&snapshot_data).expect("durable snapshot should be valid JSON");
+        assert_eq!(snapshot_json["version"], serde_json::Value::from(STRONG_TABLE_CATALOG_SNAPSHOT_VERSION));
+        assert!(snapshot_json.get("metadata_roots").is_none());
+
+        assert!(
+            store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .expect("source table lookup should succeed")
+                .is_none()
+        );
+        let destination = store
+            .load_table(bucket, "curated", "orders_v2")
+            .await
+            .expect("destination table lookup should succeed")
+            .expect("renamed table should exist");
+        assert_eq!(destination.table_id, source.table_id);
+        assert_eq!(destination.table_uuid, source.table_uuid);
+        assert_eq!(destination.warehouse_location, source.warehouse_location);
+        assert_eq!(destination.metadata_location, source.metadata_location);
+        assert_eq!(destination.version_token, source.version_token);
+        assert_eq!(destination.generation, source.generation);
+        let old_manifest = format!(
+            "{}/manifest-00001.avro",
+            default_table_metadata_dir_path(&source_namespace, &source_table)
+        );
+        assert_eq!(
+            table_maintenance_object_kind_for_entry(
+                &destination_namespace,
+                &IdentifierSegment::parse("orders_v2").expect("destination table should parse"),
+                &destination,
+                &old_manifest,
+            ),
+            Some(TableMetadataMaintenanceObjectKind::ManifestFile)
+        );
+        let resource = store
+            .resolve_table_data_plane_resource(bucket, "tables/table-id/data/part.parquet")
+            .await
+            .expect("data-plane resource lookup should succeed")
+            .expect("renamed table should own its warehouse prefix");
+        assert_eq!(resource.namespace, "curated");
+        assert_eq!(resource.table, "orders_v2");
+
+        let mut replacement = test_table_entry(
+            bucket,
+            &source_namespace,
+            &source_table,
+            default_table_metadata_file_path(&source_namespace, &source_table, "00001-replacement.metadata.json"),
+        );
+        replacement.table_id = "replacement-table-id".to_string();
+        replacement.table_uuid = "replacement-table-uuid".to_string();
+        replacement.warehouse_location = "s3://analytics/tables/replacement-table-id".to_string();
+        let error = store
+            .create_table(replacement)
+            .await
+            .expect_err("renamed table metadata root must remain exclusively owned");
+        assert_matches!(
+            error,
+            TableCatalogStoreError::Conflict(message)
+                if message.contains("metadata directory is already registered")
+        );
+
+        let next_metadata_location =
+            table_metadata_file_path_for_entry(&destination, "00002.metadata.json").expect("next metadata path should resolve");
+        backend.seed_object(bucket, &next_metadata_location, b"{}".to_vec()).await;
+        let committed = store
+            .commit_table(TableCommitRequest {
+                table_bucket: bucket.to_string(),
+                namespace: "curated".to_string(),
+                table: "orders_v2".to_string(),
+                commit_id: "rename-followup-commit".to_string(),
+                idempotency_key: Some("rename-followup-commit".to_string()),
+                operation: "append".to_string(),
+                expected_version_token: destination.version_token,
+                expected_metadata_location: destination.metadata_location,
+                new_metadata_location: next_metadata_location.clone(),
+                requirements: Vec::new(),
+                writer: Some("rename-test".to_string()),
+            })
+            .await
+            .expect("renamed table should accept a commit in its stable metadata directory");
+        assert_eq!(committed.table.metadata_location, next_metadata_location);
+
+        let restarted = StrongTableCatalogStore::new(backend);
+        assert!(
+            restarted
+                .load_table(bucket, "sales", "orders")
+                .await
+                .expect("source table lookup after restart should succeed")
+                .is_none()
+        );
+        let restarted_destination = restarted
+            .load_table(bucket, "curated", "orders_v2")
+            .await
+            .expect("destination table lookup after restart should succeed")
+            .expect("destination table should survive restart");
+        assert_eq!(restarted_destination.metadata_location, committed.table.metadata_location);
+        assert_eq!(
+            table_metadata_file_path_for_entry(&restarted_destination, "00003.metadata.json")
+                .expect("stable metadata path should survive restart"),
+            default_table_metadata_file_path(&source_namespace, &source_table, "00003.metadata.json")
+        );
+        assert_eq!(
+            table_maintenance_object_kind_for_entry(
+                &destination_namespace,
+                &IdentifierSegment::parse("orders_v2").expect("destination table should parse"),
+                &restarted_destination,
+                &old_manifest,
+            ),
+            Some(TableMetadataMaintenanceObjectKind::ManifestFile)
+        );
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_table_rename_rejects_missing_or_conflicting_destinations() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend);
+        let bucket = "analytics";
+        let source_namespace = Namespace::parse("sales").expect("source namespace should parse");
+        let destination_namespace = Namespace::parse("curated").expect("destination namespace should parse");
+        let source_table = IdentifierSegment::parse("orders").expect("source table should parse");
+        let destination_table = IdentifierSegment::parse("orders_v2").expect("destination table should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &source_namespace))
+            .await
+            .expect("source namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &destination_namespace))
+            .await
+            .expect("destination namespace should be created");
+        store
+            .create_table(test_table_entry(
+                bucket,
+                &source_namespace,
+                &source_table,
+                default_table_metadata_file_path(&source_namespace, &source_table, "00001.metadata.json"),
+            ))
+            .await
+            .expect("source table should be created");
+        let mut existing = test_table_entry(
+            bucket,
+            &destination_namespace,
+            &destination_table,
+            default_table_metadata_file_path(&destination_namespace, &destination_table, "00001.metadata.json"),
+        );
+        existing.table_id = "destination-table-id".to_string();
+        existing.table_uuid = "destination-table-uuid".to_string();
+        existing.warehouse_location = format!("s3://{bucket}/tables/destination-table-id");
+        store
+            .create_table(existing)
+            .await
+            .expect("destination table should be created");
+
+        let conflict = store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect_err("existing destination should conflict");
+        assert_matches!(conflict, TableCatalogStoreError::AlreadyExists(_));
+        let missing_namespace = store
+            .rename_table(bucket, "sales", "orders", "missing", "orders_v3")
+            .await
+            .expect_err("missing destination namespace should fail");
+        assert_matches!(missing_namespace, TableCatalogStoreError::NamespaceNotFound(_));
+        let missing_source = store
+            .rename_table(bucket, "sales", "missing", "curated", "orders_v3")
+            .await
+            .expect_err("missing source table should fail");
+        assert_matches!(missing_source, TableCatalogStoreError::TableNotFound(_));
+        let missing_self = store
+            .rename_table(bucket, "sales", "missing", "sales", "missing")
+            .await
+            .expect_err("missing self rename should report the missing source");
+        assert_matches!(missing_self, TableCatalogStoreError::TableNotFound(_));
+
+        let view_destination = IdentifierSegment::parse("orders_view").expect("view destination should parse");
+        store
+            .create_view(test_view_entry(
+                bucket,
+                &destination_namespace,
+                &view_destination,
+                default_view_metadata_file_path(&destination_namespace, &view_destination, "00001.metadata.json"),
+            ))
+            .await
+            .expect("destination view should be created");
+        let view_conflict = store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_view")
+            .await
+            .expect_err("same-name destination view should conflict");
+        assert_matches!(view_conflict, TableCatalogStoreError::AlreadyExists(_));
+        assert!(
+            store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .expect("source table lookup should succeed")
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_table_rename_rejects_inactive_source_state() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend);
+        let bucket = "analytics";
+        let source_namespace = Namespace::parse("sales").expect("source namespace should parse");
+        let destination_namespace = Namespace::parse("curated").expect("destination namespace should parse");
+        let source_table = IdentifierSegment::parse("orders").expect("source table should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &source_namespace))
+            .await
+            .expect("source namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &destination_namespace))
+            .await
+            .expect("destination namespace should be created");
+        store
+            .create_table(test_table_entry(
+                bucket,
+                &source_namespace,
+                &source_table,
+                default_table_metadata_file_path(&source_namespace, &source_table, "00001.metadata.json"),
+            ))
+            .await
+            .expect("source table should be created");
+
+        let table_key = StrongTableCatalogStore::<TestCatalogObjectBackend>::table_key(bucket, &source_namespace, &source_table);
+        store
+            .state
+            .lock()
+            .await
+            .tables
+            .get_mut(&table_key)
+            .expect("source table should exist")
+            .state = TableCatalogEntryState::Deleting;
+        let error = store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect_err("inactive source table should not rename");
+        assert_matches!(error, TableCatalogStoreError::TableNotFound(_));
+
+        let mut state = store.state.lock().await;
+        state.tables.get_mut(&table_key).expect("source table should exist").state = TableCatalogEntryState::Active;
+        let namespace_key = StrongTableCatalogStore::<TestCatalogObjectBackend>::namespace_key(bucket, &source_namespace);
+        state
+            .namespaces
+            .get_mut(&namespace_key)
+            .expect("source namespace should exist")
+            .state = TableCatalogEntryState::Deleting;
+        drop(state);
+        let error = store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect_err("table in an inactive source namespace should not rename");
+        assert_matches!(error, TableCatalogStoreError::TableNotFound(_));
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_table_rename_does_not_publish_failed_snapshot() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let source_namespace = Namespace::parse("sales").expect("source namespace should parse");
+        let destination_namespace = Namespace::parse("curated").expect("destination namespace should parse");
+        let source_table = IdentifierSegment::parse("orders").expect("source table should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &source_namespace))
+            .await
+            .expect("source namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &destination_namespace))
+            .await
+            .expect("destination namespace should be created");
+        store
+            .create_table(test_table_entry(
+                bucket,
+                &source_namespace,
+                &source_table,
+                default_table_metadata_file_path(&source_namespace, &source_table, "00001.metadata.json"),
+            ))
+            .await
+            .expect("source table should be created");
+        backend
+            .fail_next_put(
+                RUSTFS_META_BUCKET,
+                &StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path(),
+            )
+            .await;
+
+        let error = store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect_err("snapshot failure should fail rename");
+        assert_matches!(error, TableCatalogStoreError::Internal(_));
+        assert!(
+            store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .expect("source table lookup should succeed")
+                .is_some()
+        );
+        assert!(
+            store
+                .load_table(bucket, "curated", "orders_v2")
+                .await
+                .expect("destination table lookup should succeed")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn strong_catalog_table_rename_returns_success_after_committed_snapshot_reload_failure() {
+        let backend = TestCatalogObjectBackend::default();
+        let store = StrongTableCatalogStore::new(backend.clone());
+        let bucket = "analytics";
+        let source_namespace = Namespace::parse("sales").expect("source namespace should parse");
+        let destination_namespace = Namespace::parse("curated").expect("destination namespace should parse");
+        let source_table = IdentifierSegment::parse("orders").expect("source table should parse");
+        store
+            .put_table_bucket(test_bucket_entry(bucket))
+            .await
+            .expect("table bucket entry should be seeded");
+        store
+            .create_namespace(test_namespace_entry(bucket, &source_namespace))
+            .await
+            .expect("source namespace should be created");
+        store
+            .create_namespace(test_namespace_entry(bucket, &destination_namespace))
+            .await
+            .expect("destination namespace should be created");
+        store
+            .create_table(test_table_entry(
+                bucket,
+                &source_namespace,
+                &source_table,
+                default_table_metadata_file_path(&source_namespace, &source_table, "00001.metadata.json"),
+            ))
+            .await
+            .expect("source table should be created");
+        let snapshot_path = StrongTableCatalogStore::<TestCatalogObjectBackend>::snapshot_object_path();
+        backend.fail_next_read(RUSTFS_META_BUCKET, &snapshot_path).await;
+
+        store
+            .rename_table(bucket, "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect("committed rename should not be reported as failed when local reload fails");
+        assert!(!store.state.lock().await.hydrated);
+        assert!(
+            store
+                .load_table(bucket, "sales", "orders")
+                .await
+                .expect("source table lookup should reload durable state")
+                .is_none()
+        );
+        assert!(
+            store
+                .load_table(bucket, "curated", "orders_v2")
+                .await
+                .expect("destination table lookup should succeed")
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_object_catalog_rejects_table_rename() {
+        let store = ConfiguredTableCatalogStore::new(TestCatalogObjectBackend::default(), TableCatalogBackingMode::ObjectBacked);
+
+        let error = store
+            .rename_table("analytics", "sales", "orders", "curated", "orders_v2")
+            .await
+            .expect_err("object-backed rename should be unsupported");
+
+        assert_matches!(error, TableCatalogStoreError::Unsupported(_));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Expands the core Iceberg REST Catalog surface and hardens the catalog invariants used by namespace, table, view, commit, import, synchronization, rollback, and deletion operations.

- Adds hierarchical namespace behavior, namespace property updates, atomic table rename, strict pagination tokens, and standard REST response and error contracts.
- Validates Iceberg format-version requirements, table identity, schema and partition references, snapshot lineage, manifest lists, manifests, data/delete objects, and metadata logs before catalog publication.
- Preserves idempotent commit replay while rejecting mismatched payloads and making object-backed commit finalization recoverable after pointer CAS.
- Fences table/view creation, warehouse relocation, warehouse-prefix ownership, strong catalog cache hydration, and cleanup against lock loss or stale writers.
- Bounds metadata graph I/O and repeated cached manifest traversal, caches shared graph objects, and parses Avro outside async runtime workers.
- Keeps scoped credential claims, catalog authorization, and unsupported operations fail-closed.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo check -p rustfs --tests`
- `cargo clippy -p rustfs --tests -- -D warnings`
- `typos rustfs/src/admin/handlers/table_catalog.rs rustfs/src/table_catalog.rs`
- `git diff --check`
- `./scripts/check_layer_dependencies.sh`
- `./scripts/check_architecture_migration_rules.sh`
- `./scripts/check_unsafe_code_allowances.sh`
- `./scripts/check_logging_guardrails.sh`
- `./scripts/check_no_planning_docs.sh`
- `./scripts/check_no_tokio_io_uring.sh`
- `./scripts/check_extension_schema_boundaries.sh`
- `./scripts/check_body_cache_whitelist.sh`

## Impact

Iceberg REST Catalog clients receive stricter standard request and response behavior, hierarchical namespace support, safer table rename and commit semantics, and clearer failures for malformed, conflicting, incomplete, or unsupported metadata operations. Valid Iceberg format-version 1 and 2 tables remain supported, and no configuration migration is required.

## Additional Notes

- Correctness: attacked pagination boundaries, format-version transitions, snapshot identity, historical retries, and partial publication; create fencing and recoverable commit-head ordering close the concrete failure cases found.
- Simplicity: checked new helpers and state transitions for redundant abstractions or duplicate validation; retained only helpers reused across recovery or backing implementations.
- Security: attacked namespace/path normalization, warehouse ownership, credential claims, unknown request fields, and authorization scope; exact metadata reads and scoped warehouse claims remain fail-closed.
- Concurrency and durability: attacked lock loss before and after pointer CAS, stale hydration publication, warehouse-index cleanup, and retry finalization; durable state is recoverable and post-CAS success is not reported as failure.
- Compatibility: checked canonical and compatibility routes, Iceberg REST error envelopes, nested namespace encoding, format-version 1/2 metadata, and 406 unsupported behavior against the Apache Iceberg REST contract.
- Performance: attacked repeated manifest traversal, blocking Avro parsing, shared graph reads, and clean strong-store replay; traversal budgets now include cache hits and clean replay avoids unnecessary snapshot persistence.
- Test coverage: each changed invariant has positive or negative regression coverage, including state-not-advanced assertions, cache-hit budgets, lock-loss creation, post-CAS recovery, strong hydration races, and route/policy contracts.

The focused RustFS runtime test binary did not execute locally because its link step exceeded the resource-safe wrapper timeout; CI provides the full runtime test lane.
