### PR TITLE
fix(scanner): skip disk inventory in scan spans

### DIFF
--- a/crates/scanner/src/scanner_io.rs
+++ b/crates/scanner/src/scanner_io.rs
@@ -3881,7 +3881,7 @@ impl ScannerIODisk for Disk {
         Ok(size_summary)
     }
 
-    #[tracing::instrument(skip(self, budget, updates, cache))]
+    #[tracing::instrument(skip(self, budget, updates, cache, set_disks))]
     async fn nsscanner_disk(
         self: Arc<Self>,
         ctx: CancellationToken,

--- a/scripts/check_logging_guardrails.sh
+++ b/scripts/check_logging_guardrails.sh
@@ -842,6 +842,34 @@ for file in "${disk_logging_files[@]}"; do
   fi
 done
 
+# `set_disks` expands every Disk through Debug, including raw format bytes and
+# the full per-operation metrics ring. Keep it out of the INFO scanner span.
+scanner_disk_skip_pattern='#\[(tracing::)?instrument\([^]]*skip\([^)]*\bset_disks\b[^)]*\)[^]]*\)\][[:space:]]*async fn nsscanner_disk\b'
+if ! rg -U "$scanner_disk_skip_pattern" crates/scanner/src/scanner_io.rs >/dev/null; then
+  echo "❌ logging guardrail violation: nsscanner_disk must skip set_disks in its tracing instrumentation" >&2
+  exit 1
+fi
+
+for fixture in \
+  $'#[tracing::instrument(skip(self, budget, updates, cache, set_disks))]\nasync fn nsscanner_disk('; do
+  if ! printf '%s\n' "$fixture" | rg -U "$scanner_disk_skip_pattern" >/dev/null; then
+    echo "❌ logging guardrail self-test failed: safe nsscanner_disk span was rejected" >&2
+    echo "$fixture" >&2
+    exit 1
+  fi
+done
+
+for fixture in \
+  $'#[tracing::instrument(skip(self, budget, updates, cache))]\nasync fn nsscanner_disk(' \
+  $'#[tracing::instrument(skip(self, budget, updates, cache), fields(set_disks = set_disks.len()))]\nasync fn nsscanner_disk(' \
+  $'#[tracing::instrument(skip(self, budget, updates, cache, set_disks_count))]\nasync fn nsscanner_disk('; do
+  if printf '%s\n' "$fixture" | rg -U "$scanner_disk_skip_pattern" >/dev/null; then
+    echo "❌ logging guardrail self-test failed: unsafe nsscanner_disk span was accepted" >&2
+    echo "$fixture" >&2
+    exit 1
+  fi
+done
+
 # `forbidden_patterns` above only retires log lines that already shipped, so a
 # newly written sentence-style log passes every check in this script — which is
 # how one reaches review in the first place (PR #5822 added


### PR DESCRIPTION
## Related Issues

Fixes #5927.

## Summary of Changes

- Exclude `set_disks` from the `nsscanner_disk` tracing span so INFO lifecycle records no longer serialize every disk's format bytes and metrics ring.
- Extend the logging guardrail with positive and negative fixtures that require this parameter to remain skipped.

## Verification

- `bash scripts/check_logging_guardrails.sh`
- `/root/.local/bin/rustfs-cargo-safe fmt --all -- --check`
- `/root/.local/bin/rustfs-cargo-safe check -p rustfs-scanner --lib`
- `git diff --check`

## Impact

Substantially reduces scanner span log volume in development/FULL and production/CLOSE logging modes. Scanner behavior, disk selection, APIs, and on-disk data are unchanged.

## Additional Notes

N/A.
