### PR TITLE
chore: adjudicate 19 bare dead_code allows across six leaf crates

### DIFF
--- a/crates/checksums/src/http.rs
+++ b/crates/checksums/src/http.rs
@@ -38,7 +38,10 @@ pub const XXHASH_3_HEADER_NAME: &str = "x-amz-checksum-xxhash3";
 pub const XXHASH_64_HEADER_NAME: &str = "x-amz-checksum-xxhash64";
 pub const XXHASH_128_HEADER_NAME: &str = "x-amz-checksum-xxhash128";
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "Content-MD5 wire name, resolved by header_name() below and asserted by this crate's tests (backlog#1823)"
+)]
 pub(crate) static MD5_HEADER_NAME: &str = "content-md5";
 
 pub const CHECKSUM_ALGORITHMS_IN_PRIORITY_ORDER: [&str; 5] =

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -476,13 +476,19 @@ impl Checksum for Xxhash64 {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Default)]
+#[allow(
+    dead_code,
+    reason = "Content-MD5 is not a ChecksumAlgorithm variant and has no arm in into_impl: S3 carries it as its own header, separate from the x-amz-checksum-* family. This impl exists so the two paths share the Checksum trait, and is asserted by this crate's tests (backlog#1823)"
+)]
 struct Md5 {
     hasher: md5::Md5,
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "Content-MD5 is not a ChecksumAlgorithm variant and has no arm in into_impl: S3 carries it as its own header, separate from the x-amz-checksum-* family. This impl exists so the two paths share the Checksum trait, and is asserted by this crate's tests (backlog#1823)"
+)]
 impl Md5 {
     fn update(&mut self, bytes: &[u8]) {
         use md5::Digest;

--- a/crates/keystone/src/client.rs
+++ b/crates/keystone/src/client.rs
@@ -31,7 +31,10 @@ pub struct KeystoneClient {
     admin_password: Option<String>,
     admin_project: Option<String>,
     admin_domain: String,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "TLS verification flag parsed from config; the reqwest client is built before it is consulted, so nothing reads it back (backlog#1823)"
+    )]
     verify_ssl: bool,
     /// Request timeout applied to the underlying HTTP client.
     timeout: std::time::Duration,

--- a/crates/keystone/src/identity.rs
+++ b/crates/keystone/src/identity.rs
@@ -20,7 +20,10 @@ use tracing::{debug, info};
 
 /// Maps Keystone identities to RustFS concepts
 pub struct KeystoneIdentityMapper {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "keeps the Keystone client alive for the mapper's lifetime; the mapping paths do not call through it yet (backlog#1823)"
+    )]
     client: Arc<KeystoneClient>,
     role_policy_map: HashMap<String, String>,
     enable_tenant_prefix: bool,

--- a/crates/notify/src/rules/config.rs
+++ b/crates/notify/src/rules/config.rs
@@ -40,7 +40,10 @@ impl RuleEvents for RuleView {
 #[derive(Debug)]
 struct CompiledRules {
     // Keep RulesMap (can be used later if you want to make more complex judgments during the snapshot reading phase)
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "speculative retention: the comment above keeps it for richer snapshot-time judgements that no code performs yet (backlog#1823)"
+    )]
     rules_map: RulesMap,
     // for RulesContainer::iter_rules
     rule_views: Vec<RuleView>,

--- a/crates/notify/src/rules/rules_map.rs
+++ b/crates/notify/src/rules/rules_map.rs
@@ -187,7 +187,6 @@ impl RulesMap {
     /// # Parameters
     /// * `event_name` - The EventName from which to remove the rule.
     /// * `pattern` - The pattern of the rule to be removed.
-    #[allow(dead_code)]
     pub fn remove_rule(&mut self, event_name: &EventName, pattern: &str) {
         let mut remove_event = false;
 
@@ -209,7 +208,6 @@ impl RulesMap {
     ///
     /// # Parameters
     /// * `event_names` - A slice of EventNames to be removed.
-    #[allow(dead_code)]
     pub fn remove_rules(&mut self, event_names: &[EventName]) {
         for event_name in event_names {
             self.map.remove(event_name);
@@ -223,7 +221,6 @@ impl RulesMap {
     /// * `event_name` - The EventName to update.
     /// * `pattern` - The pattern of the rule to be updated.
     /// * `target_id` - The TargetID to be added.
-    #[allow(dead_code)]
     pub fn update_rule(&mut self, event_name: EventName, pattern: String, target_id: TargetID) {
         self.map.entry(event_name).or_default().add(pattern, target_id);
         self.total_events_mask |= event_name.mask(); // Update only the relevant bitmask

--- a/crates/notify/src/rules/target_id_set.rs
+++ b/crates/notify/src/rules/target_id_set.rs
@@ -18,12 +18,6 @@ use rustfs_targets::arn::TargetID;
 /// TargetIDSet - A collection representation of TargetID.
 pub type TargetIdSet = HashSet<TargetID>;
 
-/// Provides a Go-like method for TargetIdSet (can be implemented as trait if needed)
-#[allow(dead_code)]
-pub(crate) fn new_target_id_set(target_ids: Vec<TargetID>) -> TargetIdSet {
-    target_ids.into_iter().collect()
-}
-
 // HashSet has built-in clone, union, difference and other operations.
 // But the Go version of the method returns a new Set, and the HashSet method is usually iterator or modify itself.
 // If you need to exactly match Go's API style, you can add wrapper functions.

--- a/crates/policy/src/policy/function.rs
+++ b/crates/policy/src/policy/function.rs
@@ -219,10 +219,6 @@ impl PartialEq for Functions {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[allow(dead_code)]
-pub struct Value;
-
 #[cfg(test)]
 mod tests {
     use crate::policy::Functions;

--- a/crates/policy/src/policy/utils/wildcard.rs
+++ b/crates/policy/src/policy/utils/wildcard.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[allow(dead_code)]
 pub fn is_simple_match<P, N>(pattern: P, name: N) -> bool
 where
     P: AsRef<str>,
@@ -29,7 +28,10 @@ where
     inner_match(pattern, name, false)
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "prefix-matcher asserted by this file's tests; no production caller yet (backlog#1823)"
+)]
 pub fn is_match_as_pattern_prefix<P, N>(pattern: P, text: N) -> bool
 where
     P: AsRef<str>,

--- a/crates/trusted-proxies/src/cloud/metadata/aws.rs
+++ b/crates/trusted-proxies/src/cloud/metadata/aws.rs
@@ -27,6 +27,10 @@ use crate::CloudMetadataFetcher;
 #[derive(Debug, Clone)]
 pub struct AwsMetadataFetcher {
     client: Client,
+    #[allow(
+        dead_code,
+        reason = "IMDS endpoint retained beside the client it configures; requests build their own URLs (backlog#1823)"
+    )]
     metadata_endpoint: String,
 }
 
@@ -44,55 +48,6 @@ impl AwsMetadataFetcher {
         Self {
             client,
             metadata_endpoint: "http://169.254.169.254".to_string(),
-        }
-    }
-
-    /// Retrieves an IMDSv2 token for secure metadata access.
-    #[allow(dead_code)]
-    async fn get_metadata_token(&self) -> Result<String, AppError> {
-        let url = format!("{}/latest/api/token", self.metadata_endpoint);
-
-        match self
-            .client
-            .put(&url)
-            .header("X-aws-ec2-metadata-token-ttl-seconds", "21600")
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status().is_success() {
-                    let token = response
-                        .text()
-                        .await
-                        .map_err(|e| AppError::cloud(format!("Failed to read IMDSv2 token: {}", e)))?;
-                    Ok(token)
-                } else {
-                    debug!(
-                        event = "trusted_proxies.cloud_metadata",
-                        component = "trusted_proxies",
-                        subsystem = "aws_metadata",
-                        provider = "aws",
-                        operation = "imdsv2_token",
-                        result = "http_error",
-                        status = %response.status(),
-                        "trusted proxy cloud metadata request failed"
-                    );
-                    Err(AppError::cloud("Failed to obtain IMDSv2 token"))
-                }
-            }
-            Err(e) => {
-                debug!(
-                    event = "trusted_proxies.cloud_metadata",
-                    component = "trusted_proxies",
-                    subsystem = "aws_metadata",
-                    provider = "aws",
-                    operation = "imdsv2_token",
-                    result = "request_failed",
-                    error = %e,
-                    "trusted proxy cloud metadata request failed"
-                );
-                Err(AppError::cloud(format!("IMDSv2 request failed: {}", e)))
-            }
         }
     }
 }

--- a/crates/trusted-proxies/src/config/env.rs
+++ b/crates/trusted-proxies/src/config/env.rs
@@ -68,7 +68,6 @@ pub fn is_env_set(key: &str) -> bool {
 }
 
 /// Returns a list of all proxy-related environment variables and their current values.
-#[allow(dead_code)]
 pub fn get_all_proxy_env_vars() -> Vec<(String, String)> {
     let vars = [
         ENV_TRUSTED_PROXY_ENABLED,

--- a/crates/utils/src/io.rs
+++ b/crates/utils/src/io.rs
@@ -68,7 +68,6 @@ pub async fn read_full_or_eof<R: AsyncRead + Send + Sync + Unpin>(
 
 /// Read exactly buf.len() bytes into buf, or return an error if EOF is reached before any bytes are read.
 /// Like Go's io.ReadFull.
-#[allow(dead_code)]
 pub async fn read_full<R: AsyncRead + Send + Sync + Unpin>(reader: R, buf: &mut [u8]) -> std::io::Result<usize> {
     match read_full_or_eof(reader, buf).await? {
         Some(n) => Ok(n),

--- a/crates/utils/src/net.rs
+++ b/crates/utils/src/net.rs
@@ -431,7 +431,6 @@ pub fn parse_and_resolve_address(addr_str: &str) -> std::io::Result<SocketAddr> 
     Ok(resolved_addr)
 }
 
-#[allow(dead_code)]
 pub fn bytes_stream<S, E>(stream: S, content_length: usize) -> impl Stream<Item = Result<Bytes, E>> + Send + 'static
 where
     S: Stream<Item = Result<Bytes, E>> + Send + 'static,

--- a/crates/utils/src/os/fs_type.rs
+++ b/crates/utils/src/os/fs_type.rs
@@ -16,7 +16,6 @@
 ///
 /// The table follows Linux `include/uapi/linux/magic.h`; filesystem magic
 /// values without a stable Linux uapi source stay `UNKNOWN`.
-#[allow(dead_code)]
 pub(crate) fn get_fs_type(fs_type: u64) -> &'static str {
     // Magic numbers for various filesystems.
     match fs_type {

--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -70,7 +70,6 @@ pub fn is_dir_object(object: &str) -> bool {
 ///
 /// If the object name ends with `GLOBAL_DIR_SUFFIX`, it is replaced with a slash.
 /// Otherwise, the name is returned as is.
-#[allow(dead_code)]
 pub fn decode_dir_object(object: &str) -> String {
     if has_suffix(object, GLOBAL_DIR_SUFFIX) {
         format!("{}{}", object.trim_end_matches(GLOBAL_DIR_SUFFIX), SLASH_SEPARATOR)


### PR DESCRIPTION
## What

backlog#1823 **step 10, batch 1** of the repo-wide item-allow sweep. 227 bare `#[allow(dead_code)]` remain across 83 files; this takes the **19** in `utils`, `notify`, `checksums`, `policy`, `keystone` and `trusted-proxies` — small enough to verify end to end.

## Removing all 19 first, before writing any reason, is the point

**8 of them suppress nothing.** Every allow in `utils`, one in `policy` and three in `notify` sit on items that are publicly reachable, so `dead_code` never applied to them — the same shape as the swift module (#6157) and kms's `dek.rs` (#6149).

Writing a reason onto a no-op allow would dress noise up as considered judgement. Those are simply deleted.

## Three items are genuinely dead (deleted with their allows)

`notify::new_target_id_set`, the AWS metadata fetcher's `get_metadata_token`, and policy's empty `pub struct Value;` — none referenced anywhere in the tree.

## Eight keep an allow — now saying *why the item survives*, not *who calls it*

- **Test-only**: checksums' `MD5_HEADER_NAME`, policy's `is_match_as_pattern_prefix`
- **Written but never read back**: keystone's `verify_ssl` (parsed from config *after* the reqwest client is already built), keystone's `client` handle (keeps the client alive for the mapper's lifetime), the AWS IMDS endpoint (kept beside the client while requests build their own URLs), notify's `rules_map` (its own comment retains it for snapshot-time judgements no code performs)

## `checksums::Md5` needed the most care

`Crc32`, `Sha256` and seven others each have an arm in `ChecksumAlgorithm::into_impl`. `Md5` has none — which reads like a missing algorithm.

**It is not.** `ChecksumAlgorithm` has no `Md5` variant at all: S3 carries Content-MD5 as its own header, separate from the `x-amz-checksum-*` family, and this impl exists so both paths share the `Checksum` trait. The reason records that so the next reader does not re-derive it.

## Measurement note for whoever continues this sweep

**cargo does not re-emit warnings for cached compilations**, so a per-crate loop of `cargo check -p <crate>` under-reports. `checksums` showed **zero** that way while actually carrying **three**. Touch the sources and check the crates in one invocation, then attribute by path.

## Verification

- six crates warning-free under `cargo check --tests`
- `clippy --lib --tests -- -D warnings` — clean
- `cargo nextest run` — **1096 passed**
- `make pre-commit` — ✅ (exit 0)

Ref rustfs/backlog#1823.
