### PR TITLE
test(heal): cover partial rename retry admission

### DIFF
--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -72,7 +72,9 @@ fn should_fail_heal_rename(bucket: &str, object: &str, disk_index: usize) -> boo
         .expect("heal rename failure registry should not poison");
     if let Some(position) = failures
         .iter()
-        .position(|entry| entry == &(bucket.to_string(), object.to_string(), disk_index))
+        .position(|(registered_bucket, registered_object, registered_index)| {
+            registered_bucket == bucket && registered_object == object && *registered_index == disk_index
+        })
     {
         failures.swap_remove(position);
         true

--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -3768,6 +3768,23 @@ mod tests {
     }
 
     #[test]
+    fn test_retry_request_for_incomplete_heal_rename() {
+        let storage: Arc<dyn HealStorageAPI> = Arc::new(MockStorage);
+        let task = HealTask::from_request(HealRequest::object("bucket".to_string(), "object".to_string(), None), storage);
+        let result = Err(Error::TaskExecutionFailed {
+            message: "Failed to heal object bucket/object: heal rename incomplete: 1 of 2 targets committed".to_string(),
+        });
+
+        let (retry_request, retry_delay, retry_error) =
+            retry_request_for_result(&task, &result).expect("incomplete target rename should be retryable");
+
+        assert_eq!(retry_request.id, task.id);
+        assert_eq!(retry_request.retry_attempts, 1);
+        assert!(retry_delay > Duration::ZERO);
+        assert!(retry_error.contains("heal rename incomplete"));
+    }
+
+    #[test]
     fn test_retry_request_for_typed_read_quorum_error() {
         let storage: Arc<dyn HealStorageAPI> = Arc::new(MockStorage);
         let task = HealTask::from_request(HealRequest::object("bucket".to_string(), "object".to_string(), None), storage);


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Add a regression test proving that a partial heal rename is admitted to the bounded retry path.
- Avoid temporary `String` allocations in the test-only rename fault lookup.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rustfs-heal test_retry_request_for_incomplete_heal_rename`
- `cargo test -p rustfs-ecstore heal_rename_outcome_matrix_reports_partial_and_retries_failed_targets`
- `make pre-commit`

## Impact

No runtime API, configuration, CLI, Console, or compatibility changes. This strengthens regression coverage for the existing partial-rename recovery behavior.

## Additional Notes

Adversarial review attacked partial/all-target rename outcomes, bounded retry admission, temporary shard cleanup, compatibility, and test observability. No unresolved findings remain.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
