### PR TITLE
chore(kms): import canonical internal encryption header constants

### DIFF
--- a/crates/kms/Cargo.toml
+++ b/crates/kms/Cargo.toml
@@ -62,7 +62,7 @@ moka = { workspace = true, features = ["future"] }
 # Additional dependencies
 md-5 = { workspace = true }
 arc-swap = { workspace = true }
-rustfs-utils = { workspace = true }
+rustfs-utils = { workspace = true, features = ["http"] }
 rustfs-security-governance = { workspace = true }
 # `EventName` for KMS audit records. A leaf crate with no rustfs dependencies,
 # so the audit sink can live outside this crate without a second, drifting

--- a/crates/kms/src/service.rs
+++ b/crates/kms/src/service.rs
@@ -81,16 +81,14 @@ fn request_encryption_context(context: &ObjectEncryptionContext) -> HashMap<Stri
     enc_context
 }
 
-const INTERNAL_ENCRYPTION_KEY_ID_HEADER: &str = "x-rustfs-encryption-key-id";
-
-/// Carries the AEAD algorithm the object was sealed with.
-///
-/// The S3 `x-amz-server-side-encryption` header records the *SSE mode*
-/// (`AES256` / `aws:kms`), not the cipher, so it cannot round-trip
-/// `ChaCha20Poly1305`. Without this header a ChaCha-sealed object comes back
-/// from the projection claiming `aws:kms` and is then opened with the wrong
-/// cipher.
-const INTERNAL_ENCRYPTION_ALGORITHM_HEADER: &str = "x-rustfs-encryption-algorithm";
+// Canonical owners of the internal encryption header names. Note on
+// INTERNAL_ENCRYPTION_ALGORITHM_HEADER: it carries the AEAD algorithm the
+// object was sealed with. The S3 `x-amz-server-side-encryption` header records
+// the *SSE mode* (`AES256` / `aws:kms`), not the cipher, so it cannot
+// round-trip `ChaCha20Poly1305`. Without this header a ChaCha-sealed object
+// comes back from the projection claiming `aws:kms` and is then opened with
+// the wrong cipher.
+use rustfs_utils::http::object_encryption_keys::{INTERNAL_ENCRYPTION_ALGORITHM_HEADER, INTERNAL_ENCRYPTION_KEY_ID_HEADER};
 
 /// Result of object encryption
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## What

PR2 of rustfs/backlog#1833. `crates/kms/src/service.rs` re-declared two interop header names locally: `x-rustfs-encryption-key-id` and `x-rustfs-encryption-algorithm`. The canonical owners are `INTERNAL_ENCRYPTION_KEY_ID_HEADER` / `INTERNAL_ENCRYPTION_ALGORITHM_HEADER` in `crates/utils/src/http/object_encryption_keys.rs`. This enables the `http` feature on kms' existing `rustfs-utils` dependency and imports the constants instead; the explanatory comment (why the algorithm header must exist: S3's `x-amz-server-side-encryption` records the SSE mode, not the AEAD cipher, so ChaCha20Poly1305 cannot round-trip without it) moves to the import site per the issue plan.

Values are byte-identical, so no behavior change; no new crate enters the dependency graph (utils was already a dependency — only the feature flag is new).

## Verification

- `cargo test -p rustfs-kms --lib` — 518 passed
- `cargo clippy -p rustfs-kms --lib --tests -- -D warnings` — clean
- `cargo tree -p rustfs-kms --depth 1` — same direct dependencies as before
- `make pre-commit` — ✅

Ref rustfs/backlog#1833.