### PR TITLE
perf(get): avoid zeroing response body chunks

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -200,7 +200,7 @@ use tokio::sync::{OwnedSemaphorePermit, RwLock};
 use tokio_tar::Archive;
 #[cfg(test)]
 use tokio_util::io::ReaderStream;
-use tokio_util::io::StreamReader;
+use tokio_util::io::{StreamReader, poll_read_buf};
 use tracing::{debug, error, instrument, warn};
 use uuid::Uuid;
 
@@ -871,7 +871,6 @@ pin_project! {
     struct GetObjectReaderStream<R> {
         #[pin]
         reader: Option<R>,
-        buf: BytesMut,
         capacity: usize,
         strategy: &'static str,
         buffer_source: &'static str,
@@ -923,7 +922,6 @@ where
         }
         Self {
             reader: Some(reader),
-            buf: BytesMut::with_capacity(capacity.min(remaining)),
             capacity,
             strategy,
             buffer_source,
@@ -1344,21 +1342,12 @@ where
             None => return Poll::Ready(None),
         };
         let read_capacity = (*this.capacity).min(*this.remaining);
-        this.buf.resize(read_capacity, 0);
-
-        let poll_read = {
-            let mut read_buf = ReadBuf::new(&mut this.buf[..read_capacity]);
-            match reader.poll_read(cx, &mut read_buf) {
-                Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buf.filled().len())),
-                Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
-                Poll::Pending => Poll::Pending,
-            }
-        };
+        let mut buf = BytesMut::with_capacity(read_capacity);
+        let poll_read = poll_read_buf(reader, cx, &mut buf);
 
         let result: Poll<Option<Self::Item>> = match poll_read {
             Poll::Ready(Ok(bytes_read)) if bytes_read > 0 => {
-                let bytes = this.buf.split_to(bytes_read).freeze();
-                this.buf.clear();
+                let bytes = buf.freeze();
                 *this.remaining -= bytes.len();
                 #[cfg(feature = "tracing-chunk-debug")]
                 {
@@ -1377,7 +1366,6 @@ where
                 }
             }
             Poll::Ready(Ok(_)) => {
-                this.buf.clear();
                 this.reader.set(None);
                 let remaining = i64::try_from(*this.remaining).unwrap_or(i64::MAX);
                 let err = std::io::Error::new(std::io::ErrorKind::UnexpectedEof, rustfs_rio::IncompleteBody { remaining });
@@ -1391,7 +1379,6 @@ where
                 Poll::Ready(Some(Err(Box::new(err) as S3StdError)))
             }
             Poll::Ready(Err(err)) => {
-                this.buf.clear();
                 this.reader.set(None);
                 #[cfg(feature = "tracing-chunk-debug")]
                 tracing::error!(
@@ -1402,10 +1389,7 @@ where
                 );
                 Poll::Ready(Some(Err(Box::new(err) as S3StdError)))
             }
-            Poll::Pending => {
-                this.buf.clear();
-                Poll::Pending
-            }
+            Poll::Pending => Poll::Pending,
         };
 
         let emitted_bytes = match &result {


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1647

## Summary of Changes
This PR removes the per-chunk zero-fill in the GET response body stream path. `GetObjectReaderStream` now allocates a bounded `BytesMut` for the current `min(configured_capacity, remaining)` read and lets `tokio_util::io::poll_read_buf` fill it directly before freezing it into the response `Bytes` chunk.

The change preserves the existing response length contract: reads are still bounded by the remaining `Content-Length`, short EOF still returns `IncompleteBody`, over-long readers are still truncated to the committed response length, and `remaining_length()` semantics are unchanged. It also avoids adding unsafe code in the `rustfs` crate, which is built with `-D unsafe-code`.

Adversarial validation summary: correctness attacked bounded final reads, short EOF, and over-long source data; simplicity attacked a custom unsafe implementation and kept the smaller dependency-backed implementation; compatibility found no HTTP/S3 response semantic change; performance attacked per-chunk allocation and found the remaining cost is still one owned `Bytes` chunk per response chunk, while the removed cost is the previous explicit zero-fill before every read.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs get_object_reader_stream --lib`
- `cargo clippy -p rustfs --lib -- -D warnings`
- `git diff --check`
- `make pre-commit`

## Impact
No API, config, wire-format, or deployment impact. This is a GET hot-path allocation/CPU cleanup intended to reduce response body chunk preparation overhead. Cluster A/B validation was not run in this PR; the next field step should rebuild the profiling binary from this branch or the merge commit and rerun the 64KiB/128KiB/1MiB GET windows with samply focused on response body, HTTP/h2, allocator, and backpressure.

## Additional Notes
N/A
