### PR TITLE
fix(targets): surface redacted construction error detail in target failures

### DIFF
--- a/crates/targets/src/config/loader.rs
+++ b/crates/targets/src/config/loader.rs
@@ -113,6 +113,25 @@ fn redacted_target_config(config: &KVS) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Scrubs a free-form error message against an instance's merged configuration:
+/// every non-empty config value whose field is redacted in debug logs (secrets,
+/// endpoint URLs, DSNs) has its occurrences in the message replaced by the same
+/// redacted form, so a construction error can surface its underlying detail
+/// without leaking credential-bearing configuration values.
+pub(crate) fn redact_error_detail_with_config(message: &str, config: &KVS) -> String {
+    let mut redacted = message.to_string();
+    for kv in &config.0 {
+        if kv.value.is_empty() {
+            continue;
+        }
+        let replacement = redact_target_field_value(&kv.key, &kv.value);
+        if replacement != kv.value {
+            redacted = redacted.replace(&kv.value, &replacement);
+        }
+    }
+    redacted
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MergedTargetConfigRecord {
     pub instance_id: String,
@@ -392,7 +411,7 @@ where
 mod tests {
     use super::{
         collect_env_target_instance_ids_from_env, collect_target_config_results_from_env, collect_target_configs_from_env,
-        redact_target_field_value, redacted_target_config, try_collect_target_configs_from_env,
+        redact_error_detail_with_config, redact_target_field_value, redacted_target_config, try_collect_target_configs_from_env,
     };
     use crate::TargetError;
     use rustfs_config::notify::{
@@ -633,6 +652,33 @@ mod tests {
         assert_eq!(configs.len(), 1);
         assert_eq!(configs[0].0, "primary");
         assert_eq!(configs[0].1.lookup(ENABLE_KEY).as_deref(), Some(" on "));
+    }
+
+    #[test]
+    fn redact_error_detail_with_config_scrubs_sensitive_values_from_message() {
+        let mut config = KVS::new();
+        config.insert("endpoint".to_string(), "https://example.com/private/hook?sig=hunter2".to_string());
+        config.insert("auth_token".to_string(), "hook-secret-token".to_string());
+        config.insert("queue_limit".to_string(), "1000".to_string());
+
+        let detail = redact_error_detail_with_config(
+            "webhook endpoint is not allowed: https://example.com/private/hook?sig=hunter2 (auth_token hook-secret-token, queue_limit 1000)",
+            &config,
+        );
+
+        assert_eq!(
+            detail,
+            "webhook endpoint is not allowed: https://example.com (auth_token ***redacted***, queue_limit 1000)"
+        );
+    }
+
+    #[test]
+    fn redact_error_detail_with_config_leaves_untainted_message_intact() {
+        let mut config = KVS::new();
+        config.insert("auth_token".to_string(), "hook-secret-token".to_string());
+
+        let detail = redact_error_detail_with_config("queue store open failed: permission denied", &config);
+        assert_eq!(detail, "queue store open failed: permission denied");
     }
 
     #[test]

--- a/crates/targets/src/config/mod.rs
+++ b/crates/targets/src/config/mod.rs
@@ -25,6 +25,7 @@ pub use instance::{
     normalize_legacy_target_instances_from_env, normalize_target_plugin_instances, normalize_target_plugin_instances_from_env,
     try_normalize_target_plugin_instances, try_normalize_target_plugin_instances_from_env,
 };
+pub(crate) use loader::redact_error_detail_with_config;
 pub use loader::{
     collect_env_target_instance_ids, collect_env_target_instance_ids_from_env, collect_target_config_results,
     collect_target_config_results_from_env, collect_target_configs, collect_target_configs_from_env, try_collect_target_configs,

--- a/crates/targets/src/plugin.rs
+++ b/crates/targets/src/plugin.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     PluginRuntimeAdapter, RuntimeActivation, Target, TargetError,
-    config::collect_target_config_results,
+    config::{collect_target_config_results, redact_error_detail_with_config},
     manifest::{TargetPluginManifest, builtin_target_manifest},
     target::with_deferred_queue_store_open,
 };
@@ -368,9 +368,14 @@ where
                         info!(target_type = %target.id().name, instance_id = %id, "Create target successfully");
                         successful_targets.push(target);
                     }
-                    Err(_) => {
-                        failures.push(format!("{target_type}/{id}: target construction failed"));
-                        error!(target_type = %target_type, instance_id = %id, reason = "construction_failed", "Failed to create target");
+                    Err(err) => {
+                        // The underlying error names the root cause (egress policy
+                        // rejection, queue-store open failure, ...); scrub it against
+                        // the instance config so credential-bearing values never
+                        // reach the log or the Admin-visible failure summary.
+                        let detail = redact_error_detail_with_config(&err.to_string(), &merged_config);
+                        failures.push(format!("{target_type}/{id}: target construction failed: {detail}"));
+                        error!(target_type = %target_type, instance_id = %id, reason = "construction_failed", detail = %detail, "Failed to create target");
                     }
                 }
             }
@@ -570,5 +575,52 @@ mod tests {
         // false success) rather than silently dropped or fatally aborting.
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("alpha/bad"), "unexpected failure summary: {}", failures[0]);
+    }
+
+    // Regression (#5115 debugging): a construction failure must carry the
+    // underlying error detail (e.g. an egress-policy rejection) in the failure
+    // summary instead of an opaque "target construction failed", while
+    // credential-bearing config values stay redacted.
+    #[tokio::test]
+    async fn construction_failure_surfaces_redacted_error_detail() {
+        let mut registry = TargetPluginRegistry::<String>::new();
+        registry.register(TargetPluginDescriptor::new(
+            "gamma",
+            &[ENABLE_KEY, "endpoint", "auth_token"],
+            |_config| Ok(()),
+            |_id, config| {
+                let endpoint = config.lookup("endpoint").unwrap_or_default();
+                let token = config.lookup("auth_token").unwrap_or_default();
+                Err(TargetError::Configuration(format!(
+                    "webhook endpoint is not allowed: {endpoint} (auth_token {token})"
+                )))
+            },
+        ));
+
+        let mut cfg = Config(HashMap::new());
+        let mut section = HashMap::new();
+        let mut primary = KVS::new();
+        primary.insert(ENABLE_KEY.to_string(), "on".to_string());
+        primary.insert("endpoint".to_string(), "https://example.com/private/hook?sig=hunter2".to_string());
+        primary.insert("auth_token".to_string(), "hook-secret-token".to_string());
+        section.insert("primary".to_string(), primary);
+        cfg.0.insert("notify_gamma".to_string(), section);
+
+        let (targets, failures) = registry
+            .create_dormant_targets_from_config(&cfg, "notify_")
+            .await
+            .expect("a failing instance must not abort target creation");
+
+        assert!(targets.is_empty());
+        assert_eq!(failures.len(), 1);
+        let failure = &failures[0];
+        assert!(failure.contains("gamma/primary"), "unexpected failure summary: {failure}");
+        // The root cause is surfaced instead of an opaque generic message.
+        assert!(failure.contains("webhook endpoint is not allowed"), "missing error detail: {failure}");
+        // The endpoint is reduced to its origin; path, query, and token are gone.
+        assert!(failure.contains("https://example.com"), "endpoint origin should stay visible: {failure}");
+        assert!(!failure.contains("/private/hook"), "endpoint path must be redacted: {failure}");
+        assert!(!failure.contains("hunter2"), "endpoint query must be redacted: {failure}");
+        assert!(!failure.contains("hook-secret-token"), "auth token must be redacted: {failure}");
     }
 }


### PR DESCRIPTION
## Problem

When a configured notify/audit target fails to construct, `create_targets_from_config_with_store_mode` discarded the underlying `TargetError` entirely: the log line carried only `reason=construction_failed` and the returned failure summary was an opaque `{type}/{id}: target construction failed`.

In practice this made real incidents undiagnosable from logs. While debugging rustfs#5115, the only signal was `Failed to create target ... construction_failed` repeating every 5 seconds, even though the discarded error carried the actionable root cause (an egress-policy rejection: `webhook endpoint is not allowed: ...; add http://127.0.0.1:3020 to RUSTFS_OUTBOUND_ALLOW_ORIGINS ...`).

## Change

- `plugin.rs`: the `Err` branch now surfaces the error detail in both outputs — the `error!` event gains a `detail` field (keeping `reason=construction_failed` as the stable machine-readable category), and the failures summary becomes `{type}/{id}: target construction failed: {detail}`.
- `config/loader.rs`: new `redact_error_detail_with_config(message, config)` scrubs the error text against the instance's merged configuration by reusing the loader's existing per-field redaction: secret/token/auth values become `***redacted***`, endpoint/URL values are reduced to their origin (path and query dropped), and DSN passwords are masked. Any credential-bearing config value embedded in a construction error is therefore replaced before the detail reaches the log or the Admin-visible failure summary; messages without sensitive values pass through unchanged.

The existing `build_failed_error_detail` helper was deliberately not reused here: it collapses `Configuration` errors to the bare word `configuration`, which would discard the root cause again.

Downstream consumers of the failures vector (notify/audit registries, lifecycle) treat the entries as opaque summary strings, so appending the detail is compatible.

## Tests

- `plugin::tests::construction_failure_surfaces_redacted_error_detail`: end-to-end assertion that the returned failures carry the instance id, the underlying error text, and the endpoint origin, while the endpoint path, query signature, and auth token value never appear.
- `config::loader::tests::redact_error_detail_with_config_scrubs_sensitive_values_from_message` / `..._leaves_untainted_message_intact`: unit coverage for the new scrubber.

## Verification

- `cargo test -p rustfs-targets --lib` (560 passed)
- `cargo clippy -p rustfs-targets --all-targets` (clean)
- `cargo fmt --all --check` + all five architecture guard scripts (clean)