### PR TITLE
fix(get): pin resume reads to resolved version

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -1968,12 +1968,17 @@ impl GetObjectResumeContext {
         store: Arc<ECStore>,
         bucket: &str,
         key: &str,
-        opts: ObjectOptions,
+        mut opts: ObjectOptions,
         request_headers: &HeaderMap,
         info: &ObjectInfo,
         range_start: i64,
         range_end: i64,
     ) -> Self {
+        if opts.version_id.is_none()
+            && let Some(version_id) = info.version_id
+        {
+            opts.version_id = Some(version_id.to_string());
+        }
         let mut ssec_headers = HeaderMap::new();
         for name in [SSEC_ALGORITHM_HEADER, SSEC_KEY_HEADER, SSEC_KEY_MD5_HEADER] {
             if let Some(value) = request_headers.get(name) {
@@ -13181,6 +13186,67 @@ mod tests {
             matches!(result, Err(GetObjectResumeFailure::Fatal)),
             "reopening a replaced version must fail closed"
         );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn get_object_resume_context_pins_latest_read_to_resolved_version() {
+        let (_disk_paths, store, _context) = real_get_resume_test_context().await;
+        let resolved_version = Uuid::new_v4();
+        let info = ObjectInfo {
+            version_id: Some(resolved_version),
+            ..Default::default()
+        };
+
+        let ctx = GetObjectResumeContext::new(
+            Arc::clone(&store),
+            "bucket",
+            "object.bin",
+            ObjectOptions::default(),
+            &HeaderMap::new(),
+            &info,
+            0,
+            -1,
+        );
+        assert_eq!(
+            ctx.opts.version_id,
+            Some(resolved_version.to_string()),
+            "latest GET resume must reopen the initially resolved version, not the moving latest"
+        );
+
+        let explicit_version = Uuid::new_v4().to_string();
+        let explicit_opts = ObjectOptions {
+            version_id: Some(explicit_version.clone()),
+            ..Default::default()
+        };
+        let ctx = GetObjectResumeContext::new(
+            Arc::clone(&store),
+            "bucket",
+            "object.bin",
+            explicit_opts,
+            &HeaderMap::new(),
+            &info,
+            0,
+            -1,
+        );
+        assert_eq!(
+            ctx.opts.version_id.as_deref(),
+            Some(explicit_version.as_str()),
+            "an explicit request version must stay authoritative"
+        );
+
+        let unversioned_info = ObjectInfo::default();
+        let ctx = GetObjectResumeContext::new(
+            Arc::clone(&store),
+            "bucket",
+            "object.bin",
+            ObjectOptions::default(),
+            &HeaderMap::new(),
+            &unversioned_info,
+            0,
+            -1,
+        );
+        assert_eq!(ctx.opts.version_id, None, "unversioned reads have no version to pin");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Pin mid-stream GET resume reopens to the version resolved by the initial read when the request targets latest.
- Preserve explicit request version IDs and leave unversioned reads unpinned.
- Add a regression test covering latest pinning, explicit-version preservation, and unversioned reads.

## Verification
- cargo test -p rustfs get_object_resume_context_pins_latest_read_to_resolved_version --lib
- cargo test -p rustfs get_object_resume_reopen_rejects_a_replaced_object_version --lib
- cargo fmt --all --check
- git diff --check
- cargo clippy -p rustfs --lib --tests -- -D warnings
- make pre-commit

## Impact
A versioned latest GET that resumes after a mid-stream relocation now reopens the same object version selected by the initial read instead of resolving latest again. This prevents replacement versions from affecting resume attempts while keeping the existing identity check as a fail-closed guard.

## Additional Notes
No protocol, API, or on-disk format changes. High-risk adversarial review covered correctness, simplicity, security, concurrency/durability, compatibility, performance, and test coverage; no unresolved findings remain.
