### PR TITLE
fix(scanner): retry a superseded usage snapshot in seconds, not a full cycle

### DIFF
--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -84,7 +84,23 @@ const METRIC_SCANNER_LEADER_LOCK_TOTAL: &str = "rustfs_scanner_leader_lock_total
 const CLEAN_IDLE_MAX_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const MAX_SCANNER_SCHEDULE_DELAY: Duration = Duration::from_secs(365 * 24 * 60 * 60);
 const CLEAN_IDLE_BACKOFF_FACTOR: u32 = 2;
-const SUPERSEDED_RETRY_BASE_INTERVAL: Duration = Duration::from_secs(60);
+/// First-retry delay after a usage snapshot is superseded by concurrent writes.
+///
+/// A superseded cycle is the *expected* outcome of the dirty-usage fast path:
+/// a write burst marks buckets dirty, the scanner wakes within milliseconds,
+/// and the still-landing writes then supersede the snapshot it took. Charging
+/// that first race a full cycle interval means a burst of writes surfaces in
+/// usage/quota accounting roughly two cycles late (measured: ~120 s on an
+/// otherwise idle instance whose clean-idle backoff had doubled a 60 s
+/// interval), which defeats the fast path it is meant to protect.
+///
+/// The exponential growth in [`ScannerSupersededBackoff::retry_interval`] is
+/// what protects against a persistently hot bucket driving an unbroken
+/// full-scan loop, so it can start small: 5 s, 10 s, 20 s … capped by
+/// [`SUPERSEDED_RETRY_MAX_INTERVAL`]. A one-off race recovers in seconds; a
+/// genuinely hot bucket still reaches minute-scale backoff within a handful of
+/// cycles.
+const SUPERSEDED_RETRY_BASE_INTERVAL: Duration = Duration::from_secs(5);
 const SUPERSEDED_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(30 * 60);
 const SCANNER_LEADER_LOCK_POLL_INTERVAL: Duration = Duration::from_secs(1);
 #[cfg(not(test))]
@@ -6925,7 +6941,7 @@ mod tests {
         let mut backoff = ScannerSupersededBackoff::default();
         assert_eq!(backoff.retry_interval(Duration::from_secs(24 * 60 * 60)), None);
 
-        for expected in [60, 120, 240, 480, 960, 1_920, 3_840] {
+        for expected in [5, 10, 20, 40, 80, 160, 320] {
             backoff.record_cycle(ScannerCycleOutcome::Superseded);
             assert_eq!(
                 backoff.retry_interval(Duration::from_secs(24 * 60 * 60)),
@@ -6949,15 +6965,19 @@ mod tests {
         let mut backoff = ScannerSupersededBackoff::default();
         backoff.record_cycle(ScannerCycleOutcome::Superseded);
 
-        assert_eq!(backoff.retry_interval(Duration::from_secs(15)), Some(Duration::from_secs(15)));
+        // A configured cycle shorter than the base still wins: retrying sooner
+        // than the operator's own cadence buys nothing.
+        assert_eq!(backoff.retry_interval(Duration::from_secs(3)), Some(Duration::from_secs(3)));
         backoff.record_cycle(ScannerCycleOutcome::Superseded);
-        assert_eq!(backoff.retry_interval(Duration::from_secs(15)), Some(Duration::from_secs(30)));
+        assert_eq!(backoff.retry_interval(Duration::from_secs(3)), Some(Duration::from_secs(6)));
     }
 
     #[test]
     fn superseded_retry_backoff_grows_from_the_default_cycle() {
         let mut backoff = ScannerSupersededBackoff::default();
-        for expected in [60, 120, 240, 480] {
+        // The first race after a write burst retries in seconds, not a whole
+        // cycle, while repeated supersedes still climb toward the cap.
+        for expected in [5, 10, 20, 40] {
             backoff.record_cycle(ScannerCycleOutcome::Superseded);
             assert_eq!(backoff.retry_interval(Duration::from_secs(60)), Some(Duration::from_secs(expected)));
         }


### PR DESCRIPTION
Addresses the responsiveness defect found while root-causing #5806 (see [that issue's analysis comment](https://github.com/rustfs/rustfs/issues/5806#issuecomment-5218729540)).

## Problem

A superseded cycle is the **expected** outcome of the dirty-usage fast path, not a signal of pathological load: a write burst marks buckets dirty, the scanner wakes within milliseconds, and the still-landing writes then supersede the snapshot it just took. But the first such race was charged `SUPERSEDED_RETRY_BASE_INTERVAL` = 60s, so a burst of writes surfaced in usage and quota accounting roughly two cycles late.

Server-side timeline on an idle single-node instance (fresh data dir, 10 PUTs, polling `/rustfs/admin/v3/datausageinfo` every 5s, `RUST_LOG=rustfs::scanner=debug`):

```
22:52:36.318  "Scanner cycle woke for dirty usage work"          ← 0.3s after the PUTs
22:52:36.514  cycle 1 "superseded by concurrent namespace activity"
              → wait scheduled: scheduled_delay=55.6s  superseded_cycles=1
...
22:54:36      usage first visible                                  ← t+120s
```

## Change

Base the superseded retry at 5s. The exponential growth in `retry_interval` is what protects against a persistently hot bucket driving an unbroken full-scan loop, so the base does not need to be a whole cycle: 5s → 10s → 20s → 40s … still reaches minute-scale backoff within a handful of consecutive supersedes, and the `SUPERSEDED_RETRY_MAX_INTERVAL` cap is unchanged. A configured cycle shorter than the base still wins (retrying faster than the operator's own cadence buys nothing) — that floor behavior is unchanged and covered by a test.

## Measured effect

Same probe, same machine, only this constant differing:

| build | superseded retry scheduled | usage visible |
|---|---|---|
| main | 55.6s | **t+120s** |
| this PR | 4.7s | **t+70s** |

## Known remaining gap (not addressed here)

The cycle that runs immediately after the supersede completes without publishing the usage; the snapshot only lands on the *next* periodic cycle. That is why the number above is 70s rather than seconds, and it looks like a separate question about publication semantics on the post-supersede cycle (`finalize_partial_scan_cycle` advances the cycle counter but does not publish the observational snapshot, even though the admin path explicitly tolerates a raced snapshot). I did not touch it because it needs a decision from whoever owns #5742's design; details are in #5806 so it does not get lost.

## Verification

- `cargo test -p rustfs-scanner --lib` — 444 passed; the three superseded-backoff tests were updated to the new schedule (growth sequence, cap-and-reset, and the shorter-configured-cycle floor)
- `make pre-commit` — green
- End-to-end probe above, run twice per build