### PR TITLE
fix: prevent tilde expansion in DEB version substitution

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -225,7 +225,9 @@ jobs:
           VERSION="${{ needs.resolve.outputs.version }}"
           DEB_ARCH="${{ matrix.deb_arch }}"
           # DEB version: replace - with ~ (1.0.0-beta.12 -> 1.0.0~beta.12)
-          DEB_VERSION="${VERSION/-/~}"
+          # Use a variable for ~ to prevent tilde expansion by bash
+          TILDE='~'
+          DEB_VERSION="${VERSION/-/$TILDE}"
           PKG_DIR="rustfs_${DEB_VERSION}_${DEB_ARCH}"
 
           echo "Building DEB: ${PKG_DIR}.deb"


### PR DESCRIPTION
## Problem

The `package.yml` workflow fails when building DEB packages. Both x86_64 and aarch64 builds fail at the "Build DEB package" step with:

```
dpkg-deb: error: parsing file ... near line 2:
  Version field value 1.0.0/home/runnerrc.1: invalid character in version number
```

## Root Cause

Line 228 uses `${VERSION/-/~}` to replace `-` with `~` for DEB versioning (e.g. `1.0.0-rc.1` → `1.0.0~rc.1`). However, bash expands `~` to `$HOME` (`/home/runner` on GitHub Actions), producing an invalid version string like `1.0.0/home/runnerrc.1`.

## Fix

Store `~` in a variable first to prevent tilde expansion:

```bash
TILDE='~'
DEB_VERSION="${VERSION/-/$TILDE}"
```

Verified: the substitution `${VERSION/-/$TILDE}` correctly produces `1.0.0~rc.1` without tilde expansion.