### PR TITLE
perf(get): share metadata cache hits

### DIFF
--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -733,10 +733,41 @@ mod transition_matrix_tests;
 
 pub use ops::heal_walk::HealWalkVersion;
 
+pub(in crate::set_disk) enum GetObjectMetadata<T> {
+    Owned(T),
+    Shared(Arc<T>),
+}
+
+impl<T> std::ops::Deref for GetObjectMetadata<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(value) => value,
+            Self::Shared(value) => value,
+        }
+    }
+}
+
+impl<T: Clone> GetObjectMetadata<T> {
+    fn into_owned(self) -> T {
+        match self {
+            Self::Owned(value) => value,
+            Self::Shared(value) => Arc::try_unwrap(value).unwrap_or_else(|value| (*value).clone()),
+        }
+    }
+}
+
+type GetObjectFileInfo = (
+    GetObjectMetadata<FileInfo>,
+    GetObjectMetadata<Vec<FileInfo>>,
+    GetObjectMetadata<Vec<Option<DiskStore>>>,
+);
+
 pub(crate) struct PreparedGetObjectMetadata {
-    fi: FileInfo,
-    files: Vec<FileInfo>,
-    disks: Vec<Option<DiskStore>>,
+    fi: GetObjectMetadata<FileInfo>,
+    files: GetObjectMetadata<Vec<FileInfo>>,
+    disks: GetObjectMetadata<Vec<Option<DiskStore>>>,
     object_info: Option<ObjectInfo>,
 }
 
@@ -805,9 +836,9 @@ mod prepared_get_object_metadata_tests {
     #[tokio::test]
     async fn prepared_metadata_is_consumed_exactly_once() {
         let metadata = PreparedGetObjectMetadata {
-            fi: FileInfo::default(),
-            files: Vec::new(),
-            disks: Vec::new(),
+            fi: GetObjectMetadata::Owned(FileInfo::default()),
+            files: GetObjectMetadata::Owned(Vec::new()),
+            disks: GetObjectMetadata::Owned(Vec::new()),
             object_info: None,
         };
 
@@ -2463,13 +2494,13 @@ impl Hash for GetObjectMetadataCacheKey {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct GetObjectMetadataCacheEntry {
     #[allow(dead_code)] // Kept for debugging; moka handles TTL internally
     created_at: Instant,
-    fi: FileInfo,
-    parts_metadata: Vec<FileInfo>,
-    online_disks: Vec<Option<DiskStore>>,
+    fi: Arc<FileInfo>,
+    parts_metadata: Arc<Vec<FileInfo>>,
+    online_disks: Arc<Vec<Option<DiskStore>>>,
     read_quorum: usize,
 }
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -750,8 +750,8 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                 0,
                 object_info.size,
                 &mut output,
-                fi,
-                files,
+                fi.into_owned(),
+                files.into_owned(),
                 &disks,
                 self.set_index,
                 self.pool_index,
@@ -867,8 +867,8 @@ impl crate::storage_api_contracts::object::ObjectIO for SetDisks {
                 offset,
                 length,
                 &mut writer,
-                fi,
-                files,
+                fi.into_owned(),
+                files.into_owned(),
                 &disks,
                 set_index,
                 pool_index,
@@ -3198,7 +3198,8 @@ impl SetDisks {
         // Force the full quorum fanout (allow_early_stop=false): `disks` is the
         // write target below, and an early-stop subset would only carry read
         // quorum, failing write quorum on update_object_meta (backlog#872).
-        let (mut fi, _, disks) = self.get_object_fileinfo_gated(bucket, object, opts, false, false).await?;
+        let (fi, _, disks) = self.get_object_fileinfo_gated(bucket, object, opts, false, false).await?;
+        let mut fi = fi.into_owned();
 
         fi.metadata.insert(AMZ_OBJECT_TAGGING.to_owned(), tags.to_owned());
         if let Some(eval_metadata) = &opts.eval_metadata {
@@ -3221,7 +3222,7 @@ impl SetDisks {
             });
         }
 
-        self.update_object_meta(bucket, object, fi.clone(), disks.as_slice()).await?;
+        self.update_object_meta(bucket, object, fi.clone(), &disks).await?;
 
         Ok(ObjectInfo::from_file_info(&fi, bucket, object, opts.versioned || opts.version_suspended))
     }
@@ -4625,7 +4626,8 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
         //     _lock_guard = guard_opt;
         // }
 
-        let (mut fi, meta_arr, online_disks) = self.get_object_fileinfo(bucket, object, opts, true, false).await?;
+        let (fi, meta_arr, online_disks) = self.get_object_fileinfo(bucket, object, opts, true, false).await?;
+        let mut fi = fi.into_owned();
         /*if err != nil {
             return Err(to_object_err(err, vec![bucket, object]));
         }*/
@@ -4739,7 +4741,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
                 cloned_fi.size,
                 &mut writer,
                 cloned_fi,
-                meta_arr,
+                meta_arr.into_owned(),
                 &online_disks,
                 set_index,
                 pool_index,
@@ -4863,7 +4865,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
         };
         self.invalidate_get_object_metadata_cache(bucket, object).await;
         let current = self.get_object_fileinfo(bucket, object, &commit_opts, true, false).await;
-        let (mut current_fi, _, _) = match current {
+        let (current_fi, _, _) = match current {
             Ok(current) => current,
             Err(err) => {
                 drop(transition_lock_guard);
@@ -4874,6 +4876,7 @@ impl crate::storage_api_contracts::object::ObjectOperations for SetDisks {
                 return Err(err);
             }
         };
+        let mut current_fi = current_fi.into_owned();
         let source_matches = current_fi.version_id == fi.version_id
             && current_fi.data_dir == fi.data_dir
             && current_fi.mod_time == fi.mod_time
@@ -6232,9 +6235,9 @@ mod transition_commit_failure_tests {
                 cache_key.clone(),
                 Arc::new(GetObjectMetadataCacheEntry {
                     created_at: Instant::now(),
-                    fi: fi.clone(),
-                    parts_metadata,
-                    online_disks,
+                    fi: Arc::new((*fi).clone()),
+                    parts_metadata: Arc::new(parts_metadata.into_owned()),
+                    online_disks: Arc::new(online_disks.into_owned()),
                     read_quorum: 2,
                 }),
             )

--- a/crates/ecstore/src/set_disk/read.rs
+++ b/crates/ecstore/src/set_disk/read.rs
@@ -116,9 +116,9 @@ impl SetDisks {
             .then_some(GET_METADATA_CACHE_REASON_DIST_ERASURE)
     }
 
-    async fn cached_get_object_fileinfo(&self, bucket: &str, object: &str) -> Option<GetObjectMetadataCacheEntry> {
+    async fn cached_get_object_fileinfo(&self, bucket: &str, object: &str) -> Option<Arc<GetObjectMetadataCacheEntry>> {
         match self.lookup_cached_get_object_fileinfo(bucket, object).await {
-            MetadataCacheLookup::Hit(entry) => Some((*entry).clone()),
+            MetadataCacheLookup::Hit(entry) => Some(entry),
             MetadataCacheLookup::Miss | MetadataCacheLookup::RejectedInsufficientQuorum => None,
         }
     }
@@ -180,9 +180,9 @@ impl SetDisks {
         let key = GetObjectMetadataCacheKey::new(bucket, object, generation);
         let entry = Arc::new(GetObjectMetadataCacheEntry {
             created_at: Instant::now(),
-            fi: fi.clone(),
-            parts_metadata: parts_metadata.to_vec(),
-            online_disks: online_disks.to_vec(),
+            fi: Arc::new(fi.clone()),
+            parts_metadata: Arc::new(parts_metadata.to_vec()),
+            online_disks: Arc::new(online_disks.to_vec()),
             read_quorum,
         });
         self.insert_get_object_metadata_cache_entry_after_insert(key, generation, entry, || {})
@@ -257,7 +257,7 @@ impl SetDisks {
         opts: &ObjectOptions,
         read_data: bool,
         caller_allows_early_stop: bool,
-    ) -> Result<(FileInfo, Vec<FileInfo>, Vec<Option<DiskStore>>)> {
+    ) -> Result<GetObjectFileInfo> {
         self.get_object_fileinfo_gated(bucket, object, opts, read_data, caller_allows_early_stop)
             .await
     }
@@ -274,7 +274,7 @@ impl SetDisks {
         opts: &ObjectOptions,
         read_data: bool,
         allow_early_stop: bool,
-    ) -> Result<(FileInfo, Vec<FileInfo>, Vec<Option<DiskStore>>)> {
+    ) -> Result<GetObjectFileInfo> {
         let vid = opts.version_id.clone().unwrap_or_default();
         let stage_metrics_enabled = rustfs_io_metrics::get_stage_metrics_enabled();
 
@@ -300,7 +300,11 @@ impl SetDisks {
                         GET_STAGE_METADATA_CACHE_LOOKUP,
                         metadata_cache_lookup_start,
                     );
-                    return Ok((cached.fi.clone(), cached.parts_metadata.clone(), cached.online_disks.clone()));
+                    return Ok((
+                        GetObjectMetadata::Shared(Arc::clone(&cached.fi)),
+                        GetObjectMetadata::Shared(Arc::clone(&cached.parts_metadata)),
+                        GetObjectMetadata::Shared(Arc::clone(&cached.online_disks)),
+                    ));
                 }
                 MetadataCacheLookup::Miss => {
                     rustfs_io_metrics::record_get_object_metadata_cache_decision(
@@ -423,7 +427,11 @@ impl SetDisks {
 
         // let online_disks: Vec<Option<DiskStore>> = op_online_disks.iter().filter(|v| v.is_some()).cloned().collect();
 
-        Ok((fi, parts_metadata, op_online_disks))
+        Ok((
+            GetObjectMetadata::Owned(fi),
+            GetObjectMetadata::Owned(parts_metadata),
+            GetObjectMetadata::Owned(op_online_disks),
+        ))
     }
 
     #[hotpath::measure(impl_type = "SetDisks")]
@@ -2680,6 +2688,39 @@ mod metadata_cache_tests {
     }
 
     #[tokio::test]
+    async fn get_object_fileinfo_cache_hit_shares_cached_metadata() {
+        let set = new_metadata_cache_test_set().await;
+        let fi = valid_test_fileinfo("object");
+        let parts_metadata = vec![fi.clone()];
+        let online_disks = Vec::new();
+        let generation = set.get_object_metadata_cache_generation("bucket", "object");
+        set.cache_get_object_fileinfo(("bucket", "object"), generation, &fi, &parts_metadata, &online_disks, 0)
+            .await;
+        let cached = set
+            .cached_get_object_fileinfo("bucket", "object")
+            .await
+            .expect("fresh cache entry should be returned");
+
+        let (returned_fi, returned_parts_metadata, returned_online_disks) = set
+            .get_object_fileinfo("bucket", "object", &ObjectOptions::default(), true, false)
+            .await
+            .expect("cache-backed metadata lookup should succeed");
+
+        assert!(
+            matches!(returned_fi, GetObjectMetadata::Shared(ref value) if Arc::ptr_eq(value, &cached.fi)),
+            "cache hits must share FileInfo ownership"
+        );
+        assert!(
+            matches!(returned_parts_metadata, GetObjectMetadata::Shared(ref value) if Arc::ptr_eq(value, &cached.parts_metadata)),
+            "cache hits must share the metadata vector"
+        );
+        assert!(
+            matches!(returned_online_disks, GetObjectMetadata::Shared(ref value) if Arc::ptr_eq(value, &cached.online_disks)),
+            "cache hits must share the online-disk vector"
+        );
+    }
+
+    #[tokio::test]
     async fn get_object_metadata_cache_rejects_deleted_and_invalid_fileinfo() {
         let set = new_metadata_cache_test_set().await;
 
@@ -2718,9 +2759,9 @@ mod metadata_cache_tests {
                 ),
                 Arc::new(GetObjectMetadataCacheEntry {
                     created_at: Instant::now(),
-                    fi: fi.clone(),
-                    parts_metadata: vec![fi],
-                    online_disks: vec![None],
+                    fi: Arc::new(fi.clone()),
+                    parts_metadata: Arc::new(vec![fi]),
+                    online_disks: Arc::new(vec![None]),
                     read_quorum: 1,
                 }),
             )
@@ -2734,9 +2775,6 @@ mod metadata_cache_tests {
 
     #[tokio::test]
     async fn get_object_metadata_cache_rejects_stale_entries() {
-        // moka handles TTL expiry automatically via time_to_live(250ms).
-        // This test verifies that entries inserted with the cache API are retrievable
-        // while fresh, and that the cache API works correctly.
         let set = new_metadata_cache_test_set().await;
         let fi = valid_test_fileinfo("object");
 
@@ -2748,6 +2786,14 @@ mod metadata_cache_tests {
             set.cached_get_object_fileinfo("bucket", "object").await.is_some(),
             "freshly inserted entry should be returned"
         );
+
+        tokio::time::timeout(GET_OBJECT_METADATA_CACHE_TTL + Duration::from_secs(1), async {
+            while set.cached_get_object_fileinfo("bucket", "object").await.is_some() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("metadata cache entry should expire after its TTL");
     }
 
     #[tokio::test]
@@ -2809,9 +2855,13 @@ mod metadata_cache_tests {
         barrier.wait_until_paused().await;
         set.invalidate_get_object_metadata_cache(bucket, object).await;
         barrier.release();
-        read.await
+        let (fi, parts_metadata, online_disks) = read
+            .await
             .expect("metadata read task should not panic")
             .expect("metadata fanout should still return its selected FileInfo");
+        assert!(matches!(fi, GetObjectMetadata::Owned(_)));
+        assert!(matches!(parts_metadata, GetObjectMetadata::Owned(_)));
+        assert!(matches!(online_disks, GetObjectMetadata::Owned(_)));
 
         assert!(
             set.get_object_metadata_cache
@@ -2858,9 +2908,9 @@ mod metadata_cache_tests {
         let key = GetObjectMetadataCacheKey::new("bucket", "object", generation);
         let entry = Arc::new(GetObjectMetadataCacheEntry {
             created_at: Instant::now(),
-            fi: fi.clone(),
-            parts_metadata: vec![fi],
-            online_disks: Vec::new(),
+            fi: Arc::new(fi.clone()),
+            parts_metadata: Arc::new(vec![fi]),
+            online_disks: Arc::new(Vec::new()),
             read_quorum: 0,
         });
 
@@ -2968,9 +3018,9 @@ mod metadata_cache_tests {
         let entry = |fi: FileInfo| {
             Arc::new(GetObjectMetadataCacheEntry {
                 created_at: Instant::now(),
-                parts_metadata: vec![fi.clone()],
-                fi,
-                online_disks: Vec::new(),
+                parts_metadata: Arc::new(vec![fi.clone()]),
+                fi: Arc::new(fi),
+                online_disks: Arc::new(Vec::new()),
                 read_quorum: 0,
             })
         };

--- a/crates/ecstore/src/set_disk/replication.rs
+++ b/crates/ecstore/src/set_disk/replication.rs
@@ -77,9 +77,10 @@ impl SetDisks {
             version_suspended: opts.version_suspended,
             ..Default::default()
         };
-        let (mut fi, _, disks) = self
+        let (fi, _, disks) = self
             .get_object_fileinfo_gated(bucket, object, &read_opts, false, false)
             .await?;
+        let mut fi = fi.into_owned();
         if let Some(expected_operation_id) = expected_operation_id {
             require_restore_operation_id(&fi.metadata, expected_operation_id)?;
         }
@@ -101,7 +102,7 @@ impl SetDisks {
             bucket,
             object,
             fi.clone(),
-            disks.as_slice(),
+            &disks,
             &UpdateMetadataOpts {
                 replace_user_metadata: true,
                 ..Default::default()
@@ -143,9 +144,10 @@ impl SetDisks {
             version_suspended: opts.version_suspended,
             ..Default::default()
         };
-        let (mut fi, _, disks) = self
+        let (fi, _, disks) = self
             .get_object_fileinfo_gated(bucket, object, &read_opts, false, false)
             .await?;
+        let mut fi = fi.into_owned();
         if let Some(expected_operation_id) = expected_operation_id {
             match restore_operation_id_from_metadata(&fi.metadata)? {
                 Some(actual_operation_id) if actual_operation_id == expected_operation_id => {}
@@ -170,7 +172,7 @@ impl SetDisks {
             bucket,
             object,
             fi,
-            disks.as_slice(),
+            &disks,
             &UpdateMetadataOpts {
                 replace_user_metadata: true,
                 ..Default::default()


### PR DESCRIPTION
## Related Issues

Refs rustfs/backlog#1808.

## Summary of Changes

- Store immutable local metadata-cache snapshots behind `Arc` and return shared snapshots on eligible cache hits, avoiding deep clones of `FileInfo`, part metadata, and disk vectors.
- Preserve owned results for fresh reads and distributed-erasure bypasses so uncached requests do not pay additional `Arc` allocations.
- Add regression coverage that proves cache hits share snapshots, fresh reads remain owned, and stale entries actually expire after the configured TTL.

Distributed metadata caching is deliberately not enabled. The current generation fence is scoped to a single `SetDisks` instance, bucket incarnation only covers bucket delete/recreate, and there is no peer invalidation or mixed-version capability signal covering remote writes, deletes, version changes, delete markers, healing, and replication. Enabling distributed hits under those constraints could serve stale S3-visible metadata, so the existing distributed-erasure bypass remains unchanged.

## Verification

- `cargo test -p rustfs-ecstore --lib metadata_cache -- --nocapture` (36 passed)
- Focused mutation, multipart, direct-memory, versioned-latest, delete-marker, and restore-metadata tests (all passed with non-zero test counts)
- `cargo check -p rustfs-ecstore --lib`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `make pre-pr` (13,338 nextest tests passed; workspace doctests passed)

## Impact

Eligible local metadata-cache hits now clone `Arc` handles instead of deeply cloning cached metadata. S3 behavior, metadata eligibility, cache TTL, invalidation fences, on-disk and on-wire formats, public APIs, configuration, and distributed-cache behavior are unchanged. No new kill switch is required because this changes only the internal ownership representation and preserves the existing fail-closed distributed bypass.

## Additional Notes

High-risk adversarial validation verdicts:

- Correctness: attacked mutation after cache hits, COW conversion, quorum results, empty metadata, explicit versions, and delete markers; no break found.
- Simplicity: compared a unified always-`Arc` result and a separate cache-entry wrapper; the owned/shared boundary is the smaller design that avoids fresh-read allocations.
- Security: attacked trust-boundary and authorization effects; no auth, parsing, secret, or untrusted-deserialization boundary changed.
- Concurrency/durability: attacked cache replacement, immutable snapshot sharing, fence ordering, cancellation, and lock scope; no fence or durability behavior changed.
- Compatibility: attacked S3-visible results, mixed-version operation, public APIs, and wire/disk formats; the distributed bypass is preserved and no compatibility surface changed.
- Performance: attacked refcount churn and fresh-read allocation regressions; cache hits use refcounts while fresh and bypassed reads remain owned.
- Test coverage: cache-hit pointer identity detects deep-clone regressions, owned-result assertions detect fresh-read allocation regressions, and TTL plus existing mutation/fence/eligibility tests detect stale-result regressions.

Rollback is a direct revert of this commit; no data migration or cache flush is required.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
