### PR TITLE
fix(ci): pin Docker images to release source

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,6 +94,7 @@ jobs:
       short_sha: ${{ steps.check.outputs.short_sha }}
       is_prerelease: ${{ steps.check.outputs.is_prerelease }}
       create_latest: ${{ steps.check.outputs.create_latest }}
+      source_ref: ${{ steps.check.outputs.source_ref }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -118,6 +119,7 @@ jobs:
           short_sha=""
           is_prerelease=false
           create_latest=false
+          source_ref="$GITHUB_SHA"
 
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             # Triggered by build workflow completion
@@ -137,6 +139,7 @@ jobs:
             # Extract version info from commit message or use commit SHA
             # Use Git to generate consistent short SHA (ensures uniqueness like build.yml)
             short_sha=$(git rev-parse --short "$HEAD_SHA")
+            source_ref="$HEAD_SHA"
 
             # Determine build type based on triggering workflow event and ref
             triggering_event="$TRIGGERING_EVENT"
@@ -261,6 +264,23 @@ jobs:
                 echo "⚠️  Only release versions (latest, v1.0.0, 1.0.0) and prereleases (v1.0.0-alpha1, 1.0.0-beta2) are supported"
                 ;;
             esac
+
+            if [[ "$should_build" == true && "$input_version" != "latest" ]]; then
+              tag_ref="refs/tags/$input_version"
+              if ! git ls-remote --exit-code origin "$tag_ref" >/dev/null 2>&1; then
+                if [[ "$input_version" == v* ]]; then
+                  tag_ref="refs/tags/${input_version#v}"
+                else
+                  tag_ref="refs/tags/v$input_version"
+                fi
+              fi
+
+              if ! git ls-remote --exit-code origin "$tag_ref" >/dev/null 2>&1; then
+                echo "❌ Release tag not found for Docker build: $input_version"
+                exit 1
+              fi
+              source_ref="$tag_ref"
+            fi
           fi
 
           {
@@ -271,6 +291,7 @@ jobs:
             echo "short_sha=$short_sha"
             echo "is_prerelease=$is_prerelease"
             echo "create_latest=$create_latest"
+            echo "source_ref=$source_ref"
           } >> "$GITHUB_OUTPUT"
 
           echo "🐳 Docker Build Summary:"
@@ -281,6 +302,7 @@ jobs:
           echo "  - Short SHA: $short_sha"
           echo "  - Is prerelease: $is_prerelease"
           echo "  - Create latest: $create_latest"
+          echo "  - Source ref: $source_ref"
 
   # Build multi-arch Docker images
   # Strategy: Build images using pre-built binaries from dl.rustfs.com
@@ -308,6 +330,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
+          ref: ${{ needs.build-check.outputs.source_ref }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -397,7 +420,8 @@ jobs:
           LABELS="org.opencontainers.image.title=RustFS"
           LABELS="$LABELS,org.opencontainers.image.description=RustFS distributed object storage system"
           LABELS="$LABELS,org.opencontainers.image.version=$VERSION"
-          LABELS="$LABELS,org.opencontainers.image.revision=${{ github.sha }}"
+          SOURCE_REVISION="$(git rev-parse HEAD)"
+          LABELS="$LABELS,org.opencontainers.image.revision=$SOURCE_REVISION"
           LABELS="$LABELS,org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}"
           LABELS="$LABELS,org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           LABELS="$LABELS,org.opencontainers.image.build-type=$BUILD_TYPE"

--- a/scripts/security/check_preview_release_workflow.sh
+++ b/scripts/security/check_preview_release_workflow.sh
@@ -195,6 +195,13 @@ IFS= read -r -d '' expected_docker_automatic_guard <<'EOF' || true
 EOF
 expected_docker_automatic_guard=${expected_docker_automatic_guard%$'\n'}
 require_job_if "$docker_workflow" "build-check" "$expected_docker_automatic_guard"
+require_line "$docker_workflow" '      source_ref: ${{ steps.check.outputs.source_ref }}' "Docker source ref output"
+require_line "$docker_workflow" '            source_ref="$HEAD_SHA"' "automatic Docker source ref"
+require_line "$docker_workflow" '              source_ref="$tag_ref"' "manual Docker source ref"
+require_line "$docker_workflow" '          ref: ${{ needs.build-check.outputs.source_ref }}' "Docker release source checkout"
+require_line "$docker_workflow" '          SOURCE_REVISION="$(git rev-parse HEAD)"' "Docker source revision resolution"
+require_line "$docker_workflow" '          LABELS="$LABELS,org.opencontainers.image.revision=$SOURCE_REVISION"' "Docker revision label"
+require_absent "$docker_workflow" 'org.opencontainers.image.revision=${{ github.sha }}' "Docker revision must not use the workflow branch SHA"
 
 docker_manual_guard=$(awk '
   $0 == "              *-preview*)" { in_preview = 1 }


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->
N/A

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->
- Check out the commit reported by the completed release workflow before building Docker images.
- Resolve manual version builds to the matching release tag, including the existing optional `v` prefix fallback.
- Set the OCI revision label from the checked-out release source instead of the workflow branch SHA.
- Stop the available-port test from assuming the kernel cannot immediately reuse an ephemeral port.

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->
- `bash scripts/security/check_preview_release_workflow.sh`
- `actionlint .github/workflows/docker.yml`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo nextest run -p rustfs --test embedded_select_snapshot_test select_snapshot_is_stable_during_http_overwrite --no-capture`
- `cargo test -p rustfs-utils --all-features net::test::test_get_available_port -- --exact`
- `make pre-pr` reached the full test suite after passing formatting, guards, Clippy, and script tests; the suite stopped on the same Select snapshot test above, whose focused rerun passed.

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->
Versioned Docker images now use packaging files and revision metadata from the same release source as their downloaded RustFS binary. Runtime and API behavior are unchanged.

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->
This was found while publishing `1.0.0-rc.2`; the Docker workflow will be rerun for that version after merge.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
