### PR TITLE
fix(audit): move audit init after IAM bootstrap to fix startup ordering

### DIFF
--- a/rustfs/src/startup_services.rs
+++ b/rustfs/src/startup_services.rs
@@ -75,11 +75,14 @@ pub(crate) async fn init_startup_runtime_services(
     let optional_runtimes = init_optional_runtime_services().await?;
 
     init_buffer_profile_system(config);
-    init_audit_runtime().await;
     init_deadlock_detector_runtime();
 
     let buckets = init_bucket_metadata_runtime(store.clone(), ctx.clone()).await?;
     let iam_bootstrap = init_iam_runtime(store.clone(), ctx.clone(), readiness, state_manager, server_ctx).await?;
+
+    // Audit initialization requires the AppContext (server config + object store)
+    // which is published by ensure_startup_after_iam inside init_iam_runtime.
+    init_audit_runtime().await;
     // Unconditional: deferred IAM recovers in the background and has no callback into this
     // scheduler, so gating on the inline disposition would leave a recovered node with
     // self-pointing replication rules until the next restart. The task waits for IAM and


### PR DESCRIPTION
## Summary

- Move `init_audit_runtime()` after `init_iam_runtime()` in the startup service sequence so audit initialization has access to the AppContext (server config + object store)
- Fixes audit webhook targets remaining offline after boot when configured via environment variables

## Root Cause

`init_audit_runtime()` was called at `startup_services.rs:78`, before `init_iam_runtime()` creates and publishes the `AppContext` via `ensure_startup_after_iam`. Both `current_object_store_handle()` and `current_server_config()` returned `None` because no `AppContext` existed yet, causing:

```
Failed to refresh persisted audit module switch from store: storage layer not initialized
Audit system initialization failed: Global server configuration not loaded.
```

## Fix

Move `init_audit_runtime().await` from before `init_iam_runtime()` to after it. Audit has no downstream dependencies that earlier services rely on, and the event notifier (`init_event_notifier`) handles a missing store gracefully.

## Verification

- `cargo check -p rustfs` — compiles
- `cargo fmt --all --check` — passes
- Existing `startup_audit` unit tests cover the `init_event_notifier_and_audit_with` logic in isolation

Fixes #5681
