### PR TITLE
test: assert real behavior in three assertion-less tests

### DIFF
--- a/crates/ecstore/src/layout/format.rs
+++ b/crates/ecstore/src/layout/format.rs
@@ -234,11 +234,17 @@ mod test {
 
     #[test]
     fn test_format_v1() {
+        // A freshly created format must survive a serialize -> parse roundtrip
+        // unchanged (identity on every on-disk field).
         let format = FormatV3::new(1, 4);
+        let serialized = serde_json::to_string(&format).expect("FormatV3 must serialize to JSON");
+        let reparsed = FormatV3::try_from(serialized.as_str()).expect("serialized FormatV3 must parse back");
+        assert_eq!(reparsed, format);
 
-        let str = serde_json::to_string(&format);
-        println!("{str:?}");
-
+        // minio-file-format-compat: this literal pins the on-disk format.json
+        // shape (erasure version "1", distributionAlgo "CRCMOD"). `this` always
+        // carries the disk's own UUID in real format.json files; a JSON null
+        // there was never parseable and never written by MinIO or RustFS.
         let data = r#"
         {
             "version": "1",
@@ -246,7 +252,7 @@ mod test {
             "id": "321b3874-987d-4c15-8fa5-757c956b1243",
             "xl": {
                 "version": "1",
-                "this": null,
+                "this": "8ab9a908-f869-4f1f-8e42-eb067ffa7eb5",
                 "sets": [
                     [
                         "8ab9a908-f869-4f1f-8e42-eb067ffa7eb5",
@@ -259,9 +265,23 @@ mod test {
             }
         }"#;
 
-        let p = FormatV3::try_from(data);
+        let parsed = FormatV3::try_from(data).expect("pinned v1 format.json literal must keep parsing");
 
-        println!("{p:?}");
+        assert_eq!(parsed.version, FormatMetaVersion::V1);
+        assert_eq!(parsed.format, FormatBackend::Erasure);
+        assert_eq!(
+            parsed.id,
+            Uuid::parse_str("321b3874-987d-4c15-8fa5-757c956b1243").expect("literal id is a valid UUID")
+        );
+        assert_eq!(parsed.erasure.version, FormatErasureVersion::V1);
+        assert_eq!(
+            parsed.erasure.this,
+            Uuid::parse_str("8ab9a908-f869-4f1f-8e42-eb067ffa7eb5").expect("literal this is a valid UUID")
+        );
+        assert_eq!(parsed.erasure.sets.len(), 1);
+        assert_eq!(parsed.erasure.sets[0].len(), 4);
+        assert_eq!(parsed.erasure.sets[0][0], parsed.erasure.this);
+        assert_eq!(parsed.erasure.distribution_algo, DistributionAlgoVersion::V1);
     }
 
     #[test]

--- a/crates/heal/src/heal/channel.rs
+++ b/crates/heal/src/heal/channel.rs
@@ -785,9 +785,15 @@ mod tests {
         let heal_manager = create_test_heal_manager();
         let processor = HealChannelProcessor::new(heal_manager);
 
-        // Verify processor is created successfully
-        let _sender = processor.get_response_sender();
-        // If we can get the sender, processor was created correctly
+        let sender = processor.get_response_sender();
+        sender
+            .send(HealChannelResponse {
+                request_id: "request-id".to_string(),
+                success: true,
+                data: None,
+                error: None,
+            })
+            .expect("a freshly constructed processor must accept responses on its channel");
     }
 
     #[test]

--- a/rustfs/src/admin/console_test.rs
+++ b/rustfs/src/admin/console_test.rs
@@ -17,29 +17,73 @@ mod tests {
     use crate::config::Opt;
     use serial_test::serial;
 
+    /// Sends a CORS preflight request through a router wrapped with the given
+    /// layer and returns the `access-control-allow-origin` header, if any.
+    async fn preflight_allow_origin(cors: tower_http::cors::CorsLayer, origin: &str) -> Option<String> {
+        use axum::{Router, body::Body, routing::get};
+        use tower::ServiceExt;
+
+        let app = Router::new().route("/", get(|| async { "ok" })).layer(cors);
+        let response = app
+            .oneshot(
+                http::Request::builder()
+                    .method(http::Method::OPTIONS)
+                    .uri("/")
+                    .header(http::header::ORIGIN, origin)
+                    .header(http::header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                    .body(Body::empty())
+                    .expect("preflight request must build"),
+            )
+            .await
+            .expect("preflight request must not fail");
+
+        response
+            .headers()
+            .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .map(|value| value.to_str().expect("allow-origin header must be valid UTF-8").to_string())
+    }
+
     #[tokio::test]
     #[serial]
     async fn test_console_cors_configuration() {
-        // Test CORS configuration parsing
         use crate::admin::console::parse_cors_origins;
-        // Test wildcard origin
-        let cors_wildcard = Some("*".to_string());
-        let _layer1 = parse_cors_origins(cors_wildcard.as_ref());
-        // Should create a layer without error
 
-        // Test specific origins
-        let cors_specific = Some("http://localhost:3000,https://admin.example.com".to_string());
-        let _layer2 = parse_cors_origins(cors_specific.as_ref());
-        // Should create a layer without error
+        // Wildcard configuration must allow any origin.
+        let wildcard = parse_cors_origins(Some(&"*".to_string()));
+        assert_eq!(
+            preflight_allow_origin(wildcard, "http://anywhere.example").await.as_deref(),
+            Some("*"),
+            "wildcard configuration must answer preflight with a permissive allow-origin"
+        );
 
-        // Test empty origin
-        let cors_empty = Some("".to_string());
-        let _layer3 = parse_cors_origins(cors_empty.as_ref());
-        // Should create a layer without error (falls back to permissive)
+        // An explicit list must echo listed origins and refuse unlisted ones.
+        let listed = parse_cors_origins(Some(&"http://localhost:3000,https://admin.example.com".to_string()));
+        assert_eq!(
+            preflight_allow_origin(listed, "http://localhost:3000").await.as_deref(),
+            Some("http://localhost:3000"),
+            "a listed origin must be echoed back on preflight"
+        );
+        let listed = parse_cors_origins(Some(&"http://localhost:3000,https://admin.example.com".to_string()));
+        assert_eq!(
+            preflight_allow_origin(listed, "https://other.example").await,
+            None,
+            "an unlisted origin must not receive an allow-origin header"
+        );
 
-        // Test no origin
-        let _layer4 = parse_cors_origins(None);
-        // Should create a layer without error (uses default)
+        // Empty and unset configurations fall back to same-origin only:
+        // no cross-origin caller may be allowed.
+        let empty = parse_cors_origins(Some(&"".to_string()));
+        assert_eq!(
+            preflight_allow_origin(empty, "http://localhost:3000").await,
+            None,
+            "empty configuration must not allow any cross-origin caller"
+        );
+        let unset = parse_cors_origins(None);
+        assert_eq!(
+            preflight_allow_origin(unset, "http://localhost:3000").await,
+            None,
+            "unset configuration must not allow any cross-origin caller"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

PR1 of rustfs/backlog#1836 (part of the rustfs/backlog#1820 cleanup wave): the three read-verified assertion-less tests now assert real behavior. Test-only change, no production code touched.

- **`layout::format::test_format_v1`** (ecstore): the test only `println!`'d its two results. Running it on main shows the pinned v1 `format.json` literal has **never parsed**: `"this": null` fails `Uuid` deserialization (`invalid type: null, expected a formatted UUID string`) and the `Err` was printed and discarded, so a parse regression could never fail the test. Real `format.json` files always carry the disk's own UUID in `this` (Go's string marshalling never emits `null`), so the fixture now uses the disk UUID shape, and the test asserts a serialize→parse roundtrip identity plus every pinned field of the literal (version/format/id/erasure version/this/sets/distributionAlgo). The minio-file-format-compat literal is kept per the issue constraint (fixed, not deleted).
- **`admin::console_test::test_console_cors_configuration`** (rustfs): all four `parse_cors_origins` results were discarded. `CorsLayer` is opaque, so the test now drives real CORS preflight requests through an axum router wrapped with the parsed layer and asserts the `access-control-allow-origin` outcomes: wildcard → `*` for any origin; configured list → listed origin echoed, unlisted origin gets no allow-origin header; empty/unset → no cross-origin caller allowed.
- **`heal::channel::test_heal_channel_processor_new`** (heal): only constructed the processor; now asserts the response channel accepts a send.

## Verification

- `cargo test -p rustfs-ecstore --lib layout::format` — 23 passed
- `cargo test -p rustfs-heal --lib channel` — 31 passed
- `cargo test -p rustfs --lib admin::console_test` — 5 passed
- `cargo clippy -p rustfs-ecstore -p rustfs-heal -p rustfs --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅

Ref rustfs/backlog#1836.