### PR TITLE
test(scanner): refresh metadata after fixture mutation

### DIFF
--- a/crates/scanner/src/scanner_io.rs
+++ b/crates/scanner/src/scanner_io.rs
@@ -4262,6 +4262,7 @@ mod tests {
             .delete_bucket(&bucket, &DeleteBucketOptions::default())
             .await
             .expect("bucket should be removed from the first pool only");
+        init_bucket_metadata_sys_for_scanner_tests(store.clone()).await;
 
         let ctx = CancellationToken::new();
         let budget = ScannerCycleBudget::new(&ctx, ScannerCycleBudgetConfig::default());


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1860

## Summary of Changes

Refresh the scanner test's instance-scoped bucket metadata system after removing the fixture bucket from the first pool. This keeps the authoritative metadata view aligned with the final per-pool disk layout before the scanner cycle starts.

## Verification

- `make pre-commit`
- `cargo fmt --all --check`
- `git diff --check origin/main`
- `cargo nextest run --profile ci -j1 -p rustfs-scanner -E 'test(scanner_cache_locks_block_same_source_workers) | test(scanner_cache_locks_allow_cross_source_workers) | test(scanner_cycle_is_deferred_while_rebalance_is_active) | test(multi_pool_scanner_cycle_publishes_combined_usage) | test(multi_pool_scanner_cycle_zero_fills_bucket_absent_from_first_pool)' --status-level pass --final-status-level fail`

## Impact

Test-only change. Production scanner behavior, APIs, configuration, and persisted formats are unchanged.

## Additional Notes

N/A
