### PR TITLE
fix(ecstore): preserve checksums through write transforms

### DIFF
--- a/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
+++ b/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
@@ -21,9 +21,12 @@
 
 use super::common::LocalKMSTestEnvironment;
 use crate::common::{TEST_BUCKET, init_logging};
+use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{
-    ServerSideEncryption, ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration, ServerSideEncryptionRule,
+    ChecksumAlgorithm, ChecksumMode, CompletedMultipartUpload, CompletedPart, ServerSideEncryption,
+    ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration, ServerSideEncryptionRule,
 };
+use rustfs_rio::{Checksum, ChecksumType};
 use serial_test::serial;
 use tracing::{debug, info, warn};
 
@@ -273,7 +276,7 @@ async fn test_bucket_default_sse_kms_put_object() -> Result<(), Box<dyn std::err
 /// Test 3: When bucket is configured with default encryption, create_multipart_upload should inherit the configuration
 #[tokio::test]
 #[serial]
-async fn test_bucket_default_encryption_multipart_upload() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn test_bucket_default_sse_kms_multipart_crc32() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Testing bucket default encryption impact on create_multipart_upload");
 
@@ -309,15 +312,16 @@ async fn test_bucket_default_encryption_multipart_upload() -> Result<(), Box<dyn
         .await
         .expect("Failed to set bucket encryption");
 
-    // Step 2: Create multipart upload (without specifying encryption parameters)
-    info!("Creating multipart upload (without specifying encryption parameters, should use bucket default configuration)");
-    let test_key = "test-multipart-bucket-default.txt";
+    // Step 2: Declare CRC32 without specifying encryption parameters. The AWS SDK
+    // calculates each UploadPart checksum and sends it as a flexible checksum.
+    info!("Creating CRC32 multipart upload that should use bucket default encryption");
+    let test_key = "test-multipart-bucket-default-crc32.bin";
 
     let create_multipart_response = s3_client
         .create_multipart_upload()
         .bucket(TEST_BUCKET)
         .key(test_key)
-        // Note: No encryption parameters specified here, should use bucket default configuration
+        .checksum_algorithm(ChecksumAlgorithm::Crc32)
         .send()
         .await
         .expect("Failed to create multipart upload");
@@ -343,28 +347,61 @@ async fn test_bucket_default_encryption_multipart_upload() -> Result<(), Box<dyn
         "create_multipart_upload response should contain correct KMS key ID"
     );
 
-    // Step 3: Upload a part and complete multipart upload
-    info!("Uploading part and completing multipart upload");
-    let test_data = b"test-multipart-bucket-default-encryption-data";
+    // Step 3: Upload two parts. The first is exactly the S3 minimum size so this
+    // follows the same managed SSE-KMS multipart path as issue #5756.
+    const PART_SIZE: usize = 5 * 1024 * 1024;
+    let part1: Vec<u8> = (0..PART_SIZE).map(|i| (i % 251) as u8).collect();
+    let part2: Vec<u8> = (0..1024 * 1024).map(|i| ((i + 17) % 251) as u8).collect();
+    let expected_body: Vec<u8> = part1.iter().chain(&part2).copied().collect();
 
-    // Upload part 1
-    let upload_part_response = s3_client
-        .upload_part()
-        .bucket(TEST_BUCKET)
-        .key(test_key)
-        .upload_id(upload_id)
-        .part_number(1)
-        .body(test_data.to_vec().into())
-        .send()
-        .await
-        .expect("Failed to upload part");
+    let upload_part = |part_number: i32, body: Vec<u8>| {
+        s3_client
+            .upload_part()
+            .bucket(TEST_BUCKET)
+            .key(test_key)
+            .upload_id(upload_id)
+            .part_number(part_number)
+            .checksum_algorithm(ChecksumAlgorithm::Crc32)
+            .body(ByteStream::from(body))
+            .send()
+    };
 
-    let etag = upload_part_response.e_tag().unwrap().to_string();
+    let expected_part1_crc32 = Checksum::new_from_data(ChecksumType::CRC32, &part1)
+        .expect("calculate part 1 CRC32")
+        .encoded;
+    let upload1 = upload_part(1, part1).await.expect("Failed to upload part 1 with CRC32");
+    assert_eq!(
+        upload1.checksum_crc32(),
+        Some(expected_part1_crc32.as_str()),
+        "UploadPart must return the CRC32 calculated over plaintext"
+    );
+
+    let expected_part2_crc32 = Checksum::new_from_data(ChecksumType::CRC32, &part2)
+        .expect("calculate part 2 CRC32")
+        .encoded;
+    let upload2 = upload_part(2, part2).await.expect("Failed to upload part 2 with CRC32");
+    assert_eq!(
+        upload2.checksum_crc32(),
+        Some(expected_part2_crc32.as_str()),
+        "UploadPart must return the CRC32 calculated over plaintext"
+    );
 
     // Complete multipart upload
-    let completed_part = aws_sdk_s3::types::CompletedPart::builder()
-        .part_number(1)
-        .e_tag(&etag)
+    let completed_upload = CompletedMultipartUpload::builder()
+        .parts(
+            CompletedPart::builder()
+                .part_number(1)
+                .e_tag(upload1.e_tag().expect("No ETag for part 1"))
+                .checksum_crc32(upload1.checksum_crc32().expect("No CRC32 for part 1"))
+                .build(),
+        )
+        .parts(
+            CompletedPart::builder()
+                .part_number(2)
+                .e_tag(upload2.e_tag().expect("No ETag for part 2"))
+                .checksum_crc32(upload2.checksum_crc32().expect("No CRC32 for part 2"))
+                .build(),
+        )
         .build();
 
     let complete_multipart_response = s3_client
@@ -372,11 +409,7 @@ async fn test_bucket_default_encryption_multipart_upload() -> Result<(), Box<dyn
         .bucket(TEST_BUCKET)
         .key(test_key)
         .upload_id(upload_id)
-        .multipart_upload(
-            aws_sdk_s3::types::CompletedMultipartUpload::builder()
-                .parts(completed_part)
-                .build(),
-        )
+        .multipart_upload(completed_upload)
         .send()
         .await
         .expect("Failed to complete multipart upload");
@@ -400,6 +433,7 @@ async fn test_bucket_default_encryption_multipart_upload() -> Result<(), Box<dyn
         .get_object()
         .bucket(TEST_BUCKET)
         .key(test_key)
+        .checksum_mode(ChecksumMode::Enabled)
         .send()
         .await
         .expect("Failed to get object");
@@ -410,6 +444,13 @@ async fn test_bucket_default_encryption_multipart_upload() -> Result<(), Box<dyn
         Some(&ServerSideEncryption::AwsKms),
         "Final object should contain SSE-KMS encryption information"
     );
+    if let Some(completed_crc32) = complete_multipart_response.checksum_crc32() {
+        assert_eq!(
+            get_response.checksum_crc32(),
+            Some(completed_crc32),
+            "GetObject should return the persisted composite CRC32 when completion reports it"
+        );
+    }
 
     // Verify data integrity
     let downloaded_data = get_response
@@ -418,7 +459,11 @@ async fn test_bucket_default_encryption_multipart_upload() -> Result<(), Box<dyn
         .await
         .expect("Failed to collect body")
         .into_bytes();
-    assert_eq!(&downloaded_data[..], test_data, "Downloaded data should match original data");
+    assert_eq!(
+        downloaded_data.as_ref(),
+        expected_body.as_slice(),
+        "Downloaded data should match the uploaded multipart body"
+    );
 
     // Cleanup is handled automatically when the test environment is dropped
     info!("Test passed: bucket default encryption correctly applied to multipart upload");

--- a/crates/ecstore/src/io_support/rio.rs
+++ b/crates/ecstore/src/io_support/rio.rs
@@ -380,6 +380,12 @@ impl WritePlan {
     }
 
     pub fn apply(self, mut reader: HashReader, actual_size: i64) -> std::io::Result<HashReader> {
+        // Transformations create new HashReaders around the plaintext reader. Keep
+        // the request checksum metadata on the final reader for multipart/single
+        // PUT persistence, but leave verification to the plaintext reader.
+        let checksum = reader.content_hash().clone();
+        let trailer = reader.get_trailer().cloned();
+
         let encrypted = self.encryption.is_some();
         if let Some(algorithm) = self.compression {
             reader = HashReader::from_reader(
@@ -438,6 +444,12 @@ impl WritePlan {
             };
         }
 
+        // `ignore_value` deliberately avoids a second hasher over compressed or
+        // encrypted bytes. The inner reader still validates the plaintext request
+        // checksum while this outer reader exposes the request checksum context.
+        reader.add_non_trailing_checksum(checksum, true)?;
+        reader.set_trailer(trailer);
+
         Ok(reader)
     }
 }
@@ -445,9 +457,72 @@ impl WritePlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http::{HeaderMap, HeaderValue};
+    use rustfs_rio::{Checksum, ChecksumType};
     use rustfs_utils::CompressionAlgorithm;
     use std::io::Cursor;
     use tokio::io::AsyncReadExt;
+
+    async fn assert_non_trailing_checksum_survives(plan: WritePlan) {
+        let plaintext = b"checksum-context-through-write-plan".repeat(256);
+        let actual_size = plaintext.len() as i64;
+        let checksum = Checksum::new_from_data(ChecksumType::CRC32, &plaintext).expect("create CRC32 checksum");
+        let mut reader = HashReader::from_stream(Cursor::new(plaintext), actual_size, actual_size, None, None, false)
+            .expect("create hash reader");
+        reader
+            .add_non_trailing_checksum(Some(checksum.clone()), false)
+            .expect("attach plaintext checksum");
+
+        let mut transformed = plan.apply(reader, actual_size).expect("apply write plan");
+        assert_eq!(transformed.content_crc_type(), Some(ChecksumType::CRC32));
+
+        let mut transformed_bytes = Vec::new();
+        transformed
+            .read_to_end(&mut transformed_bytes)
+            .await
+            .expect("stream transformed data without rehashing ciphertext");
+
+        assert!(!transformed_bytes.is_empty());
+        assert_eq!(transformed.content_crc().get("CRC32"), Some(&checksum.encoded));
+    }
+
+    #[tokio::test]
+    async fn write_plan_preserves_non_trailing_checksum_context_across_transforms() {
+        assert_non_trailing_checksum_survives(WritePlan::new().with_compression(CompressionAlgorithm::default())).await;
+        assert_non_trailing_checksum_survives(
+            WritePlan::new().with_encryption(WriteEncryption::singlepart([0x5Au8; 32], [0xA5u8; 12])),
+        )
+        .await;
+        assert_non_trailing_checksum_survives(
+            WritePlan::new()
+                .with_compression(CompressionAlgorithm::default())
+                .with_encryption(WriteEncryption::singlepart([0x5Au8; 32], [0xA5u8; 12])),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn write_plan_preserves_trailing_checksum_type_across_transforms() {
+        let plaintext = b"trailing-checksum-context".to_vec();
+        let actual_size = plaintext.len() as i64;
+        let mut reader = HashReader::from_stream(Cursor::new(plaintext), actual_size, actual_size, None, None, false)
+            .expect("create hash reader");
+        let mut headers = HeaderMap::new();
+        headers.insert("x-amz-trailer", HeaderValue::from_static("x-amz-checksum-crc32"));
+        reader
+            .add_checksum_from_s3s(&headers, None, false)
+            .expect("attach trailing checksum metadata");
+
+        let transformed = WritePlan::new()
+            .with_encryption(WriteEncryption::singlepart([0x5Au8; 32], [0xA5u8; 12]))
+            .apply(reader, actual_size)
+            .expect("apply encryption plan");
+
+        assert_eq!(
+            transformed.content_crc_type(),
+            Some(ChecksumType(ChecksumType::CRC32.0 | ChecksumType::TRAILING.0))
+        );
+    }
 
     #[cfg(feature = "rio-v2")]
     fn s2_chunk_types(stream: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
## Related Issues

Fixes #5756.

## Summary of Changes

Follow-up tracing localized the reported error to the `UploadPart` validation guard, rather than the later managed read/decrypt path. An incoming `HashReader` carries the request CRC32 and trailer state, but compression/SSE wrapping rebuilt the outer reader without that context. Multipart validation then compared the upload's CRC32 type with `None` and returned `checksum mismatch: CRC32`.

This preserves the request checksum context across write transforms. The inner plaintext reader remains the sole checksum verifier; the outer reader only publishes the already-validated checksum metadata for multipart validation and persistence. The durable invariant is: write transforms may change stored bytes, but they must not erase the checksum identity of the original request body.

The existing bucket-default KMS multipart scenario now covers a two-part CRC32 upload, validates each part checksum, completes the upload, requests checksum metadata on GET, and checks the complete plaintext body.

## Verification

- `cargo test -p rustfs-ecstore write_plan_preserves -- --nocapture` — 2 passed.
- `cargo test -p rustfs-ecstore --features rio-v2 write_plan_preserves -- --nocapture` — 2 passed.
- Exact bucket-default SSE-KMS multipart CRC32 E2E — 1 passed against the patched binary.
- Revert control against `efd5481b35d656587d3943cf8acfb70bd6eaf018` — failed on part 1 with the reported `checksum mismatch: CRC32`, proving the E2E detects the regression.
- `cargo fmt --all --check` and `git diff --check` — passed.
- `make pre-commit` — passed with a temporary local `protoc` 35.1 installation because the validation host has no system `protoc`.

## Impact

Multipart uploads with flexible checksums continue to work when bucket-default SSE-KMS or compression wraps the write stream. There is no public API, configuration, wire-format, or persisted-schema change, and no extra payload hashing.

## Additional Notes

- Correctness: PASS — checksum context survives all write-plan branches while the plaintext reader verifies exactly once.
- Simplicity: PASS — the change is localized to write-plan wrapping and extends one existing E2E scenario.
- Test coverage: PASS — patched success plus an exact unfixed-base failure provides revert-detecting evidence.
- Security: PASS — the real E2E exercises bucket-default SSE-KMS and verifies exact plaintext recovery; encryption wrapper ordering is unchanged.
- Concurrency/durability: PASS — no synchronization, commit ordering, or persistence semantics changed.
- Compatibility: PASS — standard S3 multipart CRC32 fields only; no API or stored-format change.
- Performance: PASS — no additional hashing; two small `Checksum` metadata clones are low-cost and non-blocking.

`CompleteMultipartUpload` does not currently return a composite CRC32 on this path, so the E2E always validates per-part checksum metadata and the complete body, and compares the final checksum when the server supplies it. The KMS E2E suite is not currently wired into PR CI, so this exact scenario was also run manually on Enchufe.
