### PR TITLE
perf(get): tune body stream buffers

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -584,10 +584,14 @@ fn capacity_scope_from_disks(disks: &[Option<DiskStore>]) -> CapacityScope {
 ///
 /// **Deprecated**: Use `adaptive_duplex_buffer_size()` for object-size-aware sizing.
 pub fn get_duplex_buffer_size() -> usize {
-    rustfs_utils::get_env_usize(
-        rustfs_config::ENV_OBJECT_DUPLEX_BUFFER_SIZE,
-        rustfs_config::DEFAULT_OBJECT_DUPLEX_BUFFER_SIZE,
-    )
+    static CACHED: OnceLock<usize> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        rustfs_utils::get_env_usize(
+            rustfs_config::ENV_OBJECT_DUPLEX_BUFFER_SIZE,
+            rustfs_config::DEFAULT_OBJECT_DUPLEX_BUFFER_SIZE,
+        )
+        .max(1)
+    })
 }
 
 /// Get adaptive duplex buffer size based on object size.
@@ -597,12 +601,15 @@ pub fn get_duplex_buffer_size() -> usize {
 fn adaptive_duplex_buffer_size(object_size: i64) -> usize {
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
-    match object_size {
-        0..=1_048_576 => 64 * KB,           // <= 1MB: 64KB
+    let target = match object_size {
+        0..=131_072 => 64 * KB,             // <= 128KB: 64KB
+        131_073..=1_048_576 => 512 * KB,    // <= 1MB: reduce duplex backpressure without a 1MB pipe per request
         1_048_577..=16_777_216 => MB,       // <= 16MB: 1MB
         16_777_217..=268_435_456 => 4 * MB, // <= 256MB: 4MB
         _ => 8 * MB,                        // > 256MB: 8MB
-    }
+    };
+    let object_cap = usize::try_from(object_size).ok().filter(|size| *size > 0).unwrap_or(target);
+    target.min(object_cap.max(64 * KB)).min(get_duplex_buffer_size())
 }
 
 // ============================================================================
@@ -11128,5 +11135,14 @@ mod tests {
                 "offline (None) disk slot must map to DiskNotFound in-place, got {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn adaptive_duplex_buffer_size_raises_mid_sized_gets_without_penalizing_tiny_objects() {
+        assert_eq!(adaptive_duplex_buffer_size(64 * 1024), 64 * 1024);
+        assert_eq!(adaptive_duplex_buffer_size(128 * 1024), 64 * 1024);
+        assert_eq!(adaptive_duplex_buffer_size(256 * 1024), 256 * 1024);
+        assert_eq!(adaptive_duplex_buffer_size(1024 * 1024), 512 * 1024);
+        assert_eq!(adaptive_duplex_buffer_size(2 * 1024 * 1024), 1024 * 1024);
     }
 }

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -708,6 +708,8 @@ const LARGE_SEQUENTIAL_GET_STREAM_BUFFER_CAP_BYTES: usize = 4 * MI_B;
 const LARGE_SEQUENTIAL_GET_READAHEAD_MULTIPLIER: usize = 2;
 const LARGE_BODY_READER_STREAM_BUFFER_FLOOR_BYTES: usize = MI_B;
 const LARGE_BODY_READER_STREAM_BUFFER_THRESHOLD_BYTES: i64 = 4 * MI_B as i64;
+const MID_BODY_READER_STREAM_BUFFER_FLOOR_BYTES: usize = 512 * 1024;
+const MID_BODY_READER_STREAM_BUFFER_THRESHOLD_BYTES: i64 = MI_B as i64;
 const ENV_RUSTFS_GET_SEEK_BUFFER_ENABLE: &str = "RUSTFS_GET_SEEK_BUFFER_ENABLE";
 const ENV_RUSTFS_GET_READER_STREAM_BUFFER_SIZE: &str = "RUSTFS_GET_READER_STREAM_BUFFER_SIZE";
 const ENV_RUSTFS_GET_OUTPUT_HANDOFF_ATTRIBUTION_ENABLE: &str = "RUSTFS_GET_OUTPUT_HANDOFF_ATTRIBUTION_ENABLE";
@@ -761,6 +763,12 @@ fn tune_reader_stream_buffer_size(
         && response_content_length >= LARGE_BODY_READER_STREAM_BUFFER_THRESHOLD_BYTES
     {
         return selected_size.max(LARGE_BODY_READER_STREAM_BUFFER_FLOOR_BYTES);
+    }
+
+    if stream_strategy == GetObjectStreamStrategy::Standard
+        && response_content_length >= MID_BODY_READER_STREAM_BUFFER_THRESHOLD_BYTES
+    {
+        return selected_size.max(MID_BODY_READER_STREAM_BUFFER_FLOOR_BYTES);
     }
 
     selected_size
@@ -14938,7 +14946,11 @@ mod tests {
         );
         assert_eq!(
             tune_reader_stream_buffer_size(128 * 1024, MI_B as i64, GetObjectStreamStrategy::Standard),
-            128 * 1024
+            MID_BODY_READER_STREAM_BUFFER_FLOOR_BYTES
+        );
+        assert_eq!(
+            tune_reader_stream_buffer_size(256 * 1024, 2 * MI_B as i64, GetObjectStreamStrategy::Standard),
+            MID_BODY_READER_STREAM_BUFFER_FLOOR_BYTES
         );
         assert_eq!(
             tune_reader_stream_buffer_size(128 * 1024, 10 * MI_B as i64, GetObjectStreamStrategy::LargeSequentialReadahead),


### PR DESCRIPTION
## Related Issues
Related: rustfs/backlog#1647

## Summary of Changes
This PR tunes the GET response-body hot path for mid-sized reads, especially the 1MiB steady-state GET profile where response write/body buffer, duplex backpressure, and per-chunk allocation showed up in profiling.

Changes:
- Raise the standard GET response stream buffer floor to 512KiB for responses >= 1MiB and below the existing large-object threshold.
- Keep the existing 1MiB response stream floor for >= 4MiB standard reads and large sequential readahead.
- Raise the legacy duplex pipe target for 128KiB..=1MiB reads up to 512KiB, capped by object size and the configured `RUSTFS_OBJECT_DUPLEX_BUFFER_SIZE` maximum.
- Cache the effective duplex buffer cap after first read, matching the process-lifetime behavior of adjacent GET tuning knobs.
- Add focused boundary tests for the 128KiB, 256KiB, 1MiB, and 2MiB sizing behavior.

This reduces chunk count and bounded duplex backpressure on 1MiB GET without changing S3-visible body bytes, range handling, content length, metadata fanout, lock acquisition, or replay protection.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore adaptive_duplex_buffer_size_raises_mid_sized_gets_without_penalizing_tiny_objects`
- `cargo test -p rustfs tune_reader_stream_buffer_size_raises_large_standard_streams_only`
- `cargo clippy -p rustfs-ecstore --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="--cfg tokio_unstable" cargo clippy -p rustfs --all-targets --all-features -- -D warnings`

## Impact
Expected impact is lower response chunk count and less duplex backpressure for mid-sized GETs, with the primary target being 1MiB GET. Tiny reads remain bounded at the previous 64KiB duplex target, and configured `RUSTFS_OBJECT_DUPLEX_BUFFER_SIZE` remains an upper cap. Memory per active 1MiB legacy-duplex GET may increase because the pipe can buffer more data, but the increase is bounded and only applies to the legacy duplex path.

No S3 API behavior, metadata format, auth, replay-cache, or lock quorum semantics are changed.

## Additional Notes
ReadVersion metadata fanout and read-only GET nonce amplification were reviewed while preparing this PR. Distributed erasure metadata caching is still bypassed by design, and read-lock fanout already uses read quorum with a spare hedge. This PR intentionally does not change those defaults because doing so needs a separate AB-validated rollout due to correctness and long-tail risk.
