### PR TITLE
chore(ecstore): annotate the two dead fns the blanket removals missed

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4379,6 +4379,10 @@ pub async fn expire_transitioned_object(
     Ok(dobj)
 }
 
+#[allow(
+    dead_code,
+    reason = "MinIO-parity tier/lifecycle entry point that this port never wired (backlog#1823)"
+)]
 pub fn gen_transition_objname(bucket: &str) -> Result<String, Error> {
     let us = Uuid::new_v4().to_string();
     let mut hasher = Sha256::new();

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -1375,6 +1375,7 @@ pub fn conv_part_err_to_int(err: &Option<Error>) -> usize {
     }
 }
 
+#[allow(dead_code, reason = "asserted by this file's tests (backlog#1823)")]
 pub fn has_part_err(part_errs: &[usize]) -> bool {
     part_errs.iter().any(|err| *err != CHECK_PART_SUCCESS)
 }


### PR DESCRIPTION
## What

Adds the `#[allow(dead_code, reason = ...)]` annotation to `has_part_err` and `gen_transition_objname`, matching how their siblings were handled in #6139 and #6147.

## Why

Those two commits dropped the `disk` and `bucket` `dead_code` blankets and annotated each surviving item, but these two were left bare. Both are dead to the compiler, so `-D warnings` fails and **main is currently red on every clippy lane**: `Test and Lint (rio-v2)` and `Test and Lint (swift)` fail outright, and the rest — `Test and Lint`, `ILM Integration (serial)`, the E2E gates — are cancelled behind them. Every open PR inherits it; that is how this was found (#6151).

```
error: function `gen_transition_objname` is never used
  --> crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs:4382:8
error: function `has_part_err` is never used
  --> crates/ecstore/src/disk/mod.rs:1378:8
```

## Why annotate rather than delete

Neither is stale in the sense that would justify removal:

- `has_part_err` is exercised by tests in its own file and in `set_disk/mod.rs` — hence "asserted by this file's tests", the wording used for the same case in #6147.
- `gen_transition_objname` is a MinIO-parity tier/lifecycle entry point this port never wired, the same class as `audit_tier_actions` a few lines above it, whose annotation it copies.

backlog#1823 continues to track both.

## Verification

`cargo clippy -p rustfs -p rustfs-ecstore --all-targets --features rio-v2 -- -D warnings` — the failing lane's own command — passes with this change. On an unmodified tree at this base it reproduces both errors, which is what confirmed the breakage is pre-existing rather than introduced by any open PR.

`cargo fmt --all --check` passes.

Refs #6139, #6147.
