### PR TITLE
fix(ci): ignore strings in s3s footprint ratchet

### DIFF
--- a/scripts/check_s3s_footprint.sh
+++ b/scripts/check_s3s_footprint.sh
@@ -6,7 +6,7 @@
 # The migration's goal is to shrink the direct s3s surface, so new code must
 # not grow it. Two counters are ratcheted, baselines verified on 2026-08-05:
 #
-#   - files importing s3s:          rg -l 's3s::' --type rust        (files)
+#   - files referencing s3s paths:  rg -l "$S3S_PATH_PATTERN" --type rust (files)
 #   - s3_error! invocation lines:   rg -c 's3_error!' --type rust    (summed)
 #
 # Either count exceeding its baseline fails the check with the offending
@@ -24,7 +24,8 @@ cd "$(dirname "$0")/.."
 
 # Baselines verified on 2026-08-06. Lower-only; see header.
 S3S_IMPORT_FILES_BASELINE=236
-S3_ERROR_LINES_BASELINE=1680
+S3_ERROR_LINES_BASELINE=1679
+S3S_PATH_PATTERN='(^|[^"[:alnum:]_])s3s::'
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -41,7 +42,7 @@ run_rg_to() {
     fi
 }
 
-run_rg_to "$TMP_DIR/import_files" -l 's3s::' --type rust
+run_rg_to "$TMP_DIR/import_files" -l "$S3S_PATH_PATTERN" --type rust
 run_rg_to "$TMP_DIR/error_lines" -c 's3_error!' --type rust
 
 s3s_import_files="$(grep -c . "$TMP_DIR/import_files" || true)"
@@ -75,7 +76,7 @@ check_ratchet() {
 }
 
 check_ratchet "files importing s3s" "$s3s_import_files" "$S3S_IMPORT_FILES_BASELINE" \
-    "rg -l 's3s::' --type rust"
+    "rg -l '$S3S_PATH_PATTERN' --type rust"
 check_ratchet "s3_error! invocation lines" "$s3_error_lines" "$S3_ERROR_LINES_BASELINE" \
     "rg -c 's3_error!' --type rust"
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Restrict the s3s footprint file counter to Rust path references instead of every textual `s3s::` occurrence.
- Exclude tracing target strings such as `"s3s::auth"` from the import footprint without excluding any current direct s3s reference.
- Tighten the `s3_error!` invocation baseline from 1680 to the current count of 1679.

## Verification

- `bash -n scripts/check_s3s_footprint.sh` — passed.
- `make s3s-footprint-check` — passed with 236 s3s path-reference files and 1679 `s3_error!` invocation lines.
- Compared the broad and narrowed match sets — the only excluded file is `crates/obs/src/telemetry/filter.rs`, whose three matches are tracing target string literals.
- `git diff --check` — passed.

Focused verification was used because this is a local CI guard-only change with no runtime, build, dependency, or generated-code effect.

## Impact

The footprint ratchet no longer reports false import growth when Rust source contains an s3s tracing target string. The lower-only dependency ratchet remains at 236 files, and the macro ratchet becomes stricter at 1679 lines. There is no runtime, API, configuration, CLI, or Console impact.

## Additional Notes

- Correctness adversary: compared old and new match sets and confirmed the new expression excludes only the three `"s3s::auth"` string literals while retaining all current direct path references.
- Simplicity adversary: the change is limited to one reusable search expression and the required lower baseline update; no allowlist or raised baseline is introduced.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
