### PR TITLE
fix(ecstore): skip walkdir total timeout for listing operations

### DIFF
--- a/crates/ecstore/src/store/list_objects.rs
+++ b/crates/ecstore/src/store/list_objects.rs
@@ -4333,7 +4333,7 @@ impl ECStore {
                             filter_prefix: Some(filter_prefix.clone()),
                             forward_to: opts.marker.clone(),
                             per_disk_limit: bounded_usize_to_i32(opts.limit),
-                            skip_total_timeout: false,
+                            skip_total_timeout: opts.walkdir_timeout.is_none(),
                             walkdir_timeout: opts.walkdir_timeout,
                             walkdir_stall_timeout: opts.walkdir_stall_timeout,
                         },
@@ -4356,6 +4356,12 @@ impl ECStore {
                             forward_to: opts.marker.clone(),
                             min_disks: raw_min_disks,
                             per_disk_limit: bounded_usize_to_i32(opts.limit),
+                            // Skip the total walkdir timeout for listing operations.
+                            // Large buckets (millions of objects) can take longer than
+                            // the default 5s walkdir timeout to produce the first page
+                            // of results. The stall timeout still protects against
+                            // drives that stop making forward progress.
+                            skip_walkdir_total_timeout: opts.walkdir_timeout.is_none(),
                             walkdir_timeout: opts.walkdir_timeout,
                             walkdir_stall_timeout: opts.walkdir_stall_timeout,
                             agreed: Some(Box::new(move |entry: MetaCacheEntry| {
@@ -5554,7 +5560,7 @@ impl Sets {
                         filter_prefix: Some(filter_prefix.clone()),
                         forward_to: opts.marker.clone(),
                         per_disk_limit: bounded_usize_to_i32(opts.limit),
-                        skip_total_timeout: false,
+                        skip_total_timeout: opts.walkdir_timeout.is_none(),
                         walkdir_timeout: opts.walkdir_timeout,
                         walkdir_stall_timeout: opts.walkdir_stall_timeout,
                     },
@@ -5577,6 +5583,12 @@ impl Sets {
                         forward_to: opts.marker.clone(),
                         min_disks: raw_min_disks,
                         per_disk_limit: bounded_usize_to_i32(opts.limit),
+                        // Skip the total walkdir timeout for listing operations.
+                        // Large buckets (millions of objects) can take longer than
+                        // the default 5s walkdir timeout to produce the first page
+                        // of results. The stall timeout still protects against
+                        // drives that stop making forward progress.
+                        skip_walkdir_total_timeout: opts.walkdir_timeout.is_none(),
                         walkdir_timeout: opts.walkdir_timeout,
                         walkdir_stall_timeout: opts.walkdir_stall_timeout,
                         agreed: Some(Box::new(move |entry: MetaCacheEntry| {


### PR DESCRIPTION
## Related Issues

Fixes #5647

## Summary of Changes

Skip the walkdir total timeout for S3 ListObjects listing operations when no explicit `walkdir_timeout` is configured. The default 5-second walkdir total timeout (`DEFAULT_DRIVE_WALKDIR_TIMEOUT_SECS`) is too short for large buckets with millions of objects — the disk walk cannot produce the first page of results within that budget, causing timeouts in the web UI and `mc` CLI.

The fix sets `skip_walkdir_total_timeout: true` (and the corresponding `skip_total_timeout` for fallback supplement listings) in `ListPathRawOptions` / `ListingSupplementOptions` when `opts.walkdir_timeout` is `None`. The stall timeout (5 seconds with no forward progress) still protects against drives that stop responding.

This matches the scanner's existing behavior — `scanner_folder.rs` already uses `skip_walkdir_total_timeout: true` for the same reason.

**Changed file:** `crates/ecstore/src/store/list_objects.rs` — 4 locations (2 `ListPathRawOptions` + 2 `ListingSupplementOptions` across pool-level and set-level listing paths).

## Verification

- `make pre-commit` — all checks passed
- `cargo test -p rustfs-ecstore --lib -- store::list_objects` — 127 tests passed, 0 failed
- `cargo fmt --all --check` — clean

## Impact

- **User-facing:** Buckets with millions of objects should now be listable from the web UI and `mc` CLI without timing out.
- **Compatibility:** No API changes. No configuration changes required.
- **Performance:** Listing operations for large buckets will no longer be artificially cut short by the 5-second walkdir total timeout. The stall timeout still bounds idle time.

## Additional Notes

The 396,000 object count cap reported in the issue is a symptom of the walkdir timeout: each disk walk times out after 5 seconds, producing partial results. With this fix, the walkdir is allowed to run to completion (bounded only by the stall timeout), so the full object set can be enumerated.
