### PR TITLE
fix(admin): clarify invalid group name errors

### DIFF
--- a/crates/e2e_test/src/group_delete_test.rs
+++ b/crates/e2e_test/src/group_delete_test.rs
@@ -14,7 +14,7 @@
 
 //! E2E tests for group management (fixes #2028).
 
-use crate::common::{RustFSTestEnvironment, awscurl_delete, awscurl_get, awscurl_put, init_logging};
+use crate::common::{RustFSTestEnvironment, admin_request, awscurl_delete, awscurl_get, awscurl_put, init_logging};
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::{Client, Config};
 use serial_test::serial;
@@ -30,6 +30,56 @@ fn create_user_s3_client(env: &RustFSTestEnvironment, access_key: &str, secret_k
         .behavior_version_latest()
         .build();
     Client::from_conf(config)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_group_members_rejects_invalid_new_group_names() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    init_logging();
+
+    let mut env = RustFSTestEnvironment::new().await?;
+    env.start_rustfs_server(vec![]).await?;
+
+    let invalid_groups = [
+        ("test group", "group name contains whitespace"),
+        ("test=group", "group name contains reserved characters =,"),
+        ("test,group", "group name contains reserved characters =,"),
+    ];
+
+    for (group, expected_message) in invalid_groups {
+        let body = serde_json::json!({
+            "group": group,
+            "members": [],
+            "isRemove": false,
+            "groupStatus": "enabled"
+        })
+        .to_string();
+        let (status, response_body) = admin_request(
+            &env.url,
+            http::Method::PUT,
+            "/rustfs/admin/v3/update-group-members",
+            Some(body),
+            &env.access_key,
+            &env.secret_key,
+        )
+        .await?;
+
+        assert_eq!(
+            status,
+            reqwest::StatusCode::BAD_REQUEST,
+            "invalid group {group:?} must return HTTP 400, body: {response_body}"
+        );
+        assert!(
+            response_body.contains("<Code>InvalidArgument</Code>"),
+            "invalid group {group:?} must return InvalidArgument, body: {response_body}"
+        );
+        assert!(
+            response_body.contains(&format!("<Message>{expected_message}</Message>")),
+            "invalid group {group:?} returned an unexpected message: {response_body}"
+        );
+    }
+
+    env.stop_server();
+    Ok(())
 }
 
 /// Test that deleting a group with members fails, and deleting an empty group succeeds.

--- a/rustfs/src/admin/handlers/group.rs
+++ b/rustfs/src/admin/handlers/group.rs
@@ -619,7 +619,7 @@ impl Operation for UpdateGroupMembers {
                 && is_err_no_such_group(&err)
                 && has_space_be(&args.group)
             {
-                return Err(s3_error!(InvalidArgument, "group not found"));
+                return Err(s3_error!(InvalidArgument, "group name contains whitespace"));
             }
 
             iam_store

--- a/rustfs/src/admin/handlers/iam_error.rs
+++ b/rustfs/src/admin/handlers/iam_error.rs
@@ -23,9 +23,10 @@ pub(crate) fn iam_error_to_s3_error(err: IamError) -> S3Error {
         | IamError::NoSuchTempAccount(_)
         | IamError::NoSuchGroup(_)
         | IamError::NoSuchPolicy => S3ErrorCode::NoSuchResource,
-        IamError::InvalidAccessKeyLength | IamError::InvalidSecretKeyLength | IamError::AccessKeyAlreadyExists => {
-            S3ErrorCode::InvalidArgument
-        }
+        IamError::InvalidAccessKeyLength
+        | IamError::InvalidSecretKeyLength
+        | IamError::AccessKeyAlreadyExists
+        | IamError::GroupNameContainsReservedChars => S3ErrorCode::InvalidArgument,
         _ => S3ErrorCode::InternalError,
     };
 
@@ -73,6 +74,15 @@ mod tests {
         assert_eq!(s3_error.code(), &S3ErrorCode::InvalidArgument);
         assert_eq!(s3_error.status_code(), Some(http::StatusCode::BAD_REQUEST));
         assert_eq!(s3_error.message(), Some("access key is already in use"));
+    }
+
+    #[test]
+    fn reserved_group_name_maps_to_invalid_argument() {
+        let s3_error = iam_error_to_s3_error(IamError::GroupNameContainsReservedChars);
+
+        assert_eq!(s3_error.code(), &S3ErrorCode::InvalidArgument);
+        assert_eq!(s3_error.status_code(), Some(http::StatusCode::BAD_REQUEST));
+        assert_eq!(s3_error.message(), Some("group name contains reserved characters =,"));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

Fixes #5969.

## Summary of Changes

- Replace the misleading `group not found` response for new group names containing whitespace with `group name contains whitespace`.
- Map `GroupNameContainsReservedChars` to `InvalidArgument` so `=` and `,` return HTTP 400 instead of `InternalError`.
- Add mapper and real SigV4 admin API regression coverage for whitespace and reserved-character group names.

The existing compatibility behavior remains unchanged: whitespace is rejected only when creating a new group, so updates to legacy groups that already contain whitespace are not blocked.

## Verification

- `make pre-commit`
- `cargo build --bin rustfs`
- `cargo test -p rustfs reserved_group_name_maps_to_invalid_argument --lib`
- `cargo test -p e2e_test update_group_members_rejects_invalid_new_group_names -- --nocapture`
- Seven-role adversarial validation completed with no task-owned findings.

## Impact

Invalid new group names now return HTTP 400 with actionable messages. There are no configuration, migration, storage-format, or successful-request behavior changes.

## Additional Notes

`make pre-pr` was attempted but the full suite is currently blocked by two pre-existing OIDC tests from #5915: `oidc_discovery_accepts_extra_root_ca_for_https_provider` and `oidc_discovery_refreshes_extra_root_ca_when_generation_changes`. Both fail in unchanged `crates/iam/src/oidc.rs` with the mock discovery endpoint returning HTTP 404 due to issuer trailing-slash handling, and the first test also fails when run independently. The checks and focused tests listed above pass on this branch.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
