### PR TITLE
perf(utils): avoid metadata key lowercase allocation

### DIFF
--- a/crates/utils/src/http/header_compat.rs
+++ b/crates/utils/src/http/header_compat.rs
@@ -48,6 +48,13 @@ pub const SUFFIX_REPLICATION_SSEC_CRC: &str = "replication-ssec-crc";
 /// Returns true if the key is object-encryption metadata understood by RustFS or MinIO.
 /// Case-insensitive for metadata filtering.
 pub fn is_encryption_metadata_key(key: &str) -> bool {
+    if key.is_ascii() {
+        return super::starts_with_ignore_ascii_case(key, RUSTFS_ENCRYPTION_PREFIX)
+            || super::starts_with_ignore_ascii_case(key, MINIO_ENCRYPTION_PREFIX)
+            || super::starts_with_ignore_ascii_case(key, MINIO_INTERNAL_ENCRYPTION_PREFIX)
+            || key.eq_ignore_ascii_case(MINIO_INTERNAL_ENCRYPTED_MULTIPART);
+    }
+
     let lower = key.to_lowercase();
     lower.starts_with(RUSTFS_ENCRYPTION_PREFIX)
         || lower.starts_with(MINIO_ENCRYPTION_PREFIX)
@@ -151,7 +158,9 @@ mod tests {
         assert!(is_encryption_metadata_key("x-minio-encryption-iv"));
         assert!(is_encryption_metadata_key("X-Minio-Internal-Server-Side-Encryption-Sealed-Key"));
         assert!(is_encryption_metadata_key("X-Minio-Internal-Encrypted-Multipart"));
+        assert!(is_encryption_metadata_key("X-RUSTFS-ENCRYPTION-\u{212A}EY"));
         assert!(!is_encryption_metadata_key("x-amz-meta-custom"));
+        assert!(!is_encryption_metadata_key("x-minio-internal-encrypted-multipart-extra"));
         assert!(!is_encryption_metadata_key("x-rustfs-internal-healing"));
     }
 


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#1647

## Summary of Changes
Avoid allocating a lowercase `String` for ASCII encryption metadata keys in `is_encryption_metadata_key`.

The hot path now uses the existing allocation-free ASCII case-insensitive prefix helper and `eq_ignore_ascii_case` for the normal HTTP metadata-key path. Non-ASCII keys keep the previous `to_lowercase` fallback so the matching behavior remains compatible with the old implementation.

## Verification
- `cargo test -p rustfs-utils --features http header_compat::tests::test_is_encryption_metadata_key`
- `cargo test -p rustfs-utils --features full http::header_compat::tests`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs-utils --features full --all-targets -- -D warnings`
- `git diff --check`

## Impact
No API, config, wire-format, or deployment impact is expected. The change only removes a per-key allocation on the common ASCII metadata-key path.

## Additional Notes
`cargo clippy -p rustfs-utils --features http --all-targets -- -D warnings` fails on the existing `hash_hotpath_benchmark` target because that bench imports `HashAlgorithm`, which is only available with the `hash`/`full` feature set. The `full` feature all-targets clippy run above passed.

Adversarial validation summary:
- Correctness: attacked ASCII mixed-case prefix/equality matching and non-ASCII fallback compatibility; no break found.
- Simplicity: attacked smaller diff and helper reuse; no new helper was added, and the existing `starts_with_ignore_ascii_case` helper is reused.
- Security/compatibility: attacked encryption metadata filtering semantics; non-ASCII fallback preserves the previous lowercase behavior.
- Performance: attacked added hot-path allocations, clones, locks, IO, and logging; the diff removes one allocation path and adds none of those costs.
- Test coverage: the updated test covers mixed-case ASCII, non-ASCII fallback, and exact encrypted-multipart equality vs suffix false-positive.
