### PR TITLE
perf(get): enable inline direct-read by default + versioned buckets (#1802)

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -671,7 +671,13 @@ const ENV_RUSTFS_GET_CODEC_STREAMING_DATA_BLOCKS_FIRST_MAX_SIZE: &str = "RUSTFS_
 const DEFAULT_RUSTFS_GET_CODEC_STREAMING_DATA_BLOCKS_FIRST_MAX_SIZE: usize = 512 * 1024;
 
 const ENV_RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY: &str = "RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY";
-const DEFAULT_RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY: bool = false;
+// On by default (rustfs/backlog#1802): a small object whose data shards are
+// inlined in xl.meta is reassembled straight from the already-resolved
+// metadata, skipping the Erasure reconstruct pipeline. The path has a complete
+// fallback — if the inline reassembly returns None, the GET proceeds through
+// the normal shard-read pipeline, so a miss is correctness-neutral. Set to
+// `false` to force the legacy path (kill switch).
+const DEFAULT_RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY: bool = true;
 const ENV_RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY_THRESHOLD: &str = "RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY_THRESHOLD";
 const DEFAULT_RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY_THRESHOLD: usize = 128 * 1024;
 
@@ -1614,8 +1620,6 @@ enum GetDirectMemoryFallbackReason {
     Range,
     PartNumber,
     VersionId,
-    Versioned,
-    VersionSuspended,
     InclFreeVersions,
     SkipFreeVersion,
     DataMovement,
@@ -1641,8 +1645,6 @@ impl GetDirectMemoryFallbackReason {
             Self::Range => "range",
             Self::PartNumber => "part_number",
             Self::VersionId => "version_id",
-            Self::Versioned => "versioned",
-            Self::VersionSuspended => "version_suspended",
             Self::InclFreeVersions => "incl_free_versions",
             Self::SkipFreeVersion => "skip_free_version",
             Self::DataMovement => "data_movement",
@@ -1766,12 +1768,11 @@ fn get_small_object_direct_memory_decision_with_threshold(
     if opts.version_id.is_some() {
         return GetDirectMemoryDecision::Fallback(GetDirectMemoryFallbackReason::VersionId);
     }
-    if opts.versioned {
-        return GetDirectMemoryDecision::Fallback(GetDirectMemoryFallbackReason::Versioned);
-    }
-    if opts.version_suspended {
-        return GetDirectMemoryDecision::Fallback(GetDirectMemoryFallbackReason::VersionSuspended);
-    }
+    // Bucket-level versioning no longer blocks the inline path (rustfs/backlog#1802):
+    // `fi` here is the already-resolved target version, so reassembling its inlined
+    // data shards is correct whether the bucket is versioned or not. This direct-memory
+    // decision still falls back for an explicit versionId (the `version_id` check above);
+    // a delete-marker latest is rejected below.
     if opts.incl_free_versions {
         return GetDirectMemoryDecision::Fallback(GetDirectMemoryFallbackReason::InclFreeVersions);
     }
@@ -8681,9 +8682,11 @@ mod tests {
             128 * 1024
         ));
 
+        // Bucket-level versioning no longer blocks the inline path (rustfs/backlog#1802):
+        // a latest-version read on a versioned bucket is eligible.
         let mut versioned_opts = opts.clone();
         versioned_opts.versioned = true;
-        assert!(!is_get_small_object_direct_memory_eligible_with_threshold(
+        assert!(is_get_small_object_direct_memory_eligible_with_threshold(
             &None,
             &object_info,
             &fi,
@@ -8744,11 +8747,13 @@ mod tests {
             GetDirectMemoryDecision::Fallback(GetDirectMemoryFallbackReason::Range)
         );
 
+        // Bucket-level versioning no longer falls back (rustfs/backlog#1802): the
+        // latest version on a versioned bucket is served inline like any other.
         let mut versioned_opts = opts.clone();
         versioned_opts.versioned = true;
         assert_eq!(
             get_small_object_direct_memory_decision_with_threshold(&None, &object_info, &fi, &versioned_opts, true, 128 * 1024),
-            GetDirectMemoryDecision::Fallback(GetDirectMemoryFallbackReason::Versioned)
+            GetDirectMemoryDecision::Use { object_size: 1024 }
         );
 
         let mut encrypted = object_info.clone();
@@ -8796,8 +8801,6 @@ mod tests {
         assert_eq!(GetDirectMemoryFallbackReason::Range.as_str(), "range");
         assert_eq!(GetDirectMemoryFallbackReason::PartNumber.as_str(), "part_number");
         assert_eq!(GetDirectMemoryFallbackReason::VersionId.as_str(), "version_id");
-        assert_eq!(GetDirectMemoryFallbackReason::Versioned.as_str(), "versioned");
-        assert_eq!(GetDirectMemoryFallbackReason::VersionSuspended.as_str(), "version_suspended");
         assert_eq!(GetDirectMemoryFallbackReason::InclFreeVersions.as_str(), "incl_free_versions");
         assert_eq!(GetDirectMemoryFallbackReason::SkipFreeVersion.as_str(), "skip_free_version");
         assert_eq!(GetDirectMemoryFallbackReason::DataMovement.as_str(), "data_movement");


### PR DESCRIPTION
## What

A small object whose data shards are inlined in `xl.meta` can be reassembled straight from already-resolved metadata, skipping the Erasure reconstruct pipeline. That fast path existed but was opt-in (`RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY`, default off), so every deployment paid the full shard-read fan-out for eligible small GETs. This turns it on by default and stops excluding versioned buckets. Closes rustfs/backlog#1802 (GET-B, Wave 1 of the small-file perf program rustfs/backlog#1818).

## Why it's safe

- **Miss is correctness-neutral.** The decision only routes a GET to the inline path when it is eligible; `try_get_object_direct_data_shards_*` then returns `None` if the inlined data cannot satisfy the read (missing/short shard, length mismatch), and the GET falls through to the normal shard-read pipeline unchanged. So the worst case is "fast path didn't apply", never wrong bytes.
- **`fi` is the resolved target version.** The decision at `set_disk/ops/object.rs:694` runs on the version the GET already resolved (latest, or the versionId the caller asked for). Reassembling that version's inlined data is therefore correct regardless of bucket versioning. An explicit `?versionId=` GET still falls back (`opts.version_id`), and a delete-marker latest is still rejected.
- **Kill switch stays.** `RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY=false` restores the legacy path exactly.

## How

- `DEFAULT_RUSTFS_GET_SMALL_OBJECT_DIRECT_MEMORY` → `true` (with a comment on the fallback semantics and the kill switch).
- Dropped the bucket-level `versioned` / `version_suspended` exclusions from `get_small_object_direct_memory_decision_with_threshold`, plus the now-unused `GetDirectMemoryFallbackReason::{Versioned,VersionSuspended}` variants and their metric labels. The decision is strictly simpler than before.
- Tests updated: a versioned latest-version object is now `Use` / eligible (covers the newly allowed path); the removed reasons' label assertions are dropped.

## Verification

- `cargo fmt --all`; `cargo check -p rustfs-ecstore --lib --tests` clean; the `direct_memory` unit tests (decision, eligibility, metric labels, inline reassembly) pass on macOS. The change is fully cross-platform, so this is not a Linux-only-gated edit.
- An independent pre-PR review pass landed **可以合并 / no P0-P1**: it validated the versioned relaxation (the `fi` at the call site is the resolved target version; explicit versionId still falls back; delete-marker latest rejected; graceful fallback to the shard pipeline on `None`; multi-block safety retained), confirmed the change is a clean removal rather than a layered hack, and confirmed no e2e test asserts direct-memory as the expected path (`inline_fast_path_cluster_test.rs` explicitly forces it off). Three non-blocking P2 notes: the versionId comment was tightened (this PR); a percentage rollout to match the codec-streaming convention is a possible follow-up (the `None`-on-miss failure mode makes a hard flip defensible here); and on a degraded cluster an eligible small GET may now pay one failed inline attempt before falling back (pre-existing, slightly amplified).