### PR TITLE
fix(helm): exclude external hosts from mTLS certificate

### DIFF
--- a/helm/rustfs/templates/cert-manager-mtls/04-server-cert.yaml
+++ b/helm/rustfs/templates/cert-manager-mtls/04-server-cert.yaml
@@ -21,10 +21,6 @@ spec:
     - "*.{{ include "rustfs.fullname" . }}-headless"
     - "*.{{ include "rustfs.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ include "rustfs.clusterDomain" . }}"
     - "{{ include "rustfs.fullname" . }}-svc.{{ .Release.Namespace }}.svc.{{ include "rustfs.clusterDomain" . }}"
-  {{- range .Values.ingress.hosts }}
-    - {{ .host | quote }}
-    - {{ printf "*.%s" .host | quote }}
-  {{- end }}
   usages:
     - server auth
 {{- end }}

--- a/scripts/test_helm_templates.sh
+++ b/scripts/test_helm_templates.sh
@@ -362,6 +362,16 @@ if ! grep -q 'svc\.cluster\.local"' <<<"$cert_default"; then
   echo "Default mTLS server cert SANs must use svc.cluster.local" >&2
   exit 1
 fi
+if grep -q 'example\.rustfs\.com' <<<"$cert_default"; then
+  echo "mTLS server cert SANs must not include the default external ingress host" >&2
+  exit 1
+fi
+
+cert_external_host=$(render_server_cert --set ingress.hosts[0].host=storage.example.test)
+if grep -q 'storage\.example\.test' <<<"$cert_external_host"; then
+  echo "mTLS server cert SANs must not include custom external ingress hosts" >&2
+  exit 1
+fi
 
 cert_custom=$(render_server_cert --set clusterDomain=cluster.internal)
 if ! grep -q 'svc\.cluster\.internal"' <<<"$cert_custom"; then


### PR DESCRIPTION
## Related Issues

Fixes #3858.

## Summary of Changes

- Stop adding Ingress hostnames and wildcard entries to the mTLS server Certificate SANs.
- Preserve the cluster-internal headless and service DNS names.
- Add Helm template regression coverage for default and custom external Ingress hosts.

The server Certificate previously iterated over `ingress.hosts` unconditionally, so the default `example.rustfs.com` host was included even though this certificate is used for the RustFS backend mTLS endpoint.

## Verification

- `make pre-commit`
- `bash scripts/test_helm_templates.sh`
- `helm lint helm/rustfs --set secret.rustfs.access_key=test-access-key --set secret.rustfs.secret_key=test-secret-key`
- `bash -n scripts/test_helm_templates.sh`
- `git diff --check`

## Impact

mTLS server Certificates no longer request external Ingress SANs. Cluster-internal SANs remain unchanged. Ingress and Gateway API external TLS termination continue to use their dedicated TLS Secret, so no API, storage, or migration changes are introduced.

## Additional Notes

The regression test fails against the previous template because the default external host is present, confirming that it detects the original issue.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
