### PR TITLE
fix(ecstore): parse ARN region and id in display order

### DIFF
--- a/crates/ecstore/src/bucket/target/arn.rs
+++ b/crates/ecstore/src/bucket/target/arn.rs
@@ -64,3 +64,49 @@ impl FromStr for ARN {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Display emits `arn:rustfs:{type}:{region}:{id}:{bucket}` (madmin layout);
+    /// FromStr must read the same positions back so parse(display(a)) == a.
+    #[test]
+    fn from_str_round_trips_display_with_region_and_id() {
+        let arn = ARN::new(
+            BucketTargetType::ReplicationService,
+            "depl-123".to_string(),
+            "us-east-1".to_string(),
+            "bucket-a".to_string(),
+        );
+
+        let parsed = ARN::from_str(&arn.to_string()).expect("display output must parse");
+
+        assert_eq!(parsed.arn_type, arn.arn_type);
+        assert_eq!(parsed.region, arn.region, "region must survive display->parse round-trip");
+        assert_eq!(parsed.id, arn.id, "id must survive display->parse round-trip");
+        assert_eq!(parsed.bucket, arn.bucket);
+    }
+
+    #[test]
+    fn from_str_reads_region_then_id_in_display_order() {
+        let parsed = ARN::from_str("arn:rustfs:replication:us-east-1:depl-123:bucket-a").expect("valid ARN must parse");
+
+        assert_eq!(parsed.arn_type, BucketTargetType::ReplicationService);
+        assert_eq!(parsed.region, "us-east-1");
+        assert_eq!(parsed.id, "depl-123");
+        assert_eq!(parsed.bucket, "bucket-a");
+    }
+
+    /// RustFS commonly generates ARNs with an empty region:
+    /// `arn:rustfs:replication::<deployment_id>:<bucket>`.
+    #[test]
+    fn from_str_handles_empty_region_segment() {
+        let parsed = ARN::from_str("arn:rustfs:replication::depl-123:bucket-a").expect("valid ARN must parse");
+
+        assert_eq!(parsed.arn_type, BucketTargetType::ReplicationService);
+        assert_eq!(parsed.region, "", "region segment is empty in this form");
+        assert_eq!(parsed.id, "depl-123");
+        assert_eq!(parsed.bucket, "bucket-a");
+    }
+}

--- a/crates/ecstore/src/bucket/target/arn.rs
+++ b/crates/ecstore/src/bucket/target/arn.rs
@@ -56,10 +56,12 @@ impl FromStr for ARN {
         if parts.len() != 6 {
             return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid ARN format"));
         }
+        // Display emits `arn:rustfs:{type}:{region}:{id}:{bucket}`; read the
+        // segments back in the same order so parse(display(a)) == a.
         Ok(ARN {
             arn_type: BucketTargetType::from_str(parts[2]).unwrap_or_default(),
-            id: parts[3].to_string(),
-            region: parts[4].to_string(),
+            region: parts[3].to_string(),
+            id: parts[4].to_string(),
             bucket: parts[5].to_string(),
         })
     }


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1675 (MinIO replication compatibility review, P1 re-review urgent finding, P1-7 sub-item).

## Summary of Changes
`ARN::Display` writes `arn:rustfs:{type}:{region}:{id}:{bucket}` (matching the madmin layout) but `FromStr` read `id = parts[3], region = parts[4]` — the two fields were swapped, breaking `parse(display(a)) == a`. The bug is latent today because every consumer only reads `arn_type`, but any future use of `arn.id`/`arn.region` would silently get swapped values (including the empty-region form `arn:rustfs:replication::<id>:<bucket>` where the id landed in `region`). This PR fixes `FromStr` to parse in display order and documents the ordering contract. Scope is deliberately minimal: no prefix change (`arn:minio:` compatibility is the separate P1-7 main work), no `Display` change, no madmin-layer change.

## Summary of verification of consumers
All in-repo uses checked: `remove_target` (only reads `arn_type`), `generate_arn` (named-field construction + Display), and site-replication ARN construction (Display only) — nothing depended on the swapped semantics. The independent ARN types in `crates/targets` and `crates/policy` are self-consistent and unaffected.

## Verification
- Red-light: 3 new tests failed pre-fix with the exact swapped values (`region` got `"depl-123"` instead of `"us-east-1"`; empty-region form put the id into `region`)
- `cargo test -p rustfs-ecstore --lib bucket::target` (18 passed), `bucket_target_sys` (45 passed, includes existing ARN assertions)
- `cargo fmt --all`; `cargo clippy -p rustfs-ecstore --lib --all-features` clean

## Impact
No behavior change for existing callers; unblocks safe use of `arn.id`/`arn.region` by upcoming P1-7 work (vendor-prefix compatibility). 

## Additional Notes
`ARN::is_empty()` returns `arn_type.is_valid()` which looks inverted; it has no production callers and is left for the P1-7 main work to address.
