### PR TITLE
chore(obs): adjudicate 19 bare dead_code allows

### DIFF
--- a/crates/obs/src/metrics/config.rs
+++ b/crates/obs/src/metrics/config.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 /// Environment variable key for the global default metrics interval (seconds).
 pub const ENV_DEFAULT_METRICS_INTERVAL: &str = "RUSTFS_METRICS_DEFAULT_INTERVAL_SEC";
 /// Default interval for metrics collection if not specified otherwise.
-#[allow(dead_code)]
 pub const DEFAULT_METRICS_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Environment variable key for cluster metrics interval (seconds).

--- a/crates/obs/src/metrics/report.rs
+++ b/crates/obs/src/metrics/report.rs
@@ -145,21 +145,18 @@ impl PrometheusMetric {
     }
 
     #[inline]
-    #[allow(dead_code)]
     pub fn with_label(mut self, key: &'static str, value: impl Into<Cow<'static, str>>) -> Self {
         self.labels.push((key, value.into()));
         self
     }
 
     #[inline]
-    #[allow(dead_code)]
     pub fn with_label_owned(mut self, key: &'static str, value: String) -> Self {
         self.labels.push((key, Cow::Owned(value)));
         self
     }
 
     #[inline]
-    #[allow(dead_code)]
     pub fn with_labels(mut self, labels: Vec<(&'static str, Cow<'static, str>)>) -> Self {
         self.labels = labels;
         self

--- a/crates/obs/src/metrics/schema/entry/descriptor.rs
+++ b/crates/obs/src/metrics/schema/entry/descriptor.rs
@@ -16,7 +16,6 @@ use crate::{MetricName, MetricNamespace, MetricSubsystem, MetricType};
 use std::collections::HashSet;
 
 /// MetricDescriptor - Metric descriptors
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct MetricDescriptor {
     pub name: MetricName,
@@ -52,7 +51,6 @@ impl MetricDescriptor {
     }
 
     /// Get the full metric name in Prometheus style: <namespace>_<subsystem>_<name>
-    #[allow(dead_code)]
     pub fn get_full_metric_name(&self) -> String {
         let namespace = self.namespace.as_str();
         let formatted_subsystem = self.subsystem.as_str();
@@ -61,7 +59,6 @@ impl MetricDescriptor {
     }
 
     /// check whether the label is in the label set
-    #[allow(dead_code)]
     pub fn has_label(&mut self, label: &str) -> bool {
         self.get_label_set().contains(label)
     }

--- a/crates/obs/src/metrics/schema/entry/metric_name.rs
+++ b/crates/obs/src/metrics/schema/entry/metric_name.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 /// The metric name is the individual name of the metric
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MetricName {
     // The generic metric name
@@ -443,7 +442,6 @@ pub enum MetricName {
 }
 
 impl MetricName {
-    #[allow(dead_code)]
     pub fn as_str(&self) -> String {
         match self {
             Self::AuthTotal => "auth_total".to_string(),

--- a/crates/obs/src/metrics/schema/entry/metric_type.rs
+++ b/crates/obs/src/metrics/schema/entry/metric_type.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 /// MetricType - Indicates the type of indicator
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetricType {
     Counter,
@@ -23,7 +22,6 @@ pub enum MetricType {
 
 impl MetricType {
     /// convert the metric type to a string representation
-    #[allow(dead_code)]
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Counter => "counter",
@@ -34,7 +32,6 @@ impl MetricType {
 
     /// Convert the metric type to the Prometheus value type
     /// In a Rust implementation, this might return the corresponding Prometheus Rust client type
-    #[allow(dead_code)]
     pub fn as_prom(&self) -> &'static str {
         match self {
             Self::Counter => "counter.",

--- a/crates/obs/src/metrics/schema/entry/mod.rs
+++ b/crates/obs/src/metrics/schema/entry/mod.rs
@@ -56,7 +56,6 @@ pub fn new_gauge_md(
 }
 
 /// create a new histogram indicator descriptor
-#[allow(dead_code)]
 pub fn new_histogram_md(
     name: impl Into<MetricName>,
     help: impl Into<String>,

--- a/crates/obs/src/metrics/schema/entry/namespace.rs
+++ b/crates/obs/src/metrics/schema/entry/namespace.rs
@@ -19,7 +19,6 @@ pub enum MetricNamespace {
 }
 
 impl MetricNamespace {
-    #[allow(dead_code)]
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::RustFS => "rustfs",

--- a/crates/obs/src/metrics/schema/entry/path_utils.rs
+++ b/crates/obs/src/metrics/schema/entry/path_utils.rs
@@ -14,7 +14,6 @@
 
 /// Format the path to the metric name format
 /// Replace '/' and '-' with '_'
-#[allow(dead_code)]
 pub fn format_path_to_metric_name(path: &str) -> String {
     path.trim_start_matches('/').replace(['/', '-'], "_")
 }

--- a/crates/obs/src/metrics/schema/entry/subsystem.rs
+++ b/crates/obs/src/metrics/schema/entry/subsystem.rs
@@ -102,7 +102,6 @@ impl MetricSubsystem {
     }
 
     /// Get the formatted metric name format string
-    #[allow(dead_code)]
     pub fn as_str(&self) -> String {
         format_path_to_metric_name(self.path())
     }
@@ -151,7 +150,6 @@ impl MetricSubsystem {
     }
 
     /// A convenient way to create custom subsystems directly
-    #[allow(dead_code)]
     pub fn new(path: impl Into<String>) -> Self {
         Self::Custom(path.into())
     }
@@ -176,7 +174,6 @@ impl std::fmt::Display for MetricSubsystem {
     }
 }
 
-#[allow(dead_code)]
 pub mod subsystems {
     use super::MetricSubsystem;
 

--- a/crates/obs/src/telemetry/rolling.rs
+++ b/crates/obs/src/telemetry/rolling.rs
@@ -38,7 +38,10 @@ pub enum Rotation {
     Minutely,
     Hourly,
     Daily,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "constructed only by this file's rolling-appender tests; the lib target cannot see them (backlog#1823)"
+    )]
     Never,
 }
 


### PR DESCRIPTION
## What

backlog#1823 **step 10, batch 2**. Eighteen of the nineteen bare `#[allow(dead_code)]` in `crates/obs` suppress nothing and are deleted; **one was real** and keeps an allow that now says why.

`Rotation::Never` is constructed only by the rolling-appender tests at `rolling.rs:456`, `:477` and `:498`, so the lib target reports it as never constructed. Its allow is restored with that reason.

## Finding it corrected the method used for batch 1

Removing all nineteen and running `cargo check -p rustfs-obs --tests` reported **zero** warnings — even after touching every source file — while `clippy --lib --tests -D warnings` caught `Rotation::Never`.

**cargo's warning output is not a reliable completeness check.** It does not re-emit for cached compilations, and touching the sources did not cover the lib target here. Later batches should treat `clippy -D warnings` as the gate.

Batch 1 (#6161) has been re-checked under clippy with its six crates: clean, so that batch's conclusions stand.

## What this says about obs

Taken with #6086, which cleared this crate's **44 module-level blankets** and left six real items, obs has now had **63 dead-code suppressions examined, of which seven were suppressing anything at all**.

The rest sat on items that are publicly reachable, where `dead_code` never applied — the same shape as the swift module (#6157) and kms's `dek.rs` (#6149).

## Verification

- `clippy --lib --tests -- -D warnings` clean in the **default**, **gpu** and **pyroscope** lanes
- `cargo nextest run -p rustfs-obs` — **324 passed**
- `make pre-commit` — ✅ (exit 0)

Ref rustfs/backlog#1823.
