### PR TITLE
refactor(ecstore): unify remaining heal logs to structured event style

### DIFF
--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -404,7 +404,16 @@ impl SetDisks {
             "Set disk object metadata read"
         );
         if DiskError::is_all_not_found(&errs) {
-            debug!(bucket, object, version_id, "heal_object skipped missing object");
+            debug!(
+                event = EVENT_SET_DISK_HEAL,
+                component = LOG_COMPONENT_ECSTORE,
+                subsystem = LOG_SUBSYSTEM_SET_DISK,
+                bucket,
+                object,
+                version_id,
+                state = "missing_object_skipped",
+                "Set disk heal skipped missing object"
+            );
             let err = if !version_id.is_empty() {
                 DiskError::FileVersionNotFound
             } else {
@@ -525,7 +534,18 @@ impl SetDisks {
                                 if is_meta {
                                     meta_to_heal_count += 1;
                                 }
-                                debug!("heal_object Disk {} marked for healing (endpoint={})", index, self.set_endpoints[index]);
+                                debug!(
+                                    event = EVENT_SET_DISK_HEAL,
+                                    component = LOG_COMPONENT_ECSTORE,
+                                    subsystem = LOG_SUBSYSTEM_SET_DISK,
+                                    bucket,
+                                    object,
+                                    version_id,
+                                    disk_index = index,
+                                    endpoint = %self.set_endpoints[index],
+                                    state = "disk_marked_for_healing",
+                                    "Set disk marked for healing"
+                                );
                             }
 
                             let drive_state = match reason {
@@ -609,6 +629,8 @@ impl SetDisks {
                                     latest_meta.erasure.data_blocks
                                 );
                                 error!(
+                                    component = LOG_COMPONENT_ECSTORE,
+                                    subsystem = LOG_SUBSYSTEM_HEAL,
                                     bucket,
                                     object,
                                     version_id,
@@ -627,6 +649,8 @@ impl SetDisks {
                                     latest_meta.erasure.parity_blocks
                                 );
                                 error!(
+                                    component = LOG_COMPONENT_ECSTORE,
+                                    subsystem = LOG_SUBSYSTEM_HEAL,
                                     bucket,
                                     object,
                                     version_id,
@@ -682,6 +706,8 @@ impl SetDisks {
                                 }
                                 Err(err) => {
                                     error!(
+                                        component = LOG_COMPONENT_ECSTORE,
+                                        subsystem = LOG_SUBSYSTEM_HEAL,
                                         bucket,
                                         object,
                                         version_id,
@@ -808,8 +834,12 @@ impl SetDisks {
                             None => {
                                 if !latest_meta.deleted && !latest_meta.is_remote() {
                                     error!(
-                                        "heal: latest metadata for {}/{} has no data_dir, cannot heal object data",
-                                        bucket, object
+                                        component = LOG_COMPONENT_ECSTORE,
+                                        subsystem = LOG_SUBSYSTEM_HEAL,
+                                        bucket,
+                                        object,
+                                        version_id,
+                                        "Heal object latest metadata has no data_dir, cannot heal object data"
                                     );
                                     return Err(DiskError::FileCorrupt);
                                 }
@@ -1293,6 +1323,8 @@ impl SetDisks {
                 Ok(()) => wrote += 1,
                 Err(error) => {
                     warn!(
+                        component = LOG_COMPONENT_ECSTORE,
+                        subsystem = LOG_SUBSYSTEM_HEAL,
                         bucket,
                         object,
                         disk_index = index,
@@ -1326,7 +1358,16 @@ impl SetDisks {
             }
             Ok(_) => {}
             Err(e) => {
-                warn!(bucket, object, error = %e, "heal_object: orphan data-dir reclaim failed");
+                warn!(
+                    event = EVENT_SET_DISK_HEAL,
+                    component = LOG_COMPONENT_ECSTORE,
+                    subsystem = LOG_SUBSYSTEM_SET_DISK,
+                    bucket,
+                    object,
+                    error = %e,
+                    state = "orphan_data_reclaim_failed",
+                    "Set disk orphan data-dir reclaim failed"
+                );
             }
         }
     }
@@ -1730,7 +1771,13 @@ impl crate::storage_api_contracts::heal::HealOperations for SetDisks {
         };
 
         if count_errs(&errs, &DiskError::UnformattedDisk) == 0 {
-            info!("set disk formats success, NoHealRequired, errs: {:?}", errs);
+            debug!(
+                component = LOG_COMPONENT_ECSTORE,
+                subsystem = LOG_SUBSYSTEM_HEAL,
+                error_count = errs.iter().flatten().count(),
+                result = "no_heal_required",
+                "set disk formats success"
+            );
             return Ok((result, Some(StorageError::NoHealRequired)));
         }
 

--- a/scripts/check_logging_guardrails.sh
+++ b/scripts/check_logging_guardrails.sh
@@ -711,8 +711,7 @@ if [[ "$heal_function_count" != "$trace_heal_instrumentation_count" ]]; then
 fi
 
 unexpected_heal_info="$(
-  rg -n '\binfo!' crates/ecstore/src/set_disk/ops/heal.rs crates/ecstore/src/erasure/coding/heal.rs |
-    rg -v 'set disk formats success, NoHealRequired' || true
+  rg -n '\binfo!' crates/ecstore/src/set_disk/ops/heal.rs crates/ecstore/src/erasure/coding/heal.rs || true
 )"
 if [[ -n "$unexpected_heal_info" ]]; then
   echo "❌ logging guardrail violation: per-object set-disk heal events must not be emitted at INFO" >&2


### PR DESCRIPTION
## Related Issues

Residual cleanup for the log-amplification portion of #5716. The amplification fix itself landed in #5719, which superseded this PR's original demotion diff (see PR history and comments).

## Summary of Changes

#5719 fixed the per-object heal log amplification: per-object statements were demoted, `heal_object` spans are now forced to TRACE by a guardrail with self-tests, and raw object/disk metadata dumps are banned at every level. After rebasing, this PR carries only the remaining log-consistency cleanup on top of it, all in `crates/ecstore/src/set_disk/ops/heal.rs`:

- Convert the remaining bare-field and format-arg log statements to the file's now-dominant structured convention (`event`/`component`/`subsystem` + context fields + short message): the missing-object skip, disk-marked-for-healing, the two cannot-reconstruct `error!`s, the dangling-cleanup `error!`, the missing-`data_dir` `error!`, the xl.meta-regeneration `warn!`, and the orphan-reclaim failure `warn!` (now matching its structured success sibling).
- Demote the last remaining `info!` in the file — the per-set `heal_format` "set disk formats success, NoHealRequired" no-op message — to a structured `debug!` reporting `error_count` instead of a raw `errs` dump, and drop its whitelist exclusion in `scripts/check_logging_guardrails.sh` so the no-INFO check for set-disk heal files is strict.

No control flow, return values, or behavior changes; log levels are unchanged everywhere except the one no-op `info!` demotion.

## Verification

- `cargo fmt --all --check`
- `./scripts/check_logging_guardrails.sh` (including the #5719 self-tests, with the tightened strict no-INFO check)
- `cargo check -p rustfs-ecstore`
- Earlier revisions of this PR passed full adversarial validation per AGENTS.md and `make pre-commit`; the rebased residual diff is a strict subset of that reviewed surface (field additions and one level demotion).

## Impact

- Operational only: heal logs in this file share one structured shape for filtering (`component="ecstore"`, `subsystem="heal"/"set_disk"`); the per-set format-heal no-op message moves from INFO to DEBUG. No S3 API, on-disk format, or configuration impact.

## Additional Notes

Follow-ups tracked separately: #5727 demotes per-object heal task logging in `crates/heal` and takes over the CI wiring for `check_logging_guardrails.sh`; FileInfo Debug redaction landed in #5725.
