### PR TITLE
fix(ecstore): make inline-rollback reclamation file-precise to keep #5703's child-key safety

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -119,7 +119,7 @@ fn read_all_data_std(path: &Path) -> core::result::Result<(Vec<u8>, Option<Offse
     Ok((bytes, modtime))
 }
 
-fn inline_metadata_rollback_dir(version_id: Uuid, meta: &FileMeta) -> Uuid {
+pub(crate) fn inline_metadata_rollback_dir(version_id: Uuid, meta: &FileMeta) -> Uuid {
     let used_data_dirs: HashSet<Uuid> = meta.get_data_dirs().unwrap_or_default().into_iter().flatten().collect();
     let base = version_id.as_u128() ^ INLINE_METADATA_ROLLBACK_DIR_XOR;
     let mut salt = 0u128;
@@ -240,8 +240,15 @@ async fn write_metadata_rollback_backup(object_dir: &Path, rollback_dir: Uuid, d
 }
 
 async fn restore_metadata_backup(object_dir: &Path, xl_path: &Path, rollback_dir: Uuid) -> Result<()> {
-    let backup_path = object_dir.join(rollback_dir.to_string()).join(STORAGE_FORMAT_FILE_BACKUP);
-    rename_all(&backup_path, xl_path, object_dir).await
+    let rollback_path = object_dir.join(rollback_dir.to_string());
+    let backup_path = rollback_path.join(STORAGE_FORMAT_FILE_BACKUP);
+    rename_all(&backup_path, xl_path, object_dir).await?;
+    // A synthetic inline rollback dir held only the backup the rename above
+    // just consumed; reclaim it so the object dir can empty out. A real data
+    // dir still holds its parts, so the non-recursive remove is a benign
+    // no-op there (mirrors restore_delete_rollback).
+    let _ = fs::remove_dir(&rollback_path).await;
+    Ok(())
 }
 
 async fn restore_delete_rollback(object_dir: &Path, xl_path: &Path, rollback_dir: Uuid) -> Result<()> {
@@ -12226,6 +12233,54 @@ mod test {
                 .exists(),
             "copy fallback backup should be consumed by atomic rollback"
         );
+    }
+
+    // The undo_write restore consumes `<rollback>/xl.meta.bkp` by rename; a
+    // synthetic rollback dir is then empty and must be reclaimed so the object
+    // dir can empty out (BucketNotEmpty leak). A real data dir still holds its
+    // parts and must survive the non-recursive remove.
+    #[tokio::test]
+    async fn restore_metadata_backup_reclaims_empty_rollback_dir_only() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("temp dir should be created");
+        let object_dir = dir.path().join("bucket").join("obj");
+        let xl_path = object_dir.join(STORAGE_FORMAT_FILE);
+        let rollback_dir = Uuid::new_v4();
+        let rollback_path = object_dir.join(rollback_dir.to_string());
+        fs::create_dir_all(&rollback_path)
+            .await
+            .expect("rollback dir should be created");
+        fs::write(rollback_path.join(STORAGE_FORMAT_FILE_BACKUP), b"old-meta")
+            .await
+            .expect("backup should be written");
+
+        restore_metadata_backup(&object_dir, &xl_path, rollback_dir)
+            .await
+            .expect("restore should succeed");
+        assert_eq!(
+            fs::read(&xl_path).await.expect("xl.meta should be restored"),
+            b"old-meta",
+            "restore must move the backup back onto xl.meta"
+        );
+        assert!(!rollback_path.exists(), "an emptied synthetic rollback dir must be reclaimed");
+
+        // Real data dir: parts remain, the dir must survive.
+        let real_dir = Uuid::new_v4();
+        let real_path = object_dir.join(real_dir.to_string());
+        fs::create_dir_all(&real_path).await.expect("real data dir should be created");
+        fs::write(real_path.join(STORAGE_FORMAT_FILE_BACKUP), b"older-meta")
+            .await
+            .expect("backup should be written");
+        fs::write(real_path.join("part.1"), b"data")
+            .await
+            .expect("part should be written");
+
+        restore_metadata_backup(&object_dir, &xl_path, real_dir)
+            .await
+            .expect("restore should succeed");
+        assert!(real_path.join("part.1").exists(), "a real data dir must keep its parts");
+        assert!(real_path.exists(), "a non-empty data dir must not be removed");
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -49,7 +49,7 @@ use crate::diagnostics::get::{
 use crate::disk::local::DELETE_DATA_DIR_MARKER_PREFIX;
 use crate::disk::{
     DataDirDeleteStatus, OldCurrentSize, PART_TRANSACTION_NEW_META, PART_TRANSACTION_OLD_META, PART_TRANSACTION_ROLLBACK,
-    PartTransactionAction, part_transaction_path,
+    PartTransactionAction, STORAGE_FORMAT_FILE_BACKUP, part_transaction_path,
 };
 use crate::erasure::coding::BitrotReader;
 use crate::io_support::bitrot::ShardReader;
@@ -2950,63 +2950,63 @@ impl SetDisks {
             return Err(ret_err);
         }
 
-        // A synthetic inline-rollback dir (rollback_data_dir set, cleanup_data_dir
-        // unset) holds only the xl.meta.bkp consumed by the quorum-failure undo
-        // above. Once the commit holds quorum that window is closed, and the
-        // commit_rename_data_dir pass reclaims real old data dirs only, so the
-        // synthetic dir must be reclaimed here — otherwise every overwrite of an
-        // inline version by a non-inline one leaves <object>/<rollback-dir>/
-        // behind, and DeleteBucket keeps failing with BucketNotEmpty after the
-        // object is deleted. Best-effort: residue must not fail the durable write.
-        let rollback_only_futures: Vec<_> = disks
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, disk)| {
-                let disk = disk.clone()?;
-                if errs[idx].is_some() || cleanup_data_dirs[idx].is_some() {
-                    return None;
-                }
-                let rollback_dir = data_dirs[idx]?;
-                // Anti-misdelete guard, same posture as commit_rename_data_dir:
-                // never touch the data dir the commit just published.
-                if file_infos[idx].data_dir == Some(rollback_dir) {
-                    return None;
-                }
-                let dst_bucket = dst_bucket.clone();
-                let path = format!("{dst_object}/{rollback_dir}");
-                Some(tokio::spawn(async move {
-                    disk.delete_data_dir(
-                        &dst_bucket,
-                        &path,
-                        DeleteOptions {
-                            recursive: true,
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                }))
-            })
-            .collect();
-        for result in join_all(rollback_only_futures).await {
+        // The write is authoritatively committed, so the per-disk rollback
+        // backup (`object/<rollback_dir>/xl.meta.bkp`) is dead weight now.
+        // When the rollback dir doubles as the real dereferenced data dir it
+        // is reclaimed wholesale by `commit_rename_data_dir`; a rollback dir
+        // reported separately (an overwrite of an inline version, whose dir is
+        // synthetic) is excluded from that recursive reclamation for safety
+        // (#5703) and must be reclaimed here instead — otherwise every inline
+        // overwrite strands a backup file that keeps the object dir non-empty
+        // and makes a later DeleteBucket fail with BucketNotEmpty forever.
+        // Delete exactly the backup file, never the directory tree: the
+        // synthetic UUID is a fixed, publicly-known constant for unversioned
+        // objects, so `object/<rollback_dir>` can simultaneously be a
+        // legitimate child key's directory — recursively deleting it would
+        // reopen the authorization bypass #5703 closed. The non-recursive
+        // delete removes the directory only when the backup was its sole
+        // content. Best-effort space reclamation — like
+        // `commit_rename_data_dir`, this must never negate the already-durable
+        // ACK.
+        let mut backup_reclaims = Vec::new();
+        for (idx, disk) in disks.iter().enumerate() {
+            if errs[idx].is_some() {
+                continue;
+            }
+            let Some(rollback_dir) = data_dirs[idx] else {
+                continue;
+            };
+            if cleanup_data_dirs[idx] == Some(rollback_dir) {
+                continue;
+            }
+            let Some(disk) = disk.clone() else {
+                continue;
+            };
+            let dst_bucket = dst_bucket.clone();
+            let dst_object = dst_object.clone();
+            backup_reclaims.push(tokio::spawn(async move {
+                let backup_path = format!("{dst_object}/{rollback_dir}/{STORAGE_FORMAT_FILE_BACKUP}");
+                disk.delete(&dst_bucket, &backup_path, DeleteOptions::default()).await
+            }));
+        }
+        for result in join_all(backup_reclaims).await {
             match result {
-                Ok(Ok(_)) => {}
-                Ok(Err(err)) if err == DiskError::FileNotFound || err == DiskError::VolumeNotFound => {}
+                Ok(Ok(())) => {}
+                Ok(Err(DiskError::FileNotFound | DiskError::VolumeNotFound)) => {}
                 Ok(Err(err)) => {
                     warn!(
-                        target: "rustfs_ecstore::set_disk",
                         dst_bucket = %dst_bucket,
                         dst_object = %dst_object,
                         error = %err,
-                        "failed to reclaim synthetic inline-rollback dir after commit"
+                        "rollback backup reclamation failed after committed rename"
                     );
                 }
-                Err(err) => {
+                Err(join_err) => {
                     warn!(
-                        target: "rustfs_ecstore::set_disk",
                         dst_bucket = %dst_bucket,
                         dst_object = %dst_object,
-                        error = %err,
-                        "synthetic inline-rollback reclaim task failed"
+                        error = %join_err,
+                        "rollback backup reclamation task failed after committed rename"
                     );
                 }
             }

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -6309,6 +6309,136 @@ mod tests {
         assert_eq!(read_back.size, 9, "HEAD must observe the new version, not stale metadata");
     }
 
+    // Regression for the inline-overwrite rollback backup leak: #5703 stopped
+    // reporting the synthetic rollback dir for recursive post-commit cleanup,
+    // which stranded `object/<synthetic>/xl.meta.bkp` after every inline
+    // overwrite. The object dir then never emptied, so the s3-tests teardown
+    // sequence (delete object, delete bucket) failed with BucketNotEmpty
+    // forever. After a committed overwrite the backup must be reclaimed and a
+    // subsequent delete must leave nothing behind.
+    #[tokio::test]
+    async fn inline_overwrite_reclaims_synthetic_rollback_backup() {
+        let set_disks = make_local_bucket_test_set_disks().await;
+        let bucket = "bucket-inline-rollback-leak";
+        let object = "obj";
+
+        set_disks
+            .make_bucket(bucket, &MakeBucketOptions::default())
+            .await
+            .expect("bucket should be created");
+
+        for body in [b"hello".to_vec(), b"goodbye".to_vec()] {
+            let mut reader = PutObjReader::from_vec(body);
+            set_disks
+                .put_object(
+                    bucket,
+                    object,
+                    &mut reader,
+                    &ObjectOptions {
+                        no_lock: true,
+                        ..ObjectOptions::default()
+                    },
+                )
+                .await
+                .expect("inline write should succeed");
+        }
+
+        // The committed overwrite must leave only xl.meta in the object dir on
+        // every disk; a stranded rollback dir keeps the bucket undeletable.
+        for endpoint in &set_disks.set_endpoints {
+            let object_dir = std::path::PathBuf::from(endpoint.get_file_path()).join(bucket).join(object);
+            let mut entries: Vec<String> = std::fs::read_dir(&object_dir)
+                .expect("object dir should exist")
+                .map(|entry| entry.expect("entry should read").file_name().to_string_lossy().into_owned())
+                .collect();
+            entries.sort();
+            assert_eq!(
+                entries,
+                vec![STORAGE_FORMAT_FILE.to_string()],
+                "only xl.meta may remain after an inline overwrite in {object_dir:?}"
+            );
+        }
+
+        // With only xl.meta left, the s3-tests teardown (delete object, delete
+        // bucket) empties the dir; the delete paths themselves are covered by
+        // their own tests. This harness has no bucket metadata sys, so the
+        // full delete_object flow cannot run here.
+    }
+
+    // #5703's security property must survive the backup reclamation: the
+    // synthetic rollback dir of key K maps to the directory `K/<uuid>`, which
+    // can simultaneously be a legitimate child key. Reclaiming the backup must
+    // remove exactly the backup file — never the child key's metadata.
+    #[tokio::test]
+    async fn inline_overwrite_backup_reclaim_spares_child_key_dir() {
+        let set_disks = make_local_bucket_test_set_disks().await;
+        let bucket = "bucket-inline-rollback-child";
+        let object = "obj";
+        let synthetic = crate::disk::local::inline_metadata_rollback_dir(Uuid::nil(), &FileMeta::new());
+        let child_object = format!("{object}/{synthetic}");
+
+        set_disks
+            .make_bucket(bucket, &MakeBucketOptions::default())
+            .await
+            .expect("bucket should be created");
+
+        let mut reader = PutObjReader::from_vec(b"child".to_vec());
+        set_disks
+            .put_object(
+                bucket,
+                &child_object,
+                &mut reader,
+                &ObjectOptions {
+                    no_lock: true,
+                    ..ObjectOptions::default()
+                },
+            )
+            .await
+            .expect("child write should succeed");
+
+        // Create then overwrite the parent key: the overwrite writes its
+        // rollback backup into the child's directory and must afterwards
+        // reclaim only that file.
+        for body in [b"first".to_vec(), b"second".to_vec()] {
+            let mut reader = PutObjReader::from_vec(body);
+            set_disks
+                .put_object(
+                    bucket,
+                    object,
+                    &mut reader,
+                    &ObjectOptions {
+                        no_lock: true,
+                        ..ObjectOptions::default()
+                    },
+                )
+                .await
+                .expect("parent write should succeed");
+        }
+
+        let child_info = set_disks
+            .get_object_info(bucket, &child_object, &ObjectOptions::default())
+            .await
+            .expect("child key must survive the parent's rollback backup reclamation");
+        assert_eq!(child_info.size, 5, "child key content must be untouched");
+
+        for endpoint in &set_disks.set_endpoints {
+            let child_dir = std::path::PathBuf::from(endpoint.get_file_path())
+                .join(bucket)
+                .join(object)
+                .join(synthetic.to_string());
+            let mut entries: Vec<String> = std::fs::read_dir(&child_dir)
+                .expect("child object dir should exist")
+                .map(|entry| entry.expect("entry should read").file_name().to_string_lossy().into_owned())
+                .collect();
+            entries.sort();
+            assert_eq!(
+                entries,
+                vec![STORAGE_FORMAT_FILE.to_string()],
+                "the child dir must keep its xl.meta and lose only the stray backup in {child_dir:?}"
+            );
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_acquire_dist_delete_object_locks_batch_succeeds_with_two_healthy_lockers() {


### PR DESCRIPTION
## Related Issues

Hardens #5724 (merged), which fixed the `S3 Implemented Tests` BucketNotEmpty cascade introduced by #5703.

## Summary of Changes

#5724 correctly identified that after #5703 nobody reclaimed the synthetic inline-rollback state a committed overwrite leaves behind, and added a post-quorum reclamation pass. But that pass deletes the rollback directory with `delete_data_dir(recursive: true)`, and `delete_data_dir` has no notion of object metadata — it recursively removes whatever lives at `object/<rollback-dir>`. That reopens the exact authorization bypass #5703 closed: for unversioned objects the synthetic rollback UUID is a fixed, publicly-known constant (`72757374-6673-5f69-6e6c-696e655f7262`, ASCII `rustfs_inline_rb`), so a principal with only `PutObject` permission on key `K` can overwrite `K` twice and have the server recursively delete the legitimate child object `K/72757374-6673-5f69-6e6c-696e655f7262` — data loss without `DeleteObject` authorization, the very scenario #5703's advisory described.

This PR replaces the recursive pass with a file-precise one and completes the undo path:

1. **File-precise reclamation** (`crates/ecstore/src/set_disk/core/io_primitives.rs`): after quorum commit, delete exactly `object/<rollback>/xl.meta.bkp` with a non-recursive `delete` on every disk whose reported rollback dir is not also the cleanup dir. `delete_file`'s non-recursive parent-rmdir walk then removes the directory only when the backup was its sole content; a legitimate child key occupying the same directory keeps its `xl.meta` and merely loses the stray backup file the overwrite had written into it. The leak fix is preserved: the emptied synthetic dir is removed, the object dir can empty, DeleteBucket succeeds. #5724's trigger conditions are widened slightly (any `rollback != cleanup` mismatch rather than `cleanup == None`), which also gives pre-#5703 remote peers a safe file-precise cleanup instead of none.
2. **Undo-path parity** (`crates/ecstore/src/disk/local.rs`): `restore_metadata_backup` consumes the backup by rename but left the emptied synthetic dir behind on the quorum-failure path; it now reclaims it with a non-recursive `remove_dir` (benign no-op for real data dirs still holding parts), mirroring `restore_delete_rollback`.

#5724's regression test `rename_data_reclaims_synthetic_inline_rollback_dir_after_commit` is retained unchanged and passes against the file-precise implementation — the end state for the pure-leak case is identical.

## Verification

- `cargo test -p rustfs-ecstore --lib -- inline_overwrite_reclaims_synthetic_rollback_backup inline_overwrite_backup_reclaim_spares_child_key_dir restore_metadata_backup_reclaims_empty_rollback_dir_only inline_overwrite_does_not_report_rollback_dir_for_cleanup rename_data_reclaims_synthetic_inline_rollback_dir_after_commit` — all pass (includes #5703's and #5724's original regression tests).
- Revert-sensitivity: `inline_overwrite_reclaims_synthetic_rollback_backup` fails without the reclamation pass (verified by reverting the io_primitives hunk); `inline_overwrite_backup_reclaim_spares_child_key_dir` pins the child-key survival property that fails under #5724's recursive delete.
- `cargo clippy -p rustfs-ecstore --all-targets` — clean.
- fmt + architecture guard scripts + typos — pass.

## Impact

- Security: closes the reintroduced #5703 bypass — a child key at `K/<synthetic-uuid>` now survives any overwrite of `K`, with its content intact (pinned by a dedicated test).
- The BucketNotEmpty leak fix from #5724 is fully preserved (its test still passes); `PUT k; PUT k; DELETE k; DeleteBucket` keeps succeeding.
- No wire-format change: the reclamation is a standard non-recursive `delete` RPC tolerating `FileNotFound`/`VolumeNotFound`; mixed-version sets degrade safely.
- Cost: one spawned unlink per disk, only on overwrites of inline versions; fresh PUTs and non-inline overwrites skip the pass entirely.

## Additional Notes

Adversarial validation (all seven roles, per repo policy) was run; one-line verdicts:

- Correctness: enumerated all overwrite shapes (fresh/inline→inline/inline→streaming/non-inline old/legacy peer/delete-marker rename); only synthetic-rollback cases enter the pass; #5724's end state reproduced for the pure-leak case.
- Simplicity: the backup must outlive the set-level quorum decision (it is the undo_write restore source), so local-disk-level cleanup is impossible; file-precise deletion at the same site as #5724's pass is the minimal correct shape.
- Security: recursive deletion of an attacker-predictable path replaced by file-precise deletion of a server-derived path; child-key property has a named regression test.
- Concurrency/durability: runs post-quorum under the object write lock; a crash before reclamation leaves the same residue window as any post-commit cleanup (pre-existing shape, healed by the next overwrite of the same key).
- Compatibility: no new RPC, no response-field semantics change; legacy peers gain a safe partial cleanup.
- Performance: bounded to one unlink per disk on inline overwrites.
- Test coverage: leak, child-key guard, and undo-path dir reclaim each have a named test that fails on revert.
