### PR TITLE
fix(ecstore): classify remote inline early-stop misses

### DIFF
--- a/crates/ecstore/src/set_disk/core/io_primitives.rs
+++ b/crates/ecstore/src/set_disk/core/io_primitives.rs
@@ -666,7 +666,8 @@ pub(in crate::set_disk) async fn data_read_early_stop_inline_body_miss_reason(
     parts_metadata: &[FileInfo],
     disks: &[Option<DiskStore>],
 ) -> Option<&'static str> {
-    if !candidate.inline_data() {
+    // `inline_data` excludes remote objects; this diagnostic reports them separately.
+    if !rustfs_utils::http::contains_key_str(&candidate.metadata, rustfs_utils::http::SUFFIX_INLINE_DATA) {
         return Some(GET_METADATA_EARLY_STOP_REASON_DATA_READ_INLINE_NOT_INLINE);
     }
     if candidate.is_compressed()
@@ -6155,6 +6156,13 @@ mod tests {
         assert_eq!(
             data_read_early_stop_inline_body_miss_reason(bucket, object, &not_inline, &parts_metadata, &disks).await,
             Some(GET_METADATA_EARLY_STOP_REASON_DATA_READ_INLINE_NOT_INLINE)
+        );
+
+        let mut remote = candidate.clone();
+        remote.transition_status = TRANSITION_COMPLETE.to_string();
+        assert_eq!(
+            data_read_early_stop_inline_body_miss_reason(bucket, object, &remote, &parts_metadata, &disks).await,
+            Some(GET_METADATA_EARLY_STOP_REASON_DATA_READ_INLINE_REMOTE)
         );
 
         let mut transformed = candidate.clone();


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Report `data_read_inline_remote` when a transitioned object retains inline metadata, while preserving the existing full-fanout read path.

## Verification

- `cargo test -p rustfs-ecstore data_read_early_stop_reports_inline_miss_reasons`
- `make pre-commit`

## Impact

No S3/API or data-path behavior changes; only the early-stop miss category is corrected.

## Additional Notes

The focused test fails with the prior `inline_data()` guard because that helper intentionally excludes remote objects.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
