### PR TITLE
fix(ecstore): use existing two-set test fixture

### DIFF
--- a/crates/ecstore/src/core/sets.rs
+++ b/crates/ecstore/src/core/sets.rs
@@ -1467,7 +1467,7 @@ mod tests {
 
     #[tokio::test]
     async fn heal_object_uses_explicit_set_scope() {
-        let (_temp_dirs, sets) = two_set_test_sets().await;
+        let (_temp_dirs, sets) = make_local_two_set_sets().await;
         let selected = sets
             .get_disks_for_heal_object(
                 "object",
@@ -1483,7 +1483,7 @@ mod tests {
 
     #[tokio::test]
     async fn heal_object_without_set_scope_keeps_hash_routing() {
-        let (_temp_dirs, sets) = two_set_test_sets().await;
+        let (_temp_dirs, sets) = make_local_two_set_sets().await;
         let object = "object";
         let selected = sets
             .get_disks_for_heal_object(object, &HealOpts::default())
@@ -1494,7 +1494,7 @@ mod tests {
 
     #[tokio::test]
     async fn heal_object_rejects_invalid_set_scope() {
-        let (_temp_dirs, sets) = two_set_test_sets().await;
+        let (_temp_dirs, sets) = make_local_two_set_sets().await;
         let err = sets
             .get_disks_for_heal_object(
                 "object",


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Replace three stale `two_set_test_sets()` test calls with the existing `make_local_two_set_sets()` fixture in `crates/ecstore/src/core/sets.rs`.

This restores compilation for the explicit and hash-routed heal-object test cases without changing production behavior.

## Verification
- `RUSTFLAGS="--cfg tokio_unstable" cargo clippy --fix --all-targets --all-features --allow-dirty -- -D warnings`
- `cargo test -p rustfs-ecstore heal_object_ --lib -q`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
Test-only change. No user-facing, API, compatibility, deployment, or configuration impact.

## Additional Notes
N/A
