### PR TITLE
test(ci): fix e2e clippy and parent fixture

### DIFF
--- a/crates/e2e_test/src/bucket_stats_regression_test.rs
+++ b/crates/e2e_test/src/bucket_stats_regression_test.rs
@@ -32,7 +32,6 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{RustFSTestEnvironment, awscurl_get, init_logging};
-    use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
     use rustfs_data_usage::DataUsageInfo;
@@ -92,13 +91,13 @@ mod tests {
         for attempt in 0..18 {
             sleep(Duration::from_secs(5)).await;
 
-            if let Ok(usage) = get_data_usage(&env).await {
-                if let Some(bucket_usage) = usage.buckets_usage.get(bucket) {
-                    info!("  attempt {attempt}: objectsCount = {}", bucket_usage.objects_count);
-                    if bucket_usage.objects_count >= 10 {
-                        found_nonzero = true;
-                        break;
-                    }
+            if let Ok(usage) = get_data_usage(&env).await
+                && let Some(bucket_usage) = usage.buckets_usage.get(bucket)
+            {
+                info!("  attempt {attempt}: objectsCount = {}", bucket_usage.objects_count);
+                if bucket_usage.objects_count >= 10 {
+                    found_nonzero = true;
+                    break;
                 }
             }
         }
@@ -160,13 +159,13 @@ mod tests {
         for attempt in 0..18 {
             sleep(Duration::from_secs(5)).await;
 
-            if let Ok(usage) = get_data_usage(&env).await {
-                if let Some(bucket_usage) = usage.buckets_usage.get(bucket) {
-                    info!("  attempt {attempt}: objectsCount = {}", bucket_usage.objects_count);
-                    if bucket_usage.objects_count == 0 {
-                        found_zero = true;
-                        break;
-                    }
+            if let Ok(usage) = get_data_usage(&env).await
+                && let Some(bucket_usage) = usage.buckets_usage.get(bucket)
+            {
+                info!("  attempt {attempt}: objectsCount = {}", bucket_usage.objects_count);
+                if bucket_usage.objects_count == 0 {
+                    found_zero = true;
+                    break;
                 }
             }
         }

--- a/crates/e2e_test/src/delete_regression_test.rs
+++ b/crates/e2e_test/src/delete_regression_test.rs
@@ -31,7 +31,6 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
-    use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, Delete, ObjectIdentifier, VersioningConfiguration};
     use serial_test::serial;
@@ -85,8 +84,13 @@ mod tests {
             .await
             .expect("list objects before delete");
 
-        let keys: Vec<_> = list.contents().iter().map(|o| o.key().unwrap_or("")).collect();
-        assert!(keys.contains(&"to-delete.txt"), "RT-05 FAIL: object not in LIST before delete");
+        assert!(
+            list.contents()
+                .iter()
+                .map(|o| o.key().unwrap_or(""))
+                .any(|key| key == "to-delete.txt"),
+            "RT-05 FAIL: object not in LIST before delete"
+        );
 
         // DELETE
         client
@@ -105,9 +109,12 @@ mod tests {
             .await
             .expect("list objects after delete");
 
-        let keys: Vec<_> = list.contents().iter().map(|o| o.key().unwrap_or("")).collect();
         assert!(
-            !keys.contains(&"to-delete.txt"),
+            !list
+                .contents()
+                .iter()
+                .map(|o| o.key().unwrap_or(""))
+                .any(|key| key == "to-delete.txt"),
             "RT-05 FAIL: deleted object still in LIST (regression rustfs#5375)"
         );
 

--- a/crates/e2e_test/src/distributed_startup_regression_test.rs
+++ b/crates/e2e_test/src/distributed_startup_regression_test.rs
@@ -34,8 +34,8 @@ mod tests {
     use aws_sdk_s3::primitives::ByteStream;
     use serial_test::serial;
     use std::error::Error;
-    use tokio::time::{Duration, sleep, timeout};
-    use tracing::{info, warn};
+    use tokio::time::{Duration, sleep};
+    use tracing::info;
 
     type TestResult = Result<(), Box<dyn Error + Send + Sync>>;
 

--- a/crates/e2e_test/src/lifecycle_regression_test.rs
+++ b/crates/e2e_test/src/lifecycle_regression_test.rs
@@ -38,8 +38,7 @@ mod tests {
     };
     use serial_test::serial;
     use std::error::Error;
-    use tokio::time::{Duration, sleep, timeout};
-    use tracing::{info, warn};
+    use tracing::info;
 
     type TestResult = Result<(), Box<dyn Error + Send + Sync>>;
 

--- a/crates/e2e_test/src/listing_regression_test.rs
+++ b/crates/e2e_test/src/listing_regression_test.rs
@@ -30,7 +30,6 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
-    use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
     use serial_test::serial;
     use std::collections::HashSet;

--- a/crates/e2e_test/src/notification_startup_regression_test.rs
+++ b/crates/e2e_test/src/notification_startup_regression_test.rs
@@ -31,7 +31,6 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
-    use aws_sdk_s3::Client;
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
     use serial_test::serial;
     use std::error::Error;

--- a/crates/e2e_test/src/tier_transition_regression_test.rs
+++ b/crates/e2e_test/src/tier_transition_regression_test.rs
@@ -29,13 +29,10 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{RustFSTestEnvironment, admin_ok, init_logging};
-    use aws_sdk_s3::Client;
-    use aws_sdk_s3::primitives::ByteStream;
-    use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
     use serde_json::Value;
     use serial_test::serial;
     use std::error::Error;
-    use tracing::{info, warn};
+    use tracing::info;
 
     type TestResult = Result<(), Box<dyn Error + Send + Sync>>;
 

--- a/crates/s3select-api/src/lib.rs
+++ b/crates/s3select-api/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use datafusion::{common::DataFusionError, sql::sqlparser::parser::ParserError};
 use std::fmt::Display;
 use thiserror::Error;

--- a/rustfs/src/admin/service/federated_identity.rs
+++ b/rustfs/src/admin/service/federated_identity.rs
@@ -429,13 +429,15 @@ mod tests {
 
     #[test]
     fn issued_credentials_and_replication_item_use_minio_parent_shape() {
+        const EXPECTED_PARENT_USER: &str = "HwDfWftzOy4jiuS3WjKytC_Sg_A2hKhrRAFtBDhoBr0";
+
         let transaction = transaction();
         let secret = "federated-session-test-signing-secret";
         let selected_policy_names = vec!["readonly".to_string()];
 
         let credentials =
             issue_credentials(&transaction, &selected_policy_names, Some(secret)).expect("credential issuance should succeed");
-        assert_eq!(credentials.parent_user, "TwyekekG2eMes0qk9Tgh7KXEitwGi1z2W1f2KccrXGA");
+        assert_eq!(credentials.parent_user, EXPECTED_PARENT_USER);
         assert_eq!(credentials.groups, Some(vec!["devs".to_string()]));
         assert_eq!(credentials.status, "on");
         assert!(!credentials.access_key.is_empty());
@@ -468,11 +470,8 @@ mod tests {
                 ("preferred_username".to_string(), serde_json::json!("user")),
                 ("groups".to_string(), serde_json::json!(["devs"])),
                 ("roles".to_string(), serde_json::json!(["admin", "reader"])),
-                ("parent".to_string(), serde_json::json!("TwyekekG2eMes0qk9Tgh7KXEitwGi1z2W1f2KccrXGA")),
-                (
-                    OIDC_VIRTUAL_PARENT_CLAIM.to_string(),
-                    serde_json::json!("TwyekekG2eMes0qk9Tgh7KXEitwGi1z2W1f2KccrXGA"),
-                ),
+                ("parent".to_string(), serde_json::json!(EXPECTED_PARENT_USER)),
+                (OIDC_VIRTUAL_PARENT_CLAIM.to_string(), serde_json::json!(EXPECTED_PARENT_USER),),
                 ("policy".to_string(), serde_json::json!("readonly")),
             ])
         );
@@ -499,7 +498,7 @@ mod tests {
                     "accessKey": "<access-key>",
                     "secretKey": "<secret-key>",
                     "sessionToken": "<session-token>",
-                    "parentUser": "TwyekekG2eMes0qk9Tgh7KXEitwGi1z2W1f2KccrXGA",
+                    "parentUser": EXPECTED_PARENT_USER,
                     "parentPolicyMapping": OIDC_STS_REQUIRES_VIRTUAL_PARENT_RECEIVER_POLICY,
                     "apiVersion": SITE_REPL_API_VERSION,
                 },


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Fix the federated identity admin test fixture to use the current OIDC virtual parent value pinned by the IAM model test.
- Remove unused e2e regression-test imports reported under `-D warnings`.
- Address e2e clippy warnings by avoiding needless collection and collapsing nested polling conditionals.

## Verification
- `cargo clippy -p e2e_test --lib --tests -- -D warnings`
- `cargo test -p rustfs issued_credentials_and_replication_item_use_minio_parent_shape --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`

## Impact
No runtime, API, storage, RPC, or JSON DTO impact. This is a test/CI cleanup follow-up after #5713 was merged.

## Additional Notes
#5713 was already merged, so this PR is based on the updated `houseme/jiff-scanner-metrics-dto` branch and contains only the CI follow-up commit.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
