### PR TITLE
fix(replication): preserve multipart source mtime

### DIFF
--- a/rustfs/src/storage/options.rs
+++ b/rustfs/src/storage/options.rs
@@ -340,8 +340,10 @@ pub fn get_complete_multipart_upload_opts_with_replication_authorization(
     let mut user_defined = HashMap::new();
 
     let mut replication_request = false;
+    let mut mod_time = None;
     if replication_request_authorized && get_header(headers, SUFFIX_SOURCE_REPLICATION_REQUEST).as_deref() == Some("true") {
         replication_request = true;
+        mod_time = replication_source_mtime(headers);
         if let Some(actual_size_str) = get_header(headers, SUFFIX_REPLICATION_ACTUAL_OBJECT_SIZE) {
             rustfs_utils::http::insert_str(
                 &mut user_defined,
@@ -361,6 +363,7 @@ pub fn get_complete_multipart_upload_opts_with_replication_authorization(
         want_checksum: rustfs_rio::get_content_checksum(headers)?,
         user_defined,
         replication_request,
+        mod_time,
         ..Default::default()
     };
     apply_replica_status_from_headers(headers, &mut opts, replication_request_authorized);
@@ -408,18 +411,21 @@ pub fn put_opts_from_headers_with_replication_authorization(
     apply_replica_status_from_headers(headers, &mut opts, replication_request_authorized);
     if replication_request_authorized && get_header(headers, SUFFIX_SOURCE_REPLICATION_REQUEST).as_deref() == Some("true") {
         opts.replication_request = true;
-        if let Some(v) = get_header(headers, SUFFIX_SOURCE_MTIME) {
-            let trimmed_s = v.trim();
-            match time::OffsetDateTime::parse(trimmed_s, &time::format_description::well_known::Rfc3339) {
-                Ok(mtime) => opts.mod_time = Some(mtime),
-                Err(e) => {
-                    tracing::warn!("Invalid source-mtime value '{}' (replication request=true): {}", trimmed_s, e);
-                    opts.mod_time = None;
-                }
-            }
-        }
+        opts.mod_time = replication_source_mtime(headers);
     }
     Ok(opts)
+}
+
+fn replication_source_mtime(headers: &HeaderMap<HeaderValue>) -> Option<time::OffsetDateTime> {
+    let value = get_header(headers, SUFFIX_SOURCE_MTIME)?;
+    let value = value.trim();
+    match time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339) {
+        Ok(mtime) => Some(mtime),
+        Err(err) => {
+            tracing::warn!("Invalid source-mtime value '{}' (replication request=true): {}", value, err);
+            None
+        }
+    }
 }
 
 fn apply_replica_status_from_headers(headers: &HeaderMap<HeaderValue>, opts: &mut ObjectOptions, authorized: bool) {
@@ -1473,6 +1479,32 @@ mod tests {
         let authorized = get_complete_multipart_upload_opts_with_replication_authorization(&headers, true)
             .expect("authorized replica status header should parse");
         assert_eq!(authorized.delete_marker_replication_status(), ReplicationStatusType::Replica);
+    }
+
+    #[test]
+    fn test_complete_multipart_opts_preserves_authorized_replication_mtime() {
+        let source_mtime = "2024-05-20T10:30:00+08:00";
+        let mut headers = HeaderMap::new();
+        insert_header(&mut headers, SUFFIX_SOURCE_REPLICATION_REQUEST, "true");
+        insert_header(&mut headers, SUFFIX_SOURCE_MTIME, source_mtime);
+
+        let untrusted = get_complete_multipart_upload_opts(&headers)
+            .expect("ordinary multipart completion options should ignore replication headers");
+        assert!(!untrusted.replication_request);
+        assert!(untrusted.mod_time.is_none());
+
+        let authorized = get_complete_multipart_upload_opts_with_replication_authorization(&headers, true)
+            .expect("authorized multipart replication options should parse");
+        let expected = time::OffsetDateTime::parse(source_mtime, &time::format_description::well_known::Rfc3339)
+            .expect("test source mtime should be valid");
+        assert!(authorized.replication_request);
+        assert_eq!(authorized.mod_time, Some(expected));
+
+        insert_header(&mut headers, SUFFIX_SOURCE_MTIME, "invalid-time");
+        let invalid = get_complete_multipart_upload_opts_with_replication_authorization(&headers, true)
+            .expect("invalid replication mtime should keep existing fallback behavior");
+        assert!(invalid.replication_request);
+        assert!(invalid.mod_time.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Fixes #5662.

## Summary of Changes

Multipart replication completion now parses the authorized source modification-time header into `ObjectOptions.mod_time`, matching the existing regular PUT replication path.

Root cause: `get_complete_multipart_upload_opts_with_replication_authorization` recorded the replication request and metadata but dropped `x-rustfs-source-mtime` / `x-minio-source-mtime`. The ecstore multipart commit path then fell back to the local completion time.

The timestamp parser is shared with the regular PUT path so both flows retain the same RFC 3339 and invalid-input behavior.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs --lib storage::options::tests::test_complete_multipart_opts_preserves_authorized_replication_mtime -- --exact`
- Mutation check: removing the multipart `mod_time` assignment makes the regression test fail; restoring it makes the test pass.
- `make pre-commit`
- `make log-analyzer-rules-check clippy-check test`
  - Static guards, full workspace quick-check, log-analyzer rules, all-target/all-feature Clippy, and script tests passed.
  - Full nextest executed all 12,173 tests: 12,171 passed and two unrelated system-DNS tests failed because the local resolver maps reserved `.invalid` names to `198.18.0.7/8` instead of returning NXDOMAIN.
  - The first DNS test also passed in an isolated run before the resolver mapping was observed.
- `cargo test --all --doc`

Adversarial validation:

- Correctness: PASS — authorized valid, unauthorized, and invalid timestamp paths are pinned; multipart fallback behavior remains unchanged when no usable timestamp exists.
- Simplicity: PASS — one request-local assignment and one parser shared with the existing PUT path; no duplicate constants or parallel implementation.
- Security: PASS — source timestamps remain ignored unless replication authorization and the replication-request marker are both present.
- Concurrency and durability: PASS — no locks, awaits, shared state, commit ordering, or persistence format changed.
- Compatibility: PASS — the existing dual RustFS/MinIO header lookup and RFC 3339 parsing semantics are preserved.
- Performance: PASS — one header lookup and parse only on authorized multipart replication completion; ordinary multipart requests do no extra parsing.
- Test effectiveness: PASS — the regression test detects removal of the fix and covers the authorization boundary plus malformed input.

## Impact

Replicated multipart objects preserve the source object's `LastModified` value instead of receiving the destination completion time. There are no API, configuration, wire-format, or on-disk format changes.

## Additional Notes

The change is intentionally limited to multipart option construction. Invalid or absent source timestamps continue to use the existing completion-time fallback.