### PR TITLE
docs(guards): make the layer-dependency baseline an explicit shrink-only ratchet

### DIFF
--- a/scripts/check_layer_dependencies.sh
+++ b/scripts/check_layer_dependencies.sh
@@ -267,6 +267,12 @@ write_baseline_file() {
   cat >"$BASELINE_FILE" <<'EOF'
 # Layer dependency baseline for the rustfs binary crate.
 #
+# RATCHET RULE (backlog#1834): this file only shrinks. A PR may delete lines
+# (after migrating the violation) via --update-baseline; a PR that ADDS a line
+# is baselining a brand-new layering violation and must carry an explicit
+# exemption rationale in its description — the baseline is a migration ledger,
+# not an amnesty list.
+#
 # The guard models production imports as:
 #   composition -> interface -> app -> infra
 #
@@ -397,6 +403,8 @@ comm -23 "${TMP_DIR}/baseline_sorted.txt" "$CURRENT_BASELINE" >"$STALE_ITEMS"
 
 if [[ -s "$NEW_ITEMS" ]]; then
   echo "Layer dependency guard failed: new reverse dependencies or cycles detected"
+  echo "Fix the layering instead of baselining it. The baseline is a shrink-only migration ledger (backlog#1834):"
+  echo "re-running with --update-baseline to ADD these entries requires an explicit exemption rationale in the PR description."
   cat "$NEW_ITEMS"
   exit 1
 fi

--- a/scripts/layer-dependency-baseline.txt
+++ b/scripts/layer-dependency-baseline.txt
@@ -1,5 +1,11 @@
 # Layer dependency baseline for the rustfs binary crate.
 #
+# RATCHET RULE (backlog#1834): this file only shrinks. A PR may delete lines
+# (after migrating the violation) via --update-baseline; a PR that ADDS a line
+# is baselining a brand-new layering violation and must carry an explicit
+# exemption rationale in its description — the baseline is a migration ledger,
+# not an amnesty list.
+#
 # The guard models production imports as:
 #   composition -> interface -> app -> infra
 #


### PR DESCRIPTION
## What

PR6 of rustfs/backlog#1834. The layer-dependency baseline was drifting into an amnesty list: #5459 rebuilt it at 29 entries, then #5551 **added** two more baselined violations with zero retirements. This writes the ratchet rule into both places a contributor will actually meet it:

- **The baseline file header** (emitted by `write_baseline_file`, so it survives every `--update-baseline` regeneration): the file only shrinks; deleting lines after migrating a violation is the normal flow; adding a line means baselining a brand-new layering violation and requires an explicit exemption rationale in the PR description.
- **The guard's new-entry failure message**: points at fixing the layering first and states the exemption requirement, instead of silently suggesting `--update-baseline`.

Mechanical note: the baseline was regenerated via `--update-baseline`; entries are byte-identical, only the header text changes.

## Verification

- `bash scripts/check_layer_dependencies.sh` — passes; `--update-baseline` round-trips the new header
- `make pre-commit` — ✅

Ref rustfs/backlog#1834.