### PR TITLE
chore(release): bump version to 1.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,7 +3744,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9161,7 +9161,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "const-str",
@@ -9184,7 +9184,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9200,7 +9200,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "chrono",
  "hotpath",
@@ -9218,7 +9218,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "hotpath",
  "insta",
@@ -9231,7 +9231,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "const-str",
  "hotpath",
@@ -9241,7 +9241,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9255,7 +9255,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9276,7 +9276,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -9287,7 +9287,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -9425,7 +9425,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "hotpath",
  "serde",
@@ -9435,7 +9435,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9462,7 +9462,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -9493,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9531,7 +9531,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "bytes",
  "hotpath",
@@ -9544,7 +9544,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "criterion",
  "hotpath",
@@ -9610,7 +9610,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "bytes",
  "futures",
@@ -9637,7 +9637,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9685,7 +9685,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -9708,7 +9708,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -9731,7 +9731,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "chrono",
  "flate2",
@@ -9750,7 +9750,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "hotpath",
  "humantime",
@@ -9765,7 +9765,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9800,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "criterion",
  "futures",
@@ -9820,7 +9820,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -9837,7 +9837,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9892,7 +9892,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9923,7 +9923,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -9986,7 +9986,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "flatbuffers",
  "hotpath",
@@ -10010,7 +10010,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "byteorder",
  "bytes",
@@ -10028,7 +10028,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -10066,7 +10066,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "hotpath",
  "rustfs-s3-types",
@@ -10097,7 +10097,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "hotpath",
  "serde",
@@ -10106,7 +10106,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10135,7 +10135,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10153,7 +10153,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10193,7 +10193,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "hotpath",
  "thiserror 2.0.19",
@@ -10201,7 +10201,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10219,7 +10219,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10288,7 +10288,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "hotpath",
  "rustfs-data-usage",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "hotpath",
@@ -10325,7 +10325,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -10362,7 +10362,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10404,7 +10404,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.97.1"
-version = "1.0.0-beta.12"
+version = "1.0.0-rc.1"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -86,52 +86,52 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-beta.12" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-beta.12" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-beta.12" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-beta.12" }
-rustfs-common = { path = "crates/common", version = "1.0.0-beta.12" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-beta.12" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-beta.12" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-beta.12" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-beta.12" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-beta.12" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-beta.12" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-beta.12" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-beta.12" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-beta.12" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-beta.12" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-beta.12" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-beta.12" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-beta.12" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-beta.12" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-beta.12" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-beta.12" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-beta.12" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-beta.12", default-features = false }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-beta.12" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-beta.12" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-beta.12" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-beta.12" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-beta.12" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-beta.12" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-beta.12" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-beta.12" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-beta.12" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-beta.12" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-beta.12" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-beta.12" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-beta.12" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-beta.12" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-beta.12" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-beta.12" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-beta.12" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-beta.12" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-beta.12" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-beta.12" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-beta.12" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-beta.12" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-beta.12" }
+rustfs = { path = "./rustfs", version = "1.0.0-rc.1" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.1" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.1" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.1" }
+rustfs-common = { path = "crates/common", version = "1.0.0-rc.1" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.1" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-rc.1" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.1" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.1" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.1" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.1" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.1" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.1" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.1" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.1" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.1" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.1" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.1" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.1" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.1" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.1" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.1" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.1", default-features = false }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.1" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.1" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.1" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.1" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.1" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.1" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.1" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.1" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.1" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.1" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.1" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.1" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.1" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.1" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.1" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.1" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.1" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.1" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.1" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.1" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.1" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.1" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.1" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.12
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.1
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-beta.12
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.1
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-beta.12";
+            version = "1.0.0-rc.1";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "0.12.0"
-appVersion: "1.0.0-beta.12"
+version: "1.0.0-rc.1"
+appVersion: "1.0.0-rc.1"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease beta.12
+%global prerelease rc.1
 Name:           rustfs
 Version:        1.0.0
-Release:        beta.12
+Release:        rc.1
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Sat Aug 08 2026 overtrue <anzhengchao@gmail.com>
+- Update RPM package to RustFS 1.0.0-rc.1
+
 * Thu Jul 30 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-beta.12
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Promote the release channel from `1.0.0-beta.12` to `1.0.0-rc.1`. This is a version-only change: no product code is touched.

- `Cargo.toml` / `Cargo.lock`: workspace package version and every internal workspace dependency requirement.
- `README.md` / `README_ZH.md`: versioned Docker run example.
- `flake.nix`: package version.
- `helm/rustfs/Chart.yaml`: `appVersion` and chart `version`.
- `rustfs.spec`: `%global prerelease`, `Release`, and a new changelog entry.

The Helm chart `version` moves to `1.0.0-rc.1` rather than continuing the `0.N.0` sequence. The existing `beta.N -> 0.N.0` mapping in `scripts/helm_chart_version.sh` only special-cases `-beta.N`; every other tag falls through to `chart_version = app_version`. So for an rc tag the workflow already derives `1.0.0-rc.1`, and pinning the same value in `Chart.yaml` keeps the committed chart consistent with what CI publishes. Chart version ordering stays monotonic (`0.12.0 < 1.0.0-rc.1`) and lines the chart up to reach `1.0.0` at the stable release.

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `make pre-commit` — passed

## Impact

Release/packaging only. Docker documentation tags, the Helm chart, and the RPM spec all advertise `1.0.0-rc.1` after this lands. No runtime, API, on-disk format, or configuration behavior changes.

## Additional Notes

This is the version-bump step of the preview-validated release pipeline. After merge, `1.0.0-rc.1-preview.1` is tagged on the resulting main commit for validation, and the final `1.0.0-rc.1` tag is published on that exact same commit.
