### PR TITLE
fix(list): skip delete markers in single-object fast path for ListObjects

### DIFF
--- a/crates/ecstore/src/store/list_objects.rs
+++ b/crates/ecstore/src/store/list_objects.rs
@@ -3716,7 +3716,7 @@ impl ECStore {
         }
 
         // Optimization: use get for single object lookup with exact prefix
-        if !opts.prefix.is_empty() && max_keys == 1 && opts.marker.is_none() {
+        if !opts.prefix.is_empty() && max_keys == 1 && opts.marker.is_none() && !incl_deleted {
             match self
                 .get_object_info(
                     &opts.bucket,
@@ -3728,17 +3728,16 @@ impl ECStore {
                 )
                 .await
             {
-                Ok(res) => {
+                Ok(res) if !res.delete_marker => {
                     return Ok(ListObjectsInfo {
                         objects: vec![res],
                         ..Default::default()
                     });
                 }
-                Err(err) => {
-                    if is_err_bucket_not_found(&err) {
-                        return Err(err);
-                    }
+                Err(err) if is_err_bucket_not_found(&err) => {
+                    return Err(err);
                 }
+                _ => {}
             };
         };
 
@@ -5059,7 +5058,7 @@ impl Sets {
         // (notably `forward_past`) — see backlog#1047.
         opts.parse_marker();
 
-        if !opts.prefix.is_empty() && max_keys == 1 && opts.marker.is_none() {
+        if !opts.prefix.is_empty() && max_keys == 1 && opts.marker.is_none() && !incl_deleted {
             match self
                 .get_object_info(
                     &opts.bucket,
@@ -5071,17 +5070,16 @@ impl Sets {
                 )
                 .await
             {
-                Ok(res) => {
+                Ok(res) if !res.delete_marker => {
                     return Ok(ListObjectsInfo {
                         objects: vec![res],
                         ..Default::default()
                     });
                 }
-                Err(err) => {
-                    if is_err_bucket_not_found(&err) {
-                        return Err(err);
-                    }
+                Err(err) if is_err_bucket_not_found(&err) => {
+                    return Err(err);
                 }
+                _ => {}
             };
         }
 


### PR DESCRIPTION
## Related Issues

Fixes #5375

## Summary of Changes

The single-object fast path in `list_objects_generic` (both `ECStore` and `Sets` implementations) called `get_object_info` directly when `max_keys == 1` with an exact prefix, bypassing the `gather_results` filter that normally excludes delete markers. This caused deleted objects to appear in `ListObjects`/`ListObjectsV2` responses for versioned buckets.

**Fix (3 changes per implementation, 2 implementations = 6 lines changed):**

1. Guard the fast path with `!incl_deleted` so it never runs when the caller requests delete markers (the "Show Deleted Objects" feature).
2. Check `!res.delete_marker` before returning the result — when the latest version is a delete marker, fall through to the normal listing path.
3. Add a wildcard arm `_ => {}` to handle the new match arm.

The normal listing path (`gather_results` at `list_objects.rs:4669`) already correctly filters delete markers:
```rust
if !opts.incl_deleted && is_latest_delete_marker { continue; }
```

## Verification

- `make pre-commit` — passed (all checks including fmt, clippy, architecture guards, doc paths)
- `cargo test -p rustfs-ecstore --lib -- delete_marker` — 94 tests passed
- `cargo test -p rustfs-ecstore --lib -- list_objects` — 128 tests passed
- `cargo test -p rustfs --lib -- build_list_objects` — 2 tests passed

## Impact

Fixes a correctness bug where ListObjects/ListObjectsV2 would return objects whose latest version is a delete marker in versioned buckets. No API changes, no configuration changes, no compatibility impact.

## Additional Notes

N/A
