### PR TITLE
test(utils): allow ephemeral port reuse

### DIFF
--- a/crates/kms/tests/behavior_backup.rs
+++ b/crates/kms/tests/behavior_backup.rs
@@ -225,8 +225,6 @@ async fn nothing_readable_leaves_the_bundle_unwrapped() {
             "artifact {} carries the raw on-disk record",
             artifact.path
         );
-        // A cheap structural check too: an encrypted payload is not JSON.
-        assert_ne!(payload.first(), Some(&b'{'), "artifact {} looks like plaintext JSON", artifact.path);
     }
 
     // The manifest itself is not encrypted, so assert directly that it carries

--- a/crates/utils/src/net.rs
+++ b/crates/utils/src/net.rs
@@ -659,9 +659,6 @@ mod test {
         // Port should be in valid range (u16 max is always <= 65535)
         assert!(port1 > 0);
         assert!(port2 > 0);
-
-        // Different calls should typically return different ports
-        assert_ne!(port1, port2);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Pull Request Template for RustFS
-->

## Related Issues
<!--
List related issues, e.g. Fixes #123.
Use N/A when there is no related issue.
-->
N/A

## Summary of Changes
<!--
Briefly explain what changed and why reviewers should accept it.
Focus on behavior, compatibility, and review-relevant context.
-->
- Remove the assertion that two consecutive ephemeral-port allocations must differ. The kernel may immediately reuse the same port after each probe drops its listener.
- Remove the assertion that encrypted KMS backup data cannot start with `{`. Any byte is valid at the start of randomized ciphertext; the test still checks that the full plaintext record is absent.

## Verification
<!--
List the commands or checks you ran, for example:
- `make pre-commit`

Use N/A only when verification is not applicable.
-->
- `cargo test -p rustfs-utils --all-features net::test::test_get_available_port -- --exact`
- `cargo test -p rustfs-kms --test behavior_backup nothing_readable_leaves_the_bundle_unwrapped -- --exact`
- `cargo fmt --all --check`
- `git diff --check`

## Impact
<!--
Describe user-facing, compatibility, API, deployment, configuration, or
documentation impact. Use N/A when there is no expected impact.
-->
Test-only. Runtime behavior is unchanged.

## Additional Notes
<!-- Any extra information for reviewers, or N/A. -->
Both failures were invalid assumptions about valid kernel and cryptographic randomness behavior observed in CI.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
