### PR TITLE
fix(auth): route ListBuckets denial through ApiError to hold s3s ratchet

### DIFF
--- a/rustfs/src/error.rs
+++ b/rustfs/src/error.rs
@@ -33,6 +33,16 @@ impl std::fmt::Display for ApiError {
 impl std::error::Error for ApiError {}
 
 impl ApiError {
+    /// Access-denied error with the exact message emitted by the authorization
+    /// paths in `storage::access`; callers there match on the code only.
+    pub fn access_denied() -> Self {
+        ApiError {
+            code: S3ErrorCode::AccessDenied,
+            message: "Access Denied".to_string(),
+            source: None,
+        }
+    }
+
     pub fn other<E>(error: E) -> Self
     where
         E: std::fmt::Display + Into<Box<dyn std::error::Error + Send + Sync>>,

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -859,7 +859,7 @@ pub async fn authorize_request<T>(req: &mut S3Request<T>, action: Action) -> S3R
         }
 
         if action == Action::S3Action(S3Action::ListAllMyBucketsAction) {
-            return Err(s3_error!(AccessDenied, "Access Denied"));
+            return Err(ApiError::access_denied().into());
         }
 
         let policy_allowed_fallback = PolicySys::try_is_allowed(&BucketPolicyArgs {


### PR DESCRIPTION
## Related Issues

Ratchet race between #5726 and #5739. Migration direction: rustfs/backlog#1677 (review finding F1), acceptance criteria in rustfs/backlog#1733.

## Summary of Changes

`scripts/check_s3s_footprint.sh` (added by #5739) froze `S3_ERROR_LINES_BASELINE=1686`, but the baseline was counted before #5726 merged. #5726 added one new `s3_error!(AccessDenied, ...)` call in `authorize_request` (`rustfs/src/storage/access.rs`, the early-return for `ListAllMyBucketsAction` feeding the filtered ListBuckets fallback), so `make pre-commit` fails with `+1` on any clean main-derived branch.

Per the ratchet's own guidance, this PR routes the offending call through the gateway-side error abstraction instead of raising the baseline:

- `rustfs/src/error.rs`: add an `ApiError::access_denied()` constructor.
- `rustfs/src/storage/access.rs`: replace the new `s3_error!` invocation with `ApiError::access_denied().into()`.

Behavior is unchanged: the converted `S3Error` carries the identical `AccessDenied` code and `"Access Denied"` message (byte-for-byte the same as the sibling branches in `authorize_request`), and the filtered ListBuckets fallback in `bucket_usecase.rs` matches on the error code only, so the #5726 e2e regression test (`list_buckets_auth_test.rs`) is unaffected.

The constructor also gives future migrations of the remaining identical `AccessDenied` call sites in `access.rs` an obvious reuse point (lower the baseline in the same PR when doing so).

## Verification

- `make pre-commit` — passed; s3s footprint ratchet back at baseline (files importing s3s 236/236, `s3_error!` lines 1686/1686)
- `cargo check -p rustfs` — passed
- `cargo fmt --all` — clean

## Impact

N/A — no user-facing, API, or wire-format change; the emitted S3 error code and message are identical.

## Additional Notes

The `"Access Denied"` message (no trailing period) is intentionally kept consistent with the other `authorize_request` branches rather than `ApiError::error_code_to_message` (`"Access Denied."`). A stray branch commit (6e089c42f) fixed the same failure by bumping the baseline to 1687; that approach violates the ratchet's lower-only rule and was not used.
