### PR TITLE
fix(filemeta): redact sealed keys and elide inline data in FileInfo Debug

### DIFF
--- a/crates/filemeta/src/fileinfo.rs
+++ b/crates/filemeta/src/fileinfo.rs
@@ -19,6 +19,7 @@ use rustfs_utils::HashAlgorithm;
 use rustfs_utils::http::{
     SUFFIX_COMPRESSION, SUFFIX_DATA_MOVED, SUFFIX_FREE_VERSION, SUFFIX_HEALING, SUFFIX_INLINE_DATA, SUFFIX_TIER_FV_ID,
     SUFFIX_TIER_FV_MARKER, SUFFIX_TIER_SKIP_FV_ID, contains_key_str, get_str, has_internal_suffix, insert_str,
+    is_encryption_metadata_key, starts_with_ignore_ascii_case,
 };
 use s3s::dto::{RestoreStatus, Timestamp};
 use s3s::header::X_AMZ_RESTORE;
@@ -231,7 +232,7 @@ pub enum TransitionVersionState {
     Exact,
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FileInfo {
     pub volume: String,
     pub name: String,
@@ -269,6 +270,117 @@ pub struct FileInfo {
     pub versioned: bool,
     /// True when version meta was parsed via rmp_serde fallback (legacy format).
     pub uses_legacy_checksum: bool,
+}
+
+/// Metadata keys whose values carry sealed encryption material (KEK-wrapped DEK,
+/// IV) under either the `x-rustfs-internal-` or `x-minio-internal-` prefix.
+/// Values of these keys must never reach logs at any level.
+fn is_sensitive_metadata_key(key: &str) -> bool {
+    // `is_encryption_metadata_key` covers the x-minio-internal- SSE prefix but not
+    // its x-rustfs-internal- twin, which the dual-key invariant writes alongside it.
+    is_encryption_metadata_key(key) || starts_with_ignore_ascii_case(key, "x-rustfs-internal-server-side-encryption-")
+}
+
+struct RedactedMetadata<'a>(&'a HashMap<String, String>);
+
+impl std::fmt::Debug for RedactedMetadata<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut map = f.debug_map();
+        for (key, value) in self.0 {
+            if is_sensitive_metadata_key(key) {
+                map.entry(key, &format_args!("<redacted {} bytes>", value.len()));
+            } else {
+                map.entry(key, value);
+            }
+        }
+        map.finish()
+    }
+}
+
+struct ElidedBytes<'a>(&'a Option<Bytes>);
+
+impl std::fmt::Debug for ElidedBytes<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(bytes) => write!(f, "Some(<{} bytes elided>)", bytes.len()),
+            None => f.write_str("None"),
+        }
+    }
+}
+
+// Manual Debug: `data` holds full inline object bytes (plaintext user content for
+// non-SSE objects) and `metadata` holds sealed key material — both must stay out
+// of Debug output so whole-struct log dumps cannot leak them. `checksum` is elided
+// too: for non-SSE objects it fingerprints plaintext content, and its raw bytes
+// carry no diagnostic value. The exhaustive destructuring (no `..`) forces every
+// future field through an explicit show/redact decision here.
+impl std::fmt::Debug for FileInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            volume,
+            name,
+            version_id,
+            is_latest,
+            deleted,
+            transition_status,
+            transitioned_objname,
+            transition_tier,
+            transition_version_id,
+            transition_version,
+            transition_version_state,
+            expire_restored,
+            data_dir,
+            mod_time,
+            size,
+            mode,
+            written_by_version,
+            metadata,
+            parts,
+            erasure,
+            mark_deleted,
+            replication_state_internal,
+            data,
+            num_versions,
+            successor_mod_time,
+            fresh,
+            idx,
+            checksum,
+            versioned,
+            uses_legacy_checksum,
+        } = self;
+        f.debug_struct("FileInfo")
+            .field("volume", volume)
+            .field("name", name)
+            .field("version_id", version_id)
+            .field("is_latest", is_latest)
+            .field("deleted", deleted)
+            .field("transition_status", transition_status)
+            .field("transitioned_objname", transitioned_objname)
+            .field("transition_tier", transition_tier)
+            .field("transition_version_id", transition_version_id)
+            .field("transition_version", transition_version)
+            .field("transition_version_state", transition_version_state)
+            .field("expire_restored", expire_restored)
+            .field("data_dir", data_dir)
+            .field("mod_time", mod_time)
+            .field("size", size)
+            .field("mode", mode)
+            .field("written_by_version", written_by_version)
+            .field("metadata", &RedactedMetadata(metadata))
+            .field("parts", parts)
+            .field("erasure", erasure)
+            .field("mark_deleted", mark_deleted)
+            .field("replication_state_internal", replication_state_internal)
+            .field("data", &ElidedBytes(data))
+            .field("num_versions", num_versions)
+            .field("successor_mod_time", successor_mod_time)
+            .field("fresh", fresh)
+            .field("idx", idx)
+            .field("checksum", &ElidedBytes(checksum))
+            .field("versioned", versioned)
+            .field("uses_legacy_checksum", uses_legacy_checksum)
+            .finish()
+    }
 }
 
 #[derive(Deserialize)]
@@ -2409,5 +2521,55 @@ mod tests {
             ..Default::default()
         };
         assert!(with_state.replication_info_equals(&with_state_clone));
+    }
+
+    #[test]
+    fn debug_redacts_sealed_encryption_metadata_values() {
+        let sealed_key = "IAAfANqt7wIJfVSgFAG3f5S6HuC2eyM5DdJlx7RSJKw2ZakSb3d5";
+        let sealed_iv = "0Vr8QLGvQThk8gIWFCUnBOTUwZgs7TTBteRnAK9avD0=";
+        let mut fi = FileInfo::default();
+        for key in [
+            "X-Rustfs-Internal-Server-Side-Encryption-Sealed-Key",
+            "X-Minio-Internal-Server-Side-Encryption-Sealed-Key",
+        ] {
+            fi.metadata.insert(key.to_string(), sealed_key.to_string());
+        }
+        for key in [
+            "X-Rustfs-Internal-Server-Side-Encryption-Iv",
+            "X-Minio-Internal-Server-Side-Encryption-Iv",
+            "x-rustfs-encryption-iv",
+        ] {
+            fi.metadata.insert(key.to_string(), sealed_iv.to_string());
+        }
+        fi.metadata.insert("content-type".to_string(), "text/plain".to_string());
+
+        let dump = format!("{fi:?}");
+        assert!(!dump.contains(sealed_key), "sealed key leaked into Debug output: {dump}");
+        assert!(!dump.contains(sealed_iv), "sealed IV leaked into Debug output: {dump}");
+        // Keys stay visible so operators can still see which metadata is present.
+        assert!(dump.contains("X-Rustfs-Internal-Server-Side-Encryption-Sealed-Key"));
+        assert!(dump.contains(&format!("<redacted {} bytes>", sealed_key.len())));
+        // Non-sensitive metadata values keep their diagnostic value.
+        assert!(dump.contains("text/plain"));
+    }
+
+    #[test]
+    fn debug_elides_inline_data_bytes() {
+        let fi = FileInfo {
+            data: Some(Bytes::from_static(b"plaintext user object content")),
+            checksum: Some(Bytes::from_static(b"\x01\x02checksumblob")),
+            ..Default::default()
+        };
+
+        let dump = format!("{fi:?}");
+        assert!(
+            !dump.contains("plaintext user object content"),
+            "inline data leaked into Debug output: {dump}"
+        );
+        assert!(!dump.contains("checksumblob"), "checksum bytes leaked into Debug output: {dump}");
+        assert!(dump.contains("data: Some(<29 bytes elided>)"), "missing data length summary: {dump}");
+
+        let empty = FileInfo::default();
+        assert!(format!("{empty:?}").contains("data: None"));
     }
 }

--- a/crates/utils/src/http/metadata_compat.rs
+++ b/crates/utils/src/http/metadata_compat.rs
@@ -65,7 +65,7 @@ pub const SUFFIX_REPLICATION_DELETE_MARKER_VERSION_ARN_PREFIX: &str = "replicati
 /// Case-insensitive (ASCII) check that `s` begins with `prefix`. Equivalent to
 /// `s.to_lowercase().starts_with(prefix)` when `prefix` is ASCII (as both internal prefixes are),
 /// but without allocating.
-fn starts_with_ignore_ascii_case(s: &str, prefix: &str) -> bool {
+pub fn starts_with_ignore_ascii_case(s: &str, prefix: &str) -> bool {
     s.len() >= prefix.len() && s.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
 }
 


### PR DESCRIPTION
## Related Issues

Follow-up to the security review of #5719 (finding SEC1, pre-existing, non-blocking): whole-struct `FileInfo` log dumps in `crates/ecstore/src/set_disk/ops/heal.rs` leak sealed key material and inline object bytes when an operator enables verbose logging on that module.

## Summary of Changes

`FileInfo`'s derived `Debug` printed two things that must never reach logs at any level:

- `metadata: HashMap<String, String>` including `X-Rustfs-Internal-Server-Side-Encryption-Sealed-Key` / `-Iv` (and the `X-Minio-Internal-*` twins) — KEK-wrapped DEK ciphertext and IV.
- `data: Option<Bytes>` — full inline object bytes, which are plaintext user content for non-SSE small objects. `heal_object` reads with `read_data=true`, so the heal dumps carried real user data.

This PR replaces the derive with a manual `Debug` impl in `crates/filemeta/src/fileinfo.rs`:

- Encryption metadata values are redacted (`<redacted N bytes>`); keys stay visible so operators can still see which metadata is present, and non-sensitive values (content-type, actual-size, transition info, etc.) keep their diagnostic value. The predicate reuses `is_encryption_metadata_key` and adds the `x-rustfs-internal-server-side-encryption-` twin prefix that the shared helper does not cover, matching the dual internal metadata key invariant.
- `data` and `checksum` bytes are elided to a length summary (`Some(<N bytes elided>)`). `checksum` is included because for non-SSE objects it fingerprints plaintext content, and its raw bytes carry no diagnostic value.
- The impl destructures `Self` exhaustively (no `..`), so any future `FileInfo` field fails compilation here until it gets an explicit show/redact decision.
- `starts_with_ignore_ascii_case` in `rustfs-utils` is made `pub` for reuse instead of duplicating the byte-compare locally.

Repo-wide check of whole-`FileInfo` Debug dump sites: the only live non-test sites are the two `heal_object` dumps and the `should_heal_object_on_disk` dump, all of which #5719 independently replaces with field summaries and guards in `check_logging_guardrails.sh`. This change is complementary defense in depth: it makes those dumps safe on main before #5719 merges and defangs any future whole-struct dump regardless of log site. No conflict with #5719 (disjoint files).

Two regression tests pin the behavior: sealed key/IV values under both internal prefixes (plus `x-rustfs-encryption-iv`) never appear in Debug output while keys and non-sensitive values still do, and inline data/checksum bytes are elided with correct length summaries.

Adversarial validation (correctness+compatibility, security, simplicity, test coverage) found no blocking issues. Notable non-blocking observations recorded during review: `ObjectPartInfo`/`ErasureInfo` checksums and etags still print (consistent with existing repo practice of logging etags, e.g. `quorum_etag` in heal), and other filemeta structs (`FileMeta`, `MetaObject`, `MetaCacheEntry`) retain derived `Debug` but have zero live dump sites repo-wide.

## Verification

- `make pre-commit` — pass (fmt, arch checks including logging guardrails, workspace quick-check)
- `cargo test -p rustfs-filemeta --lib` — 225 passed (includes the 2 new Debug redaction tests)
- `cargo test -p rustfs-utils --lib` — 24 passed
- `cargo clippy -p rustfs-filemeta -p rustfs-utils --all-targets -- -D warnings` — clean
- `cargo check -p rustfs-ecstore` — pass (largest downstream consumer of `FileInfo` Debug)

## Impact

Log output only: `Debug` formatting of `FileInfo` no longer prints encryption metadata values or raw inline/checksum bytes. No wire, on-disk, or API change — serde serialization paths are separate and untouched. Operators debugging heal/tier issues still see all metadata keys, lengths, and every non-sensitive field.

## Additional Notes

`is_encryption_metadata_key` itself does not recognize the `x-rustfs-internal-server-side-encryption-` prefix (only the MinIO twin). Extending the shared helper would also change encryption classification semantics for `is_object_encryption_marker` consumers on copy/read paths, so this PR deliberately keeps the extra prefix local to the redaction predicate; a follow-up audit of the shared predicate may be worthwhile.
