### PR TITLE
fix(rustfs): give the rio-v2 fixture reader the new part-checksums field

### DIFF
--- a/rustfs/src/storage/minio_generated_read_test.rs
+++ b/rustfs/src/storage/minio_generated_read_test.rs
@@ -103,6 +103,9 @@ fn load_file_info(case_dir: &Path, manifest: &ManifestRecord) -> FileInfo {
         FileInfoOpts {
             data: true,
             include_free_versions: true,
+            // Pre-field behavior: the legacy into_fileinfo path always
+            // included part checksums, and this fixture test read through it.
+            include_part_checksums: true,
         },
     )
     .unwrap_or_else(|err| panic!("decode {}: {err}", xl_meta_path.display()))


### PR DESCRIPTION
## Urgent-ish: the rio-v2 CI lane fails on every PR

Single-lane merge race (same class as #6055's): `include_part_checksums` landed on `FileInfoOpts` with every default-feature initializer updated, but `rustfs/src/storage/minio_generated_read_test.rs` compiles **only under `--features rio-v2`**, so its initializer was missed — `Test and Lint (rio-v2)` now fails with E0063 on every PR (first seen on #6031, reproduced on clean main).

## Fix

Add the field with `true`: the legacy `into_fileinfo` path these MinIO fixtures read through always included part checksums (see `into_fileinfo` vs the new `into_fileinfo_without_part_checksums` opt-out in filemeta), so `true` is exactly the behavior this test exercised before the field existed — matching the ecstore `store/init.rs` test updates in the same change.

## Verification

- `cargo clippy -p rustfs -p rustfs-ecstore --all-targets --features rio-v2 -- -D warnings` (the lane's exact command) — fails on main, passes here
- The file's tests are `#[ignore]`d fixture probes (need generated MinIO data + a static KMS key), so compilation is the gate