### PR TITLE
chore(deps): refresh hotpath allocator support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4992,9 +4992,9 @@ dependencies = [
 
 [[package]]
 name = "hotpath"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66750a77f4f6b408a148be5102ef1f3ba7172def7ee92b1cfc75d9f7a3870453"
+checksum = "ab303f15e2bbd9633a577338c9813a86bc1aef74beb8b536e27f28c80e84befc"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -5026,9 +5026,9 @@ dependencies = [
 
 [[package]]
 name = "hotpath-macros"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe0e1900d2dbe2e2df8e9522b97ebd7a5598ba18478f57e247957022dffedbe"
+checksum = "4777d4dd3474c9b9c9391be713c6b570da0ac49e992a8cbfed67f60ca0f7e33d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5037,15 +5037,15 @@ dependencies = [
 
 [[package]]
 name = "hotpath-macros-meta"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f2f70b29b6f42311acd2fb0b2f91a34d9a573c76fb8a7f51970670a1673a49"
+checksum = "833200923e0ba8150fb91d6a3a39643eef95e604c7394c2f2679905cae13862c"
 
 [[package]]
 name = "hotpath-meta"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b771f77b2f409086bb40ff029f850ce99d17118d4e207df0f28cb32bd7568c7"
+checksum = "eca34dbbafc05f5da2a2696ce2640018fbe29e9932736309efbf3a990f0b2832"
 dependencies = [
  "hotpath-macros-meta",
 ]
@@ -5445,9 +5445,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
  "serde",
 ]
@@ -5923,9 +5923,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -8036,9 +8036,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -11405,9 +11405,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
 dependencies = [
  "cc",
  "cfg-if",
@@ -11714,7 +11714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -11824,9 +11824,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ tower-http = { version = "0.7.0" }
 # Serialization and Data Formats
 apache-avro = "0.21.0"
 bytes = { version = "1.12.1" }
-bytesize = "2.6.0"
+bytesize = "2.7.0"
 byteorder = "1.5.0"
 flatbuffers = "25.12.19"
 form_urlencoded = "1.2.2"
@@ -212,7 +212,7 @@ zeroize = { version = "1.9.0" }
 chrono = { version = "0.4.45" }
 humantime = "2.4.0"
 jiff = { version = "0.2.35" }
-time = { version = "0.3.54" }
+time = { version = "0.3.55" }
 
 # Database
 deadpool-postgres = { version = "0.14" }
@@ -350,7 +350,7 @@ dav-server = "0.11.0"
 # Performance Analysis and Memory Profiling
 mimalloc = { version = "0.1.52", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "1cdadea43e9c5a0f054b65be21200ce580e4eb13" }
 libmimalloc-sys = { version = "0.1.49", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "1cdadea43e9c5a0f054b65be21200ce580e4eb13", features = ["extended"] }
-hotpath = { version = "0.22.0", default-features = false }
+hotpath = { version = "0.23.0", default-features = false }
 # Snapshot testing for output format regression detection
 insta = { version = "1.48" }
 

--- a/rustfs/src/main.rs
+++ b/rustfs/src/main.rs
@@ -47,7 +47,7 @@ unsafe impl GlobalAlloc for MiMallocAllocator {
 
 #[cfg(all(feature = "hotpath", feature = "hotpath-alloc"))]
 #[global_allocator]
-static GLOBAL: hotpath::CountingAllocator<MiMallocAllocator> = hotpath::CountingAllocator::new();
+static GLOBAL: hotpath::CountingAllocator<MiMallocAllocator> = hotpath::CountingAllocator::with(MiMallocAllocator);
 
 #[cfg(not(all(feature = "hotpath", feature = "hotpath-alloc")))]
 #[global_allocator]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Refresh workspace dependencies with `cargo update --verbose` and `cargo upgrade --exclude ratelimit --verbose`, preserving the `ratelimit` exclusion.
- Upgrade the HotPath crate family to `0.23.0`.
- Adapt the `hotpath + hotpath-alloc` global allocator initialization to HotPath 0.23 custom allocator support by constructing `CountingAllocator` with the existing `MiMallocAllocator` wrapper, preserving MiMalloc as the inner allocator for allocation diagnostics builds.

## Verification
- `cargo check -p rustfs --features hotpath,hotpath-alloc --bin rustfs`
- `cargo test -p rustfs --features hotpath,hotpath-alloc --bin rustfs mimalloc`
- `cargo check -p rustfs --features hotpath,hotpath-cpu --bin rustfs`
- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps`
- `cargo tree -i ratelimit@0.10.1 --workspace --depth 1`
- `cargo tree -i hotpath@0.23.0 --workspace --depth 1`
- `git diff --check`
- `make pre-pr`

## Impact
Default builds continue to use `mimalloc::MiMalloc` directly. Builds with `hotpath` and `hotpath-alloc` continue to use HotPath allocation counting while preserving MiMalloc as the allocator backend. No runtime configuration, storage format, S3 API, or deployment change is expected.

## Additional Notes
HotPath 0.23 changes custom allocator construction and forwards all `GlobalAlloc` methods to the inner allocator, including `alloc_zeroed` and `realloc`. This PR keeps RustFS aligned with that API while retaining the existing allocator forwarding tests.
