### PR TITLE
fix(heal): demote per-object heal logs and cap erasure-set failure warns

### DIFF
--- a/.github/workflows/ci-docs-only.yml
+++ b/.github/workflows/ci-docs-only.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Check architecture migration rules
         run: ./scripts/check_architecture_migration_rules.sh
 
+      - name: Check logging guardrails
+        run: ./scripts/check_logging_guardrails.sh
+
       - name: Check tokio io-uring feature guard
         run: ./scripts/check_no_tokio_io_uring.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Check architecture migration rules
         run: ./scripts/check_architecture_migration_rules.sh
 
+      - name: Check logging guardrails
+        run: ./scripts/check_logging_guardrails.sh
+
       - name: Check tokio io-uring feature guard
         run: ./scripts/check_no_tokio_io_uring.sh
 

--- a/crates/heal/src/heal/erasure_healer.rs
+++ b/crates/heal/src/heal/erasure_healer.rs
@@ -16,7 +16,7 @@ use crate::heal::{
     progress::HealProgress,
     resume::{CheckpointManager, ResumeManager, ResumeUtils, compose_key},
     storage::{HealStorageAPI, next_heal_listing_token},
-    task::is_missing_object_dir_heal_result,
+    task::{demote_to_debug_when, is_missing_object_dir_heal_result, take_failure_log_sample},
 };
 use crate::{Error, Result};
 use futures::{StreamExt, stream::FuturesUnordered};
@@ -612,6 +612,12 @@ impl ErasureSetHealer {
         let page_concurrency_limit =
             Self::effective_heal_page_object_concurrency_for_source(self.source, self.heal_opts.scan_mode);
         let in_flight = Arc::new(AtomicUsize::new(0));
+        // Per-bucket sample caps for per-object warn! lines: a flapping rebuild
+        // disk can fail/skip hundreds of thousands of versions in one sweep, so
+        // only the first few occurrences warn and the rest demote to debug!.
+        // The end-of-pass summary reports the full failed/skipped counts.
+        let mut transient_skip_samples_logged = 0_u64;
+        let mut failure_samples_logged = 0_u64;
 
         // backlog#920: select the per-erasure-set DISK-WALK union enumerator when
         // the scan is Deep OR the request came from AutoHeal — these are the paths
@@ -748,8 +754,7 @@ impl ErasureSetHealer {
                     Err(Error::TransientSkip { message }) => {
                         *skipped_objects += 1;
                         checkpoint_manager.add_skipped_object(key).await?;
-                        warn!(
-                            target: "rustfs::heal::erasure_healer",
+                        demote_to_debug_when!(!take_failure_log_sample(&mut transient_skip_samples_logged), warn, target: "rustfs::heal::erasure_healer", {
                             event = EVENT_HEAL_ERASURE_OBJECT_STATE,
                             component = LOG_COMPONENT_HEAL,
                             subsystem = LOG_SUBSYSTEM_ERASURE_HEALER,
@@ -760,13 +765,12 @@ impl ErasureSetHealer {
                             state = "transient_skip",
                             error = %message,
                             "Erasure set object heal skipped due to transient error"
-                        );
+                        });
                     }
                     Err(err) => {
                         *failed_objects += 1;
                         checkpoint_manager.add_failed_object(key).await?;
-                        warn!(
-                            target: "rustfs::heal::erasure_healer",
+                        demote_to_debug_when!(!take_failure_log_sample(&mut failure_samples_logged), warn, target: "rustfs::heal::erasure_healer", {
                             event = EVENT_HEAL_ERASURE_OBJECT_STATE,
                             component = LOG_COMPONENT_HEAL,
                             subsystem = LOG_SUBSYSTEM_ERASURE_HEALER,
@@ -777,7 +781,7 @@ impl ErasureSetHealer {
                             state = "failed",
                             error = %err,
                             "Erasure set object heal failed"
-                        );
+                        });
                     }
                 }
 

--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -15,7 +15,7 @@
 use crate::heal::{
     progress::{HealProgress, HealStatistics},
     storage::HealStorageAPI,
-    task::{HealOptions, HealPriority, HealRequest, HealTask, HealTaskStatus, HealType},
+    task::{HealOptions, HealPriority, HealRequest, HealTask, HealTaskStatus, HealType, demote_to_debug_when},
 };
 use crate::{Error, Result};
 use metrics::{counter, gauge};
@@ -53,6 +53,13 @@ const EVENT_HEAL_QUEUE_STATE: &str = "heal_queue_state";
 const EVENT_HEAL_UNCLEAN_SHUTDOWN: &str = "heal_unclean_shutdown";
 const MAX_RECOVERABLE_HEAL_RETRIES: u32 = 3;
 const MAX_RECOVERABLE_HEAL_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+// Admission/scheduler outcomes for per-object requests (Object/Metadata/MRF/
+// ECDecode) log via demote_to_debug_when! — MRF, autoheal, and scanner
+// recovery loops submit those per object, so a full queue or a retry storm
+// would otherwise emit one warn! per object (rustfs/rustfs#5716). The
+// `rustfs_heal_admission_total` metric and the `heal_queue_state` backlog
+// event keep the aggregate signal at operator-visible levels.
 
 #[cfg(test)]
 struct RetryOwnershipTestHook {
@@ -976,6 +983,7 @@ impl HealManager {
         let queue_len = queue.len();
         publish_heal_queue_length(queue);
         let queue_capacity = config.queue_size;
+        let per_object_request = request.heal_type.is_per_object();
 
         if queue_len >= queue_capacity && !request.force_start {
             if Self::can_displace_queued_work(&request) && queue.can_displace_lower_priority(request.priority) {
@@ -985,8 +993,7 @@ impl HealManager {
                 if let Some(displaced) = queue.push_displacing_lower_priority(request) {
                     publish_heal_queue_length(queue);
                     Self::record_admission_metric(source, HealAdmissionResult::Accepted, context);
-                    warn!(
-                        target: "rustfs::heal::manager",
+                    demote_to_debug_when!(per_object_request, warn, target: "rustfs::heal::manager", {
                         event = EVENT_HEAL_QUEUE_ADMISSION,
                         component = LOG_COMPONENT_HEAL,
                         subsystem = LOG_SUBSYSTEM_MANAGER,
@@ -1000,12 +1007,11 @@ impl HealManager {
                         queue_capacity,
                         result = "accepted_by_displacement",
                         "Heal queue request accepted by displacement"
-                    );
+                    });
                     return HealAdmissionResult::Accepted;
                 }
 
-                warn!(
-                    target: "rustfs::heal::manager",
+                demote_to_debug_when!(per_object_request, warn, target: "rustfs::heal::manager", {
                     event = EVENT_HEAL_QUEUE_ADMISSION,
                     component = LOG_COMPONENT_HEAL,
                     subsystem = LOG_SUBSYSTEM_MANAGER,
@@ -1017,7 +1023,7 @@ impl HealManager {
                     queue_capacity,
                     result = "full_no_displacement_candidate",
                     "Heal queue request rejected without displacement"
-                );
+                });
                 Self::record_admission_metric(source, HealAdmissionResult::Full, context);
                 return HealAdmissionResult::Full;
             }
@@ -1026,8 +1032,7 @@ impl HealManager {
             Self::record_admission_metric(request.source, admission, context);
             match admission {
                 HealAdmissionResult::Dropped(reason) => {
-                    warn!(
-                        target: "rustfs::heal::manager",
+                    demote_to_debug_when!(per_object_request, warn, target: "rustfs::heal::manager", {
                         event = EVENT_HEAL_QUEUE_ADMISSION,
                         component = LOG_COMPONENT_HEAL,
                         subsystem = LOG_SUBSYSTEM_MANAGER,
@@ -1040,11 +1045,10 @@ impl HealManager {
                         reason = reason.as_str(),
                         result = "dropped_full",
                         "Heal queue request dropped"
-                    );
+                    });
                 }
                 HealAdmissionResult::Full => {
-                    warn!(
-                        target: "rustfs::heal::manager",
+                    demote_to_debug_when!(per_object_request, warn, target: "rustfs::heal::manager", {
                         event = EVENT_HEAL_QUEUE_ADMISSION,
                         component = LOG_COMPONENT_HEAL,
                         subsystem = LOG_SUBSYSTEM_MANAGER,
@@ -1056,7 +1060,7 @@ impl HealManager {
                         queue_capacity,
                         result = "rejected_full",
                         "Heal queue request rejected"
-                    );
+                    });
                 }
                 HealAdmissionResult::Accepted | HealAdmissionResult::Merged => {}
             }
@@ -1481,6 +1485,7 @@ impl HealManager {
             drop(retrying_heals);
             drop(queue);
             drop(active_heals);
+            Self::record_admission_metric(request.source, admission, "duplicate");
 
             match admission {
                 HealAdmissionResult::Merged => {
@@ -1501,8 +1506,7 @@ impl HealManager {
                     );
                 }
                 HealAdmissionResult::Dropped(reason) => {
-                    warn!(
-                        target: "rustfs::heal::manager",
+                    demote_to_debug_when!(request.heal_type.is_per_object(), warn, target: "rustfs::heal::manager", {
                         event = EVENT_HEAL_QUEUE_ADMISSION,
                         component = LOG_COMPONENT_HEAL,
                         subsystem = LOG_SUBSYSTEM_MANAGER,
@@ -1512,7 +1516,7 @@ impl HealManager {
                         duplicate_state,
                         result = "dropped_duplicate",
                         "Heal queue admission decided"
-                    );
+                    });
                 }
                 HealAdmissionResult::Accepted | HealAdmissionResult::Full => {}
             }
@@ -2554,8 +2558,7 @@ impl HealManager {
                         Err(e) => {
                             let will_retry = retry_request.is_some();
                             if will_retry {
-                                warn!(
-                                    target: "rustfs::heal::manager",
+                                demote_to_debug_when!(task.heal_type.is_per_object(), warn, target: "rustfs::heal::manager", {
                                     event = EVENT_HEAL_SCHEDULER_STATE,
                                     component = LOG_COMPONENT_HEAL,
                                     subsystem = LOG_SUBSYSTEM_MANAGER,
@@ -2566,7 +2569,7 @@ impl HealManager {
                                     retry_attempt = task.retry_attempts.saturating_add(1),
                                     error = %e,
                                     "Heal scheduler task retrying"
-                                );
+                                });
                             } else {
                                 error!(
                                     target: "rustfs::heal::manager",
@@ -2669,7 +2672,7 @@ impl HealManager {
                             loop {
                                 tokio::select! {
                                     _ = retry_cancel_token.cancelled() => {
-                                        info!(
+                                        debug!(
                                             target: "rustfs::heal::manager",
                                             event = EVENT_HEAL_QUEUE_ADMISSION,
                                             component = LOG_COMPONENT_HEAL,
@@ -2702,7 +2705,7 @@ impl HealManager {
                                 };
                                 if active_duplicate {
                                     retrying_heals_for_spawn.lock().await.remove(&retry_request_id);
-                                    info!(
+                                    debug!(
                                         target: "rustfs::heal::manager",
                                         event = EVENT_HEAL_QUEUE_ADMISSION,
                                         component = LOG_COMPONENT_HEAL,
@@ -2730,7 +2733,7 @@ impl HealManager {
                                         retrying_heals_for_spawn.lock().await.remove(&retry_request_id);
                                         drop(queue);
                                         retry_completed_heals.lock().await.remove(&retry_request_id);
-                                        info!(
+                                        debug!(
                                             target: "rustfs::heal::manager",
                                             event = EVENT_HEAL_QUEUE_ADMISSION,
                                             component = LOG_COMPONENT_HEAL,
@@ -2751,7 +2754,7 @@ impl HealManager {
                                     HealAdmissionResult::Merged => {
                                         retrying_heals_for_spawn.lock().await.remove(&retry_request_id);
                                         drop(queue);
-                                        info!(
+                                        debug!(
                                             target: "rustfs::heal::manager",
                                             event = EVENT_HEAL_QUEUE_ADMISSION,
                                             component = LOG_COMPONENT_HEAL,
@@ -2765,7 +2768,11 @@ impl HealManager {
                                         return;
                                     }
                                     HealAdmissionResult::Full => {
-                                        warn!(
+                                        // admit_request_to_queue already logged the
+                                        // rejection (context = "retry"); this repeats
+                                        // every backoff cycle while the queue stays
+                                        // full, so keep it at debug!.
+                                        debug!(
                                             target: "rustfs::heal::manager",
                                             event = EVENT_HEAL_QUEUE_ADMISSION,
                                             component = LOG_COMPONENT_HEAL,

--- a/crates/heal/src/heal/task.rs
+++ b/crates/heal/src/heal/task.rs
@@ -47,6 +47,25 @@ const MAX_RETAINED_HEAL_RESULT_ITEMS: usize = 1024;
 const EVENT_HEAL_OBJECT_RESULT: &str = "heal_object_result";
 const MAX_BUCKET_OBJECT_HEAL_RETRIES: u32 = 3;
 const MAX_BUCKET_FAILURE_LOG_SAMPLES: u64 = 5;
+
+/// Emits at `$level`, demoted to `debug!` when `$demote` is true. Keeps
+/// per-object heal work — Object/Metadata/MRF/ECDecode tasks queued per
+/// object by MRF/autoheal/scanner loops, and per-object sweep failures past
+/// a sample cap — from amplifying into one info!/warn!/error! line per
+/// object during mass recovery (rustfs/rustfs#5716). Aggregate task kinds
+/// and foreground (admin/internal) requests keep operator-visible levels;
+/// metrics and end-of-sweep summaries carry the aggregate signal for the
+/// demoted paths.
+macro_rules! demote_to_debug_when {
+    ($demote:expr, $level:ident, target: $target:expr, { $($fields:tt)* }) => {
+        if $demote {
+            tracing::debug!(target: $target, $($fields)*);
+        } else {
+            tracing::$level!(target: $target, $($fields)*);
+        }
+    };
+}
+pub(crate) use demote_to_debug_when;
 const EVENT_HEAL_BUCKET_STAGE: &str = "heal_bucket_stage";
 const EVENT_HEAL_BUCKET_RESULT: &str = "heal_bucket_result";
 const EVENT_HEAL_METADATA_STAGE: &str = "heal_metadata_stage";
@@ -100,6 +119,18 @@ impl HealType {
             Self::ECDecode { .. } => "ec_decode",
         }
     }
+
+    /// Task kinds enqueued at per-object granularity (MRF, autoheal, scanner,
+    /// read-repair loops). Their lifecycle and admission logs stay at `debug!`
+    /// so a recovery loop queuing hundreds of thousands of object heal tasks
+    /// cannot amplify into per-object `info!`/`warn!` lines; aggregate kinds
+    /// (cluster/bucket/prefix/erasure-set) keep operator-visible levels.
+    pub(crate) fn is_per_object(&self) -> bool {
+        matches!(
+            self,
+            Self::Object { .. } | Self::Metadata { .. } | Self::MRF { .. } | Self::ECDecode { .. }
+        )
+    }
 }
 
 fn is_object_level_not_found_error(err: &Error) -> bool {
@@ -113,6 +144,20 @@ fn is_object_level_not_found_error(err: &Error) -> bool {
 
 pub(crate) fn is_missing_object_dir_heal_result(object: &str, err: &Error) -> bool {
     object.ends_with(SLASH_SEPARATOR) && is_object_level_not_found_error(err)
+}
+
+/// Sample cap for per-object failure logs during a sweep: returns true (and
+/// consumes a sample slot) for the first [`MAX_BUCKET_FAILURE_LOG_SAMPLES`]
+/// calls, false afterwards so callers demote the remaining occurrences to
+/// `debug!`. Aggregate failed/skipped counts still surface in end-of-sweep
+/// summaries.
+pub(crate) fn take_failure_log_sample(samples_logged: &mut u64) -> bool {
+    if *samples_logged < MAX_BUCKET_FAILURE_LOG_SAMPLES {
+        *samples_logged = samples_logged.saturating_add(1);
+        true
+    } else {
+        false
+    }
 }
 
 /// Heal priority
@@ -618,8 +663,7 @@ impl HealTask {
         )
         .increment(1);
 
-        info!(
-            target: "rustfs::heal::task",
+        demote_to_debug_when!(self.heal_type.is_per_object(), info, target: "rustfs::heal::task", {
             event = EVENT_HEAL_TASK_STATE,
             component = LOG_COMPONENT_HEAL,
             subsystem = LOG_SUBSYSTEM_TASK,
@@ -628,7 +672,7 @@ impl HealTask {
             state = "started",
             queue_delay = ?queue_delay,
             "Heal task started"
-        );
+        });
 
         let result = match &self.heal_type {
             HealType::Cluster => self.heal_cluster().await,
@@ -660,8 +704,7 @@ impl HealTask {
             Ok(_) => {
                 let mut status = self.status.write().await;
                 *status = HealTaskStatus::Completed;
-                info!(
-                    target: "rustfs::heal::task",
+                demote_to_debug_when!(self.heal_type.is_per_object(), info, target: "rustfs::heal::task", {
                     event = EVENT_HEAL_TASK_STATE,
                     component = LOG_COMPONENT_HEAL,
                     subsystem = LOG_SUBSYSTEM_TASK,
@@ -669,7 +712,7 @@ impl HealTask {
                     heal_type = self.heal_type.log_kind(),
                     state = "completed",
                     "Heal task completed"
-                );
+                });
             }
             Err(Error::TaskCancelled) => {
                 let mut status = self.status.write().await;
@@ -688,8 +731,7 @@ impl HealTask {
             Err(Error::TaskTimeout) => {
                 let mut status = self.status.write().await;
                 *status = HealTaskStatus::Timeout;
-                warn!(
-                    target: "rustfs::heal::task",
+                demote_to_debug_when!(self.heal_type.is_per_object(), warn, target: "rustfs::heal::task", {
                     event = EVENT_HEAL_TASK_STATE,
                     component = LOG_COMPONENT_HEAL,
                     subsystem = LOG_SUBSYSTEM_TASK,
@@ -697,13 +739,16 @@ impl HealTask {
                     heal_type = self.heal_type.log_kind(),
                     state = "timed_out",
                     "Heal task timed out"
-                );
+                });
             }
             Err(e) => {
                 let mut status = self.status.write().await;
                 *status = HealTaskStatus::Failed { error: e.to_string() };
-                error!(
-                    target: "rustfs::heal::task",
+                // Per-object failures are already logged with full object
+                // context by the heal_* implementations and terminally by the
+                // scheduler's task_failed error!; this generic duplicate would
+                // multiply every failed object by the retry count.
+                demote_to_debug_when!(self.heal_type.is_per_object(), error, target: "rustfs::heal::task", {
                     event = EVENT_HEAL_TASK_STATE,
                     component = LOG_COMPONENT_HEAL,
                     subsystem = LOG_SUBSYSTEM_TASK,
@@ -712,7 +757,7 @@ impl HealTask {
                     state = "failed",
                     error = %e,
                     "Heal task failed"
-                );
+                });
             }
         }
 
@@ -830,17 +875,21 @@ impl HealTask {
         };
 
         if !object_exists {
-            warn!(
-                target: "rustfs::heal::task",
+            // Background loops (scanner/MRF/autoheal/read-repair) routinely
+            // race object deletion, so a missing target is per-object noise
+            // for them; only foreground admin/internal requests keep the warn.
+            let background_source = !matches!(self.source, HealRequestSource::Admin | HealRequestSource::Internal);
+            demote_to_debug_when!(background_source, warn, target: "rustfs::heal::task", {
                 event = EVENT_HEAL_OBJECT_MISSING,
                 component = LOG_COMPONENT_HEAL,
                 subsystem = LOG_SUBSYSTEM_OBJECT,
                 task_id = %self.id,
                 bucket,
                 object,
+                source = self.source.as_str(),
                 recreate_missing = self.options.recreate_missing,
                 "Heal target object is missing"
-            );
+            });
             if self.options.recreate_missing {
                 debug!(
                     target: "rustfs::heal::task",
@@ -1536,8 +1585,7 @@ impl HealTask {
                             }
                             first_failed_object.get_or_insert_with(|| object.to_string());
                             first_error.get_or_insert_with(|| err.to_string());
-                            if failure_samples_logged < MAX_BUCKET_FAILURE_LOG_SAMPLES {
-                                failure_samples_logged = failure_samples_logged.saturating_add(1);
+                            if take_failure_log_sample(&mut failure_samples_logged) {
                                 warn!(
                                     target: "rustfs::heal::task",
                                     event = EVENT_HEAL_BUCKET_RESULT,
@@ -2394,6 +2442,66 @@ mod tests {
         bucket_heal_calls: Mutex<Vec<String>>,
         block_heal_object: Mutex<bool>,
         resume_disk: Mutex<Option<DiskStore>>,
+    }
+
+    #[test]
+    fn per_object_heal_types_are_classified_for_log_demotion() {
+        assert!(
+            HealType::Object {
+                bucket: "b".to_string(),
+                object: "o".to_string(),
+                version_id: None,
+            }
+            .is_per_object()
+        );
+        assert!(
+            HealType::Metadata {
+                bucket: "b".to_string(),
+                object: "o".to_string(),
+            }
+            .is_per_object()
+        );
+        assert!(
+            HealType::MRF {
+                meta_path: "p".to_string(),
+            }
+            .is_per_object()
+        );
+        assert!(
+            HealType::ECDecode {
+                bucket: "b".to_string(),
+                object: "o".to_string(),
+                version_id: None,
+            }
+            .is_per_object()
+        );
+        assert!(!HealType::Cluster.is_per_object());
+        assert!(!HealType::Bucket { bucket: "b".to_string() }.is_per_object());
+        assert!(
+            !HealType::Prefix {
+                bucket: "b".to_string(),
+                prefix: "p".to_string(),
+            }
+            .is_per_object()
+        );
+        assert!(
+            !HealType::ErasureSet {
+                buckets: Vec::new(),
+                set_disk_id: "s".to_string(),
+            }
+            .is_per_object()
+        );
+    }
+
+    #[test]
+    fn failure_log_sampling_caps_at_max_samples() {
+        let mut samples_logged = 0_u64;
+        for _ in 0..MAX_BUCKET_FAILURE_LOG_SAMPLES {
+            assert!(take_failure_log_sample(&mut samples_logged));
+        }
+        assert!(!take_failure_log_sample(&mut samples_logged));
+        assert!(!take_failure_log_sample(&mut samples_logged));
+        assert_eq!(samples_logged, MAX_BUCKET_FAILURE_LOG_SAMPLES);
     }
 
     /// Build a latest, non-delete-marker heal list item with no version id.

--- a/scripts/check_logging_guardrails.sh
+++ b/scripts/check_logging_guardrails.sh
@@ -752,4 +752,38 @@ if [[ "$stdout_sink_calls" != "2" ]]; then
   exit 1
 fi
 
+# Heal log amplification guards (rustfs/rustfs#5716 follow-up): per-object heal
+# work (Object/Metadata/MRF/ECDecode tasks queued by MRF/autoheal/scanner loops)
+# must not emit info!/warn!/error! lines per object during mass recovery.
+# The 1000-char window covers the measured 541-710 chars of structured fields
+# between the macro open and the message at every retry-admission site.
+if rg -n -U '(info|warn)!\(\s*target: "rustfs::heal::manager",[\s\S]{0,1000}"Heal retry admission decided"' crates/heal/src/heal/manager.rs >/dev/null; then
+  echo "❌ logging guardrail violation: heal retry admission decisions repeat per retrying task (per-object under MRF retry storms) and must stay at DEBUG" >&2
+  exit 1
+fi
+
+demoted_task_sites="$(rg -c -F 'demote_to_debug_when!(self.heal_type.is_per_object()' crates/heal/src/heal/task.rs || echo 0)"
+if [[ "$demoted_task_sites" -lt 4 ]]; then
+  echo "❌ logging guardrail violation: per-object heal task lifecycle/failure logs must stay demoted to DEBUG via demote_to_debug_when! (expected >= 4 sites in crates/heal/src/heal/task.rs, found $demoted_task_sites)" >&2
+  exit 1
+fi
+
+demoted_task_total_sites="$(rg -c -F 'demote_to_debug_when!(' crates/heal/src/heal/task.rs || echo 0)"
+if [[ "$demoted_task_total_sites" -lt 5 ]]; then
+  echo "❌ logging guardrail violation: the background-source missing-object warn in crates/heal/src/heal/task.rs must stay level-split via demote_to_debug_when! (expected >= 5 total sites, found $demoted_task_total_sites)" >&2
+  exit 1
+fi
+
+erasure_sampled_sites="$(rg -c -F 'take_failure_log_sample(' crates/heal/src/heal/erasure_healer.rs || echo 0)"
+if [[ "$erasure_sampled_sites" -lt 2 ]]; then
+  echo "❌ logging guardrail violation: erasure-set per-object failure/skip warns must stay sample-capped via take_failure_log_sample (expected >= 2 sites in crates/heal/src/heal/erasure_healer.rs, found $erasure_sampled_sites)" >&2
+  exit 1
+fi
+
+demoted_admission_sites="$(rg -c -F 'demote_to_debug_when!(' crates/heal/src/heal/manager.rs || echo 0)"
+if [[ "$demoted_admission_sites" -lt 6 ]]; then
+  echo "❌ logging guardrail violation: heal queue admission/scheduler warns for per-object requests must stay level-split via demote_to_debug_when! (expected >= 6 sites in crates/heal/src/heal/manager.rs, found $demoted_admission_sites)" >&2
+  exit 1
+fi
+
 echo "✅ Logging guardrails check passed"


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
Fixes #5716 (remaining heal-side amplification sources; the ecstore per-object heal INFO demotion landed separately).

## Summary of Changes
A recovery loop that queues hundreds of thousands of per-object heal tasks (MRF replay, autoheal, scanner) amplified into per-object `info!`/`warn!`/`error!` lines from `crates/heal`. This PR removes the remaining amplification sources while keeping aggregate task kinds, foreground (admin/internal) requests, and all unique failure diagnostics at operator-visible levels.

- **Shared level-split macro**: new `demote_to_debug_when!(cond, level, target, { fields })` in `task.rs` (plus `HealType::is_per_object()` classifying Object/Metadata/MRF/ECDecode vs Cluster/Bucket/Prefix/ErasureSet). A future `HealType` variant defaults to aggregate, i.e. louder logging (fail-safe direction).
- **`task.rs` lifecycle logs**: `Heal task started`/`completed` (2 `info!` lines per object), `timed_out` (`warn!`), and the generic `failed` `error!` demote to `debug!` for per-object task kinds. The failed arm was a strict-subset duplicate: per-attempt object context still `error!`s inside `heal_object` (`result = "failed"`), and terminal failures still `error!` at the scheduler (`state = "task_failed"`); previously one recoverable per-object failure emitted up to 9 `error!` lines across the three layers.
- **`task.rs` missing-object warn**: `Heal target object is missing` fired per missing object; background sources (scanner/MRF/autoheal/read-repair) routinely race object deletion, so it demotes to `debug!` for them and keeps `warn!` (now with a `source` field) for admin/internal requests.
- **`erasure_healer.rs` sweep warns**: the per-failed/per-skipped-object `transient_skip` and `failed` `warn!`s are now sample-capped per bucket via a shared `take_failure_log_sample` helper (extracted from the existing `heal_bucket_objects` precedent, `MAX_BUCKET_FAILURE_LOG_SAMPLES = 5`); over-cap occurrences log at `debug!`. A flapping rebuild disk can no longer produce ~289k warns per sweep — the end-of-pass `retry_scheduled` warn / `failed_after_retries` error still report full failed/skipped counts.
- **`manager.rs` admission and retry logs**: queue-full/drop/displacement/duplicate-drop `warn!`s and the scheduler `task_retrying` warn level-split by request kind; the per-retry admission decision logs (`retry_enqueued` etc.) demote to `debug!` unconditionally — they fire once per retrying task (per object under MRF retry storms), repeat every backoff cycle while the queue is full, and duplicate both `admit_request_to_queue`'s own logging (context `retry`) and the scheduler `task_retrying` event. `rustfs_heal_admission_total`, the queue-length gauge, and the `heal_queue_state` backlog event keep the aggregate signal. The previously unmetered duplicate-admission short-circuit now records `rustfs_heal_admission_total{context="duplicate"}` so demoted per-object duplicate drops stay observable.
- **Guardrails**: `scripts/check_logging_guardrails.sh` gains four checks pinning the demotions (retry-admission messages must not appear at `info!`/`warn!`, count-based checks on the macro/sampling call sites). The regex window and the count thresholds were verified by injection: flipping any demoted site back fails the script, and it passes on the clean tree. The script now also runs in CI quick-checks — it previously only ran via `make pre-commit`/`pre-pr` — added to both `ci.yml` and its byte-identical `ci-docs-only.yml` mirror per the mandate in those files.

## Verification
- `./scripts/check_logging_guardrails.sh` — passes; regression injection verified both directions (flipping `retry_enqueued`/`retry_cancelled` back to `info!`/`warn!` in a scratch copy is caught; single-site reverts of counted macro/sampling sites drop below the thresholds).
- `cargo clippy -p rustfs-heal --all-targets -- -D warnings` — clean.
- `cargo test -p rustfs-heal --lib` — 233 passed (includes new `per_object_heal_types_are_classified_for_log_demotion` covering all 8 `HealType` variants and `failure_log_sampling_caps_at_max_samples`).
- `cargo test -p rustfs-heal --tests` — all pass except `heal_b920_subquorum_union_test` (2 failures), which fails identically on unmodified `main` (3/3 runs, panic in `ecstore/src/runtime/sources.rs` global disk map setup when the whole binary runs; each test passes in isolation) — pre-existing, tracked for a separate fix.
- `make pre-commit` — passes.
- `actionlint .github/workflows/ci.yml .github/workflows/ci-docs-only.yml` and `./scripts/check_ci_paths_sync.sh` — pass; quick-checks step lists verified mirrored.

Adversarial validation (high-risk tier, all seven roles): correctness — attacked macro expansion/side-effect-once semantics, sampling counter equivalence with the replaced inline code, and control-flow identity at every touched branch; no behavior break. Simplicity — consolidated three hand-written level-split shapes into the shared macro (~90 duplicated lines removed) and de-brittled the guardrail checks per findings. Security — verified every demoted path keeps an aggregate metric or summary signal (no failure mode is invisible at INFO and unmetered after the duplicate-admission metric fix); no content moved to higher levels. Concurrency — sample counters are single-consumer locals (concurrent page futures never touch them); no log moved relative to lock drops/state mutations; no cancellation points changed. Compatibility — no consumer (including `log-analyzer` heal rules) anchors on the demoted events/messages; no metrics or admin-visible types changed; CI mirror-job mandate honored. Performance — no new allocation on demoted paths (lazy field sigils, `matches!` gating); residual per-object missing-object/timeout/failed duplication found by review is fixed in this PR. Test coverage — guardrail dead-regex finding fixed and injection-verified; count thresholds sit exactly at the current site counts so single-site reverts fail CI.

## Impact
Operational logging only: per-object heal noise moves from `info!`/`warn!`/`error!` to `debug!`; operators keep aggregate signals (`rustfs_heal_admission_total`, `rustfs_heal_task_start_total`, queue gauges, `heal_queue_state` backlog event, per-bucket sampled warns, end-of-sweep summaries, terminal `task_failed` errors). No API, storage-format, metric, or configuration changes. Log-based alerting that matched the demoted per-object messages at INFO/WARN (none found in-repo) would need to switch to the aggregate events or metrics.

## Additional Notes
`heal_b920_subquorum_union_test` failures are pre-existing on `main` and unrelated (verified by stashing this diff); flagged separately for a dedicated fix.
