### PR TITLE
chore(ecstore): drop the io_support dead_code blanket

### DIFF
--- a/crates/ecstore/src/io_support/mod.rs
+++ b/crates/ecstore/src/io_support/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // #730: I/O backend selection keeps test-only and staged rio helpers scoped here.
-#![allow(dead_code)]
 
 pub(crate) mod bitrot;
 pub(crate) mod compress;

--- a/crates/ecstore/src/io_support/rio.rs
+++ b/crates/ecstore/src/io_support/rio.rs
@@ -25,9 +25,20 @@ use tokio::io::AsyncRead;
 
 #[cfg(feature = "rio-v2")]
 const MINIO_S2_COMPRESSION_SCHEME: &str = "klauspost/compress/s2";
+// The S2 padding multiple rio-v2 pads compressed streams to before
+// encryption. Only the padding test asserts it today, so the lib target sees
+// it as unused (backlog#1823).
 #[cfg(feature = "rio-v2")]
+#[allow(dead_code, reason = "on-disk contract asserted by the rio-v2 padding test (backlog#1823)")]
 const ENCRYPTED_S2_PADDING_MULTIPLE: usize = 256;
 
+/// Which rio implementation this build compiled in. Only the feature-seam
+/// guard test in lib.rs reads it, so the lib target sees it as unused
+/// (backlog#1823).
+#[allow(
+    dead_code,
+    reason = "asserted by the rio backend feature-seam test in lib.rs (backlog#1823)"
+)]
 pub const fn backend_name() -> &'static str {
     #[cfg(feature = "rio-v2")]
     {
@@ -53,17 +64,6 @@ pub fn compression_metadata_value(algorithm: CompressionAlgorithm) -> String {
     }
 }
 
-pub fn compression_scheme_to_algorithm(scheme: &str) -> std::io::Result<CompressionAlgorithm> {
-    #[cfg(feature = "rio-v2")]
-    if scheme.eq_ignore_ascii_case(MINIO_S2_COMPRESSION_SCHEME) {
-        // rio_v2 currently routes all compressed-object handling through the S2
-        // reader implementation, so the enum is only a placeholder token here.
-        return Ok(CompressionAlgorithm::default());
-    }
-
-    CompressionAlgorithm::from_str(scheme)
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReadCompressionBackend {
     Legacy,
@@ -82,6 +82,11 @@ pub fn compression_scheme_to_read_plan(scheme: &str) -> std::io::Result<(Compres
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReadEncryptionBackend {
     Legacy,
+    // Never constructed today — every read still selects Legacy — but the
+    // decrypt paths below carry live match arms for it. This is the rio-v2
+    // read seam (backlog#1638 / #1835), not dead code: deleting the variant
+    // would delete those arms with it.
+    #[allow(dead_code, reason = "rio-v2 read seam; match arms below are live (backlog#1823)")]
     V2,
 }
 


### PR DESCRIPTION
## What

Step 2 of rustfs/backlog#1823, first module root. Removing `io_support`'s module-root `#![allow(dead_code)]` exposes four items. They are triaged by evidence rather than uniformly deleted — **three of four are kept** with item-level allows that say why:

| Item | Disposition | Why |
|---|---|---|
| `backend_name` | kept + allow | A guard test in `lib.rs` asserts which rio implementation the build compiled in — test-only, not dead |
| `ENCRYPTED_S2_PADDING_MULTIPLE` | kept + allow | On-disk S2 padding contract asserted by the rio-v2 padding test; invisible to the lib target |
| `ReadEncryptionBackend::V2` | kept + allow | Never constructed, but the decrypt paths carry **live match arms** for it — deleting the variant deletes the rio-v2 read seam (backlog#1638 / #1835) |
| `compression_scheme_to_algorithm` | deleted | Superseded by `compression_scheme_to_read_plan` (returns backend alongside algorithm); zero consumers under either feature |

## Two verification notes for the remaining 17 roots

**1. Lib-target dead-code warnings are blind to test-only consumers.** An item still warns under `--tests` when only a test uses it, because the warning comes from the lib target. So the warning list *nominates* candidates but cannot *confirm* deletions.

I got this wrong first: I deleted `backend_name` on that mistaken reading and the compiler rejected it (E0425). The contributing error was a shared grep regex that collided with an unrelated local variable named `backend_name` in kms, whose hits buried the real one. **Each candidate needs its own name-anchored grep.**

**2. This file is feature-gated.** `--features rio-v2` surfaces a *different* warning set (one extra item), so both lanes must be checked — the same blind spot that broke the rio-v2 CI lane earlier.

## Verification

- `cargo check -p rustfs-ecstore` — warning-free under **both** default and `rio-v2`
- `cargo nextest run -p rustfs-ecstore` — **4039 passed, 0 failed**
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — clean under **both** features
- `make pre-commit` — ✅ (exit 0)

Remaining small roots (`runtime`, `layout`, `error`, `diagnostics`) exposed 44 more warnings between them and are separate PRs per the issue's plan.

Ref rustfs/backlog#1823.