### PR TITLE
fix(ecstore): rename stale two_set_test_sets references to make_local_two_set_sets

### DIFF
--- a/crates/ecstore/src/core/sets.rs
+++ b/crates/ecstore/src/core/sets.rs
@@ -1467,7 +1467,7 @@ mod tests {
 
     #[tokio::test]
     async fn heal_object_uses_explicit_set_scope() {
-        let (_temp_dirs, sets) = two_set_test_sets().await;
+        let (_temp_dirs, sets) = make_local_two_set_sets().await;
         let selected = sets
             .get_disks_for_heal_object(
                 "object",
@@ -1483,7 +1483,7 @@ mod tests {
 
     #[tokio::test]
     async fn heal_object_without_set_scope_keeps_hash_routing() {
-        let (_temp_dirs, sets) = two_set_test_sets().await;
+        let (_temp_dirs, sets) = make_local_two_set_sets().await;
         let object = "object";
         let selected = sets
             .get_disks_for_heal_object(object, &HealOpts::default())
@@ -1494,7 +1494,7 @@ mod tests {
 
     #[tokio::test]
     async fn heal_object_rejects_invalid_set_scope() {
-        let (_temp_dirs, sets) = two_set_test_sets().await;
+        let (_temp_dirs, sets) = make_local_two_set_sets().await;
         let err = sets
             .get_disks_for_heal_object(
                 "object",


### PR DESCRIPTION
## Problem

Commit 70deb3284 (`fix(select): pin object snapshot for query lifetime (#5835)`) renamed the test helper `two_set_test_sets` to `make_local_two_set_sets` (moved from `mod tests` to a `pub(crate)` function) but missed updating 3 call sites in `crates/ecstore/src/core/sets.rs`.

This caused `make pre-pr` to fail with:
```
error[E0425]: cannot find function `two_set_test_sets` in this scope
```

## Fix

Replaced the 3 stale `two_set_test_sets()` calls with `make_local_two_set_sets()`:

- `heal_object_uses_explicit_set_scope` (line 1470)
- `heal_object_without_set_scope_keeps_hash_routing` (line 1486)
- `heal_object_rejects_invalid_set_scope` (line 1497)

## Verification

- `cargo fmt --all --check` ✅
- `make pre-commit` ✅
- `cargo test -p rustfs-ecstore --lib -- sets::tests` — all 21 tests passed ✅
- `make clippy-check` ✅
