### PR TITLE
fix(ecstore): raise replay cache auto capacity

### DIFF
--- a/crates/ecstore/src/cluster/rpc/http_auth.rs
+++ b/crates/ecstore/src/cluster/rpc/http_auth.rs
@@ -77,9 +77,9 @@ const SIGNATURE_VALID_DURATION: i64 = 300; // 5 minutes
 const REPLAY_CACHE_RETENTION: Duration = Duration::from_secs(601);
 const REPLAY_CACHE_RETENTION_SECS: usize = 601;
 const REPLAY_CACHE_ENTRY_BYTES_ESTIMATE: u64 = 128;
-const REPLAY_CACHE_AUTO_MEMORY_PERCENT: u64 = 4;
-const REPLAY_CACHE_AUTO_RPC_RPS_PER_CPU: usize = 1024;
-const REPLAY_CACHE_AUTO_MAX_CAPACITY: usize = 8_388_608;
+const REPLAY_CACHE_AUTO_MEMORY_PERCENT: u64 = 8;
+const REPLAY_CACHE_AUTO_RPC_RPS_PER_CPU: usize = 2048;
+const REPLAY_CACHE_AUTO_MAX_CAPACITY: usize = 16_777_216;
 const NS_SCANNER_CAPABILITY_AUTH_DOMAIN: &[u8] = b"rustfs-ns-scanner-capability-v3";
 pub const TONIC_RPC_PREFIX: &str = "/node_service.NodeService";
 static INTERNODE_RPC_SIGNATURE_STRICT: LazyLock<bool> = LazyLock::new(|| {
@@ -2301,9 +2301,21 @@ mod tests {
 
         assert_eq!(decision.source, ReplayCacheCapacitySource::Auto);
         assert_eq!(decision.memory_basis, Some(MemoryBasis::Host));
-        assert_eq!(decision.memory_based_capacity, 5_368_709);
-        assert_eq!(decision.cpu_based_capacity, 4_923_392);
-        assert_eq!(decision.capacity, 4_923_392);
+        assert_eq!(decision.memory_based_capacity, 10_737_418);
+        assert_eq!(decision.cpu_based_capacity, 9_846_784);
+        assert_eq!(decision.capacity, 9_846_784);
+    }
+
+    #[test]
+    fn replay_cache_capacity_auto_reaches_hotpath_verified_capacity_on_larger_nodes() {
+        let gib = 1024_u64 * 1024 * 1024;
+        let decision =
+            replay_cache_capacity_decision(rustfs_utils::EnvParseOutcome::Absent, 16, Some(32 * gib), Some(MemoryBasis::Host));
+
+        assert_eq!(decision.source, ReplayCacheCapacitySource::Auto);
+        assert_eq!(decision.memory_based_capacity, 21_474_836);
+        assert_eq!(decision.cpu_based_capacity, 19_693_568);
+        assert_eq!(decision.capacity, 16_777_216);
     }
 
     #[test]
@@ -2325,7 +2337,7 @@ mod tests {
         let decision = replay_cache_capacity_decision(rustfs_utils::EnvParseOutcome::Invalid, 8, None, None);
 
         assert_eq!(decision.source, ReplayCacheCapacitySource::AutoInvalidEnv);
-        assert_eq!(decision.capacity, 4_923_392);
+        assert_eq!(decision.capacity, 9_846_784);
     }
 
     fn check_test_nonce_record(cache: &mut RpcNonceCache, record: RpcNonceRecord<'_>) -> std::io::Result<()> {


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1647

## Summary of Changes
Increase the internode RPC replay cache auto-sizing model so resource-aware capacity can reach 16,777,216 entries on larger nodes when `RUSTFS_INTERNODE_RPC_REPLAY_CACHE_CAPACITY` is not explicitly set.

This keeps explicit operator values authoritative, preserves the existing default floor for very small nodes, and does not change signature verification, nonce insertion, overflow handling, or fail-closed replay protection.

The change is motivated by the 4-node 1MiB GET hotpath validation recorded in rustfs/backlog#1647: 8,388,608 entries reached capacity pressure and produced `replay_cache_capacity` auth failures plus long-tail/corruption symptoms, while 16,777,216 entries kept the same workload at roughly 48% cache waterline with zero replay overflows and zero auth failures.

Adversarial validation summary for this high-risk auth/network path:
- Correctness: attacked env parsed/absent/invalid branches, small-node floor, and larger-node auto sizing; no fail-open path or zero-capacity outcome introduced.
- Simplicity: attacked the diff for unnecessary helper/control-flow changes; the final change is an in-place constant/test update only.
- Security: attacked replay protection semantics; HMAC binding, nonce recording, duplicate rejection, and capacity overflow still fail closed and are unchanged.
- Concurrency/durability: attacked lock/await/disk mutation surface; no lock, await, IO, or durability behavior changed.
- Compatibility: attacked wire/on-disk/API surface; no protocol fields, serialized formats, or env names changed.
- Performance: attacked hot-path allocations/logging; no per-request work is added, but the automatic cache headroom increases memory budget on sufficiently sized nodes.
- Test coverage: the capacity sizing claims are covered by focused `replay_cache_capacity_*` unit tests, including a 16 CPU / 32 GiB larger-node case.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore replay_cache_capacity --lib`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `make pre-commit`

## Impact
When the replay cache capacity env var is absent or invalid, larger nodes may now auto-size up to 16,777,216 entries instead of being capped at 8,388,608. Operators can still set `RUSTFS_INTERNODE_RPC_REPLAY_CACHE_CAPACITY` explicitly; values below the default floor are still clamped upward.

No API, wire-format, on-disk-format, or mixed-version compatibility changes are expected.

## Additional Notes
The related field validation showed 16,777,216 entries did not produce an obvious RSS explosion on the tested 4-node environment, while it eliminated the observed replay capacity overflow and `replay_cache_capacity` auth failures for the 1MiB GET long run.
