### PR TITLE
chore(release): prepare 1.0.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3764,7 +3764,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e_test"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -9093,7 +9093,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9231,7 +9231,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-audit"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "const-str",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-checksums"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-common"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "chrono",
  "hotpath",
@@ -9288,7 +9288,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-concurrency"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "insta",
@@ -9301,7 +9301,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-config"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "const-str",
  "hotpath",
@@ -9311,7 +9311,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-credentials"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "base64-simd",
  "hmac 0.13.0",
@@ -9325,7 +9325,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-crypto"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9346,7 +9346,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-data-usage"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "rmp-serde",
@@ -9356,7 +9356,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-ecstore"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -9495,7 +9495,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-extension-schema"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "serde",
@@ -9505,7 +9505,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-filemeta"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "byteorder",
@@ -9532,7 +9532,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-heal"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -9563,7 +9563,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-iam"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9604,7 +9604,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-core"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "bytes",
  "hotpath",
@@ -9617,7 +9617,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-io-metrics"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "criterion",
  "hotpath",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-keystone"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "bytes",
  "futures",
@@ -9708,7 +9708,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-kms"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9757,7 +9757,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lifecycle"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -9780,7 +9780,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-lock"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "compact_str",
@@ -9803,7 +9803,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-log-analyzer"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "chrono",
  "flate2",
@@ -9822,7 +9822,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-madmin"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "humantime",
@@ -9837,7 +9837,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-notify"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9872,7 +9872,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-capacity"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "criterion",
  "futures",
@@ -9892,7 +9892,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-object-data-cache"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "bytes",
  "criterion",
@@ -9909,7 +9909,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-obs"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -9964,7 +9964,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-policy"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -9995,7 +9995,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protocols"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -10057,7 +10057,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-protos"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "flatbuffers",
  "hotpath",
@@ -10081,7 +10081,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-replication"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "byteorder",
  "bytes",
@@ -10099,7 +10099,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "aes-gcm",
  "arc-swap",
@@ -10137,7 +10137,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-rio-v2"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -10160,7 +10160,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-ops"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "rustfs-s3-types",
@@ -10168,7 +10168,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3-types"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "serde",
@@ -10177,7 +10177,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-api"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10207,7 +10207,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-s3select-query"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10226,7 +10226,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-scanner"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10266,7 +10266,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-security-governance"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "thiserror 2.0.20",
@@ -10274,7 +10274,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-signer"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -10292,7 +10292,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-storage-api"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "hotpath",
@@ -10307,7 +10307,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-targets"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -10361,7 +10361,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-test-utils"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "hotpath",
  "rustfs-data-usage",
@@ -10377,7 +10377,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-tls-runtime"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "hotpath",
@@ -10398,7 +10398,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-trusted-proxies"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -10435,7 +10435,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-utils"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "base64-simd",
  "blake2",
@@ -10477,7 +10477,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-zip"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/rustfs/rustfs"
 rust-version = "1.97.1"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 homepage = "https://rustfs.com"
 description = "RustFS is a high-performance distributed object storage software built using Rust, one of the most popular languages worldwide. "
 keywords = ["RustFS", "Minio", "object-storage", "filesystem", "s3"]
@@ -86,52 +86,52 @@ redundant_clone = "warn"
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rustfs = { path = "./rustfs", version = "1.0.0-rc.2" }
-rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.2" }
-rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.2" }
-rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.2" }
-rustfs-common = { path = "crates/common", version = "1.0.0-rc.2" }
-rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.2" }
-rustfs-config = { path = "./crates/config", version = "1.0.0-rc.2" }
-rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.2" }
-rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.2" }
-rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.2" }
-rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.2" }
-rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.2" }
-rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.2" }
-rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.2" }
-rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.2" }
-rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.2" }
-rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.2" }
-rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.2" }
-rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.2" }
-rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.2" }
-rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.2" }
-rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.2" }
-rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.2", default-features = false }
-rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.2" }
-rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.2" }
-rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.2" }
-rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.2" }
-rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.2" }
-rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.2" }
-rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.2" }
-rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.2" }
-rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.2" }
-rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.2" }
-rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.2" }
-rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.2" }
-rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.2" }
-rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.2" }
-rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.2" }
-rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.2" }
-rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.2" }
-rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.2" }
-rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.2" }
-rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.2" }
-rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.2" }
-rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.2" }
-rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.2" }
+rustfs = { path = "./rustfs", version = "1.0.0-rc.3" }
+rustfs-heal = { path = "crates/heal", version = "1.0.0-rc.3" }
+rustfs-audit = { path = "crates/audit", version = "1.0.0-rc.3" }
+rustfs-checksums = { path = "crates/checksums", version = "1.0.0-rc.3" }
+rustfs-common = { path = "crates/common", version = "1.0.0-rc.3" }
+rustfs-data-usage = { path = "crates/data-usage", version = "1.0.0-rc.3" }
+rustfs-config = { path = "./crates/config", version = "1.0.0-rc.3" }
+rustfs-concurrency = { path = "./crates/concurrency", version = "1.0.0-rc.3" }
+rustfs-credentials = { path = "crates/credentials", version = "1.0.0-rc.3" }
+rustfs-crypto = { path = "crates/crypto", version = "1.0.0-rc.3" }
+rustfs-ecstore = { path = "crates/ecstore", version = "1.0.0-rc.3" }
+rustfs-filemeta = { path = "crates/filemeta", version = "1.0.0-rc.3" }
+rustfs-iam = { path = "crates/iam", version = "1.0.0-rc.3" }
+rustfs-keystone = { path = "crates/keystone", version = "1.0.0-rc.3" }
+rustfs-lifecycle = { path = "crates/lifecycle", version = "1.0.0-rc.3" }
+rustfs-kms = { path = "crates/kms", version = "1.0.0-rc.3" }
+rustfs-lock = { path = "crates/lock", version = "1.0.0-rc.3" }
+rustfs-madmin = { path = "crates/madmin", version = "1.0.0-rc.3" }
+rustfs-notify = { path = "crates/notify", version = "1.0.0-rc.3" }
+rustfs-io-metrics = { path = "crates/io-metrics", version = "1.0.0-rc.3" }
+rustfs-io-core = { path = "crates/io-core", version = "1.0.0-rc.3" }
+rustfs-object-capacity = { path = "crates/object-capacity", version = "1.0.0-rc.3" }
+rustfs-object-data-cache = { path = "crates/object-data-cache", version = "1.0.0-rc.3", default-features = false }
+rustfs-log-analyzer = { path = "crates/log-analyzer", version = "1.0.0-rc.3" }
+rustfs-obs = { path = "crates/obs", version = "1.0.0-rc.3" }
+rustfs-policy = { path = "crates/policy", version = "1.0.0-rc.3" }
+rustfs-protos = { path = "crates/protos", version = "1.0.0-rc.3" }
+rustfs-protocols = { path = "crates/protocols", version = "1.0.0-rc.3" }
+rustfs-replication = { path = "crates/replication", version = "1.0.0-rc.3" }
+rustfs-rio = { path = "crates/rio", version = "1.0.0-rc.3" }
+rustfs-rio-v2 = { path = "crates/rio-v2", version = "1.0.0-rc.3" }
+rustfs-s3-types = { path = "crates/s3-types", version = "1.0.0-rc.3" }
+rustfs-s3-ops = { path = "crates/s3-ops", version = "1.0.0-rc.3" }
+rustfs-s3select-api = { path = "crates/s3select-api", version = "1.0.0-rc.3" }
+rustfs-s3select-query = { path = "crates/s3select-query", version = "1.0.0-rc.3" }
+rustfs-scanner = { path = "crates/scanner", version = "1.0.0-rc.3" }
+rustfs-security-governance = { path = "crates/security-governance", version = "1.0.0-rc.3" }
+rustfs-extension-schema = { path = "crates/extension-schema", version = "1.0.0-rc.3" }
+rustfs-signer = { path = "crates/signer", version = "1.0.0-rc.3" }
+rustfs-storage-api = { path = "crates/storage-api", version = "1.0.0-rc.3" }
+rustfs-trusted-proxies = { path = "crates/trusted-proxies", version = "1.0.0-rc.3" }
+rustfs-targets = { path = "crates/targets", version = "1.0.0-rc.3" }
+rustfs-test-utils = { path = "crates/test-utils", version = "1.0.0-rc.3" }
+rustfs-tls-runtime = { path = "crates/tls-runtime", version = "1.0.0-rc.3" }
+rustfs-utils = { path = "crates/utils", version = "1.0.0-rc.3" }
+rustfs-zip = { path = "./crates/zip", version = "1.0.0-rc.3" }
 
 # Async Runtime and Networking
 async-channel = "2.5.0"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # Using specific version
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.2
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.3
 ```
 
 If you use [podman](https://github.com/containers/podman) instead of docker, you can install the RustFS with the below command

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -113,7 +113,7 @@ chown -R 10001:10001 data logs
 docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:latest
 
 # 使用指定版本运行
-docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.2
+docker run -d -p 9000:9000 -p 9001:9001 -v $(pwd)/data:/data -v $(pwd)/logs:/logs rustfs/rustfs:1.0.0-rc.3
 ```
 
 如果您通过绑定挂载启用 TLS 证书目录，也请用同样方式准备该目录：

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         {
           default = rustPlatform.buildRustPackage {
             pname = "rustfs";
-            version = "1.0.0-rc.2";
+            version = "1.0.0-rc.3";
 
             src = ./.;
 

--- a/helm/rustfs/Chart.yaml
+++ b/helm/rustfs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustfs
 description: RustFS helm chart to deploy RustFS on kubernetes cluster.
 type: application
-version: "1.0.0-rc.2"
-appVersion: "1.0.0-rc.2"
+version: "1.0.0-rc.3"
+appVersion: "1.0.0-rc.3"
 home: https://rustfs.com
 icon: https://media.sys.truenas.net/apps/rustfs/icons/icon.svg
 maintainers:

--- a/rustfs.spec
+++ b/rustfs.spec
@@ -1,9 +1,9 @@
 %global _enable_debug_packages 0
 %global _empty_manifest_terminate_build 0
-%global prerelease rc.2
+%global prerelease rc.3
 Name:           rustfs
 Version:        1.0.0
-Release:        rc.2
+Release:        rc.3
 Summary:       High-performance distributed object storage for MinIO alternative
 
 License:        Apache-2.0
@@ -58,6 +58,9 @@ install %_builddir/%{name}-%{version}-%{prerelease}/target/%_arch/%_arch-unknown
 %_bindir/rustfs
 
 %changelog
+* Mon Aug 17 2026 唐小鸭 <tangtang1251@qq.com>
+- Update RPM package to RustFS 1.0.0-rc.3
+
 * Fri Aug 14 2026 overtrue <anzhengchao@gmail.com>
 - Update RPM package to RustFS 1.0.0-rc.2
 


### PR DESCRIPTION
## Related Issues

N/A

## Summary of Changes

Prepare the `1.0.0-rc.3` release: bump every release version file from `1.0.0-rc.2` to `1.0.0-rc.3` in one commit (workspace `Cargo.toml` + internal crate dependency versions, `Cargo.lock`, versioned Docker examples in `README.md`/`README_ZH.md`, `flake.nix`, `helm/rustfs/Chart.yaml` version/appVersion, and `rustfs.spec` prerelease/Release plus a new changelog entry).

Motivation: the `1.0.0-rc.2` tag points at a commit that contains the site-replication peer-edit ordering fence but not the hybrid-logical-clock generation fix (#6119, merged after the tag). A deployment on rc.2 can hit the unilateral-removal rejoin fencing bug that #6119 fixes, and downgrading from a future HLC build back to rc.2 leaves nanosecond-scale marks that permanently fence plain-counter origins. rc.3 is cut from a main commit that includes #6119, closing that interval.

## Verification

- `cargo fmt --all --check` — pass
- `make pre-commit` — pass (fmt + arch checks + quick-check)
- `rg -n "1\.0\.0-rc\.2"` across the seven release files — no leftovers outside historical spec changelog entries

## Impact

Version metadata only; no code change. The release itself follows the preview-validated pipeline: preview tag validation precedes the final `1.0.0-rc.3` tag on the same commit.

## Additional Notes

The rc.2 release notes should gain a downgrade warning (tracked separately). PR #6123 (peer-edit fence admissibility hardening) is still in review and intentionally not part of rc.3.
