### PR TITLE
perf(ecstore): borrow rename metadata during commit fanout

### DIFF
--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -2280,7 +2280,7 @@ impl DiskAPI for RemoteDisk {
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: FileInfo,
+        fi: &FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
@@ -2301,8 +2301,8 @@ impl DiskAPI for RemoteDisk {
         self.execute_with_timeout_for_op(
             "rename_data",
             || async {
-                let file_info = compat_json(&fi)?;
-                let file_info_bin = encode_file_info_msgpack(&fi)?;
+                let file_info = compat_json(fi)?;
+                let file_info_bin = encode_file_info_msgpack(fi)?;
                 let mut client = self
                     .get_client()
                     .await

--- a/crates/ecstore/src/cluster/rpc/remote_disk.rs
+++ b/crates/ecstore/src/cluster/rpc/remote_disk.rs
@@ -1359,6 +1359,71 @@ fn validate_decoded_file_info(file_info: &FileInfo) -> Result<()> {
     file_info.validate_for_metadata_read().map_err(Into::into)
 }
 
+impl RemoteDisk {
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub(crate) async fn rename_data_borrowed(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: &FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+    ) -> Result<RenameDataResp> {
+        trace!(
+            event = EVENT_REMOTE_DISK_RPC,
+            component = LOG_COMPONENT_ECSTORE,
+            subsystem = LOG_SUBSYSTEM_REMOTE_DISK,
+            endpoint = %self.endpoint,
+            src_volume,
+            src_path,
+            dst_volume,
+            dst_path,
+            op = "rename_data",
+            state = "started",
+            "Remote disk RPC started"
+        );
+
+        self.execute_with_timeout_for_op(
+            "rename_data",
+            || async {
+                let file_info = compat_json(fi)?;
+                let file_info_bin = encode_file_info_msgpack(fi)?;
+                let mut client = self
+                    .get_client()
+                    .await
+                    .map_err(|err| Error::other(format!("can not get client, err: {err}")))?;
+                let mut request = Request::new(RenameDataRequest {
+                    disk: self.endpoint.to_string(),
+                    src_volume: src_volume.to_string(),
+                    src_path: src_path.to_string(),
+                    file_info,
+                    dst_volume: dst_volume.to_string(),
+                    dst_path: dst_path.to_string(),
+                    file_info_bin: file_info_bin.into(),
+                });
+                let canonical_body = rustfs_protos::canonical_rename_data_request_body(request.get_ref());
+                attach_mutation_body_digest(&mut request, canonical_body, "rename_data")?;
+
+                let response = client.rename_data(request).await?.into_inner();
+
+                if !response.success {
+                    return Err(response.error.unwrap_or_default().into());
+                }
+
+                let rename_data_resp = decode_msgpack_or_json::<RenameDataResp>(
+                    &response.rename_data_resp_bin,
+                    &response.rename_data_resp,
+                    "RenameDataResp",
+                )?;
+
+                Ok(rename_data_resp)
+            },
+            get_max_timeout_duration(),
+        )
+        .await
+    }
+}
+
 #[async_trait::async_trait]
 impl DiskAPI for RemoteDisk {
     #[tracing::instrument(level = "trace", skip_all)]
@@ -2280,62 +2345,12 @@ impl DiskAPI for RemoteDisk {
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: &FileInfo,
+        fi: FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
-        trace!(
-            event = EVENT_REMOTE_DISK_RPC,
-            component = LOG_COMPONENT_ECSTORE,
-            subsystem = LOG_SUBSYSTEM_REMOTE_DISK,
-            endpoint = %self.endpoint,
-            src_volume,
-            src_path,
-            dst_volume,
-            dst_path,
-            op = "rename_data",
-            state = "started",
-            "Remote disk RPC started"
-        );
-
-        self.execute_with_timeout_for_op(
-            "rename_data",
-            || async {
-                let file_info = compat_json(fi)?;
-                let file_info_bin = encode_file_info_msgpack(fi)?;
-                let mut client = self
-                    .get_client()
-                    .await
-                    .map_err(|err| Error::other(format!("can not get client, err: {err}")))?;
-                let mut request = Request::new(RenameDataRequest {
-                    disk: self.endpoint.to_string(),
-                    src_volume: src_volume.to_string(),
-                    src_path: src_path.to_string(),
-                    file_info,
-                    dst_volume: dst_volume.to_string(),
-                    dst_path: dst_path.to_string(),
-                    file_info_bin: file_info_bin.into(),
-                });
-                let canonical_body = rustfs_protos::canonical_rename_data_request_body(request.get_ref());
-                attach_mutation_body_digest(&mut request, canonical_body, "rename_data")?;
-
-                let response = client.rename_data(request).await?.into_inner();
-
-                if !response.success {
-                    return Err(response.error.unwrap_or_default().into());
-                }
-
-                let rename_data_resp = decode_msgpack_or_json::<RenameDataResp>(
-                    &response.rename_data_resp_bin,
-                    &response.rename_data_resp,
-                    "RenameDataResp",
-                )?;
-
-                Ok(rename_data_resp)
-            },
-            get_max_timeout_duration(),
-        )
-        .await
+        self.rename_data_borrowed(src_volume, src_path, &fi, dst_volume, dst_path)
+            .await
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/crates/ecstore/src/disk/disk_store.rs
+++ b/crates/ecstore/src/disk/disk_store.rs
@@ -1981,7 +1981,7 @@ impl DiskAPI for LocalDiskWrapper {
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: FileInfo,
+        fi: &FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {

--- a/crates/ecstore/src/disk/disk_store.rs
+++ b/crates/ecstore/src/disk/disk_store.rs
@@ -241,6 +241,40 @@ pub fn get_drive_list_dir_timeout() -> Duration {
     )
 }
 
+pub(crate) trait DiskStoreRenameDataExt {
+    async fn rename_data_borrowed(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: &FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+    ) -> Result<RenameDataResp>;
+}
+
+impl DiskStoreRenameDataExt for LocalDiskWrapper {
+    async fn rename_data_borrowed(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: &FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+    ) -> Result<RenameDataResp> {
+        self.track_disk_health_mutation(
+            "rename_data",
+            DiskMetricMutation::Write,
+            || async {
+                self.disk
+                    .rename_data_borrowed(src_volume, src_path, fi, dst_volume, dst_path)
+                    .await
+            },
+            get_max_timeout_duration(),
+        )
+        .await
+    }
+}
+
 pub fn get_drive_walkdir_timeout() -> Duration {
     get_drive_timeout_duration(
         rustfs_config::ENV_DRIVE_WALKDIR_TIMEOUT_SECS,
@@ -1981,17 +2015,12 @@ impl DiskAPI for LocalDiskWrapper {
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: &FileInfo,
+        fi: FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
-        self.track_disk_health_mutation(
-            "rename_data",
-            DiskMetricMutation::Write,
-            || async { self.disk.rename_data(src_volume, src_path, fi, dst_volume, dst_path).await },
-            get_max_timeout_duration(),
-        )
-        .await
+        self.rename_data_borrowed(src_volume, src_path, &fi, dst_volume, dst_path)
+            .await
     }
 
     async fn list_dir(&self, origvolume: &str, volume: &str, dir_path: &str, count: i32) -> Result<Vec<String>> {

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -8689,12 +8689,12 @@ impl DiskAPI for LocalDisk {
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: &FileInfo,
+        fi: FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
         crate::hp_guard!("LocalDisk::rename_data");
-        let mut fi = fi.clone();
+        let mut fi = fi;
         // A non-force DeleteBucket must not remove a directory while a local
         // object commit is publishing into it. The peer's empty scan remains
         // optimistic; this lease establishes the local commit/delete order and
@@ -10580,17 +10580,16 @@ impl DiskAPI for LocalDisk {
     }
 }
 
-#[cfg(test)]
 impl LocalDisk {
-    async fn rename_data(
+    pub(crate) async fn rename_data_borrowed(
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: FileInfo,
+        fi: &FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
-        <Self as DiskAPI>::rename_data(self, src_volume, src_path, &fi, dst_volume, dst_path).await
+        <Self as DiskAPI>::rename_data(self, src_volume, src_path, fi.clone(), dst_volume, dst_path).await
     }
 }
 

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -8689,11 +8689,12 @@ impl DiskAPI for LocalDisk {
         &self,
         src_volume: &str,
         src_path: &str,
-        mut fi: FileInfo,
+        fi: &FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
         crate::hp_guard!("LocalDisk::rename_data");
+        let mut fi = fi.clone();
         // A non-force DeleteBucket must not remove a directory while a local
         // object commit is publishing into it. The peer's empty scan remains
         // optimistic; this lease establishes the local commit/delete order and
@@ -10576,6 +10577,20 @@ impl DiskAPI for LocalDisk {
         let volume_dir = self.io_get_bucket_path(volume)?;
         let (data, _) = self.read_all_data_with_dmtime(volume, volume_dir, file_path).await?;
         Ok(data.into())
+    }
+}
+
+#[cfg(test)]
+impl LocalDisk {
+    async fn rename_data(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+    ) -> Result<RenameDataResp> {
+        <Self as DiskAPI>::rename_data(self, src_volume, src_path, &fi, dst_volume, dst_path).await
     }
 }
 

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -430,7 +430,7 @@ impl DiskAPI for Disk {
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: FileInfo,
+        fi: &FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
@@ -664,6 +664,20 @@ impl DiskAPI for Disk {
             Disk::Local(local_disk) => local_disk.read_metadata(volume, path).await,
             Disk::Remote(remote_disk) => remote_disk.read_metadata(volume, path).await,
         }
+    }
+}
+
+#[cfg(test)]
+impl Disk {
+    async fn rename_data(
+        &self,
+        src_volume: &str,
+        src_path: &str,
+        fi: FileInfo,
+        dst_volume: &str,
+        dst_path: &str,
+    ) -> Result<RenameDataResp> {
+        <Self as DiskAPI>::rename_data(self, src_volume, src_path, &fi, dst_volume, dst_path).await
     }
 }
 
@@ -904,7 +918,7 @@ pub trait DiskAPI: Debug + Send + Sync + 'static {
         &self,
         src_volume: &str,
         src_path: &str,
-        file_info: FileInfo,
+        file_info: &FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp>;

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -55,6 +55,7 @@ pub fn part_transaction_path(part_path: &str) -> String {
 
 use crate::cluster::rpc::RemoteDisk;
 use crate::cluster::rpc::build_internode_data_transport_from_env;
+use crate::disk::disk_store::DiskStoreRenameDataExt;
 use crate::disk::disk_store::LocalDiskWrapper;
 use crate::disk::health_state::RuntimeDriveHealthState;
 use crate::disk::local::ScanGuard;
@@ -430,14 +431,12 @@ impl DiskAPI for Disk {
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: &FileInfo,
+        fi: FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
-        match self {
-            Disk::Local(local_disk) => local_disk.rename_data(src_volume, src_path, fi, dst_volume, dst_path).await,
-            Disk::Remote(remote_disk) => remote_disk.rename_data(src_volume, src_path, fi, dst_volume, dst_path).await,
-        }
+        self.rename_data_borrowed(src_volume, src_path, &fi, dst_volume, dst_path)
+            .await
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -667,17 +666,27 @@ impl DiskAPI for Disk {
     }
 }
 
-#[cfg(test)]
 impl Disk {
-    async fn rename_data(
+    pub(crate) async fn rename_data_borrowed(
         &self,
         src_volume: &str,
         src_path: &str,
-        fi: FileInfo,
+        fi: &FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp> {
-        <Self as DiskAPI>::rename_data(self, src_volume, src_path, &fi, dst_volume, dst_path).await
+        match self {
+            Disk::Local(local_disk) => {
+                local_disk
+                    .rename_data_borrowed(src_volume, src_path, fi, dst_volume, dst_path)
+                    .await
+            }
+            Disk::Remote(remote_disk) => {
+                remote_disk
+                    .rename_data_borrowed(src_volume, src_path, fi, dst_volume, dst_path)
+                    .await
+            }
+        }
     }
 }
 
@@ -918,7 +927,7 @@ pub trait DiskAPI: Debug + Send + Sync + 'static {
         &self,
         src_volume: &str,
         src_path: &str,
-        file_info: &FileInfo,
+        file_info: FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> Result<RenameDataResp>;

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -3011,6 +3011,35 @@ impl RenameConvergence {
     }
 }
 
+pub(in crate::set_disk) struct RenameDataCommit {
+    pub(in crate::set_disk) online_disks: Vec<Option<DiskStore>>,
+    pub(in crate::set_disk) convergence: RenameConvergence,
+    pub(in crate::set_disk) data_dir: Option<Uuid>,
+    pub(in crate::set_disk) cleanup_disks: Vec<Option<DiskStore>>,
+    pub(in crate::set_disk) old_current_size: Option<OldCurrentSize>,
+    pub(in crate::set_disk) committed_file_info: Option<FileInfo>,
+}
+
+type RenameDataLegacyTuple = (
+    Vec<Option<DiskStore>>,
+    RenameConvergence,
+    Option<Uuid>,
+    Vec<Option<DiskStore>>,
+    Option<OldCurrentSize>,
+);
+
+impl RenameDataCommit {
+    fn into_legacy_tuple(self) -> RenameDataLegacyTuple {
+        (
+            self.online_disks,
+            self.convergence,
+            self.data_dir,
+            self.cleanup_disks,
+            self.old_current_size,
+        )
+    }
+}
+
 impl SetDisks {
     pub(in crate::set_disk) fn default_read_quorum(&self) -> usize {
         self.set_drive_count - self.default_parity_count
@@ -3088,6 +3117,14 @@ impl SetDisks {
         Ok(())
     }
 
+    pub(in crate::set_disk) fn assign_rename_data_indexes(file_infos: &mut [FileInfo]) {
+        for (index, file_info) in file_infos.iter_mut().enumerate() {
+            if file_info.erasure.index == 0 {
+                file_info.erasure.index = index + 1;
+            }
+        }
+    }
+
     pub(in crate::set_disk) async fn abort_quota_reservation_after_fence(
         reservation: crate::bucket::quota::reservation::QuotaReservation,
         disks: &[Option<DiskStore>],
@@ -3118,13 +3155,22 @@ impl SetDisks {
         dst_bucket: &str,
         dst_object: &str,
         write_quorum: usize,
-    ) -> disk::error::Result<(
-        Vec<Option<DiskStore>>,
-        RenameConvergence,
-        Option<Uuid>,
-        Vec<Option<DiskStore>>,
-        Option<OldCurrentSize>,
-    )> {
+    ) -> disk::error::Result<RenameDataLegacyTuple> {
+        Self::rename_data_owned(disks, src_bucket, src_object, file_infos.to_vec(), dst_bucket, dst_object, write_quorum)
+            .await
+            .map(RenameDataCommit::into_legacy_tuple)
+    }
+
+    #[tracing::instrument(level = "debug", skip(disks, file_infos))]
+    pub(in crate::set_disk) async fn rename_data_owned(
+        disks: &[Option<DiskStore>],
+        src_bucket: &str,
+        src_object: &str,
+        file_infos: Vec<FileInfo>,
+        dst_bucket: &str,
+        dst_object: &str,
+        write_quorum: usize,
+    ) -> disk::error::Result<RenameDataCommit> {
         if let Some(file_info) = disks
             .iter()
             .zip(file_infos.iter())
@@ -3149,7 +3195,7 @@ impl SetDisks {
 
         let disk_count = disks.len();
         let fanout_disks = disks.to_vec();
-        let fanout_file_infos = file_infos.to_vec();
+        let fanout_file_infos = file_infos;
         let fanout_src_bucket = src_bucket.clone();
         let fanout_src_object = src_object.clone();
         let fanout_dst_bucket = dst_bucket.clone();
@@ -3161,9 +3207,9 @@ impl SetDisks {
         let fanout = tokio::spawn(async move {
             let futures = fanout_disks
                 .into_iter()
-                .zip(fanout_file_infos)
+                .zip(fanout_file_infos.iter())
                 .enumerate()
-                .map(|(i, (disk, mut file_info))| {
+                .map(|(i, (disk, file_info))| {
                     let src_bucket = fanout_src_bucket.clone();
                     let src_object = fanout_src_object.clone();
                     let dst_object = fanout_dst_object.clone();
@@ -3180,11 +3226,15 @@ impl SetDisks {
                         };
 
                         let is_delete_marker = file_info.is_canonical_delete_marker();
-                        if file_info.erasure.index == 0 {
-                            file_info.erasure.index = i + 1;
-                        }
-
-                        if !is_delete_marker && !file_info.has_valid_erasure_geometry() {
+                        let mut local_file_info;
+                        let file_info = if file_info.erasure.index == 0 {
+                            local_file_info = file_info.clone();
+                            local_file_info.erasure.index = i + 1;
+                            &local_file_info
+                        } else {
+                            file_info
+                        };
+                        if file_info.erasure.index == 0 || (!is_delete_marker && !file_info.has_valid_erasure_geometry()) {
                             return Err(DiskError::FileCorrupt);
                         }
 
@@ -3197,7 +3247,8 @@ impl SetDisks {
                     })
                     .catch_unwind()
                 });
-            join_all(futures).await
+            let results = join_all(futures).await;
+            (results, fanout_file_infos)
         });
 
         let mut disk_versions = vec![None; disk_count];
@@ -3205,7 +3256,7 @@ impl SetDisks {
         let mut cleanup_data_dirs = vec![None; disk_count];
         let mut old_current_sizes = vec![None; disk_count];
 
-        let results = fanout.await.map_err(|_| DiskError::Unexpected)?;
+        let (results, mut file_infos) = fanout.await.map_err(|_| DiskError::Unexpected)?;
 
         for (idx, result) in results.iter().enumerate() {
             match result {
@@ -3261,7 +3312,7 @@ impl SetDisks {
                 }
 
                 if let Some(disk) = disks[i].as_ref() {
-                    let fi = file_infos[i].clone();
+                    let fi = std::mem::take(&mut file_infos[i]);
                     let old_data_dir = data_dirs[i];
                     let disk = disk.clone();
                     let dst_bucket = dst_bucket.clone();
@@ -3384,6 +3435,10 @@ impl SetDisks {
         let convergence = Self::classify_rename_convergence(&disk_versions, &errs);
         let old_current_size = Self::reduce_common_old_current_size(&old_current_sizes, write_quorum);
         let online_disks = Self::eval_disks(disks, &errs);
+        let committed_file_info = online_disks
+            .iter()
+            .position(Option::is_some)
+            .map(|slot| std::mem::take(&mut file_infos[slot]));
         let cleanup_disks = if let Some(data_dir) = data_dir {
             disks
                 .iter()
@@ -3401,7 +3456,14 @@ impl SetDisks {
             vec![None; disks.len()]
         };
 
-        Ok((online_disks, convergence, data_dir, cleanup_disks, old_current_size))
+        Ok(RenameDataCommit {
+            online_disks,
+            convergence,
+            data_dir,
+            cleanup_disks,
+            old_current_size,
+            committed_file_info,
+        })
     }
 
     /// rustfs/backlog#1009: reduce the per-disk observations of the

--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -46,6 +46,7 @@ use crate::diagnostics::get::{
     GetObjectFailureReason, classify_disk_error, get_stage_timer_if_enabled, record_get_object_pipeline_failure,
     record_get_object_pipeline_failure_for_path, record_get_stage_duration_if_enabled,
 };
+use crate::disk::disk_store::DiskStoreRenameDataExt;
 use crate::disk::local::DELETE_DATA_DIR_MARKER_PREFIX;
 use crate::disk::{
     DataDirDeleteStatus, OldCurrentSize, PART_TRANSACTION_NEW_META, PART_TRANSACTION_OLD_META, PART_TRANSACTION_ROLLBACK,
@@ -3017,7 +3018,7 @@ pub(in crate::set_disk) struct RenameDataCommit {
     pub(in crate::set_disk) data_dir: Option<Uuid>,
     pub(in crate::set_disk) cleanup_disks: Vec<Option<DiskStore>>,
     pub(in crate::set_disk) old_current_size: Option<OldCurrentSize>,
-    pub(in crate::set_disk) committed_file_info: Option<FileInfo>,
+    pub(in crate::set_disk) committed_file_info: FileInfo,
 }
 
 type RenameDataLegacyTuple = (
@@ -3242,7 +3243,7 @@ impl SetDisks {
                         // A no-op immediately-ready future in production.
                         Self::rename_fanout_barrier(&dst_object, i, rename_fanout_barrier_phase::RENAME).await;
 
-                        disk.rename_data(&src_bucket, &src_object, file_info, &dst_bucket, &dst_object)
+                        disk.rename_data_borrowed(&src_bucket, &src_object, file_info, &dst_bucket, &dst_object)
                             .await
                     })
                     .catch_unwind()
@@ -3435,10 +3436,8 @@ impl SetDisks {
         let convergence = Self::classify_rename_convergence(&disk_versions, &errs);
         let old_current_size = Self::reduce_common_old_current_size(&old_current_sizes, write_quorum);
         let online_disks = Self::eval_disks(disks, &errs);
-        let committed_file_info = online_disks
-            .iter()
-            .position(Option::is_some)
-            .map(|slot| std::mem::take(&mut file_infos[slot]));
+        let committed_slot = online_disks.iter().position(Option::is_some).ok_or(DiskError::Unexpected)?;
+        let committed_file_info = std::mem::take(&mut file_infos[committed_slot]);
         let cleanup_disks = if let Some(data_dir) = data_dir {
             disks
                 .iter()

--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::super::*;
+use crate::disk::disk_store::DiskStoreRenameDataExt;
 use crate::io_support::bitrot::object_mmap_read_enabled;
 use crate::storage_api_contracts::namespace::NamespaceLocking as _;
 use tracing::trace;
@@ -1164,8 +1165,14 @@ impl SetDisks {
                                 let rename_result = if should_fail_heal_rename(bucket, object, index) {
                                     Err(DiskError::Unexpected)
                                 } else {
-                                    disk.rename_data(RUSTFS_META_TMP_BUCKET, &tmp_id, &parts_metadata[index], bucket, object)
-                                        .await
+                                    disk.rename_data_borrowed(
+                                        RUSTFS_META_TMP_BUCKET,
+                                        &tmp_id,
+                                        &parts_metadata[index],
+                                        bucket,
+                                        object,
+                                    )
+                                    .await
                                 };
 
                                 if let Err(err) = &rename_result {

--- a/crates/ecstore/src/set_disk/ops/heal.rs
+++ b/crates/ecstore/src/set_disk/ops/heal.rs
@@ -1164,14 +1164,8 @@ impl SetDisks {
                                 let rename_result = if should_fail_heal_rename(bucket, object, index) {
                                     Err(DiskError::Unexpected)
                                 } else {
-                                    disk.rename_data(
-                                        RUSTFS_META_TMP_BUCKET,
-                                        &tmp_id,
-                                        parts_metadata[index].clone(),
-                                        bucket,
-                                        object,
-                                    )
-                                    .await
+                                    disk.rename_data(RUSTFS_META_TMP_BUCKET, &tmp_id, &parts_metadata[index], bucket, object)
+                                        .await
                                 };
 
                                 if let Err(err) = &rename_result {

--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -2604,9 +2604,7 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
                 return Err(StorageError::Unexpected);
             }
 
-            if let Some(committed) = committed_file_info {
-                fi = committed;
-            }
+            fi = committed_file_info;
             let committed_dir = fi.data_dir.unwrap_or_default().to_string();
 
             commit_set.record_capacity_scope_if_needed(commit_capacity_scope_token, &online_disks);

--- a/crates/ecstore/src/set_disk/ops/multipart.rs
+++ b/crates/ecstore/src/set_disk/ops/multipart.rs
@@ -2527,11 +2527,12 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
             // The trailing `_` drops the rename_data old-size backfill
             // (rustfs/backlog#1009): CompleteMultipartUpload keeps its pre-commit
             // `get_object_info` lookup, so the backfill has no consumer here yet.
-            let rename_result = SetDisks::rename_data(
+            Self::assign_rename_data_indexes(&mut parts_metadatas);
+            let rename_result = SetDisks::rename_data_owned(
                 &commit_disks,
                 RUSTFS_META_MULTIPART_BUCKET,
                 &commit_upload_id_path,
-                &parts_metadatas,
+                parts_metadatas,
                 &commit_bucket,
                 &commit_object,
                 write_quorum,
@@ -2550,10 +2551,15 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
             if rename_result.is_ok() {
                 quota_reservation.commit().await;
             }
-            let (online_disks, convergence, op_old_dir, cleanup_disks, _) = match rename_result {
+            let rename_commit = match rename_result {
                 Ok(result) => result,
                 Err(err) => return Err(err.into()),
             };
+            let online_disks = rename_commit.online_disks;
+            let convergence = rename_commit.convergence;
+            let op_old_dir = rename_commit.data_dir;
+            let cleanup_disks = rename_commit.cleanup_disks;
+            let committed_file_info = rename_commit.committed_file_info;
 
             // Detach admission before any post-commit await: client cancellation
             // must not couple durable convergence repair to cleanup work.
@@ -2598,8 +2604,8 @@ impl crate::storage_api_contracts::multipart::MultipartOperations for SetDisks {
                 return Err(StorageError::Unexpected);
             }
 
-            if let Some(committed_slot) = online_disks.iter().position(Option::is_some) {
-                fi = parts_metadatas[committed_slot].clone();
+            if let Some(committed) = committed_file_info {
+                fi = committed;
             }
             let committed_dir = fi.data_dir.unwrap_or_default().to_string();
 

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -97,6 +97,7 @@ fn duration_millis_f64(duration: std::time::Duration) -> f64 {
     duration.as_secs_f64() * 1000.0
 }
 
+#[cfg(test)]
 fn committed_response_metadata_slot<D>(committed_disks: &[Option<D>], fallback_slot: usize) -> usize {
     committed_disks.iter().position(Option::is_some).unwrap_or(fallback_slot)
 }
@@ -2236,11 +2237,13 @@ impl SetDisks {
                     return Err(err);
                 }
 
-                let rename_result = SetDisks::rename_data(
+                Self::assign_rename_data_indexes(&mut parts_metadatas);
+                let fallback_file_info = parts_metadatas.get(response_metadata_slot).cloned();
+                let rename_result = SetDisks::rename_data_owned(
                     &commit_disks,
                     RUSTFS_META_TMP_BUCKET,
                     commit_tmp_dir.as_str(),
-                    &parts_metadatas,
+                    parts_metadatas,
                     &commit_bucket,
                     &commit_object,
                     write_quorum,
@@ -2259,7 +2262,7 @@ impl SetDisks {
                 if rename_result.is_ok() {
                     quota_reservation.commit().await;
                 }
-                let (online_disks, convergence, op_old_dir, cleanup_disks, old_current_size) = match rename_result {
+                let rename_commit = match rename_result {
                     Ok(commit) => commit,
                     Err(err) => {
                         if let Err(cleanup_err) = commit_set.delete_all(RUSTFS_META_TMP_BUCKET, &commit_tmp_dir).await {
@@ -2274,6 +2277,22 @@ impl SetDisks {
                             );
                         }
                         return Err(err.into());
+                    }
+                };
+                let online_disks = rename_commit.online_disks;
+                let convergence = rename_commit.convergence;
+                let op_old_dir = rename_commit.data_dir;
+                let cleanup_disks = rename_commit.cleanup_disks;
+                let old_current_size = rename_commit.old_current_size;
+                let mut fi = match rename_commit.committed_file_info.or(fallback_file_info) {
+                    Some(file_info) => file_info,
+                    None => {
+                        warn!(
+                            bucket = %commit_bucket,
+                            object = %commit_object,
+                            "rename_data committed without response metadata"
+                        );
+                        FileInfo::default()
                     }
                 };
                 // Do this before any post-commit await so request cancellation cannot
@@ -2383,9 +2402,6 @@ impl SetDisks {
                         );
                     }
                 }
-
-                let committed_metadata_slot = committed_response_metadata_slot(&online_disks, response_metadata_slot);
-                let mut fi = std::mem::take(&mut parts_metadatas[committed_metadata_slot]);
 
                 if is_compressed {
                     record_compression_total_memory(actual_size as u64, w_size as u64).await;

--- a/crates/ecstore/src/set_disk/ops/object.rs
+++ b/crates/ecstore/src/set_disk/ops/object.rs
@@ -97,11 +97,6 @@ fn duration_millis_f64(duration: std::time::Duration) -> f64 {
     duration.as_secs_f64() * 1000.0
 }
 
-#[cfg(test)]
-fn committed_response_metadata_slot<D>(committed_disks: &[Option<D>], fallback_slot: usize) -> usize {
-    committed_disks.iter().position(Option::is_some).unwrap_or(fallback_slot)
-}
-
 pub(in crate::set_disk::ops) fn assign_object_transaction_epoch(
     shuffle_disks: &[Option<DiskStore>],
     parts_metadatas: &mut [FileInfo],
@@ -237,38 +232,6 @@ mod duration_metrics_tests {
     #[test]
     fn duration_millis_preserves_sub_millisecond_precision() {
         assert_eq!(duration_millis_f64(Duration::from_micros(125)), 0.125);
-    }
-}
-
-#[cfg(test)]
-mod put_metadata_tests {
-    use super::*;
-
-    #[test]
-    fn committed_file_info_follows_exact_quorum_success_slot() {
-        let mut first_success = FileInfo::new("bucket/object", 2, 2);
-        first_success.name = "first-success".to_string();
-        let mut second_success = first_success.clone();
-        second_success.name = "second-success".to_string();
-        let mut parts_metadata = [FileInfo::default(), first_success, second_success, FileInfo::default()];
-        let committed_disks = [None, Some(()), Some(()), None];
-
-        assert_eq!(
-            committed_disks.iter().filter(|disk| disk.is_some()).count(),
-            2,
-            "fixture must meet exact quorum"
-        );
-        let selected_slot = committed_response_metadata_slot(&committed_disks, 3);
-        let selected = std::mem::take(&mut parts_metadata[selected_slot]);
-
-        assert_eq!(selected.name, "first-success");
-        assert_eq!(parts_metadata[1], FileInfo::default(), "selected metadata should move without cloning");
-        assert_eq!(parts_metadata[2].name, "second-success", "other committed metadata must remain available");
-        assert_eq!(
-            committed_response_metadata_slot::<()>(&[None, None, None, None], 3),
-            3,
-            "a violated post-commit success-mask invariant must not turn a durable PUT into an error"
-        );
     }
 }
 
@@ -2238,7 +2201,6 @@ impl SetDisks {
                 }
 
                 Self::assign_rename_data_indexes(&mut parts_metadatas);
-                let fallback_file_info = parts_metadatas.get(response_metadata_slot).cloned();
                 let rename_result = SetDisks::rename_data_owned(
                     &commit_disks,
                     RUSTFS_META_TMP_BUCKET,
@@ -2284,17 +2246,7 @@ impl SetDisks {
                 let op_old_dir = rename_commit.data_dir;
                 let cleanup_disks = rename_commit.cleanup_disks;
                 let old_current_size = rename_commit.old_current_size;
-                let mut fi = match rename_commit.committed_file_info.or(fallback_file_info) {
-                    Some(file_info) => file_info,
-                    None => {
-                        warn!(
-                            bucket = %commit_bucket,
-                            object = %commit_object,
-                            "rename_data committed without response metadata"
-                        );
-                        FileInfo::default()
-                    }
-                };
+                let mut fi = rename_commit.committed_file_info;
                 // Do this before any post-commit await so request cancellation cannot
                 // bypass best-effort admission. A process crash before admission
                 // remains subject to the existing scanner reconciliation path.

--- a/rustfs/src/storage/rpc/node_service/disk.rs
+++ b/rustfs/src/storage/rpc/node_service/disk.rs
@@ -1049,7 +1049,7 @@ impl NodeService {
                 .rename_data(
                     &request.src_volume,
                     &request.src_path,
-                    decoded_file_info.value,
+                    &decoded_file_info.value,
                     &request.dst_volume,
                     &request.dst_path,
                 )

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -1150,7 +1150,7 @@ pub(crate) trait StorageDiskRpcExt {
         &self,
         src_volume: &str,
         src_path: &str,
-        file_info: rustfs_filemeta::FileInfo,
+        file_info: &rustfs_filemeta::FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> DiskResult<RenameDataResp>;
@@ -1301,7 +1301,7 @@ where
         &self,
         src_volume: &str,
         src_path: &str,
-        file_info: rustfs_filemeta::FileInfo,
+        file_info: &rustfs_filemeta::FileInfo,
         dst_volume: &str,
         dst_path: &str,
     ) -> DiskResult<RenameDataResp> {

--- a/rustfs/src/storage/storage_api.rs
+++ b/rustfs/src/storage/storage_api.rs
@@ -1305,7 +1305,7 @@ where
         dst_volume: &str,
         dst_path: &str,
     ) -> DiskResult<RenameDataResp> {
-        ecstore_disk::DiskAPI::rename_data(self, src_volume, src_path, file_info, dst_volume, dst_path).await
+        ecstore_disk::DiskAPI::rename_data(self, src_volume, src_path, file_info.clone(), dst_volume, dst_path).await
     }
 
     async fn list_dir(&self, origvolume: &str, volume: &str, dir_path: &str, count: i32) -> DiskResult<Vec<String>> {


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1792

## Summary of Changes
This PR reduces PUT commit fanout metadata cloning in `SetDisks::rename_data` by adding an owned commit path that keeps the per-disk `FileInfo` vector inside the cancellation-resistant coordinator and borrows each entry for the disk rename call. The existing slice-based `rename_data` entry remains as a compatibility wrapper for older call shapes and focused tests.

The disk `rename_data` API now accepts `&FileInfo`; local disk clones only when it must mutate metadata for the durable local commit, while remote disk can encode the borrowed `FileInfo` directly. Ordinary PUT and CompleteMultipartUpload assign per-slot erasure indexes before the owned rename call and consume the returned committed `FileInfo` for response metadata instead of keeping the full vector alive past commit.

The wire payload, `xl.meta` format, bitrot framing, quorum decisions, rollback, fsync ordering, and RPC request/response schema are unchanged.

## Verification
- `cargo check -p rustfs-ecstore --lib`
- `cargo check -p rustfs --lib`
- `cargo test -p rustfs-ecstore --lib set_disk::core::io_primitives::tests::rename_data -- --nocapture`
- `cargo test -p rustfs-ecstore --lib inline_put_direct_commit -- --nocapture`
- `cargo clippy -p rustfs-ecstore --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check_logging_guardrails.sh`

## Impact
No user-facing API, configuration, deployment, or on-disk compatibility change is expected. The intended impact is lower per-object allocation/clone pressure on PUT and multipart commit fanout, especially when the coordinator targets remote disks.

High-risk validation summary: correctness attacked quorum-1 rollback, delete marker metadata, inline exact quorum and post-encode rename failures with focused tests; concurrency/durability attacked cancellation-resistant coordinator ownership, rollback and post-commit cleanup ordering with no break found; compatibility attacked RPC wire shape, `RenameDataResp`, `FileInfo` encoding, `xl.meta`, and bitrot layout with no format change found; security attacked secret/log/auth/path surfaces and found no new untrusted input or secret exposure; performance attacked per-disk `FileInfo` cloning and confirmed the remote fanout clone is removed while local durable commit still keeps its required local mutable copy; test coverage maps the changed path to existing rename_data and inline PUT commit tests.

## Additional Notes
This does not claim an end-to-end Warp throughput improvement by itself; it is a narrow hot-path allocation reduction. Fleet validation should still use the same allocator, stage-metrics gate, and ABBA discipline as the ongoing small PUT investigation.
