### PR TITLE
fix: update s3s footprint baseline after table-catalog hardening

### DIFF
--- a/scripts/check_s3s_footprint.sh
+++ b/scripts/check_s3s_footprint.sh
@@ -26,7 +26,7 @@ cd "$(dirname "$0")/.."
 # Excludes crates/e2e_test/ — test infrastructure legitimately uses s3s
 # to verify S3 behavior and does not widen the production s3s surface.
 S3S_IMPORT_FILES_BASELINE=213
-S3_ERROR_LINES_BASELINE=1617
+S3_ERROR_LINES_BASELINE=1621
 S3S_PATH_PATTERN='(^|[^"[:alnum:]_])s3s::'
 E2E_TEST_GLOB='--glob=!crates/e2e_test/**'
 


### PR DESCRIPTION
## Problem

`make pre-pr` fails on main with an s3s footprint ratchet violation:

```
❌ s3s footprint ratchet violation: s3_error! invocation lines is 1621, baseline is 1617 (+4)
```

The baseline was set to 1617 in `31cb72047` (fix: exclude e2e_test from s3s footprint ratchet baseline). Two subsequent commits landed on main without updating the baseline:

- `5e3010c6b` fix(table-catalog): harden commit publication (#5779) — **+8** s3_error! lines
- `e9728192e` fix(select): enforce typed S3 Select error semantics (#5942) — **-4** s3_error! lines

Net change: **+4** (1617 → 1621).

## Fix

Update `S3_ERROR_LINES_BASELINE` from 1617 to 1621 in `scripts/check_s3s_footprint.sh`.

## Verification

```
s3s footprint OK: files importing s3s is 213 (baseline: 213)
s3s footprint OK: s3_error! invocation lines is 1621 (baseline: 1621)
✅ s3s footprint ratchet check passed
```

`make pre-commit`: all checks passed.
`cargo nextest run --exclude e2e_test --all --no-fail-fast`: 13197/13198 passed (1 flaky timing-sensitive test passes in isolation; 1 DNS environment issue — Cisco Umbrella resolves `.invalid` domains).
