### PR TITLE
ci: install awscurl for full e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,6 +770,19 @@ jobs:
           cache-save-if: 'false'
           install-build-packaging-tools: 'false'
 
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install awscurl
+        run: |
+          python3 -m pip install --user --upgrade pip awscurl
+          echo "AWSCURL_PATH=$HOME/.local/bin/awscurl" >> "$GITHUB_ENV"
+
+      - name: Verify awscurl
+        run: test -x "$AWSCURL_PATH"
+
       # Download after the cache restore so the freshly built binary from the
       # build job always wins over anything restored into target/debug.
       - name: Download debug binary

--- a/crates/e2e_test/src/bucket_stats_regression_test.rs
+++ b/crates/e2e_test/src/bucket_stats_regression_test.rs
@@ -88,12 +88,21 @@ mod tests {
 
         // Wait for scanner to process (up to 90 seconds)
         let mut found_nonzero = false;
+        let mut last_query_error = None;
         for attempt in 0..18 {
             sleep(Duration::from_secs(5)).await;
 
-            if let Ok(usage) = get_data_usage(&env).await
-                && let Some(bucket_usage) = usage.buckets_usage.get(bucket)
-            {
+            let usage = match get_data_usage(&env).await {
+                Ok(usage) => {
+                    last_query_error = None;
+                    usage
+                }
+                Err(err) => {
+                    last_query_error = Some(err.to_string());
+                    continue;
+                }
+            };
+            if let Some(bucket_usage) = usage.buckets_usage.get(bucket) {
                 info!("  attempt {attempt}: objectsCount = {}", bucket_usage.objects_count);
                 if bucket_usage.objects_count >= 10 {
                     found_nonzero = true;
@@ -104,7 +113,8 @@ mod tests {
 
         assert!(
             found_nonzero,
-            "RT-09 FAIL: bucket object count did not update after PUT 10 objects (regression: stats stuck at 0)"
+            "RT-09 FAIL: bucket object count did not update after PUT 10 objects (regression: stats stuck at 0); last query error: {}",
+            last_query_error.as_deref().unwrap_or("none")
         );
 
         info!("RT-09 PASS: bucket object count updates after PUT");
@@ -156,12 +166,21 @@ mod tests {
 
         // Wait for scanner to update stats (up to 90 seconds)
         let mut found_zero = false;
+        let mut last_query_error = None;
         for attempt in 0..18 {
             sleep(Duration::from_secs(5)).await;
 
-            if let Ok(usage) = get_data_usage(&env).await
-                && let Some(bucket_usage) = usage.buckets_usage.get(bucket)
-            {
+            let usage = match get_data_usage(&env).await {
+                Ok(usage) => {
+                    last_query_error = None;
+                    usage
+                }
+                Err(err) => {
+                    last_query_error = Some(err.to_string());
+                    continue;
+                }
+            };
+            if let Some(bucket_usage) = usage.buckets_usage.get(bucket) {
                 info!("  attempt {attempt}: objectsCount = {}", bucket_usage.objects_count);
                 if bucket_usage.objects_count == 0 {
                     found_zero = true;
@@ -172,7 +191,8 @@ mod tests {
 
         assert!(
             found_zero,
-            "RT-09b FAIL: bucket object count did not update to 0 after deleting all objects (regression rustfs#5615)"
+            "RT-09b FAIL: bucket object count did not update to 0 after deleting all objects (regression rustfs#5615); last query error: {}",
+            last_query_error.as_deref().unwrap_or("none")
         );
 
         info!("RT-09b PASS: bucket object count updates to 0 after DELETE");


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Install and verify `awscurl` in the full E2E merge-gate job using the repository's existing Python setup pattern.

Preserve the bucket-statistics polling window while retaining the latest admin API query error, so missing tooling and persistent request failures are reported instead of being misdiagnosed as stale object counts.

## Verification

Not run per requester instruction. Tests, formatting checks, and `actionlint` were intentionally skipped; CI will provide validation.

## Impact

CI-only impact. The full E2E lane now exercises its `awscurl`-dependent data-usage checks, and failures include the underlying query error without changing RustFS production behavior.

## Additional Notes

Root cause analysis was based on https://github.com/rustfs/rustfs/actions/runs/31165319833. The preceding main run failed the same two tests, confirming the failure was unrelated to the rebalance commit that triggered that run.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
