### PR TITLE
fix(ecstore): raise replay cache auto headroom

### DIFF
--- a/crates/ecstore/src/cluster/rpc/http_auth.rs
+++ b/crates/ecstore/src/cluster/rpc/http_auth.rs
@@ -84,7 +84,7 @@ const REPLAY_CACHE_RETENTION_SECS: usize = 601;
 const REPLAY_CACHE_ENTRY_BYTES_ESTIMATE: u64 = 128;
 const REPLAY_CACHE_AUTO_MEMORY_PERCENT: u64 = 8;
 const REPLAY_CACHE_AUTO_RPC_RPS_PER_CPU: usize = 2048;
-const REPLAY_CACHE_AUTO_MAX_CAPACITY: usize = 16_777_216;
+const REPLAY_CACHE_AUTO_MAX_CAPACITY: usize = 33_554_432;
 const NS_SCANNER_CAPABILITY_AUTH_DOMAIN: &[u8] = b"rustfs-ns-scanner-capability-v3";
 pub const TONIC_RPC_PREFIX: &str = "/node_service.NodeService";
 static INTERNODE_RPC_SIGNATURE_STRICT: LazyLock<bool> = LazyLock::new(|| {
@@ -2505,7 +2505,7 @@ mod tests {
     }
 
     #[test]
-    fn replay_cache_capacity_auto_reaches_hotpath_verified_capacity_on_larger_nodes() {
+    fn replay_cache_capacity_auto_uses_resource_model_on_larger_nodes() {
         let gib = 1024_u64 * 1024 * 1024;
         let decision =
             replay_cache_capacity_decision(rustfs_utils::EnvParseOutcome::Absent, 16, Some(32 * gib), Some(MemoryBasis::Host));
@@ -2513,7 +2513,17 @@ mod tests {
         assert_eq!(decision.source, ReplayCacheCapacitySource::Auto);
         assert_eq!(decision.memory_based_capacity, 21_474_836);
         assert_eq!(decision.cpu_based_capacity, 19_693_568);
-        assert_eq!(decision.capacity, 16_777_216);
+        assert_eq!(decision.capacity, 19_693_568);
+    }
+
+    #[test]
+    fn replay_cache_capacity_auto_caps_extreme_nodes() {
+        let gib = 1024_u64 * 1024 * 1024;
+        let decision =
+            replay_cache_capacity_decision(rustfs_utils::EnvParseOutcome::Absent, 128, Some(512 * gib), Some(MemoryBasis::Host));
+
+        assert_eq!(decision.source, ReplayCacheCapacitySource::Auto);
+        assert_eq!(decision.capacity, REPLAY_CACHE_AUTO_MAX_CAPACITY);
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1647.

## Summary of Changes
This PR raises the internode RPC replay cache auto-sizing ceiling from 16,777,216 to 33,554,432 entries.

The existing resource model already estimates capacity from CPU count, memory budget, and replay retention. However, the fixed 16M auto ceiling truncated the model on the verified 16 vCPU / ~32 GiB HotPath nodes: CPU-based capacity was 19,693,568 and memory-based capacity was 21,474,836, but the effective capacity stayed at 16,777,216. A small-object GET replay-cache staircase on the four-node field cluster filled the cache at concurrency 64 and produced `replay_cache_capacity` auth failures even though the node had enough resource-model headroom.

This change does not alter replay verification, nonce retention, signature binding, fail-closed behavior, or explicit operator-provided `RUSTFS_INTERNODE_RPC_REPLAY_CACHE_CAPACITY` values. Small nodes still keep the historical default floor, and very large nodes remain capped by the new auto maximum.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore replay_cache_capacity --lib`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `make pre-commit`

## Impact
On larger nodes where the CPU/memory resource model previously exceeded 16M, the automatically selected replay cache capacity can now grow above 16M up to 32M. This reduces false `replay_cache_capacity` fail-closed events under legitimate high-throughput internode GET traffic.

Low-resource nodes remain protected by the default floor and memory-based sizing. Operators can still override the capacity explicitly with `RUSTFS_INTERNODE_RPC_REPLAY_CACHE_CAPACITY`.

## Additional Notes
Adversarial validation summary:

- Correctness: replay admission still removes expired entries before capacity checks and still fails closed on duplicate or over-capacity nonce records; only the auto ceiling changed.
- Security: replay scope signature verification, timestamp checks, boot epoch validation, and nonce retention are unchanged.
- Concurrency/durability: no new locks, awaits, disk IO, RPC calls, or lock ordering changes.
- Compatibility: no wire-format, header, environment variable, or explicit env override behavior changes.
- Performance: larger auto capacity can increase replay-cache memory use on capable nodes, but remains bounded by resource sizing and the new auto cap.
- Test coverage: updated the 16 vCPU / 32 GiB model test to assert the resource-derived capacity, and added an extreme-node cap test.
