### PR TITLE
fix(lock): let waiters hear releases and let acquisition succeed past registered waiters

### DIFF
--- a/crates/lock/src/fast_lock/shard.rs
+++ b/crates/lock/src/fast_lock/shard.rs
@@ -215,12 +215,30 @@ impl LockShard {
             let remaining = deadline - Instant::now();
 
             if retry_count < MAX_RETRIES && remaining > Duration::from_millis(10) {
-                // For early retries, use a brief exponential backoff instead of full notification wait
+                // For early retries, wait for a release notification bounded by
+                // an exponential backoff. The bound (not a bare sleep) matters:
+                // a plain `sleep` subscribes to nothing, so a release during
+                // the backoff wakes nobody — `notify_writer`/`notify_readers`
+                // are gated on the waiter counters, which a sleeper never
+                // increments. Under N-writer same-key contention the lock sits
+                // free while every loser sleeps out its full backoff, and the
+                // ladder compounds superlinearly with N. The backoff cap still
+                // protects against lost/stolen wakeups, exactly as
+                // NOTIFY_WAIT_CAP does for the post-retry wait below.
                 let backoff_ms = std::cmp::min(10 << retry_count, 100); // 10ms, 20ms, 40ms, 80ms, 100ms max
                 let backoff_duration = Duration::from_millis(backoff_ms);
 
                 if backoff_duration < remaining {
-                    tokio::time::sleep(backoff_duration).await;
+                    match request.mode {
+                        LockMode::Shared => {
+                            let _waiter_guard = WaiterCounterGuard::new(state.clone(), LockMode::Shared);
+                            let _ = timeout(backoff_duration, state.optimized_notify.wait_for_read()).await;
+                        }
+                        LockMode::Exclusive => {
+                            let _waiter_guard = WaiterCounterGuard::new(state.clone(), LockMode::Exclusive);
+                            let _ = timeout(backoff_duration, state.optimized_notify.wait_for_write()).await;
+                        }
+                    }
                     retry_count += 1;
                     continue;
                 }

--- a/crates/lock/src/fast_lock/shard.rs
+++ b/crates/lock/src/fast_lock/shard.rs
@@ -871,6 +871,70 @@ mod tests {
         assert!(shard.release_lock(&key, &owner1, LockMode::Exclusive));
     }
 
+    // Regression for the waiter-preserving early retry (rustfs#5657).
+    //
+    // The early retries used a bare `sleep`, which subscribes to nothing.
+    // `notify_writer`/`notify_readers` are gated on the waiter counters, so a
+    // sleeping waiter is invisible to every release: the lock sits free while
+    // each loser sleeps out its full 10/20/40/80/100ms rung, and under N-writer
+    // same-key contention that ladder — not the hold — is what the wait costs.
+    // Registration is what lets a release reach the waiter at all; the wakeup
+    // itself is covered by `write_lock_waiter_is_not_stranded_by_missed_wakeup`.
+    //
+    // MAX_RETRIES rungs total ~750ms, so the window sampled here sits entirely
+    // inside the early-retry phase, where a sleeping waiter registers nowhere.
+    //
+    // Wakeup *latency* is deliberately not asserted: NOTIFY_POOL is a global of
+    // 128 `Notify`s shared by every lock in the process, so a waiter in another
+    // concurrently-running test can consume this one's `notify_one` and push it
+    // out to the end of its rung. That is the same stolen wakeup NOTIFY_WAIT_CAP
+    // exists to bound, and it makes any latency budget flaky in-suite.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn early_retry_registers_as_waiter() {
+        let shard = Arc::new(LockShard::new(0));
+        let key = ObjectKey::new("bucket", "object");
+        let holder: Arc<str> = Arc::from("holder");
+        let waiter: Arc<str> = Arc::from("waiter");
+
+        let request = |owner: Arc<str>| ObjectLockRequest {
+            key: key.clone(),
+            mode: LockMode::Exclusive,
+            owner,
+            acquire_timeout: Duration::from_secs(5),
+            lock_timeout: Duration::from_secs(30),
+            priority: LockPriority::Normal,
+        };
+
+        assert!(shard.acquire_lock(&request(holder.clone())).await.is_ok());
+
+        let waiter_shard = shard.clone();
+        let waiter_request = request(waiter.clone());
+        let waiter_task = tokio::spawn(async move { waiter_shard.acquire_lock(&waiter_request).await });
+
+        let sample_until = Instant::now() + Duration::from_millis(200);
+        let mut registered = false;
+        while !registered && Instant::now() < sample_until {
+            registered = shard
+                .objects
+                .read()
+                .get(&key)
+                .is_some_and(|state| state.atomic_state.writers_waiting_count() > 0);
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        assert!(
+            registered,
+            "a waiter in the early-retry backoff must be registered in the writer waiter count, \
+             otherwise releases cannot reach it"
+        );
+
+        assert!(shard.release_lock(&key, &holder, LockMode::Exclusive));
+        waiter_task
+            .await
+            .expect("waiter task should not panic")
+            .expect("waiter must acquire once the holder releases");
+    }
+
     #[test]
     fn test_adaptive_timeout_does_not_exceed_request_acquire_timeout() {
         let shard = LockShard::new(0);

--- a/crates/lock/src/fast_lock/state.rs
+++ b/crates/lock/src/fast_lock/state.rs
@@ -110,13 +110,31 @@ impl AtomicLockState {
     pub fn try_acquire_exclusive(&self) -> bool {
         self.update_access_time();
 
-        // Must be completely unlocked to acquire exclusive
-        let expected = 0;
-        let new_state = WRITER_FLAG_MASK;
+        loop {
+            let current = self.state.load(Ordering::Acquire);
 
-        self.state
-            .compare_exchange(expected, new_state, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
+            // Only ownership bits may block acquisition: no writer flag, no
+            // active readers. The waiting counters are preserved, not
+            // required to be zero — demanding a fully-zero word means a lock
+            // with registered waiters can be acquired by *no one*, including
+            // the waiters themselves (each sees the others' registration),
+            // so contended acquisition only succeeds in windows where every
+            // waiter happens to be unregistered. `try_acquire_shared` above
+            // already masks correctly; this mirrors it.
+            if (current & (WRITER_FLAG_MASK | READERS_MASK)) != 0 {
+                return false;
+            }
+
+            let new_state = current | WRITER_FLAG_MASK;
+
+            if self
+                .state
+                .compare_exchange_weak(current, new_state, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                return true;
+            }
+        }
     }
 
     /// Release shared lock

--- a/crates/lock/src/fast_lock/state.rs
+++ b/crates/lock/src/fast_lock/state.rs
@@ -548,6 +548,45 @@ mod tests {
         assert!(!state.release_exclusive());
     }
 
+    // Regression for the waiter-preserving exclusive CAS.
+    //
+    // The acquisition CAS used to demand a fully-zero state word, which
+    // includes the readers_waiting/writers_waiting counters. A free lock with
+    // registered waiters was then acquirable by *no one* — including the
+    // waiters themselves, each blocked by the others' registration — so
+    // contended acquisition only succeeded in windows where every waiter
+    // happened to be unregistered. Reverting to `expected = 0` must fail here.
+    #[test]
+    fn exclusive_acquisition_ignores_registered_waiters() {
+        let state = AtomicLockState::new();
+
+        // Waiters register while the lock is held, then the holder releases.
+        assert!(state.try_acquire_exclusive());
+        assert!(state.inc_writers_waiting());
+        assert!(state.inc_readers_waiting());
+        assert!(state.release_exclusive());
+
+        // The lock is now free — only the waiting counters are set.
+        assert!(
+            state.try_acquire_exclusive(),
+            "registered waiters must not block acquisition of a free lock"
+        );
+        // ...and the CAS must preserve those counters, not clobber them.
+        assert_eq!(state.writers_waiting_count(), 1);
+        assert_eq!(state.readers_waiting_count(), 1);
+
+        assert!(state.release_exclusive());
+        state.dec_writers_waiting();
+
+        // Ownership bits still block, registered waiters or not.
+        assert!(state.try_acquire_shared());
+        assert!(!state.try_acquire_exclusive(), "an active reader must still block");
+        assert!(state.release_shared());
+
+        state.dec_readers_waiting();
+        assert!(state.is_free());
+    }
+
     #[test]
     fn test_object_lock_state() {
         let state = ObjectLockState::new();

--- a/crates/lock/src/fast_lock/tests.rs
+++ b/crates/lock/src/fast_lock/tests.rs
@@ -18,7 +18,7 @@ mod fast_lock_tests {
     use crate::fast_lock::types::{LockConfig, LockMode, LockPriority, LockResult, ObjectKey, ObjectLockRequest};
     use crate::fast_lock::{DEFAULT_SHARD_COUNT, FastObjectLockManager};
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
     use tokio::time::sleep;
 
     /// Helper function to create a test lock manager
@@ -468,6 +468,67 @@ mod fast_lock_tests {
         for handle in handles {
             handle.await.expect("lock task should not panic");
         }
+    }
+
+    // Regression for the waiter-preserving exclusive CAS, end to end
+    // (rustfs#5657 same-key write contention).
+    //
+    // `try_acquire_exclusive` used to demand a fully-zero state word, which
+    // includes the waiting counters. Once the slow path's retries register as
+    // waiters — as they must, to hear a release — a lock with waiters becomes
+    // acquirable by no one, each waiter blocked by the others' registration, so
+    // every waiter here sits out its full acquire deadline instead of draining.
+    //
+    // The holder is held long enough for all waiters to be registered before
+    // the single release. After it they only serialize on each other, holding
+    // nothing, so they should drain in tens of milliseconds.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn contended_writers_drain_promptly_after_release() {
+        let manager = Arc::new(create_test_manager());
+        let key = ObjectKey::new("bucket", "hot-object");
+        const WAITERS: usize = 16;
+        const HOLD: Duration = Duration::from_millis(300);
+        // Generous next to the ~20ms the fixed path needs for these waiters, and
+        // far below the 5s acquire deadline a zero-state CAS makes them all
+        // sit out.
+        const DRAIN_BUDGET: Duration = Duration::from_millis(1000);
+
+        let mut holder = manager
+            .acquire_write_lock(key.clone(), "holder")
+            .await
+            .expect("holder should acquire immediately");
+
+        let mut handles = Vec::new();
+        for i in 0..WAITERS {
+            let manager = manager.clone();
+            let key = key.clone();
+            handles.push(tokio::spawn(async move {
+                let request =
+                    ObjectLockRequest::new_write(key, format!("waiter-{i}")).with_acquire_timeout(Duration::from_secs(5));
+                let mut guard = manager
+                    .acquire_lock(request)
+                    .await
+                    .expect("every waiter must acquire once the holder releases");
+                assert!(guard.release());
+            }));
+        }
+
+        // Let every waiter fail its fast path and register in the retry ladder.
+        sleep(HOLD).await;
+
+        let released_at = Instant::now();
+        assert!(holder.release());
+
+        for handle in handles {
+            handle.await.expect("waiter task should not panic");
+        }
+
+        let drain = released_at.elapsed();
+        assert!(
+            drain < DRAIN_BUDGET,
+            "{WAITERS} waiters took {drain:?} to drain after the release (budget {DRAIN_BUDGET:?}) - \
+             registered waiters are blocking acquisition"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues

Fixes #5657.

## Summary of Changes

Same-key write contention scaled superlinearly with writer count: 8 concurrent conditional PUTs on one key cost ~340–460 ms, 16 cost ~700 ms, 32 cost ~5 s — against ~4 ms per uncontended write and ~10 ms actual lock holds (measured with `RUSTFS_OBJECT_LOCK_DIAG_ENABLE` at 1 ms thresholds). Outcomes were always correct (exactly one winner, N−1 `412`s, zero errors); the cost was pure waiting.

Two coupled defects in `fast_lock` caused it:

1. **Sleepers can't hear releases.** The slow path's early retries used a bare `tokio::time::sleep(backoff)` without registering as a waiter. `notify_writer()`/`notify_readers()` are gated on the waiter counters, which a sleeper never increments, so a release during the backoff woke nobody. The lock sat free while every loser slept out its full backoff, and the ladder compounded — the object-lock diag shows successive acquires landing at the cumulative ladder offsets (19/37/70/135/235/336/438 ms for 7 losers, i.e. 10+20+40+80+100… ms) against ~10 ms of total hold time.

2. **Registered waiters block all acquisition.** `try_acquire_exclusive` CAS-ed from `expected = 0` — the *entire* packed word, including the `readers_waiting`/`writers_waiting` counter bits. A lock with registered waiters could be acquired by **no one**, including the waiters themselves (each sees the others' registration). This is why (1) could not be fixed by just registering the sleepers — registration alone deadlocks acquisition until the acquire deadline (`test_concurrent_write_lock_contention` goes from 0.17 s to hard timeout) — and why the post-`MAX_RETRIES` notification branch starves at higher N: once several waiters are registered, acquisition only succeeds in windows where all of them happen to be unregistered simultaneously. That is the superlinear blowup. `try_acquire_shared` already masks correctly (it refuses only on `WRITER_FLAG | WRITERS_WAITING` and preserves the counter bits in its CAS); the exclusive path now mirrors it.

The fix, two small changes:

- `state.rs`: mask the exclusive-acquisition CAS to ownership bits only (writer flag + active readers), preserving the waiting counters.
- `shard.rs`: turn the early-retry sleep into a notification wait bounded by the same backoff, so a release wakes a waiter immediately while the bound still protects against lost/stolen wakeups exactly as `NOTIFY_WAIT_CAP` does for the post-retry wait.

## Regression coverage

Added in `fd15a52` after review: the fix commit touched only production files, and the existing `test_concurrent_write_lock_contention` merely waits for five writers to finish — it never asserts that acquisition happens before the backoff ladder runs out, so either half could be reverted with the suite still green. Three tests now guard it, one per revertable line, each checked by reverting that line in isolation and re-running the suite:

| test | file | fails when reverting |
|---|---|---|
| `exclusive_acquisition_ignores_registered_waiters` | `state.rs` | the masked CAS |
| `early_retry_registers_as_waiter` | `shard.rs` | the bounded notification wait |
| `contended_writers_drain_promptly_after_release` | `tests.rs` | the masked CAS, end to end |

- **`exclusive_acquisition_ignores_registered_waiters`** — a free lock with registered waiters must be acquirable, and the CAS must preserve the counters rather than clobber them. Deterministic, no timing.
- **`early_retry_registers_as_waiter`** — a waiter in the early-retry backoff must appear in the writer waiter count, since `notify_writer`/`notify_readers` are gated on those counters. The sampled window sits inside the ~750 ms early-retry phase, where a bare `sleep` registers nowhere. Also deterministic.
- **`contended_writers_drain_promptly_after_release`** — 16 same-key writers, all registered behind one holder, must drain within 1 s of the release instead of sitting out their 5 s acquire deadlines. Against the all-zero `expected` they all time out.

**Wakeup latency is deliberately not asserted anywhere.** The sharper test of the `shard.rs` half is a latency probe (independent keys, release timed to land just past a rung boundary), and it does fail correctly on that revert — but it is not safe to keep in-suite. `NOTIFY_POOL` is a process-global of 128 `Notify` slots shared by every lock, so a waiter in a concurrently-running test consumes this one's `notify_one` and the robbed waiter sleeps out its rung. Measured on the fixed tree with a 24-key probe: **~150 µs** mean in isolation, **~92 ms** — a full unexpired rung, for 22 of 24 waiters — running alongside the existing 64-key `write_lock_waiter_is_not_stranded_by_missed_wakeup`. That is the same stolen wakeup `NOTIFY_WAIT_CAP` exists to bound (see the audit above), so it is bounded rather than broken, but it makes any latency budget flaky for reasons unrelated to this change. Registration is the property the fix actually adds; prompt delivery *given* registration is already covered by `write_lock_waiter_is_not_stranded_by_missed_wakeup`.

## Concurrency-impact audit

Everything the old strictness could have been silently protecting was checked before proposing this. Behavior changes first, then the paths verified unaffected.

**Deliberate behavior changes (2):**

- **Barging.** A fresh requester can now acquire past registered waiters — identical to what `try_acquire_shared` already permits past `readers_waiting`, and `notify_one` never provided FIFO ordering among waiters. The previous exclusive behavior wasn't fairness; it was mutual starvation. Under sustained contention, waiters still make progress via their bounded re-poll ladder.
- **Writer preference now binds.** `try_acquire_shared` defers to `writers_waiting > 0`; previously writers were rarely registered (only inside the post-retry notification window), so this preference was mostly inert. With backoff waiters registered, readers genuinely queue behind waiting writers — which is the release path's stated intent ("prefer writers over readers"). Standard write-preference caveat: a sustained writer stream on one key delays readers on that key; reader waits remain bounded by their own acquire deadline and drain when `writers_waiting` does.

**Paths verified unaffected (audited against `main` @ 2fb88d2):**

- **Single caller.** `try_acquire_exclusive` has exactly one production caller (`try_acquire_exclusive_fast`); nothing else depends on the all-zero-word semantics.
- **No raw writes to the packed word.** The only `.store()` on the state struct is `last_accessed`. Acquisition, release (`current & !WRITER_FLAG_MASK`), and `force_release_all` (which iterates owners through the normal `release_lock`) all mutate via CAS loops that preserve the waiting-counter bits — nothing can zero the word under a registered waiter.
- **Flags `[7:1]` / reserved `[63:48]` bits.** Referenced nowhere in code (layout comment only). The masked check ignores them exactly as the shared path always has.
- **Object-pool recycling.** `object_pool.acquire()` calls `reset_for_reuse()`, which installs a fresh zeroed `AtomicLockState` and a fresh `OptimizedNotify` — the masked CAS can never accept a recycled state carrying stale waiter counts.
- **Detached-state double lock.** The slow-path loop re-fetches the state from the shard map on every iteration; a parked waiter only ever *waits* on its iteration's `Arc`, never acquires through it. If cleanup swaps the map entry mid-wait, the waiter wakes (bounded) and operates on the current entry.
- **Cleanup races — strictly improved.** `cleanup_expired` and the release path retain entries with `has_waiters()`. Stock backoff sleepers were *invisible* to that check, so their state could be reclaimed mid-backoff; registered waiters are now visible and protected.
- **Counter under/overflow.** `dec_*` no-ops at 0; `inc_*` saturates at 0xFFFF and returns `false`, in which case the guard skips its decrement and that waiter simply degrades to the old blind-sleep behavior.
- **Shared `NOTIFY_POOL` permit theft.** More notifications are produced now (releases see registered waiters), and a `notify_one` permit can be consumed by a waiter of a different key hashing to the same slot. Both directions are bounded: a stolen wakeup costs the victim at most its backoff bound (then it re-polls), and a spurious wake costs one extra retry. No unbounded wait is possible in either branch.
- **Adaptive timeout.** `calculate_adaptive_timeout` scales off `objects.len()` + active guards and only *extends* under load (min multiplier 0.9×); waiter registration doesn't feed it a shrinking input.

## Verification

- `cargo test -p rustfs-lock`: 116/116 (113 pre-existing + the 3 regression tests above), runtime at pristine parity (1.46 s vs 1.47 s), including `test_concurrent_write_lock_contention`.
- `cargo test -p rustfs-ecstore --lib lock` (233 tests, parallel): **identical results to pristine on the same machine** — 225 passed and the same 8 tests fail name-for-name on both trees under parallel load (they pass in isolation on both; pre-existing interference, tracked separately from this change).
- `cargo fmt` / `cargo clippy -p rustfs-lock --all-targets`: clean.
- End-to-end S3 benchmark (release build, single node, N concurrent `PUT`s racing the same key with `If-Match`; client-side SDK retries disabled so nothing masks server behavior):

| N racers, same key | before | after |
|---|---|---|
| 8 (plain create-only, `If-None-Match: *`) | 338–466 ms | **17 ms** |
| 8 (conditional, `If-Match`) | 362–440 ms | **29 ms** |
| 16 | ~700 ms | **15 ms** |
| 32 | ~5,000 ms | **20–53 ms** |

Outcomes at every width, before and after: exactly 1 winner, N−1 losers with `412`, 0 errors — including three repeated N=32 runs (20/23/40/53 ms) to check stability. Contended same-key writes now resolve in release order at notification speed instead of sleeping past a free lock.

## Impact

Latency improvement for any workload doing concurrent writes to the same key (conditional-write/CAS protocols over pointer objects, multipart commit contention, metadata hot keys). Two intentional semantics refinements documented in the audit above (barging past registered waiters; writer preference now effective). No API, configuration, or compatibility changes. No new dependencies.

## Additional Notes

Diagnosis details and reproduction harness are in #5657. The object-lock diag (`RUSTFS_OBJECT_LOCK_DIAG_ENABLE=true` with 1 ms thresholds) is what made the ladder visible — the acquire timestamps in the log reproduce the cumulative backoff sequence exactly.

