### PR TITLE
fix(get): give UringBackend the only fd cache for its disk

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -2955,11 +2955,31 @@ impl std::fmt::Debug for StdBackend {
 
 impl StdBackend {
     pub(crate) fn new(root: PathBuf) -> Self {
+        Self::build(root, true)
+    }
+
+    /// Construct without the descriptor cache.
+    ///
+    /// `UringBackend` wraps a `StdBackend` and runs its own `FdCache` over the
+    /// same positioned reads. If the inner `StdBackend` also built a cache, a
+    /// fallback read (`UringBackend::pread_bytes` delegates to the inner backend
+    /// on latch-off / O_DIRECT / buffered errors) would populate a *second*
+    /// cache that `UringBackend`'s invalidation never touches — re-opening the
+    /// stale-inode hazard `FdCache` exists to close (rustfs/backlog#1176/#1801).
+    /// The wrapper therefore owns the only cache for the disk; the inner backend
+    /// opens per read. This also avoids double-counting `FD_CACHE_CAPACITY`
+    /// against `RLIMIT_NOFILE` (rustfs/backlog#1178).
+    #[cfg(target_os = "linux")]
+    pub(crate) fn new_without_fd_cache(root: PathBuf) -> Self {
+        Self::build(root, false)
+    }
+
+    fn build(root: PathBuf, build_fd_cache: bool) -> Self {
         // Gate the fd cache on RLIMIT_NOFILE headroom (rustfs/backlog#1178):
         // 512 fds/disk with a low soft limit and several disks would hit EMFILE.
         // Fall back to open-per-read when the limit is too small.
         #[cfg(target_os = "linux")]
-        let fd_cache = if is_local_fd_cache_enabled() {
+        let fd_cache = if build_fd_cache && is_local_fd_cache_enabled() {
             if rlimit_allows_fd_cache() {
                 Some(FdCache::new())
             } else {
@@ -2973,6 +2993,10 @@ impl StdBackend {
         } else {
             None
         };
+        // `build_fd_cache` is only consulted on Linux (for the fd cache); on
+        // other platforms it has no effect and would trip the unused-variable lint.
+        #[cfg(not(target_os = "linux"))]
+        let _ = build_fd_cache;
         Self {
             root,
             #[cfg(target_os = "linux")]
@@ -4120,7 +4144,7 @@ impl UringBackend {
                 // struct (rustfs/backlog#1185).
                 let root_label = root.display().to_string();
                 Some(Self {
-                    inner: StdBackend::new(root.clone()),
+                    inner: StdBackend::new_without_fd_cache(root.clone()),
                     root,
                     root_label,
                     driver: std::mem::ManuallyDrop::new(driver),
@@ -19916,6 +19940,23 @@ mod test {
         // Invalidating by the object prefix drops the cached descriptor.
         backend.invalidate_cached_fds_under(volume, "obj/abc");
         assert_eq!(cache.entry_count().await, 0, "prefix invalidation must drop the cached descriptor");
+    }
+
+    /// `StdBackend::new_without_fd_cache` must not build a descriptor cache.
+    /// `UringBackend` wraps a `StdBackend` and owns the only cache for the disk,
+    /// so an inner cache would be populated by fallback reads
+    /// (`UringBackend::pread_bytes` delegates inward) yet never invalidated —
+    /// the stale-inode hazard `FdCache` exists to close (backlog#1176/#1801).
+    /// This pins the contract so a future constructor change cannot regress it.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn new_without_fd_cache_builds_no_descriptor_cache() {
+        let root_dir = tempfile::tempdir().expect("operation should succeed");
+        let backend = StdBackend::new_without_fd_cache(root_dir.path().to_path_buf());
+        assert!(
+            backend.fd_cache.is_none(),
+            "new_without_fd_cache must not build a descriptor cache — UringBackend owns the only cache for the disk"
+        );
     }
 
     /// The mutation paths on `LocalDisk` must actually call


### PR DESCRIPTION
## What

A post-merge re-review of the Wave 1 GET PRs found a P1 in #1801's interaction with `UringBackend`. This fixes it. Follow-up to #1801 (rustfs/rustfs#5965); part of the small-file perf program (rustfs/backlog#1818).

## The bug (P1, io_uring only)

#1801 made `StdBackend::new` always build a descriptor cache. `UringBackend` wraps a `StdBackend` (`inner`), so under io_uring a disk ended up with **two** `FdCache`s — the wrapper's and the inner's. `UringBackend::pread_bytes` delegates to `inner.pread_bytes` on four fallback paths (latch-off, O_DIRECT unsupported/error, buffered-read error), which populate `inner.fd_cache`, but `UringBackend`'s invalidation only touches its own cache — **the inner cache was never invalidated.** For up to `FD_CACHE_TTL` (5s) after a heal/rename/delete, a fallback read could serve the pre-mutation inode: exactly the stale-descriptor hazard `FdCache`'s generation guard exists to close (rustfs/backlog#1176). It also double-counted `FD_CACHE_CAPACITY` (512 fds) against `RLIMIT_NOFILE` per disk (backlog#1178).

Default (non-io_uring) deployments were unaffected — `StdBackend` standalone is correct; the gap is only under the opt-in `UringBackend` wrapper, and only on a fallback read.

## Fix — one cache per disk

`UringBackend` now constructs its inner `StdBackend` with the new `StdBackend::new_without_fd_cache`, so the wrapper owns the only cache for the disk. The inner backend opens per read on fallback, leaving nothing unguarded. `StdBackend::new` (the standalone default) is unchanged; a private `build(root, build_fd_cache)` holds the shared construction.

- Default (non-io_uring) path: byte-for-byte unchanged.
- io_uring path: one cache per disk, fully covered by the wrapper's invalidation; halves the per-disk fd budget under `RLIMIT_NOFILE`.
- `RUSTFS_IO_URING_FD_CACHE` / `RUSTFS_LOCAL_FD_CACHE` semantics preserved.
- Regression test pins `new_without_fd_cache` → no cache.

This is the minimal fix that resolves both the P1 and the double-rlimit P2 without churning the env surface or the io_uring fd-cache test suite.

## Verification

- `cargo fmt --all`; `cargo check -p rustfs-ecstore --lib --tests` clean; `cargo clippy -p rustfs-ecstore --lib` (0 warnings).
- The change is mostly Linux-gated (`new_without_fd_cache`, the io_uring wrapper); the Linux compile + the io_uring fd-cache suite run in CI here.

## Re-review summary (#1801 / #1802 / #1803)

A post-merge holistic re-review (the PRs now coexist on `main`) found all three individually clean; the only actionable item was this #1801 io_uring interaction. #1802 and #1803 need no follow-up (minor P2 notes — kill-switch doc precision, inline-concat dedupe, `read_version_optimized` Arc<str> ride-along, a possible spawn→FuturesUnordered benchmark PR — are recorded in rustfs/backlog#1818 as optional polish, not defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
