### PR TITLE
test(admin): relax object-lambda SNI test timeout under full-suite load

### DIFF
--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -4671,6 +4671,11 @@ mod tests {
             Url::parse(&format!("https://object-lambda.test:{}/transform", address.port())).expect("object lambda TLS endpoint");
         let mut config = object_lambda_test_config(endpoint.clone());
         config.client_ca = ca_path.to_string_lossy().into_owned();
+        // This is the only object-lambda test that performs a real TLS
+        // handshake; under a full-suite nextest run the CPU contention from
+        // neighboring tests pushes it past the helper's tight 2s request
+        // deadline. SNI preservation, not latency, is under test here.
+        config.response_header_timeout = Some(Duration::from_secs(30));
 
         let response = build_object_lambda_http_client_with_resolver(&config, StaticResolver(address.ip()))
             .expect("object lambda TLS client should build")


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

`admin::router::tests::object_lambda_client_preserves_hostname_for_tls_sni` (from #5135) fails deterministically in full local `cargo nextest run --all --exclude e2e_test` runs on some machines while always passing when run alone. The test helper `object_lambda_test_config` sets `response_header_timeout` to 2s, which maps to reqwest's whole-request timeout. This is the only object-lambda test that performs a real TLS handshake (fresh rcgen cert, aws-lc-rs provider init, rustls-platform-verifier trust evaluation), and when the deterministic nextest schedule places it in the same window as the ~20 fsync-heavy `TestECStoreEnv` bootstrap tests in the same binary (`admin::runtime_sources`, `admin::service::config`, `admin::handlers::site_replication`), the request is pushed past the 2s deadline and fails with `reqwest::Error { kind: Request, source: TimedOut }`. Whether the overlap happens depends on the per-build test ordering, which is why the failure is deterministic on one build and invisible on another (e.g. CI).

Ruled out during diagnosis: HTTP(S)_PROXY env (the client sets `.no_proxy()`), DNS (the test injects a static resolver), fd/port pressure, and pure CPU contention (the test passes solo under 18 busy-loop processes). Those neighbor tests themselves slow from ~0.3s to 4-6s in the same window but have no tight deadline, so only this test fails.

The fix overrides the timeout to 30s inside this test only: the test verifies SNI preservation, not latency, and 30s still bounds a genuine regression. Other users of the shared helper keep the 2s default.

## Verification

- `make pre-commit`
- Unfixed baseline reproduces: `cargo nextest run --all --exclude e2e_test -E 'test(/^admin::(runtime_sources|service::config|handlers::site_replication)::/) | test(preserves_hostname_for_tls_sni)'` fails 3/3 runs on origin/main on the affected machine (also fails in the full suite and in `-E 'test(/^admin::/)'`).
- With the fix, the same forced-contention filter and the full `cargo nextest run --all --exclude e2e_test --no-fail-fast` suite pass (12941 tests, the only remaining failure is the pre-existing macOS-only tempdir-symlink issue in `disk::local::test::test_rename_data_writes_old_metadata_backup_for_inline_overwrite`, unrelated to this change).

## Impact

N/A (test-only change; no production code affected).

## Additional Notes

The forced-contention filter above reproduces the failure independently of build-specific test ordering and may be useful for investigating similar load-sensitive timeouts.
