### PR TITLE
chore(ecstore): drop the cluster and erasure dead_code blankets

### DIFF
--- a/crates/ecstore/src/cluster/mod.rs
+++ b/crates/ecstore/src/cluster/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // #730: cluster/RPC migration leaves transport capabilities staged for upcoming owners.
-#![allow(dead_code)]
 
 mod control_plane;
 pub(crate) mod rpc;

--- a/crates/ecstore/src/cluster/rpc/client.rs
+++ b/crates/ecstore/src/cluster/rpc/client.rs
@@ -256,6 +256,7 @@ impl<S> ReplayScopeChannel<S> {
     }
 }
 
+#[allow(dead_code, reason = "replay-state probe asserted by this file's tests (backlog#1823)")]
 fn peer_replay_state(audience: &str) -> PeerReplayState {
     PEER_REPLAY_STATES
         .lock()

--- a/crates/ecstore/src/cluster/rpc/internode_data_transport.rs
+++ b/crates/ecstore/src/cluster/rpc/internode_data_transport.rs
@@ -43,6 +43,10 @@ use tokio::io::{AsyncReadExt, AsyncWrite};
 use tokio::sync::OnceCell;
 use uuid::Uuid;
 
+#[allow(
+    dead_code,
+    reason = "live in the cfg(not(test)) half of build_internode_data_transport_from_env (backlog#1823)"
+)]
 static INTERNODE_DATA_TRANSPORT: OnceLock<std::result::Result<Arc<dyn InternodeDataTransport>, String>> = OnceLock::new();
 
 const READ_FILE_STREAM_PATH: &str = "/rustfs/rpc/read_file_stream";
@@ -134,6 +138,10 @@ fn put_file_capability_status_is_legacy(status: u16) -> bool {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[allow(
+    dead_code,
+    reason = "capability-negotiation seam; constructed only by transport test doubles (backlog#1823)"
+)]
 pub struct InternodeDataTransportCapabilities {
     /// Backend can open a streaming remote disk reader.
     pub streaming_read: bool,
@@ -150,6 +158,10 @@ pub struct InternodeDataTransportCapabilities {
 }
 
 impl InternodeDataTransportCapabilities {
+    #[allow(
+        dead_code,
+        reason = "capability-negotiation seam; used by transport test doubles (backlog#1823)"
+    )]
     pub const fn tcp_http() -> Self {
         Self {
             streaming_read: true,
@@ -234,7 +246,12 @@ pub trait InternodeDataTransport: Send + Sync + std::fmt::Debug {
     async fn probe_ns_scanner(&self, _request: NsScannerCapabilityRequest) -> Result<Uuid> {
         Err(Error::MethodNotAllowed)
     }
+    // Interface facet nobody calls yet: every transport implements both, but no
+    // caller negotiates on them. Kept for the internode transport split
+    // (backlog#1350); deleting them would delete the seam and six impls.
+    #[allow(dead_code, reason = "unused capability-negotiation facet (backlog#1823)")]
     fn name(&self) -> &'static str;
+    #[allow(dead_code, reason = "unused capability-negotiation facet (backlog#1823)")]
     fn capabilities(&self) -> InternodeDataTransportCapabilities;
 }
 
@@ -670,6 +687,10 @@ fn build_internode_data_transport_result(
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "live in the cfg(test) half of build_internode_data_transport_from_env, which bypasses the process static (backlog#1823)"
+)]
 pub fn build_internode_data_transport(configured_transport: Option<&str>) -> Result<Arc<dyn InternodeDataTransport>> {
     build_internode_data_transport_result(configured_transport).map_err(Error::other)
 }

--- a/crates/ecstore/src/cluster/rpc/peer_s3_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_s3_client.rs
@@ -854,7 +854,6 @@ impl PeerS3Client for LocalPeerS3Client {
 
 #[derive(Debug)]
 pub struct RemotePeerS3Client {
-    pub node: Option<Node>,
     pub pools: Option<Vec<usize>>,
     addr: String,
     /// Health tracker for connection monitoring
@@ -886,7 +885,6 @@ impl RemotePeerS3Client {
     pub fn new(node: Option<Node>, pools: Option<Vec<usize>>) -> Self {
         let addr = node.as_ref().map(|v| v.url.to_string()).unwrap_or_default();
         let client = Self {
-            node,
             pools,
             addr,
             health: Arc::new(DiskHealthTracker::new()),
@@ -903,10 +901,6 @@ impl RemotePeerS3Client {
         node_service_time_out_client(&self.addr, TonicInterceptor::Signature(gen_tonic_signature_interceptor()))
             .await
             .map_err(|err| Error::other(format!("can not get client, err: {err}")))
-    }
-
-    pub fn get_addr(&self) -> String {
-        self.addr.clone()
     }
 
     /// Start health monitoring for the remote peer
@@ -1208,6 +1202,10 @@ impl PeerS3Client for RemotePeerS3Client {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "local bucket-heal path reached only by this file's tests (backlog#1823)"
+)]
 pub async fn heal_bucket_local(bucket: &str, opts: &HealOpts) -> Result<HealResultItem> {
     let disks = clone_drives().await;
     heal_bucket_local_on_disks(bucket, opts, disks).await
@@ -1404,6 +1402,10 @@ pub(crate) async fn heal_bucket_local_on_disks(
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "reached only through heal_bucket_local, which only tests call (backlog#1823)"
+)]
 async fn clone_drives() -> Vec<Option<DiskStore>> {
     runtime_sources::local_disk_entries().await
 }
@@ -1585,15 +1587,7 @@ mod tests {
     }
 
     fn test_remote_peer(addr: &str) -> RemotePeerS3Client {
-        let node = Node {
-            url: url::Url::parse(addr).expect("test peer URL should parse"),
-            pools: vec![0],
-            is_local: false,
-            grid_host: addr.to_string(),
-        };
-
         RemotePeerS3Client {
-            node: Some(node),
             pools: Some(vec![0]),
             addr: addr.to_string(),
             health: Arc::new(DiskHealthTracker::new()),

--- a/crates/ecstore/src/cluster/rpc/remote_locker.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_locker.rs
@@ -48,10 +48,6 @@ impl RemoteClient {
         Self { addr: endpoint }
     }
 
-    pub fn from_url(url: url::Url) -> Self {
-        Self { addr: url.to_string() }
-    }
-
     fn build_ping_request() -> PingRequest {
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
         let payload = fbb.create_vector(b"health-check");

--- a/crates/ecstore/src/erasure/codec/bridge.rs
+++ b/crates/ecstore/src/erasure/codec/bridge.rs
@@ -26,6 +26,7 @@ pub(crate) const GET_RECONSTRUCT_OUTCOME_SKIP_DATA_COMPLETE: &str = "skip_data_c
 pub(crate) const GET_RECONSTRUCT_OUTCOME_SKIP_EMPTY_PAYLOAD: &str = "skip_empty_payload";
 
 pub(crate) trait DecodeWorkspace: Send + Sync + 'static {
+    #[allow(dead_code, reason = "workspace width asserted by decode_reader tests (backlog#1823)")]
     fn shard_len(&self) -> usize;
 }
 
@@ -33,11 +34,14 @@ pub(crate) trait ErasureDecodeEngine: Send + Sync + 'static {
     type Workspace: DecodeWorkspace;
 
     fn data_shards(&self) -> usize;
+    #[allow(dead_code, reason = "engine trait facet asserted by decode_reader tests (backlog#1823)")]
     fn parity_shards(&self) -> usize;
     fn block_size(&self) -> usize;
     fn engine_name(&self) -> &'static str;
 
+    #[allow(dead_code, reason = "engine trait facet asserted by decode_reader tests (backlog#1823)")]
     fn supports_progressive_decode(&self) -> bool;
+    #[allow(dead_code, reason = "engine trait facet asserted by decode_reader tests (backlog#1823)")]
     fn supports_aligned_shards(&self) -> bool;
 
     fn prepare_workspace(&self, shard_len: usize) -> io::Result<Self::Workspace>;

--- a/crates/ecstore/src/erasure/codec/workspace.rs
+++ b/crates/ecstore/src/erasure/codec/workspace.rs
@@ -24,6 +24,7 @@ impl RustfsCodecDecodeWorkspace {
     }
 
     #[inline]
+    #[allow(dead_code, reason = "workspace width asserted by decode_reader tests (backlog#1823)")]
     pub(crate) fn shard_len(&self) -> usize {
         self.shard_len
     }

--- a/crates/ecstore/src/erasure/coding/decode.rs
+++ b/crates/ecstore/src/erasure/coding/decode.rs
@@ -213,6 +213,7 @@ fn shard_read_launch_rank(cost: ShardReadCost) -> u8 {
     }
 }
 
+#[allow(dead_code, reason = "launch ordering asserted by this file's tests (backlog#1823)")]
 fn shard_read_launch_order(read_costs: &[ShardReadCost], num_readers: usize, locality_preference_enabled: bool) -> Vec<usize> {
     let mut order: Vec<usize> = (0..num_readers).collect();
     if locality_preference_enabled {
@@ -408,6 +409,10 @@ where
     R: crate::erasure::coding::ShardSource,
 {
     // Readers should handle disk errors before being passed in, ensuring each reader reaches the available number of BitrotReaders
+    #[allow(
+        dead_code,
+        reason = "ParallelReader constructor used only by this file's tests (backlog#1823)"
+    )]
     pub fn new(readers: Vec<Option<BitrotReader<R>>>, e: Erasure, offset: usize, total_length: usize) -> Self {
         Self::new_with_metrics_path_read_timeout_and_reconstruction_verification(
             readers,
@@ -420,6 +425,7 @@ where
         )
     }
 
+    #[allow(dead_code, reason = "constructor used only by this file's tests (backlog#1823)")]
     pub fn new_with_metrics_path(
         readers: Vec<Option<BitrotReader<R>>>,
         e: Erasure,
@@ -438,6 +444,7 @@ where
         )
     }
 
+    #[allow(dead_code, reason = "constructor used only by this file's tests (backlog#1823)")]
     pub fn new_with_metrics_path_and_read_costs(
         readers: Vec<Option<BitrotReader<R>>>,
         e: Erasure,
@@ -514,6 +521,7 @@ where
         )
     }
 
+    #[allow(dead_code, reason = "constructor used only by this file's tests (backlog#1823)")]
     fn new_with_read_timeout(
         readers: Vec<Option<BitrotReader<R>>>,
         e: Erasure,
@@ -1330,10 +1338,6 @@ where
             }
         }
     }
-
-    pub fn can_decode(&self, shards: &[Option<Vec<u8>>]) -> bool {
-        shards.iter().filter(|s| s.is_some()).count() >= self.data_shards
-    }
 }
 
 #[async_trait::async_trait]
@@ -1539,6 +1543,7 @@ impl Erasure {
             .await
     }
 
+    #[allow(dead_code, reason = "read-cost decode path asserted by this file's tests (backlog#1823)")]
     pub(crate) async fn decode_with_read_costs<W, R>(
         &self,
         writer: &mut W,
@@ -1609,9 +1614,9 @@ impl Erasure {
             *ret_err = Some(err.into());
         }
 
-        // Equivalent to `ParallelReader::can_decode`; inlined so this helper does
-        // not need to borrow the reader, leaving the reader free for the
-        // concurrent next-stripe read under prefetch.
+        // Shard-availability check, written out here rather than called on the
+        // reader so this helper does not need to borrow it, leaving the reader
+        // free for the concurrent next-stripe read under prefetch.
         let available_shards = shards.iter().filter(|shard| shard.is_some()).count();
         if available_shards < self.data_shards {
             let reason = GetObjectFailureReason::ReadQuorum;

--- a/crates/ecstore/src/erasure/coding/decode_reader.rs
+++ b/crates/ecstore/src/erasure/coding/decode_reader.rs
@@ -138,6 +138,10 @@ where
     S: ShardStripeSource + Send + 'static,
     E: ErasureDecodeEngine + Clone + Send + Sync + 'static,
 {
+    #[allow(
+        dead_code,
+        reason = "default-metrics-path constructor used only by this file's tests (backlog#1823)"
+    )]
     pub(crate) fn new(source: S, engine: E, total_length: usize) -> io::Result<Self> {
         Self::new_with_metrics_path(source, engine, total_length, GET_OBJECT_PATH_CODEC_STREAMING)
     }
@@ -679,6 +683,10 @@ pub(crate) struct SyncErasureDecodeReader<R> {
 }
 
 impl<R> SyncErasureDecodeReader<R> {
+    #[allow(
+        dead_code,
+        reason = "default-metrics-path constructor used only by this file's tests (backlog#1823)"
+    )]
     pub(crate) fn new(inner: R) -> Self {
         Self::new_with_metrics_path(inner, GET_OBJECT_PATH_CODEC_STREAMING)
     }
@@ -805,6 +813,7 @@ where
     Ok(true)
 }
 
+#[allow(dead_code, reason = "shard emission asserted by this file's tests (backlog#1823)")]
 fn emit_data_shards(state: &StripeReadState, data_shards: usize, block_size: usize, remaining: usize) -> io::Result<Vec<u8>> {
     let mut output = Vec::new();
     emit_data_shards_into(state, data_shards, block_size, remaining, &mut output)?;

--- a/crates/ecstore/src/erasure/coding/encode.rs
+++ b/crates/ecstore/src/erasure/coding/encode.rs
@@ -166,6 +166,7 @@ where
     if total == 0 { Ok(None) } else { Ok(Some(total)) }
 }
 
+#[allow(dead_code, reason = "byte accounting asserted by this file's tests (backlog#1823)")]
 fn queued_block_bytes(block: &[Bytes]) -> usize {
     block.iter().map(Bytes::len).sum()
 }

--- a/crates/ecstore/src/erasure/coding/erasure.rs
+++ b/crates/ecstore/src/erasure/coding/erasure.rs
@@ -1110,6 +1110,10 @@ impl Erasure {
     ///
     /// # Errors
     /// Returns error if reading from reader fails or if callback returns error
+    #[allow(
+        dead_code,
+        reason = "callback encode path exercised only by this file's tests (backlog#1823)"
+    )]
     pub(crate) async fn encode_stream_callback_async<F, Fut, E, R>(
         self: std::sync::Arc<Self>,
         reader: &mut R,

--- a/crates/ecstore/src/erasure/mod.rs
+++ b/crates/ecstore/src/erasure/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // #730: erasure codec migration keeps staged streaming decode paths in this module.
-#![allow(dead_code)]
 
 pub(crate) mod codec;
 pub(crate) mod coding;


### PR DESCRIPTION
## What

`cluster` and `erasure` roots. Removing both blankets exposes **23 items**, of which only **four** are deleted. The ratio is the point: close to the core data path these blankets were hiding test assertions and migration seams, not dead code.

## A cfg-split function makes two live symbols both look dead

`build_internode_data_transport_from_env` has **two bodies**:

```rust
#[cfg(test)]      { build_internode_data_transport(configured.as_deref()) }   // bypasses the static
#[cfg(not(test))] INTERNODE_DATA_TRANSPORT.get_or_init(...)                   // uses the static
```

So `build_internode_data_transport` is live only in the test build and `INTERNODE_DATA_TRANSPORT` only in the production build. Because `cargo check --tests` compiles **both** the lib target and the test harness, both symbols land in one warning list — and deleting either breaks the other lane. Both kept with allows naming their half.

## Three deletion candidates withdrawn after a per-name grep

`ParallelReader::new`, `ErasureDecodeReader::new` and `SyncErasureDecodeReader::new` all have test callers. The last two are **exactly the shape of the dead wrapper deleted in #6084** — a thin forward to a `new_with_metrics_path` sibling — except here that sibling is live in production (`set_disk/read.rs:1450`) and the wrappers are used by tests.

## Deleted (4)

- `RemotePeerS3Client::get_addr`, `RemoteLocker::from_url` — no consumer in any lane.
- `RemotePeerS3Client`'s `node` field — `new` writes it after using it to derive `addr`, and nothing ever reads it. Its only other writer was a test helper that built a whole `Node` solely to fill the field; that block goes too.
- `ParallelReader::can_decode` — superseded by an inlined copy. The copy's comment **named the method it replaced**, so deleting the method alone would have left a dangling reference; the comment now describes the check instead.

## Kept with allows

Erasure: decode/encode invariants asserted by their own files' tests — `shard_read_launch_order`, `decode_with_read_costs`, `emit_data_shards`, `queued_block_bytes`, the engine trait facets, the `ParallelReader` and decode-reader constructors, `encode_stream_callback_async`.

Cluster: `peer_replay_state`, `heal_bucket_local`, `clone_drives` are test-only; `InternodeDataTransportCapabilities` and `tcp_http` are constructed only by transport test doubles; the `InternodeDataTransport` trait's `name`/`capabilities` pair is an unused capability-negotiation facet kept for the transport split (rustfs/backlog#1350) — six impls provide them, no caller negotiates on them yet.

## Verification

Warning-free in **four lanes**: default, `--tests`, `--features rio-v2 --tests`, `--features test-util --tests`.

- `cargo nextest run -p rustfs-ecstore` — **4041 passed, 0 failed**
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅ (exit 0)

Ref rustfs/backlog#1823.
