### PR TITLE
chore(ecstore): remove test-only BitrotErrorType and pin wire-only disk variants

### DIFF
--- a/crates/ecstore/src/api/mod.rs
+++ b/crates/ecstore/src/api/mod.rs
@@ -344,7 +344,7 @@ pub mod disk {
     }
 
     pub mod error {
-        pub use crate::disk::error::{BitrotErrorType, DiskError, Error, FileAccessDeniedWithContext, Result};
+        pub use crate::disk::error::{DiskError, Error, FileAccessDeniedWithContext, Result};
     }
 
     pub mod error_reduce {

--- a/crates/ecstore/src/disk/error.rs
+++ b/crates/ecstore/src/disk/error.rs
@@ -113,6 +113,9 @@ pub enum DiskError {
     #[error("bit-rot hash algorithm is invalid")]
     BitrotHashAlgoInvalid,
 
+    /// Never constructed locally by RustFS (only reachable through wire
+    /// decoding, and no current node sends it). The wire code is kept for
+    /// cross-version compatibility — do not renumber or remove (backlog#1831).
     #[error("Rename across devices not allowed, please fix your backend configuration")]
     CrossDeviceLink,
 
@@ -143,6 +146,9 @@ pub enum DiskError {
     #[error("io error {0}")]
     Io(#[source] io::Error),
 
+    /// Never constructed locally by RustFS (only reachable through wire
+    /// decoding, and no current node sends it). The wire code is kept for
+    /// cross-version compatibility — do not renumber or remove (backlog#1831).
     #[error("source stalled")]
     SourceStalled,
 
@@ -642,19 +648,6 @@ impl Hash for DiskError {
 // is currently commented out to avoid complexity. These can be re-enabled
 // when needed for specific disk quorum checking and error aggregation logic.
 
-/// Bitrot errors
-#[derive(Debug, thiserror::Error)]
-pub enum BitrotErrorType {
-    #[error("bitrot checksum verification failed")]
-    BitrotChecksumMismatch { expected: String, got: String },
-}
-
-impl From<BitrotErrorType> for DiskError {
-    fn from(e: BitrotErrorType) -> Self {
-        DiskError::other(e)
-    }
-}
-
 /// Context wrapper for file access errors
 #[derive(Debug, thiserror::Error)]
 pub struct FileAccessDeniedWithContext {
@@ -867,19 +860,6 @@ mod tests {
         let json_str = r#"{"invalid": json}"#; // Invalid JSON
         let json_error = serde_json::from_str::<serde_json::Value>(json_str).unwrap_err();
         let _disk_error: DiskError = json_error.into();
-    }
-
-    #[test]
-    fn test_bitrot_error_type() {
-        let bitrot_error = BitrotErrorType::BitrotChecksumMismatch {
-            expected: "abc123".to_string(),
-            got: "def456".to_string(),
-        };
-
-        assert!(bitrot_error.to_string().contains("bitrot checksum verification failed"));
-
-        let disk_error: DiskError = bitrot_error.into();
-        assert!(matches!(disk_error, DiskError::Io(_)));
     }
 
     #[test]


### PR DESCRIPTION
## What

PR4 of rustfs/backlog#1831, the last item.

- **`BitrotErrorType` deleted**: the enum was constructed only by its own unit test — production bitrot mismatches never flow through it (they surface as `DiskError::other` strings). The `From<BitrotErrorType> for DiskError` impl, the self-test, and the api facade re-export (`crates/ecstore/src/api/mod.rs`) go with it, per the issue's coordination constraint. `docs/architecture/ecstore-api-facade-inventory.md` does not name the type, so no doc edit is needed.
- **`SourceStalled` / `CrossDeviceLink` pinned, not removed**: never constructed locally, reachable only through wire decoding, and no current node sends them. Decode arms stay (cross-version compatibility, per the issue constraint); each variant now carries a doc comment recording that judgment so future dead-code sweeps don't re-litigate. Their consumer arms (heal recoverability classifier `crates/heal/src/error.rs`, batch processor) are deliberately untouched — the issue marks their removal optional and unobservable, and the heal classifier is pinned as do-not-touch in the rc window.

## Verification

- `cargo test -p rustfs-ecstore --lib disk::error` — 56 passed
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅ (arch facade guards green)

Ref rustfs/backlog#1831.