### PR TITLE
test(ecstore): deflake multipart listing tests under plain cargo test

### DIFF
--- a/crates/ecstore/src/core/sets.rs
+++ b/crates/ecstore/src/core/sets.rs
@@ -1749,7 +1749,19 @@ mod tests {
             upload_id_marker = page.next_upload_id_marker;
         }
 
-        assert_eq!(actual, expected, "set-level merge must return every upload exactly once");
+        // Compare only the decoded `<uuid>x<timestamp>` suffixes: the full
+        // upload id embeds the process-global deployment id, which a
+        // concurrently running test can swap between create and list time.
+        let normalize = |uploads: &[(String, String)]| {
+            let mut normalized = uploads
+                .iter()
+                .map(|(key, upload_id)| (key.clone(), runtime_sources::upload_uuid_suffix(upload_id)))
+                .collect::<Vec<_>>();
+            normalized.sort();
+            normalized
+        };
+        let actual = normalize(&actual);
+        assert_eq!(actual, normalize(&expected), "set-level merge must return every upload exactly once");
         let mut deduped = actual.clone();
         deduped.dedup();
         assert_eq!(deduped.len(), actual.len(), "set-level pagination must not duplicate uploads");

--- a/crates/ecstore/src/runtime/sources.rs
+++ b/crates/ecstore/src/runtime/sources.rs
@@ -246,6 +246,22 @@ pub fn deployment_id() -> Option<String> {
     get_global_deployment_id()
 }
 
+/// Test-only inverse of [`deployment_upload_id`]: returns the raw
+/// `<uuid>x<timestamp>` suffix without the deployment-id prefix. Under plain
+/// `cargo test` (thread-parallel, shared process globals) a concurrently
+/// running test that re-initializes a store can swap the global deployment id
+/// between create time and list time, so assertions must compare only this
+/// suffix, never the full encoded upload id.
+#[cfg(test)]
+pub(crate) fn upload_uuid_suffix(upload_id: &str) -> String {
+    base64_simd::URL_SAFE_NO_PAD
+        .decode_to_vec(upload_id.as_bytes())
+        .ok()
+        .and_then(|decoded| String::from_utf8(decoded).ok())
+        .and_then(|decoded| decoded.split_once('.').map(|(_, suffix)| suffix.to_owned()))
+        .unwrap_or_else(|| upload_id.to_owned())
+}
+
 pub(crate) fn replication_pool() -> Option<Arc<DynReplicationPool>> {
     crate::runtime::global::current_ctx().replication_pool()
 }

--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -3976,6 +3976,9 @@ mod tests {
         }
 
         // Start more in-progress uploads on the same object than a single page holds.
+        // Track only the decoded `<uuid>x<timestamp>` suffixes: the full upload id
+        // embeds the process-global deployment id, which a concurrently running
+        // test can swap between create and list time.
         let total = 5usize;
         let mut created = HashSet::new();
         for _ in 0..total {
@@ -3983,7 +3986,10 @@ mod tests {
                 .new_multipart_upload(bucket, object, &ObjectOptions::default())
                 .await
                 .expect("multipart upload should be created");
-            assert!(created.insert(res.upload_id), "each upload id must be unique");
+            assert!(
+                created.insert(runtime_sources::upload_uuid_suffix(&res.upload_id)),
+                "each upload id must be unique"
+            );
         }
 
         // A single page must never return more than max_uploads entries.
@@ -4038,7 +4044,7 @@ mod tests {
             assert!(page.uploads.len() <= 1, "max_uploads=1 must never return more than one upload");
             for upload in &page.uploads {
                 assert!(
-                    seen.insert(upload.upload_id.clone()),
+                    seen.insert(runtime_sources::upload_uuid_suffix(&upload.upload_id)),
                     "upload {} was returned more than once across pages",
                     upload.upload_id
                 );
@@ -4067,13 +4073,16 @@ mod tests {
             disk.make_volume(bucket).await.expect("bucket volume should be created");
         }
 
+        // Compare only the decoded `<uuid>x<timestamp>` suffixes: the full
+        // upload id embeds the process-global deployment id, which a
+        // concurrently running test can swap between create and list time.
         let mut expected = Vec::new();
         for object in ["logs/a.bin", "logs/a.bin", "logs/b.bin", "other/c.bin"] {
             let upload = set_disks
                 .new_multipart_upload(bucket, object, &ObjectOptions::default())
                 .await
                 .expect("multipart upload should be created");
-            expected.push((object.to_string(), upload.upload_id));
+            expected.push((object.to_string(), runtime_sources::upload_uuid_suffix(&upload.upload_id)));
         }
         expected.sort();
 
@@ -4081,11 +4090,12 @@ mod tests {
             .list_multipart_uploads_for_incarnation(bucket, "", None, None, None, 1000, None)
             .await
             .expect("bucket-wide multipart listing should succeed");
-        let listed = all
+        let mut listed = all
             .uploads
             .iter()
-            .map(|upload| (upload.object.clone(), upload.upload_id.clone()))
+            .map(|upload| (upload.object.clone(), runtime_sources::upload_uuid_suffix(&upload.upload_id)))
             .collect::<Vec<_>>();
+        listed.sort();
         assert_eq!(listed, expected);
         assert!(!all.is_truncated);
 
@@ -4149,7 +4159,18 @@ mod tests {
             assert!(upload_id_marker.is_some());
         }
 
-        assert_eq!(listed, expected);
+        // Compare only the decoded `<uuid>x<timestamp>` suffixes: the full
+        // upload id embeds the process-global deployment id, which a
+        // concurrently running test can swap between create and list time.
+        let normalize = |uploads: &[(String, String)]| {
+            let mut normalized = uploads
+                .iter()
+                .map(|(object, upload_id)| (object.clone(), runtime_sources::upload_uuid_suffix(upload_id)))
+                .collect::<Vec<_>>();
+            normalized.sort();
+            normalized
+        };
+        assert_eq!(normalize(&listed), normalize(&expected));
 
         let key_only = set_disks
             .list_multipart_uploads_for_incarnation(bucket, "logs/", Some("logs/a.bin".to_string()), None, None, 1000, None)
@@ -4268,7 +4289,13 @@ mod tests {
             .await
             .expect("incarnation-scoped multipart listing should succeed");
         assert_eq!(scoped.uploads.len(), 1);
-        assert_eq!(scoped.uploads[0].upload_id, current.upload_id);
+        // Compare only the decoded `<uuid>x<timestamp>` suffixes: the full
+        // upload id embeds the process-global deployment id, which a
+        // concurrently running test can swap between create and list time.
+        assert_eq!(
+            runtime_sources::upload_uuid_suffix(&scoped.uploads[0].upload_id),
+            runtime_sources::upload_uuid_suffix(&current.upload_id)
+        );
     }
 
     /// Recursively collect every file named `file_name` under the multipart
@@ -4755,7 +4782,13 @@ mod tests {
                 .list_multipart_uploads_for_incarnation(bucket, object, None, None, None, 1000, None)
                 .await
                 .expect("listing multipart uploads should succeed");
-            page.uploads.iter().any(|u| u.upload_id == upload_id)
+            // Compare only the decoded `<uuid>x<timestamp>` suffixes: the full
+            // upload id embeds the process-global deployment id, which a
+            // concurrently running test can swap between create and list time.
+            let expected_suffix = runtime_sources::upload_uuid_suffix(upload_id);
+            page.uploads
+                .iter()
+                .any(|u| runtime_sources::upload_uuid_suffix(&u.upload_id) == expected_suffix)
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Multipart upload ids embed the process-global deployment id: `new_multipart_upload` encodes it at create time and the listing paths re-encode it from the same global at list time (`runtime_sources::deployment_upload_id`). Under plain `cargo test` (thread-parallel, shared process globals) a concurrently running test that re-initializes a store — e.g. via `isolated_store_over_temp_disks` or hermetic init — can swap the global deployment id between those two reads, so tests asserting full upload-id equality across create/list fail spuriously. Observed: `core::sets::tests::list_multipart_uploads_merges_all_sets_without_pagination_loss` fails when run concurrently with `bucket::quota` checker tests but passes in isolation. The operational code paths are immune (`get_upload_id_dir` decodes and keeps only the suffix); only test assertions compare the full encoded id.

This PR is test-only hardening:

- Add a `#[cfg(test)]` `upload_uuid_suffix` helper in `runtime/sources.rs` next to `deployment_upload_id`: it base64-decodes the upload id and returns the raw `<uuid>x<timestamp>` suffix without the deployment-id prefix.
- Rework every create-vs-list full-upload-id assertion to compare only decoded suffixes:
  - `core/sets.rs`: `list_multipart_uploads_merges_all_sets_without_pagination_loss`
  - `set_disk/ops/multipart.rs`: `list_multipart_uploads_enumerates_bucket_and_prefix`, `list_multipart_uploads_paginates_across_same_key_boundary`, `list_multipart_uploads_caps_each_page_at_max_uploads_and_paginates_cleanly`, `list_multipart_uploads_hides_uploads_from_another_incarnation`, and the `crash_consistency::upload_is_listed` helper (its `#[serial]` does not protect against non-serial tests swapping the global).
- Where normalization affects within-key ordering, both sides are sorted before comparison: the URL-safe base64 alphabet is not in ASCII byte order (e.g. `z` sorts after `0` by encoded value but before it in the decoded bytes), so listing order by encoded id and sort order by decoded suffix can legitimately differ for uploads on the same key.

Deliberately not done: the tests were not added to the `ecstore-serial-flaky` nextest group — nextest already runs process-per-test so it never sees this flake, and the group would not affect plain `cargo test`, which is where the flake lives. Store-level pagination tests in `store/multipart.rs` use synthetic ids (`"u1"`, …) with no deployment prefix and need no change. A residual theoretical window remains where the global swaps between two pages of one listing (markers carry full encoded ids), but that window is milliseconds versus the create-to-list window spanning many awaits, and it cannot occur in production where the deployment id is stable for the process lifetime.

## Verification

- `make pre-commit` — passed
- `cargo test -p rustfs-ecstore --lib -- list_multipart_uploads quota` — 8 consecutive rounds, all green (reproduces the original concurrent-with-quota-tests scenario)
- `cargo test -p rustfs-ecstore --lib -- crash_consistency` — passed
- `cargo clippy -p rustfs-ecstore --lib --tests` — clean

## Impact

N/A — test-only change plus one `#[cfg(test)]` helper; no production code or behavior is affected.

## Additional Notes

CI (nextest, process-per-test) was never affected by this flake; the hardening targets local plain `cargo test` runs.
