### PR TITLE
fix(scanner): canonicalize temp_dir for drive field assertion on macOS

### DIFF
--- a/crates/scanner/src/scanner_folder.rs
+++ b/crates/scanner/src/scanner_folder.rs
@@ -4621,6 +4621,8 @@ mod tests {
         let _subscriber_guard = tracing::subscriber::set_default(subscriber);
 
         let (mut scanner, temp_dir) = build_test_scanner().await;
+        // Canonicalize for the "drive" field comparison (scanner resolves symlinks).
+        let canonical_temp_dir = std::fs::canonicalize(&temp_dir).unwrap_or_else(|_| temp_dir.clone());
         let _guard = TestGuard::new(60, 100, &mut scanner, temp_dir.clone());
 
         let object_dir = temp_dir.join("bucket").join("object");
@@ -4689,7 +4691,7 @@ mod tests {
         let fields = &events[0]["fields"];
         assert_eq!(fields["component"], LOG_COMPONENT_SCANNER);
         assert_eq!(fields["subsystem"], LOG_SUBSYSTEM_FOLDER);
-        assert_eq!(fields["drive"], temp_dir.to_string_lossy().as_ref());
+        assert_eq!(fields["drive"], canonical_temp_dir.to_string_lossy().as_ref());
         assert_eq!(fields["bucket"], "bucket");
         assert_eq!(fields["object"], "object");
         assert_eq!(fields["metadata_path"], metadata_path.to_string_lossy().as_ref());


### PR DESCRIPTION
## Problem

The test `test_scan_folder_corrupt_xl_meta_stops_erasure_data_dir_descent` fails on macOS due to path canonicalization mismatch.

On macOS, `/var` is a symlink to `/private/var`. The scanner's `local_disk.path()` returns the canonicalized `/private/var/...` path, but `tempfile::tempdir()` returns the non-canonical `/var/...` path. The `drive` field assertion compared them directly and failed.

## Fix

Canonicalize `temp_dir` specifically for the `drive` field comparison, while keeping the non-canonical path for `metadata_path` and `failed_objects` keys (which use the original directory walk paths as-is).

## Verification

- Targeted test passes: `cargo test -p rustfs-scanner test_scan_folder_corrupt_xl_meta_stops_erasure_data_dir_descent`
- `cargo fmt --all --check` passes
- `make pre-pr` runs clean for all checks except a pre-existing flaky performance test (`test_registry_operations_performance` in `rustfs-audit`, 100ms threshold vs 119ms actual on loaded machine — unrelated to this change)
