### PR TITLE
fix(kms): let the Vault Transit backend start against an empty transit engine

### DIFF
--- a/crates/kms/src/backends/vault_transit.rs
+++ b/crates/kms/src/backends/vault_transit.rs
@@ -101,6 +101,23 @@ fn is_cas_conflict(error: &ClientError) -> bool {
     )
 }
 
+/// Whether a transit LIST failed with the 404 Vault uses for "mounted, but no
+/// keys yet".
+///
+/// Vault answers a LIST on a mounted transit engine that holds no keys with a
+/// 404 whose `errors` array is empty — the mount routed and answered the
+/// request, so the engine is reachable. A 404 for a path with no mount behind
+/// it instead carries a "no handler for route" message, so the empty `errors`
+/// array is what separates "engine reachable but empty" from "engine missing".
+///
+/// An empty non-transit engine (e.g. KV v1) at the configured path answers
+/// with byte-identical 404s, so this probe cannot detect that misconfiguration
+/// — no LIST-based probe can. The data path still fails hard on the first real
+/// transit operation against such a mount.
+fn is_empty_transit_list(error: &ClientError) -> bool {
+    matches!(error, ClientError::APIError { code: 404, errors } if errors.is_empty())
+}
+
 #[derive(Debug, Clone)]
 struct TransitKeyMetadata {
     key_usage: KeyUsage,
@@ -1242,12 +1259,17 @@ impl VaultTransitKmsClient {
         let mut all_keys = self
             .run("vault_transit_list_keys", OpClass::ReadIdempotent, move || async move {
                 let vault = self.vault().map_err(AttemptError::fatal)?;
-                key::list(&vault.client, &self.config.mount_path).await.map_err(|e| {
-                    AttemptError::from_vaultrs(e, |e| KmsError::backend_error(format!("Failed to list Vault Transit keys: {e}")))
-                })
+                match key::list(&vault.client, &self.config.mount_path).await {
+                    Ok(response) => Ok(response.keys),
+                    // An empty transit engine answers LIST with a bare 404;
+                    // that is an empty listing, not a backend failure.
+                    Err(error) if is_empty_transit_list(&error) => Ok(Vec::new()),
+                    Err(e) => Err(AttemptError::from_vaultrs(e, |e| {
+                        KmsError::backend_error(format!("Failed to list Vault Transit keys: {e}"))
+                    })),
+                }
             })
-            .await?
-            .keys;
+            .await?;
         // Vault's own LIST ordering is not part of its contract, so the sort is
         // what makes the marker a stable cursor across calls.
         all_keys.sort_unstable();
@@ -1420,12 +1442,17 @@ impl VaultTransitKmsClient {
     pub(crate) async fn health_check(&self) -> Result<()> {
         self.run("vault_transit_health_check", OpClass::ReadIdempotent, move || async move {
             let vault = self.vault().map_err(AttemptError::fatal)?;
-            key::list(&vault.client, &self.config.mount_path)
-                .await
-                .map(|_| ())
-                .map_err(|e| {
-                    AttemptError::from_vaultrs(e, |e| KmsError::backend_error(format!("Vault Transit health check failed: {e}")))
-                })
+            match key::list(&vault.client, &self.config.mount_path).await {
+                Ok(_) => Ok(()),
+                // A brand-new transit mount holds no keys until something
+                // creates one, and this check gates startup before the service
+                // creates its own probe key — treating "empty" as unhealthy
+                // would keep a first-ever deployment from ever starting.
+                Err(error) if is_empty_transit_list(&error) => Ok(()),
+                Err(e) => Err(AttemptError::from_vaultrs(e, |e| {
+                    KmsError::backend_error(format!("Vault Transit health check failed: {e}"))
+                })),
+            }
         })
         .await
     }
@@ -2082,6 +2109,107 @@ mod tests {
             requests.iter().all(|line| line.starts_with("GET ")),
             "the rejected create must not write anything: {requests:?}"
         );
+    }
+
+    /// Regression test for the first-boot chicken-and-egg on a fresh transit
+    /// mount (rustfs/backlog#1774).
+    ///
+    /// Vault answers a LIST on a mounted-but-empty transit engine with a 404
+    /// carrying an empty `errors` array. The health check gates startup before
+    /// the service creates its probe key, so this 404 must count as healthy —
+    /// failing it means a first-ever deployment on a fresh mount can never
+    /// start until an operator creates some transit key out-of-band.
+    #[tokio::test]
+    async fn health_check_passes_on_an_empty_transit_engine() {
+        let (vault, client) = scripted_client(vec![ScriptedResponse::Http {
+            status: 404,
+            body: serde_json::json!({ "errors": [] }).to_string(),
+        }])
+        .await;
+
+        client
+            .health_check()
+            .await
+            .expect("an empty transit engine is reachable and must pass the health check");
+
+        let requests = vault.requests();
+        assert_eq!(
+            requests,
+            vec!["LIST /v1/transit/keys".to_string()],
+            "the empty-list 404 must be accepted on the first attempt, not retried"
+        );
+    }
+
+    /// A 404 whose body says "no handler for route" means no transit engine is
+    /// mounted at the configured path at all; that must keep failing the
+    /// health check instead of riding the empty-engine allowance.
+    #[tokio::test]
+    async fn health_check_fails_when_the_transit_mount_is_missing() {
+        let (_vault, client) = scripted_client(vec![ScriptedResponse::error(
+            404,
+            "no handler for route \"transit/keys\". route entry not found.",
+        )])
+        .await;
+
+        let error = client
+            .health_check()
+            .await
+            .expect_err("a missing transit mount must fail the health check");
+        assert!(matches!(error, KmsError::BackendError { .. }), "got {error:?}");
+    }
+
+    /// The empty-engine allowance is scoped to 404 alone: any other status
+    /// whose body happens to carry an empty `errors` array (an intermediary
+    /// answering for Vault, for instance) must keep failing the health check.
+    #[tokio::test]
+    async fn health_check_fails_on_a_non_404_error_with_an_empty_errors_body() {
+        let (_vault, client) = scripted_client(vec![ScriptedResponse::Http {
+            status: 403,
+            body: serde_json::json!({ "errors": [] }).to_string(),
+        }])
+        .await;
+
+        let error = client
+            .health_check()
+            .await
+            .expect_err("only a 404 may ride the empty-engine allowance");
+        assert!(matches!(error, KmsError::BackendError { .. }), "got {error:?}");
+    }
+
+    /// The listing's own copy of the discriminator must not widen into "every
+    /// LIST failure is an empty listing" — a missing mount still fails loudly.
+    #[tokio::test]
+    async fn list_fails_when_the_transit_mount_is_missing() {
+        let (_vault, client) = scripted_client(vec![ScriptedResponse::error(
+            404,
+            "no handler for route \"transit/keys\". route entry not found.",
+        )])
+        .await;
+
+        let error = client
+            .list_keys(&ListKeysRequest::default(), None)
+            .await
+            .expect_err("a missing transit mount must fail the listing, not empty it");
+        assert!(matches!(error, KmsError::BackendError { .. }), "got {error:?}");
+    }
+
+    /// The same empty-engine 404 on the listing path is an empty result set,
+    /// not a backend failure.
+    #[tokio::test]
+    async fn list_keys_returns_an_empty_page_on_an_empty_transit_engine() {
+        let (_vault, client) = scripted_client(vec![ScriptedResponse::Http {
+            status: 404,
+            body: serde_json::json!({ "errors": [] }).to_string(),
+        }])
+        .await;
+
+        let response = client
+            .list_keys(&ListKeysRequest::default(), None)
+            .await
+            .expect("an empty transit engine must list as empty, not fail");
+        assert!(response.keys.is_empty(), "got {:?}", response.keys);
+        assert!(!response.truncated, "an empty listing has nothing left to page through");
+        assert_eq!(response.next_marker, None);
     }
 
     fn test_vault_transit_config() -> VaultTransitConfig {


### PR DESCRIPTION
## Problem

The Vault Transit KMS backend can never start against a brand-new (empty) transit engine. Repro: fresh `vault server -dev`, enable the transit engine, create zero transit keys, configure RustFS KMS with the VaultTransit backend and start → `KmsServiceManager::start` fails with `Failed to create KMS backend: Backend error: Vault Transit health check failed: The Vault server returned an error (status code 404)`.

Root cause: `VaultTransitKmsClient::health_check` probes the backend with `key::list`, and Vault answers a LIST on a mounted transit engine that holds no keys with HTTP 404 (body `{"errors":[]}`). The service's own synthetic probe key would populate the engine, but it is created only after the backend health check passes (`create_healthy_service_version` gates startup; the probe worker is spawned at publish time) — a chicken-and-egg that means a first-ever deployment on a fresh transit mount can never start until an operator creates some transit key out-of-band.

## Fix

Treat the empty-list 404 as "healthy: engine reachable but empty". The distinguisher is the response body Vault sends, surfaced by vaultrs as `ClientError::APIError { code, errors }`:

- LIST on a mounted-but-empty transit engine → 404 with an **empty** `errors` array — the mount routed and answered the request, so the engine is reachable. The new `is_empty_transit_list` helper matches exactly this shape.
- LIST on a path with no mount behind it → 404 with `"no handler for route ..."` in `errors` — still fails the health check.
- 403 (permission denied), 5xx, sealed Vault, and connection failures are untouched and still fail. A 404 whose body is not Vault's JSON error envelope (a proxy error page, say) stays a `RestClientError` and also still fails.

`list_keys` had the same latent misclassification (an empty engine listed as a backend error instead of an empty page), so it now maps the same 404 to an empty key set.

Known limitation, documented on the helper: an empty *non-transit* engine (KV v1) mounted at the configured path answers with byte-identical 404s, so no LIST-based probe can distinguish it. That misconfiguration now passes startup instead of failing it, and surfaces at the first real transit operation, which fails hard — no path serves or stores data unencrypted as a result. A non-empty KV engine at the transit path already passed the old health check (LIST 200), so this widens an existing corner by one case rather than opening a new one.

## Tests

Five scripted-vault regression tests pin the wire contract; all drive the real path (loopback HTTP → reqwest/rustify/vaultrs → the retry wrapper), not the helper directly:

- `health_check_passes_on_an_empty_transit_engine` — empty-errors 404 → `Ok`, and exactly one `LIST /v1/transit/keys` request (accepted on the first attempt, not retried).
- `health_check_fails_when_the_transit_mount_is_missing` — 404 with a "no handler for route" body → `Err(BackendError)`.
- `health_check_fails_on_a_non_404_error_with_an_empty_errors_body` — 403 with `{"errors":[]}` → `Err`, pinning the allowance to 404 alone.
- `list_fails_when_the_transit_mount_is_missing` — the listing must not widen into "every LIST failure is an empty listing".
- `list_keys_returns_an_empty_page_on_an_empty_transit_engine` — empty-engine 404 → empty page, not truncated, no marker.

The last two exist because a mutation check found both mutants (`code: _` in the helper, and `Err(_) => Ok(Vec::new())` in the listing arm) surviving the first three tests; each new test was verified to fail against its mutant and pass against the fix.

## Verification

- `cargo test -p rustfs-kms` — green (526 lib tests + all integration suites; live-Vault tests ignored as usual)
- `cargo clippy -p rustfs-kms --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Discovered during rustfs/backlog#1774 (Vault CI lane) local validation. The CI lane's pre-created probe key (`vault write -f transit/keys/rustfs-ci-lane-probe`) stops being load-bearing with this fix but remains harmless.

Refs rustfs/backlog#1774
