### PR TITLE
test(filemeta): cover crc heal classification

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -7391,6 +7391,12 @@ mod tests {
         let (should_heal, _, _) = should_heal_object_on_disk(&err, &[], &meta, &latest_meta);
         assert!(should_heal);
 
+        let err = Some(DiskError::FileCorrupt);
+        let (should_heal, is_meta, reason) = should_heal_object_on_disk(&err, &[], &meta, &latest_meta);
+        assert!(should_heal);
+        assert!(is_meta);
+        assert_eq!(reason, Some(DiskError::FileCorrupt));
+
         // Test with no error and no part errors
         let (should_heal, _, _) = should_heal_object_on_disk(&None, &[CHECK_PART_SUCCESS], &meta, &latest_meta);
         assert!(!should_heal);

--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -1482,6 +1482,17 @@ mod test {
     }
 
     #[test]
+    fn test_is_indexed_meta_reports_file_corrupt_on_crc_mismatch() {
+        let fm = FileMeta::default();
+        let mut buf = fm.marshal_msg().expect("serialize default FileMeta");
+        let idx = 8 + 5;
+        buf[idx] ^= 0xff;
+
+        let err = FileMeta::is_indexed_meta(&buf).expect_err("corrupted indexed metadata must fail");
+        assert_eq!(err, Error::FileCorrupt, "indexed CRC mismatch must classify as FileCorrupt, got: {err}");
+    }
+
+    #[test]
     fn test_unmarshal_rejects_absurd_version_count() {
         let mut meta = Vec::new();
         rmp::encode::write_uint(&mut meta, XL_HEADER_VERSION as u64).unwrap();

--- a/crates/filemeta/src/filemeta.rs
+++ b/crates/filemeta/src/filemeta.rs
@@ -1463,6 +1463,24 @@ mod test {
     /// Regression test for rustfs/rustfs#2715: a corrupted version count in
     /// xl.meta must yield a decode error instead of sizing a huge allocation
     /// from the bogus count (which aborts the whole process).
+    /// A CRC mismatch means the bytes on disk are not the bytes that were
+    /// written — bitrot. It must surface as `Error::FileCorrupt` specifically:
+    /// that variant converts to `DiskError::FileCorrupt`, which is the only
+    /// corruption signal `should_heal_object_on_disk` recognises. As a generic
+    /// error the drive is skipped, the heal reports success, and the damaged
+    /// `xl.meta` is never rewritten.
+    #[test]
+    fn test_unmarshal_reports_file_corrupt_on_crc_mismatch() {
+        let mut fm = FileMeta::default();
+        let mut buf = fm.marshal_msg().expect("serialize default FileMeta");
+        // Flip one byte inside the meta blob: past the 8-byte XL2 header and
+        // the 5-byte bin32 length prefix, before the CRC trailer.
+        let idx = 8 + 5;
+        buf[idx] ^= 0xff;
+        let err = fm.unmarshal_msg(&buf).expect_err("corrupted meta must fail to decode");
+        assert_eq!(err, Error::FileCorrupt, "CRC mismatch must classify as FileCorrupt, got: {err}");
+    }
+
     #[test]
     fn test_unmarshal_rejects_absurd_version_count() {
         let mut meta = Vec::new();

--- a/crates/filemeta/src/filemeta/codec.rs
+++ b/crates/filemeta/src/filemeta/codec.rs
@@ -97,7 +97,20 @@ impl FileMeta {
         let meta_crc = xxh64::xxh64(meta, XXHASH_SEED) as u32;
 
         if crc != meta_crc {
-            return Err(Error::other("xl file crc check failed"));
+            error!(
+                event = "filemeta_xl_crc_mismatch",
+                component = "filemeta",
+                expected_crc = meta_crc,
+                actual_crc = crc,
+                "xl.meta payload failed its CRC check"
+            );
+            // Error::FileCorrupt, not a generic error, for the same reason
+            // check_xl2_v1 classifies a bad magic as FileCorrupt: heal
+            // classification (should_heal_object_on_disk) recognises
+            // corruption only by the DiskError::FileCorrupt variant this
+            // converts to. As a generic error the drive is skipped,
+            // heal_object reports ok, and on-disk bitrot is never repaired.
+            return Err(Error::FileCorrupt);
         }
 
         Ok((meta, inline_data))
@@ -163,8 +176,16 @@ impl FileMeta {
         let meta_crc = xxh64::xxh64(meta, XXHASH_SEED) as u32;
 
         if crc != meta_crc {
-            error!("xl file crc check failed: expected CRC {:#x}, got {:#x}", meta_crc, crc);
-            return Err(Error::other("xl file crc check failed"));
+            error!(
+                event = "filemeta_xl_crc_mismatch",
+                component = "filemeta",
+                expected_crc = meta_crc,
+                actual_crc = crc,
+                "xl.meta payload failed its CRC check"
+            );
+            // See is_indexed_meta: the FileCorrupt variant is what makes heal
+            // classify this drive as needing metadata repair.
+            return Err(Error::FileCorrupt);
         }
 
         if !buf.is_empty() {


### PR DESCRIPTION
## Related Issues
Refs #5837.
Follow-up to #5838.

## Summary of Changes
Adds regression coverage after #5838: `FileMeta::is_indexed_meta` now has a CRC mismatch test asserting `Error::FileCorrupt`, and `should_heal_object_on_disk` now asserts metadata-level `DiskError::FileCorrupt` marks the disk for metadata heal.

The branch has been merged with the latest `origin/main`; the PR diff is now only the focused test coverage.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p rustfs-filemeta file_corrupt_on_crc_mismatch`
- `cargo test -p rustfs-ecstore test_should_heal_object_on_disk`

## Impact
Test-only coverage. No runtime behavior, API, configuration, deployment, or compatibility impact.

## Additional Notes
N/A
