### PR TITLE
perf(ecstore): raise replay cache auto capacity

### DIFF
--- a/crates/ecstore/src/cluster/rpc/http_auth.rs
+++ b/crates/ecstore/src/cluster/rpc/http_auth.rs
@@ -89,8 +89,9 @@ const SIGNATURE_VALID_DURATION: i64 = 300; // 5 minutes
 const REPLAY_CACHE_RETENTION: Duration = Duration::from_secs(601);
 const REPLAY_CACHE_RETENTION_SECS: usize = 601;
 const REPLAY_CACHE_ENTRY_BYTES_ESTIMATE: u64 = 128;
-const REPLAY_CACHE_AUTO_MEMORY_PERCENT: u64 = 8;
-const REPLAY_CACHE_AUTO_RPC_RPS_PER_CPU: usize = 2048;
+// Keep 16 CPU / 32 GiB field nodes at the 32M cap without requiring an env override.
+const REPLAY_CACHE_AUTO_MEMORY_PERCENT: u64 = 13;
+const REPLAY_CACHE_AUTO_RPC_RPS_PER_CPU: usize = 4096;
 const REPLAY_CACHE_AUTO_MAX_CAPACITY: usize = 33_554_432;
 const NS_SCANNER_CAPABILITY_AUTH_DOMAIN: &[u8] = b"rustfs-ns-scanner-capability-v3";
 pub const TONIC_RPC_PREFIX: &str = "/node_service.NodeService";
@@ -2694,21 +2695,27 @@ mod tests {
 
         assert_eq!(decision.source, ReplayCacheCapacitySource::Auto);
         assert_eq!(decision.memory_basis, Some(MemoryBasis::Host));
-        assert_eq!(decision.memory_based_capacity, 10_737_418);
-        assert_eq!(decision.cpu_based_capacity, 9_846_784);
-        assert_eq!(decision.capacity, 9_846_784);
+        assert_eq!(decision.memory_based_capacity, 17_448_304);
+        assert_eq!(decision.cpu_based_capacity, 19_693_568);
+        assert_eq!(decision.capacity, 17_448_304);
     }
 
     #[test]
-    fn replay_cache_capacity_auto_uses_resource_model_on_larger_nodes() {
+    fn replay_cache_capacity_auto_uses_32m_on_field_sized_nodes() {
         let gib = 1024_u64 * 1024 * 1024;
         let decision =
             replay_cache_capacity_decision(rustfs_utils::EnvParseOutcome::Absent, 16, Some(32 * gib), Some(MemoryBasis::Host));
 
         assert_eq!(decision.source, ReplayCacheCapacitySource::Auto);
-        assert_eq!(decision.memory_based_capacity, 21_474_836);
-        assert_eq!(decision.cpu_based_capacity, 19_693_568);
-        assert_eq!(decision.capacity, 19_693_568);
+        assert_eq!(decision.memory_based_capacity, 34_896_609);
+        assert_eq!(decision.cpu_based_capacity, 39_387_136);
+        assert_eq!(decision.capacity, REPLAY_CACHE_AUTO_MAX_CAPACITY);
+
+        let observed_field_node =
+            replay_cache_capacity_decision(rustfs_utils::EnvParseOutcome::Absent, 16, Some(31 * gib), Some(MemoryBasis::Host));
+        assert_eq!(observed_field_node.memory_based_capacity, 33_806_090);
+        assert_eq!(observed_field_node.cpu_based_capacity, 39_387_136);
+        assert_eq!(observed_field_node.capacity, REPLAY_CACHE_AUTO_MAX_CAPACITY);
     }
 
     #[test]
@@ -2740,7 +2747,7 @@ mod tests {
         let decision = replay_cache_capacity_decision(rustfs_utils::EnvParseOutcome::Invalid, 8, None, None);
 
         assert_eq!(decision.source, ReplayCacheCapacitySource::AutoInvalidEnv);
-        assert_eq!(decision.capacity, 9_846_784);
+        assert_eq!(decision.capacity, 19_693_568);
     }
 
     fn check_test_nonce_record(cache: &mut RpcNonceCache, record: RpcNonceRecord<'_>) -> std::io::Result<()> {


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1647

## Summary of Changes
Raise the internode RPC replay cache auto-sizing model so field-sized 16 CPU / 31-32 GiB nodes resolve to the existing 32M auto cap without requiring `RUSTFS_INTERNODE_RPC_REPLAY_CACHE_CAPACITY=33554432`.

This keeps explicit env configuration first, preserves the historical default floor for undersized env or small nodes, and does not change replay signature verification, nonce recording, fail-closed overflow handling, wire formats, or persisted data.

High-risk review notes:
- Correctness: auto sizing now covers 16 CPU / 31-32 GiB nodes at the 32M cap; small nodes remain clamped to the historical default.
- Simplicity: this is a constants-only model adjustment plus focused tests; no new helper or control flow was added.
- Security: replay protection remains fail-closed and env values below the default are still clamped upward.
- Concurrency/durability: no lock, async scheduling, disk, quorum, or persistence paths changed.
- Compatibility: no env name, protocol, metrics name, or on-wire/on-disk format changed.
- Performance: larger auto-sized caches reduce legitimate overflow risk while remaining capped by `REPLAY_CACHE_AUTO_MAX_CAPACITY`.
- Test coverage: the replay cache capacity tests assert the changed 8 CPU, 16 CPU / 31 GiB, 16 CPU / 32 GiB, invalid env, small-node floor, and extreme-node cap cases.

## Verification
- `cargo test -p rustfs-ecstore replay_cache_capacity -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `RUSTFLAGS="--cfg tokio_unstable" cargo clippy -p rustfs-ecstore --all-targets --all-features -- -D warnings`

## Impact
Clusters that do not explicitly set `RUSTFS_INTERNODE_RPC_REPLAY_CACHE_CAPACITY` may auto-size to a larger replay cache on medium and large nodes. This should reduce fail-closed `replay_cache_capacity` auth failures under high-QPS internode RPC traffic. Explicit env values continue to take precedence, with values below the default still clamped to the default floor.

Four-node runtime validation is not included in this PR because the shared validation cluster is currently occupied by an existing run; it should be performed after the cluster is available.

## Additional Notes
The follow-up optimization should separately reduce `ReadVersion` and `Lock` / `UnLock` nonce amplification on the GET path. This PR intentionally keeps that higher-risk scheduling and lock-semantics work separate from the capacity safety margin.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
