### PR TITLE
docs(ci): make e2e-replication-nightly test-count comments drift-resistant

### DIFF
--- a/.github/workflows/e2e-replication-nightly.yml
+++ b/.github/workflows/e2e-replication-nightly.yml
@@ -14,25 +14,24 @@
 
 # Nightly full replication e2e lane (backlog#1147 repl-1, deps: ci-4).
 #
-# The per-PR gate (ci.yml `e2e-tests` job, `--profile e2e-smoke`) runs the 20
-# FAST replication tests. This scheduled lane runs the remaining 27
-# heavier replication e2e tests that are unfit for a per-PR gate:
-#
-#   * 2 remote-target TLS validation tests.
-#   * 12 bucket-replication data-plane/helper tests (PUT/delete + poll for
-#     convergence; two replicate over HTTPS, two pin active SSE failure
-#     contracts, and one guards event/history observers). The SSE-S3 contract
-#     remains ignored under backlog#1291.
-#   * 11 `_real_dual_node` site-replication tests (each spawns TWO rustfs
-#     servers and drives the cross-process site-replication control plane).
-#   * 1 `_real_three_node` site-replication test.
-#   * 1 `_real_single_node` service-account round-trip test.
+# The per-PR gate (ci.yml `e2e-tests` job, `--profile e2e-smoke`) runs the
+# FAST replication tests. This scheduled lane runs the remaining heavier
+# replication e2e tests that are unfit for a per-PR gate: remote-target TLS
+# validation, bucket-replication data-plane/helper tests (PUT/delete + poll
+# for convergence, HTTPS targets, active SSE failure contracts, event/history
+# observers), and the `_real_dual_node` / `_real_three_node` /
+# `_real_single_node` site-replication tests that each spawn full rustfs
+# server processes.
 #
 # The selection is the [profile.e2e-repl-nightly] default-filter in
 # .config/nextest.toml — the single wiring mechanism (repl-1 / ci-4). Do NOT
-# add ad-hoc cargo-test steps here; change the filterset instead.
+# add ad-hoc cargo-test steps here; change the filterset instead. The
+# authoritative membership and count come from
+# `cargo nextest list -p e2e_test --profile e2e-repl-nightly`; the PR/nightly
+# count invariant is maintained next to the filtersets in .config/nextest.toml
+# (deliberately not duplicated here).
 #
-# Explicit division of labor: these 27 tests run ONLY here, never double-run
+# Explicit division of labor: the nightly subset runs ONLY here, never double-run
 # in ci-5's future e2e-full merge gate. TODO(ci-7): once the ci domain's
 # consolidated scheduled e2e workflow exists, fold this interim repl-owned lane
 # into it rather than growing a second scheduled entrypoint.


### PR DESCRIPTION
## Summary

The header comment in `.github/workflows/e2e-replication-nightly.yml` claimed the lane runs **27** nightly replication e2e tests (lines 18 and 35) with a per-category breakdown. The lane has since grown to **36** on `main` (and will become 38 once the in-flight `fix/p1-21-delayed-purge-failure-handling` branch lands), so both the headline counts and the itemized list had drifted.

Rather than bumping the numbers (which would go stale again on the very next filterset change, and whose correct value depends on merge order with in-flight branches), this drops the exact counts and per-category tallies from the workflow comment entirely and points to the single authority instead:

- `cargo nextest list -p e2e_test --profile e2e-repl-nightly` for authoritative membership and count
- the count invariant maintained next to the filtersets in `.config/nextest.toml` (deliberately not duplicated in the workflow)

The qualitative description of what the lane covers (remote-target TLS validation, data-plane/helper convergence tests, `_real_*_node` site-replication tests) is retained.

## Verification

- Comment-only change; no workflow behavior affected (`on:`, jobs, and steps untouched).
- Counts cross-checked on current `main`: `cargo nextest list -p e2e_test --profile e2e-repl-nightly` → 36 tests; smoke replication subset → 20; matches the `20 here + 36 nightly = 56 total` invariant at `.config/nextest.toml`.