### PR TITLE
chore(deps): refresh mimalloc revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7946,7 +7946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -7966,7 +7966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7987,7 +7987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8000,7 +8000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -11717,7 +11717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -145,9 +145,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amq-protocol"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eab68e8836c5812a01b34c5364d28db50bf686b442e902d9d93e4472318d86e"
+checksum = "b63f30a81ad95c7a278080be6d993d5b3e971d93e1b00bd894067220fc756804"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8689f976dbd9864922f4f53e01ad2b43700ed3eb1bb5667b260522f291434dae"
+checksum = "2b1bcecdd743111f05c26294d26b887ba6b2e4789c27515aa48f0fe32066e96c"
 dependencies = [
  "amq-protocol-uri",
  "async-rs",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27894e9e57d07f701251aeee3d2ab3d7d114bc830bf722d6626027eb55f3b222"
+checksum = "8a268a50e97bd5d52292a8b96636f6436215def6f3d128fb8218318f5feb4c33"
 dependencies = [
  "cookie-factory",
  "nom 8.0.0",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "10.6.2"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fd5ca63f1b8cba2309aaec8595483c36f3a671225d5ab9fe8265adb9213514"
+checksum = "8a34581b010818ef3da6b5a853e94f6438b3903914baba77a15f7fb2c7ad8958"
 dependencies = [
  "amq-protocol-types",
  "percent-encoding",
@@ -1490,9 +1490,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64-simd"
@@ -2677,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "datafusion"
@@ -3744,7 +3744,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sts",
  "aws-smithy-http-client",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "clap",
@@ -5915,7 +5915,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
-source = "git+https://github.com/xonatius/mimalloc_rust.git?rev=1cdadea43e9c5a0f054b65be21200ce580e4eb13#1cdadea43e9c5a0f054b65be21200ce580e4eb13"
+source = "git+https://github.com/xonatius/mimalloc_rust.git?rev=ce6338661179c8be22e516b00af7483f151485a7#ce6338661179c8be22e516b00af7483f151485a7"
 dependencies = [
  "cc",
  "cty",
@@ -6029,9 +6029,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -6324,7 +6324,7 @@ dependencies = [
 [[package]]
 name = "mimalloc"
 version = "0.1.52"
-source = "git+https://github.com/xonatius/mimalloc_rust.git?rev=1cdadea43e9c5a0f054b65be21200ce580e4eb13#1cdadea43e9c5a0f054b65be21200ce580e4eb13"
+source = "git+https://github.com/xonatius/mimalloc_rust.git?rev=ce6338661179c8be22e516b00af7483f151485a7#ce6338661179c8be22e516b00af7483f151485a7"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -6480,7 +6480,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru 0.18.1",
+ "lru 0.18.2",
  "mysql_common",
  "percent-encoding",
  "rand 0.10.2",
@@ -7946,7 +7946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -7966,7 +7966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7987,7 +7987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8000,7 +8000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8573,9 +8573,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8906,9 +8906,9 @@ dependencies = [
 
 [[package]]
 name = "russh-sftp"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed8949eca4163c18a8f59ff96d32cf61e9c13b9735e21ef32b3907f4aafa1a9"
+checksum = "9de67aace74530a29086db0671fa200c470a58eb380081f28ad512ffb0c5356b"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
@@ -9008,7 +9008,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "base64-simd",
  "bytes",
  "chacha20poly1305",
@@ -9270,7 +9270,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "base64 0.23.0",
+ "base64 0.23.1",
  "base64-simd",
  "byteorder",
  "bytes",
@@ -9435,7 +9435,7 @@ name = "rustfs-heal"
 version = "1.0.0-beta.12"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "futures",
  "hotpath",
  "http 1.5.0",
@@ -9619,7 +9619,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chacha20poly1305",
  "hex",
  "hotpath",
@@ -9898,7 +9898,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "dav-server",
  "futures",
@@ -10002,7 +10002,7 @@ dependencies = [
  "aes-gcm",
  "arc-swap",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "crc-fast",
  "faster-hex",
@@ -10458,9 +10458,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-connector"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7664e32b0ffbec386bdf1d7cbca51a89551a90d3278f135186cd6cb3cfa889c"
+checksum = "09a5abe04eec18f8b9fbe87885bcaee6426de80bbc579958c0bc064b728ee617"
 dependencies = [
  "futures-io",
  "futures-rustls",
@@ -11717,7 +11717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -13316,9 +13316,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ aws-sdk-sts = { default-features = false, version = "1.110.0" }
 aws-smithy-http-client = { default-features = false, version = "1.2.0" }
 aws-smithy-runtime-api = { version = "1.14.0" }
 aws-smithy-types = { version = "1.6.1" }
-base64 = "0.23.0"
+base64 = "0.23.1"
 base64-simd = "0.8.0"
 brotli = "8.0.4"
 clap = { version = "4.6.5" }
@@ -341,14 +341,14 @@ unftp-core = "0.1.0"
 suppaftp = { version = "10.0.1" }
 rcgen = { version = "0.14.8", default-features = false, features = ["aws_lc_rs", "crypto", "pem"] }
 russh = { version = "0.62.5" }
-russh-sftp = "2.3.0"
+russh-sftp = "2.4.0"
 
 # WebDAV
 dav-server = "0.11.0"
 
 # Performance Analysis and Memory Profiling
-mimalloc = { version = "0.1.52", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "1cdadea43e9c5a0f054b65be21200ce580e4eb13" }
-libmimalloc-sys = { version = "0.1.49", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "1cdadea43e9c5a0f054b65be21200ce580e4eb13", features = ["extended"] }
+mimalloc = { version = "0.1.52", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "ce6338661179c8be22e516b00af7483f151485a7" }
+libmimalloc-sys = { version = "0.1.49", git = "https://github.com/xonatius/mimalloc_rust.git", rev = "ce6338661179c8be22e516b00af7483f151485a7", features = ["extended"] }
 hotpath = { version = "0.23.0", default-features = false }
 # Snapshot testing for output format regression detection
 insta = { version = "1.48" }

--- a/crates/iam/tests/iam_bootstrap_no_lock_test.rs
+++ b/crates/iam/tests/iam_bootstrap_no_lock_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Regression test for rustfs#4304: IAM bootstrap must not depend on the
 //! distributed namespace-lock quorum.
 //!

--- a/rustfs/tests/embedded_deferred_iam_test.rs
+++ b/rustfs/tests/embedded_deferred_iam_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::{Client, Config};
 use reqwest::StatusCode;

--- a/rustfs/tests/embedded_multi_instance_test.rs
+++ b/rustfs/tests/embedded_multi_instance_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! End-to-end acceptance for backlog#1052: two embedded RustFS servers coexist
 //! in one process, on different ports and volumes, and their S3 data planes
 //! stay isolated.
@@ -455,17 +457,30 @@ async fn second_embedded_server_fails_closed_until_its_context_slot_is_installed
     let b_access_key = "startup-window-access-b";
     let b_secret_key = "startup-window-secret-b";
     let mut barrier = pause_embedded_startup_after_http_bind(port_b);
-    let startup_b = tokio::spawn(async move {
-        RustFSServerBuilder::new()
-            .address(format!("127.0.0.1:{port_b}"))
-            .access_key(b_access_key)
-            .secret_key(b_secret_key)
-            .build()
-            .await
-    });
-    tokio::time::timeout(Duration::from_secs(10), barrier.wait_until_http_bound())
-        .await
-        .expect("server B must bind HTTP before installing its context slot");
+    let startup_b = RustFSServerBuilder::new()
+        .address(format!("127.0.0.1:{port_b}"))
+        .access_key(b_access_key)
+        .secret_key(b_secret_key)
+        .build();
+    tokio::pin!(startup_b);
+    {
+        let bound = tokio::time::timeout(Duration::from_secs(10), barrier.wait_until_http_bound());
+        tokio::pin!(bound);
+        tokio::select! {
+            bound = &mut bound => {
+                bound.expect("server B must bind HTTP before installing its context slot");
+            }
+            startup = startup_b.as_mut() => {
+                match startup {
+                    Ok(server) => {
+                        server.shutdown().await;
+                        panic!("server B startup completed before the HTTP-bind barrier fired");
+                    }
+                    Err(err) => panic!("server B startup failed before the HTTP-bind barrier fired: {err}"),
+                }
+            }
+        }
+    }
 
     let http = reqwest::Client::builder()
         .no_proxy()
@@ -487,10 +502,9 @@ async fn second_embedded_server_fails_closed_until_its_context_slot_is_installed
     );
 
     barrier.release();
-    let server_b = tokio::time::timeout(Duration::from_secs(20), startup_b)
+    let server_b = tokio::time::timeout(Duration::from_secs(20), startup_b.as_mut())
         .await
         .expect("server B startup must complete after releasing the barrier")
-        .expect("server B startup task must not panic")
         .expect("start embedded server B");
     let client_b = s3_client(&server_b.endpoint(), server_b.access_key(), server_b.secret_key());
     client_b

--- a/rustfs/tests/embedded_notification_lifecycle_test.rs
+++ b/rustfs/tests/embedded_notification_lifecycle_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Refreshed dependencies with `cargo update --verbose` and `cargo upgrade --exclude ratelimit --verbose`, keeping `ratelimit` on `0.10.1`.
- Updated `mimalloc` and `libmimalloc-sys` to git revision `ce6338661179c8be22e516b00af7483f151485a7` while preserving the `extended` feature on `libmimalloc-sys`.
- Added crate-level recursion limits for all-feature integration test crates that overflowed rustc query depth.
- Kept the embedded startup barrier test on the current task by pinning the startup future instead of spawning it across threads, avoiding the all-feature `Send` lifetime error while preserving the fail-closed assertion.

## Verification
- `cargo update --verbose && cargo upgrade --exclude ratelimit --verbose` - passed
- `cargo update -p mimalloc -p libmimalloc-sys --verbose` - passed
- `cargo metadata --locked --no-deps --format-version 1` - passed
- `cargo fmt --all --check` - passed
- `git diff --check` - passed
- `cargo check -p rustfs --locked` - passed
- `cargo check --workspace --all-targets --locked` - passed
- `cargo test -p rustfs --bin rustfs --locked --features hotpath-alloc mimalloc` - passed
- `RUSTFLAGS="--cfg tokio_unstable" cargo check --workspace --all-targets --all-features --locked` - passed
- `RUSTFLAGS="--cfg tokio_unstable" cargo clippy --fix --all-targets --all-features --allow-dirty -- -D warnings` - passed
- `make pre-commit` - not run; waiting for CI per maintainer request.

## Impact
- Updates compatible dependency versions and the pinned mimalloc git revision.
- No runtime configuration, API, storage format, or migration changes are expected.
- All-feature test compilation is hardened for heavier dependency graphs.

## Additional Notes
Local verification was not rerun after the final commit at maintainer request; CI is expected to provide the final validation signal.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
