### PR TITLE
fix(ecstore): address review comments for batch shard pread

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -6701,7 +6701,7 @@ pub(crate) async fn batch_shard_pread(requests: Vec<(std::path::PathBuf, usize, 
             let r = (|| -> Result<Bytes> {
                 let meta = std::fs::metadata(&file_path).map_err(DiskError::from)?;
                 let end = offset.checked_add(length).ok_or(DiskError::FileCorrupt)?;
-                if meta.len() < end as u64 {
+                if meta.len() < u64::try_from(end).unwrap_or(u64::MAX) {
                     return Err(DiskError::FileCorrupt);
                 }
 
@@ -6710,7 +6710,7 @@ pub(crate) async fn batch_shard_pread(requests: Vec<(std::path::PathBuf, usize, 
                 let mut total = 0usize;
                 while total < length {
                     let nbytes = file
-                        .read_at(&mut buf[total..], (offset + total) as u64)
+                        .read_at(&mut buf[total..], u64::try_from(offset + total).unwrap_or(u64::MAX))
                         .map_err(DiskError::from)?;
                     if nbytes == 0 {
                         return Err(DiskError::FileCorrupt);
@@ -17986,5 +17986,6 @@ mod test {
         assert!(results[0].is_ok());
         assert_eq!(results[0].as_ref().unwrap().as_ref(), b"good data");
         assert!(results[1].is_err());
+        assert!(matches!(results[1].as_ref().unwrap_err(), DiskError::Io(_)));
     }
 }

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -63,7 +63,6 @@ use metrics::counter;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     future::Future,
-    io::Cursor,
     pin::Pin,
     sync::OnceLock,
     task::{Context, Poll},
@@ -1425,6 +1424,7 @@ async fn try_create_bitrot_readers_via_batch_pread(
     skip_verify_bitrot: bool,
 ) -> Option<BitrotReaderSetup> {
     use crate::disk::local::batch_shard_pread;
+    use std::io::Cursor;
 
     let (adj_off, adj_len) = adjust_shard_read_params(read_offset, read_length, shard_size, &checksum_algo);
     if adj_len > object_mmap_read_max_length() {


### PR DESCRIPTION
## Summary

Address review comments from PR #5679 for the batch shard pread follow-up.

### Changes

1. **m2 — Move `use std::io::Cursor` import into function scope** (`io_primitives.rs`)
   - Removed `Cursor` from the top-level `use` block and added it as a local import inside `try_create_bitrot_readers_via_batch_pread`, following the convention of scoping imports to where they are used.

2. **m1 — Verify concrete error type in test** (`local.rs`)
   - Added `assert!(matches!(results[1].as_ref().unwrap_err(), DiskError::Io(_)))` to `test_batch_shard_pread_partial_errors` to verify the specific error variant rather than just checking `is_err()`.

3. **M1 — Replace `as u64` with safe conversion** (`local.rs`)
   - Changed two `as u64` casts in `batch_shard_pread` to `u64::try_from(...).unwrap_or(u64::MAX)` to avoid silent truncation on 32-bit platforms.

## Verification

- `cargo check -p rustfs-ecstore` — passes
- `cargo test -p rustfs-ecstore --lib test_batch_shard_pread` — both tests pass
- `cargo fmt --all --check` — clean
