### PR TITLE
perf(get): slim metadata fanout allocations

### DIFF
--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -1251,7 +1251,7 @@ pub struct VolumeInfo {
     pub created: Option<OffsetDateTime>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Copy)]
 pub struct ReadOptions {
     pub incl_free_versions: bool,
     pub read_data: bool,

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -2222,18 +2222,18 @@ impl SetDisks {
         let mut ress = Vec::with_capacity(disks.len());
         let mut errors = Vec::with_capacity(disks.len());
         let mut observations = observe.then(|| Vec::with_capacity(disks.len()));
-        let opts = Arc::new(ReadOptions {
+        let opts = ReadOptions {
             incl_free_versions,
             read_data,
             healing,
-        });
-        let org_bucket = Arc::new(org_bucket.to_string());
-        let bucket = Arc::new(bucket.to_string());
-        let object = Arc::new(object.to_string());
-        let version_id = Arc::new(version_id.to_string());
+        };
+        let org_bucket: Arc<str> = Arc::from(org_bucket);
+        let bucket: Arc<str> = Arc::from(bucket);
+        let object: Arc<str> = Arc::from(object);
+        let version_id: Arc<str> = Arc::from(version_id);
         let futures = disks.iter().enumerate().map(|(disk_index, disk)| {
             let disk = disk.clone();
-            let opts = opts.clone();
+            let task_opts = opts;
             let org_bucket = org_bucket.clone();
             let bucket = bucket.clone();
             let object = object.clone();
@@ -2242,7 +2242,8 @@ impl SetDisks {
                 let response_start = observe.then(Instant::now);
                 let result = if let Some(disk) = disk {
                     Self::record_read_version_call(&object, disk_index);
-                    disk.read_version(&org_bucket, &bucket, &object, &version_id, &opts).await
+                    disk.read_version(&org_bucket, &bucket, &object, &version_id, &task_opts)
+                        .await
                 } else {
                     Err(DiskError::DiskNotFound)
                 };
@@ -2307,21 +2308,21 @@ impl SetDisks {
         let mut observations = Vec::with_capacity(disks.len());
         let mut accumulator =
             MetadataQuorumAccumulator::new(disks.len(), default_parity_count, true).with_requested_version_id(version_id);
-        let opts = Arc::new(ReadOptions {
+        let opts = ReadOptions {
             incl_free_versions,
             read_data,
             healing,
-        });
-        let org_bucket = Arc::new(org_bucket.to_string());
-        let bucket = Arc::new(bucket.to_string());
-        let object = Arc::new(object.to_string());
-        let version_id = Arc::new(version_id.to_string());
+        };
+        let org_bucket: Arc<str> = Arc::from(org_bucket);
+        let bucket: Arc<str> = Arc::from(bucket);
+        let object: Arc<str> = Arc::from(object);
+        let version_id: Arc<str> = Arc::from(version_id);
         let mut join_set = JoinSet::new();
         let bounded_fanout = is_get_metadata_early_stop_bounded_fanout_enabled();
         let mut next_disk_index = 0usize;
         let spawn_read_version =
             |join_set: &mut JoinSet<(usize, disk::error::Result<FileInfo>, Duration)>, index: usize, disk: Option<DiskStore>| {
-                let opts = opts.clone();
+                let task_opts = opts;
                 let org_bucket = org_bucket.clone();
                 let bucket = bucket.clone();
                 let object = object.clone();
@@ -2332,7 +2333,8 @@ impl SetDisks {
                         Self::record_read_version_call(&object, index);
                         #[cfg(test)]
                         Self::read_version_fanout_barrier(&object, index).await;
-                        disk.read_version(&org_bucket, &bucket, &object, &version_id, &opts).await
+                        disk.read_version(&org_bucket, &bucket, &object, &version_id, &task_opts)
+                            .await
                     } else {
                         Err(DiskError::DiskNotFound)
                     };

--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -362,9 +362,9 @@ impl SetDisks {
             healing: true,
         };
         let checks = target_disks.into_iter().map(|disk| {
-            let read_options = read_options.clone();
+            let task_read_options = read_options;
             async move {
-                let file_info = match disk.read_version("", bucket, object, version_id, &read_options).await {
+                let file_info = match disk.read_version("", bucket, object, version_id, &task_read_options).await {
                     Ok(file_info) => file_info,
                     Err(
                         DiskError::DiskNotFound

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -224,7 +224,7 @@ impl SetDisks {
         let bucket = bucket.to_string();
         let object = object.to_string();
         let version_id = version_id.to_string();
-        let opts = opts.clone();
+        let opts = *opts;
 
         let processor = runtime_sources::batch_processors().read_processor();
         let tasks: Vec<_> = disks
@@ -235,9 +235,9 @@ impl SetDisks {
                     let bucket = bucket.clone();
                     let object = object.clone();
                     let version_id = version_id.clone();
-                    let opts = opts.clone();
+                    let task_opts = opts;
 
-                    async move { disk.read_version(&bucket, &bucket, &object, &version_id, &opts).await }
+                    async move { disk.read_version(&bucket, &bucket, &object, &version_id, &task_opts).await }
                 })
             })
             .collect();


### PR DESCRIPTION
## What

Every GET fans out a `read_version` across all disks to resolve `xl.meta`. Each fanout allocated an `Arc<ReadOptions>` (three bools) plus four `Arc<String>` (`Arc::new(x.to_string())` = two allocations each) and cloned them into every spawned task. This trims that per-fanout allocation footprint. Closes rustfs/backlog#1803 (GET-C, Wave 1 of the small-file perf program rustfs/backlog#1818).

## How

- `ReadOptions` is three bools, so it is now `Copy` (`disk/mod.rs`). The fanout drops the `Arc<ReadOptions>` and hands each spawned task a stack copy; the two pre-existing `ReadOptions::clone()` sites (`set_disk/read.rs`, `set_disk/ops/heal.rs`) stop cloning a `Copy` type.
- The four request strings use `Arc::<str>::from(&str)` (one allocation each) instead of `Arc::new(..to_string())` (string buffer + Arc = two each) — four fewer allocations per fanout, transparent to every `read_version(&str)` / `record_read_version_call(&str)` call site via deref coercion.

## Why it's a no-op behaviorally

The fanout still spawns exactly one task per disk (`tokio::spawn` in `full_wait`, `JoinSet` in `early_stop`), still relies on `join_all` order / index placement, still maps `JoinError → DiskError::Unexpected`, and the quorum / early-stop / bounded-fanout / hedge logic is untouched. `read_version_call_counter_observes_spawned_fanout` still passes, proving the per-disk counter observes every increment across workers.

## Scope — two audit items intentionally deferred

- `tokio::spawn → FuturesUnordered`: the spawn is deliberate and tested — it gives panic isolation (a panicking `read_version` becomes a per-disk `JoinError → Unexpected` instead of aborting the whole fanout) and the `read_version_call_counter_observes_spawned_fanout` test encodes the cross-worker counter contract for #1309/#1314. Converting would regress both.
- `vec![FileInfo::default(); N]`: `FileInfo`'s empty `String`/`HashMap`/`Vec`/`Option` do not allocate on `Default`/`clone`, so this is one `Vec` buffer allocation, not the per-element heap allocation the audit implied — a one-time fanout-setup cost, not a per-task hot spot.

## Verification

- `cargo fmt --all`; `cargo clippy -p rustfs-ecstore --lib` (0 warnings); `cargo check -p rustfs --lib --tests` clean.
- 28 relevant unit tests pass: `read_version_call_counter_observes_spawned_fanout`, the `metadata_fanout` / `early_stop` suites, and `read_version_optimized`. The change is fully cross-platform, so this is not a Linux-only-gated edit.
- An independent pre-PR review pass landed **可合并 / no P0-P1**: it confirmed `ReadOptions: Copy` is serde/RPC-wire compatible, `Arc<str>` deref coercion holds at every call site (no `AsRef`/generic-receiver corners), per-task `Copy` capture has no shared mutability, and fanout behavior (spawn count, ordering, error mapping, quorum/early-stop) is identical to `main`. Its only two notes were clarity-only (naming consistency, closure-capture style) — no change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
