### PR TITLE
fix(admin): allow owner service account updates

### DIFF
--- a/crates/e2e_test/src/admin_iam_crud_test.rs
+++ b/crates/e2e_test/src/admin_iam_crud_test.rs
@@ -26,7 +26,9 @@
 //! Later batches tracked on backlog#1154: config get/set, info, pools status,
 //! group lifecycle, import/export IAM.
 
-use crate::common::{RustFSTestEnvironment, admin_ok, admin_request, init_logging};
+use crate::common::{
+    RustFSTestEnvironment, admin_ok, admin_request, admin_request_with_session_token, build_test_sts_client, init_logging,
+};
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};
@@ -85,6 +87,255 @@ fn bucket_rw_policy(bucket: &str) -> String {
         }]
     })
     .to_string()
+}
+
+async fn create_user_with_service_account_update_policy(
+    env: &RustFSTestEnvironment,
+    user: &str,
+    secret: &str,
+    policy: &str,
+) -> TestResult {
+    admin_ok(
+        env,
+        http::Method::PUT,
+        &format!("/rustfs/admin/v3/add-user?accessKey={user}"),
+        Some(serde_json::json!({ "secretKey": secret, "status": "enabled" }).to_string()),
+    )
+    .await?;
+    admin_ok(
+        env,
+        http::Method::PUT,
+        &format!("/rustfs/admin/v3/add-canned-policy?name={policy}"),
+        Some(
+            serde_json::json!({
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["admin:UpdateServiceAccount"]
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": ["sts:AssumeRole"],
+                        "Resource": ["arn:aws:s3:::*"]
+                    }
+                ]
+            })
+            .to_string(),
+        ),
+    )
+    .await?;
+    admin_ok(
+        env,
+        http::Method::POST,
+        "/rustfs/admin/v3/idp/builtin/policy/attach",
+        Some(serde_json::json!({ "policies": [policy], "user": user }).to_string()),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn create_service_account_for(
+    env: &RustFSTestEnvironment,
+    parent: &str,
+) -> Result<(String, String), Box<dyn Error + Send + Sync>> {
+    let response = admin_ok(
+        env,
+        http::Method::PUT,
+        "/rustfs/admin/v3/add-service-accounts",
+        Some(serde_json::json!({ "targetUser": parent }).to_string()),
+    )
+    .await?;
+    let response: serde_json::Value = serde_json::from_str(&response)?;
+    let access_key = response["credentials"]["accessKey"]
+        .as_str()
+        .ok_or("service account response should contain credentials.accessKey")?
+        .to_owned();
+    let secret_key = response["credentials"]["secretKey"]
+        .as_str()
+        .ok_or("service account response should contain credentials.secretKey")?
+        .to_owned();
+    Ok((access_key, secret_key))
+}
+
+async fn assert_admin_status(
+    env: &RustFSTestEnvironment,
+    credentials: (&str, &str, Option<&str>),
+    path: &str,
+    body: String,
+    expected: StatusCode,
+    context: &str,
+) -> TestResult {
+    let (access_key, secret_key, session_token) = credentials;
+    let (status, response) =
+        admin_request_with_session_token(&env.url, http::Method::POST, path, Some(body), access_key, secret_key, session_token)
+            .await?;
+    assert_eq!(status, expected, "{context}: got {status}: {response}");
+    if expected == StatusCode::FORBIDDEN {
+        assert!(response.contains("AccessDenied"), "{context}: expected AccessDenied body, got {response}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_update_service_account_enforces_owner_and_parent_scope() -> TestResult {
+    init_logging();
+
+    let mut env = RustFSTestEnvironment::new().await?;
+    env.start_rustfs_server(vec![]).await?;
+
+    let parent = "updateparent";
+    let parent_secret = "updateparentsecret";
+    let outsider = "updateoutsider";
+    let outsider_secret = "updateoutsidersecret";
+    let ordinary = "updateordinary";
+    let ordinary_secret = "updateordinarysecret";
+    create_user_with_service_account_update_policy(&env, parent, parent_secret, "update-parent-policy").await?;
+    create_user_with_service_account_update_policy(&env, outsider, outsider_secret, "update-outsider-policy").await?;
+    admin_ok(
+        &env,
+        http::Method::PUT,
+        &format!("/rustfs/admin/v3/add-user?accessKey={ordinary}"),
+        Some(serde_json::json!({ "secretKey": ordinary_secret, "status": "enabled" }).to_string()),
+    )
+    .await?;
+
+    let (target_access_key, _) = create_service_account_for(&env, parent).await?;
+    let target_path = format!("/rustfs/admin/v3/update-service-account?accessKey={target_access_key}");
+
+    assert_admin_status(
+        &env,
+        (&env.access_key, &env.secret_key, None),
+        &target_path,
+        serde_json::json!({}).to_string(),
+        StatusCode::NO_CONTENT,
+        "root no-op update across parents must succeed",
+    )
+    .await?;
+
+    let custom_policy = serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Action": ["s3:GetObject"],
+            "Resource": ["arn:aws:s3:::update-scope/*"]
+        }]
+    });
+    assert_admin_status(
+        &env,
+        (&env.access_key, &env.secret_key, None),
+        &target_path,
+        serde_json::json!({ "newPolicy": custom_policy }).to_string(),
+        StatusCode::NO_CONTENT,
+        "root implied-to-custom update across parents must succeed",
+    )
+    .await?;
+
+    assert_admin_status(
+        &env,
+        (parent, parent_secret, None),
+        &target_path,
+        serde_json::json!({ "newDescription": "updated by parent" }).to_string(),
+        StatusCode::NO_CONTENT,
+        "parent with UpdateServiceAccount may update its own service account",
+    )
+    .await?;
+
+    let takeover = serde_json::json!({
+        "newSecretKey": "cross-parent-takeover-secret",
+        "newDescription": "cross-parent takeover"
+    })
+    .to_string();
+    assert_admin_status(
+        &env,
+        (ordinary, ordinary_secret, None),
+        &target_path,
+        takeover.clone(),
+        StatusCode::FORBIDDEN,
+        "ordinary user must not update another parent's service account",
+    )
+    .await?;
+    assert_admin_status(
+        &env,
+        (outsider, outsider_secret, None),
+        &target_path,
+        takeover.clone(),
+        StatusCode::FORBIDDEN,
+        "non-owner with UpdateServiceAccount must not update across parents",
+    )
+    .await?;
+
+    let (derived_access_key, derived_secret_key) = create_service_account_for(&env, outsider).await?;
+    assert_admin_status(
+        &env,
+        (&derived_access_key, &derived_secret_key, None),
+        &target_path,
+        takeover.clone(),
+        StatusCode::FORBIDDEN,
+        "service-account credential must not update across parents",
+    )
+    .await?;
+
+    let assumed = build_test_sts_client(&env.url, outsider, outsider_secret, None, "e2e-admin-update-service-account")
+        .assume_role()
+        .role_arn("arn:aws:iam::123456789012:role/update-service-account")
+        .role_session_name("update-service-account-scope")
+        .send()
+        .await?;
+    let temporary = assumed
+        .credentials()
+        .ok_or("AssumeRole response should contain credentials")?;
+    assert_admin_status(
+        &env,
+        (temporary.access_key_id(), temporary.secret_access_key(), Some(temporary.session_token())),
+        &target_path,
+        takeover,
+        StatusCode::FORBIDDEN,
+        "temporary credential must not update across parents",
+    )
+    .await?;
+
+    let info = admin_ok(
+        &env,
+        http::Method::GET,
+        &format!("/rustfs/admin/v3/info-service-account?accessKey={target_access_key}"),
+        None,
+    )
+    .await?;
+    let info: serde_json::Value = serde_json::from_str(&info)?;
+    assert_eq!(
+        info["impliedPolicy"].as_bool(),
+        Some(false),
+        "root update must replace the implied policy with a custom policy"
+    );
+    assert!(
+        info["policy"].as_str().is_some_and(|policy| policy.contains("s3:GetObject")),
+        "custom policy must round-trip through the handler: {info}"
+    );
+    assert_eq!(
+        info["description"].as_str(),
+        Some("updated by parent"),
+        "denied takeover attempts must not mutate target"
+    );
+
+    let (missing_status, missing_body) = admin_request(
+        &env.url,
+        http::Method::POST,
+        "/rustfs/admin/v3/update-service-account?accessKey=missing-service-account",
+        Some(serde_json::json!({}).to_string()),
+        &env.access_key,
+        &env.secret_key,
+    )
+    .await?;
+    assert_eq!(missing_status, StatusCode::NOT_FOUND, "missing target must fail closed: {missing_body}");
+    assert!(
+        missing_body.contains("NoSuchResource"),
+        "missing target must preserve the lookup error: {missing_body}"
+    );
+
+    env.stop_server();
+    Ok(())
 }
 
 /// Full user -> policy -> service-account lifecycle, proving each management

--- a/crates/e2e_test/src/common.rs
+++ b/crates/e2e_test/src/common.rs
@@ -137,6 +137,18 @@ pub(crate) async fn admin_request(
     access_key: &str,
     secret_key: &str,
 ) -> Result<(StatusCode, String), Box<dyn std::error::Error + Send + Sync>> {
+    admin_request_with_session_token(base_url, method, path_and_query, body, access_key, secret_key, None).await
+}
+
+pub(crate) async fn admin_request_with_session_token(
+    base_url: &str,
+    method: http::Method,
+    path_and_query: &str,
+    body: Option<String>,
+    access_key: &str,
+    secret_key: &str,
+    session_token: Option<&str>,
+) -> Result<(StatusCode, String), Box<dyn std::error::Error + Send + Sync>> {
     let url = format!("{base_url}{path_and_query}");
     let uri = url.parse::<http::Uri>()?;
     let authority = uri.authority().ok_or("admin URL missing authority")?.to_string();
@@ -150,7 +162,14 @@ pub(crate) async fn admin_request(
     }
 
     let content_length = i64::try_from(body.as_ref().map_or(0, String::len)).map_err(|_| "admin request body is too large")?;
-    let signed = sign_v4(request.body(Body::empty())?, content_length, access_key, secret_key, "", "us-east-1");
+    let signed = sign_v4(
+        request.body(Body::empty())?,
+        content_length,
+        access_key,
+        secret_key,
+        session_token.unwrap_or_default(),
+        "us-east-1",
+    );
 
     let mut request = local_http_client().request(method, &url);
     for (name, value) in signed.headers() {

--- a/rustfs/src/admin/handlers/service_account.rs
+++ b/rustfs/src/admin/handlers/service_account.rs
@@ -631,7 +631,9 @@ impl Operation for UpdateServiceAccount {
             .await
             .map_err(|e| map_service_account_lookup_error(e, "get service account failed"))?;
 
-        if !is_service_account_owner_of(&cred, &svc_account.parent_user) {
+        // The admin action permits updates within a caller's scope; only an
+        // owner may cross service-account parent boundaries.
+        if !owner && !is_service_account_owner_of(&cred, &svc_account.parent_user) {
             return Err(s3_error!(AccessDenied, "access denied"));
         }
 
@@ -1688,6 +1690,14 @@ mod tests {
 
         assert_eq!(*err.code(), S3ErrorCode::NoSuchResource);
         assert_eq!(err.message(), Some("service account 'missing' does not exist"));
+    }
+
+    #[test]
+    fn map_service_account_lookup_error_fails_closed_for_decode_errors() {
+        let err = map_service_account_lookup_error(rustfs_iam::error::Error::ErrCredMalformed, "get service account failed");
+
+        assert_eq!(*err.code(), S3ErrorCode::InternalError);
+        assert_eq!(err.message(), Some("get service account failed"));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Fixes #5778.

## Summary of Changes

The update-service-account handler already required `admin:UpdateServiceAccount`, but it then unconditionally required the caller's effective parent to match the target service account's parent. As a result, the authenticated owner/root passed the admin-action check but still received `403 AccessDenied` when editing a service account owned by another user.

This change keeps the explicit admin-action check and target lookup in their existing order, then lets only the authentication layer's existing `owner` result bypass the parent-scope comparison. Possessing `consoleAdmin` or `admin:UpdateServiceAccount` alone does not grant cross-parent update access. That restriction matters because this endpoint can replace the secret key and session policy.

The real Admin API regression test covers this permission matrix:

| Caller | Target parent | Expected |
| --- | --- | --- |
| owner/root | another ordinary user | allow no-op and implied-to-custom policy updates |
| parent user with explicit update action | self | allow |
| ordinary non-owner | another user | deny |
| non-owner with explicit update action (including the relevant consoleAdmin capability) | another user | deny |
| service-account credential | another user | deny |
| STS temporary credential | another user | deny |
| owner/root | missing target | fail closed with `NoSuchResource` |

Denied takeover attempts are also verified not to mutate the target. A narrow unit regression verifies malformed IAM credential data maps to an internal error instead of being accepted.

## Verification

- Red-light regression proof on unpatched `origin/main`:  
  `cargo test -p e2e_test test_update_service_account_enforces_owner_and_parent_scope -- --nocapture` failed at the first owner/root cross-parent no-op update with expected `204`, actual `403 AccessDenied`.
- Patched real-handler E2E (final run):  
  `cargo test -p e2e_test test_update_service_account_enforces_owner_and_parent_scope -- --nocapture` — passed (1 passed).
- Targeted lookup-error unit tests:  
  `cargo test -p rustfs map_service_account_lookup_error_ -- --nocapture` — passed (2 passed).
- Formatting:  
  `cargo fmt --all --check` — passed.
- High-risk gate:  
  `make pre-pr` was executed. Formatting, all repository guard scripts, workspace Clippy with `-D warnings`, and script tests passed. The full nextest run completed with 12,676/12,677 passing; the sole failure was an unrelated host-DNS behavior where the reserved nonexistent hostname was synthesized to `198.18.0.19`/`fdfe:dcba:9876::1d` instead of returning a resolver error.
- Full no-fail-fast confirmation:  
  `cargo nextest run --all --exclude e2e_test --no-fail-fast` — 12,676 passed, only the same unrelated DNS-environment test failed; no other failures.
- Isolated DNS-environment confirmation in the network-isolated sandbox:  
  `cargo nextest run --all --exclude e2e_test -E 'test(resolve_domain_preserves_system_resolver_error_provenance)'` — passed (1 passed).
- Documentation tests:  
  `cargo test --all --doc` — passed.

Local builds emitted the existing macOS linker warning that the `__eh_frame` section is too large; it is unrelated to these IAM changes.

## Impact

Administrators authenticated as the existing owner/root identity can edit service accounts belonging to other users from the Console, including submitting an unchanged form or replacing an inherited policy with a custom session policy.

Non-owner behavior remains scoped to the caller's effective parent. This does not change Add, Delete, Info, request/response schemas, routes, persistence order, or site-replication hooks.

## Additional Notes

High-risk adversarial validation verdicts:

- **Correctness:** pass — action authorization, lookup, parent scope, mutation, and replication-hook ordering are preserved; owner/root cross-parent updates now reach the existing mutation path.
- **Simplicity:** pass — the production change is one short-circuit condition plus a security-boundary comment; helper additions exist only to drive the required API matrix.
- **Security:** pass — only the existing authenticated `owner` result bypasses parent matching; consoleAdmin/action-only users, ordinary users, service accounts, and temporary credentials remain denied across parents, and lookup/decode errors fail closed.
- **Concurrency/durability:** pass — no locks, awaits, persistence operations, or replication ordering changed.
- **Compatibility:** pass — no wire, schema, route, status, or non-owner behavior changes; the fix restores the existing owner cross-user service-account management contract.
- **Performance:** pass — one boolean short-circuit was added with no allocation, I/O, synchronization, or extra IAM lookup.
- **Test-coverage skeptic:** pass — reverting the production condition reproduces the issue through the real handler; the final E2E covers success, denial, mutation resistance, temporary/derived credentials, no-op, policy transition, and missing-target behavior.