### PR TITLE
perf(ecstore): cache modern erasure codec construction

### DIFF
--- a/crates/ecstore/src/erasure/coding/erasure.rs
+++ b/crates/ecstore/src/erasure/coding/erasure.rs
@@ -20,12 +20,21 @@ use bytes::{Bytes, BytesMut};
 use reed_solomon_erasure::galois_8::ReedSolomon;
 use reed_solomon_simd;
 use smallvec::SmallVec;
-use std::io;
+use std::{
+    collections::HashMap,
+    io,
+    sync::{Arc, OnceLock, RwLock},
+};
 use tokio::io::AsyncRead;
 use tracing::warn;
 use uuid::Uuid;
 
 const MODERN_MAX_TOTAL_SHARDS: usize = <reed_solomon_erasure::galois_8::Field as reed_solomon_erasure::Field>::ORDER;
+const MODERN_REED_SOLOMON_CACHE_MAX_ENTRIES: usize = 64;
+
+type ModernReedSolomonCache = RwLock<HashMap<(usize, usize), Arc<ReedSolomon>>>;
+
+static MODERN_REED_SOLOMON_CACHE: OnceLock<ModernReedSolomonCache> = OnceLock::new();
 
 /// Errors returned when constructing an [`Erasure`] codec.
 #[derive(Debug, thiserror::Error)]
@@ -275,7 +284,7 @@ impl LegacyReedSolomonEncoder {
 pub struct ReedSolomonEncoder {
     data_shards: usize,
     parity_shards: usize,
-    encoder: Option<ReedSolomon>,
+    encoder: Option<Arc<ReedSolomon>>,
 }
 
 impl Clone for ReedSolomonEncoder {
@@ -291,7 +300,7 @@ impl Clone for ReedSolomonEncoder {
 impl ReedSolomonEncoder {
     fn try_new_typed(data_shards: usize, parity_shards: usize) -> Result<Self, reed_solomon_erasure::Error> {
         let encoder = if parity_shards > 0 {
-            Some(ReedSolomon::new(data_shards, parity_shards)?)
+            Some(cached_modern_reed_solomon(data_shards, parity_shards)?)
         } else {
             None
         };
@@ -360,6 +369,30 @@ impl ReedSolomonEncoder {
     fn encode_parity(&self, shards: &mut [Option<Vec<u8>>]) -> io::Result<()> {
         encode_parity_shards(shards, self.data_shards, self.parity_shards, |shards| self.encode(shards))
     }
+}
+
+fn cached_modern_reed_solomon(data_shards: usize, parity_shards: usize) -> Result<Arc<ReedSolomon>, reed_solomon_erasure::Error> {
+    let key = (data_shards, parity_shards);
+    let cache = MODERN_REED_SOLOMON_CACHE.get_or_init(|| RwLock::new(HashMap::new()));
+
+    if let Some(encoder) = cache
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&key)
+        .cloned()
+    {
+        return Ok(encoder);
+    }
+
+    let encoder = Arc::new(ReedSolomon::new(data_shards, parity_shards)?);
+    let mut cache = cache.write().unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(existing) = cache.get(&key) {
+        return Ok(Arc::clone(existing));
+    }
+    if cache.len() < MODERN_REED_SOLOMON_CACHE_MAX_ENTRIES {
+        cache.insert(key, Arc::clone(&encoder));
+    }
+    Ok(encoder)
 }
 
 fn encode_parity_shards<F>(shards: &mut [Option<Vec<u8>>], data_shards: usize, parity_shards: usize, encode: F) -> io::Result<()>
@@ -1270,6 +1303,16 @@ mod tests {
         let legacy = Erasure::try_new_with_options(4, 2, 64, true).expect("legacy codec should construct");
         assert!(legacy.encoder.is_none());
         assert!(legacy.legacy_encoder.is_some());
+    }
+
+    #[test]
+    fn modern_encoder_construction_reuses_cached_codec() {
+        let first = ReedSolomonEncoder::try_new_typed(31, 7).expect("modern codec should construct");
+        let second = ReedSolomonEncoder::try_new_typed(31, 7).expect("modern codec should construct");
+
+        let first = first.encoder.as_ref().expect("modern codec should initialize an encoder");
+        let second = second.encoder.as_ref().expect("modern codec should initialize an encoder");
+        assert!(Arc::ptr_eq(first, second));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#1647

## Summary of Changes
Cache modern Reed-Solomon codec construction for repeated erasure layouts.

The 1 MiB GET profiles in rustfs/backlog#1647 showed `available_parallelism -> resolve_runtime_parallel_policy_cache -> ReedSolomon::with_options` in the erasure construction path. RustFS constructs `Erasure` from object `FileInfo` on GET/read paths, so repeated objects with the same `(data_shards, parity_shards)` layout were repeatedly constructing the underlying modern codec and its runtime policy cache.

This change stores modern `ReedSolomon` instances behind `Arc` and reuses them through a small process-wide bounded cache keyed by `(data_shards, parity_shards)`. The cache is capped at 64 entries; if unusual or corrupt metadata exceeds that diversity, RustFS simply falls back to constructing the codec without caching the new layout. Legacy SIMD codecs are intentionally left per-instance because their encoder/decoder caches are mutable and protected by per-instance locks.

## Verification
- `cargo test -p rustfs-ecstore erasure::coding::erasure::tests::modern_encoder_construction_reuses_cached_codec`
- `cargo test -p rustfs-ecstore erasure::coding::erasure::tests:: --lib`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings`
- `cargo check -p rustfs-ecstore --all-targets`
- `git diff --check`

## Impact
No API, wire-format, configuration, or deployment changes are expected. The effective parallel policy for a modern erasure layout becomes a first-use process-level cache entry instead of being recomputed on every codec construction for the same layout.

## Additional Notes
Adversarial validation summary:
- Correctness: attacked zero-parity, modern, legacy, encode/decode, reconstruct, and verify paths through the existing erasure module tests; no break found.
- Simplicity: kept the change local to the RustFS wrapper, without touching the dependency crate or GET call sites.
- Security/compatibility: bounded the cache at 64 entries so corrupt metadata cannot grow it unbounded; legacy behavior remains per-instance.
- Concurrency/durability: the cache uses `RwLock` only around lookup/insert and does not hold locks across IO or await points; no durability path changes.
- Performance: removes repeated modern codec/policy construction for common object layouts, at the cost of one short cache lookup during construction.
- Test coverage: added a test that fails if identical modern layouts stop reusing the cached codec instance.
