### PR TITLE
fix(replication): report remote target latency as Go duration nanoseconds

### DIFF
--- a/rustfs/src/admin/handlers/replication.rs
+++ b/rustfs/src/admin/handlers/replication.rs
@@ -348,9 +348,10 @@ impl RemoteTargetRequest {
 }
 
 /// Admin-response encoding of a remote target: the persisted bucket-targets
-/// format keeps `healthCheckDuration`/`totalDowntime` in seconds, but madmin
-/// decodes them as Go `time.Duration` (nanoseconds) — re-encode just those
-/// fields without touching the persistence wire format.
+/// format keeps `healthCheckDuration`/`totalDowntime` in seconds and the
+/// `latency` stats in milliseconds, but madmin decodes all of them as Go
+/// `time.Duration` (nanoseconds) — re-encode just those fields without
+/// touching the persistence wire format.
 fn remote_target_admin_json(target: &BucketTarget) -> Result<serde_json::Value, serde_json::Error> {
     fn go_duration_nanos(duration: Duration) -> serde_json::Value {
         // Saturate instead of truncating: >u64::MAX nanoseconds (~584 years)
@@ -361,6 +362,11 @@ fn remote_target_admin_json(target: &BucketTarget) -> Result<serde_json::Value, 
     let mut value = serde_json::to_value(target)?;
     value["healthCheckDuration"] = go_duration_nanos(target.health_check_duration);
     value["totalDowntime"] = go_duration_nanos(target.total_downtime);
+    value["latency"] = serde_json::json!({
+        "curr": go_duration_nanos(target.latency.curr),
+        "avg": go_duration_nanos(target.latency.avg),
+        "max": go_duration_nanos(target.latency.max),
+    });
     Ok(value)
 }
 
@@ -1219,7 +1225,7 @@ mod tests {
         SUPPORTED_REMOTE_TARGET_API, TargetUpdateOp, build_mrf_response, extract_query_params, parse_remote_target_update_ops,
         unique_replication_peers, validate_remote_target_tls_settings,
     };
-    use crate::admin::storage_api::bucket::target::BucketTarget;
+    use crate::admin::storage_api::bucket::target::{BucketTarget, LatencyStat};
     use crate::admin::storage_api::replication::{BucketStats, DurableMrfBacklog, MrfOpKind, MrfReplicateEntry};
     use http::Uri;
 
@@ -1748,6 +1754,11 @@ mod tests {
             target_bucket: "target".to_string(),
             health_check_duration: std::time::Duration::from_secs(60),
             total_downtime: std::time::Duration::from_secs(90),
+            latency: LatencyStat {
+                curr: std::time::Duration::from_millis(12),
+                avg: std::time::Duration::from_millis(34),
+                max: std::time::Duration::from_millis(250),
+            },
             ..Default::default()
         };
 
@@ -1755,10 +1766,43 @@ mod tests {
 
         assert_eq!(value["healthCheckDuration"], 60_000_000_000u64);
         assert_eq!(value["totalDowntime"], 90_000_000_000u64);
-        // Persistence keeps seconds: the response path must not leak into it.
+        assert_eq!(value["latency"]["curr"], 12_000_000u64);
+        assert_eq!(value["latency"]["avg"], 34_000_000u64);
+        assert_eq!(value["latency"]["max"], 250_000_000u64);
+        // Persistence keeps seconds/milliseconds: the response path must not
+        // leak into it.
         let persisted = serde_json::to_value(&target).expect("persisted form should serialize");
         assert_eq!(persisted["healthCheckDuration"], 60);
         assert_eq!(persisted["totalDowntime"], 90);
+        assert_eq!(persisted["latency"]["curr"], 12);
+        assert_eq!(persisted["latency"]["avg"], 34);
+        assert_eq!(persisted["latency"]["max"], 250);
+    }
+
+    #[test]
+    fn remote_target_admin_json_latency_round_trips_through_go_duration() {
+        // Round trip: a madmin reader decodes the latency values as Go
+        // time.Duration nanoseconds — decoding must recover the exact
+        // durations the server reported.
+        let target = BucketTarget {
+            latency: LatencyStat {
+                curr: std::time::Duration::from_micros(1_500),
+                avg: std::time::Duration::from_millis(87),
+                max: std::time::Duration::from_secs(2),
+            },
+            ..Default::default()
+        };
+
+        let value = super::remote_target_admin_json(&target).expect("admin response should serialize");
+
+        for (field, expected) in [
+            ("curr", target.latency.curr),
+            ("avg", target.latency.avg),
+            ("max", target.latency.max),
+        ] {
+            let nanos = value["latency"][field].as_u64().expect("latency field must be a u64");
+            assert_eq!(std::time::Duration::from_nanos(nanos), expected, "latency.{field} must round-trip");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

N/A (found by the MinIO compatibility review, P2; follow-up to #5754)

## Summary of Changes

madmin-go decodes `LatencyStat.curr/avg/max` in the list-remote-targets admin
response as Go `time.Duration` (nanosecond integers), but RustFS serialized
them via the persisted milliseconds encoding. mc therefore showed remote
target latency shrunk by 10^6 (e.g. 50ms rendered as 50ns).

- Extend `remote_target_admin_json` — the response-only re-encode path that
  #5754 introduced for `healthCheckDuration`/`totalDowntime` — to also emit
  the latency stats as nanoseconds.
- The persisted bucket-targets wire format (milliseconds) is untouched:
  `BucketTargetSys::list_targets` overwrites latency from live health stats
  before serialization, so the admin response is the single conversion point.
- Tests: extend the existing response-encoding test to cover latency (nanos
  in the admin response, milliseconds in the persisted form), and add a
  round-trip test decoding the emitted values the way a Go
  `time.Duration` reader would, including a sub-millisecond sample.

## Verification

- `make pre-commit` — passed
- `cargo test -p rustfs --lib admin::handlers::replication` — 27 passed
- `cargo test -p rustfs-ecstore --lib bucket_target` — 60 passed
- `cargo clippy -p rustfs --lib --tests` — no warnings

## Impact

- mc / madmin clients now see correct remote target latency values from
  `GET /minio/admin/v3/list-remote-targets`.
- No persistence format change; no API shape change (same JSON fields, the
  numbers switch from milliseconds to nanoseconds, matching what madmin-go
  has always assumed).
- Legacy RustFS clients that decoded the admin response as milliseconds
  would now over-read latency; the repository's own madmin mirror
  (`crates/madmin`) already models these fields as nanoseconds, so no known
  consumer relies on the old encoding.

## Additional Notes

The milliseconds codec dates back to the #590 replication rewrite and was
never a deliberate wire convention — RustFS's own madmin mirror defines the
same fields as `curr_ns`/`average_ns`/`max_ns`. This aligns the last
duration field on this response with the madmin-go contract, completing the
unit fixes started in #5754.
