### PR TITLE
fix(site-replication): admit same-generation peer-edit fan-out bodies

### DIFF
--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -2401,15 +2401,20 @@ async fn wait_for_site_replication_info<F>(
 where
     F: Fn(&SiteReplicationInfo) -> bool,
 {
-    for _ in 0..40 {
+    // 30s to match wait_for_replication_state: the three-node site tests run
+    // several full rustfs processes on one runner, so peer-state propagation
+    // can take well over 10s under CI load.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
         let info = site_replication_info(env).await?;
         if predicate(&info) {
             return Ok(info);
         }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!("site replication info did not reach expected state on {}", env.address).into());
+        }
         sleep(Duration::from_millis(250)).await;
     }
-
-    Err(format!("site replication info did not reach expected state on {}", env.address).into())
 }
 
 async fn wait_for_site_replication_status<F>(
@@ -2420,15 +2425,19 @@ async fn wait_for_site_replication_status<F>(
 where
     F: Fn(&SRStatusInfo) -> bool,
 {
-    for _ in 0..40 {
+    // Same 30s ceiling as wait_for_site_replication_info: the status probes
+    // fan out to every peer, so they see the same multi-process CI load.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
         let status = site_replication_status(env, query).await?;
         if predicate(&status) {
             return Ok(status);
         }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!("site replication status did not reach expected state on {}", env.address).into());
+        }
         sleep(Duration::from_millis(250)).await;
     }
-
-    Err(format!("site replication status did not reach expected state on {}", env.address).into())
 }
 
 async fn wait_for_replication_reset_target<F>(

--- a/rustfs/src/admin/handlers/site_replication.rs
+++ b/rustfs/src/admin/handlers/site_replication.rs
@@ -5932,15 +5932,18 @@ fn peer_edit_fence(queries: &HashMap<String, String>) -> Option<(String, u64)> {
     Some((origin.clone(), generation))
 }
 
-/// True when a newer edit from the same origin site already landed here. The
-/// process mutex on the sending node cannot order deliveries issued by two
-/// nodes of that site, so ordering is decided here, on the generation the
-/// sender allocated under the distributed lock.
+/// True when a strictly newer edit from the same origin site already landed
+/// here. The process mutex on the sending node cannot order deliveries issued
+/// by two nodes of that site, so ordering is decided here, on the generation
+/// the sender allocated under the distributed lock. Equal generations are NOT
+/// stale: one edit legitimately fans out several deliveries under a single
+/// generation (the ILM-expiry edit sends every peer's record), and a replay of
+/// an applied delivery re-applies the same edit idempotently.
 fn peer_edit_delivery_is_stale(state: &SiteReplicationState, origin: &str, generation: u64) -> bool {
     state
         .applied_edit_generations
         .get(origin)
-        .is_some_and(|applied| *applied >= generation)
+        .is_some_and(|applied| *applied > generation)
 }
 
 fn record_applied_peer_edit_generation(state: &mut SiteReplicationState, origin: &str, generation: u64) {
@@ -12783,8 +12786,11 @@ mod tests {
 
         // The delivery that lost the race carries the older generation.
         assert!(peer_edit_delivery_is_stale(&state, "origin-site", 6));
-        // A replay of the generation already applied is stale too.
-        assert!(peer_edit_delivery_is_stale(&state, "origin-site", 7));
+        // The generation already applied is NOT stale: one edit fans out one
+        // delivery per peer record under a single generation (the ILM-expiry
+        // edit), so an equal-generation delivery is the same edit's next body
+        // (or an idempotent replay) and must apply.
+        assert!(!peer_edit_delivery_is_stale(&state, "origin-site", 7));
         // The next edit from that origin still applies...
         assert!(!peer_edit_delivery_is_stale(&state, "origin-site", 8));
         // ...and another origin site is ordered independently.
@@ -12796,6 +12802,65 @@ mod tests {
         assert_eq!(peer_edit_path_with_fence(None, 9), SITE_REPLICATION_PEER_EDIT_PATH);
         assert_eq!(peer_edit_path_with_fence(Some(""), 9), SITE_REPLICATION_PEER_EDIT_PATH);
         assert!(peer_edit_fence(&HashMap::new()).is_none());
+    }
+
+    /// One edit fans out one delivery per peer record under a single
+    /// generation (the ILM-expiry edit sends every peer's record). The
+    /// receiver's fenced sequence — staleness check, apply, raise the
+    /// high-water mark — must therefore accept every body of that fan-out,
+    /// not just the first, while a strictly older delivery stays rejected.
+    #[test]
+    fn peer_edit_fence_admits_every_body_of_one_edits_fan_out() {
+        let local = PeerInfo {
+            deployment_id: "site-a".to_string(),
+            ..peer("site-a", "https://site-a.example.com")
+        };
+        let mut state = SiteReplicationState {
+            peers: BTreeMap::from([
+                ("site-a".to_string(), local.clone()),
+                (
+                    "site-b".to_string(),
+                    PeerInfo {
+                        deployment_id: "site-b".to_string(),
+                        ..peer("site-b", "https://site-b.example.com")
+                    },
+                ),
+                (
+                    "site-c".to_string(),
+                    PeerInfo {
+                        deployment_id: "site-c".to_string(),
+                        ..peer("site-c", "https://site-c.example.com")
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+        let origin = "origin-site";
+        let generation = 2;
+
+        let bodies: Vec<PeerInfo> = state
+            .peers
+            .values()
+            .map(|peer| PeerInfo {
+                replicate_ilm_expiry: true,
+                ..peer.clone()
+            })
+            .collect();
+        for body in bodies {
+            assert!(
+                !peer_edit_delivery_is_stale(&state, origin, generation),
+                "a same-generation fan-out body must not be fenced out"
+            );
+            state = apply_internal_peer_edit(state, &local, body, None).expect("fan-out body applies");
+            record_applied_peer_edit_generation(&mut state, origin, generation);
+        }
+
+        assert!(
+            state.peers.values().all(|peer| peer.replicate_ilm_expiry),
+            "every peer record from the fan-out must be applied: {:?}",
+            state.peers
+        );
+        assert!(peer_edit_delivery_is_stale(&state, origin, generation - 1));
     }
 
     /// P1-15 review follow-up: a site that leaves the mesh drops below two


### PR DESCRIPTION
## Related Issues

Refs #5767 (second of two fixes for the nightly replication lane; the versioning-suspension fix lands separately).

## Summary of Changes

`peer_edit_delivery_is_stale` now treats only a strictly newer applied generation as stale (`>` instead of `>=`).

Why: #5882 introduced the `editOrigin`/`editGeneration` fence on site-replication peer edits. One edit legitimately fans out several `PeerInfo` bodies under a single generation — the ILM-expiry edit sends every peer's record (`peers_to_send = state.peers`). With `>=`, the receiver applied the first body, raised its high-water mark to that generation, and then acked-success while silently dropping every remaining body of the same edit. `enableILMExpiryReplication` therefore never converged on receiving sites: `test_site_replication_edit_and_status_peer_state_real_three_node` failed on the first nightly after #5882 merged (issue #5767, 2026-08-12 run) and reproduced deterministically on a local three-node run, where the receiving sites' `/site-replication/info` kept reporting `replicate_ilm_expiry=false` for all but one peer while every `peer/edit` delivery returned 200.

Equal generation implies the same logical edit (the sender allocates one generation per edit and commits it before the fan-out), and re-applying a delivery is idempotent (`update_peer` overwrites the peer record wholesale; the high-water mark is raised with `max`), so admitting equal generations is safe. Strictly older deliveries — the cross-node ordering case the fence exists for — are still rejected.

Also in this PR:

- A composed unit test (`peer_edit_fence_admits_every_body_of_one_edits_fan_out`) drives three same-generation bodies through the receiver's fenced sequence (staleness check → `apply_internal_peer_edit` → `record_applied_peer_edit_generation`) and asserts all of them apply while a strictly older delivery stays fenced — so this regression shape is caught by the per-PR gate, not just nightly.
- The replication e2e's two site-replication wait helpers (`wait_for_site_replication_info`, `wait_for_site_replication_status`) move from a 10s polling ceiling to the same 30s deadline loop the file's other waits use: the three-node tests run several full rustfs processes on one CI runner and 10s has proven too tight under load.

## Verification

- `cargo nextest run -p e2e_test -E 'test(test_site_replication_edit_and_status_peer_state_real_three_node)'` — failed deterministically before the fix (full 30s wait burn, same signature as the nightly), PASS after (21s).
- `cargo nextest run -p rustfs -E 'test(peer_edit_fence_rejects_a_delivery_the_newer_edit_already_passed) or test(peer_edit_fence_admits_every_body_of_one_edits_fan_out) or test(peer_edit_marks_do_not_outlive_the_peer_that_earned_them) or test(test_peer_edit_generations_are_unique_across_nodes)'` — 4/4 PASS.
- `cargo clippy -p rustfs -p e2e_test --all-targets` — clean.
- `cargo fmt --all --check` — clean.
- Adversarial validation (all seven roles, high-risk tier): the fence is not a security boundary (SigV4 + `SiteReplicationOperationAction` authz run before it), the equal-generation apply is idempotent and its write amplification is bounded by site count on the admin control plane, and no new lost-update interleavings were found (details in the follow-ups below).

## Impact

Behavior change is receiver-side acceptance only; the wire format (query params, JSON bodies, state schema) is unchanged, so mixed-version meshes stay compatible: an unupgraded receiver keeps dropping fan-out bodies 2..N until it is upgraded (staged behavior, no protocol break). The relaxation also closes a crash window on the endpoint-refresh path, whose two-commit sequence records the high-water mark before the apply: with `>=`, a crash between the two commits made the retried same-generation delivery permanently fenced out.

## Additional Notes

Pre-existing debts observed during review, unchanged by this PR and left as follow-ups for the #5882 series (PR2):

- The per-origin fence is a scalar high-water mark, so when edits from two nodes of the same origin site interleave, bodies of the superseded edit that the newer edit did not touch are dropped without a retry trace (identical outcome under `>=`).
- Endpoint-refresh and join/finalize commits are unfenced (no generation stamped), so their ordering against fenced edits relies on arrival order.
- Generation allocation on the edit path still runs under the process guard only; the distributed-lock transaction helper from #5882 has not yet been migrated to this call site, so two nodes of one origin site can in principle collide on a generation.
