### PR TITLE
perf(get): avoid memory body stream wrapper

### DIFF
--- a/rustfs/src/app/object_usecase.rs
+++ b/rustfs/src/app/object_usecase.rs
@@ -1074,7 +1074,7 @@ where
 }
 
 impl futures::Stream for MemoryTrackedBytesStream {
-    type Item = std::io::Result<Bytes>;
+    type Item = Result<Bytes, S3StdError>;
 
     fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -1105,7 +1105,8 @@ impl futures::Stream for MemoryTrackedBytesStream {
             return Poll::Ready(Some(Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("materialized GET body length mismatch: expected {}, got {}", this.expected, actual),
-            ))));
+            )
+            .into())));
         }
 
         let Some(bytes) = this.bytes.take() else {
@@ -1129,6 +1130,16 @@ impl futures::Stream for MemoryTrackedBytesStream {
             );
         }
         Poll::Ready(Some(Ok(bytes)))
+    }
+}
+
+impl ByteStream for MemoryTrackedBytesStream {
+    fn remaining_length(&self) -> RemainingLength {
+        if self.emitted || self.bytes.is_none() {
+            RemainingLength::new_exact(0)
+        } else {
+            RemainingLength::new_exact(self.expected)
+        }
     }
 }
 
@@ -4149,7 +4160,7 @@ impl DefaultObjectUsecase {
         let bytes_len = bytes.len();
         let guard = rustfs_io_metrics::track_get_object_buffered_bytes(bytes_len);
         let remaining = usize::try_from(response_content_length.max(0)).unwrap_or(usize::MAX);
-        let blob = StreamingBlob::wrap(MemoryTrackedBytesStream::new(bytes, remaining, source, guard, lifecycle));
+        let blob = StreamingBlob::new(MemoryTrackedBytesStream::new(bytes, remaining, source, guard, lifecycle));
         if let Some(handoff_start) = handoff_start {
             rustfs_io_metrics::record_get_object_response_handoff(
                 "single_chunk",
@@ -12882,7 +12893,10 @@ mod tests {
             .await
             .expect("mismatched memory body must yield an item")
             .expect_err("a short memory body must fail the stream instead of serving a truncated body");
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(
+            err.downcast_ref::<std::io::Error>().map(std::io::Error::kind),
+            Some(std::io::ErrorKind::InvalidData)
+        );
         assert!(stream.next().await.is_none(), "stream must terminate after the error");
     }
 
@@ -12901,7 +12915,22 @@ mod tests {
             .await
             .expect("mismatched memory body must yield an item")
             .expect_err("an over-long memory body must fail the stream instead of serving mismatched bytes");
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(
+            err.downcast_ref::<std::io::Error>().map(std::io::Error::kind),
+            Some(std::io::ErrorKind::InvalidData)
+        );
+    }
+
+    #[test]
+    fn memory_blob_preserves_exact_remaining_length() {
+        let blob = DefaultObjectUsecase::build_memory_bytes_blob(
+            Bytes::from_static(b"hello"),
+            5,
+            GET_MEMORY_BODY_SOURCE_BUFFERED_BODY,
+            GetObjectBodyLifecycle::disabled(),
+        );
+
+        assert_eq!(blob.remaining_length().exact(), Some(5));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1647

## Summary of Changes
Avoid the generic `StreamingBlob::wrap` adapter for in-memory GET response bodies by making `MemoryTrackedBytesStream` implement `s3s::stream::ByteStream` directly.

This keeps the small-object memory/single-chunk path inside the existing `StreamingBlob` contract while preserving exact remaining length, request lifecycle tracking, buffered-byte accounting, first-byte/poll metrics, and length-mismatch fail-closed behavior.

This does not change the non-inline streaming reader path, so objects larger than the in-memory body path continue to use the existing streaming body strategy.

## Verification
- `cargo fmt --all --check`
- `cargo test -p rustfs --lib memory_ -- --nocapture`
- `git diff --check`
- `cargo check -p rustfs --lib`

Attempted but not completed locally:
- `cargo clippy -p rustfs --lib -- -D warnings` was interrupted after a prolonged no-output tail; CI should provide the full clippy signal.

Adversarial review:
- Correctness: no byte/output semantic change; mismatch errors still fail the stream and lifecycle state still completes through the same `MemoryTrackedBytesStream`.
- Simplicity: smaller than introducing a new body type or s3s bypass route; reuses the existing `ByteStream` contract already used by the streaming reader.
- Compatibility: public S3 response body type remains `StreamingBlob`; no wire/API/header changes.
- Concurrency/durability: no lock, permit, or disk-read behavior changes; only materialized in-memory response bodies are affected.
- Performance: removes one generic stream wrapper/poll layer for memory/single-chunk GET bodies; non-inline streaming bodies are unchanged.
- Test coverage: `memory_blob_preserves_exact_remaining_length` fails if the path regresses to `StreamingBlob::wrap`, and existing memory stream tests cover short/over-long body failure plus request guard release.

## Impact
Expected impact is limited to small/materialized GET bodies. Larger non-inline streaming GETs should not regress because their body construction path is unchanged.

This is still a performance candidate: it must be validated with testing1 metrics-on A/B/A or ABBA before claiming throughput improvement.

## Additional Notes
Earlier in this investigation, making the HTTP compression middleware optional when compression is disabled was rejected locally because `CompressionLayer` changes the response body type; skipping it safely would require broader body-type unification, likely adding its own hot-path cost.

The next validation target remains testing1 small-object GET metrics-on A/B, with 1KiB as the primary signal and 4MiB as the >128KiB guardrail.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
