### PR TITLE
fix(admin): stop logging STS AssumeRole JWT claims

### DIFF
--- a/rustfs/src/admin/handlers/sts.rs
+++ b/rustfs/src/admin/handlers/sts.rs
@@ -49,7 +49,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use serde_urlencoded::from_bytes;
 use time::{Duration, OffsetDateTime};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 const ASSUME_ROLE_ACTION: &str = "AssumeRole";
 const ASSUME_ROLE_WITH_WEB_IDENTITY_ACTION: &str = "AssumeRoleWithWebIdentity";
@@ -74,6 +74,15 @@ fn clamp_assume_role_duration(duration_seconds: usize) -> usize {
     } else {
         duration_seconds.clamp(STS_MIN_DURATION_SECS, STS_MAX_DURATION_SECS)
     }
+}
+
+/// Record that AssumeRole assembled its session claims without echoing any claim values.
+///
+/// Claims carry caller-supplied identity material (parent user, session policy, arbitrary
+/// JWT fields); interpolating them into logs repeats the GHSA-r54g-49rx-98cr /
+/// GHSA-8cm2-h255-v749 credential-leak class. Only derived metadata may be logged here.
+fn trace_assume_role_claims(claims: &std::collections::HashMap<String, Value>) {
+    debug!(claim_count = claims.len(), "AssumeRole assembled session claims");
 }
 
 /// Build the site-replication IAM item that mirrors an AssumeRole temporary credential to peers.
@@ -141,7 +150,7 @@ pub struct AssumeRoleHandle {}
 #[async_trait::async_trait]
 impl Operation for AssumeRoleHandle {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
-        warn!("handle AssumeRoleHandle");
+        debug!("handle AssumeRoleHandle");
 
         let mut input = req.input;
 
@@ -241,7 +250,7 @@ async fn handle_assume_role(
         return Err(s3_error!(InvalidArgument, "global active sk not init"));
     };
 
-    info!("AssumeRole get claims {:?}", &claims);
+    trace_assume_role_claims(&claims);
 
     let mut new_cred = get_new_credentials_with_metadata(&claims, &secret)
         .map_err(|e| S3Error::with_message(S3ErrorCode::InternalError, format!("get new cred failed {e}")))?;
@@ -385,6 +394,64 @@ fn xml_escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn assume_role_claims_log_never_echoes_claim_values() {
+        #[derive(Clone, Default)]
+        struct CapturedLog(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+        struct CapturedLogWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+        impl std::io::Write for CapturedLogWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().expect("captured log lock").extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'writer> tracing_subscriber::fmt::MakeWriter<'writer> for CapturedLog {
+            type Writer = CapturedLogWriter;
+
+            fn make_writer(&'writer self) -> Self::Writer {
+                CapturedLogWriter(self.0.clone())
+            }
+        }
+
+        let captured = CapturedLog::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::TRACE)
+            .with_writer(captured.clone())
+            .finish();
+
+        let mut claims = std::collections::HashMap::new();
+        claims.insert("parent".to_string(), Value::String("sensitive-parent-user".to_string()));
+        claims.insert("sessionPolicy".to_string(), Value::String("eyJzZWNyZXQtcG9saWN5LWJsb2Ii".to_string()));
+        claims.insert("sub".to_string(), Value::String("sensitive-subject-id".to_string()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            trace_assume_role_claims(&claims);
+        });
+
+        let logs = String::from_utf8(captured.0.lock().expect("captured log lock").clone()).expect("captured logs must be UTF-8");
+        assert!(
+            logs.contains("claim_count"),
+            "expected the redacted claims log line to be emitted: {logs}"
+        );
+        for secret in [
+            "sensitive-parent-user",
+            "eyJzZWNyZXQtcG9saWN5LWJsb2Ii",
+            "sensitive-subject-id",
+            "sessionPolicy",
+        ] {
+            assert!(!logs.contains(secret), "AssumeRole claims log leaked {secret}: {logs}");
+        }
+    }
 
     #[test]
     fn test_xml_escape() {

--- a/scripts/check_logging_guardrails.sh
+++ b/scripts/check_logging_guardrails.sh
@@ -690,6 +690,17 @@ if [[ -n "$unmasked_revoke_fields" ]]; then
   exit 1
 fi
 
+# STS claims carry caller-supplied identity material (parent user, session policy, JWT
+# fields). Interpolating the claims map into any log or error repeats the
+# GHSA-r54g-49rx-98cr / GHSA-8cm2-h255-v749 credential-leak class. Only derived metadata
+# such as claims.len() may be logged (see trace_assume_role_claims in sts.rs).
+sts_claims_content_logs="$(rg -n '\{:\?\}.*claims|claims.*\{:\?\}|\{&?claims:\?\}|[?%]\s*&?claims\b' rustfs/src/admin/handlers/sts.rs || true)"
+if [[ -n "$sts_claims_content_logs" ]]; then
+  echo "❌ logging guardrail violation: STS handlers must not interpolate JWT claims into logs or errors (GHSA-r54g-49rx-98cr / GHSA-8cm2-h255-v749 class); log derived metadata such as claims.len() instead" >&2
+  echo "$sts_claims_content_logs" >&2
+  exit 1
+fi
+
 heal_hotpath_files=(
   "crates/ecstore/src/store/heal.rs"
   "crates/ecstore/src/store/mod.rs"


### PR DESCRIPTION
## Problem

`rustfs/src/admin/handlers/sts.rs` logged the complete JWT claims map at **info** level on every successful AssumeRole:

```rust
info!("AssumeRole get claims {:?}", &claims);
```

The claims map carries caller-supplied identity material — parent user, embedded session policy, and arbitrary JWT fields — so default-level logs contained credential-grade data. This is the same leak class as GHSA-r54g-49rx-98cr (STS credentials at info) and GHSA-8cm2-h255-v749 (session token / JWT claims at debug), just one occurrence that survived those fixes.

Tracked in rustfs/backlog#1754 (found during gateway P10 migration decomposition; fixed now because a log leak should not wait for the migration).

## Fix

- The claims dump is replaced by `trace_assume_role_claims`, which logs only derived metadata (`claim_count`) at debug level. The function doc states the invariant so the next editor knows why no claim value may appear there.
- The per-request `warn!("handle AssumeRoleHandle")` at handler entry is downgraded to debug — it fired at warn on every STS request and is pure noise at that level.
- The unused `info` import is dropped.

A repo-wide sweep found no other whole-claims interpolation; adjacent `{:?}` sites in admin handlers print error objects, not claim/credential contents.

## Regression guards

- **Log-capture test** `assume_role_claims_log_never_echoes_claim_values`: installs a TRACE-level capturing subscriber, emits the claims log for a map holding sensitive parent-user / session-policy / subject values, and asserts none of the values (nor the `sessionPolicy` key) appear while the redacted line does.
- **Logging guardrail**: `scripts/check_logging_guardrails.sh` now rejects any tracing/error interpolation of the claims map in `sts.rs` (`{:?}` dumps and `?claims`/`%claims` field captures). Injection-verified: re-adding the original line makes the script fail with the new violation message; current tree passes.

## Verification

- `./scripts/check_logging_guardrails.sh` — pass (and fails on injected violation)
- `cargo test -p rustfs --lib admin::handlers::sts` — 6 passed (includes new test)
- `cargo clippy -p rustfs --lib --tests` — clean
- `make pre-commit` — all checks passed

## Adversarial validation

- **security-adversary**: claims values can no longer reach logs from this path; guardrail blocks reintroduction including tracing field-capture spellings. No new logging of any other sensitive field introduced.
- **compatibility**: wire responses unchanged; only log output changes (one line removed from default-level logs, one entry line moves warn→debug).
- **test-adversary**: the capture test asserts both absence of every sensitive value and presence of the replacement line, so it cannot pass vacuously if the log statement is deleted.

Closes rustfs/backlog#1754.
