### PR TITLE
chore(ecstore): drop the client dead_code blanket

### DIFF
--- a/crates/ecstore/src/client/api_error_response.rs
+++ b/crates/ecstore/src/client/api_error_response.rs
@@ -229,17 +229,6 @@ pub fn http_resp_to_error_response(
     err_resp
 }
 
-pub fn err_transfer_acceleration_bucket(bucket_name: &str) -> ErrorResponse {
-    ErrorResponse {
-        status_code: StatusCode::BAD_REQUEST,
-        code: S3ErrorCode::InvalidArgument,
-        message: "The name of the bucket used for Transfer Acceleration must be DNS-compliant and must not contain periods ‘.’."
-            .to_string(),
-        bucket_name: bucket_name.to_string(),
-        ..Default::default()
-    }
-}
-
 pub fn err_entity_too_large(total_size: i64, max_object_size: i64, bucket_name: &str, object_name: &str) -> ErrorResponse {
     let msg = format!(
         "Your proposed upload size ‘{}’ exceeds the maximum allowed object size ‘{}’ for single PUT operation.",
@@ -289,16 +278,6 @@ pub fn err_invalid_argument(message: &str) -> ErrorResponse {
     ErrorResponse {
         status_code: StatusCode::BAD_REQUEST,
         code: S3ErrorCode::InvalidArgument,
-        message: message.to_string(),
-        request_id: "rustfs".to_string(),
-        ..Default::default()
-    }
-}
-
-pub fn err_api_not_supported(message: &str) -> ErrorResponse {
-    ErrorResponse {
-        status_code: StatusCode::NOT_IMPLEMENTED,
-        code: S3ErrorCode::Custom("APINotSupported".into()),
         message: message.to_string(),
         request_id: "rustfs".to_string(),
         ..Default::default()

--- a/crates/ecstore/src/client/api_get_object.rs
+++ b/crates/ecstore/src/client/api_get_object.rs
@@ -135,6 +135,10 @@ impl Object {
         Self { ..Default::default() }
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity reader surface with no caller in this port (backlog#1823)"
+    )]
     fn do_get_request(&self, request: &GetRequest) -> Result<GetResponse, std::io::Error> {
         let _ = request.did_offset_change;
         let _ = request.offset;
@@ -150,12 +154,20 @@ impl Object {
         ))
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity Object reader method with no caller in this port (backlog#1823)"
+    )]
     fn set_offset(&mut self, bytes_read: i64) -> Result<(), std::io::Error> {
         self.curr_offset += bytes_read;
 
         Ok(())
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity Object reader method with no caller in this port (backlog#1823)"
+    )]
     fn read(&mut self, b: &[u8]) -> Result<i64, std::io::Error> {
         let mut read_req = GetRequest {
             is_read_op: true,
@@ -180,6 +192,10 @@ impl Object {
         Ok(response.size)
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity Object reader method with no caller in this port (backlog#1823)"
+    )]
     fn stat(&self) -> Result<ObjectInfo, std::io::Error> {
         if !self.is_started || !self.object_info_set {
             let _ = self.do_get_request(&GetRequest {
@@ -192,6 +208,10 @@ impl Object {
         Ok(self.object_info.clone())
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity Object reader method with no caller in this port (backlog#1823)"
+    )]
     fn read_at(&mut self, b: &[u8], offset: i64) -> Result<i64, std::io::Error> {
         self.curr_offset = offset;
 
@@ -219,6 +239,10 @@ impl Object {
         Ok(response.size)
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity Object reader method with no caller in this port (backlog#1823)"
+    )]
     fn seek(&mut self, offset: i64, whence: i64) -> Result<i64, std::io::Error> {
         if !self.is_started || !self.object_info_set {
             let seek_req = GetRequest {
@@ -253,6 +277,10 @@ impl Object {
         Ok(self.curr_offset)
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity Object reader method with no caller in this port (backlog#1823)"
+    )]
     fn close(&mut self) -> Result<(), std::io::Error> {
         self.is_closed = true;
         Ok(())

--- a/crates/ecstore/src/client/api_put_object.rs
+++ b/crates/ecstore/src/client/api_put_object.rs
@@ -37,7 +37,7 @@ use crate::client::{
     api_put_object_common::optimal_part_info,
     api_put_object_multipart::UploadPartParams,
     api_s3_datatypes::{CompleteMultipartUpload, CompletePart, ObjectPart},
-    constants::{ISO8601_DATEFORMAT, MAX_MULTIPART_PUT_OBJECT_SIZE, MIN_PART_SIZE, TOTAL_WORKERS},
+    constants::{ISO8601_DATEFORMAT, MAX_MULTIPART_PUT_OBJECT_SIZE, MIN_PART_SIZE},
     credentials::SignatureType,
     transition_api::{ReaderImpl, TransitionClient, UploadInfo},
     utils::{is_amz_header, is_minio_header, is_rustfs_header, is_standard_header, is_storageclass_header},

--- a/crates/ecstore/src/client/api_put_object_common.rs
+++ b/crates/ecstore/src/client/api_put_object_common.rs
@@ -30,10 +30,6 @@ pub fn is_object(reader: &ReaderImpl) -> bool {
     matches!(reader, ReaderImpl::ObjectBody(_))
 }
 
-pub fn is_read_at(reader: ReaderImpl) -> bool {
-    matches!(reader, ReaderImpl::ObjectBody(_))
-}
-
 pub fn optimal_part_info(object_size: i64, configured_part_size: u64) -> Result<(i64, i64, i64), std::io::Error> {
     let unknown_size;
     let mut object_size = object_size;

--- a/crates/ecstore/src/client/api_put_object_streaming.rs
+++ b/crates/ecstore/src/client/api_put_object_streaming.rs
@@ -81,18 +81,6 @@ async fn read_multipart_part(reader: &mut ReaderImpl, want: usize) -> Result<Vec
     }
 }
 
-pub struct UploadedPartRes {
-    pub error: std::io::Error,
-    pub part_num: i64,
-    pub size: i64,
-    pub part: ObjectPart,
-}
-
-pub struct UploadPartReq {
-    pub part_num: i64,
-    pub part: ObjectPart,
-}
-
 impl TransitionClient {
     pub async fn put_object_multipart_stream(
         self: Arc<Self>,

--- a/crates/ecstore/src/client/api_s3_datatypes.rs
+++ b/crates/ecstore/src/client/api_s3_datatypes.rs
@@ -29,10 +29,6 @@ use crate::client::utils::base64_decode;
 
 use super::transition_api;
 
-pub struct ListAllMyBucketsResult {
-    pub owner: Owner,
-}
-
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CommonPrefix {
     pub prefix: String,
@@ -89,6 +85,10 @@ pub struct ListVersionsResult {
     pub next_version_id_marker: String,
 }
 
+#[allow(
+    dead_code,
+    reason = "fields of a MinIO-parity list result that this port builds but never reads back (backlog#1823)"
+)]
 pub struct ListBucketResult {
     common_prefixes: Vec<CommonPrefix>,
     contents: Vec<transition_api::ObjectInfo>,
@@ -102,6 +102,10 @@ pub struct ListBucketResult {
     prefix: String,
 }
 
+#[allow(
+    dead_code,
+    reason = "fields of a MinIO-parity list result that this port builds but never reads back (backlog#1823)"
+)]
 pub struct ListMultipartUploadsResult {
     bucket: String,
     key_marker: String,
@@ -117,14 +121,13 @@ pub struct ListMultipartUploadsResult {
     common_prefixes: Vec<CommonPrefix>,
 }
 
+#[allow(
+    dead_code,
+    reason = "fields of a MinIO-parity list result that this port builds but never reads back (backlog#1823)"
+)]
 pub struct Initiator {
     id: String,
     display_name: String,
-}
-
-pub struct CopyObjectResult {
-    pub etag: String,
-    pub last_modified: OffsetDateTime,
 }
 
 #[derive(Debug, Clone)]
@@ -260,6 +263,7 @@ pub struct CompletePart {
 }
 
 impl CompletePart {
+    #[allow(dead_code, reason = "MinIO-parity accessor with no caller in this port (backlog#1823)")]
     fn checksum(&self, t: &ChecksumMode) -> String {
         match t {
             ChecksumMode::ChecksumCRC32C => {
@@ -282,11 +286,6 @@ impl CompletePart {
             }
         }
     }
-}
-
-pub struct CopyObjectPartResult {
-    pub etag: String,
-    pub last_modified: OffsetDateTime,
 }
 
 #[derive(Debug, Default, serde::Serialize)]
@@ -357,29 +356,14 @@ impl CompleteMultipartUpload {
     }
 }
 
-pub struct CreateBucketConfiguration {
-    pub location: String,
-}
-
+#[allow(
+    dead_code,
+    reason = "live via quick_xml::de::from_str in bucket_cache.rs; serde deserialization is not a construction (backlog#1823)"
+)]
 #[derive(serde::Serialize)]
 pub struct DeleteObject {
     //api has
     pub key: String,
-    pub version_id: String,
-}
-
-pub struct DeletedObject {
-    //s3s has
-    pub key: String,
-    pub version_id: String,
-    pub deletemarker: bool,
-    pub deletemarker_version_id: String,
-}
-
-pub struct NonDeletedObject {
-    pub key: String,
-    pub code: String,
-    pub message: String,
     pub version_id: String,
 }
 
@@ -402,6 +386,7 @@ impl DeleteMultiObjects {
         Ok(buf)
     }
 
+    #[allow(dead_code, reason = "MinIO-parity XML helper with no caller in this port (backlog#1823)")]
     pub fn unmarshal(buf: &[u8]) -> Result<Self, std::io::Error> {
         #[derive(Debug, Deserialize)]
         struct WireDeleteObject {
@@ -435,9 +420,4 @@ impl DeleteMultiObjects {
                 .collect(),
         })
     }
-}
-
-pub struct DeleteMultiObjectsResult {
-    pub deleted_objects: Vec<DeletedObject>,
-    pub undeleted_objects: Vec<NonDeletedObject>,
 }

--- a/crates/ecstore/src/client/checksum.rs
+++ b/crates/ecstore/src/client/checksum.rs
@@ -365,6 +365,10 @@ mod tests {
 pub struct Checksum {
     checksum_type: ChecksumMode,
     r: Vec<u8>,
+    #[allow(
+        dead_code,
+        reason = "checksum bookkeeping field kept beside the value it guards (backlog#1823)"
+    )]
     computed: bool,
 }
 

--- a/crates/ecstore/src/client/constants.rs
+++ b/crates/ecstore/src/client/constants.rs
@@ -32,8 +32,5 @@ pub const MAX_MULTIPART_PUT_OBJECT_SIZE: i64 = 1024 * 1024 * 1024 * 1024 * 5;
 pub const UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
 pub const UNSIGNED_PAYLOAD_TRAILER: &str = "STREAMING-UNSIGNED-PAYLOAD-TRAILER";
 
-pub const TOTAL_WORKERS: i64 = 4;
-
-pub const SIGN_V4_ALGORITHM: &str = "AWS4-HMAC-SHA256";
 pub const ISO8601_DATEFORMAT: &[FormatItem<'_>] =
     format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]Z");

--- a/crates/ecstore/src/client/credentials.rs
+++ b/crates/ecstore/src/client/credentials.rs
@@ -67,6 +67,10 @@ impl<P: Provider + Default> Credentials<P> {
         Ok(self.creds.clone())
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity credential surface with no caller in this port (backlog#1823)"
+    )]
     fn expire(&mut self) {
         self.force_refresh = true;
     }
@@ -133,6 +137,10 @@ impl Provider for Static {
 
 #[derive(Debug, Clone, Default)]
 pub struct STSError {
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity STS error detail that this port never reads back (backlog#1823)"
+    )]
     pub r#type: String,
     pub code: String,
     pub message: String,
@@ -141,6 +149,10 @@ pub struct STSError {
 #[derive(Debug, Clone, thiserror::Error)]
 pub struct ErrorResponse {
     pub sts_error: STSError,
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity STS error detail that this port never reads back (backlog#1823)"
+    )]
     pub request_id: String,
 }
 
@@ -157,23 +169,4 @@ impl ErrorResponse {
         }
         return self.sts_error.message.clone();
     }
-}
-
-pub fn xml_decoder<T>(body: &[u8]) -> Result<T, Error>
-where
-    for<'de> T: Deserialize<'de>,
-{
-    match std::str::from_utf8(body) {
-        Ok(xml_body) => quick_xml::de::from_str::<T>(xml_body).map_err(|err| Error::new(ErrorKind::InvalidData, err.to_string())),
-        Err(err) => Err(Error::new(ErrorKind::InvalidData, err.to_string())),
-    }
-}
-
-pub fn xml_decode_and_body<T>(body_reader: &[u8]) -> Result<(Vec<u8>, T), std::io::Error>
-where
-    for<'de> T: Deserialize<'de>,
-{
-    let body = body_reader.to_vec();
-    let parsed = xml_decoder(&body)?;
-    Ok((body, parsed))
 }

--- a/crates/ecstore/src/client/mod.rs
+++ b/crates/ecstore/src/client/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // #730: S3 client compatibility models are kept while ECStore callers move to narrower facades.
-#![allow(dead_code)]
 
 pub mod admin_handler_utils;
 pub mod api_error_response;

--- a/crates/ecstore/src/client/object_api_utils.rs
+++ b/crates/ecstore/src/client/object_api_utils.rs
@@ -77,39 +77,6 @@ fn part_number_to_rangespec(oi: ObjectInfo, part_number: usize) -> Option<HTTPRa
     })
 }
 
-fn get_compressed_offsets(oi: ObjectInfo, offset: i64) -> (i64, i64, i64, i64, u64) {
-    let mut skip_length: i64 = 0;
-    let mut cumulative_actual_size: i64 = 0;
-    let mut first_part_idx: i64 = 0;
-    let mut compressed_offset: i64 = 0;
-    let mut part_skip: i64 = 0;
-    let mut decrypt_skip: i64 = 0;
-    let mut seq_num: u64 = 0;
-    for (i, part) in oi.parts.iter().enumerate() {
-        cumulative_actual_size += part.actual_size as i64;
-        if cumulative_actual_size <= offset {
-            compressed_offset += part.size as i64;
-        } else {
-            first_part_idx = i as i64;
-            skip_length = cumulative_actual_size - part.actual_size as i64;
-            break;
-        }
-    }
-    skip_length = offset - skip_length;
-
-    let parts: &[ObjectPartInfo] = &oi.parts;
-    if skip_length > 0
-        && parts.len() > first_part_idx as usize
-        && parts[first_part_idx as usize].index.as_ref().is_some_and(|idx| idx.len() > 0)
-    {
-        let _ = part_skip;
-        let _ = decrypt_skip;
-        let _ = seq_num;
-    }
-
-    (compressed_offset, part_skip, first_part_idx, decrypt_skip, seq_num)
-}
-
 pub fn new_getobjectreader<'a>(
     rs: &Option<HTTPRangeSpec>,
     oi: &'a ObjectInfo,

--- a/crates/ecstore/src/client/provider_versions.rs
+++ b/crates/ecstore/src/client/provider_versions.rs
@@ -23,6 +23,7 @@ const X_OBS_VERSION_ID: &str = "x-obs-version-id";
 const MAX_REMOTE_VERSION_ID_LEN: usize = 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code, reason = "bucket versioning states kept as a complete vocabulary (backlog#1823)")]
 pub(crate) enum BucketVersioningState {
     Unknown,
     Disabled,
@@ -47,6 +48,7 @@ impl RemoteVersion {
         }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity accessor with no caller in this port (backlog#1823)")]
     pub(crate) fn exact_request_id(&self) -> Result<Option<&str>, Error> {
         match self {
             Self::Unknown => Err(Error::new(

--- a/crates/ecstore/src/client/transition_api.rs
+++ b/crates/ecstore/src/client/transition_api.rs
@@ -101,6 +101,10 @@ where
 
 const C_UNKNOWN: i32 = -1;
 const C_OFFLINE: i32 = 0;
+#[allow(
+    dead_code,
+    reason = "reachable only from the unused transition client methods below (backlog#1823)"
+)]
 const C_ONLINE: i32 = 1;
 
 fn invalid_utf8_header_error(scope: &str, header_name: &str) -> std::io::Error {
@@ -320,6 +324,10 @@ impl TransitionClient {
         Ok(client)
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client surface with no caller in this port (backlog#1823)"
+    )]
     fn endpoint_url(&self) -> Url {
         self.endpoint_url.clone()
     }
@@ -348,12 +356,20 @@ impl TransitionClient {
             .to_string())
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn trace_errors_only_off(&self) {
         if let Ok(mut trace_errors_only) = self.trace_errors_only.lock() {
             *trace_errors_only = false;
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn trace_off(&self) {
         if let Ok(mut is_trace_enabled) = self.is_trace_enabled.lock() {
             *is_trace_enabled = false;
@@ -363,12 +379,20 @@ impl TransitionClient {
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn set_s3_transfer_accelerate(&self, accelerate_endpoint: &str) {
         if let Ok(mut endpoint) = self.s3_accelerate_endpoint.lock() {
             *endpoint = accelerate_endpoint.to_string();
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn set_s3_enable_dual_stack(&self, enabled: bool) {
         if let Ok(mut dual_stack) = self.s3_dual_stack_enabled.lock() {
             *dual_stack = enabled;
@@ -398,10 +422,18 @@ impl TransitionClient {
         (hash_algos, hash_sums)
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn is_online(&self) -> bool {
         !self.is_offline()
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn mark_offline(&self) {
         self.health_status
             .compare_exchange(C_ONLINE, C_OFFLINE, Ordering::SeqCst, Ordering::SeqCst);
@@ -411,10 +443,18 @@ impl TransitionClient {
         self.health_status.load(Ordering::SeqCst) == C_OFFLINE
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn health_check(hc_duration: Duration) {
         let _ = hc_duration;
     }
 
+    #[allow(
+        dead_code,
+        reason = "MinIO-parity transition client method with no caller in this port (backlog#1823)"
+    )]
     fn dump_http(&self, req: &Request<s3s::Body>, resp: &Response<Incoming>) -> Result<(), std::io::Error> {
         let mut resp_trace: Vec<u8>;
 
@@ -1102,6 +1142,7 @@ impl Default for ObjectInfo {
 }
 
 impl ObjectInfo {
+    #[allow(dead_code, reason = "MinIO-parity accessor with no caller in this port (backlog#1823)")]
     pub(crate) fn remote_version(
         &self,
         capabilities: ProviderVersionCapabilities,

--- a/crates/ecstore/src/client/utils.rs
+++ b/crates/ecstore/src/client/utils.rs
@@ -48,10 +48,6 @@ lazy_static! {
     };
 }
 
-pub fn is_standard_query_value(qs_key: &str) -> bool {
-    SUPPORTED_QUERY_VALUES[qs_key]
-}
-
 pub fn is_storageclass_header(header_key: &str) -> bool {
     header_key.to_lowercase() == X_AMZ_STORAGE_CLASS.as_str().to_lowercase()
 }


### PR DESCRIPTION
## What

`client` root — 33 items in the MinIO-derived S3 client. **17 deleted, 16 kept** with reasoned item-level allows.

## Deleted (17), in three groups

**Shell types with no derives and no reference anywhere** — `ListAllMyBucketsResult`, `CopyObjectResult`, `CopyObjectPartResult`, `DeletedObject`, `DeleteMultiObjectsResult` + `NonDeletedObject`, `UploadedPartRes`, `UploadPartReq`, `api_s3_datatypes::CreateBucketConfiguration`. Without a `Deserialize` impl these cannot even be parsed into — MinIO parity that was never wired.

**Cross-crate duplicates** — `client::object_api_utils::get_compressed_offsets` shadows the live `object_api::readers::get_compressed_offsets` that the **production GET path** uses (different signature, no caller). `client::constants::{TOTAL_WORKERS, SIGN_V4_ALGORITHM}` duplicate the live definitions in `crates/signer`.

**Unreferenced helpers** — `err_transfer_acceleration_bucket`, `err_api_not_supported`, `is_read_at`, `xml_decoder` + `xml_decode_and_body`, `is_standard_query_value`.

## One trap worth naming for reviewers

`api_s3_datatypes::CreateBucketConfiguration` is deleted, but **`transition_api` defines a struct of the same name** — and *that* one derives `Serialize, Deserialize` and is the one `bucket_cache.rs` imports and parses XML into:

```rust
// bucket_cache.rs — imports from transition_api, not api_s3_datatypes
transition_api::{CreateBucketConfiguration, LocationConstraint, TransitionClient},
```

Grepping the bare type name, or reading a few lines above the declaration, can attribute the **live** type's derive to the **dead** one. They have to be told apart by module path. (I made exactly that mistake mid-review and corrected it.)

## Kept with allows (16)

The `Object` reader methods and the `TransitionClient` methods are MinIO-parity surface with no caller in this port. These are added **per method rather than on their impl blocks** — `impl TransitionClient` is mostly live, and a block-level allow would be a smaller version of the blanket this issue is removing.

`ListBucketResult`, `ListMultipartUploadsResult` and `Initiator` are *built* by the list helpers but never read back, so their allow sits on the struct. The rest: the checksum bookkeeping field, the STS error details, the bucket-versioning vocabulary, and the transition client's online-state constant.

## Verification

Warning-free in four lanes: default, `--tests`, `--features rio-v2 --tests`, `--features test-util --tests`.

- `cargo nextest run -p rustfs-ecstore` — **4041 passed, 0 failed**
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — clean
- `make pre-commit` — ✅ (exit 0)

Ref rustfs/backlog#1823.
