### PR TITLE
chore(rustfs): remove the orphan starshard bucket-cache backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9201,7 +9201,6 @@ dependencies = [
  "sha2 0.11.0",
  "shadow-rs",
  "socket2",
- "starshard",
  "subtle",
  "sysinfo",
  "temp-env",

--- a/rustfs/Cargo.toml
+++ b/rustfs/Cargo.toml
@@ -243,7 +243,6 @@ rustfs-object-data-cache = { workspace = true, features = ["cache"] }
 rustfs-concurrency = { workspace = true }
 rustfs-scanner = { workspace = true }
 tempfile = { workspace = true }
-starshard = { workspace = true, features = ["rayon", "async", "serde"] }
 
 # Async Runtime and Networking
 async-trait = { workspace = true }

--- a/rustfs/src/storage/ecfs_extend.rs
+++ b/rustfs/src/storage/ecfs_extend.rs
@@ -765,76 +765,44 @@ where
 
 /// Bucket validation cache to avoid repeated stat_volume() calls on every GET.
 ///
-/// **Adaptive strategy** (selected once at startup via env var):
-///
-/// | Backend | Env var | Best for |
-/// |---------|---------|----------|
-/// | `RwLock<HashMap>` | default | < 100 buckets — lower per-op overhead |
-/// | `starshard::ShardedHashMap` | `RUSTFS_BUCKET_CACHE_STARSHARD=1` | >= 100 buckets — sharded locks reduce contention |
+/// Backend: `RwLock<HashMap>`. A parallel opt-in starshard backend
+/// (`RUSTFS_BUCKET_CACHE_STARSHARD`) used to double-write every operation
+/// here; no deployment ever set the variable and the branch was removed in
+/// backlog#1832.
 ///
 /// Entries expire after `BUCKET_VALIDATION_TTL` (checked on read).
 /// Write operations (delete/make bucket) invalidate the cache explicitly.
 const BUCKET_VALIDATION_TTL: Duration = Duration::from_secs(5);
 
-/// Tracks which backend is active: `false` = HashMap, `true` = starshard.
-static USE_STARSHARD_CACHE: OnceLock<bool> = OnceLock::new();
-
-fn use_starshard() -> bool {
-    *USE_STARSHARD_CACHE.get_or_init(|| {
-        std::env::var("RUSTFS_BUCKET_CACHE_STARSHARD")
-            .ok()
-            .and_then(|v| v.parse::<bool>().ok())
-            .unwrap_or(false)
-    })
-}
-
-/// --- HashMap backend (default) ---
 static BUCKET_CACHE_SMALL: OnceLock<RwLock<HashMap<String, Instant>>> = OnceLock::new();
 
 fn small_cache() -> &'static RwLock<HashMap<String, Instant>> {
     BUCKET_CACHE_SMALL.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-/// --- starshard backend (opt-in) ---
-static BUCKET_CACHE_LARGE: OnceLock<starshard::ShardedHashMap<String, Instant>> = OnceLock::new();
-
-fn large_cache() -> &'static starshard::ShardedHashMap<String, Instant> {
-    BUCKET_CACHE_LARGE.get_or_init(|| starshard::ShardedHashMap::new(128))
-}
-
-/// Get a value from the active cache backend.
+/// Get a value from the cache.
 fn cache_get(bucket: &str) -> Option<Instant> {
-    if use_starshard() {
-        large_cache().get(&bucket.to_string())
-    } else {
-        small_cache().read().ok()?.get(bucket).copied()
-    }
+    small_cache().read().ok()?.get(bucket).copied()
 }
 
-/// Insert a value into the active cache backend.
+/// Insert a value into the cache.
 fn cache_insert(bucket: String, ts: Instant) {
-    if use_starshard() {
-        large_cache().insert(bucket, ts);
-    } else if let Ok(mut map) = small_cache().write() {
+    if let Ok(mut map) = small_cache().write() {
         map.insert(bucket, ts);
     }
 }
 
-/// Remove a value from the active cache backend.
+/// Remove a value from the cache.
 fn cache_remove(bucket: &str) {
-    if use_starshard() {
-        large_cache().remove(&bucket.to_string());
-    } else if let Ok(mut map) = small_cache().write() {
+    if let Ok(mut map) = small_cache().write() {
         map.remove(bucket);
     }
 }
 
-/// Clear all entries in the active cache backend.
+/// Clear all entries in the cache.
 #[allow(dead_code)]
 fn cache_clear() {
-    if use_starshard() {
-        large_cache().clear();
-    } else if let Ok(mut map) = small_cache().write() {
+    if let Ok(mut map) = small_cache().write() {
         map.clear();
     }
 }


### PR DESCRIPTION
## What

PR3 of rustfs/backlog#1832. The bucket validation cache (`rustfs/src/storage/ecfs_extend.rs`) kept **two complete backends** behind `RUSTFS_BUCKET_CACHE_STARSHARD` — an env var with zero references anywhere in the repo, docs, or any known deployment. Every `cache_get`/`cache_insert`/`cache_remove`/`cache_clear` branched on a `OnceLock` switch for a path nothing could enable.

- The starshard arm, the `use_starshard()` switch, `BUCKET_CACHE_LARGE`, and the backend-selection doc table are removed; the `RwLock<HashMap>` backend stays as the only implementation — behavior on the default path is byte-identical.
- The rustfs crate now has no starshard usage, so its `Cargo.toml` dependency is dropped too. `object-data-cache` and `notify` keep their own starshard dependencies (the issue's constraint — the workspace dep stays).

## Verification

- `cargo nextest run -p rustfs --lib` on the storage/rpc selection — 131 passed (nextest is the repo's authoritative runner)
- Note: plain `cargo test -p rustfs --lib storage` shows 8 failures in RPC-auth/policy-metadata tests **unrelated to this diff** — they pass in isolation and under nextest, a pre-existing in-process shared-state artifact of the thread-based runner (same class as the documented b920 family)
- `cargo clippy -p rustfs --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅

Ref rustfs/backlog#1832.