### PR TITLE
chore(obs): drop 44 dead_code blankets from the metrics tree

### DIFF
--- a/crates/obs/src/metrics/collectors/audit.rs
+++ b/crates/obs/src/metrics/collectors/audit.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Audit metrics collector.
 //!
 //! Collects audit log metrics including failed messages, queue length,

--- a/crates/obs/src/metrics/collectors/cluster_config.rs
+++ b/crates/obs/src/metrics/collectors/cluster_config.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Cluster config metrics collector.
 //!
 //! Collects cluster configuration metrics including storage class

--- a/crates/obs/src/metrics/collectors/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/collectors/cluster_erasure_set.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Cluster erasure set metrics collector.
 //!
 //! Collects erasure coding set metrics including parity, quorum,

--- a/crates/obs/src/metrics/collectors/cluster_health.rs
+++ b/crates/obs/src/metrics/collectors/cluster_health.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Cluster health metrics collector.
 //!
 //! Collects cluster-wide health metrics including drive counts

--- a/crates/obs/src/metrics/collectors/cluster_iam.rs
+++ b/crates/obs/src/metrics/collectors/cluster_iam.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Cluster IAM metrics collector.
 //!
 //! Collects IAM (Identity and Access Management) metrics including

--- a/crates/obs/src/metrics/collectors/cluster_usage.rs
+++ b/crates/obs/src/metrics/collectors/cluster_usage.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Cluster usage metrics collector.
 //!
 //! Collects cluster-wide and per-bucket usage metrics including

--- a/crates/obs/src/metrics/collectors/ilm.rs
+++ b/crates/obs/src/metrics/collectors/ilm.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! ILM (Information Lifecycle Management) metrics collector.
 //!
 //! Collects ILM metrics including pending tasks, active tasks,

--- a/crates/obs/src/metrics/collectors/notification.rs
+++ b/crates/obs/src/metrics/collectors/notification.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Notification metrics collector.
 //!
 //! Collects notification system metrics including events sent,

--- a/crates/obs/src/metrics/collectors/notification_target.rs
+++ b/crates/obs/src/metrics/collectors/notification_target.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::metrics::report::PrometheusMetric;
 use crate::metrics::schema::notification_target::{
     NOTIFICATION_TARGET_FAILED_MESSAGES_BY_SERVER_MD, NOTIFICATION_TARGET_FAILED_MESSAGES_MD,

--- a/crates/obs/src/metrics/collectors/replication.rs
+++ b/crates/obs/src/metrics/collectors/replication.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Replication metrics collector.
 //!
 //! Collects cluster-wide replication metrics including queue stats,

--- a/crates/obs/src/metrics/collectors/request.rs
+++ b/crates/obs/src/metrics/collectors/request.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! API request metrics collector.
 //!
 //! Collects API request metrics including request counts, errors,

--- a/crates/obs/src/metrics/collectors/scanner.rs
+++ b/crates/obs/src/metrics/collectors/scanner.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Scanner metrics collector.
 //!
 //! Collects background scanner metrics including bucket-drive scans,

--- a/crates/obs/src/metrics/collectors/system_cpu.rs
+++ b/crates/obs/src/metrics/collectors/system_cpu.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! System CPU metrics collector.
 //!
 //! Collects CPU metrics including load average, CPU time distribution,

--- a/crates/obs/src/metrics/collectors/system_drive.rs
+++ b/crates/obs/src/metrics/collectors/system_drive.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! System drive metrics collector.
 //!
 //! Collects detailed drive/disk metrics including capacity, I/O statistics,

--- a/crates/obs/src/metrics/collectors/system_gpu.rs
+++ b/crates/obs/src/metrics/collectors/system_gpu.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! System GPU metrics collector.
 //!
 //! Collects GPU memory usage metrics using NVML library.

--- a/crates/obs/src/metrics/collectors/system_memory.rs
+++ b/crates/obs/src/metrics/collectors/system_memory.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! System memory metrics collector.
 //!
 //! Collects memory-related metrics including total, used, free,

--- a/crates/obs/src/metrics/collectors/system_network.rs
+++ b/crates/obs/src/metrics/collectors/system_network.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! System network metrics collector.
 //!
 //! Collects internode network metrics including errors, dial times,

--- a/crates/obs/src/metrics/collectors/system_process.rs
+++ b/crates/obs/src/metrics/collectors/system_process.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! System process metrics collector.
 //!
 //! Collects process-level metrics including file descriptors, memory,

--- a/crates/obs/src/metrics/schema/audit.rs
+++ b/crates/obs/src/metrics/schema/audit.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/bucket.rs
+++ b/crates/obs/src/metrics/schema/bucket.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/bucket_replication.rs
+++ b/crates/obs/src/metrics/schema/bucket_replication.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/cluster.rs
+++ b/crates/obs/src/metrics/schema/cluster.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/cluster_config.rs
+++ b/crates/obs/src/metrics/schema/cluster_config.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/cluster_erasure_set.rs
+++ b/crates/obs/src/metrics/schema/cluster_erasure_set.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/cluster_health.rs
+++ b/crates/obs/src/metrics/schema/cluster_health.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/cluster_iam.rs
+++ b/crates/obs/src/metrics/schema/cluster_iam.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/cluster_notification.rs
+++ b/crates/obs/src/metrics/schema/cluster_notification.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/cluster_usage.rs
+++ b/crates/obs/src/metrics/schema/cluster_usage.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/ilm.rs
+++ b/crates/obs/src/metrics/schema/ilm.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/node_bucket.rs
+++ b/crates/obs/src/metrics/schema/node_bucket.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_gauge_md};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/node_disk.rs
+++ b/crates/obs/src/metrics/schema/node_disk.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_gauge_md};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/notification_target.rs
+++ b/crates/obs/src/metrics/schema/notification_target.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/process_resource.rs
+++ b/crates/obs/src/metrics/schema/process_resource.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::node_identity::SERVER_LABEL;
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_gauge_md};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/replication.rs
+++ b/crates/obs/src/metrics/schema/replication.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/request.rs
+++ b/crates/obs/src/metrics/schema/request.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, MetricSubsystem, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 /// name label
@@ -32,6 +30,13 @@ const API_SERVER_NAME_TYPE_LE_LABELS: [&str; 4] = [SERVER_LABEL, NAME_LABEL, TYP
 const API_TYPE_LABELS: [&str; 1] = [TYPE_LABEL];
 const API_SERVER_TYPE_LABELS: [&str; 2] = [SERVER_LABEL, TYPE_LABEL];
 
+// Declared for MinIO metric parity but never emitted: no collector passes these
+// descriptors to `PrometheusMetric::from_descriptor`, so the wire names
+// (`rejected_auth_total`, `rejected_header_total`, `rejected_timestamp_total`,
+// `rejected_invalid_total`, `waiting_total`, `incoming_total`) never appear in a
+// scrape. Kept so the gap stays greppable rather than silently disappearing with
+// their `MetricName` variants; wiring an emitter is what retires these allows.
+#[allow(dead_code, reason = "declared metric with no emitter; see note above (backlog#1823)")]
 pub static API_REJECTED_AUTH_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::ApiRejectedAuthTotal,
@@ -41,6 +46,7 @@ pub static API_REJECTED_AUTH_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::ne
     )
 });
 
+#[allow(dead_code, reason = "declared metric with no emitter; see note above (backlog#1823)")]
 pub static API_REJECTED_HEADER_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::ApiRejectedHeaderTotal,
@@ -50,6 +56,7 @@ pub static API_REJECTED_HEADER_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::
     )
 });
 
+#[allow(dead_code, reason = "declared metric with no emitter; see note above (backlog#1823)")]
 pub static API_REJECTED_TIMESTAMP_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::ApiRejectedTimestampTotal,
@@ -59,6 +66,7 @@ pub static API_REJECTED_TIMESTAMP_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLoc
     )
 });
 
+#[allow(dead_code, reason = "declared metric with no emitter; see note above (backlog#1823)")]
 pub static API_REJECTED_INVALID_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_counter_md(
         MetricName::ApiRejectedInvalidTotal,
@@ -68,6 +76,7 @@ pub static API_REJECTED_INVALID_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock:
     )
 });
 
+#[allow(dead_code, reason = "declared metric with no emitter; see note above (backlog#1823)")]
 pub static API_REQUESTS_WAITING_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_gauge_md(
         MetricName::ApiRequestsWaitingTotal,
@@ -77,6 +86,7 @@ pub static API_REQUESTS_WAITING_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock:
     )
 });
 
+#[allow(dead_code, reason = "declared metric with no emitter; see note above (backlog#1823)")]
 pub static API_REQUESTS_INCOMING_TOTAL_MD: LazyLock<MetricDescriptor> = LazyLock::new(|| {
     new_gauge_md(
         MetricName::ApiRequestsIncomingTotal,

--- a/crates/obs/src/metrics/schema/scanner.rs
+++ b/crates/obs/src/metrics/schema/scanner.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/system_cpu.rs
+++ b/crates/obs/src/metrics/schema/system_cpu.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::node_identity::SERVER_LABEL;
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 /// CPU system-related metric descriptors

--- a/crates/obs/src/metrics/schema/system_drive.rs
+++ b/crates/obs/src/metrics/schema/system_drive.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;
 

--- a/crates/obs/src/metrics/schema/system_gpu.rs
+++ b/crates/obs/src/metrics/schema/system_gpu.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! GPU-related metric descriptors.
 //!
 //! This module defines metric descriptors for GPU monitoring,

--- a/crates/obs/src/metrics/schema/system_memory.rs
+++ b/crates/obs/src/metrics/schema/system_memory.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::node_identity::SERVER_LABEL;
 use crate::{MetricDescriptor, MetricName, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_network.rs
+++ b/crates/obs/src/metrics/schema/system_network.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::node_identity::SERVER_LABEL;
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_network_host.rs
+++ b/crates/obs/src/metrics/schema/system_network_host.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::node_identity::SERVER_LABEL;
 use crate::{MetricDescriptor, MetricName, new_counter_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/schema/system_process.rs
+++ b/crates/obs/src/metrics/schema/system_process.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use crate::node_identity::SERVER_LABEL;
 use crate::{MetricDescriptor, MetricName, new_counter_md, new_gauge_md, subsystems};
 use std::sync::LazyLock;

--- a/crates/obs/src/metrics/stats_collector.rs
+++ b/crates/obs/src/metrics/stats_collector.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Statistics collection functions for metrics.
 //!
 //! This module contains functions that collect statistics from various


### PR DESCRIPTION
## What

Every file under `crates/obs/src/metrics` carried a file-level `#![allow(dead_code)]` — **44 of them**. Removing all 44 leaves **six** warnings, all in one file. The code under the other 38 blankets is entirely live; those suppressions were pure noise.

## The six

All metric descriptors in `metrics/schema/request.rs`:

`API_REJECTED_AUTH_TOTAL_MD`, `API_REJECTED_HEADER_TOTAL_MD`, `API_REJECTED_TIMESTAMP_TOTAL_MD`, `API_REJECTED_INVALID_TOTAL_MD`, `API_REQUESTS_WAITING_TOTAL_MD`, `API_REQUESTS_INCOMING_TOTAL_MD`.

Each has the full three-part declaration — a `MetricName` variant, a wire-name mapping, and the descriptor — **but no emitter**. A live descriptor reaches a scrape via `PrometheusMetric::from_descriptor` in `metrics/collectors/request.rs`; none of these six is ever passed to it. So the wire names `rejected_auth_total`, `rejected_header_total`, `rejected_timestamp_total`, `rejected_invalid_total`, `waiting_total`, `incoming_total` **never appear in any scrape**, and no doc or dashboard references them.

## Why kept, not deleted

Deleting the six would also orphan their `MetricName` variants and wire-name mappings, erasing the evidence that RustFS declares MinIO-parity API metrics it does not emit. That is a gap an operator meets as *"why is this counter never present?"* — six greppable markers state it plainly; wiring an emitter is what retires them.

Happy to flip to deletion in one commit if maintainers would rather drop the parity intent.

## Scope note

This tree is **outside the eighteen blankets rustfs/backlog#1823 enumerated** (that list covered the ecstore module roots). It is the same burn-down and the largest single cluster in the repo — 44 of the ~74 repo-wide blankets.

## Verification

- `cargo check -p rustfs-obs` — warning-free under lib and `--tests`
- `cargo nextest run -p rustfs-obs` — **324 passed, 0 failed**
- `cargo clippy -p rustfs-obs --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅ (exit 0)

Ref rustfs/backlog#1823.
