### PR TITLE
docs: sync ARCHITECTURE.md structural inventory with measured state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md
 
-> Last updated: 2026-07-02 · Revision: 2
+> Last updated: 2026-08-12 · Revision: 3
 >
 > This document describes the high-level architecture of RustFS.
 > If you want to familiarize yourself with the code base, you are in the right place!
@@ -119,19 +119,44 @@ module split is tracked under `docs/architecture/`.
 
 3. **Each type has exactly one definition.** Types shared across crates must be defined
    in one crate and re-exported or imported by others.
-   - ⚠️ VIOLATED: `ReplicationStats` (4 copies), `LastMinuteLatency` (3 copies),
-     `BackpressureConfig` (3 copies), `DataUsageInfo` (2 copies).
+   - ⚠️ VIOLATED: `ReplicationStats` names three unrelated types
+     (`crates/data-usage/src/data_usage.rs`,
+     `crates/obs/src/metrics/collectors/replication.rs`,
+     `crates/ecstore/src/bucket/replication/replication_state.rs`) — a naming
+     collision, not copies; renaming is tracked in rustfs/backlog#1847.
+   - `LastMinuteLatency` has two deliberately different implementations: the
+     per-second bucketed accumulator in `crates/common/src/last_minute.rs` and
+     the in-memory endpoint-health sample tracker in
+     `crates/ecstore/src/bucket/bucket_target_sys.rs` (its doc comment explains
+     why it stays local).
+   - ✅ RESOLVED: `BackpressureConfig` and `DataUsageInfo` each have exactly one
+     definition (`crates/io-core/src/backpressure.rs`,
+     `crates/data-usage/src/data_usage.rs`). A zero-consumer
+     `BackpressureSettings` copy lingers in `crates/io-metrics/src/config.rs`;
+     its removal is tracked in rustfs/backlog#1833.
 
 4. **ecstore does not know about HTTP or S3 protocol details.** It operates on
    storage-level abstractions (objects, buckets, disks, pools).
+   - ⚠️ VIOLATED: 58 files under `crates/ecstore/src` reference `s3s`
+     (`rg -l 's3s' crates/ecstore/src | wc -l`), `crates/ecstore/src/client/`
+     is a ~9.4K-line embedded S3 HTTP client, and `crates/ecstore/Cargo.toml`
+     depends on `s3s`, `http`, `hyper`/`hyper-util`/`hyper-rustls`, and
+     `reqwest`. Target state: the engine's need to act as an S3 client
+     (tiering, replication targets) is served by an extracted client crate,
+     and ecstore holds no wire or DTO types.
 
 5. **The `rustfs` binary crate is the only place that wires everything together.**
    Individual crates should be testable in isolation.
 
 6. **Error types use `thiserror` with descriptive names** (e.g., `StorageError`,
    not bare `Error`).
-   - ⚠️ VIOLATED: 6 crates use `pub enum Error`; 2 crates use `snafu`;
-      `heal` use `anyhow` in library code.
+   - ✅ RESOLVED (strategy): `snafu` is gone from source
+     (`rg -l snafu crates/ rustfs/` is empty) and library code no longer uses
+     `anyhow` (remaining hits are test code and the `e2e_test` crate; `heal`
+     uses `thiserror`).
+   - ⚠️ VIOLATED (naming): 6 crates still export a bare `pub enum Error`:
+     `crypto`, `filemeta`, `heal`, `iam`, `policy`, and `replication`
+     (`src/resync.rs`) — all `thiserror`-derived.
 
 ## Known Structural Issues
 
@@ -140,13 +165,25 @@ module split is tracked under `docs/architecture/`.
 
 ### Critical
 
-- **common/scanner code duplication (~3K lines).** `scanner` depends on `common`
-  but maintains its own copies of `DataUsageInfo`, `LastMinuteLatency`, and related
-  types instead of importing them.
+- **scanner/data-usage duplicate `.usage-cache.bin` serialization types.** The
+  original finding ("common/scanner code duplication, ~3K lines") is resolved:
+  `scanner` imports the shared data-usage types from `rustfs-data-usage` (see
+  the `pub use rustfs_data_usage::…` re-exports at the top of
+  `crates/scanner/src/data_usage_define.rs`). What remains: `scanner` and
+  `data-usage` each hold their own serialization types for the scanner cache
+  file (`DataUsageCacheInfo`/`DataUsageEntryInfo` in
+  `crates/scanner/src/data_usage_define.rs` vs
+  `DataUsageCacheInfo`/`DataUsageEntry` in
+  `crates/data-usage/src/data_usage.rs`); convergence is tracked in
+  rustfs/backlog#1828.
 
-- **ecstore is a monolith (87K lines, 163 files).** It contains disk management,
-  bucket management, erasure coding, replication, lifecycle, RPC, and configuration
-  — all in one crate. It should be decomposed along its existing subdirectories.
+- **ecstore is a monolith (265 files, ~288K lines — roughly half is inline
+  `#[cfg(test)]` code).** Measured with
+  `find crates/ecstore/src -name '*.rs' | xargs wc -l`. It contains disk
+  management, bucket management, erasure coding, replication, lifecycle, RPC,
+  and configuration — all in one crate. It should be decomposed along its
+  existing subdirectories; the split plan lives in
+  [docs/architecture/ecstore-module-split-plan.md](docs/architecture/ecstore-module-split-plan.md).
 
 ### High
 
@@ -154,19 +191,26 @@ module split is tracked under `docs/architecture/`.
   `common → filemeta/madmin` edges must stay removed so leaf/helper crates do
   not regain upward dependencies.
 
-- **Three-layer BackpressureConfig/DeadlockConfig duplication** across io-core,
-  concurrency, and `rustfs/src/storage`. Storage policies now expose and consume
-  explicit projections into the concurrency/io-core policy shapes, and workload
+- **Three-layer backpressure/deadlock policy bridging** across io-core,
+  concurrency, and `rustfs/src/storage`. The config types are no longer
+  duplicated (`BackpressureConfig` and `DeadlockDetectorConfig` are each
+  defined once, in io-core). Storage policies expose and consume explicit
+  projections into the concurrency/io-core policy shapes, and workload
   admission snapshots are composed through provider registries; later work
   should use those bridges before deleting compatibility wrappers.
 
 ### Medium
 
-- **Inconsistent error handling.** Three strategies (thiserror/snafu/anyhow) and
-  mixed naming (bare `Error` vs descriptive names).
+- **Bare `Error` naming.** Error-handling strategy has converged on `thiserror`
+  (no `snafu`, no `anyhow` in library code); the remaining inconsistency is the
+  bare `pub enum Error` naming in the 6 crates listed under Invariant 6.
 
-- **Ambiguous common vs utils boundary.** Both described as "utilities and data
-  structures." Need clear ownership rules.
+- **`common` is mostly parked domain code, not shared utilities.** Of its
+  6,724 lines, ~83% is scanner/heal domain code stranded there to break
+  dependency cycles (`metrics.rs`, ~4,810 lines of scanner-domain metrics;
+  `heal_channel.rs`, ~776 lines of heal-domain channel types). The
+  "common vs utils" naming ambiguity is secondary to moving that code to its
+  domain owners.
 
 ## Cross-Cutting Concerns
 
@@ -232,7 +276,7 @@ The binary (`main.rs`) boots in this order:
 
 ```
                             ┌─────────┐
-                            │  rustfs │  (binary + lib, 75K lines)
+                            │  rustfs │  (binary + lib)
                             │  main   │
                             └────┬────┘
                                  │
@@ -255,7 +299,7 @@ The binary (`main.rs`) boots in this order:
               │                  │                  │
         ┌─────▼──────┐    ┌──────▼──────┐    ┌──────▼──────┐
         │  ecstore   │    │     rio     │    │   io-core   │
-        │ (87K,core) │    │  (readers)  │    │ (zero-copy) │
+        │   (core)   │    │  (readers)  │    │ (zero-copy) │
         └─────┬──────┘    └─────────────┘    └─────────────┘
               │
      ┌─────┬──┼──┬─────┬──────┐

--- a/docs/architecture/ecstore-module-split-plan.md
+++ b/docs/architecture/ecstore-module-split-plan.md
@@ -10,9 +10,27 @@ and rollback steps.
 | Area | Current owner | Size | Split status |
 |---|---|---:|---|
 | Bucket lifecycle | `crates/lifecycle/` + `crates/ecstore/src/bucket/lifecycle/` | core contracts + ECStore runtime | Core contract extracted |
-| Bucket replication | `crates/ecstore/src/bucket/replication/` | 8,730 lines | Contracts extracted; runtime move pending |
+| Bucket replication | `crates/ecstore/src/bucket/replication/` | 15,619 lines | Contracts extracted; runtime move pending |
 | Set disks | `crates/ecstore/src/set_disk/` | state carrier plus operation modules | Keep in ECStore |
 | Public ECStore facade | `crates/ecstore/src/api/mod.rs` | broad compatibility surface | Shrink only through guarded PRs |
+
+Measured 2026-08-12: the whole crate is 265 files / ~288K lines (roughly half
+is inline `#[cfg(test)]` code). The largest single files are `disk/local.rs`
+(21,063 lines), `bucket/lifecycle/bucket_lifecycle_ops.rs` (11,961 lines), and
+`set_disk/mod.rs` (11,151 lines). Reproduce with:
+
+```bash
+find crates/ecstore/src -name '*.rs' | xargs wc -l | sort -rn | head
+find crates/ecstore/src/bucket/replication -name '*.rs' | xargs wc -l | tail -1
+```
+
+No split step has landed since the contract-extraction PRs of 2026-07-04,
+while the `bucket/replication` runtime grew from 8,730 to 15,619 lines (+79%)
+through feature work (e.g. SSE-C ciphertext passthrough replication #5898,
+delete-marker purge retry/replay #5864). To keep the gap from widening: in
+domains that already have a contract crate, new replication runtime logic that
+does not need ECStore runtime state must land in `rustfs-replication`, not in
+`crates/ecstore/src/bucket/replication/`.
 
 The file split inside `set_disk/` is already operation-oriented: read, write,
 list, multipart, lock, heal, and replication code live in separate modules.


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues

rustfs/backlog#1825

## Summary of Changes

Documentation-only. `ARCHITECTURE.md` (last revised 2026-07-02) had drifted in both directions: it kept claiming problems that are already fixed and understated problems that have grown. This PR re-measures every quantified claim in the "Architecture Invariants" and "Known Structural Issues" sections and rewrites them to the measured state, and refreshes the sizes in `docs/architecture/ecstore-module-split-plan.md`.

Old claim vs measured state:

| Old claim | Measured (2026-08-12) |
|---|---|
| `ReplicationStats` 4 copies | 3 same-named but unrelated types (data-usage, obs collector, ecstore replication_state) — a naming collision, not copies; rename tracked in rustfs/backlog#1847 |
| `LastMinuteLatency` 3 copies | 2 deliberately different implementations (`crates/common/src/last_minute.rs` bucketed accumulator vs the documented in-memory endpoint-health tracker in `crates/ecstore/src/bucket/bucket_target_sys.rs`) |
| `BackpressureConfig` 3 copies | 1 definition (`crates/io-core/src/backpressure.rs`); a zero-consumer `BackpressureSettings` copy in `crates/io-metrics/src/config.rs` is tracked in rustfs/backlog#1833 |
| `DataUsageInfo` 2 copies | 1 definition (`crates/data-usage/src/data_usage.rs`) |
| common/scanner duplication ~3K lines (Critical) | Resolved as stated (`scanner` re-exports from `rustfs-data-usage`); real residue is the duplicated `.usage-cache.bin` serialization types in scanner vs data-usage, tracked in rustfs/backlog#1828 |
| ecstore monolith 87K lines / 163 files | 265 files / 288,467 lines, roughly half inline `#[cfg(test)]` (46.8% by test-module tail measurement) |
| Invariant 4 (no HTTP/S3 in ecstore) unmarked | Marked ⚠️ VIOLATED: 58 files reference `s3s`, `src/client/` is a 9,353-line embedded S3 HTTP client, Cargo.toml depends on `s3s`/`http`/`hyper*`/`reqwest` |
| 6 crates bare `Error`, 2 crates snafu, heal uses anyhow | snafu gone from source, no anyhow in library code (heal uses thiserror; remaining anyhow hits are test code and `e2e_test`); residue is bare `pub enum Error` naming in crypto, filemeta, heal, iam, policy, replication (`src/resync.rs`) |
| Ambiguous common vs utils boundary | Rewritten to the measured diagnosis: 83% of `crates/common` (5,586 of 6,724 lines: `metrics.rs` 4,810 + `heal_channel.rs` 776) is scanner/heal domain code parked to break dependency cycles |
| Three-layer BackpressureConfig/DeadlockConfig duplication | Copy counts removed (each config type now defined once in io-core); the projection/bridge description is kept |
| split plan: bucket/replication 8,730 lines | 15,619 lines (+79% since the 2026-07-04 contract-extraction PRs, grown by feature work such as #5898 and #5864); added the largest-file inventory (`disk/local.rs` 21,063, `bucket_lifecycle_ops.rs` 11,961, `set_disk/mod.rs` 11,151), the reproduction commands, and a ratchet rule that contract-crate-eligible replication runtime logic lands in `rustfs-replication` |

Also dropped the stale line counts from the dependency diagram (87K/75K), matching the document's own policy of avoiding line-count snapshots outside measured sections. Deviations from the issue text: `disk/local.rs` measured 21,063 (issue estimated ~20,760) and `set_disk/mod.rs` 11,151 (issue estimated 11,148); the measured values are used.

## Verification

- `bash scripts/check_doc_paths.sh`
- `git diff --check`
- Every number written into the documents was reproduced with the command cited next to it, e.g. `find crates/ecstore/src -name '*.rs' | xargs wc -l` (288,467 / 265 files), `find crates/ecstore/src/bucket/replication -name '*.rs' | xargs wc -l` (15,619), `rg -l 's3s' crates/ecstore/src | wc -l` (58), `rg -l snafu crates/ rustfs/` (empty), `rg -n '^\s*pub enum Error\b' crates/` (6 crates), `wc -l crates/common/src/*.rs` (6,724 total)
- Documentation-only change: compilation, clippy, and tests skipped per the repository validation floor

## Impact

Documentation only. No runtime, build, CI, or dependency impact. Contributors reading `ARCHITECTURE.md` now see measured violation status instead of stale counts, and the ecstore split plan carries a ratchet rule for new replication runtime code.

## Additional Notes

Tracking pointers reference the private backlog repo (rustfs/backlog#1825, #1828, #1833, #1847) so maintainers can follow the remediation items; the surrounding text is self-contained for external readers.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
