### PR TITLE
docs(io-metrics): remove stale unified-config docs left by #6008

### DIFF
--- a/crates/io-core/CHANGELOG.md
+++ b/crates/io-core/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the rustfs-io-core and rustfs-io-metrics crates will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+#### rustfs-io-metrics
+- **Unified configuration** (added in 0.0.5): the zero-consumer `IoConfig`, `CacheSettings`, `IoSchedulerSettings`, `BackpressureSettings`, `TimeoutSettings`, `DeadlockDetectionSettings` types and their `DEFAULT_*` constants were removed (rustfs/rustfs#6008); rustfs-io-core's `IoSchedulerConfig`/`BackpressureConfig` remain the canonical configuration types.
+
 ## [0.0.5] - 2025-01-XX
 
 ### Added

--- a/crates/io-metrics/README.md
+++ b/crates/io-metrics/README.md
@@ -27,7 +27,6 @@
 - **Metrics Collection**: Unified metrics recording and reporting
 - **Bandwidth Monitoring**: Real-time bandwidth observation and analysis
 - **Performance Metrics**: I/O performance metrics collection
-- **Unified Configuration**: Centralized configuration management
 - **Exporter Boundary**: Emit via `metrics`, export via `rustfs-obs`, no Prometheus HTTP endpoint
 
 ## Features
@@ -203,30 +202,6 @@ path and include:
 deltas with `operation` and `backend` columns, so the TCP baseline can attribute
 bytes and request/error counts to `tcp-http` transport operations.
 
-### Unified Configuration
-
-Centralized configuration management:
-
-```rust
-use rustfs_io_metrics::{
-    IoConfig, CacheSettings, IoSchedulerSettings,
-    BackpressureSettings, TimeoutSettings,
-};
-
-let config = IoConfig::new()
-    .with_cache(CacheSettings::new()
-        .with_max_capacity(10_000)
-        .with_ttl(std::time::Duration::from_secs(300)))
-    .with_scheduler(IoSchedulerSettings::new()
-        .with_max_concurrent_reads(64))
-    .with_backpressure(BackpressureSettings::new())
-    .with_timeout(TimeoutSettings::new());
-
-// Access configuration
-println!("Cache capacity: {}", config.cache.max_capacity);
-println!("Max concurrent reads: {}", config.scheduler.max_concurrent_reads);
-```
-
 ## Module Structure
 
 ```
@@ -235,7 +210,6 @@ rustfs-io-metrics/
 │   ├── lib.rs               # Module entry
 │   ├── cache_config.rs      # Cache configuration
 │   ├── adaptive_ttl.rs      # Adaptive TTL
-│   ├── config.rs            # Unified configuration
 │   ├── io_metrics.rs        # I/O metrics
 │   ├── backpressure_metrics.rs # Backpressure metrics
 │   ├── deadlock_metrics.rs  # Deadlock metrics
@@ -278,7 +252,6 @@ Useful source references:
 
 - [Crate API overview](./src/lib.rs)
 - [Metrics example](./examples/metrics_example.rs)
-- [Configuration module](./src/config.rs)
 - [Adaptive TTL module](./src/adaptive_ttl.rs)
 
 ## Related Modules

--- a/crates/io-metrics/README_zh.md
+++ b/crates/io-metrics/README_zh.md
@@ -27,7 +27,6 @@
 - **指标收集**：统一的指标记录和上报
 - **带宽监控**：实时带宽观测和分析
 - **性能指标**：I/O 性能指标收集
-- **统一配置**：集中式配置管理
 - **导出边界**：通过 `metrics` 主动上报，由 `rustfs-obs` 负责 OTEL 导出，不提供 Prometheus HTTP 端点
 
 ## ✨ 核心功能
@@ -172,30 +171,6 @@ println!("读取速率: {} bytes/s", snapshot.read_bytes_per_sec);
 println!("写入速率: {} bytes/s", snapshot.write_bytes_per_sec);
 ```
 
-### 统一配置 (IoConfig)
-
-集中式配置管理：
-
-```rust
-use rustfs_io_metrics::{
-    IoConfig, CacheSettings, IoSchedulerSettings,
-    BackpressureSettings, TimeoutSettings,
-};
-
-let config = IoConfig::new()
-    .with_cache(CacheSettings::new()
-        .with_max_capacity(10_000)
-        .with_ttl(std::time::Duration::from_secs(300)))
-    .with_scheduler(IoSchedulerSettings::new()
-        .with_max_concurrent_reads(64))
-    .with_backpressure(BackpressureSettings::new())
-    .with_timeout(TimeoutSettings::new());
-
-// 访问配置
-println!("缓存容量: {}", config.cache.max_capacity);
-println!("最大并发读: {}", config.scheduler.max_concurrent_reads);
-```
-
 ## 📊 指标类型
 
 ### I/O 调度指标
@@ -233,21 +208,6 @@ println!("最大并发读: {}", config.scheduler.max_concurrent_reads);
 | `operation_duration_secs` | 操作时长 | Histogram |
 | `operation_progress` | 操作进度 | Gauge |
 
-## 🔧 配置
-
-### 代码配置
-
-```rust
-use rustfs_io_metrics::{CacheSettings, IoConfig};
-
-let settings = CacheSettings::new()
-    .with_max_capacity(5000)
-    .with_ttl(std::time::Duration::from_secs(600))
-    .with_max_memory(200 * 1024 * 1024);
-
-let config = IoConfig::new().with_cache(settings);
-```
-
 ## 📁 模块结构
 
 ```
@@ -256,7 +216,6 @@ rustfs-io-metrics/
 │   ├── lib.rs               # 模块入口
 │   ├── cache_config.rs      # 缓存配置
 │   ├── adaptive_ttl.rs      # 自适应 TTL
-│   ├── config.rs            # 统一配置
 │   ├── io_metrics.rs        # I/O 指标
 │   ├── backpressure_metrics.rs # 背压指标
 │   ├── deadlock_metrics.rs  # 死锁指标
@@ -297,7 +256,6 @@ cargo doc --package rustfs-io-metrics --no-deps --open
 
 - [Crate API 概览](./src/lib.rs)
 - [指标示例](./examples/metrics_example.rs)
-- [配置模块](./src/config.rs)
 - [自适应 TTL 模块](./src/adaptive_ttl.rs)
 
 ## 🔗 相关模块

--- a/crates/io-metrics/examples/metrics_example.rs
+++ b/crates/io-metrics/examples/metrics_example.rs
@@ -29,9 +29,7 @@ fn main() {
     // 3. Access tracking example
     access_tracker_example();
 
-    // 4. Unified configuration example
-
-    // 5. Metrics recording example
+    // 4. Metrics recording example
     metrics_recording_example();
 }
 


### PR DESCRIPTION
## What

Follow-up to #6008, which deleted the zero-consumer `crates/io-metrics/src/config.rs` module but left the crate's own documentation still teaching the deleted API. None of this is CI-visible: `scripts/check_doc_paths.sh` scans only AGENTS.md / CLAUDE.md / ARCHITECTURE.md / docs/architecture, and `./src/...` relative links don't match its path-prefix regex anyway.

- `crates/io-metrics/README.md`: drop the "Unified Configuration" feature bullet and section (its `IoConfig`/`*Settings` snippet no longer compiles), the `config.rs` module-tree entry, and the dead `./src/config.rs` source link.
- `crates/io-metrics/README_zh.md`: same, plus the second stale `CacheSettings`/`IoConfig` snippet under `## 🔧 配置` that has no English counterpart.
- `crates/io-metrics/examples/metrics_example.rs`: remove the orphaned `// 4. Unified configuration example` comment #6008 left behind and renumber the walkthrough.
- `crates/io-core/CHANGELOG.md`: add an Unreleased → Removed entry so the changelog (which by its own header covers rustfs-io-metrics) no longer advertises the deleted API with no removal trail.

Kept deliberately: the "metrics and configuration module" blurbs and all `cache_config.rs` references — `CacheConfig`/`AdaptiveTTL` still exist and are exported.

## Verification

- `rg -n "IoConfig|CacheSettings|IoSchedulerSettings|BackpressureSettings|TimeoutSettings|DeadlockDetectionSettings|unified.config" crates/io-metrics/ crates/io-core/CHANGELOG.md` — remaining hits are only the new Removed entry and the historical 0.0.5 Added entry (kept as history per Keep a Changelog)
- `cargo clippy -p rustfs-io-metrics --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `make pre-commit` — ✅

Ref rustfs/backlog#1833.
