### PR TITLE
fix(ecstore): honor scoped object heal placement

### DIFF
--- a/crates/ecstore/src/core/sets.rs
+++ b/crates/ecstore/src/core/sets.rs
@@ -286,6 +286,23 @@ impl Sets {
         self.get_disks(self.get_hashed_set_index(key))
     }
 
+    fn get_heal_object_disks(&self, object: &str, opts: &HealOpts) -> Result<Arc<SetDisks>> {
+        if let Some(set_idx) = opts.set {
+            return self.disk_set.get(set_idx).cloned().ok_or_else(|| {
+                Error::InvalidArgument(
+                    "heal".to_string(),
+                    "scope".to_string(),
+                    format!(
+                        "invalid object heal set index {set_idx} for pool {} with {} sets",
+                        self.pool_idx, self.set_count
+                    ),
+                )
+            });
+        }
+
+        Ok(self.get_disks_by_key(object))
+    }
+
     pub(crate) async fn storage_info_snapshot(&self) -> rustfs_madmin::StorageInfo {
         let mut futures = Vec::with_capacity(self.disk_set.len());
 
@@ -1101,7 +1118,7 @@ impl crate::storage_api_contracts::heal::HealOperations for Sets {
         version_id: &str,
         opts: &HealOpts,
     ) -> Result<(HealResultItem, Option<Error>)> {
-        self.get_disks_by_key(object)
+        self.get_heal_object_disks(object, opts)?
             .heal_object(bucket, object, version_id, opts)
             .await
     }
@@ -1429,6 +1446,44 @@ mod tests {
             ctx: bootstrap_ctx(),
         });
         (temp_dirs, sets)
+    }
+
+    #[tokio::test]
+    async fn heal_object_uses_requested_set_instead_of_object_hash() {
+        let (_temp_dirs, sets) = two_set_test_sets().await;
+        let object = (0..100)
+            .map(|idx| format!("hashes-to-set-zero-{idx}"))
+            .find(|object| sets.get_hashed_set_index(object) == 0)
+            .expect("test object should hash to set zero");
+
+        let selected = sets
+            .get_heal_object_disks(
+                &object,
+                &HealOpts {
+                    set: Some(1),
+                    ..Default::default()
+                },
+            )
+            .expect("requested set should exist");
+
+        assert!(Arc::ptr_eq(&selected, &sets.disk_set[1]));
+    }
+
+    #[tokio::test]
+    async fn heal_object_rejects_requested_set_outside_pool() {
+        let (_temp_dirs, sets) = two_set_test_sets().await;
+
+        let err = sets
+            .get_heal_object_disks(
+                "object",
+                &HealOpts {
+                    set: Some(2),
+                    ..Default::default()
+                },
+            )
+            .expect_err("missing requested set must fail closed");
+
+        assert!(matches!(err, Error::InvalidArgument(_, _, message) if message.contains("set index 2")));
     }
 
     #[tokio::test]

--- a/crates/ecstore/src/store/heal.rs
+++ b/crates/ecstore/src/store/heal.rs
@@ -20,6 +20,31 @@ const LOG_COMPONENT_ECSTORE: &str = "ecstore";
 const LOG_SUBSYSTEM_HEAL: &str = "heal";
 const EVENT_HEAL_FORMAT_COMPLETED: &str = "heal_format_completed";
 const EVENT_HEAL_OBJECT_STARTED: &str = "heal_object_started";
+const HEAL_SCOPE_OPERATION: &str = "heal";
+const HEAL_SCOPE_ARGUMENT: &str = "scope";
+
+fn invalid_heal_scope_error(message: String) -> Error {
+    Error::InvalidArgument(HEAL_SCOPE_OPERATION.to_string(), HEAL_SCOPE_ARGUMENT.to_string(), message)
+}
+
+fn heal_object_scope_matches_pool(pool_idx: usize, set_count: usize, opts: &HealOpts) -> bool {
+    if let Some(target_pool) = opts.pool
+        && pool_idx != target_pool
+    {
+        return false;
+    }
+    if let Some(target_set) = opts.set {
+        return target_set < set_count;
+    }
+    true
+}
+
+fn invalid_heal_object_scope_error(opts: &HealOpts, pool_count: usize) -> Error {
+    invalid_heal_scope_error(format!(
+        "invalid object heal scope pool={:?} set={:?} for {pool_count} pools",
+        opts.pool, opts.set
+    ))
+}
 
 impl ECStore {
     #[instrument(skip(self))]
@@ -106,11 +131,19 @@ impl ECStore {
         let object = encode_dir_object(object);
 
         let mut futures = Vec::with_capacity(self.pools.len());
+        let mut selected_pool = false;
         for pool in self.pools.iter() {
+            if !heal_object_scope_matches_pool(pool.pool_idx, pool.set_count, opts) {
+                continue;
+            }
+            selected_pool = true;
             if self.is_suspended(pool.pool_idx).await {
                 continue;
             }
             futures.push(pool.heal_object(bucket, &object, version_id, opts));
+        }
+        if !selected_pool && (opts.pool.is_some() || opts.set.is_some()) {
+            return Ok((HealResultItem::default(), Some(invalid_heal_object_scope_error(opts, self.pools.len()))));
         }
         let results = join_all(futures).await;
 
@@ -177,6 +210,76 @@ mod tests {
     use crate::disk::{DiskOption, format::FormatV3, new_disk};
     use crate::layout::endpoints::{Endpoints, PoolEndpoints};
     use crate::store::init_format::{load_format_erasure, save_format_file};
+
+    #[test]
+    fn heal_object_scope_matches_only_target_pool() {
+        let opts = HealOpts {
+            pool: Some(1),
+            ..Default::default()
+        };
+
+        assert!(!heal_object_scope_matches_pool(0, 2, &opts));
+        assert!(heal_object_scope_matches_pool(1, 2, &opts));
+    }
+
+    #[test]
+    fn heal_object_scope_rejects_missing_set() {
+        let opts = HealOpts {
+            set: Some(2),
+            ..Default::default()
+        };
+
+        assert!(!heal_object_scope_matches_pool(0, 2, &opts));
+        assert!(heal_object_scope_matches_pool(1, 3, &opts));
+    }
+
+    #[test]
+    fn invalid_heal_object_scope_reports_requested_coordinates() {
+        let opts = HealOpts {
+            pool: Some(4),
+            set: Some(2),
+            ..Default::default()
+        };
+
+        let err = invalid_heal_object_scope_error(&opts, 2);
+
+        assert!(
+            matches!(err, Error::InvalidArgument(_, _, message) if message.contains("pool=Some(4)") && message.contains("set=Some(2)"))
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_heal_object_rejects_unmatched_scoped_pool() {
+        let endpoint_pools = EndpointServerPools::from(Vec::<PoolEndpoints>::new());
+        let store = ECStore {
+            id: Uuid::new_v4(),
+            disk_map: HashMap::new(),
+            pools: Vec::new(),
+            peer_sys: S3PeerSys::new(&endpoint_pools),
+            pool_meta: RwLock::new(PoolMeta::default()),
+            rebalance_meta: RwLock::new(None),
+            decommission_cancelers: RwLock::new(Vec::new()),
+            start_gate: Mutex::new(()),
+            pool_meta_save_gate: Mutex::new(()),
+            ctx: crate::runtime::instance::bootstrap_ctx(),
+            bucket_fence_registry: std::sync::Arc::default(),
+        };
+
+        let (_, err) = store
+            .handle_heal_object(
+                "bucket",
+                "object",
+                "",
+                &HealOpts {
+                    pool: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("invalid scope should be reported as a heal result error");
+
+        assert!(matches!(err, Some(Error::InvalidArgument(_, _, message)) if message.contains("pool=Some(1)")));
+    }
 
     #[tokio::test]
     async fn handle_heal_format_continues_after_a_pool_error() {


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Honor `HealOpts.pool` when dispatching object heal across ECStore pools.
- Honor `HealOpts.set` when selecting the erasure set inside a pool instead of always falling back to the object hash.
- Fail closed with `InvalidArgument` for scoped object-heal requests that do not match any pool/set, preventing a scoped heal from silently expanding to the whole deployment.
- Add regression tests for pool filtering, requested-set selection, and invalid scoped coordinates.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p rustfs-ecstore heal_object_scope --lib`
- `cargo test -p rustfs-ecstore handle_heal_object_rejects_unmatched_scoped_pool --lib`
- `cargo test -p rustfs-ecstore heal_object_uses_requested_set_instead_of_object_hash --lib`
- `cargo test -p rustfs-ecstore heal_object_rejects_requested_set_outside_pool --lib`
- `make pre-commit`
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy --all-targets -- -D warnings`

## Impact
Scoped object heal now targets only the requested placement. Unscoped object heal keeps the existing all-pool fan-out behavior. Invalid scoped heal coordinates now surface as `InvalidArgument` instead of falling through to unrelated pools. No S3 API, RPC wire format, or on-disk format changes.

## Additional Notes
The default `make pre-pr` wrapper was attempted, but the local machine repeatedly terminated the default workspace clippy process with SIGTERM/SIGINT under normal parallelism. I reran the full workspace clippy command successfully with `CARGO_BUILD_JOBS=1`, and kept the focused ecstore tests listed above for the changed behavior.
