### PR TITLE
chore(rustfs): drop two dead_code allows sitting on live code

### DIFF
--- a/rustfs/src/admin/handlers/tier.rs
+++ b/rustfs/src/admin/handlers/tier.rs
@@ -672,7 +672,6 @@ impl Operation for RemoveTier {
     }
 }
 
-#[allow(dead_code)]
 pub struct VerifyTier {}
 #[async_trait::async_trait]
 impl Operation for VerifyTier {
@@ -776,7 +775,6 @@ fn filter_tier_stats(daily_stats: DailyAllTierStats, tier_name: Option<&str>) ->
         .collect()
 }
 
-#[allow(dead_code)]
 fn map_tier_verify_error(err: std::io::Error) -> S3Error {
     if let Some(admin_err) = err.get_ref().and_then(|inner| inner.downcast_ref::<AdminError>()) {
         return match admin_err.code.as_str() {


### PR DESCRIPTION
## What

Step 7 of rustfs/backlog#1823. Two `#[allow(dead_code)]` attributes had inverted into claims that live code is dead:

- `VerifyTier` (`tier.rs:675`) — registered as a route at `tier.rs:186`
- `map_tier_verify_error` (`tier.rs:779`) — production caller at `tier.rs:701`, plus two unit tests

Neither suppressed anything: clippy with `-D warnings` is clean without them. An annotation like this is worse than none, because it teaches the next reader that a live path is unused.

**The issue's third case is already gone.** It lists `auth_keystone.rs:146` as a third inverted allow; that file now carries **no** `allow` attributes at all — an earlier refactor resolved it. Nothing to do there, and I'm not claiming it as fixed here.

## Discriminator for the rest of the burn-down

Remove the attribute and let clippy answer. An allow that suppresses nothing is a no-op the compiler never needed — which is also why the issue's note about `pub` library items holds: `allow(dead_code)` on a `pub` item cannot fire in the first place, so the ~38 Swift-side allows in step 8 can be triaged the same cheap way.

## Verification

- `cargo clippy -p rustfs --lib --tests -- -D warnings` — clean
- `cargo test -p rustfs --lib admin::handlers::tier` — 16 passed
- `make pre-commit` — ✅ (exit 0)

Ref rustfs/backlog#1823.