### PR TITLE
test(e2e): align backpressure assertion with recovery

### DIFF
--- a/crates/e2e_test/src/inline_fast_path_cluster_test.rs
+++ b/crates/e2e_test/src/inline_fast_path_cluster_test.rs
@@ -2211,11 +2211,6 @@ async fn four_node_manual_transition_distributed_admission_conflict_reports_stat
             "queue_snapshot.{field} must be readable in terminal status: {terminal}"
         );
     }
-    assert!(
-        cold_tier_object_count(&cold_client).await? < 64,
-        "queue pressure should leave at least one object untransitioned"
-    );
-
     Ok(())
 }
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Remove the final cold-tier object-count assertion from the distributed transition backpressure E2E test.
- Keep the terminal status, failure reason, queue snapshot, and `skipped_queue_full` assertions that directly verify admission backpressure.
- Align the test with durable recovery semantics, where queue-full work may be restored and completed before the final cold-tier count is observed.

## Verification

- `git diff --check`
- Tests not run because this is a test-only change, as requested.

## Impact

No production behavior, API, configuration, or compatibility impact. The E2E assertion now validates the stable backpressure contract without depending on eventual recovery timing.

## Additional Notes

N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
