### PR TITLE
refactor(storage): migrate RPC DTO timestamps to jiff

### DIFF
--- a/crates/ecstore/src/bucket/target/bucket_target.rs
+++ b/crates/ecstore/src/bucket/target/bucket_target.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::error::{Error, Result};
+use jiff::Timestamp;
 use rmp_serde::Serializer as rmpSerializer;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -32,7 +33,7 @@ pub struct Credentials {
     #[serde(rename = "secretKey")]
     pub secret_key: String,
     pub session_token: Option<String>,
-    pub expiration: Option<chrono::DateTime<chrono::Utc>>,
+    pub expiration: Option<Timestamp>,
 }
 
 impl Credentials {
@@ -408,7 +409,11 @@ mod tests {
         assert_eq!(credentials.access_key, "test-access-key");
         assert_eq!(credentials.secret_key, "test-secret-key");
         assert_eq!(credentials.session_token, Some("test-session-token".to_string()));
-        assert!(credentials.expiration.is_some());
+        assert_eq!(
+            serde_json::to_value(credentials.expiration.expect("expiration should parse"))
+                .expect("expiration should serialize to JSON"),
+            serde_json::json!("2024-12-31T23:59:59Z")
+        );
 
         // Verify latency statistics
         assert_eq!(target.latency.curr, Duration::from_millis(100));
@@ -562,12 +567,15 @@ mod tests {
                 .and_then(|credentials| credentials.session_token.as_deref()),
             Some("legacy-session-token")
         );
-        assert!(
+        assert_eq!(
             target
                 .credentials
                 .as_ref()
                 .and_then(|credentials| credentials.expiration)
-                .is_some()
+                .map(serde_json::to_value)
+                .transpose()
+                .expect("expiration should serialize to JSON"),
+            Some(serde_json::json!("2024-12-31T23:59:59Z"))
         );
     }
 
@@ -609,7 +617,11 @@ mod tests {
             credentials.session_token,
             Some("AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT".to_string())
         );
-        assert!(credentials.expiration.is_some());
+        assert_eq!(
+            serde_json::to_value(credentials.expiration.expect("expiration should parse"))
+                .expect("expiration should serialize to JSON"),
+            serde_json::json!("2024-12-31T23:59:59Z")
+        );
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -95,17 +95,13 @@ struct RemoteTargetCredentialsRequest {
     expiration: Option<Timestamp>,
 }
 
-fn jiff_to_chrono_datetime(timestamp: Timestamp) -> chrono::DateTime<chrono::Utc> {
-    chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::from(timestamp))
-}
-
 impl From<RemoteTargetCredentialsRequest> for TargetCredentials {
     fn from(value: RemoteTargetCredentialsRequest) -> Self {
         Self {
             access_key: value.access_key,
             secret_key: value.secret_key,
             session_token: value.session_token,
-            expiration: value.expiration.map(jiff_to_chrono_datetime),
+            expiration: value.expiration,
         }
     }
 }
@@ -1367,7 +1363,10 @@ mod tests {
         let credentials = crate::admin::storage_api::bucket::target::Credentials::from(credentials);
         let expiration = credentials.expiration.expect("expiration should be preserved");
 
-        assert_eq!(expiration.to_rfc3339_opts(chrono::SecondsFormat::Secs, true), "2026-01-01T00:00:00Z");
+        assert_eq!(
+            serde_json::to_value(expiration).expect("expiration should serialize to JSON"),
+            serde_json::json!("2026-01-01T00:00:00Z")
+        );
     }
 
     #[test]

--- a/rustfs/src/storage/rpc/node_service/heal.rs
+++ b/rustfs/src/storage/rpc/node_service/heal.rs
@@ -14,6 +14,7 @@
 
 use crate::startup_background::{heal_enabled_from_env, scanner_enabled_from_env};
 use crate::storage::storage_api::runtime_sources_consumer::EndpointServerPools;
+use jiff::Timestamp;
 use rmp_serde::Deserializer;
 use rustfs_common::heal_channel::HealScanMode;
 use rustfs_heal::HealOperationsSnapshot;
@@ -27,6 +28,31 @@ use super::super::encode_msgpack_map;
 const NODE_HEAL_STATUS_VERSION: u8 = 1;
 const NODE_HEAL_STATUS_MAX_SIZE: usize = 64 * 1024;
 const HEAL_TOPOLOGY_FINGERPRINT_DOMAIN: &[u8] = b"rustfs-heal-topology-v1\0";
+
+fn chrono_to_jiff_timestamp(timestamp: chrono::DateTime<chrono::Utc>) -> Timestamp {
+    let seconds = timestamp.timestamp();
+    let nanoseconds = match i32::try_from(timestamp.timestamp_subsec_nanos()) {
+        Ok(nanoseconds) => nanoseconds,
+        Err(_) => {
+            return if seconds < 0 { Timestamp::MIN } else { Timestamp::MAX };
+        }
+    };
+
+    match Timestamp::new(seconds, nanoseconds) {
+        Ok(timestamp) => timestamp,
+        Err(_) => {
+            if seconds < 0 {
+                Timestamp::MIN
+            } else {
+                Timestamp::MAX
+            }
+        }
+    }
+}
+
+fn jiff_to_chrono_datetime(timestamp: Timestamp) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::from(timestamp))
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct HealControlCoordinator {
@@ -156,7 +182,7 @@ pub(crate) struct NodeHealProgress {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct NodeHealInfo {
-    bitrot_start_time: Option<chrono::DateTime<chrono::Utc>>,
+    bitrot_start_time: Option<Timestamp>,
     bitrot_start_cycle: u64,
     current_scan_mode: HealScanMode,
 }
@@ -164,7 +190,7 @@ struct NodeHealInfo {
 impl From<BackgroundHealInfo> for NodeHealInfo {
     fn from(info: BackgroundHealInfo) -> Self {
         Self {
-            bitrot_start_time: info.bitrot_start_time,
+            bitrot_start_time: info.bitrot_start_time.map(chrono_to_jiff_timestamp),
             bitrot_start_cycle: info.bitrot_start_cycle,
             current_scan_mode: info.current_scan_mode,
         }
@@ -174,7 +200,7 @@ impl From<BackgroundHealInfo> for NodeHealInfo {
 impl From<NodeHealInfo> for BackgroundHealInfo {
     fn from(info: NodeHealInfo) -> Self {
         Self {
-            bitrot_start_time: info.bitrot_start_time,
+            bitrot_start_time: info.bitrot_start_time.map(jiff_to_chrono_datetime),
             bitrot_start_cycle: info.bitrot_start_cycle,
             current_scan_mode: info.current_scan_mode,
         }
@@ -213,7 +239,7 @@ impl NodeHealStatusSnapshot {
 
     pub(crate) fn info(&self) -> BackgroundHealInfo {
         BackgroundHealInfo {
-            bitrot_start_time: self.info.bitrot_start_time,
+            bitrot_start_time: self.info.bitrot_start_time.map(jiff_to_chrono_datetime),
             bitrot_start_cycle: self.info.bitrot_start_cycle,
             current_scan_mode: self.info.current_scan_mode,
         }
@@ -270,6 +296,7 @@ mod tests {
         Endpoint,
         ecstore_layout::{EndpointServerPools, Endpoints, PoolEndpoints},
     };
+    use chrono::SecondsFormat;
     use rustfs_heal::HealOperationsSnapshot;
     use rustfs_scanner::scanner::BackgroundHealInfo;
 
@@ -459,6 +486,54 @@ mod tests {
         let decoded = decode_node_heal_status(&encoded).expect("fixed v1 fixture should decode");
         assert_eq!(decoded.info().bitrot_start_cycle, 9);
         assert_eq!(decoded.operations.queue_length, 2);
+    }
+
+    #[test]
+    fn node_heal_status_timestamp_json_remains_rfc3339() {
+        let fixture = serde_json::json!({
+            "version": 1,
+            "servicesEnabled": true,
+            "initialized": true,
+            "info": {"bitrotStartTime": "2023-11-14T22:13:20.123456Z", "bitrotStartCycle": 9, "currentScanMode": 1},
+            "operations": {
+                "queueLength": 2, "activeTasks": 1, "retryingTasks": 0,
+                "queuedByPriority": {"low": 0, "normal": 2, "high": 0, "urgent": 0},
+                "activeByPriority": {"low": 0, "normal": 0, "high": 1, "urgent": 0},
+                "retryingByPriority": {"low": 0, "normal": 0, "high": 0, "urgent": 0},
+                "queuedBySource": {"scanner": 2, "admin": 0, "autoHeal": 0, "internal": 0, "readRepair": 0},
+                "activeBySource": {"scanner": 0, "admin": 1, "autoHeal": 0, "internal": 0, "readRepair": 0},
+                "retryingBySource": {"scanner": 0, "admin": 0, "autoHeal": 0, "internal": 0, "readRepair": 0}
+            },
+            "progress": null
+        });
+        let encoded = rmp_serde::to_vec_named(&fixture).expect("fixture should encode");
+        let decoded = decode_node_heal_status(&encoded).expect("timestamp fixture should decode");
+        let info = decoded.info();
+
+        assert_eq!(
+            info.bitrot_start_time
+                .expect("bitrot start time should be preserved")
+                .to_rfc3339_opts(SecondsFormat::Micros, true),
+            "2023-11-14T22:13:20.123456Z"
+        );
+
+        let started_at = chrono::DateTime::parse_from_rfc3339("2023-11-14T22:13:20.123456Z")
+            .expect("fixture timestamp should parse")
+            .with_timezone(&chrono::Utc);
+        let snapshot = NodeHealStatusSnapshot::for_test(
+            true,
+            true,
+            BackgroundHealInfo {
+                bitrot_start_time: Some(started_at),
+                bitrot_start_cycle: 9,
+                current_scan_mode: rustfs_common::heal_channel::HealScanMode::Deep,
+            },
+            HealOperationsSnapshot::default(),
+            None,
+        );
+        let encoded = encode_node_heal_status(&snapshot).expect("snapshot should encode");
+        let encoded_json: serde_json::Value = rmp_serde::from_slice(&encoded).expect("encoded snapshot should decode as JSON");
+        assert_eq!(encoded_json["info"]["bitrotStartTime"], serde_json::json!("2023-11-14T22:13:20.123456Z"));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
This is stacked on `houseme/jiff-scanner-metrics-dto` after #5712 was merged into that stack branch, and continues the scoped chrono-to-jiff migration for RPC/storage DTO boundaries.

- Migrates bucket target credential expiration storage DTOs from `chrono::DateTime<Utc>` to `jiff::Timestamp` while preserving the existing RFC3339 JSON contract.
- Removes the temporary admin-to-storage chrono bridge for remote target credentials now that the storage DTO accepts `jiff::Timestamp` directly.
- Migrates the node heal status RPC DTO timestamp to `jiff::Timestamp` and keeps scanner's internal `chrono` state behind a narrow conversion bridge for this phase.
- Pins fixed JSON/msgpack timestamp formats for bucket target credentials and node heal status.

## Verification
- `cargo test -p rustfs-ecstore test_credentials_json_deserialize --lib`
- `cargo test -p rustfs-ecstore historical_bucket_target_options_remain_readable --lib`
- `cargo test -p rustfs-ecstore user_provided_json --lib`
- `cargo test -p rustfs rfc3339 --lib`
- `cargo check -p rustfs-ecstore -p rustfs`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo shear --fix` (completed with the existing 35 hotpath feature-only dependency warnings)
- `make pre-commit` (passed; guard output still includes the existing missing `rustfs/src/table_catalog.rs` and no-PCRE2 ripgrep notices before passing)

## Impact
No intended S3 API behavior change. Bucket target credential expiration and node heal status timestamps remain serialized as RFC3339 UTC strings. The Rust type of the internal storage/RPC DTO timestamp fields changes to `jiff::Timestamp`; scanner runtime state remains `chrono` in this phase.

## Additional Notes
Adversarial validation: correctness attacked chrono/jiff conversion and null/non-null timestamp paths with no break found; simplicity attacked helper scope and rejected widening `common`/scanner migration in this PR; security attacked credential redaction and unsupported session token/expiration handling with no secret leakage found; concurrency/durability found no changed locks, awaits, quorum, or persistence ordering; compatibility attacked historical bucket target JSON, `0001-01-01T00:00:00Z`, fixed node heal msgpack keys, and encode-side timestamp string output with tests passing; performance found no hot-path I/O, logging, allocation, or lock changes; test coverage maps the claimed JSON/msgpack format preservation to the targeted tests listed above.
