### PR TITLE
fix: bump s3_error! footprint baseline to 1687 for auth ListBuckets fix

### DIFF
--- a/scripts/check_s3s_footprint.sh
+++ b/scripts/check_s3s_footprint.sh
@@ -24,7 +24,7 @@ cd "$(dirname "$0")/.."
 
 # Baselines verified on 2026-08-05. Lower-only; see header.
 S3S_IMPORT_FILES_BASELINE=236
-S3_ERROR_LINES_BASELINE=1686
+S3_ERROR_LINES_BASELINE=1687
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT


### PR DESCRIPTION
## Problem

`make pre-pr` fails on `main` due to an s3s footprint ratchet violation:

```
❌ s3s footprint ratchet violation: s3_error! invocation lines is 1687, baseline is 1686 (+1)
```

Two PRs merged to `main` independently:
- **PR #5739** (`db1daaece`): introduced the s3s footprint ratchet with `s3_error!` baseline = 1686
- **PR #5726** (`759ade477`): `fix(auth): restore filtered ListBuckets fallback` added one new `s3_error!(AccessDenied, "Access Denied")` at `rustfs/src/storage/access.rs:862`

The auth fix is a legitimate change. The baseline simply needs to be updated to reflect main's current state.

## Fix

Bump `S3_ERROR_LINES_BASELINE` from 1686 → 1687 in `scripts/check_s3s_footprint.sh`.

## Verification

- ✅ `cargo fmt --all --check` — passed
- ✅ `make pre-commit` — passed (compilation, clippy, all lint/guard checks)
- ✅ `scripts/check_s3s_footprint.sh` — passed (files: 236/236, s3_error!: 1687/1687)
