### PR TITLE
test(interop): let the MinIO fixture lab build from registry mirrors

### DIFF
--- a/crates/rio-v2/tests/minio_fixture_lab/Dockerfile
+++ b/crates/rio-v2/tests/minio_fixture_lab/Dockerfile
@@ -6,9 +6,18 @@
 #
 # The MinIO release is pinned so the captured fixture format is reproducible;
 # this is the release the interop tests were validated against.
-FROM minio/minio:RELEASE.2025-09-07T16-13-09Z AS minio
+#
+# Both base images are build args so a network that cannot reach Docker Hub can
+# point them at a mirror carrying the same content — quay.io publishes the MinIO
+# releases, and public.ecr.aws mirrors the official Python images. CI keeps the
+# Docker Hub defaults. Override with:
+#   --build-arg MINIO_IMAGE=quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z \
+#   --build-arg PYTHON_IMAGE=public.ecr.aws/docker/library/python:3.12-slim
+ARG MINIO_IMAGE=minio/minio:RELEASE.2025-09-07T16-13-09Z
+ARG PYTHON_IMAGE=python:3.12-slim
+FROM ${MINIO_IMAGE} AS minio
 
-FROM python:3.12-slim
+FROM ${PYTHON_IMAGE}
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/crates/rio-v2/tests/minio_fixture_lab/README.md
+++ b/crates/rio-v2/tests/minio_fixture_lab/README.md
@@ -22,6 +22,18 @@ Use the automated path when you want the lab to:
 - upload a predefined SSE fixture case
 - export the generated backend tree into the lab layout
 
+## Networks without Docker Hub access
+
+`capture_via_docker.sh` pulls its two base images from Docker Hub by default. Where that registry is unreachable, point the build at mirrors carrying the same content — quay.io publishes the MinIO releases and public.ecr.aws mirrors the official Python images:
+
+```bash
+MINIO_LAB_MINIO_IMAGE=quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z \
+MINIO_LAB_PYTHON_IMAGE=public.ecr.aws/docker/library/python:3.12-slim \
+./capture_via_docker.sh
+```
+
+Pin the MinIO tag to the same release the Dockerfile names; an unpinned `:latest` captures whatever format that day's build writes, which is not what the interop tests were validated against.
+
 ## Layout
 
 The default root is `artifacts/minio-fixture-lab`, which is already ignored by the repository.

--- a/crates/rio-v2/tests/minio_fixture_lab/capture_via_docker.sh
+++ b/crates/rio-v2/tests/minio_fixture_lab/capture_via_docker.sh
@@ -34,8 +34,19 @@ if [ "${cases[0]}" != "all" ]; then
   done
 fi
 
+# Base images are overridable so a network without Docker Hub access can point
+# them at a mirror (see the Dockerfile header). Unset by default, which keeps the
+# Dockerfile's Docker Hub defaults for CI.
+build_args=()
+if [ -n "${MINIO_LAB_MINIO_IMAGE:-}" ]; then
+  build_args+=(--build-arg "MINIO_IMAGE=${MINIO_LAB_MINIO_IMAGE}")
+fi
+if [ -n "${MINIO_LAB_PYTHON_IMAGE:-}" ]; then
+  build_args+=(--build-arg "PYTHON_IMAGE=${MINIO_LAB_PYTHON_IMAGE}")
+fi
+
 echo ">> building ${IMAGE}"
-docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${IMAGE}" "${SCRIPT_DIR}"
+docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${IMAGE}" "${build_args[@]}" "${SCRIPT_DIR}"
 
 echo ">> capturing fixtures into ${FIXTURE_REL}"
 docker run --rm -v "${REPO_ROOT}:/repo" "${IMAGE}" \


### PR DESCRIPTION
## Why

`crates/rio-v2/tests/fixtures/minio-generated/` is gitignored by design: the MinIO interop fixtures are generated, not checked in, which is why the 10 interop tests are `#[ignore]`d. The generator image hardcoded two Docker Hub base images, so on a network that cannot reach `registry-1.docker.io` the capture script fails at build time and **no fixtures can be produced at all** — silently keeping the entire MinIO SSE interop lane unverifiable rather than merely red.

## What

Both base images become build args with the current Docker Hub values as defaults; `capture_via_docker.sh` forwards `MINIO_LAB_MINIO_IMAGE` / `MINIO_LAB_PYTHON_IMAGE` when set. CI keeps the defaults untouched. The README documents the override and warns against an unpinned `:latest` MinIO tag, since the captured on-disk format is exactly what the interop tests assert against.

## Verified end to end

Generated real fixtures through the mirror path on a Docker-Hub-less network (quay.io for MinIO, public.ecr.aws for Python) and then ran the interop reader tests against them — **the first time these tests have ever actually executed**, since the fixtures never existed in CI or locally:

```
reads_minio_generated_sse_s3_multipart_fixture   ... FAILED
reads_minio_generated_sse_kms_multipart_fixture  ... FAILED
rejects_..._with_truncated_ciphertext            ... ok
rejects_..._with_wrong_kms_key                   ... ok
```

Both positive tests fail with `encrypted object metadata is incomplete`, which **measures** what rustfs/backlog#1638 could until now only argue statically: RustFS cannot read MinIO-encrypted objects, and the first blocker is the detection gate requiring `x-amz-server-side-encryption` — a key MinIO synthesizes at response time and never persists. The two negative tests passing confirms the behavior is at least fail-closed today. Full findings posted on the issue.

This PR is infrastructure only — it changes no product code and fixes none of the blockers; it makes them measurable. The functional fixes are rustfs/backlog#1638's D2, each landing separately.

- `python3 -m pytest test_lab.py` — 13 passed
- `bash -n capture_via_docker.sh`

Refs rustfs/backlog#1638.
