### PR TITLE
chore(ecstore): drop the layout dead_code blanket

### DIFF
--- a/crates/ecstore/src/layout/endpoints.rs
+++ b/crates/ecstore/src/layout/endpoints.rs
@@ -209,15 +209,12 @@ impl AsMut<Vec<Endpoints>> for PoolEndpointList {
 }
 
 impl PoolEndpointList {
-    /// creates a list of endpoints per pool, resolves their relevant
-    /// hostnames and discovers those are local or remote.
-    async fn create_pool_endpoints(server_addr: &str, disks_layout: &DisksLayout) -> Result<Self> {
-        Self::create_pool_endpoints_with(server_addr, disks_layout, None, None).await
-    }
-
-    /// Same as [`create_pool_endpoints`] but lets tests inject an explicit
-    /// startup topology convergence policy and local endpoint host instead of
-    /// resolving them from the environment.
+    /// Creates a list of endpoints per pool, resolves their relevant hostnames
+    /// and discovers whether those are local or remote.
+    ///
+    /// The policy and host overrides let tests inject an explicit startup
+    /// topology convergence policy and local endpoint host instead of
+    /// resolving them from the environment; production passes `None` for both.
     async fn create_pool_endpoints_with(
         server_addr: &str,
         disks_layout: &DisksLayout,
@@ -594,6 +591,10 @@ impl PoolEndpointList {
 }
 
 const DNS_RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
+#[allow(
+    dead_code,
+    reason = "retry-cap bound asserted by this file's dns_retry_delay tests (backlog#1823)"
+)]
 const DNS_RETRY_MAX_DELAY: Duration = Duration::from_secs(8);
 const DNS_RETRY_JITTER_PERCENT: u64 = 20;
 /// Minimum spacing between "still retrying" warnings so a long orchestrated

--- a/crates/ecstore/src/layout/mod.rs
+++ b/crates/ecstore/src/layout/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // #730: set-layout contracts are staged while ECStore ownership boundaries shrink.
-#![allow(dead_code)]
 
 //! Static ECStore layout boundaries.
 //!

--- a/crates/ecstore/src/layout/set_layout.rs
+++ b/crates/ecstore/src/layout/set_layout.rs
@@ -4,6 +4,7 @@ use std::io::{Error, Result};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code, reason = "ESET-001 layout model; exercised by this file's tests (backlog#1823)")]
 pub(crate) struct StaticSetLayoutSnapshot {
     pub(crate) deployment_id: Uuid,
     pub(crate) set_count: usize,
@@ -12,6 +13,7 @@ pub(crate) struct StaticSetLayoutSnapshot {
     pub(crate) distribution_algo: DistributionAlgoVersion,
 }
 
+#[allow(dead_code, reason = "ESET-001 layout model; exercised by this file's tests (backlog#1823)")]
 impl StaticSetLayoutSnapshot {
     pub(crate) fn from_format(format: &FormatV3) -> Self {
         let disk_ids = format.erasure.sets.clone();
@@ -39,17 +41,20 @@ impl StaticSetLayoutSnapshot {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code, reason = "ESET-001 layout model; exercised by this file's tests (backlog#1823)")]
 pub(crate) struct SetDiskPosition {
     pub(crate) set_index: usize,
     pub(crate) disk_index: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code, reason = "ESET-001 layout model; exercised by this file's tests (backlog#1823)")]
 pub(crate) struct RuntimeSetLayoutPlan {
     pub(crate) sets: Vec<Vec<RuntimeSetDrivePlan>>,
     lock_hosts_by_set: Vec<Vec<String>>,
 }
 
+#[allow(dead_code, reason = "ESET-001 layout model; exercised by this file's tests (backlog#1823)")]
 impl RuntimeSetLayoutPlan {
     pub(crate) fn from_endpoint_hosts<S>(set_count: usize, drives_per_set: usize, endpoint_hosts: &[S]) -> Result<Self>
     where
@@ -108,6 +113,7 @@ impl RuntimeSetLayoutPlan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code, reason = "ESET-001 layout model; exercised by this file's tests (backlog#1823)")]
 pub(crate) struct RuntimeSetDrivePlan {
     pub(crate) set_index: usize,
     pub(crate) disk_index: usize,


### PR DESCRIPTION
## What

Step 2 of rustfs/backlog#1823, third module root. Removing `layout`'s module-root `#![allow(dead_code)]` exposes **8 items**: seven kept with reasoned item-level allows, one deleted.

## The deletion pulled a doc reference with it

`create_pool_endpoints` is deleted — it only forwarded to `create_pool_endpoints_with(.., None, None)` and has no callers. **But it held the real documentation.** The surviving variant's doc read:

> `/// Same as [create_pool_endpoints] but lets tests inject an explicit startup topology convergence policy…`

Removing the wrapper alone would leave that pointing at a function that no longer exists. Both docs are merged into `create_pool_endpoints_with`: what it does, what the two override parameters are for, and that production passes `None` for both.

## Kept with allows (7)

- **`set_layout.rs`** — all four structs (`StaticSetLayoutSnapshot`, `SetDiskPosition`, `RuntimeSetLayoutPlan`, `RuntimeSetDrivePlan`) and two impls are exercised only by that file's own tests. But those tests carry a requirement id (`test_eset_001_static_layout_snapshot_preserves_format_distribution`) and assert the snapshot preserves the format's distribution — the file is **ESET-001's executable spec**, not scaffolding. Deleting it would delete that requirement's only mechanical check.
- **`DNS_RETRY_MAX_DELAY`** — the retry cap asserted by the `dns_retry_delay` backoff tests.

## Verification

- `cargo check -p rustfs-ecstore` — warning-free under **both** default and `rio-v2`
- `cargo nextest run -p rustfs-ecstore` — **4041 passed, 0 failed**
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅ (exit 0)

Remaining small roots: `runtime`, `error`.

Ref rustfs/backlog#1823.
