### PR TITLE
test(e2e): make scanner snapshot tests deterministic

### DIFF
--- a/crates/e2e_test/src/bucket_stats_regression_test.rs
+++ b/crates/e2e_test/src/bucket_stats_regression_test.rs
@@ -31,7 +31,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::common::{RustFSTestEnvironment, awscurl_get, init_logging};
+    use crate::common::{FAST_DATA_USAGE_SCANNER_ENV, RustFSTestEnvironment, awscurl_get, init_logging};
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
     use rustfs_data_usage::DataUsageInfo;
@@ -65,7 +65,7 @@ mod tests {
         info!("RT-09: bucket object count updates after PUT");
 
         let mut env = RustFSTestEnvironment::new().await.expect("create test environment");
-        env.start_rustfs_server_with_env(vec![], &[("RUSTFS_CONSOLE_ENABLE", "false")])
+        env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV)
             .await
             .expect("start RustFS");
 
@@ -132,7 +132,7 @@ mod tests {
         info!("RT-09b: bucket object count updates after DELETE");
 
         let mut env = RustFSTestEnvironment::new().await.expect("create test environment");
-        env.start_rustfs_server_with_env(vec![], &[("RUSTFS_CONSOLE_ENABLE", "false")])
+        env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV)
             .await
             .expect("start RustFS");
 
@@ -152,6 +152,22 @@ mod tests {
                 .await
                 .expect("put object");
         }
+
+        let mut found_nonzero = false;
+        for attempt in 0..18 {
+            sleep(Duration::from_secs(5)).await;
+
+            if let Ok(usage) = get_data_usage(&env).await
+                && let Some(bucket_usage) = usage.buckets_usage.get(bucket)
+            {
+                info!("  baseline attempt {attempt}: objectsCount = {}", bucket_usage.objects_count);
+                if bucket_usage.objects_count >= 5 {
+                    found_nonzero = true;
+                    break;
+                }
+            }
+        }
+        assert!(found_nonzero, "RT-09b setup failed: scanner did not observe the 5 uploaded objects");
 
         // Delete all objects
         for i in 0..5 {

--- a/crates/e2e_test/src/common.rs
+++ b/crates/e2e_test/src/common.rs
@@ -47,6 +47,10 @@ use walkdir::WalkDir;
 pub const DEFAULT_ACCESS_KEY: &str = "rustfsadmin";
 pub const DEFAULT_SECRET_KEY: &str = "rustfsadmin";
 pub const ENV_RUSTFS_BUILD_FEATURES: &str = "RUSTFS_BUILD_FEATURES";
+pub(crate) const FAST_DATA_USAGE_SCANNER_ENV: &[(&str, &str)] = &[
+    ("RUSTFS_SCANNER_CYCLE", "1"),
+    ("RUSTFS_SCANNER_START_DELAY_SECS", "0"),
+];
 pub const TEST_BUCKET: &str = "e2e-test-bucket";
 const RUSTFS_FULL_FEATURE: &str = "full";
 

--- a/crates/e2e_test/src/common.rs
+++ b/crates/e2e_test/src/common.rs
@@ -47,10 +47,8 @@ use walkdir::WalkDir;
 pub const DEFAULT_ACCESS_KEY: &str = "rustfsadmin";
 pub const DEFAULT_SECRET_KEY: &str = "rustfsadmin";
 pub const ENV_RUSTFS_BUILD_FEATURES: &str = "RUSTFS_BUILD_FEATURES";
-pub(crate) const FAST_DATA_USAGE_SCANNER_ENV: &[(&str, &str)] = &[
-    ("RUSTFS_SCANNER_CYCLE", "1"),
-    ("RUSTFS_SCANNER_START_DELAY_SECS", "0"),
-];
+pub(crate) const FAST_DATA_USAGE_SCANNER_ENV: &[(&str, &str)] =
+    &[("RUSTFS_SCANNER_CYCLE", "1"), ("RUSTFS_SCANNER_START_DELAY_SECS", "0")];
 pub const TEST_BUCKET: &str = "e2e-test-bucket";
 const RUSTFS_FULL_FEATURE: &str = "full";
 

--- a/crates/e2e_test/src/data_usage_test.rs
+++ b/crates/e2e_test/src/data_usage_test.rs
@@ -66,8 +66,7 @@ async fn data_usage_reports_all_objects() -> Result<(), Box<dyn std::error::Erro
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV)
-        .await?;
+    env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV).await?;
 
     let client = env.create_s3_client();
 
@@ -125,8 +124,7 @@ async fn data_usage_reports_versioned_objects_and_delete_markers() -> Result<(),
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV)
-        .await?;
+    env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV).await?;
 
     let client = env.create_s3_client();
     let bucket = "data-usage-versioned";

--- a/crates/e2e_test/src/data_usage_test.rs
+++ b/crates/e2e_test/src/data_usage_test.rs
@@ -18,7 +18,7 @@ use rustfs_data_usage::DataUsageInfo;
 use serial_test::serial;
 use tokio::time::{Duration, sleep};
 
-use crate::common::{RustFSTestEnvironment, TEST_BUCKET, awscurl_get, init_logging};
+use crate::common::{FAST_DATA_USAGE_SCANNER_ENV, RustFSTestEnvironment, TEST_BUCKET, awscurl_get, init_logging};
 
 async fn get_data_usage_info(env: &RustFSTestEnvironment) -> Result<DataUsageInfo, Box<dyn std::error::Error + Send + Sync>> {
     let url = format!("{}/rustfs/admin/v3/datausageinfo", env.url);
@@ -35,16 +35,26 @@ where
     F: FnMut(&DataUsageInfo) -> bool,
 {
     let mut last_usage = DataUsageInfo::default();
+    let mut last_query_error = None;
     for _ in 0..45 {
-        let usage = get_data_usage_info(env).await?;
-        if usage.buckets_usage.contains_key(bucket) && predicate(&usage) {
-            return Ok(usage);
+        match get_data_usage_info(env).await {
+            Ok(usage) => {
+                last_query_error = None;
+                if usage.buckets_usage.contains_key(bucket) && predicate(&usage) {
+                    return Ok(usage);
+                }
+                last_usage = usage;
+            }
+            Err(err) => last_query_error = Some(err.to_string()),
         }
-        last_usage = usage;
         sleep(Duration::from_secs(2)).await;
     }
 
-    Err(format!("bucket usage did not converge for {bucket}; last usage: {last_usage:?}").into())
+    Err(format!(
+        "bucket usage did not converge for {bucket}; last usage: {last_usage:?}; last query error: {}",
+        last_query_error.as_deref().unwrap_or("none")
+    )
+    .into())
 }
 
 /// Regression test for data usage accuracy (issue #1012).
@@ -56,7 +66,8 @@ async fn data_usage_reports_all_objects() -> Result<(), Box<dyn std::error::Erro
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server(vec![]).await?;
+    env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV)
+        .await?;
 
     let client = env.create_s3_client();
 
@@ -74,8 +85,14 @@ async fn data_usage_reports_all_objects() -> Result<(), Box<dyn std::error::Erro
             .await?;
     }
 
-    // Query admin data usage API
-    let usage = get_data_usage_info(&env).await?;
+    let usage = wait_for_bucket_usage(&env, TEST_BUCKET, |usage| {
+        usage
+            .buckets_usage
+            .get(TEST_BUCKET)
+            .map(|bucket_usage| usage.objects_total_count >= 1000 && bucket_usage.objects_count >= 1000)
+            .unwrap_or(false)
+    })
+    .await?;
 
     // Assert total object count and per-bucket count are not truncated
     let bucket_usage = usage
@@ -108,7 +125,8 @@ async fn data_usage_reports_versioned_objects_and_delete_markers() -> Result<(),
     init_logging();
 
     let mut env = RustFSTestEnvironment::new().await?;
-    env.start_rustfs_server(vec![]).await?;
+    env.start_rustfs_server_with_env(vec![], FAST_DATA_USAGE_SCANNER_ENV)
+        .await?;
 
     let client = env.create_s3_client();
     let bucket = "data-usage-versioned";
@@ -184,8 +202,8 @@ async fn data_usage_reports_versioned_objects_and_delete_markers() -> Result<(),
     assert_eq!(usage.versions_total_count, 3, "total version count should match bucket usage");
     assert_eq!(usage.delete_markers_total_count, 1, "total delete marker count should match bucket usage");
 
-    env.stop_server();
-    env.start_rustfs_server(vec![]).await?;
+    env.restart_server_preserving_data(vec![], FAST_DATA_USAGE_SCANNER_ENV)
+        .await?;
 
     let restarted_usage = wait_for_bucket_usage(&env, bucket, |usage| {
         usage


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Start data-usage and bucket-stat regression servers with an explicit one-second scanner cycle and zero startup delay.
- Poll the data-usage endpoint until the expected snapshot is visible and tolerate transient admin endpoint errors during convergence.
- Establish a nonzero scanner baseline before the bucket-stat delete test verifies that usage returns to zero.
- Preserve the same scanner timing configuration across the versioned data-usage restart.

## Verification

- `cargo fmt --all`
- `git diff --check`
- Tests were not run because this PR changes test code only, as requested.
- GitHub Actions `Quick Checks` passed after the formatting correction.

## Impact

No production behavior changes. Full-gate E2E scanner snapshot tests no longer depend on the production scanner's default scheduling interval.

## Additional Notes

- Correctness adversary: attacked first-start and restart readiness gaps, transient admin endpoint failures, false-positive delete assertions, and nextest process isolation; no remaining break found.
- Simplicity adversary: consolidated the shared scanner profile in the E2E harness, preserved the existing server lifecycle helpers, and found no smaller equivalent change.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
