### PR TITLE
test(replication): cover rule id byte limit

### DIFF
--- a/crates/replication/src/config.rs
+++ b/crates/replication/src/config.rs
@@ -795,6 +795,33 @@ mod tests {
     }
 
     #[test]
+    fn structure_validation_counts_rule_id_limit_in_bytes() {
+        let mut within_byte_limit = replication_rule(&"\u{00e9}".repeat(127), "arn:target:a");
+        within_byte_limit.priority = Some(1);
+        assert_eq!(
+            within_byte_limit.id.as_ref().expect("rule id should be present").len(),
+            REPLICATION_CONFIG_MAX_RULE_ID_LEN - 1
+        );
+        assert_eq!(validate_replication_config_structure(&structure_config(vec![within_byte_limit])), Ok(()));
+
+        let mut over_byte_limit = replication_rule(&"\u{00e9}".repeat(128), "arn:target:a");
+        over_byte_limit.priority = Some(1);
+        assert!(
+            over_byte_limit
+                .id
+                .as_ref()
+                .expect("rule id should be present")
+                .chars()
+                .count()
+                < REPLICATION_CONFIG_MAX_RULE_ID_LEN
+        );
+        assert_eq!(
+            validate_replication_config_structure(&structure_config(vec![over_byte_limit])),
+            Err(ReplicationConfigStructureError::RuleIdTooLong)
+        );
+    }
+
+    #[test]
     fn structure_validation_rejects_filter_with_both_prefix_and_tag() {
         let mut rule = replication_rule("rule-1", "arn:target:a");
         let mut filter = tag_filter();


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Adds a focused regression test for replication rule ID validation so the 255 limit stays byte-based, matching the MinIO/Go `len` contract. The test accepts a 254-byte multibyte ID and rejects a 256-byte ID whose character count is still below the limit, which catches an accidental switch to character counting.

## Verification
- `RUSTC_WRAPPER= cargo test -p rustfs-replication structure_validation_counts_rule_id_limit_in_bytes -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `RUSTC_WRAPPER= make pre-commit`

## Impact
Test-only. No runtime behavior change.

## Additional Notes
N/A
