### PR TITLE
chore: drop the remaining product-code dead_code blankets

### DIFF
--- a/crates/checksums/src/base64.rs
+++ b/crates/checksums/src/base64.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![allow(dead_code)]
 
 use base64_simd::STANDARD;
 

--- a/crates/kms/src/encryption/dek.rs
+++ b/crates/kms/src/encryption/dek.rs
@@ -18,8 +18,6 @@
 //! data encryption keys using master keys. It abstracts the encryption
 //! operations so that different backends can share the same encryption logic.
 
-#![allow(dead_code)] // Trait methods may be used by implementations
-
 use crate::error::{KmsError, Result};
 use crate::persisted_observability::{BoundedUnknownFieldName, UnknownFieldSummary};
 use async_trait::async_trait;

--- a/rustfs/src/storage/deadlock_detector.rs
+++ b/rustfs/src/storage/deadlock_detector.rs
@@ -56,7 +56,6 @@
 //! ```
 
 // Allow dead_code for public API that may be used by external modules or future features
-#![allow(dead_code)]
 
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, HashSet};
@@ -264,6 +263,10 @@ pub struct ResourceUsage {
 /// Deadlock detector.
 pub struct DeadlockDetector {
     /// Configuration.
+    #[allow(
+        dead_code,
+        reason = "policy snapshot retained beside the detector it configures (backlog#1823)"
+    )]
     config: RequestHangDetectionPolicy,
     /// Shared concurrency facade policy.
     policy: DeadlockMonitorPolicy,

--- a/rustfs/src/storage/lock_optimizer.rs
+++ b/rustfs/src/storage/lock_optimizer.rs
@@ -31,7 +31,6 @@
 //! ```
 
 // Allow dead_code for public API that may be used by external modules or future features
-#![allow(dead_code)]
 //! # Key Features
 //!
 //! - Early lock release after metadata read

--- a/rustfs/src/storage/s3_api/mod.rs
+++ b/rustfs/src/storage/s3_api/mod.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! Facade modules for incremental S3 API extraction from `ecfs.rs`.
 //!
 //! This file intentionally starts as skeleton-only. Behavior remains in place
@@ -28,18 +26,6 @@ pub(crate) mod bucket;
 pub(crate) mod common;
 pub(crate) mod multipart;
 pub(crate) mod tagging;
-
-pub(crate) fn default_bucket_usecase() -> DefaultBucketUsecase {
-    DefaultBucketUsecase::from_global()
-}
-
-pub(crate) fn default_multipart_usecase() -> DefaultMultipartUsecase {
-    DefaultMultipartUsecase::from_global()
-}
-
-pub(crate) fn default_object_usecase() -> DefaultObjectUsecase {
-    DefaultObjectUsecase::from_global()
-}
 
 /// Resolve the object use-case for a server's request path (backlog#1052 S6):
 /// bind it to the server's own application context so it resolves that

--- a/rustfs/src/table_catalog/iceberg/manifest.rs
+++ b/rustfs/src/table_catalog/iceberg/manifest.rs
@@ -71,6 +71,10 @@ pub(crate) struct DecodedManifest {
     pub partition_spec_id: Option<i32>,
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn manifest_paths_from_manifest_list_avro(data: &[u8]) -> TableCatalogStoreResult<Vec<String>> {
     Ok(manifest_list_references_from_manifest_list_avro(data)?
         .into_iter()
@@ -78,6 +82,10 @@ pub(crate) fn manifest_paths_from_manifest_list_avro(data: &[u8]) -> TableCatalo
         .collect())
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn manifest_list_references_from_manifest_list_avro(
     data: &[u8],
 ) -> TableCatalogStoreResult<Vec<ManifestListReference>> {
@@ -157,6 +165,10 @@ pub(crate) async fn decode_manifest_list_avro_async(data: Vec<u8>) -> TableCatal
         .map_err(|err| TableCatalogStoreError::Internal(format!("manifest-list parser task failed: {err}")))?
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn file_references_from_manifest_avro(
     data: &[u8],
 ) -> TableCatalogStoreResult<Vec<(String, TableMetadataMaintenanceObjectKind)>> {
@@ -166,6 +178,10 @@ pub(crate) fn file_references_from_manifest_avro(
         .collect())
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn data_file_references_from_manifest_avro(data: &[u8]) -> TableCatalogStoreResult<Vec<ManifestDataFileReference>> {
     Ok(decode_manifest_avro(data)?.references)
 }

--- a/rustfs/src/table_catalog/iceberg/validation.rs
+++ b/rustfs/src/table_catalog/iceberg/validation.rs
@@ -103,6 +103,10 @@ pub(crate) fn table_warehouse_index_entry(entry: &TableEntry) -> TableCatalogSto
     })
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 fn table_warehouse_data_dir_path(entry: &TableEntry) -> TableCatalogStoreResult<String> {
     Ok(format!("{}{}", table_warehouse_object_prefix(entry)?, DATA_DIR))
 }
@@ -2414,11 +2418,35 @@ struct SnapshotGraphManifestLocation {
     sequence_number: Option<i64>,
     min_sequence_number: Option<i64>,
     added_snapshot_id: Option<i64>,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     added_files_count: Option<u64>,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     existing_files_count: Option<u64>,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     deleted_files_count: Option<u64>,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     added_rows_count: Option<u64>,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     existing_rows_count: Option<u64>,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     deleted_rows_count: Option<u64>,
     from_manifest_list: bool,
 }

--- a/rustfs/src/table_catalog/identifier.rs
+++ b/rustfs/src/table_catalog/identifier.rs
@@ -87,6 +87,10 @@ impl Namespace {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub struct TableIdentifier {
     warehouse: IdentifierSegment,
     namespace: Namespace,
@@ -94,6 +98,10 @@ pub struct TableIdentifier {
 }
 
 impl TableIdentifier {
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub fn new(warehouse: IdentifierSegment, namespace: Namespace, name: IdentifierSegment) -> Self {
         Self {
             warehouse,
@@ -116,6 +124,10 @@ impl TableIdentifier {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub struct TablePathResolver {
     reserved_prefix: &'static str,
 }
@@ -129,14 +141,26 @@ impl Default for TablePathResolver {
 }
 
 impl TablePathResolver {
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub fn current_pointer_path(&self, table: &TableIdentifier) -> String {
         format!("{}/{}", self.table_root(table), CURRENT_POINTER_FILE)
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub fn metadata_dir_path(&self, table: &TableIdentifier) -> String {
         format!("{}/{}", self.table_root(table), METADATA_DIR)
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub fn metadata_file_path(&self, table: &TableIdentifier, metadata_file_name: &str) -> String {
         format!("{}/{}", self.metadata_dir_path(table), metadata_file_name)
     }
@@ -169,6 +193,10 @@ pub(crate) fn default_namespace_root_prefix() -> String {
     )
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn default_namespace_marker_path(namespace: &Namespace) -> String {
     format!("{}{}/{}", default_namespace_root_prefix(), namespace.storage_id(), NAMESPACE_MARKER_FILE)
 }
@@ -185,6 +213,10 @@ pub(crate) fn default_table_bucket_publication_lock_path() -> String {
     rustfs_common::table_catalog::TABLE_BUCKET_PUBLICATION_LOCK_PATH.to_string()
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn default_table_marker_path(namespace: &Namespace, table: &IdentifierSegment) -> String {
     format!("{}{}/{}", default_table_root_prefix(namespace), table.as_str(), TABLE_MARKER_FILE)
 }
@@ -225,14 +257,26 @@ pub(crate) fn default_table_metadata_file_path(
     format!("{}/{}", default_table_metadata_dir_path(namespace, table), metadata_file_name)
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn default_table_current_pointer_path(namespace: &Namespace, table: &IdentifierSegment) -> String {
     format!("{}{}/{}", default_table_root_prefix(namespace), table.as_str(), CURRENT_POINTER_FILE)
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn default_table_lifecycle_path(namespace: &Namespace, table: &IdentifierSegment) -> String {
     format!("{}{}/{}", default_table_root_prefix(namespace), table.as_str(), LIFECYCLE_FILE)
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn namespace_name_from_marker_path(object_key: &str) -> Option<String> {
     let prefix = default_namespace_root_prefix();
     let suffix = format!("/{NAMESPACE_MARKER_FILE}");
@@ -244,6 +288,10 @@ pub(crate) fn namespace_name_from_marker_path(object_key: &str) -> Option<String
         .map(|value| value.replace('/', "."))
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn table_name_from_marker_path(namespace: &Namespace, object_key: &str) -> Option<String> {
     let prefix = default_table_root_prefix(namespace);
     let suffix = format!("/{TABLE_MARKER_FILE}");

--- a/rustfs/src/table_catalog/mod.rs
+++ b/rustfs/src/table_catalog/mod.rs
@@ -18,8 +18,6 @@
 //! S3 object behavior. It defines the stable internal boundary that later
 //! catalog routes and object guards can share.
 
-#![allow(dead_code)]
-
 use std::{
     collections::{BTreeMap, BTreeSet},
     num::NonZeroUsize,
@@ -87,8 +85,20 @@ pub(crate) const RESERVED_CATALOG_OBJECT_MESSAGE: &str = "Object key is reserved
 pub(crate) const TABLE_BUCKET_CATALOG_TYPE: &str = "iceberg-rest";
 pub(crate) const TABLE_BUCKET_CONFIG_VERSION: u16 = 1;
 pub(crate) const DEFAULT_WAREHOUSE_ID: &str = "default";
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) const TABLE_NAMESPACE_MARKER_VERSION: u16 = 1;
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) const TABLE_RESOURCE_MARKER_VERSION: u16 = 1;
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) const TABLE_METADATA_POINTER_VERSION: u16 = 1;
 pub(crate) const TABLE_CATALOG_ENTRY_VERSION: u16 = 1;
 pub(crate) const TABLE_WAREHOUSE_INDEX_STATE_VERSION: u16 = 2;
@@ -123,9 +133,25 @@ const WAREHOUSE_ROOT: &str = "warehouses";
 const NAMESPACE_ROOT: &str = "namespaces";
 const TABLE_ROOT: &str = "tables";
 const VIEW_ROOT: &str = "views";
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 const NAMESPACE_MARKER_FILE: &str = "namespace.json";
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 const TABLE_MARKER_FILE: &str = "table.json";
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 const CURRENT_POINTER_FILE: &str = "current.json";
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 const LIFECYCLE_FILE: &str = "lifecycle.json";
 const METADATA_DIR: &str = "metadata";
 const DATA_DIR: &str = "data";

--- a/rustfs/src/table_catalog/model.rs
+++ b/rustfs/src/table_catalog/model.rs
@@ -1076,6 +1076,10 @@ pub(crate) enum TableCatalogBackingKind {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum TableCatalogAuthority {
     RustfsSysObject,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     LinearizableMetadataKv,
 }
 
@@ -1083,6 +1087,10 @@ pub(crate) enum TableCatalogAuthority {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum TableCatalogConsistencyMode {
     ConditionalObjectCas,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     LinearizableCas,
 }
 
@@ -1090,6 +1098,10 @@ pub(crate) enum TableCatalogConsistencyMode {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum TableCatalogDurabilityMode {
     StagedCommitLogBeforePointerUpdate,
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     WalBeforeStateMachineApply,
 }
 
@@ -1409,12 +1421,20 @@ pub(crate) struct TableCommitRecoveryReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) struct NamespaceMarker {
     pub version: u16,
     pub namespace: String,
 }
 
 impl NamespaceMarker {
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub fn new(namespace: &Namespace) -> Self {
         Self {
             version: TABLE_NAMESPACE_MARKER_VERSION,
@@ -1423,11 +1443,19 @@ impl NamespaceMarker {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn namespace_marker_json(namespace: &Namespace) -> Result<Vec<u8>, serde_json::Error> {
     serde_json::to_vec(&NamespaceMarker::new(namespace))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) struct TableMarker {
     pub version: u16,
     pub namespace: String,
@@ -1436,6 +1464,10 @@ pub(crate) struct TableMarker {
 }
 
 impl TableMarker {
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub fn new(namespace: &Namespace, table: &IdentifierSegment) -> Self {
         Self {
             version: TABLE_RESOURCE_MARKER_VERSION,
@@ -1446,17 +1478,29 @@ impl TableMarker {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn table_marker_json(namespace: &Namespace, table: &IdentifierSegment) -> Result<Vec<u8>, serde_json::Error> {
     serde_json::to_vec(&TableMarker::new(namespace, table))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) struct TableMetadataPointer {
     pub version: u16,
     pub metadata_location: String,
 }
 
 impl TableMetadataPointer {
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub fn new(metadata_location: String) -> Self {
         Self {
             version: TABLE_METADATA_POINTER_VERSION,
@@ -1465,10 +1509,18 @@ impl TableMetadataPointer {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn table_metadata_pointer_json(metadata_location: String) -> Result<Vec<u8>, serde_json::Error> {
     serde_json::to_vec(&TableMetadataPointer::new(metadata_location))
 }
 
+#[allow(
+    dead_code,
+    reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+)]
 pub(crate) fn parse_table_metadata_pointer(data: &[u8]) -> Result<TableMetadataPointer, serde_json::Error> {
     serde_json::from_slice(data)
 }

--- a/rustfs/src/table_catalog/store/mod.rs
+++ b/rustfs/src/table_catalog/store/mod.rs
@@ -164,6 +164,10 @@ pub(crate) trait TableCatalogStore: Send + Sync {
         ))
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     async fn list_namespaces_page(
         &self,
         table_bucket: &str,
@@ -193,8 +197,16 @@ pub(crate) trait TableCatalogStore: Send + Sync {
 
     async fn drop_namespace(&self, table_bucket: &str, namespace: &str) -> TableCatalogStoreResult<()>;
 
+    #[allow(
+        dead_code,
+        reason = "declared trait method: implementors provide it but no caller dispatches through the trait yet (backlog#1823)"
+    )]
     async fn create_table(&self, entry: TableEntry) -> TableCatalogStoreResult<()>;
 
+    #[allow(
+        dead_code,
+        reason = "declared trait method: implementors provide it but no caller dispatches through the trait yet (backlog#1823)"
+    )]
     async fn register_table(&self, entry: TableEntry) -> TableCatalogStoreResult<()>;
 
     async fn register_table_with_publication(
@@ -250,6 +262,10 @@ pub(crate) trait TableCatalogStore: Send + Sync {
     ///
     /// Callers publishing client-supplied Iceberg metadata must validate its logical shape and the physical graph of
     /// newly introduced or changed snapshots before invoking this persistence boundary.
+    #[allow(
+        dead_code,
+        reason = "declared trait method: implementors provide it but no caller dispatches through the trait yet (backlog#1823)"
+    )]
     async fn commit_table(&self, request: TableCommitRequest) -> TableCatalogStoreResult<TableCommitResult>;
 
     async fn commit_table_with_publication(
@@ -495,6 +511,10 @@ pub(crate) struct TableCatalogLockGuard {
 }
 
 impl TableCatalogLockGuard {
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) fn stable(guard: impl Send + 'static) -> Self {
         Self {
             _guard: Box::new(guard),
@@ -615,6 +635,10 @@ pub(crate) trait TableCatalogObjectBackend: Clone + Send + Sync + 'static {
 
     async fn object_exists(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<bool>;
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     async fn object_exists_unlocked(&self, bucket: &str, object: &str) -> TableCatalogStoreResult<bool> {
         self.object_exists(bucket, object).await
     }
@@ -1006,6 +1030,10 @@ where
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) fn backing_mode(&self) -> TableCatalogBackingMode {
         match self {
             Self::ObjectBacked(_) => TableCatalogBackingMode::ObjectBacked,
@@ -1529,6 +1557,10 @@ where
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) async fn get_external_catalog_bridge(
         &self,
         table_bucket: &str,
@@ -1541,6 +1573,10 @@ where
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) async fn put_external_catalog_bridge(
         &self,
         entry: ExternalCatalogBridgeEntry,

--- a/rustfs/src/table_catalog/store/object.rs
+++ b/rustfs/src/table_catalog/store/object.rs
@@ -1270,6 +1270,10 @@ where
         Ok(Some((entry, etag)))
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     async fn write_table_entry(
         &self,
         entry: TableEntry,
@@ -1690,6 +1694,10 @@ where
         Ok(config)
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) async fn put_table_bucket_maintenance_config(
         &self,
         table_bucket: &str,
@@ -3006,6 +3014,10 @@ where
         table_compaction_planning_report(&self.backend, table_bucket, &namespace, &table, &entry, &current_metadata, config).await
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) async fn commit_table_compaction(
         &self,
         table_bucket: &str,
@@ -3559,6 +3571,10 @@ where
         Ok(report)
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) async fn delete_table_metadata_maintenance_candidates(
         &self,
         table_bucket: &str,
@@ -3573,6 +3589,10 @@ where
             .await
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(crate) async fn run_table_metadata_maintenance(
         &self,
         table_bucket: &str,
@@ -3754,6 +3774,10 @@ where
         Ok(report)
     }
 
+    #[allow(
+        dead_code,
+        reason = "exercised by table_catalog/tests.rs; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     pub(in crate::table_catalog) async fn delete_table_metadata_maintenance_report(
         &self,
         table_bucket: &str,


### PR DESCRIPTION
## What

The six blankets outside ecstore — the last ones sitting on **product code**. 46 items exposed, **three deleted**.

## Two of the six were suppressing nothing at all

`crates/checksums/src/base64.rs` and `crates/kms/src/encryption/dek.rs` both go **warning-free the moment the blanket comes off**. `rustfs/src/storage/lock_optimizer.rs` is the same story.

The kms one carried this comment:

```rust
#![allow(dead_code)] // Trait methods may be used by implementations
```

That reads like a considered technical reason, but it defends against a problem that does not exist: `DekCrypto`, `AesDekCrypto` and their neighbours are re-exported from `encryption/mod.rs`, so they are **publicly reachable** — `dead_code` never applied to them.

## Deleted (3)

All in `rustfs/src/storage/s3_api/mod.rs`: `default_bucket_usecase`, `default_multipart_usecase`, `default_object_usecase`.

The last is a **dead twin of the live function of the same name** in `admin/runtime_sources.rs:49`, which `admin/router.rs` imports and calls at :2916. The other two have no caller at all.

## Kept with allows (43)

The `table_catalog` cluster — 41 items across `identifier`, `model`, `iceberg/{manifest,validation}` and the store layer — is exercised by `table_catalog/tests.rs`, so it only reads as dead in the lib target. Plus one write-only policy-snapshot field in `deadlock_detector.rs`.

**Three of those allows sit on trait method *declarations***, not implementations: `create_table`, `register_table`, `commit_table` in `store/mod.rs` have no body, so implementors must supply them while no caller dispatches through the trait yet. Their reason says exactly that, rather than the test-consumer wording used elsewhere in this diff — which would have described the wrong layer.

## Verification

- `cargo check --tests` warning-free for `rustfs`, `rustfs-checksums`, `rustfs-kms`
- `cargo clippy --lib --tests -- -D warnings` clean for all three
- `make pre-commit` — ✅ (exit 0)

## What is deliberately left

Six blankets remain repo-wide, **all in test-support files**: `crates/kms/tests/common`, `crates/e2e_test/*` (4), `crates/protocols/src/sftp/test_support.rs`, `common/dummy_storage.rs`.

Those are a different shape — an integration-test harness where each test binary uses a different slice of the module, which is what the kms one's own comment states. Left for a separate judgement rather than folded into this sweep.

Ref rustfs/backlog#1823.
