### PR TITLE
fix(sse): align copy-path unknown-algorithm fallback with put path

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -162,8 +162,9 @@ use s3s::dto::{
     GetObjectInput, GetObjectOutput, HeadObjectInput, HeadObjectOutput, MetadataDirective, ObjectAttributes, ObjectLockLegalHold,
     ObjectLockLegalHoldStatus, ObjectLockMode, ObjectLockRetention, ObjectLockRetentionMode, ObjectPart, PutObjectInput,
     PutObjectOutput, Range, RequestCharged, RestoreObjectInput, RestoreObjectOutput, RestoreStatus, SSECustomerAlgorithm,
-    SSECustomerKeyMD5, SSEKMSKeyId, SelectObjectContentInput, SelectObjectContentOutput, ServerSideEncryption, StorageClass,
-    StreamingBlob, TaggingDirective, TaggingHeader, Timestamp, TimestampFormat, WebsiteRedirectLocation,
+    SSECustomerKeyMD5, SSEKMSKeyId, SelectObjectContentInput, SelectObjectContentOutput, ServerSideEncryption,
+    ServerSideEncryptionByDefault, StorageClass, StreamingBlob, TaggingDirective, TaggingHeader, Timestamp, TimestampFormat,
+    WebsiteRedirectLocation,
 };
 use s3s::header::{X_AMZ_RESTORE, X_AMZ_RESTORE_OUTPUT_PATH};
 use s3s::stream::{ByteStream, DynByteStream, RemainingLength};
@@ -2562,6 +2563,25 @@ fn has_put_sse_request_headers(headers: &HeaderMap) -> bool {
     headers.get(AMZ_SERVER_SIDE_ENCRYPTION).is_some()
         || headers.get(AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM).is_some()
         || headers.get(AMZ_SERVER_SIDE_ENCRYPTION_KMS_ID).is_some()
+}
+
+/// Managed SSE resolved from a bucket default encryption rule on the copy path.
+///
+/// Unknown algorithms fall back to AES256, the same total mapping as the PUT and
+/// extract paths and the storage-layer resolver (`prepare_sse_configuration`), which
+/// `sse_encryption` re-runs when it mints the destination DEK. Resolving `None` here
+/// instead lets a same-name copy under a malformed bucket default pass the
+/// `copy_changes_encryption` guard and take the metadata-only shortcut while the
+/// storage layer still encrypts: fresh DEK metadata is committed beside the untouched
+/// plaintext blocks and the object becomes unreadable. Reachable only via corrupt or
+/// hand-edited bucket metadata — PutBucketEncryption rejects unknown algorithms
+/// (backlog#1826).
+fn bucket_default_write_sse(sse: &ServerSideEncryptionByDefault) -> ServerSideEncryption {
+    match sse.sse_algorithm.as_str() {
+        "AES256" => ServerSideEncryption::from_static(ServerSideEncryption::AES256),
+        "aws:kms" => ServerSideEncryption::from_static(ServerSideEncryption::AWS_KMS),
+        _ => ServerSideEncryption::from_static(ServerSideEncryption::AES256),
+    }
 }
 
 fn should_use_small_eager_put_path(
@@ -7180,11 +7200,7 @@ impl DefaultObjectUsecase {
                 config.rules.first().and_then(|rule| {
                     rule.apply_server_side_encryption_by_default
                         .as_ref()
-                        .and_then(|sse| match sse.sse_algorithm.as_str() {
-                            "AES256" => Some(ServerSideEncryption::from_static(ServerSideEncryption::AES256)),
-                            "aws:kms" => Some(ServerSideEncryption::from_static(ServerSideEncryption::AWS_KMS)),
-                            _ => None,
-                        })
+                        .map(bucket_default_write_sse)
                 })
             })
         });
@@ -9574,7 +9590,8 @@ mod tests {
         DefaultRetention, Delete, DeleteMarkerReplication, DeleteMarkerReplicationStatus, DeleteReplication,
         DeleteReplicationStatus, Destination, ExistingObjectReplication, ExistingObjectReplicationStatus, ObjectIdentifier,
         ObjectLockConfiguration, ObjectLockEnabled, ObjectLockRule, ReplicaModifications, ReplicaModificationsStatus,
-        ReplicationConfiguration, ReplicationRule, ReplicationRuleStatus, RestoreRequest, SourceSelectionCriteria,
+        ReplicationConfiguration, ReplicationRule, ReplicationRuleStatus, RestoreRequest, ServerSideEncryptionConfiguration,
+        ServerSideEncryptionRule, SourceSelectionCriteria,
     };
     use std::pin::Pin;
     use std::sync::Arc;
@@ -9767,6 +9784,46 @@ mod tests {
         assert!(lookup_opts.http_preconditions.is_none());
         assert_eq!(lookup_opts.version_id.as_deref(), Some(version_id.as_str()));
         assert!(lookup_opts.no_lock);
+    }
+
+    // A malformed bucket-default algorithm reaches this resolution only through
+    // corrupt or hand-edited bucket metadata (PutBucketEncryption validates the
+    // value), so the invariant is pinned here rather than end-to-end: the copy
+    // path must resolve managed AES256 exactly like PUT/extract. With an
+    // unencrypted same-name source and no SSE-C, the resolved default alone
+    // keeps `copy_changes_encryption` true, so the metadata-only shortcut stays
+    // off while `sse_encryption` mints a fresh DEK (backlog#1826).
+    #[test]
+    fn copy_bucket_default_unknown_sse_algorithm_falls_back_to_aes256() {
+        let config = ServerSideEncryptionConfiguration {
+            rules: vec![ServerSideEncryptionRule {
+                apply_server_side_encryption_by_default: Some(ServerSideEncryptionByDefault {
+                    sse_algorithm: ServerSideEncryption::from(String::from("garbage")),
+                    kms_master_key_id: None,
+                }),
+                bucket_key_enabled: None,
+            }],
+        };
+
+        let effective_sse = config
+            .rules
+            .first()
+            .and_then(|rule| rule.apply_server_side_encryption_by_default.as_ref())
+            .map(bucket_default_write_sse);
+
+        assert_eq!(effective_sse.as_ref().map(|sse| sse.as_str()), Some(ServerSideEncryption::AES256));
+
+        // Valid algorithms map to themselves, byte-identical to the PUT path.
+        for (configured, expected) in [
+            (ServerSideEncryption::AES256, ServerSideEncryption::AES256),
+            (ServerSideEncryption::AWS_KMS, ServerSideEncryption::AWS_KMS),
+        ] {
+            let sse = ServerSideEncryptionByDefault {
+                sse_algorithm: ServerSideEncryption::from_static(configured),
+                kms_master_key_id: None,
+            };
+            assert_eq!(bucket_default_write_sse(&sse).as_str(), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1826 (PR1 of 3)

## Summary of Changes

The bucket-default SSE resolution block is copy-pasted across the PUT, COPY, and extract paths in `app/object_usecase.rs`, and the copies had diverged: PUT/extract map an unknown `sse_algorithm` to an AES256 fallback while the COPY path mapped it to `None`. This PR extracts the COPY path's mapping into a named helper `bucket_default_write_sse` whose fallback matches the other paths (and the storage-layer resolver `prepare_sse_configuration`), and documents the actual failure shape in the helper's doc comment.

That failure shape (established by adversarial review, sharper than the naive reading): resolving `None` does NOT write an unencrypted copy — downstream `sse_encryption` re-applies the AES256 fallback when minting the destination DEK. The hazard is the same-name-copy `copy_changes_encryption` guard: with `None` resolved at the app layer, a same-name copy under a malformed bucket default could take the metadata-only shortcut while the storage layer still encrypts — fresh DEK metadata committed beside untouched plaintext blocks, making the object unreadable. Reachable only via corrupt or hand-edited bucket metadata (`PutBucketEncryption` rejects unknown algorithms), which is why the invariant is pinned at the resolution level rather than end-to-end.

New test `copy_bucket_default_unknown_sse_algorithm_falls_back_to_aes256` pins: unknown algorithm → AES256, and valid algorithms (AES256, aws:kms) → themselves, byte-identical to the PUT path. Mutation check: a deliberately wrong fallback (`AWS_KMS`) makes the test fail, so a revert or wrong-direction edit is detected.

Adversarial validation (high tier, one-line verdicts):
- Correctness — total mapping now identical across PUT/COPY/extract and storage resolver; wrong-fallback mutant caught by the new test; no break found.
- Simplicity — one named helper replacing an inline closure, no new abstraction; no break found.
- Security — closes the malformed-default metadata-only/encryption mismatch (data-destruction-shaped); no new untrusted input parsing; no break found.
- Concurrency/durability — no locking or IO-ordering changes; no break found.
- Compatibility — valid-algorithm behavior byte-identical (pinned by test); the only behavior change is for invalid persisted config, aligning COPY with PUT; S3-visible behavior for valid configs unchanged; no break found.
- Performance — `from_static`, no allocations added on the copy path; no break found.
- Test-coverage skeptic — resolution-level pinning justified (invalid value unreachable through the API); residual risk recorded: the end-to-end metadata-only shortcut path is not exercised with this input; follow-up dedup PR (backlog#1826 PR2) will centralize the semantics.

## Verification

- `cargo nextest run -p rustfs -E 'test(/object_usecase/)'` → 236 passed (includes the new test)
- `cargo fmt --all --check`
- Compilation coverage via the nextest build of the rustfs test targets

## Impact

No behavior change for any valid bucket encryption configuration. For a malformed persisted default (corrupt/hand-edited metadata), the COPY path now resolves AES256 like PUT/extract instead of `None`, removing a data-destruction-shaped mismatch on same-name copies. Follow-ups: PR2 extracts one shared `resolve_bucket_default_sse` for all four sites; PR3 evaluates collapsing PUT's double resolution (rustfs/backlog#1826).

## Additional Notes

Part of the pre-1.0 cleanup program tracked in rustfs/backlog#1820.
