### PR TITLE
fix(ecstore): silence two dead_code warnings left on main

### DIFF
--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -4379,6 +4379,10 @@ pub async fn expire_transitioned_object(
     Ok(dobj)
 }
 
+#[allow(
+    dead_code,
+    reason = "MinIO-parity tier/lifecycle entry point that this port never wired (backlog#1823)"
+)]
 pub fn gen_transition_objname(bucket: &str) -> Result<String, Error> {
     let us = Uuid::new_v4().to_string();
     let mut hasher = Sha256::new();

--- a/crates/ecstore/src/disk/mod.rs
+++ b/crates/ecstore/src/disk/mod.rs
@@ -1375,6 +1375,7 @@ pub fn conv_part_err_to_int(err: &Option<Error>) -> usize {
     }
 }
 
+#[allow(dead_code, reason = "asserted by this file's tests (backlog#1823)")]
 pub fn has_part_err(part_errs: &[usize]) -> bool {
     part_errs.iter().any(|err| *err != CHECK_PART_SUCCESS)
 }

--- a/crates/ecstore/src/set_disk/mod.rs
+++ b/crates/ecstore/src/set_disk/mod.rs
@@ -102,9 +102,7 @@ use crate::storage_api_contracts::{
 };
 use crate::store::utils::is_reserved_or_invalid_bucket;
 use crate::{
-    bucket::lifecycle::bucket_lifecycle_ops::{
-        LifecycleOps, gen_transition_objname, get_transitioned_object_reader_with_tier_manager, put_restore_opts,
-    },
+    bucket::lifecycle::bucket_lifecycle_ops::{LifecycleOps, get_transitioned_object_reader_with_tier_manager, put_restore_opts},
     cache_value::metacache_set::{ListPathRawOptions, list_path_raw},
     config::storageclass,
     disk::{


### PR DESCRIPTION
## main is emitting two dead_code warnings

```
bucket/lifecycle/bucket_lifecycle_ops.rs:4382  gen_transition_objname is never used
disk/mod.rs:1378                               has_part_err is never used
```

That fails `clippy -D warnings` for every PR.

## Why they slipped through

Both surface from removing the `bucket` and `disk` module blankets in #6147 and #6139 — **but neither appeared in those PRs' warning lists.** main lost their last non-test callers between those branches being cut and merged, so the combination only warns once both landed.

Same shape as the earlier kms merge race and the type-alias interaction between #6087 and #6078: **each side green alone, red after the merge.** Without a merge queue this class only shows up post-merge.

## The fix

`has_part_err` is asserted by the tests directly below it → allow.

`gen_transition_objname` needed **both halves**:
- an allow on the function, and
- removal of its import in `set_disk/mod.rs:105`, which imports the name without calling it.

An allow alone leaves an `unused_imports` error. `cargo check` and `pre-commit` both report that only as a *warning* while `clippy -D warnings` fails on it — the same gap #6147 hit at the end, so this PR verifies with clippy rather than waiting for CI to say so.

## Verification

- `cargo check -p rustfs-ecstore` clean for lib **and** `--tests`
- `cargo check -p rustfs` clean
- `cargo clippy -p rustfs-ecstore --lib --tests -- -D warnings` — clean
- `cargo nextest run -p rustfs-ecstore --lib` — **4069 passed**
- `make pre-commit` — ✅ (exit 0)
