### PR TITLE
perf(rpc): size remote shard read buffers

### DIFF
--- a/rustfs/src/storage/rpc/http_service.rs
+++ b/rustfs/src/storage/rpc/http_service.rs
@@ -39,7 +39,6 @@ use rustfs_io_metrics::internode_metrics::{
     INTERNODE_OPERATION_NS_SCANNER, INTERNODE_OPERATION_PUT_FILE_CAPABILITY, INTERNODE_OPERATION_PUT_FILE_STREAM,
     INTERNODE_OPERATION_READ_FILE_STREAM, INTERNODE_OPERATION_WALK_DIR, INTERNODE_TRANSPORT_BACKEND_TCP_HTTP,
 };
-use rustfs_utils::net::bytes_stream;
 use s3s::Body;
 use s3s::dto::StreamingBlob;
 use serde::de::DeserializeOwned;
@@ -51,7 +50,7 @@ use std::pin::Pin;
 use std::sync::{Arc, LazyLock, Weak};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
-use tokio::io::{self, AsyncWriteExt};
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Mutex, oneshot};
 use tokio_util::{io::ReaderStream, sync::CancellationToken};
 use tower::Service;
@@ -663,15 +662,24 @@ where
     R: tokio::io::AsyncRead + Unpin + Send + Sync + 'static,
 {
     let metrics = runtime_sources::current_internode_metrics();
-    let stream = ReaderStream::with_capacity(reader, DEFAULT_READ_BUFFER_SIZE).map_ok(move |bytes| {
+    let read_buffer_size = read_file_stream_buffer_size(length);
+    let read_limit = if length == 0 {
+        u64::MAX
+    } else {
+        u64::try_from(length).unwrap_or(u64::MAX)
+    };
+    let stream = ReaderStream::with_capacity(reader.take(read_limit), read_buffer_size).map_ok(move |bytes| {
         metrics.record_sent_bytes_for_operation_and_backend(operation, INTERNODE_TRANSPORT_BACKEND_TCP_HTTP, bytes.len());
         bytes
     });
+    Box::pin(stream)
+}
 
+fn read_file_stream_buffer_size(length: usize) -> usize {
     if length == 0 {
-        Box::pin(stream)
+        DEFAULT_READ_BUFFER_SIZE
     } else {
-        Box::pin(bytes_stream(stream, length))
+        length.min(DEFAULT_READ_BUFFER_SIZE)
     }
 }
 
@@ -1664,7 +1672,7 @@ fn put_file_stage_error_message(stage: &str, query: &PutFileQuery, err: &dyn std
 #[cfg(test)]
 mod tests {
     use super::{
-        DiskError, InternodeRpcService, LOG_SUBSYSTEM_DIRECTORY_WALK, LOG_SUBSYSTEM_FILE_TRANSFER,
+        DEFAULT_READ_BUFFER_SIZE, DiskError, InternodeRpcService, LOG_SUBSYSTEM_DIRECTORY_WALK, LOG_SUBSYSTEM_FILE_TRANSFER,
         LOG_SUBSYSTEM_NAMESPACE_SCANNER, LOG_SUBSYSTEM_ROUTING, NS_SCANNER_BODY_SHA256_QUERY,
         NS_SCANNER_CAPABILITY_CHALLENGE_QUERY, NS_SCANNER_CYCLE_QUERY, NS_SCANNER_LEADER_EPOCH_QUERY, NS_SCANNER_PATH,
         NS_SCANNER_REQUEST_ID_QUERY, NS_SCANNER_SERVER_EPOCH_QUERY, NS_SCANNER_SESSION_ID_QUERY,
@@ -1673,10 +1681,10 @@ mod tests {
         append_walk_dir_completion, internode_http_operation, internode_rpc_subsystem, is_internode_rpc_path,
         ns_scanner_response_body, ns_scanner_server_epoch_matches, put_body_size_mismatch, put_file_auth_nonce,
         put_file_capability_response, put_file_server_epoch_matches, put_file_stage_error_message, put_file_target_lock,
-        read_file_body_stream, remote_scanner_claim_rejection, response_with_disk_error, supports_walk_dir_stream_completion,
-        validate_walk_dir_completion_request, verify_internode_rpc_signature, verify_ns_scanner_body_digest,
-        verify_walk_dir_body_digest, walk_dir_response_body, write_authenticated_put_file, write_body_chunks_to_writer,
-        write_put_file_body_chunks_to_writer,
+        read_file_body_stream, read_file_stream_buffer_size, remote_scanner_claim_rejection, response_with_disk_error,
+        supports_walk_dir_stream_completion, validate_walk_dir_completion_request, verify_internode_rpc_signature,
+        verify_ns_scanner_body_digest, verify_walk_dir_body_digest, walk_dir_response_body, write_authenticated_put_file,
+        write_body_chunks_to_writer, write_put_file_body_chunks_to_writer,
     };
     use crate::storage::storage_api::ecstore_rpc::{build_put_file_auth_trailer, gen_signature_headers};
     use crate::storage::storage_api::rpc_consumer::http_service::{DiskAPI as _, DiskOption, DiskStore, Endpoint, new_disk};
@@ -1703,6 +1711,23 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream};
     use tokio_stream::StreamExt;
     use tokio_stream::iter;
+
+    struct RejectExtraPollReader {
+        emitted: bool,
+    }
+
+    impl io::AsyncRead for RejectExtraPollReader {
+        fn poll_read(mut self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &mut io::ReadBuf<'_>) -> Poll<io::Result<()>> {
+            if self.emitted {
+                return Poll::Ready(Err(io::Error::other("reader polled past the requested length")));
+            }
+
+            let bytes = b"hello world";
+            buf.put_slice(&bytes[..buf.remaining().min(bytes.len())]);
+            self.emitted = true;
+            Poll::Ready(Ok(()))
+        }
+    }
 
     async fn new_put_file_test_disk() -> (DiskStore, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("temp directory should be created");
@@ -2842,11 +2867,7 @@ mod tests {
 
     #[tokio::test]
     async fn read_file_body_stream_truncates_to_requested_length() {
-        let (reader, mut writer) = tokio::io::duplex(64);
-        tokio::spawn(async move {
-            writer.write_all(b"hello world").await.expect("write succeeds");
-        });
-
+        let reader = RejectExtraPollReader { emitted: false };
         let mut stream = read_file_body_stream(reader, 5, INTERNODE_OPERATION_READ_FILE_STREAM);
         let mut out = Vec::new();
         while let Some(chunk) = stream.next().await {
@@ -2854,6 +2875,18 @@ mod tests {
         }
 
         assert_eq!(out, b"hello");
+    }
+
+    #[test]
+    fn read_file_body_stream_sizes_buffer_to_requested_length() {
+        for (length, expected_capacity) in [
+            (0, DEFAULT_READ_BUFFER_SIZE),
+            (40 * 1024, 40 * 1024),
+            (DEFAULT_READ_BUFFER_SIZE, DEFAULT_READ_BUFFER_SIZE),
+            (DEFAULT_READ_BUFFER_SIZE + 1, DEFAULT_READ_BUFFER_SIZE),
+        ] {
+            assert_eq!(read_file_stream_buffer_size(length), expected_capacity);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

- Size the internode read stream buffer to the requested shard length when it is below the existing 1 MiB ceiling.
- Preserve the 1 MiB buffer for full-file reads and requests at or above the ceiling.
- Bound non-zero reads with `AsyncReadExt::take` so a smaller buffer cannot amplify reads or polls past the requested range.
- Add regression coverage for zero, below-ceiling, exact-ceiling, and above-ceiling capacities, plus the no-extra-poll boundary.

## Verification

- `make pre-pr` — passed before the conflict-free rebase; 13,199 nextest tests passed, 165 skipped, and all doctests passed.
- `make pre-commit` — passed after rebasing onto the latest `origin/main`.
- `cargo test -p rustfs --lib read_file_body_stream_ -- --nocapture` — passed after the rebase; 3 tests passed.
- Fixed-1-MiB and removed-read-limit mutation probes both caused their corresponding regression tests to fail.

## Impact

Remote shard reads below 1 MiB allocate capacity proportional to the requested length instead of reserving 1 MiB per stream. Reads below the ceiling still fit in one stream chunk, reads at or above the ceiling retain the existing chunk size, and `length == 0` keeps the existing full-file behavior. There are no wire-format, API, configuration, persistence, or mixed-version compatibility changes.

## Additional Notes

- Correctness: attacked zero length, boundary lengths, short EOF, and over-read behavior; no unresolved issue found.
- Simplicity: attacked shared-helper reuse, one-off abstractions, and redundant stream wrappers; the final change remains local to the RPC body path.
- Security: attacked peer-controlled small-length amplification and post-boundary polling; the explicit read limit closes the amplification path.
- Concurrency and durability: attacked cancellation, shared state, and persistence effects; no locking or durability behavior changes.
- Compatibility: attacked mixed-version and HTTP body behavior; no protocol or error contract changes.
- Performance: attacked chunk-count growth, allocation behavior, and full-file overhead; sub-1-MiB reads reduce allocation while existing 1-MiB chunking is retained elsewhere.
- Test coverage: boundary and no-extra-poll mutations were verified to fail the added regression tests.
- Rollback is a single-commit revert; no data migration or cleanup is required.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
