### PR TITLE
test: give the twenty-one bare #[ignore] attributes their reasons

### DIFF
--- a/crates/e2e_test/src/protocols/sftp_compliance_tests.rs
+++ b/crates/e2e_test/src/protocols/sftp_compliance_tests.rs
@@ -2854,7 +2854,7 @@ pub(crate) mod cmptst_30 {
         result
     }
 
-    #[ignore]
+    #[ignore = "timing-sensitive backend-pressure latency probe; run explicitly with --ignored"]
     #[tokio::test]
     async fn regression() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         crate::common::init_logging();

--- a/crates/s3select-query/src/instance.rs
+++ b/crates/s3select-query/src/instance.rs
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "requires a live RustFS store with a pre-seeded test object (bucket 'dandan')"]
     async fn test_simple_sql() {
         let sql = "select * from S3Object";
         let input = SelectObjectContentInput {
@@ -354,7 +354,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "requires a live RustFS store with a pre-seeded test object (bucket 'dandan')"]
     async fn test_func_sql() {
         let sql = "SELECT * FROM S3Object s";
         let input = SelectObjectContentInput {

--- a/crates/targets/src/target/nats/jetstream.rs
+++ b/crates/targets/src/target/nats/jetstream.rs
@@ -760,7 +760,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "requires a live NATS JetStream server (docker run nats:2 -js; RUSTFS_TEST_NATS_URL overrides)"]
     async fn tls_change_rebuilds_the_context_and_drains_the_old_acker() {
         // A TLS fingerprint change on the publish path rebuilds the cached context from the new client and drains the old acker.
         let subject = format!("rustfs.tlsrebuild.{}", Uuid::new_v4().simple());
@@ -839,7 +839,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "requires a live NATS JetStream server (docker run nats:2 -js; RUSTFS_TEST_NATS_URL overrides)"]
     async fn tls_change_after_a_failed_reconnect_still_rebuilds_the_context() {
         // A rotation detected while the broker is unreachable does not orphan the cached context: a failed reconnect followed by a successful one ends bound to the rebuilt context.
         let subject = format!("rustfs.tlsfail.{}", Uuid::new_v4().simple());
@@ -917,7 +917,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "requires a live NATS JetStream server (docker run nats:2 -js; RUSTFS_TEST_NATS_URL overrides)"]
     async fn publish_gate_rejects_an_unsafe_stream_and_heals_after_the_stream_is_fixed() {
         // The gate rejects every publish while the stream's duplicate window is below the retry lifetime, and starts publishing once the operator widens it, without a restart.
         let subject = format!("rustfs.gate.{}", Uuid::new_v4().simple());
@@ -975,7 +975,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "requires a live NATS JetStream server (docker run nats:2 -js; RUSTFS_TEST_NATS_URL overrides)"]
     async fn a_remapped_subject_is_rejected_by_the_ack_stream_check_and_the_entry_stays_queued() {
         // After a subject remap the takeover stream acknowledges, so the ack-stream check rejects it with the mismatch detail, keeps the entry queued, and resets the verdict for re-validation.
         let subject = format!("rustfs.remap.{}", Uuid::new_v4().simple());

--- a/crates/targets/tests/mysql_integration.rs
+++ b/crates/targets/tests/mysql_integration.rs
@@ -107,7 +107,7 @@ async fn drop_table(dsn: &str, table: &str) {
         .await;
 }
 
-#[ignore]
+#[ignore = "requires a live MySQL 8.0+/TiDB instance (see module docs for the container command)"]
 #[tokio::test]
 async fn direct_write_and_read() {
     let dsn = test_dsn();
@@ -131,7 +131,7 @@ async fn direct_write_and_read() {
     drop_table(&dsn, &table).await;
 }
 
-#[ignore]
+#[ignore = "requires a live MySQL 8.0+/TiDB instance (see module docs for the container command)"]
 #[tokio::test]
 async fn delete_appends_row_does_not_remove_old() {
     let dsn = test_dsn();
@@ -155,7 +155,7 @@ async fn delete_appends_row_does_not_remove_old() {
     drop_table(&dsn, &table).await;
 }
 
-#[ignore]
+#[ignore = "requires a live MySQL 8.0+/TiDB instance (see module docs for the container command)"]
 #[tokio::test]
 async fn queue_store_saves_entry_and_replays() {
     let dsn = test_dsn();
@@ -195,7 +195,7 @@ async fn queue_store_saves_entry_and_replays() {
     drop_table(&dsn, &table).await;
 }
 
-#[ignore]
+#[ignore = "requires a live MySQL 8.0+/TiDB instance (see module docs for the container command)"]
 #[tokio::test]
 async fn duplicate_replay_produces_duplicate_rows() {
     let dsn = test_dsn();
@@ -236,7 +236,7 @@ async fn duplicate_replay_produces_duplicate_rows() {
     drop_table(&dsn, &table).await;
 }
 
-#[ignore]
+#[ignore = "requires a live MySQL 8.0+/TiDB instance (see module docs for the container command)"]
 #[tokio::test]
 async fn incompatible_schema_init_fails() {
     let dsn = test_dsn();
@@ -267,7 +267,7 @@ async fn incompatible_schema_init_fails() {
     drop_table(&dsn, &table).await;
 }
 
-#[ignore]
+#[ignore = "requires a live MySQL 8.0+/TiDB instance (see module docs for the container command)"]
 #[tokio::test]
 async fn check_mysql_server_available_succeeds_against_existing_table() {
     let dsn = test_dsn();

--- a/crates/targets/tests/nats_jetstream_regression_guards.rs
+++ b/crates/targets/tests/nats_jetstream_regression_guards.rs
@@ -181,7 +181,7 @@ fn jetstream_args(subject: &str, stream_name: &str, queue_dir: &str) -> NATSArgs
 ///
 /// Ignored by default because it needs a running NATS server with JetStream.
 #[tokio::test]
-#[ignore]
+#[ignore = "requires a live NATS JetStream server (see module docs; RUSTFS_TEST_NATS_URL overrides)"]
 async fn end_to_end_publish_is_acked_on_the_stream() {
     use rustfs_targets::EventName;
     use rustfs_targets::Target;

--- a/crates/targets/tests/nats_jetstream_validation_integration.rs
+++ b/crates/targets/tests/nats_jetstream_validation_integration.rs
@@ -82,7 +82,7 @@ async fn remove_stream(stream_name: &str) {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "requires a live NATS JetStream server (see module docs; RUSTFS_TEST_NATS_URL overrides)"]
 async fn missing_stream_fails_the_health_check() {
     let stream_name = format!("RUSTFS_TEST_{}", Uuid::new_v4().simple());
     let args = jetstream_args("rustfs.events", &stream_name);
@@ -94,7 +94,7 @@ async fn missing_stream_fails_the_health_check() {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "requires a live NATS JetStream server (see module docs; RUSTFS_TEST_NATS_URL overrides)"]
 async fn valid_stream_passes_the_health_check() {
     let stream_name = format!("RUSTFS_TEST_{}", Uuid::new_v4().simple());
     let subject = "rustfs.events";
@@ -106,7 +106,7 @@ async fn valid_stream_passes_the_health_check() {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "requires a live NATS JetStream server (see module docs; RUSTFS_TEST_NATS_URL overrides)"]
 async fn stream_not_capturing_the_subject_fails_the_health_check() {
     let stream_name = format!("RUSTFS_TEST_{}", Uuid::new_v4().simple());
     // The stream binds a different subject than the target publishes to.
@@ -118,7 +118,7 @@ async fn stream_not_capturing_the_subject_fails_the_health_check() {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "requires a live NATS JetStream server (see module docs; RUSTFS_TEST_NATS_URL overrides)"]
 async fn too_small_duplicate_window_fails_the_health_check() {
     let stream_name = format!("RUSTFS_TEST_{}", Uuid::new_v4().simple());
     let subject = "rustfs.events";

--- a/rustfs/tests/concurrent_download_tool.rs
+++ b/rustfs/tests/concurrent_download_tool.rs
@@ -369,7 +369,7 @@ async fn run_concurrent_downloads(settings: DownloadSettings) -> Result<Download
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "manual performance tool: requires a running RustFS server configured via env vars"]
 async fn concurrent_download_tool() -> Result<()> {
     let settings = DownloadSettings::from_env()?;
     let summary = run_concurrent_downloads(settings).await?;

--- a/rustfs/tests/gt1g_get_benchmark_tool.rs
+++ b/rustfs/tests/gt1g_get_benchmark_tool.rs
@@ -512,7 +512,7 @@ async fn run_bench(settings: &ToolSettings, client: &Client) -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "manual >1GiB GET benchmark: requires a running RustFS server configured via env vars"]
 async fn gt1g_get_benchmark_tool() -> Result<()> {
     let settings = ToolSettings::from_env()?;
     let client = build_client(&settings).await?;

--- a/rustfs/tests/lifecycle_minio_sdk_test.rs
+++ b/rustfs/tests/lifecycle_minio_sdk_test.rs
@@ -179,7 +179,7 @@ impl Oss {
 
 #[tokio::test]
 #[serial]
-#[ignore]
+#[ignore = "requires a running RustFS server at TEST_RUSTFS_SERVER (default http://localhost:9000)"]
 async fn test_lifecycle_minio_sdk() -> Result<()> {
     let settings = Settings::new();
     let oss = Oss::new(&settings).await?;


### PR DESCRIPTION
## What

PR4 of rustfs/backlog#1830, the optional hygiene tail. The 21 bare `#[ignore]`s violate no written rule (the refuter confirmed the flake policy's issue-link requirement governs nextest quarantine entries, not ignore attributes), but a bare ignore invites exactly the stale-reason drift the 30-test wave just cleaned up. Each now states its dependency:

- NATS JetStream (×9: unit-file 4, validation integration 4, regression guard 1) — live `nats -js` server, `RUSTFS_TEST_NATS_URL` override
- MySQL integration (×6) — live MySQL 8.0+/TiDB per the module docs' container command
- s3select instance (×2) — live store with a pre-seeded object
- Manual perf tools (×2) and the MinIO-SDK lifecycle test (×1) — running RustFS server via env
- SFTP backend-pressure probe (×1) — timing-sensitive, explicit `--ignored` run

Attribute-only; no test semantics change.

## Verification

- `cargo check -p rustfs-s3select-query -p rustfs-targets` — clean (attribute syntax)
- `make pre-commit` — ✅

Ref rustfs/backlog#1830.