### PR TITLE
test(sse): align KMS context error assertion

### DIFF
--- a/rustfs/src/storage/sse.rs
+++ b/rustfs/src/storage/sse.rs
@@ -4565,11 +4565,9 @@ mod tests {
         })
         .await
         .expect_err("mismatched kms context should fail");
-        assert!(
-            err.message.contains("context") || err.message.contains("Context"),
-            "unexpected error for mismatched kms context: {}",
-            err.message
-        );
+        assert_eq!(err.code, S3ErrorCode::InternalError);
+        assert_eq!(err.message, ApiError::error_code_to_message(&S3ErrorCode::InternalError));
+        assert_eq!(super::kms_data_plane_error_class(&err), "context_mismatch");
 
         manager.stop().await.expect("kms service should stop cleanly");
         reset_sse_dek_provider();


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
N/A

## Summary of Changes
Update the Rio SSE-KMS context mismatch test to verify the redacted S3 error and retained internal `context_mismatch` classification.

## Verification
- `cargo nextest run -p rustfs --features rio-v2 test_sse_kms_roundtrip_persists_and_uses_minio_context`
- `cargo fmt --all --check`
- `cargo clippy -p rustfs -p rustfs-ecstore --all-targets --features rio-v2 -- -D warnings`
- `make pre-commit`
- `git diff --check`

## Impact
Test-only change; no runtime or API behavior changes.

## Additional Notes
Fixes the Rio CI blocker observed while preparing `1.0.0-rc.2`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
