### PR TITLE
chore(release): prepare 1.0.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9227,7 +9227,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "const-str",
@@ -9250,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9266,7 +9266,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "chrono",
  "hotpath",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "insta",
@@ -9297,7 +9297,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "const-str",
  "hotpath",
@@ -9307,7 +9307,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9321,7 +9321,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9342,7 +9342,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "rmp-serde",
@@ -9352,7 +9352,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -9491,7 +9491,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "serde",
@@ -9501,7 +9501,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9528,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -9559,7 +9559,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "bytes",
  "hotpath",
@@ -9613,7 +9613,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "criterion",
  "hotpath",
@@ -9677,7 +9677,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "bytes",
  "futures",
@@ -9704,7 +9704,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9753,7 +9753,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -9776,7 +9776,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "compact_str",
@@ -9799,7 +9799,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "chrono",
  "flate2",
@@ -9818,7 +9818,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "humantime",
@@ -9833,7 +9833,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9868,7 +9868,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "criterion",
  "futures",
@@ -9888,7 +9888,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "bytes",
  "criterion",
@@ -9905,7 +9905,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9960,7 +9960,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9991,7 +9991,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -10053,7 +10053,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "flatbuffers",
  "hotpath",
@@ -10077,7 +10077,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "byteorder",
  "bytes",
@@ -10095,7 +10095,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -10133,7 +10133,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -10156,7 +10156,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "rustfs-s3-types",
@@ -10164,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "serde",
@@ -10173,7 +10173,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10203,7 +10203,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10222,7 +10222,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "thiserror 2.0.20",
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10288,7 +10288,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10303,7 +10303,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10357,7 +10357,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "hotpath",
  "rustfs-data-usage",
@@ -10373,7 +10373,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arc-swap",
  "hotpath",
@@ -10394,7 +10394,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -10431,7 +10431,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10473,7 +10473,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.97.1"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -86,52 +86,52 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-rc.1" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.1" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.1" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.1" }
-rustfs-common = { path = "crates/common", version = "1.0.0-rc.1" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.1" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-rc.1" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.1" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.1" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.1" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.1" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.1" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.1" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.1" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.1" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.1" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.1" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.1" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.1" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.1" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.1" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.1" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.1", default-features = false }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.1" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.1" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.1" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.1" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.1" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.1" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.1" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.1" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.1" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.1" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.1" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.1" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.1" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.1" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.1" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.1" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.1" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.1" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.1" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.1" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.1" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.1" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.1" }
+rustfs = { path = "./rustfs", version = "1.0.0-rc.2" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.2" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.2" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.2" }
+rustfs-common = { path = "crates/common", version = "1.0.0-rc.2" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.2" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-rc.2" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.2" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.2" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.2" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.2" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.2" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.2" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.2" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.2" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.2" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.2" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.2" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.2" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.2" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.2" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.2" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.2", default-features = false }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.2" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.2" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.2" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.2" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.2" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.2" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.2" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.2" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.2" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.2" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.2" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.2" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.2" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.2" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.2" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.2" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.2" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.2" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.2" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.2" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.2" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.2" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.2" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.1
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.2
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.1
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.2
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-rc.1";
+            version = "1.0.0-rc.2";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "1.0.0-rc.1"
-appVersion: "1.0.0-rc.1"
+version: "1.0.0-rc.2"
+appVersion: "1.0.0-rc.2"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease rc.1
+%global prerelease rc.2
 Name:           rustfs
 Version:        1.0.0
-Release:        rc.1
+Release:        rc.2
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Fri Aug 14 2026 overtrue <anzhengchao@gmail.com>
+- Update RPM package to RustFS 1.0.0-rc.2
+
 * Sat Aug 08 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-rc.1
 


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
- Bump workspace packages and release assets to `1.0.0-rc.2`.
- Update Docker examples, Helm metadata, Nix metadata, and the RPM changelog.

## Verification
- `cargo fmt --all --check`
- `cargo metadata --no-deps --format-version 1`
- `make pre-commit`
- `git diff --check`

## Impact
Prepares the repository metadata and packaging assets for the `1.0.0-rc.2` release. No runtime behavior changes.

## Additional Notes
The embedded Console release gate was completed with `v0.1.21` before this version bump.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
