### PR TITLE
perf(filemeta): reduce meta object key allocations

### DIFF
--- a/crates/filemeta/src/filemeta/version.rs
+++ b/crates/filemeta/src/filemeta/version.rs
@@ -93,6 +93,8 @@ fn read_msgp_bin<R: std::io::Read>(rd: &mut R) -> Result<Vec<u8>> {
     read_exact_vec(rd, len)
 }
 
+const MSGP_OBJECT_KEY_STACK_CAP: usize = 16;
+
 /// Writes an `OffsetDateTime` as the ext8 / legacy (type 5, 12-byte
 /// seconds+nanos) msgpack time encoding used by the V1 (Legacy) object body.
 /// `read_msgp_time` decodes exactly this shape via `MSGPACK_TIME_EXT_LEGACY`.
@@ -2060,16 +2062,33 @@ impl MetaObject {
                 tracing::error!(error = %e, "decode_from: read_str_len key failed");
                 e
             })?;
-            let key_buf = read_exact_vec(rd, key_len as usize).map_err(|e| {
-                tracing::error!(error = %e, "decode_from: read key_buf failed");
-                e
-            })?;
-            let key = String::from_utf8(key_buf).map_err(|e| {
-                tracing::error!(error = %e, "decode_from: from_utf8 key failed");
-                e
+            let key_len = usize::try_from(key_len).map_err(|e| {
+                tracing::error!(error = %e, "decode_from: key length conversion failed");
+                Error::other(e)
             })?;
 
-            match key.as_str() {
+            let mut inline_key = [0u8; MSGP_OBJECT_KEY_STACK_CAP];
+            let heap_key;
+            let key_buf = if key_len <= MSGP_OBJECT_KEY_STACK_CAP {
+                rd.read_exact(&mut inline_key[..key_len]).map_err(|e| {
+                    tracing::error!(error = %e, "decode_from: read key_buf failed");
+                    Error::from(e)
+                })?;
+                &inline_key[..key_len]
+            } else {
+                heap_key = read_exact_vec(rd, key_len).map_err(|e| {
+                    tracing::error!(error = %e, "decode_from: read key_buf failed");
+                    e
+                })?;
+                heap_key.as_slice()
+            };
+
+            let key = std::str::from_utf8(key_buf).map_err(|e| {
+                tracing::error!(error = %e, "decode_from: from_utf8 key failed");
+                Error::FromUtf8(e.to_string())
+            })?;
+
+            match key {
                 "ID" => {
                     let _ = rmp::decode::read_bin_len(rd).map_err(|e| {
                         tracing::error!(error = %e, "decode_from: read_bin_len ID failed");
@@ -2285,6 +2304,7 @@ impl MetaObject {
                         Some(n) => n,
                     };
                     self.meta_sys.clear();
+                    self.meta_sys.reserve(prealloc_hint(len));
                     for _ in 0..len {
                         let k_len = rmp::decode::read_str_len(rd).map_err(|e| {
                             tracing::error!(error = %e, "decode_from: read_str_len MetaSys key failed");
@@ -2323,6 +2343,7 @@ impl MetaObject {
                         Some(n) => n,
                     };
                     self.meta_user.clear();
+                    self.meta_user.reserve(prealloc_hint(len));
                     for _ in 0..len {
                         let k_len = rmp::decode::read_str_len(rd).map_err(|e| {
                             tracing::error!(error = %e, "decode_from: read_str_len MetaUsr key failed");
@@ -4822,6 +4843,46 @@ mod tests {
             meta_user: HashMap::from([("content-type".to_string(), "text/plain".to_string())]),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn meta_object_decode_round_trips_stack_sized_keys() {
+        let object = signed_object();
+        let encoded = object.marshal_msg().expect("object marshal should succeed");
+
+        let mut decoded = MetaObject::default();
+        decoded
+            .decode_from(&mut std::io::Cursor::new(&encoded))
+            .expect("object decode should succeed");
+
+        assert_eq!(decoded, object);
+    }
+
+    #[test]
+    fn meta_object_decode_skips_unknown_valid_utf8_field() {
+        let mut encoded = Vec::new();
+        rmp::encode::write_map_len(&mut encoded, 1).expect("map header should encode");
+        rmp::encode::write_str(&mut encoded, "UnknownFutureField").expect("field key should encode");
+        rmp::encode::write_nil(&mut encoded).expect("nil payload should encode");
+
+        let mut decoded = MetaObject::default();
+        decoded
+            .decode_from(&mut std::io::Cursor::new(&encoded))
+            .expect("unknown valid UTF-8 field should be skipped");
+
+        assert_eq!(decoded, MetaObject::default());
+    }
+
+    #[test]
+    fn meta_object_decode_rejects_invalid_utf8_field_name() {
+        let encoded = [0x81, 0xa1, 0xff, 0xc0];
+        let mut decoded = MetaObject::default();
+
+        let err = decoded
+            .decode_from(&mut std::io::Cursor::new(encoded))
+            .expect_err("invalid UTF-8 field name should fail");
+
+        assert!(matches!(err, Error::FromUtf8(_)), "unexpected error: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Relates to rustfs/backlog#1647.

## Summary of Changes
Reduce per-object heap allocation in the `MetaObject::decode_from` hot path observed in the 1MiB GET profiling run. Known short MessagePack field names are now read into a stack buffer and matched as `&str` instead of allocating a `Vec<u8>` and converting it into a `String` for every object metadata field.

The fallback for longer field names still uses the bounded `read_exact_vec` path, so corrupt length prefixes continue to fail closed. Unknown valid UTF-8 fields are still skipped for forward compatibility, and invalid UTF-8 field names still fail with `Error::FromUtf8`.

`MetaSys` and `MetaUsr` now reserve map capacity from the decoded map length using the existing `prealloc_hint` guard, reducing growth reallocations while preserving the existing corrupted-count allocation cap.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-filemeta meta_object_decode_ --lib`
- `cargo test -p rustfs-filemeta --lib`
- `cargo clippy -p rustfs-filemeta --lib --tests -- -D warnings`
- `git diff --check`
- `make pre-commit`

## Impact
This is an internal metadata decode hot-path optimization. It does not change xl.meta encoding, on-disk format, wire format, public API, deployment configuration, or compatibility behavior.

Expected runtime impact is lower allocation pressure during object metadata decode, especially on GET workloads where `MetaObject::decode_from` appeared in the `mi_malloc_aligned` profile stack. This PR does not claim end-to-end performance improvement until CI passes and a follow-up four-node profiling validation is run.

## Additional Notes
Adversarial validation summary:
- Correctness: attacked round-trip decode, unknown-field skip, invalid UTF-8 field names, and long-key fallback; no break found.
- Simplicity: removed the one-caller helper version and kept the change inline in the existing decode flow; no smaller equivalent found that preserves bounded long-key handling and error classification.
- Security: preserved corrupt length bound via `read_exact_vec`, fail-closed invalid UTF-8 handling, and unknown-field skip semantics; no auth or secret-handling paths touched.
- Concurrency/durability: no locks, async awaits, disk writes, fsync, or persistence ordering changed.
- Compatibility: no serialized field names or formats changed; existing real MinIO/xl.meta compatibility tests pass.
- Performance: removes heap allocation for short known object metadata field names and preallocates `MetaSys`/`MetaUsr`; no new per-request logging, cloning, or blocking work.
- Test coverage: added tests for stack-sized key round trip, unknown valid UTF-8 field skip, and invalid UTF-8 field rejection with `Error::FromUtf8`.
