### PR TITLE
docs(replication): register the http interop duplication and pin its wire values

### DIFF
--- a/crates/replication/src/http.rs
+++ b/crates/replication/src/http.rs
@@ -12,6 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! DELIBERATE DUPLICATION — do not merge these declarations into the
+//! rustfs-utils http module without a maintainer decision on the crate
+//! boundary.
+//!
+//! The canonical owners of these interop-contract values live in the
+//! rustfs-utils crate: `crates/utils/src/http/metadata_compat.rs` (dual
+//! x-rustfs-internal-/x-minio-internal- metadata keys),
+//! `crates/utils/src/http/header_compat.rs` (x-rustfs-/x-minio- header pairs),
+//! and `crates/utils/src/http/headers.rs` (standard S3 header names). This
+//! crate keeps a local copy because
+//! `rustfs-replication` is a wire-contract crate that must stay free of
+//! internal dependencies: `scripts/check_architecture_migration_rules.sh`
+//! rejects any `rustfs-utils` import or dependency here ("replication crate
+//! HTTP/helper contracts must not import or depend on rustfs-utils"), and the
+//! same rule bans `rustfs-filemeta` and `rustfs-storage-api`.
+//!
+//! Drift protection lives in the test module below: every constant's literal
+//! wire value is pinned, so a change on either side that breaks interop fails
+//! this crate's tests rather than silently forking the contract.
+
 use std::collections::HashMap;
 
 const RUSTFS_INTERNAL_PREFIX: &str = "x-rustfs-internal-";
@@ -144,5 +164,32 @@ mod tests {
         assert_eq!(trim_etag("\"abc\""), "abc");
         assert!(has_prefix_fold("X-Amz-Meta-Foo", "x-amz-meta-"));
         assert!(!has_prefix_fold("X-Amz-Meta-Foo", "amz-meta"));
+    }
+
+    /// Pins every duplicated interop constant to its literal wire value. The
+    /// canonical owner lives in the rustfs-utils crate (see the module doc);
+    /// an arch guard forbids depending on it from this crate, so byte-for-byte
+    /// pinning here is what keeps the two copies from drifting apart.
+    #[test]
+    fn duplicated_interop_constants_pin_canonical_wire_values() {
+        use super::*;
+
+        assert_eq!(AMZ_BUCKET_REPLICATION_STATUS, "X-Amz-Replication-Status");
+        assert_eq!(AMZ_OBJECT_LOCK_LEGAL_HOLD, "X-Amz-Object-Lock-Legal-Hold");
+        assert_eq!(AMZ_OBJECT_LOCK_MODE, "X-Amz-Object-Lock-Mode");
+        assert_eq!(AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE, "X-Amz-Object-Lock-Retain-Until-Date");
+        assert_eq!(AMZ_OBJECT_TAGGING, "X-Amz-Tagging");
+        assert_eq!(AMZ_WEBSITE_REDIRECT_LOCATION, "x-amz-website-redirect-location");
+        assert_eq!(CACHE_CONTROL, "Cache-Control");
+        assert_eq!(CONTENT_DISPOSITION, "Content-Disposition");
+        assert_eq!(CONTENT_ENCODING, "Content-Encoding");
+        assert_eq!(CONTENT_LANGUAGE, "Content-Language");
+        assert_eq!(EXPIRES, "Expires");
+        assert_eq!(SSEC_ALGORITHM_HEADER, "x-amz-server-side-encryption-customer-algorithm");
+        assert_eq!(SSEC_KEY_HEADER, "x-amz-server-side-encryption-customer-key");
+        assert_eq!(SSEC_KEY_MD5_HEADER, "x-amz-server-side-encryption-customer-key-md5");
+        assert_eq!(SUFFIX_ACTUAL_SIZE, "actual-size");
+        assert_eq!(SUFFIX_REPLICATION_STATUS, "replication-status");
+        assert_eq!(SUFFIX_REPLICATION_RESET_STATUS, "replication-reset-status");
     }
 }

--- a/crates/utils/src/http/header_compat.rs
+++ b/crates/utils/src/http/header_compat.rs
@@ -17,6 +17,13 @@
 //!
 //! Use suffix-based API: `get_header(headers, SUFFIX_FORCE_DELETE)` queries both
 //! x-rustfs-force-delete and x-minio-force-delete.
+//!
+//! This module is the canonical owner of these interop values. One deliberate
+//! copy exists: `crates/replication/src/http.rs` re-declares the subset it
+//! needs because the wire-contract crate must stay free of internal
+//! dependencies (arch guard in `scripts/check_architecture_migration_rules.sh`
+//! bans replication -> rustfs-utils). When changing a value here, check the
+//! pinned copy there; its tests pin the shared wire values byte-for-byte.
 
 use http::{HeaderMap, HeaderValue};
 use std::borrow::Cow;

--- a/crates/utils/src/http/metadata_compat.rs
+++ b/crates/utils/src/http/metadata_compat.rs
@@ -14,6 +14,13 @@
 
 //! System metadata compatibility: write both x-rustfs-internal-* and x-minio-internal-*
 //! for MinIO interoperability. Read prefers RustFS, fallback to MinIO.
+//!
+//! This module is the canonical owner of these interop values. One deliberate
+//! copy exists: `crates/replication/src/http.rs` re-declares the subset it
+//! needs because the wire-contract crate must stay free of internal
+//! dependencies (arch guard in `scripts/check_architecture_migration_rules.sh`
+//! bans replication -> rustfs-utils). When changing a value here, check the
+//! pinned copy there; its tests pin the shared wire values byte-for-byte.
 
 use std::collections::{BTreeMap, HashMap};
 


### PR DESCRIPTION
## What

PR1 of rustfs/backlog#1833, adjusted after hitting a standing guard. The issue prescribed deduplicating `crates/replication/src/http.rs` onto the canonical `rustfs-utils` http modules via `rustfs-utils = { workspace = true, features: ["http"] }` plus a re-export facade. I implemented that first — it compiles and all 158 replication tests pass against the canonical implementations — but `make pre-commit` rejects it: **`check_architecture_migration_rules.sh` bans any rustfs-utils import or dependency from the replication crate** ("replication crate HTTP/helper contracts must not import or depend on rustfs-utils"), alongside the same bans for `rustfs-filemeta` and `rustfs-storage-api`. The wire-contract crate deliberately has zero internal dependencies (docs/architecture/crate-boundaries.md: contract crates stay below implementation crates); the guard even matches the token in comments. The issue's adversarial review missed this guard.

Per the rc-window guard policy I did not weaken the guard. This PR lands the issue's own fallback shape for un-mergeable clusters (the bidirectional do-not-merge pattern it prescribes for the policy `path.rs` cluster):

- `crates/replication/src/http.rs`: module doc declaring the DELIBERATE DUPLICATION, naming the canonical owners (`crates/utils/src/http/{metadata_compat,header_compat,headers}.rs`) and the guard that forces the local copy.
- `crates/utils/src/http/metadata_compat.rs` + `header_compat.rs`: mirror notes pointing back at the pinned copy.
- New test `duplicated_interop_constants_pin_canonical_wire_values`: pins all 17 duplicated constants to their literal wire values, so either side drifting breaks a test instead of silently forking the interop contract (the issue's stated cost was "前瞻性漂移").

Comment/doc/test-only — no production code changed.

## If the boundary should move instead

If the maintainer prefers the original dedup, the unblock is a deliberate guard change (relax `REPLICATION_CRATE_UTILS_BYPASS` to allow the `http` feature of rustfs-utils), which is a separate decision I did not take unilaterally in the rc window. The verified facade diff is trivial to resurrect.

## Verification

- `cargo test -p rustfs-replication --lib` — 158 passed (159 with the new pin test)
- `cargo test -p rustfs-utils --lib` — 24 passed
- `cargo clippy -p rustfs-replication -p rustfs-utils --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅ (including the architecture migration guard)

Ref rustfs/backlog#1833.