### PR TITLE
perf(lock): bound distributed read lock fanout

### DIFF
--- a/crates/lock/src/distributed_lock.rs
+++ b/crates/lock/src/distributed_lock.rs
@@ -40,6 +40,7 @@ const UNLOCK_RETRY_ATTEMPTS: usize = 3;
 const UNLOCK_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 const LOCK_ACQUIRE_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
 const LOCK_ACQUIRE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(1);
+const LOCK_ACQUIRE_SPARE_HEDGES: usize = 1;
 const REMOTE_LOCK_RPC_FAILED_PREFIX: &str = "remote lock rpc failed:";
 const REMOTE_LOCK_RPC_TIMED_OUT_PREFIX: &str = "remote lock rpc timed out:";
 const UNRECOVERABLE_QUORUM_FAILURE_PREFIX: &str = "unrecoverable quorum failure";
@@ -672,13 +673,22 @@ impl DistributedLock {
         self.acquire_guard(&req).await
     }
 
-    fn spawn_lock_requests(&self, request: &LockRequest) -> JoinSet<LockAcquireTaskResult> {
-        let mut pending = JoinSet::new();
-        for (idx, client) in self.clients.iter().cloned().enumerate() {
+    fn spawn_lock_requests_until(
+        &self,
+        pending: &mut JoinSet<LockAcquireTaskResult>,
+        request: &LockRequest,
+        next_client_index: &mut usize,
+        target_pending: usize,
+    ) {
+        while pending.len() < target_pending {
+            let Some(client) = self.clients.get(*next_client_index).cloned() else {
+                break;
+            };
+            let idx = *next_client_index;
+            *next_client_index = (*next_client_index).saturating_add(1);
             let request = request.clone();
             pending.spawn(async move { (idx, client.acquire_lock(&request).await) });
         }
-        pending
     }
 
     fn lock_acquire_retry_backoff(attempt: usize, rng: &mut impl rand::Rng) -> Duration {
@@ -911,7 +921,16 @@ impl DistributedLock {
     async fn acquire_lock_quorum_once(&self, request: &LockRequest) -> Result<LockAcquireQuorumResult> {
         let required_quorum = self.required_quorum(request.lock_type);
         let attempt_started = Instant::now();
-        let mut pending = self.spawn_lock_requests(request);
+        let mut pending = JoinSet::new();
+        let mut next_client_index = 0usize;
+        self.spawn_lock_requests_until(
+            &mut pending,
+            request,
+            &mut next_client_index,
+            required_quorum
+                .saturating_add(LOCK_ACQUIRE_SPARE_HEDGES)
+                .min(self.clients.len()),
+        );
         let mut individual_locks: Vec<HeldLockEntry> = Vec::new();
         let fallback_lock_id = request.lock_id.clone();
         let mut last_failure = None;
@@ -1085,7 +1104,15 @@ impl DistributedLock {
                 });
             }
 
-            if individual_locks.len() + pending.len() < required_quorum {
+            let needed = required_quorum.saturating_sub(individual_locks.len());
+            self.spawn_lock_requests_until(
+                &mut pending,
+                request,
+                &mut next_client_index,
+                needed.saturating_add(LOCK_ACQUIRE_SPARE_HEDGES),
+            );
+            let unstarted_clients = self.clients.len().saturating_sub(next_client_index);
+            if individual_locks.len() + pending.len() + unstarted_clients < required_quorum {
                 let rollback_count = individual_locks.len();
                 Self::spawn_release_cleanup(
                     individual_locks.iter().map(HeldLockEntry::release_entry).collect(),
@@ -1905,6 +1932,99 @@ mod tests {
         assert!(should_warn_lock_failure("Unrecoverable quorum failure: 1/3 required"));
         assert!(!should_warn_lock_failure("Remote lock RPC timed out: RPC timed out after 50ms"));
         assert!(!should_warn_lock_failure("Lock acquisition timeout"));
+    }
+
+    #[tokio::test]
+    async fn shared_lock_acquire_starts_quorum_plus_one_clients() {
+        let seen_ids = (0..4).map(|_| Arc::new(Mutex::new(Vec::new()))).collect::<Vec<_>>();
+        let clients: Vec<Arc<dyn LockClient>> = vec![
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Success {
+                    delay: Duration::from_millis(20),
+                }],
+                seen_ids[0].clone(),
+            )),
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Success {
+                    delay: Duration::from_millis(20),
+                }],
+                seen_ids[1].clone(),
+            )),
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Success {
+                    delay: Duration::from_millis(200),
+                }],
+                seen_ids[2].clone(),
+            )),
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Success { delay: Duration::ZERO }],
+                seen_ids[3].clone(),
+            )),
+        ];
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Shared, "owner")
+            .with_acquire_timeout(Duration::from_secs(1));
+
+        let guard = lock
+            .acquire_guard(&request)
+            .await
+            .expect("shared lock acquisition should not error")
+            .expect("read quorum should be reached");
+
+        assert_eq!(guard.entries.len(), 2, "read quorum should track exactly two acquired entries");
+        assert_eq!(
+            seen_ids[3].lock().unwrap().len(),
+            0usize,
+            "fourth client should stay unstarted while one hedge is pending"
+        );
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn shared_lock_acquire_replenishes_after_early_failure() {
+        let seen_ids = (0..4).map(|_| Arc::new(Mutex::new(Vec::new()))).collect::<Vec<_>>();
+        let clients: Vec<Arc<dyn LockClient>> = vec![
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Failure {
+                    error: "lock already held",
+                    delay: Duration::ZERO,
+                }],
+                seen_ids[0].clone(),
+            )),
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Success {
+                    delay: Duration::from_millis(80),
+                }],
+                seen_ids[1].clone(),
+            )),
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Success {
+                    delay: Duration::from_millis(120),
+                }],
+                seen_ids[2].clone(),
+            )),
+            Arc::new(SequencedClient::new(
+                vec![AcquirePlan::Success { delay: Duration::ZERO }],
+                seen_ids[3].clone(),
+            )),
+        ];
+        let lock = DistributedLock::new("test".to_string(), clients, 3);
+        let request = LockRequest::new(ObjectKey::new("bucket", "object"), LockType::Shared, "owner")
+            .with_acquire_timeout(Duration::from_secs(1));
+
+        let guard = lock
+            .acquire_guard(&request)
+            .await
+            .expect("shared lock acquisition should not error")
+            .expect("read quorum should be reached after replenishing the failed slot");
+
+        assert_eq!(guard.entries.len(), 2, "read quorum should be reached");
+        assert_eq!(
+            seen_ids[3].lock().unwrap().len(),
+            1usize,
+            "fourth client should be started after an early failure"
+        );
+        drop(guard);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1647

## Summary of Changes
This PR bounds distributed lock acquisition fanout for read/shared lock paths by starting with quorum plus one spare hedge instead of immediately spawning requests to every lock client. When an early acquire attempt fails, the scheduler replenishes pending work from the remaining clients so the quorum requirement remains fail-closed. On the current 4-node RustFS GET path this reduces initial shared-lock RPC attempts from 4 to 3 while still requiring read quorum, and 4-node write/exclusive locks continue to start all 4 clients because their write quorum is 3.

The change is intentionally narrow: it keeps the existing lock IDs, quorum calculation, rollback, pending cleanup, timeout handling, retry classification, heartbeat, and guard release paths intact. It only changes how many lock acquire RPCs are launched before quorum progress requires another client.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs-lock -- --nocapture`
- `RUSTFLAGS="--cfg tokio_unstable" cargo clippy -p rustfs-lock --all-targets --all-features -- -D warnings`
- `cargo test -p rustfs-ecstore test_acquire_dist_delete_object_locks_batch -- --nocapture`
- `git diff --check`

## Impact
This should reduce internode Lock nonce amplification for high-throughput GET/read-lock hot paths without changing public API, configuration, wire format, storage format, or the required lock quorum. The main expected runtime impact is fewer initial lock acquire RPCs for read/shared locks when the cluster has more lock clients than the read quorum plus one hedge. A 4-node shared lock now starts 3 clients instead of 4, then replenishes only if an early failure leaves quorum progress at risk.

## Additional Notes
Remote 4-node profiling validation was not run in this PR step because vm004..vm007 currently have running `/usr/local/bin/rustfs` processes. Following the backlog workflow, this PR handles the code-side Lock nonce amplification reduction first and leaves service takeover, profiling binary deployment, and GET size matrix validation for the next available cluster window.

High-risk adversarial validation summary:
- Correctness: quorum requirements are unchanged; new tests cover quorum-plus-one startup and early-failure replenishment, while existing lock tests cover timeout, rollback, transient RPC failure, contention, heartbeat, and cleanup paths.
- Simplicity: the production diff adds one small scheduler helper and one hedge constant, avoiding a new manager or protocol-level abstraction.
- Security: no authentication, authorization, token, secret, or replay-protection behavior is loosened; fewer lock RPCs means fewer nonce entries are produced, but a lock is still granted only after quorum succeeds.
- Concurrency/durability: no new shared lock is held across await, unstarted clients require no cleanup, and pending/successful late clients still flow through the existing cleanup and rollback paths.
- Compatibility: no public API, on-wire schema, on-disk format, configuration, or mixed-version protocol contract changes.
- Performance: the intended hot-path effect is lower shared-lock RPC fanout and replay-cache pressure on GET; the remaining risk is that a fixed quorum-plus-one subset can be slower than all-client fanout when the unstarted client would have been the fastest responder, so this requires the planned 4-node AB validation before claiming field performance improvement.
- Test coverage: this PR includes focused regression tests that fail if shared locks return to all-client fanout or stop replenishing after an early failure; broader GET performance validation remains pending until the cluster is free.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
