### PR TITLE
fix(heal): count scoped object heals in set bulkhead

### DIFF
--- a/crates/heal/src/heal/manager.rs
+++ b/crates/heal/src/heal/manager.rs
@@ -2475,7 +2475,7 @@ impl HealManager {
             return;
         }
 
-        let mut running_per_set = running_erasure_set_counts(&active_heals_guard);
+        let mut running_per_set = running_heal_set_counts(&active_heals_guard);
         let mut tasks_started = 0usize;
         let mut delayed_by_mainline_throttle = false;
 
@@ -2854,8 +2854,20 @@ impl std::fmt::Debug for HealManager {
 }
 
 fn heal_request_set_key(request: &HealRequest) -> Option<String> {
-    match &request.heal_type {
+    heal_type_set_key(&request.heal_type, &request.options)
+}
+
+fn heal_type_set_key(heal_type: &HealType, options: &HealOptions) -> Option<String> {
+    match heal_type {
         HealType::ErasureSet { set_disk_id, .. } => Some(set_disk_id.clone()),
+        HealType::Object { .. } => heal_options_set_key(options),
+        _ => None,
+    }
+}
+
+fn heal_options_set_key(options: &HealOptions) -> Option<String> {
+    match (options.pool_index, options.set_index) {
+        (Some(pool), Some(set)) => Some(format!("pool_{pool}_set_{set}")),
         _ => None,
     }
 }
@@ -2905,14 +2917,18 @@ fn update_task_running_metric_for_task(active_heals: &HashMap<String, Arc<HealTa
     .set(count as f64);
 }
 
-fn running_erasure_set_counts(active_heals: &HashMap<String, Arc<HealTask>>) -> HashMap<String, usize> {
+fn running_heal_set_counts(active_heals: &HashMap<String, Arc<HealTask>>) -> HashMap<String, usize> {
     let mut running = HashMap::new();
     for task in active_heals.values() {
-        if let HealType::ErasureSet { set_disk_id, .. } = &task.heal_type {
-            *running.entry(set_disk_id.clone()).or_insert(0) += 1;
+        if let Some(set_key) = heal_request_set_key_for_task(task) {
+            *running.entry(set_key).or_insert(0) += 1;
         }
     }
     running
+}
+
+fn heal_request_set_key_for_task(task: &HealTask) -> Option<String> {
+    heal_type_set_key(&task.heal_type, &task.options)
 }
 
 fn prune_completed_heal_statuses(completed_heals: &mut HashMap<String, CompletedHealStatus>) {
@@ -3513,6 +3529,30 @@ mod tests {
                 set_disk_id: "pool_0_set_1".to_string(),
             },
             HealOptions::default(),
+            HealPriority::Normal,
+        );
+
+        let mut running = HashMap::new();
+        running.insert("pool_0_set_1".to_string(), 1);
+
+        assert!(!can_schedule_request(&request, &running, 1));
+        assert!(can_schedule_request(&request, &running, 2));
+    }
+
+    #[test]
+    fn test_can_schedule_scoped_object_request_respects_per_set_limit() {
+        let options = HealOptions {
+            pool_index: Some(0),
+            set_index: Some(1),
+            ..Default::default()
+        };
+        let request = HealRequest::new(
+            HealType::Object {
+                bucket: "bucket".to_string(),
+                object: "object".to_string(),
+                version_id: None,
+            },
+            options,
             HealPriority::Normal,
         );
 
@@ -5136,7 +5176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_running_erasure_set_counts_groups_only_erasure_tasks() {
+    fn test_running_heal_set_counts_groups_set_scoped_tasks() {
         let storage: Arc<dyn HealStorageAPI> = Arc::new(MockStorage);
         let erasure_task = Arc::new(HealTask::from_request(
             HealRequest::new(
@@ -5145,6 +5185,23 @@ mod tests {
                     set_disk_id: "pool_0_set_1".to_string(),
                 },
                 HealOptions::default(),
+                HealPriority::Normal,
+            ),
+            storage.clone(),
+        ));
+        let scoped_options = HealOptions {
+            pool_index: Some(0),
+            set_index: Some(1),
+            ..Default::default()
+        };
+        let scoped_object_task = Arc::new(HealTask::from_request(
+            HealRequest::new(
+                HealType::Object {
+                    bucket: "bucket".to_string(),
+                    object: "scoped-object".to_string(),
+                    version_id: None,
+                },
+                scoped_options,
                 HealPriority::Normal,
             ),
             storage.clone(),
@@ -5164,10 +5221,11 @@ mod tests {
 
         let mut active = HashMap::new();
         active.insert(erasure_task.id.clone(), erasure_task);
+        active.insert(scoped_object_task.id.clone(), scoped_object_task);
         active.insert(object_task.id.clone(), object_task);
 
-        let counts = running_erasure_set_counts(&active);
-        assert_eq!(counts.get("pool_0_set_1"), Some(&1));
+        let counts = running_heal_set_counts(&active);
+        assert_eq!(counts.get("pool_0_set_1"), Some(&2));
         assert_eq!(counts.len(), 1);
     }
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Include set-scoped object heal tasks in the scheduler's per-set running counts.
- Reuse the existing erasure-set key format for object heal requests that carry both `pool_index` and `set_index`.
- Keep unscoped object heal behavior unchanged: only requests with explicit pool and set coordinates participate in the set bulkhead.
- Add regression tests for scoped object admission and active running-count aggregation.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-heal can_schedule --lib`
- `cargo test -p rustfs-heal running_heal_set_counts --lib`
- `cargo clippy -p rustfs-heal --all-targets -- -D warnings`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 make pre-commit`

## Impact
Set-scoped object heal work now respects the same per-set scheduler bulkhead as erasure-set heal work. This prevents multiple scoped object heal tasks from bypassing `max_concurrent_per_set` on the same erasure set. There are no RPC, on-disk, S3 API, or configuration format changes.

## Additional Notes
The default parallel `make pre-commit` quick-check was terminated locally by SIGTERM during dependency compilation. Re-running the same pre-commit gate with `CARGO_BUILD_JOBS=1` completed successfully.
