### PR TITLE
fix(docker): support TZ environment variable

### DIFF
--- a/.config/make/tests.mak
+++ b/.config/make/tests.mak
@@ -25,6 +25,7 @@ TEST_THREADS ?= 1
 script-tests: ## Run shell script tests
 	@echo "Running script tests..."
 	./scripts/test_build_rustfs_options.sh
+	./scripts/test_docker_runtime_timezone.sh
 	./scripts/test_entrypoint_credentials.sh
 	./scripts/test_internode_grpc_ab_bench.sh
 	./scripts/test_object_batch_bench_enhanced.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,12 @@ LABEL name="RustFS" \
 # Upgrade base-image packages so published images pick up security fixes
 # (e.g. openssl/libssl3 CVEs) without waiting for a new Alpine point release.
 RUN apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates coreutils curl
+    apk add --no-cache \
+    ca-certificates \
+    coreutils \
+    curl \
+    tzdata \
+    && test "$(TZ=Asia/Kolkata date +%z)" = "+0530"
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /build/rustfs /usr/bin/rustfs

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -96,9 +96,11 @@ LABEL name="RustFS" \
 # Upgrade base-image packages so published images pick up security fixes
 # (e.g. tar/gzip/perl CVEs) without waiting for a new Ubuntu point release.
 RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    tzdata \
+    && test "$(TZ=Asia/Kolkata date +%z)" = "+0530" \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /build/rustfs /usr/bin/rustfs

--- a/scripts/test_docker_runtime_timezone.sh
+++ b/scripts/test_docker_runtime_timezone.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+for dockerfile in Dockerfile Dockerfile.glibc; do
+  runtime_stage=$(
+    awk '
+      /^FROM[[:space:]]/ { stage = "" }
+      { stage = stage $0 ORS }
+      END { printf "%s", stage }
+    ' "$ROOT_DIR/$dockerfile"
+  )
+
+  if ! grep -Eq '^[[:space:]]*tzdata([[:space:]]*\\)?[[:space:]]*$' <<<"$runtime_stage"; then
+    echo "$dockerfile runtime stage must install tzdata" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq 'test "$(TZ=Asia/Kolkata date +%z)" = "+0530"' <<<"$runtime_stage"; then
+    echo "$dockerfile runtime stage must verify IANA timezone resolution" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Related Issues

Fixes #5843.

## Summary of Changes

- Install `tzdata` in the published Alpine and Ubuntu runtime images so `TZ` can select an IANA timezone.
- Verify IANA timezone resolution while building each runtime image.
- Add a regression guard covering both final Dockerfile stages.

## Verification

- `./scripts/test_docker_runtime_timezone.sh`
- `make pre-pr`

## Impact

Docker deployments can set `TZ` to an IANA timezone such as `Asia/Kolkata`. Existing deployments that do not set `TZ` retain their current default behavior. Runtime images gain the `tzdata` package.

## Additional Notes

`Dockerfile.source` already installs `tzdata`; this change aligns both published binary image variants.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
