### PR TITLE
fix(quota): keep the degraded-baseline fallback off the write path's stack

### DIFF
--- a/crates/ecstore/src/bucket/quota/checker.rs
+++ b/crates/ecstore/src/bucket/quota/checker.rs
@@ -214,7 +214,13 @@ impl QuotaChecker {
         // the writes issued before the next complete scanner cycle. Buckets
         // with no persisted baseline anywhere keep failing closed.
         let store = self.metadata_sys.read().await.object_store();
-        if let Some(baseline) = crate::data_usage::lookup_degraded_bucket_usage_baseline(store, bucket).await {
+        // Box the fallback: it embeds the whole snapshot-load future, and every
+        // object write nests a quota check several futures deep, so keeping it
+        // inline would grow each write's state machine by the loader's full
+        // size — the debug-build 2MiB worker-stack overflow class fixed for
+        // bucket-config writes in #5648. The allocation only happens on the
+        // degraded path; the authoritative fast path returns above.
+        if let Some(baseline) = Box::pin(crate::data_usage::lookup_degraded_bucket_usage_baseline(store, bucket)).await {
             debug!(bucket, baseline, "Bucket quota admission using degraded persisted usage baseline");
             return Ok(baseline);
         }


### PR DESCRIPTION
Follow-up to #5722 (merged before this hardening landed on its branch).

The degraded-baseline fallback added in #5722 embeds the whole snapshot-loader future inside `QuotaChecker::get_real_time_usage`, and every object write nests a quota check several futures deep — so the fallback's full state-machine size was added to every write path future even when the authoritative fast path returns early. That is the same debug-build 2MiB worker-stack overflow class that #5648 fixed for bucket-config writes (the ILM Integration serial lane is where it bites first). Box the fallback at its call site: the write path future now carries only a pointer, and the allocation happens only on the degraded path.

## Testing

- `cargo check -p rustfs-ecstore` on top of current main
- No behavior change; the boxed future is awaited identically

Refs #5716, #5722, #5648