### PR TITLE
fix(ecstore): map disk-representable StorageError variants in reverse conversion

### DIFF
--- a/crates/ecstore/src/disk/error.rs
+++ b/crates/ecstore/src/disk/error.rs
@@ -331,7 +331,14 @@ impl From<std::io::Error> for DiskError {
         }
         match e.downcast::<DiskError>() {
             Ok(disk_error) => disk_error,
-            Err(io_error) => DiskError::Io(io_error),
+            // Mirror `From<io::Error> for StorageError`: a StorageError boxed
+            // through `From<StorageError> for io::Error` must recover its typed
+            // classification instead of degrading to `DiskError::Io`, which
+            // quorum aggregation (`reduce_errs`) would count as a distinct error.
+            Err(io_error) => match io_error.downcast::<crate::error::StorageError>() {
+                Ok(storage_error) => storage_error.into(),
+                Err(io_error) => DiskError::Io(io_error),
+            },
         }
     }
 }
@@ -951,6 +958,27 @@ mod tests {
         // Convert io::Error back to DiskError
         let recovered_disk_error: DiskError = io_with_disk_error.into();
         assert_eq!(original_disk_error, recovered_disk_error);
+    }
+
+    #[test]
+    fn test_io_error_with_storage_error_inside() {
+        use crate::error::StorageError;
+
+        // An io::Error boxing a disk-representable StorageError (as produced by
+        // `From<StorageError> for io::Error`) must recover the typed DiskError
+        // variant instead of degrading to an opaque DiskError::Io.
+        let io_with_storage_error: std::io::Error = StorageError::FaultyRemoteDisk.into();
+        let recovered: DiskError = io_with_storage_error.into();
+        assert_eq!(recovered, DiskError::FaultyRemoteDisk);
+
+        let io_with_storage_error: std::io::Error = StorageError::FileAccessDenied.into();
+        let recovered: DiskError = io_with_storage_error.into();
+        assert_eq!(recovered, DiskError::FileAccessDenied);
+
+        // A StorageError with no DiskError analog stays an opaque Io error.
+        let io_with_bucket_error: std::io::Error = StorageError::BucketNotFound("bucket".to_string()).into();
+        let recovered: DiskError = io_with_bucket_error.into();
+        assert!(matches!(recovered, DiskError::Io(_)));
     }
 
     #[test]

--- a/crates/ecstore/src/error/mod.rs
+++ b/crates/ecstore/src/error/mod.rs
@@ -358,6 +358,13 @@ impl From<StorageError> for DiskError {
             StorageError::VolumeNotFound => DiskError::VolumeNotFound,
             StorageError::VolumeExists => DiskError::VolumeExists,
             StorageError::FileNameTooLong => DiskError::FileNameTooLong,
+            StorageError::FaultyRemoteDisk => DiskError::FaultyRemoteDisk,
+            StorageError::DiskAccessDenied => DiskError::DiskAccessDenied,
+            StorageError::DriveIsRoot => DiskError::DriveIsRoot,
+            StorageError::IsNotRegular => DiskError::IsNotRegular,
+            StorageError::VolumeNotEmpty => DiskError::VolumeNotEmpty,
+            StorageError::VolumeAccessDenied => DiskError::VolumeAccessDenied,
+            StorageError::FileAccessDenied => DiskError::FileAccessDenied,
             _ => DiskError::other(val),
         }
     }
@@ -1489,6 +1496,49 @@ mod tests {
                 StorageError::from_u32(code).unwrap_or_else(|| panic!("failed to recover error from code: {code:#x}"));
 
             assert_eq!(std::mem::discriminant(&original_error), std::mem::discriminant(&recovered_error));
+        }
+    }
+
+    // Every DiskError variant must survive DiskError -> StorageError -> DiskError
+    // unchanged. A variant that degrades to `DiskError::Io` on the way back loses
+    // its identity for quorum aggregation (`reduce_errs` classifies by variant
+    // equality), so ignore-list entries such as FaultyRemoteDisk and
+    // DiskAccessDenied would silently stop matching.
+    #[test]
+    fn test_disk_error_storage_error_round_trip_identity_all_variants() {
+        // DiskError codes are contiguous from 0x01, so enumerating via from_u32
+        // covers every variant and picks up newly appended ones automatically.
+        let all_variants: Vec<DiskError> = (1u32..).map_while(DiskError::from_u32).collect();
+        assert!(
+            all_variants.len() >= 42,
+            "DiskError variant enumeration shrank: got {}, expected at least 42",
+            all_variants.len()
+        );
+
+        for original in all_variants {
+            let storage_error: StorageError = original.clone().into();
+            let round_tripped: DiskError = storage_error.into();
+
+            assert_eq!(
+                std::mem::discriminant(&original),
+                std::mem::discriminant(&round_tripped),
+                "round trip changed variant: {original:?} -> {round_tripped:?}"
+            );
+            assert_eq!(original, round_tripped, "round trip not identical for {original:?}");
+        }
+
+        // Io is the only payload-carrying variant: a representative kind and
+        // message must both survive the round trip.
+        let io_original = DiskError::Io(IoError::new(ErrorKind::PermissionDenied, "denied"));
+        let storage_error: StorageError = io_original.clone().into();
+        let io_round_tripped: DiskError = storage_error.into();
+        assert_eq!(io_original, io_round_tripped);
+        match io_round_tripped {
+            DiskError::Io(inner) => {
+                assert_eq!(inner.kind(), ErrorKind::PermissionDenied);
+                assert_eq!(inner.to_string(), "denied");
+            }
+            other => panic!("expected DiskError::Io, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues

Implements PR1 (T1) of rustfs/backlog#1827.

## Summary of Changes

`From<StorageError> for DiskError` dropped seven variants that have exact `DiskError` counterparts — `FaultyRemoteDisk`, `DiskAccessDenied`, `DriveIsRoot`, `IsNotRegular`, `VolumeNotEmpty`, `VolumeAccessDenied`, `FileAccessDenied` — into the `DiskError::other` fallback, degrading them to an opaque `DiskError::Io`. Because `reduce_errs` classifies by variant equality and `FaultyRemoteDisk`/`DiskAccessDenied` sit on the quorum ignore-lists (`OBJECT_OP_IGNORED_ERRS`, `BASE_IGNORED_ERRS` in `crates/ecstore/src/disk/error_reduce.rs`), a degraded instance would stop matching the ignore list and count toward the dominant error. This PR adds the seven explicit reverse arms, mirrors the StorageError-side io::Error downdrill in `From<io::Error> for DiskError` (a `StorageError` boxed via `From<StorageError> for io::Error` now recovers its typed classification instead of wrapping as `Io`), and adds a round-trip identity test covering every `DiskError` variant plus a boxed-StorageError recovery test.

**Call-site impact analysis (compiler-enumerated, not grep-only).** Temporarily stubbing `impl From<StorageError> for DiskError` with `#[cfg(any())]` and running `cargo check -p rustfs-ecstore --all-targets` enumerates every conversion site; a matching stub run on `impl From<StorageError> for std::io::Error` enumerates every producer that can box a StorageError into an io::Error. Result: no existing call site changes its observed classification.

- `crates/ecstore/src/disk/local.rs:5007` (`ensure_data_usage_layout(...).map_err(DiskError::from)`): the helper only produces `StorageError::Io` (`Error::other` on `create_dir_all`) — takes the pre-existing `Io` arm, unchanged.
- `crates/ecstore/src/set_disk/ops/heal.rs:456` (`new_ns_lock(...).await?`): `new_ns_lock` is infallible in practice (always returns `Ok` at its tail) — plumbing only, unchanged.
- `crates/ecstore/src/set_disk/ops/heal.rs:461` (`map_namespace_lock_error(...)` via `?`): produces only `NamespaceLockQuorumUnavailable` or `Lock` — neither is among the seven, still routed to the fallback, unchanged.
- `crates/ecstore/src/store/list_objects.rs:4308` and `:5539` (`ensure_non_empty_listing_disks(...)?`): produces only `ErasureReadQuorum`, which already had an explicit arm, unchanged.
- No StorageError→DiskError conversion exists outside `rustfs-ecstore`: the `DiskError`-returning functions in `crates/heal`, `crates/scanner`, and `rustfs/src/storage/rpc/node_service*` call DiskError-native disk APIs only.
- io::Error downdrill blast radius: StorageError-boxed io::Errors are produced only in `crates/ecstore/src/client/api_put_object*.rs`, `client/transition_api.rs:719`, and `services/tier/warm_backend_{gcs,s3sdk}.rs` — tier/remote-client paths whose errors never convert into `DiskError` (verified: no `DiskError` usage in `services/tier` or `client`; the one lifecycle consumer uses DiskError-native disk APIs). The `DiskError::from(io_error)` site in `set_disk/read.rs` is test code on a plain BrokenPipe error.

The quorum ignore-list slices and `reduce_errs` are untouched; since no current path can feed one of the seven variants through the conversion, existing quorum decisions are byte-identical. The change removes the latent misclassification for any future flow.

## Verification

- `cargo test -p rustfs-ecstore --lib error` (363 passed, includes the new `test_disk_error_storage_error_round_trip_identity_all_variants` and both `test_io_error_with_storage_error_inside` tests)
- `cargo test -p rustfs-ecstore --lib error_reduce` (11 passed — quorum ignore-list semantics pinned)
- `cargo clippy -p rustfs-ecstore --all-targets` (clean)
- `cargo fmt --all --check`
- Mutation checks executed: removing the `FaultyRemoteDisk` arm fails the round-trip test; removing the io::Error downdrill fails `disk::error::tests::test_io_error_with_storage_error_inside`.

## Impact

No user-facing, API, on-wire, or on-disk impact: RPC error codes (`to_u32`/`from_u32`) are untouched and no existing conversion site changes its output (analysis above). Error-classification hardening only.

## Additional Notes

Adversarial validation (high-risk tier, all seven roles, one-line verdicts):

- **Correctness adversary:** attacked downdrill recursion termination (each step unwraps one boxed layer — finite), InternodeHttpError check ordering, empty-payload `Io(other(""))` round trip, and mixed-source variant splitting in `reduce_errs` — no break found; the pre-change `Io` degradation was itself the latent split-count bug.
- **Simplicity adversary:** tested the 1-line alternative `DiskError::from(StorageError::from(io_error))` (rejected: double-dispatch with subtler recursion reasoning) and a 42-line explicit variant list for the test (rejected for `from_u32` enumeration with a length floor) — no smaller equivalent found.
- **Security reviewer:** no authn/authz, deserialization, or logging surface; downcasts operate on in-process boxes, not wire bytes; RPC codes untouched; error Display strings unchanged for all existing flows — no break found.
- **Concurrency/durability reviewer:** no locks, awaits, or IO ordering touched; `error_reduce.rs` byte-identical; verified no existing conversion site can produce an ignore-list variant, so current quorum decisions are unchanged — no break found.
- **Compatibility reviewer:** attacked on-wire (proto error codes unchanged), S3-visible error text (no reachable flow changes), and mixed-version interleavings (conversions are in-process only) — no break found.
- **Performance reviewer:** one added TypeId-compare downcast on error paths only, no allocation, no hot-path logging — no break found.
- **Test-coverage skeptic:** executed both mutations (each fails a named test, output captured above); negative case (`BucketNotFound` stays `Io`) asserted; every functional changed line is covered — no gap found.
