### PR TITLE
fix: isolate ssh stdin in hotpath artifact collection

### DIFF
--- a/scripts/collect_remote_samply_artifacts.sh
+++ b/scripts/collect_remote_samply_artifacts.sh
@@ -89,7 +89,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
 
   quoted_remote_dir=$(shell_quote "$remote_dir")
   remote_cmd="chmod -R a+rX $quoted_remote_dir; find $quoted_remote_dir -maxdepth 1 -type f -printf '%f %s bytes\n'"
-  "$SSH_BIN" "$node" "sudo su - root -c $(shell_quote "$remote_cmd")" >"$OUT_DIR/${node}-files.txt" 2>&1
+  "$SSH_BIN" "$node" "sudo su - root -c $(shell_quote "$remote_cmd")" >"$OUT_DIR/${node}-files.txt" 2>&1 </dev/null
   "$SCP_BIN" -q -r "$node:${remote_dir%/}/"* "$node_out_dir/" </dev/null 2>"$OUT_DIR/${node}-scp.err"
   processed=$((processed + 1))
 done <"$MAPPING"

--- a/scripts/test_collect_remote_samply_artifacts.sh
+++ b/scripts/test_collect_remote_samply_artifacts.sh
@@ -11,6 +11,10 @@ mkdir -p "$mock_bin"
 cat >"$mock_bin/ssh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if read -r consumed; then
+  printf 'ssh-consumed-stdin:%s\n' "$consumed" >>"$CALL_LOG"
+  exit 24
+fi
 printf 'ssh:%s\n' "$*" >>"$CALL_LOG"
 echo "profile.json.gz 128 bytes"
 echo "profile.syms.json 64 bytes"
@@ -47,7 +51,12 @@ output=$("$repo_root/scripts/collect_remote_samply_artifacts.sh" \
 [[ "$output" == "collected_nodes=2" ]]
 [[ -f "$tmp_dir/out/vm004/copied-profile.json.gz" ]]
 [[ -f "$tmp_dir/out/vm005/copied-profile.json.gz" ]]
+[[ "$(grep -c '^ssh:' "$CALL_LOG")" -eq 2 ]]
 [[ "$(grep -c '^scp:' "$CALL_LOG")" -eq 2 ]]
+if grep -q '^ssh-consumed-stdin:' "$CALL_LOG"; then
+  echo "ssh consumed the mapping loop stdin" >&2
+  exit 1
+fi
 if grep -q '^scp-consumed-stdin:' "$CALL_LOG"; then
   echo "scp consumed the mapping loop stdin" >&2
   exit 1


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1647.

## Summary of Changes
- Redirect the metadata-listing `ssh` call in `collect_remote_samply_artifacts.sh` from `/dev/null`, matching the existing `scp` stdin isolation.
- Extend the shell regression test so the mocked `ssh` command attempts to read stdin and fails if it can consume the mapping loop input.

## Verification
- `shellcheck scripts/collect_remote_samply_artifacts.sh scripts/test_collect_remote_samply_artifacts.sh`
- `bash scripts/test_collect_remote_samply_artifacts.sh`
- `git diff --check`
- `cargo fmt --all --check`

## Impact
Operational tooling only. This prevents multi-node artifact collection from stopping after the first mapping row when `ssh` consumes stdin. RustFS runtime behavior, storage formats, APIs, and configuration are unchanged.

## Additional Notes
Found during the follow-up 4-node HotPath validation after PR #5848: `scp` stdin was isolated, but the preceding `ssh` call could still consume the mapping file.
