### PR TITLE
test(ecstore): update prepared GET fanout default

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -837,10 +837,7 @@ mod prepared_get_object_metadata_tests {
                     .await
                     .expect("prepared metadata should resolve");
                 let prepared_calls = calls.total(disk_call_counters::KIND_READ_VERSION);
-                assert_eq!(
-                    prepared_calls, 3,
-                    "default prepared GET metadata should stop after the 2+2 read/write quorum"
-                );
+                assert_eq!(prepared_calls, 4, "default prepared GET metadata should keep full data-read fanout");
 
                 let mut reader = set_disks
                     .get_object_reader_with_prepared_metadata(bucket, object, None, HeaderMap::new(), &opts, metadata)
@@ -864,7 +861,7 @@ mod prepared_get_object_metadata_tests {
         );
         assert_eq!(
             calls.total(disk_call_counters::KIND_READ_VERSION),
-            3,
+            4,
             "reader construction must consume prepared metadata instead of repeating the fanout"
         );
     }


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#1647 and follow-up to #5929.

## Summary of Changes
- Update `prepared_reader_reuses_metadata_fanout_exactly_once` to match the merged #5929 default behavior.
- #5929 keeps GET data-read metadata early-stop and bounded fanout opt-in by default, so prepared GET metadata should now assert the default full 2+2 fanout of 4 `ReadVersion` calls.
- Preserve the core regression: prepared metadata is consumed by reader construction, so the reader does not issue a second metadata fanout.

## Verification
- `cargo test -p rustfs-ecstore prepared_reader_reuses_metadata_fanout_exactly_once -- --nocapture`
- `cargo test -p rustfs-ecstore prepared_reader -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `RUSTFLAGS="--cfg tokio_unstable" cargo clippy --fix --all-targets --all-features --allow-dirty -- -D warnings`

## Impact
Test-only fix. No runtime, API, configuration, or compatibility impact.

## Additional Notes
This fixes the CI failure observed after #5929 merged: the default prepared GET test still expected bounded data-read fanout of 3, while the reviewed and merged default behavior intentionally keeps full data-read fanout.
