### PR TITLE
fix(ecstore): scope UploadPart commit lock per part number

### DIFF
--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -162,6 +162,22 @@ fn map_upload_id_metadata_error(bucket: &str, object: &str, upload_id: &str, err
     err.into()
 }
 
+/// Abort a multipart commit when the guard's refresh heartbeat has observed a
+/// refresh-quorum loss (backlog#899 Phase 2): a stale holder must not race a
+/// concurrent committer past its fenced commit point.
+fn fence_commit_on_lock_loss(guard: Option<&ObjectLockDiagGuard>, mode: &'static str, lock_path: &str) -> Result<()> {
+    if guard.is_some_and(|guard| guard.is_lock_lost()) {
+        return Err(StorageError::NamespaceLockQuorumUnavailable {
+            mode,
+            bucket: RUSTFS_META_MULTIPART_BUCKET.to_string(),
+            object: lock_path.to_string(),
+            required: 1,
+            achieved: 0,
+        });
+    }
+    Ok(())
+}
+
 fn multipart_bucket_incarnation_id(metadata: &HashMap<String, String>) -> Result<Option<Uuid>> {
     let Some(value) = rustfs_utils::http::metadata_compat::get_consistent_str(metadata, SUFFIX_BUCKET_INCARNATION_ID) else {
         if rustfs_utils::http::metadata_compat::contains_key_str(metadata, SUFFIX_BUCKET_INCARNATION_ID) {
@@ -1066,29 +1082,38 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
             }
 
             let part_path = format!("{}/{}/{}", upload_id_path, fi.data_dir.unwrap_or_default(), part_suffix);
+            let part_lock_path = format!("{upload_id_path}/{part_suffix}");
 
             #[cfg(test)]
             pause_multipart_commit(bucket, object, MultipartCommitPause::PutPartBeforeLockAcquire).await;
-            // Serialize only the commit (rename_part), not the whole upload. Each
-            // concurrent stream writes to its own unique temp dir (see `tmp_part`
-            // above), so the encode/stream phase never conflicts and must stay
-            // lock-free — holding a lock across it would serialize slow re-transmits
-            // of the same part and defeat the S3 "last finisher wins" semantics
-            // (it also caused UploadPart lock-acquire timeouts). The mixed-generation
-            // hazard is confined to rename_part, where two temp parts are moved
-            // cross-disk onto the SAME final part_path: interleaving there can leave
-            // shards from two generations, each individually bitrot-valid, that only
-            // surface as silent corruption at read time (backlog#853). A write lock
-            // scoped to the uploadId namespace makes each commit atomic across disks,
-            // so the last committer wins consistently. A guarded completion takes
-            // the object lock before this upload lock to preserve global ordering.
-            let _upload_commit_guard = if opts.no_lock {
-                None
+            // Serialize only same-part commits (rename_part), not the whole upload.
+            // Each concurrent stream writes to its own unique temp dir (see
+            // `tmp_part` above), so the encode/stream phase never conflicts and must
+            // stay lock-free — holding a lock across it would serialize slow
+            // re-transmits of the same part and defeat the S3 "last finisher wins"
+            // semantics. The mixed-generation hazard is confined to rename_part,
+            // where two temp parts are moved cross-disk onto the SAME final
+            // part_path: interleaving there can leave shards from two generations,
+            // each individually bitrot-valid, that only surface as silent corruption
+            // at read time (backlog#853). A write lock scoped to this part number
+            // makes each same-part commit atomic across disks, so the last committer
+            // wins consistently, while different part numbers commit onto disjoint
+            // part paths and stay concurrent (issue#5961 — an uploadId-wide write
+            // lock serialized them into 503 lock-acquire timeouts). The shared
+            // uploadId read lock keeps completion/abort (which take the uploadId
+            // write lock) from racing any in-flight part commit; a guarded
+            // completion takes the object lock before the upload lock to preserve
+            // global ordering.
+            let (_upload_commit_guard, _part_commit_guard) = if opts.no_lock {
+                (None, None)
             } else {
-                Some(
-                    self.acquire_write_lock_diag("put_object_part_commit", RUSTFS_META_MULTIPART_BUCKET, &upload_id_path)
-                        .await?,
-                )
+                let upload_guard = self
+                    .acquire_read_lock_diag("put_object_part_commit", RUSTFS_META_MULTIPART_BUCKET, &upload_id_path)
+                    .await?;
+                let part_guard = self
+                    .acquire_write_lock_diag("put_object_part_commit", RUSTFS_META_MULTIPART_BUCKET, &part_lock_path)
+                    .await?;
+                (Some(upload_guard), Some(part_guard))
             };
             let (commit_fi, _) = self.check_upload_id_exists(bucket, object, upload_id, false).await?;
             ensure_multipart_bucket_incarnation(
@@ -1102,15 +1127,8 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
             .await?;
             #[cfg(test)]
             pause_multipart_commit(bucket, object, MultipartCommitPause::PutPartBeforeLockLost).await;
-            if _upload_commit_guard.as_ref().is_some_and(|guard| guard.is_lock_lost()) {
-                return Err(StorageError::NamespaceLockQuorumUnavailable {
-                    mode: "put_object_part_commit",
-                    bucket: RUSTFS_META_MULTIPART_BUCKET.to_string(),
-                    object: upload_id_path.clone(),
-                    required: 1,
-                    achieved: 0,
-                });
-            }
+            fence_commit_on_lock_loss(_upload_commit_guard.as_ref(), "put_object_part_commit", &upload_id_path)?;
+            fence_commit_on_lock_loss(_part_commit_guard.as_ref(), "put_object_part_commit", &part_lock_path)?;
             ensure_multipart_bucket_lifecycle_lock_held(bucket, object, opts)?;
 
             let _ = self
@@ -1134,6 +1152,7 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
 
             #[cfg(test)]
             pause_multipart_commit(bucket, object, MultipartCommitPause::PutPartAfterRename).await;
+            drop(_part_commit_guard);
             drop(_upload_commit_guard);
 
             let ret: PartInfo = PartInfo {
@@ -3506,6 +3525,268 @@ mod tests {
             .await
             .expect("abort task should not panic")
             .expect("abort should delete the upload after UploadPart releases the lock");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn put_object_part_different_part_numbers_commit_concurrently() {
+        use tokio::io::AsyncReadExt as _;
+
+        const PART1_SIZE: usize = 5 * 1024 * 1024; // non-final parts must be >= 5MiB to complete
+        const PART2_SIZE: usize = 4096;
+
+        let manager = Arc::new(rustfs_lock::GlobalLockManager::new());
+        let locker: Arc<dyn LockClient> = Arc::new(LocalClient::with_manager(manager));
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks_with_lockers(4, 0, 2, vec![locker]).await;
+        let bucket = "multipart-concurrent-part-numbers-bucket";
+        let object = "object";
+        make_bucket_on_all(&disk_stores, bucket).await;
+        let upload = set_disks
+            .new_multipart_upload(bucket, object, &ObjectOptions::default())
+            .await
+            .expect("multipart upload should be created");
+        let upload_id = upload.upload_id;
+        let _setup_type_guard = SetupTypeGuard::switch_to(SetupType::DistErasure).await;
+        // issue#5961: the barrier releases only once BOTH commits are paused
+        // inside their commit sections, so reaching wait_until_paused proves the
+        // two part numbers held their commit locks concurrently. Under an
+        // uploadId-wide exclusive commit lock the second put errors at the 5s
+        // lock-acquire timeout instead of arriving, and wait_until_paused fails
+        // deterministically. No wall-clock bound on the success path.
+        let barrier = MultipartCommitBarrier::install_for_arrivals(bucket, object, MultipartCommitPause::PutPartAfterRename, 2);
+
+        let put1_store = set_disks.clone();
+        let put1_upload_id = upload_id.clone();
+        let put1 = tokio::spawn(async move {
+            let mut reader = PutObjReader::from_vec(vec![0x51; PART1_SIZE]);
+            put1_store
+                .put_object_part(bucket, object, &put1_upload_id, 1, &mut reader, &ObjectOptions::default())
+                .await
+        });
+        let put2_store = set_disks.clone();
+        let put2_upload_id = upload_id.clone();
+        let put2 = tokio::spawn(async move {
+            let mut reader = PutObjReader::from_vec(vec![0x52; PART2_SIZE]);
+            put2_store
+                .put_object_part(bucket, object, &put2_upload_id, 2, &mut reader, &ObjectOptions::default())
+                .await
+        });
+        barrier.wait_until_paused().await;
+
+        barrier.release();
+        let part1 = put1
+            .await
+            .expect("part 1 task should not panic")
+            .expect("part 1 should commit after the barrier is released");
+        let part2 = put2
+            .await
+            .expect("part 2 task should not panic")
+            .expect("part 2 should commit after the barrier is released");
+        assert_eq!(part1.part_num, 1);
+        assert_eq!(part2.part_num, 2);
+
+        set_disks
+            .clone()
+            .complete_multipart_upload(
+                bucket,
+                object,
+                &upload_id,
+                vec![
+                    CompletePart {
+                        part_num: part1.part_num,
+                        etag: part1.etag.clone(),
+                        ..Default::default()
+                    },
+                    CompletePart {
+                        part_num: part2.part_num,
+                        etag: part2.etag.clone(),
+                        ..Default::default()
+                    },
+                ],
+                &ObjectOptions::default(),
+            )
+            .await
+            .expect("completion should succeed with both concurrently committed parts");
+
+        let mut reader = set_disks
+            .get_object_reader(bucket, object, None, HeaderMap::new(), &ObjectOptions::default())
+            .await
+            .expect("completed object should open");
+        let mut body = Vec::new();
+        reader
+            .stream
+            .read_to_end(&mut body)
+            .await
+            .expect("completed object should stream fully");
+        assert_eq!(body.len(), PART1_SIZE + PART2_SIZE);
+        assert!(body[..PART1_SIZE].iter().all(|b| *b == 0x51), "part 1 bytes must round-trip");
+        assert!(body[PART1_SIZE..].iter().all(|b| *b == 0x52), "part 2 bytes must round-trip");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn put_object_part_same_part_retries_serialize_on_part_lock() {
+        use tokio::io::AsyncReadExt as _;
+
+        let manager = Arc::new(rustfs_lock::GlobalLockManager::new());
+        let signaling = Arc::new(SignalingLockClient::new(Arc::new(LocalClient::with_manager(manager))));
+        let lockers: Vec<Arc<dyn LockClient>> = vec![signaling.clone()];
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks_with_lockers(4, 0, 2, lockers).await;
+        let bucket = "multipart-same-part-retry-bucket";
+        let object = "object";
+        make_bucket_on_all(&disk_stores, bucket).await;
+        let upload = set_disks
+            .new_multipart_upload(bucket, object, &ObjectOptions::default())
+            .await
+            .expect("multipart upload should be created");
+        let upload_id = upload.upload_id;
+        let upload_id_path = SetDisks::get_upload_id_dir(bucket, object, &upload_id);
+        let part_lock_path = format!("{upload_id_path}/part.1");
+        let _setup_type_guard = SetupTypeGuard::switch_to(SetupType::DistErasure).await;
+        let barrier = MultipartCommitBarrier::install(bucket, object, MultipartCommitPause::PutPartAfterRename);
+
+        let first_store = set_disks.clone();
+        let first_upload_id = upload_id.clone();
+        let first = tokio::spawn(async move {
+            let mut reader = PutObjReader::from_vec(vec![0x53; 4096]);
+            first_store
+                .put_object_part(bucket, object, &first_upload_id, 1, &mut reader, &ObjectOptions::default())
+                .await
+        });
+        barrier.wait_until_paused().await;
+
+        // The paused commit must hold its part lock EXCLUSIVELY: even a shared
+        // probe on the part key has to time out. This pins the write-ness of the
+        // part lock — a shared part lock would let two same-part rename_part
+        // calls interleave into mixed-generation shards (backlog#853).
+        let probe = set_disks
+            .new_ns_lock(RUSTFS_META_MULTIPART_BUCKET, &part_lock_path)
+            .await
+            .expect("part namespace lock should be created")
+            .get_read_lock(Duration::from_secs(1))
+            .await;
+        assert!(
+            probe.is_err(),
+            "the in-flight part commit must hold an exclusive write lock on its part key"
+        );
+
+        signaling.set_target(rustfs_lock::ObjectKey::new(RUSTFS_META_MULTIPART_BUCKET, part_lock_path));
+        let retry_store = set_disks.clone();
+        let retry_upload_id = upload_id.clone();
+        let retry = tokio::spawn(async move {
+            let mut reader = PutObjReader::from_vec(vec![0x54; 4096]);
+            retry_store
+                .put_object_part(bucket, object, &retry_upload_id, 1, &mut reader, &ObjectOptions::default())
+                .await
+        });
+        signaling.wait_for_attempts(1).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !retry.is_finished(),
+            "a retry of the same part number must wait for the in-flight commit (backlog#853)"
+        );
+
+        barrier.release();
+        first
+            .await
+            .expect("first attempt task should not panic")
+            .expect("first attempt should commit after the barrier is released");
+        let retry_part = retry
+            .await
+            .expect("retry task should not panic")
+            .expect("the retry should commit after the first attempt releases the part lock");
+
+        set_disks
+            .clone()
+            .complete_multipart_upload(
+                bucket,
+                object,
+                &upload_id,
+                vec![CompletePart {
+                    part_num: retry_part.part_num,
+                    etag: retry_part.etag.clone(),
+                    ..Default::default()
+                }],
+                &ObjectOptions::default(),
+            )
+            .await
+            .expect("the last committed retry must win the final part generation");
+        let mut reader = set_disks
+            .get_object_reader(bucket, object, None, HeaderMap::new(), &ObjectOptions::default())
+            .await
+            .expect("completed object should open");
+        let mut body = Vec::new();
+        reader
+            .stream
+            .read_to_end(&mut body)
+            .await
+            .expect("completed object should stream fully");
+        assert_eq!(body, vec![0x54; 4096], "the retry's generation must be the one served");
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[serial]
+    async fn put_object_part_fences_part_lock_loss_before_rename() {
+        let target = Arc::new(std::sync::RwLock::new(None));
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let lockers: Vec<Arc<dyn LockClient>> = (0..4)
+            .map(|_| {
+                Arc::new(SelectiveLockLossClient::new(Arc::clone(&target), Arc::clone(&refresh_calls))) as Arc<dyn LockClient>
+            })
+            .collect();
+        let (_temp_dirs, disk_stores, set_disks) = hermetic_set_disks_with_lockers(4, 0, 2, lockers).await;
+        let bucket = "multipart-put-part-part-lock-loss-bucket";
+        let object = "object";
+        make_bucket_on_all(&disk_stores, bucket).await;
+        let upload = set_disks
+            .new_multipart_upload(bucket, object, &ObjectOptions::default())
+            .await
+            .expect("multipart upload should be created");
+        let upload_id = upload.upload_id;
+        let upload_id_path = SetDisks::get_upload_id_dir(bucket, object, &upload_id);
+        let part_lock_path = format!("{upload_id_path}/part.1");
+        *target.write().expect("lock-loss target should be writable") =
+            Some(rustfs_lock::ObjectKey::new(RUSTFS_META_MULTIPART_BUCKET, part_lock_path.clone()));
+        let _setup_type_guard = SetupTypeGuard::switch_to(SetupType::DistErasure).await;
+        let barrier = MultipartCommitBarrier::install(bucket, object, MultipartCommitPause::PutPartBeforeLockLost);
+
+        let put_store = set_disks.clone();
+        let put_upload_id = upload_id.clone();
+        let put = tokio::spawn(async move {
+            let mut reader = PutObjReader::from_vec(vec![0x47; 4096]);
+            put_store
+                .put_object_part(bucket, object, &put_upload_id, 1, &mut reader, &ObjectOptions::default())
+                .await
+        });
+        barrier.wait_until_paused().await;
+        tokio::time::advance(Duration::from_secs(11)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            refresh_calls.load(Ordering::Acquire) > 0,
+            "part lock heartbeat should reach the test client"
+        );
+        barrier.release();
+
+        let err = put
+            .await
+            .expect("UploadPart task should not panic")
+            .expect_err("UploadPart must fail after losing the part lock");
+        match err {
+            StorageError::NamespaceLockQuorumUnavailable {
+                bucket: lock_bucket,
+                object: lock_object,
+                ..
+            } => {
+                assert_eq!(lock_bucket, RUSTFS_META_MULTIPART_BUCKET);
+                assert_eq!(lock_object, part_lock_path);
+            }
+            other => panic!("unexpected lock-loss error: {other:?}"),
+        }
+        let listed = set_disks
+            .list_object_parts(bucket, object, &upload_id, None, MAX_PARTS_COUNT, &ObjectOptions::default())
+            .await
+            .expect("part lock loss before rename must leave the upload readable");
+        assert!(listed.parts.is_empty(), "part lock loss before rename must not publish the part");
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues

Fixes #5961.

## Summary of Changes

`put_object_part` previously took an exclusive write lock on the whole `upload_id_path` namespace for its commit phase, so concurrent `UploadPart` commits for **different part numbers** of the same upload ID serialized behind one lock. When one commit held the lock longer than the 5s default lock-acquire timeout (slow storage, many parallel parts), the queued commits failed and surfaced as `503 ServiceUnavailable` — deterministic checkpoint failures for clients like Flink that upload parts in parallel.

This PR adopts MinIO's `PutObjectPart` lock scope (minio/minio `erasure-multipart.go`):

- The part commit now takes a **shared read lock on `upload_id_path`** plus an **exclusive write lock on `{upload_id_path}/part.{part_number}`**, acquired in that order (upload → part), scoped to the commit only.
- Different part numbers commit concurrently: they rename onto disjoint final part paths, so the mixed-generation shard hazard (backlog#853) does not apply across part numbers.
- Retries of the **same** part number still serialize on the part-scoped write lock, keeping each same-part commit atomic across disks (last committer wins consistently).
- `CompleteMultipartUpload` / `AbortMultipartUpload` are unchanged: they take the upload-ID **write** lock, so they still mutually exclude every in-flight part commit (the shared read locks block them), and completion still takes the object lock before the upload lock.
- The lock-loss commit fence now covers both guards (extracted into `fence_commit_on_lock_loss`): losing refresh quorum on either the upload read lock or the part write lock aborts the commit before `rename_part`.

## Verification

- New regression test `put_object_part_different_part_numbers_commit_concurrently` reproduces the issue deterministically with no wall-clock bound: a two-arrival commit barrier releases only once BOTH part commits are simultaneously paused inside their commit sections holding their locks. On `main` the second commit blocks on the upload-wide write lock and errors at the 5s acquire timeout, so the barrier is never reached and the test fails. The test then completes the upload and byte-verifies both parts round-trip.
- New test `put_object_part_same_part_retries_serialize_on_part_lock` pins backlog#853 from both directions: while the first commit is paused holding its locks, (a) a shared probe on the part key must time out — pinning that the part lock is exclusive, not shared; (b) a same-part retry must block on the part key before committing; the retry's generation is then completed and byte-verified as the served content.
- New test `put_object_part_fences_part_lock_loss_before_rename` pins the new part-guard half of the lock-loss fence, asserting the failure names the part lock key (mirrors the existing upload-guard fence test).
- Existing lock-linearization tests pass unchanged against the new scheme (54 passed in the multipart suite): `put_object_part_holds_upload_lock_through_rename` (abort waits for an in-flight part commit), `complete_validates_parts_after_an_inflight_upload_part_commit` (completion waits and revalidates), `put_object_part_rechecks_upload_after_commit_lock`, `put_object_part_fences_upload_lock_loss_before_rename`, and the complete/abort linearization suite.
- `cargo test -p rustfs-ecstore --lib set_disk::ops::multipart::tests`
- `make pre-pr` (fmt + arch checks + clippy + tests): all gates green; 13316/13316 workspace tests passed. One pre-existing test unrelated to this diff, `rustfs-utils net::test::test_resolve_domain_preserves_system_resolver_error_provenance`, was excluded locally because this development machine's fake-IP DNS proxy resolves the RFC 6761 `.invalid` TLD to 198.18.x.x, which breaks the test in any branch; it is expected to pass in CI.

Adversarial Validation (high-risk tier, all seven roles):

- Correctness: no blocker/major; lock key is exact-match and collision-free for legit IDs; failure ordering and 503 mapping verified. Pre-existing input-validation gap (crafted base64 uploadId can decode to a `/`-containing path and alias lock keys) recorded for follow-up — independent of this change.
- Concurrency/durability: no blocker/major; lock hierarchy lifecycle→object→upload→part is acyclic across all production sites; both guards heartbeat and fence independently; `recover_part_transactions` only ever runs under the upload write lock or per-part under the part lock.
- Compatibility: no format/wire change; rolling upgrade verified at key and quorum level — old-node upload write locks and new-node read+part locks mutually exclude in both directions (worst case is the old serialized behavior); `ListParts` concurrency with in-flight commits matches MinIO RLock semantics.
- Security: no new log lines; part number is capped at 10000 before locking, so the lock-key space is bounded; error payload exposes the same opaque hash form as the existing upload-path fence.
- Performance: +1 lock-quorum RTT per UploadPart commit, against removal of upload-wide head-of-line blocking; guard live range otherwise unchanged; diag metrics gated off by default.
- Simplicity: duplicate fence blocks extracted into a helper; inert test scaffolding removed.
- Test-coverage skeptic: revert-detection matrix complete for all four behavior hunks; the write→read weakening of the part lock is now pinned by the exclusivity probe; the wall-clock bound flagged as flaky was replaced by the two-arrival barrier design.

## Impact

- Behavior: normal S3 multipart concurrency (parallel `UploadPart` for different part numbers of one upload) no longer serializes on an upload-wide lock and no longer returns 503 under storage latency; same-part retry semantics and complete/abort linearization are unchanged.
- Compatibility: no on-disk, metadata, or wire format change. During a rolling upgrade, an old node's upload-wide write lock and a new node's read+part locks still mutually exclude, degrading to the old serialized behavior at worst.
- Performance: one extra namespace lock acquisition per `UploadPart` commit, in exchange for removing upload-wide head-of-line blocking.

## Additional Notes

Lock ordering stays acyclic: part commits acquire `upload(read) → part(write)`; completion acquires `object(write) → upload(write)`; abort acquires `upload(write)` only. No path acquires the part lock before the upload lock, and no path holding the part lock waits on the object lock. Holding the upload read lock while waiting on the part lock mirrors MinIO's nesting (MinIO holds the uploadID RLock across the entire `PutObjectPart`, including its partID lock wait; this change confines that window to the commit phase only), and the local lock shard is writer-preferring, so completion cannot be starved by a stream of new part commits.
