### PR TITLE
feat(helm): add TLSRoute passthrough support for gateway api

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -273,6 +273,10 @@ uer. `ClusterIssuer` or `Issuer`. |
 | gatewayApi.listeners.http.port| int | `8000` | Gateway API http listener port. |
 | gatewayApi.listeners.https.name | string | `websecure` | Gateway API https listener name. |
 | gatewayApi.listeners.https.port| int | `8443` | Gateway API https listener port. |
+| gatewayApi.listeners.tls.enabled | bool | `false` | Enable a TLS passthrough listener and generate a TLSRoute. |
+| gatewayApi.listeners.tls.name | string | `tls` | Gateway API TLS passthrough listener name. |
+| gatewayApi.listeners.tls.port | int | `443` | Gateway API TLS passthrough listener port. |
+| gatewayApi.listeners.tls.backendPort | int | `null` | Backend service port that terminates TLS; defaults to the console port. |
 | gatewayApi.hostname | string | Hostname to access RustFS via gateway api. |
 | gatewayApi.secretName | string | Secret tls to via RustFS using HTTPS. |
 | gatewayApi.existingGateway.name | string | `""` |  The existing gateway name, instead of creating a new one. |
@@ -446,6 +450,8 @@ rustfs-route   ["example.rustfs.com"]   172m
 ```
 
 Then, via RustFS instance via `https://example.rustfs.com` or `http://example.rustfs.com`.
+
+For end-to-end encryption, set `gatewayApi.listeners.tls.enabled` to `true`. The chart then adds a `TLS` listener with `tls.mode: Passthrough` to the `Gateway` and generates a `TLSRoute` that forwards the encrypted stream to the RustFS service, where TLS is terminated on the backend side. Note that backend TLS termination must be configured on RustFS itself (for example `RUSTFS_TLS_PATH` pointing to server certificates), and the installed Gateway API CRDs must include `TLSRoute`.
 
 # Uninstall
 

--- a/helm/rustfs/templates/gateway-api/gateway.yml
+++ b/helm/rustfs/templates/gateway-api/gateway.yml
@@ -26,5 +26,15 @@ spec:
           - name: {{ include "rustfs.fullname" $ }}-tls
             kind: Secret
   {{- end }}
+  {{- if .tls.enabled }}
+    - name: {{ .tls.name }}
+      port: {{ .tls.port }}
+      protocol: TLS
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/rustfs/templates/gateway-api/tlsroute.yml
+++ b/helm/rustfs/templates/gateway-api/tlsroute.yml
@@ -1,0 +1,25 @@
+{{- if and .Values.gatewayApi.enabled .Values.gatewayApi.listeners.tls.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: {{ include "rustfs.fullname" . }}-tlsroute
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    {{- if .Values.gatewayApi.existingGateway.name }}
+    - name: {{ .Values.gatewayApi.existingGateway.name }}
+      {{- if .Values.gatewayApi.existingGateway.namespace }}
+      namespace: {{ .Values.gatewayApi.existingGateway.namespace }}
+      {{- end }}
+      sectionName: {{ .Values.gatewayApi.listeners.tls.name }}
+    {{- else }}
+    - name: {{ include "rustfs.fullname" $ }}-gateway
+      sectionName: {{ .Values.gatewayApi.listeners.tls.name }}
+    {{- end }}
+  hostnames:
+    - {{ .Values.gatewayApi.hostname }}
+  rules:
+    - backendRefs:
+        - name: {{ include "rustfs.fullname" . }}-svc
+          port: {{ .Values.gatewayApi.listeners.tls.backendPort | default .Values.service.console.port }}
+{{- end }}

--- a/helm/rustfs/values.yaml
+++ b/helm/rustfs/values.yaml
@@ -369,6 +369,12 @@ gatewayApi:
     https:
       name: websecure
       port: 8443
+    tls: # Optional TLS passthrough listener; renders a TLSRoute so TLS terminates at the RustFS backend.
+      enabled: false
+      name: tls
+      port: 443
+      # Service port that terminates TLS on the backend; defaults to the console port.
+      backendPort: null
   hostname: example.rustfs.com
   httpToHttpsRedirect: true
   existingGateway:


### PR DESCRIPTION
## Related Issues

Fixes #3862.

## Summary of Changes

Adds an optional TLS passthrough listener to the Helm chart Gateway API support. When `gatewayApi.listeners.tls.enabled` is set to `true`, the chart renders a `TLS` listener with `tls.mode: Passthrough` on the `Gateway` and generates a `TLSRoute` that forwards the encrypted stream to the RustFS service, so TLS is terminated on the backend side for end-to-end encryption. The feature is opt-in and disabled by default, so existing deployments render identical manifests.

## Verification

- `helm template` with `gatewayApi.enabled=true` and `gatewayApi.listeners.tls.enabled=true` renders the TLS listener and TLSRoute; without the flag it renders no TLS listener and no TLSRoute
- `helm lint ./helm/rustfs`
- `./scripts/test_helm_templates.sh`

## Impact

Adds new opt-in `gatewayApi.listeners.tls.*` values (`enabled`, `name`, `port`, `backendPort`); default values are unchanged. Users enabling passthrough must install Gateway API CRDs that include `TLSRoute` (`gateway.networking.k8s.io/v1`, Standard channel) and configure backend TLS termination on RustFS itself (for example `RUSTFS_TLS_PATH` pointing to server certificates).

## Additional Notes

N/A
