### PR TITLE
fix(ci): isolate Linux release runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,10 +207,10 @@ jobs:
           fi
 
           all='{"include":[
-            {"target_id":"linux-x86_64-musl","os":"sm-standard-2","target":"x86_64-unknown-linux-musl","cross":false,"platform":"linux","rustflags":""},
-            {"target_id":"linux-aarch64-musl","os":"sm-standard-2","target":"aarch64-unknown-linux-musl","cross":true,"platform":"linux","rustflags":""},
-            {"target_id":"linux-x86_64-gnu","os":"sm-standard-2","target":"x86_64-unknown-linux-gnu","cross":false,"platform":"linux","rustflags":""},
-            {"target_id":"linux-aarch64-gnu","os":"sm-standard-2","target":"aarch64-unknown-linux-gnu","cross":true,"platform":"linux","rustflags":""},
+            {"target_id":"linux-x86_64-musl","os":"ubicloud-standard-2","target":"x86_64-unknown-linux-musl","cross":false,"platform":"linux","rustflags":""},
+            {"target_id":"linux-aarch64-musl","os":"ubicloud-standard-2","target":"aarch64-unknown-linux-musl","cross":true,"platform":"linux","rustflags":""},
+            {"target_id":"linux-x86_64-gnu","os":"ubicloud-standard-2","target":"x86_64-unknown-linux-gnu","cross":false,"platform":"linux","rustflags":""},
+            {"target_id":"linux-aarch64-gnu","os":"ubicloud-standard-2","target":"aarch64-unknown-linux-gnu","cross":true,"platform":"linux","rustflags":""},
             {"target_id":"macos-aarch64","os":"macos-latest","target":"aarch64-apple-darwin","cross":false,"platform":"macos","rustflags":""},
             {"target_id":"windows-x86_64","os":"windows-latest","target":"x86_64-pc-windows-msvc","cross":false,"platform":"windows","rustflags":""}
           ]}'


### PR DESCRIPTION
### Motivation
- Prevent a CI supply-chain risk where trusted Linux release builds ran on the same self-hosted runner label used by `pull_request` jobs, allowing untrusted PR code to persist and tamper with later release artifacts and upload credentials.
- Keep release build execution isolated to an ephemeral/trusted runner pool while preserving the existing build matrix and artifact flows.

### Description
- Changed the Linux build matrix runner label in `.github/workflows/build.yml` so Linux targets use `ubicloud-standard-2` instead of the PR-used `sm-standard-2` label. 
- Did not alter non-Linux matrix entries, cross-compilation flags, or artifact upload steps; the change is limited to runner selection for Linux targets.
- Left CI `pull_request` jobs intact (they continue to target `sm-standard-2`) and retained repository checks that assert runner ephemerality (`scripts/ci/check_runner_ephemerality.sh`).

### Testing
- Parsed both workflow files with YAML (via `ruby -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71875501888329ad9fcf0cd6cf0d01)