### PR TITLE
fix(versioning): reject suspending versioning while a replication config exists

### DIFF
--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -4235,37 +4235,49 @@ async fn test_bucket_replication_acceptance_matrix_local_dual_targets() -> TestR
         "tag rule with disabled delete-marker replication created a marker: {tagged_state:?}"
     );
 
-    set_bucket_versioning(&source_env, source_bucket, BucketVersioningStatus::Suspended).await?;
-    set_bucket_versioning(&target_env_a, target_bucket_a, BucketVersioningStatus::Suspended).await?;
-    let null_put = source_client
+    // AWS S3 and MinIO both reject suspending versioning on a bucket that
+    // carries a replication configuration (InvalidBucketState): suspension
+    // would mint null versions that versioned replication can never converge.
+    let suspend_err = source_client
+        .put_bucket_versioning()
+        .bucket(source_bucket)
+        .versioning_configuration(
+            VersioningConfiguration::builder()
+                .status(BucketVersioningStatus::Suspended)
+                .build(),
+        )
+        .send()
+        .await
+        .expect_err("suspending versioning on a replication source must be rejected");
+    assert_eq!(
+        suspend_err.as_service_error().and_then(|error| error.code()),
+        Some("InvalidBucketState"),
+        "suspension on a replication source must fail with InvalidBucketState: {suspend_err:?}"
+    );
+
+    // The rejected suspension must leave the versioning + replication state
+    // fully intact: a fresh matched PUT still replicates with a real version.
+    let post_reject_put = source_client
         .put_object()
         .bucket(source_bucket)
-        .key("prefix/null.txt")
-        .body(ByteStream::from_static(b"null version"))
+        .key("prefix/after-rejected-suspend.txt")
+        .body(ByteStream::from_static(b"still replicating"))
         .send()
         .await?;
-    assert!(null_put.version_id().is_none(), "suspended source PUT must create a null version");
-    wait_for_replication_state(&target_client_a, target_bucket_a, "null version did not replicate", |state| {
-        state
-            .iter()
-            .any(|entry| entry.key == "prefix/null.txt" && entry.version_id == "null" && !entry.delete_marker)
-    })
-    .await?;
-    let null_delete = source_client
-        .delete_object()
-        .bucket(source_bucket)
-        .key("prefix/null.txt")
-        .send()
-        .await?;
-    assert!(
-        null_delete.version_id().is_none(),
-        "suspended source DELETE must create a null delete marker"
-    );
-    wait_for_replication_state(&target_client_a, target_bucket_a, "null delete marker did not replicate", |state| {
-        state
-            .iter()
-            .any(|entry| entry.key == "prefix/null.txt" && entry.version_id == "null" && entry.delete_marker)
-    })
+    let post_reject_version_id = post_reject_put
+        .version_id()
+        .ok_or("PUT after rejected suspension omitted version ID")?
+        .to_string();
+    wait_for_replication_state(
+        &target_client_a,
+        target_bucket_a,
+        "replication stopped after rejected versioning suspension",
+        |state| {
+            state
+                .iter()
+                .any(|entry| entry.key == "prefix/after-rejected-suspend.txt" && entry.version_id == post_reject_version_id)
+        },
+    )
     .await?;
 
     Ok(())

--- a/rustfs/src/app/bucket_usecase.rs
+++ b/rustfs/src/app/bucket_usecase.rs
@@ -738,6 +738,22 @@ async fn validate_bucket_versioning_update(bucket: &str, config: &VersioningConf
         Err(StorageError::ConfigNotFound) => {}
         Err(err) => return Err(ApiError::from(err).into()),
     }
+    // AWS S3 and MinIO both refuse to suspend versioning while a replication
+    // configuration exists: suspension would start minting null versions that
+    // the replication engine (versioned by contract) can never converge.
+    if config.suspended() {
+        match metadata_sys::get_replication_config(bucket).await {
+            Ok(_) => {
+                return Err(S3Error::with_message(
+                    S3ErrorCode::InvalidBucketState,
+                    "A replication configuration is present on this bucket, bucket wide versioning cannot be suspended."
+                        .to_string(),
+                ));
+            }
+            Err(StorageError::ConfigNotFound) => {}
+            Err(err) => return Err(ApiError::from(err).into()),
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Related Issues

Refs #5767 (first of two fixes for the nightly replication lane; the site-replication fence fix lands separately).

## Summary of Changes

`PutBucketVersioning` with `Status=Suspended` on a bucket that carries a replication configuration now fails with `InvalidBucketState`, matching AWS S3 and MinIO (the message text is byte-for-byte MinIO's: "A replication configuration is present on this bucket, bucket wide versioning cannot be suspended."). Enabling versioning is unaffected: the replication-config lookup only runs when the request asks for suspension, and it reuses the already-cached bucket metadata.

Why: `e2e-replication-nightly` has failed every night since 2026-08-02 (issue #5767). The deterministic failure was `test_bucket_replication_acceptance_matrix_local_dual_targets` (added in #5642): it suspended versioning on the replication source and then expected the resulting null versions to replicate. That state is unreachable on AWS and MinIO — both reject the suspension — and RustFS's versioned replication engine never converges null versions minted after suspension, so the test could never pass. This PR fixes the product to reject the transition and rewrites the test tail to pin the rejection contract (`InvalidBucketState`) plus a post-rejection sanity check that a fresh matched PUT still replicates with a real version id.

## Verification

- `cargo nextest run -p e2e_test -E 'test(test_bucket_replication_acceptance_matrix_local_dual_targets)'` — PASS locally (was the nightly's deterministic failure; the rewritten tail exercises the new rejection and post-rejection replication).
- `cargo clippy -p rustfs -p e2e_test --all-targets` — clean.
- `cargo fmt --all --check` — clean.
- Adversarial validation (all seven roles, high-risk tier): one comment trimmed and the wait-helper coverage note below addressed; remaining findings are pre-existing debts disclosed under Additional Notes.

## Impact

S3-visible behavior change: suspending versioning on a bucket with a replication configuration previously succeeded (and silently broke replication convergence); it now returns `InvalidBucketState`. This matches AWS S3 semantics. Note s3s maps `InvalidBucketState` to HTTP 409 (AWS behavior); MinIO returns 400 with the same error code and message — client SDKs dispatch on the code string, so the difference is not consequential. Existing buckets already in the suspended-with-replication state are unaffected: the check gates only new `PutBucketVersioning` requests, and the escape hatch (re-enable versioning, or delete the replication config and then suspend) works as before.

## Additional Notes

- The check is validate-then-write, the same shape as the adjacent object-lock check and MinIO's handler: a concurrent `PutBucketReplication` can still race the suspension in. Before this PR the forbidden combination was reachable with no race at all, so this strictly narrows the window.
- Site-replication metadata sync applies versioning configs directly through `metadata_sys` and intentionally bypasses this S3-layer check, mirroring MinIO's peer-receiver layering. In a mixed-version site-replication mesh an unupgraded peer can still accept a suspension and fan it out; once all sites run this check the gap closes (SR-managed buckets carry a real replication config in steady state).
- MinIO additionally rejects suspension globally while site replication is enabled (`globalSiteReplicationSys.isEnabled()`); that guard is not ported here since steady-state SR buckets are already covered by the replication-config check. Possible follow-up.
- Coverage disclosure: the rejection is exercised by the rewritten nightly e2e. A unit test of `validate_bucket_versioning_update`'s new branch would require the global bucket-metadata-sys to be initialized (the existing unit test only covers the branch that returns before any metadata lookup), so a revert of this check would be caught by the scheduled nightly lane rather than the per-PR gate.
- On a corrupt persisted replication config, suspension now returns an internal error (fail-closed) where MinIO would swallow the error and allow the suspension; this follows the repo's explicit-failure posture.
