### PR TITLE
fix(replication): report FAILED when replication put options cannot be built

### DIFF
--- a/crates/ecstore/src/bucket/replication/replication_resyncer.rs
+++ b/crates/ecstore/src/bucket/replication/replication_resyncer.rs
@@ -2550,6 +2550,12 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
         let (put_opts, is_multipart) = match replication_put_object_options(&tgt_client.storage_class, &object_info) {
             Ok((put_opts, is_mp)) => (put_opts, is_mp),
             Err(e) => {
+                // Unsupported source metadata (e.g. managed SSE) is a fail-closed
+                // condition: report FAILED so the composite status and the
+                // OperationFailedReplication event reflect that nothing reached
+                // the target, instead of leaking the optimistic Completed above.
+                rinfo.replication_status = ReplicationStatusType::Failed;
+                rinfo.error = Some(e.to_string());
                 warn!(
                     event = EVENT_RESYNC_TARGET_OPERATION_FAILED,
                     component = LOG_COMPONENT_ECSTORE,
@@ -2954,6 +2960,11 @@ impl ReplicateObjectInfoExt for ReplicateObjectInfo {
         let (put_opts, is_multipart) = match replication_put_object_options(&tgt_client.storage_class, &object_info) {
             Ok((put_opts, is_mp)) => (put_opts, is_mp),
             Err(e) => {
+                // Unsupported source metadata (e.g. managed SSE) is a fail-closed
+                // condition: report FAILED so the composite status and the
+                // OperationFailedReplication event reflect that nothing reached
+                // the target, instead of leaking the optimistic Completed above.
+                rinfo.replication_status = ReplicationStatusType::Failed;
                 rinfo.error = Some(e.to_string());
                 warn!(
                     event = EVENT_RESYNC_TARGET_OPERATION_FAILED,


### PR DESCRIPTION
## Problem

The `e2e-replication-nightly` lane failed on 2026-08-03 and 2026-08-04 (runs [30786733120](https://github.com/rustfs/rustfs/actions/runs/30786733120), [30879681269](https://github.com/rustfs/rustfs/actions/runs/30879681269)): `replication_extension_test::test_bucket_replication_sse_kms_failure_contract` timed out after ~33s waiting for the `s3:Replication:OperationFailedReplication` event, both nights at nearly identical elapsed time — a deterministic regression, not a flake.

## Root cause

#5633 made `classify_replication_source_encryption` case-insensitive. Before it, the managed-SSE gate in `replication_put_object_options` compared canonical-case header constants (`X-Amz-Server-Side-Encryption`) against `user_defined` keys that are actually stored lowercase (`rustfs/src/storage/sse.rs`), so the gate never matched: SSE-KMS objects sailed through to the target PUT, which failed and correctly produced FAILED + the failure event. After #5633 the gate fires at the source — but both per-target methods (`replicate_object`, `replicate_all` in `replication_resyncer.rs`) assign the optimistic `ReplicationStatusType::Completed` to `rinfo` before building put options, and the `Err` branch returned `rinfo` unchanged.

The result was worse than a test failure: a fail-closed rejection was reported as success. The source object was marked COMPLETED, `ObjectReplicationComplete` was emitted, and nothing existed on the target.

## Fix

In both `Err` branches, set `rinfo.replication_status = Failed` before returning (and record `rinfo.error` in the `replicate_object` branch, which previously dropped it). This restores the pre-#5633 observable contract and matches MinIO, which only flips the per-target status to Completed after a successful transfer. The config-shaped error intentionally does not go through `mark_replication_target_offline_if_needed` — the target is healthy; the source metadata is what is unsupported.

## Verification

- `cargo build --bin rustfs && cargo nextest run -p e2e_test -E 'test(test_bucket_replication_sse_kms_failure_contract)'` — PASS in 19.3s against the rebuilt binary. This is the exact nightly test that regressed; it fails without this change (30s failure-event timeout).
- `cargo clippy -p rustfs-ecstore --all-targets` — clean
- `cargo fmt --all --check` — clean
- `scripts/check_layer_dependencies.sh`, `scripts/check_architecture_migration_rules.sh`, `scripts/check_logging_guardrails.sh` — OK

## Notes

The other nightly failures between 07-18 and 08-02 (`test_site_replication_edit_and_status_peer_state_real_three_node`, the delete-marker convergence tests) stopped reproducing on 08-03/08-04 after the 08-02→08-03 replication fixes landed; they are not addressed here and worth watching in the next few nightly runs.
