### PR TITLE
fix(log-analyzer): drop stale heal rule anchor

### DIFF
--- a/crates/log-analyzer/src/rules/seed/heal.rs
+++ b/crates/log-analyzer/src/rules/seed/heal.rs
@@ -97,7 +97,7 @@ pub(super) fn rules() -> Vec<Rule> {
             )
         },
         Rule {
-            anchors: strings(["Heal task execution failed", "Heal manager is not running"]),
+            anchors: strings(["Heal task execution failed"]),
             ..base(
                 "heal-task-failure",
                 P2Degraded,


### PR DESCRIPTION
## Related Issues

Follow-up to #6031. Unblocks CI for #6090 and other pull requests based on the affected `main` revision.

## Summary of Changes

Remove the obsolete `Heal manager is not running` source anchor from the built-in `heal-task-failure` rule after #6031 removed the corresponding dead `ManagerNotRunning` error variant.

Keep the matcher for that message so `rustfs diagnose` can still classify logs produced by older RustFS versions. The remaining `Heal task execution failed` anchor continues to tie the message-based rule to current source.

## Verification

- `./scripts/check_log_analyzer_rules.sh`
- `cargo test -p rustfs-log-analyzer`
- `cargo clippy --all-targets -p rustfs-log-analyzer -- -D warnings`
- `make pre-commit`
- `git diff --check`

## Impact

Restores the log-analyzer anchor CI guard on current `main`. Runtime rule matching, public APIs, configuration, and stored formats are unchanged.

## Additional Notes

Adversarial validation found no correctness, simplicity, compatibility, or test-coverage issues. Reverting this change reproduces the missing-anchor failure in `scripts/check_log_analyzer_rules.sh`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
