### PR TITLE
test: un-ignore the remaining seven global-state tests, drop one stale premise

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -11846,7 +11846,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires isolated global object layer state"]
     #[serial]
     async fn ecstore_new_succeeds_on_fresh_local_volumes() {
         let test_base_dir = format!("/tmp/rustfs_ecstore_empty_boot_{}", Uuid::new_v4());

--- a/rustfs/src/app/multipart_usecase.rs
+++ b/rustfs/src/app/multipart_usecase.rs
@@ -2332,7 +2332,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires isolated global object layer state"]
     async fn execute_list_multipart_uploads_returns_internal_error_when_store_uninitialized() {
         let input = ListMultipartUploadsInput::builder()
             .bucket("bucket".to_string())
@@ -2375,7 +2374,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires isolated global object layer state"]
     async fn execute_list_parts_returns_internal_error_when_store_uninitialized() {
         let input = ListPartsInput::builder()
             .bucket("bucket".to_string())
@@ -2422,7 +2420,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires isolated global object layer state"]
     async fn execute_upload_part_copy_returns_internal_error_when_store_uninitialized() {
         let input = UploadPartCopyInput::builder()
             .bucket("bucket".to_string())

--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -16668,7 +16668,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires isolated global object layer state"]
     async fn execute_get_object_attributes_returns_internal_error_when_store_uninitialized() {
         let input = GetObjectAttributesInput::builder()
             .bucket("test-bucket".to_string())
@@ -16811,7 +16810,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires isolated global object layer state"]
     async fn execute_restore_object_returns_internal_error_when_store_uninitialized() {
         let restore_request = RestoreRequest {
             days: Some(1),

--- a/rustfs/src/storage/access.rs
+++ b/rustfs/src/storage/access.rs
@@ -3452,35 +3452,6 @@ mod tests {
         assert_eq!(conditions.get("delimiter"), Some(&vec!["/".to_string()]));
     }
 
-    /// When policy metadata cannot be loaded, tag-based check is conservative (returns true).
-    #[tokio::test]
-    #[ignore = "requires isolated global object layer state"]
-    async fn test_bucket_policy_needs_existing_object_tag_load_failure_is_conservative() {
-        let conditions = HashMap::new();
-        let store = crate::app::gating_test_env::shared_gating_ecstore().await;
-        let hint = load_bucket_policy_existing_object_tag_hint(
-            store.as_ref(),
-            "test-bucket-no-policy-xyz-absent",
-            Action::S3Action(S3Action::GetObjectAction),
-        )
-        .await;
-        let no_groups: Option<Vec<String>> = None;
-        let args = BucketPolicyArgs {
-            bucket: "test-bucket-no-policy-xyz-absent",
-            action: Action::S3Action(S3Action::GetObjectAction),
-            is_owner: false,
-            account: "",
-            groups: &no_groups,
-            conditions: &conditions,
-            object: "obj",
-        };
-        let result = bucket_policy_needs_existing_object_tag_from_hint(&hint, &args).await;
-        assert!(
-            result,
-            "when policy metadata cannot be loaded, ExistingObjectTag should be fetched conservatively"
-        );
-    }
-
     #[test]
     fn test_bucket_policy_existing_object_tag_condition_key_detection() {
         let condition_key_policy = r#"{


### PR DESCRIPTION
## What

PR3 of rustfs/backlog#1830, completing the un-ignore sweep started in #6046/#6047. The last seven `#[ignore = "requires isolated global object layer state"]` tests (multipart_usecase ×3, object_usecase ×2, storage/access ×1, ecstore bucket_lifecycle_ops ×1) executed in **no** CI lane.

- **Six un-ignore cleanly**: all pass under nextest, and unlike the previous waves they also pass in shared-process `cargo test` runs (verified across multiple full-tree sweeps — none ever fails), so no premise guard is needed.
- **One is deleted per the issue's stale-test policy**: `test_bucket_policy_needs_existing_object_tag_load_failure_is_conservative` fails under nextest too. It asserted that an *absent bucket* triggers the conservative ExistingObjectTag fetch, but since bucket-policy load errors were classified (`PolicyMissing`/`BucketMissing` → definitive no-tag-requirement; only `Other` errors → conservative), an absent bucket can no longer construct the load-failure premise the test describes. The conservative intent stays pinned by `test_classify_bucket_policy_raw_load_error` and the malformed-policy conservative-fetch test. Gap noted: an end-to-end `Other`-error → hint probe would need fault injection into the metadata path — recorded on the issue rather than silently lost.

## Dual-runner evidence

- nextest: 318 passed (storage::access + app usecases), 170 passed (ecstore bucket_lifecycle, including the un-ignored one)
- Full-tree `cargo test -p rustfs --lib storage` — pre-existing baseline (8 unrelated failures, unchanged)
- `cargo test -p rustfs --lib app` — keeps its pre-existing nondeterministic shared-state failures (16–22 per run on main and branch alike); the un-ignored five never appear among them
- `cargo test -p rustfs-ecstore --lib bucket_lifecycle_ops::tests::tier_free` — 30 passed
- `cargo clippy -p rustfs -p rustfs-ecstore --lib --tests -- -D warnings` — clean; `make pre-commit` — ✅

Ref rustfs/backlog#1830.