### PR TITLE
fix(rebalance): fence batch delete source pools

### DIFF
--- a/crates/ecstore/src/store/init.rs
+++ b/crates/ecstore/src/store/init.rs
@@ -602,7 +602,7 @@ mod tests {
         error::{Error, Result, StorageError},
         layout::endpoints::{EndpointServerPools, Endpoints, PoolEndpoints},
         object_api::{GetObjectReader, ObjectInfo, ObjectOptions, PutObjReader},
-        services::rebalance::RebalanceMeta,
+        services::rebalance::{RebalStatus, RebalanceInfo, RebalanceMeta, RebalanceStats},
         storage_api_contracts::{
             bucket::{BucketOperations as _, MakeBucketOptions},
             multipart::MultipartOperations as _,
@@ -1153,6 +1153,81 @@ mod tests {
         .expect("store should build around the fresh context");
 
         (instance_ctx, store, shutdown)
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(storage_class_env)]
+    async fn delete_objects_skips_active_rebalance_source_pool() {
+        let temp_dir = tempfile::tempdir().expect("create batch-delete writer-fencing store dir");
+        let (_ctx, store, shutdown) =
+            without_storage_class_env(build_isolated_test_store(temp_dir.path(), "batch-delete-rebalance", &[4, 4])).await;
+        crate::bucket::metadata_sys::init_bucket_metadata_sys(store.clone(), Vec::new()).await;
+
+        let bucket = format!("batch-delete-rebalance-{}", uuid::Uuid::new_v4());
+        let object = "delete-me.bin";
+        store
+            .make_bucket(&bucket, &MakeBucketOptions::default())
+            .await
+            .expect("create batch delete rebalance bucket");
+
+        let mut source_reader = PutObjReader::from_vec(b"source-body".to_vec());
+        store.pools[0]
+            .put_object(&bucket, object, &mut source_reader, &ObjectOptions::default())
+            .await
+            .expect("write object on active source pool");
+        let mut target_reader = PutObjReader::from_vec(b"target-body".to_vec());
+        store.pools[1]
+            .put_object(&bucket, object, &mut target_reader, &ObjectOptions::default())
+            .await
+            .expect("write object on non-rebalancing target pool");
+
+        let mut pool_stats = vec![RebalanceStats::default(); store.pools.len()];
+        pool_stats[0] = RebalanceStats {
+            participating: true,
+            info: RebalanceInfo {
+                start_time: Some(OffsetDateTime::now_utc()),
+                status: RebalStatus::Started,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        *store.rebalance_meta.write().await = Some(RebalanceMeta {
+            id: uuid::Uuid::new_v4().to_string(),
+            pool_stats,
+            ..Default::default()
+        });
+        assert!(store.is_pool_rebalancing(0).await, "pool 0 must be marked as an active rebalance source");
+
+        let (deleted, errs) = store
+            .delete_objects(
+                &bucket,
+                vec![crate::storage_api_contracts::object::ObjectToDelete {
+                    object_name: object.to_string(),
+                    ..Default::default()
+                }],
+                ObjectOptions::default(),
+            )
+            .await;
+        assert!(matches!(errs.as_slice(), [None]), "batch delete must not fail: {errs:?}");
+        assert!(
+            matches!(deleted.as_slice(), [deleted] if deleted.found && deleted.object_name == object),
+            "batch delete must report the non-rebalancing pool deletion"
+        );
+
+        store.pools[0]
+            .get_object_info(&bucket, object, &ObjectOptions::default())
+            .await
+            .expect("active source pool object must not be deleted by DeleteObjects");
+        let target_err = store.pools[1]
+            .get_object_info(&bucket, object, &ObjectOptions::default())
+            .await
+            .expect_err("non-rebalancing target pool object must be deleted");
+        assert!(
+            matches!(target_err, StorageError::ObjectNotFound(_, _)),
+            "target pool should report object not found after DeleteObjects, got {target_err:?}"
+        );
+
+        shutdown.cancel();
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/store/object.rs
+++ b/crates/ecstore/src/store/object.rs
@@ -1923,6 +1923,9 @@ impl ECStore {
         let mut futures = Vec::with_capacity(self.pools.len());
 
         for pool in self.pools.iter() {
+            if self.is_pool_rebalancing(pool.pool_idx).await {
+                continue;
+            }
             futures.push(pool.delete_objects(bucket, objects.clone(), opts.clone()));
         }
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Skip active rebalance source pools before ECStore fans out `DeleteObjects` to set pools.
- Add a regression that writes the same key to an active source pool and a non-rebalancing target pool, then verifies batch delete preserves the source copy while deleting the target copy.
- Keep the fence at the ECStore layer so S3, internal, and tier-journal batch delete callers share the same protection without adding per-object pre-stat fanout.

## Verification
- `cargo fmt --all --check` — passed.
- `git diff --check` — passed.
- `cargo test -p rustfs-ecstore --lib delete_objects_skips_active_rebalance_source_pool -- --nocapture` — passed.
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` — passed.
- `make pre-pr` — repository guards, workspace clippy, script tests, and `cargo-nextest nextest run --all --exclude e2e_test` passed with 12797 passed and 165 skipped; doctest compilation was intentionally interrupted after nextest per maintainer direction.

## Impact
Safer `DeleteObjects` behavior while rebalance is active: batch deletes no longer delete from a pool that is currently an active rebalance source. There is no S3 API, CLI, console, wire-format, on-disk-format, configuration, or migration impact.

## Additional Notes
High-risk adversarial review verdicts:
- Correctness: Attacked active-source deletion where the same key exists on source and target; the new regression proves `DeleteObjects` deletes only the non-rebalancing pool and preserves the active source copy.
- Simplicity: Minimal one-branch store-layer fan-out filter; removed a one-caller helper after review; no per-object pre-stat or pool remapping.
- Security: No auth, path parsing, secret, or deserialization changes; the diff reduces destructive reach into active source pools.
- Concurrency/durability: No new locks and no commit-order or fsync changes; filtering occurs after existing batch write locks and before set-layer destructive work.
- Compatibility: No S3/API/wire/on-disk/CLI/console changes; behavior only fences active rebalance sources during `DeleteObjects`.
- Performance: One existing rebalance-state check per pool, not per object; avoids serial per-key stat fanout and adds no logging or fsync.
- Test coverage: The new regression fails if the filter is reverted; full nextest also covers existing `DeleteObjects` object-lock and batch semantics.
