### PR TITLE
chore(ecstore): adjudicate 32 bare dead_code allows

### DIFF
--- a/crates/ecstore/src/bucket/bucket_target_sys.rs
+++ b/crates/ecstore/src/bucket/bucket_target_sys.rs
@@ -1549,8 +1549,8 @@ impl Default for PutObjectOptions {
     }
 }
 
-#[allow(dead_code)]
 impl PutObjectOptions {
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn set_match_etag(&mut self, etag: &str) {
         if etag == "*" {
             self.custom_header
@@ -1561,6 +1561,7 @@ impl PutObjectOptions {
         }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn set_match_etag_except(&mut self, etag: &str) {
         if etag == "*" {
             self.custom_header
@@ -1696,6 +1697,7 @@ impl PutObjectOptions {
         header
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn validate(&self, _c: Arc<TargetClient>) -> Result<(), std::io::Error> {
         //if self.checksum.is_set() {
         /*if !self.trailing_header_support {

--- a/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
+++ b/crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs
@@ -456,16 +456,23 @@ impl<'a> LifecycleExpiryTrace<'a> {
     }
 }
 
-#[allow(dead_code)]
 impl ExpiryStats {
     pub fn missed_tasks(&self) -> i64 {
         self.missed_expiry_tasks.load(Ordering::SeqCst)
     }
 
+    #[allow(
+        dead_code,
+        reason = "asserted by this file's tests; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     fn missed_free_vers_tasks(&self) -> i64 {
         self.missed_freevers_tasks.load(Ordering::SeqCst)
     }
 
+    #[allow(
+        dead_code,
+        reason = "asserted by this file's tests; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     fn missed_tier_journal_tasks(&self) -> i64 {
         self.missed_tier_journal_tasks.load(Ordering::SeqCst)
     }

--- a/crates/ecstore/src/bucket/lifecycle/tier_last_day_stats.rs
+++ b/crates/ecstore/src/bucket/lifecycle/tier_last_day_stats.rs
@@ -80,7 +80,10 @@ impl LastDayTierStats {
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "asserted by this file's tests; the lib target cannot see test-only consumers (backlog#1823)"
+    )]
     fn merge(&self, m: LastDayTierStats) -> LastDayTierStats {
         let mut cl = self.clone();
         let mut cm = m;

--- a/crates/ecstore/src/bucket/lifecycle/tier_sweeper.rs
+++ b/crates/ecstore/src/bucket/lifecycle/tier_sweeper.rs
@@ -177,9 +177,10 @@ fn should_record_remote_delete_failure(err: &std::io::Error) -> bool {
 }
 
 #[derive(Default)]
-#[allow(dead_code)]
 struct ObjSweeper {
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     object: String,
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     bucket: String,
     version_id: Option<Uuid>,
     versioned: bool,
@@ -191,9 +192,9 @@ struct ObjSweeper {
     remote_object: String,
 }
 
-#[allow(dead_code)]
 impl ObjSweeper {
     #[allow(clippy::new_ret_no_self)]
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     pub async fn new(bucket: &str, object: &str) -> Result<Self, std::io::Error> {
         Ok(Self {
             object: object.into(),
@@ -202,17 +203,20 @@ impl ObjSweeper {
         })
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     pub fn with_version(&mut self, vid: Option<Uuid>) -> &Self {
         self.version_id = vid.clone();
         self
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     pub fn with_versioning(&mut self, versioned: bool, suspended: bool) -> &Self {
         self.versioned = versioned;
         self.suspended = suspended;
         self
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     pub fn get_opts(&self) -> lifecycle::ObjectOpts {
         let mut opts = ObjectOpts {
             version_id: self.version_id.clone(),
@@ -226,6 +230,7 @@ impl ObjSweeper {
         opts
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     pub fn set_transition_state(&mut self, info: TransitionedObject) {
         self.transition_tier = info.tier;
         self.transition_status = info.status;
@@ -266,6 +271,7 @@ impl ObjSweeper {
         None
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     pub async fn sweep(&self, api: Arc<ECStore>) {
         let Some(je) = self.should_remove_remote_object() else {
             return;

--- a/crates/ecstore/src/bucket/quota/mod.rs
+++ b/crates/ecstore/src/bucket/quota/mod.rs
@@ -312,9 +312,7 @@ mod tests {
         }
         #[derive(Deserialize)]
         struct LegacyBucketQuota {
-            #[allow(dead_code)]
             quota: Option<u64>,
-            #[allow(dead_code)]
             quota_type: LegacyQuotaType,
         }
         let legacy = serde_json::from_slice::<LegacyBucketQuota>(&json)

--- a/crates/ecstore/src/client/api_get_object.rs
+++ b/crates/ecstore/src/client/api_get_object.rs
@@ -95,7 +95,6 @@ impl TransitionClient {
 }
 
 #[derive(Default)]
-#[allow(dead_code)]
 pub struct GetRequest {
     pub buffer: Vec<u8>,
     pub offset: i64,
@@ -107,11 +106,12 @@ pub struct GetRequest {
     pub setting_object_info: bool,
 }
 
-#[allow(dead_code)]
 pub struct GetResponse {
     pub size: i64,
     //pub error:       error,
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     pub did_read: bool,
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     pub object_info: ObjectInfo,
 }
 

--- a/crates/ecstore/src/client/api_get_options.rs
+++ b/crates/ecstore/src/client/api_get_options.rs
@@ -27,7 +27,6 @@ use tracing::warn;
 use crate::client::api_error_response::err_invalid_argument;
 
 #[derive(Default)]
-#[allow(dead_code)]
 pub struct AdvancedGetOptions {
     pub replication_delete_marker: bool,
     pub is_replication_ready_for_delete_marker: bool,

--- a/crates/ecstore/src/client/api_list.rs
+++ b/crates/ecstore/src/client/api_list.rs
@@ -360,7 +360,6 @@ impl TransitionClient {
 }
 
 #[derive(Default)]
-#[allow(dead_code)]
 pub struct ListObjectsOptions {
     reverse_versions: bool,
     with_versions: bool,

--- a/crates/ecstore/src/client/api_put_object.rs
+++ b/crates/ecstore/src/client/api_put_object.rs
@@ -137,8 +137,8 @@ impl Default for PutObjectOptions {
     }
 }
 
-#[allow(dead_code)]
 impl PutObjectOptions {
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn set_match_etag(&mut self, etag: &str) {
         if etag == "*" {
             self.custom_header.insert("If-Match", HeaderValue::from_static("*"));
@@ -149,6 +149,7 @@ impl PutObjectOptions {
         }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn set_match_etag_except(&mut self, etag: &str) {
         if etag == "*" {
             self.custom_header.insert("If-None-Match", HeaderValue::from_static("*"));
@@ -259,6 +260,7 @@ impl PutObjectOptions {
         header
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn validate(&self, c: TransitionClient) -> Result<(), std::io::Error> {
         //if self.checksum.is_set() {
         /*if !self.trailing_header_support {

--- a/crates/ecstore/src/client/api_remove.rs
+++ b/crates/ecstore/src/client/api_remove.rs
@@ -55,7 +55,6 @@ pub struct RemoveBucketOptions {
 const DELETE_RESPONSE_PREVIEW_LEN: usize = 1024;
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct AdvancedRemoveOptions {
     pub replication_delete_marker: bool,
     pub replication_status: ReplicationStatus,
@@ -465,10 +464,10 @@ impl TransitionClient {
 }
 
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 pub struct RemoveObjectError {
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     object_name: String,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     version_id: String,
     err: Option<std::io::Error>,
 }

--- a/crates/ecstore/src/client/checksum.rs
+++ b/crates/ecstore/src/client/checksum.rs
@@ -372,8 +372,8 @@ pub struct Checksum {
     computed: bool,
 }
 
-#[allow(dead_code)]
 impl Checksum {
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn new(t: ChecksumMode, b: &[u8]) -> Checksum {
         if t.is_set() && b.len() == t.raw_byte_len() {
             return Checksum {
@@ -385,7 +385,7 @@ impl Checksum {
         Checksum::default()
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn new_checksum_string(t: ChecksumMode, s: &str) -> Result<Checksum, std::io::Error> {
         let b = match base64_decode(s.as_bytes()) {
             Ok(b) => b,
@@ -412,7 +412,7 @@ impl Checksum {
         base64_encode(&self.r)
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn raw(&self) -> Option<Vec<u8>> {
         if !self.is_set() {
             return None;

--- a/crates/ecstore/src/client/object_api_utils.rs
+++ b/crates/ecstore/src/client/object_api_utils.rs
@@ -37,16 +37,17 @@ pub struct PutObjReader {
     //pub sealMD5Fn: SealMD5CurrFn,
 }
 
-#[allow(dead_code)]
 impl PutObjReader {
     pub fn new(reader: HashReader) -> Self {
         Self { reader }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn md5_current_hex_string(&self) -> String {
         self.reader.checksum().map(|v| v.encoded).unwrap_or_default()
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn with_encryption(&mut self, enc_reader: HashReader) -> Result<(), std::io::Error> {
         self.reader = enc_reader;
 

--- a/crates/ecstore/src/config/audit.rs
+++ b/crates/ecstore/src/config/audit.rs
@@ -39,7 +39,6 @@ use rustfs_config::{
 };
 use std::sync::LazyLock;
 
-#[allow(dead_code)]
 #[allow(clippy::declare_interior_mutable_const)]
 /// Default KVS for audit webhook settings.
 pub static DEFAULT_AUDIT_WEBHOOK_KVS: LazyLock<KVS> = LazyLock::new(|| {
@@ -117,7 +116,6 @@ pub static DEFAULT_AUDIT_WEBHOOK_KVS: LazyLock<KVS> = LazyLock::new(|| {
     ])
 });
 
-#[allow(dead_code)]
 #[allow(clippy::declare_interior_mutable_const)]
 /// Default KVS for audit MQTT settings.
 pub static DEFAULT_AUDIT_MQTT_KVS: LazyLock<KVS> = LazyLock::new(|| {
@@ -375,7 +373,6 @@ pub static DEFAULT_AUDIT_NATS_KVS: LazyLock<KVS> = LazyLock::new(|| {
     ])
 });
 
-#[allow(dead_code)]
 pub static DEFAULT_AUDIT_PULSAR_KVS: LazyLock<KVS> = LazyLock::new(|| {
     KVS(vec![
         KV {

--- a/crates/ecstore/src/config/heal.rs
+++ b/crates/ecstore/src/config/heal.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::{Error, Result};
 use rustfs_config::server_config::{KV, KVS};
 use rustfs_config::{DEFAULT_HEAL_BITROT_CYCLE_SECS, HEAL_BITROT_CYCLE};
-use rustfs_utils::string::parse_bool;
 use std::sync::LazyLock;
-use std::time::Duration;
 
 pub static DEFAULT_KVS: LazyLock<KVS> = LazyLock::new(|| {
     KVS(vec![KV {
@@ -26,59 +23,3 @@ pub static DEFAULT_KVS: LazyLock<KVS> = LazyLock::new(|| {
         hidden_if_empty: false,
     }])
 });
-
-#[derive(Debug, Default)]
-pub struct Config {
-    pub bitrot: String,
-    pub sleep: Duration,
-    pub io_count: usize,
-    pub drive_workers: usize,
-    pub cache: Duration,
-}
-
-impl Config {
-    pub fn bitrot_scan_cycle(&self) -> Duration {
-        self.cache
-    }
-
-    pub fn get_workers(&self) -> usize {
-        self.drive_workers
-    }
-
-    pub fn update(&mut self, nopts: &Config) {
-        self.bitrot = nopts.bitrot.clone();
-        self.io_count = nopts.io_count;
-        self.sleep = nopts.sleep;
-        self.drive_workers = nopts.drive_workers;
-    }
-}
-
-const RUSTFS_BITROT_CYCLE_IN_MONTHS: u64 = 1;
-
-fn parse_bitrot_config(s: &str) -> Result<Duration> {
-    match parse_bool(s) {
-        Ok(enabled) => {
-            if enabled {
-                Ok(Duration::from_secs_f64(0.0))
-            } else {
-                Ok(Duration::from_secs_f64(-1.0))
-            }
-        }
-        Err(_) => {
-            if !s.ends_with("m") {
-                return Err(Error::other("unknown format"));
-            }
-
-            match s.trim_end_matches('m').parse::<u64>() {
-                Ok(months) => {
-                    if months < RUSTFS_BITROT_CYCLE_IN_MONTHS {
-                        return Err(Error::other(format!("minimum bitrot cycle is {RUSTFS_BITROT_CYCLE_IN_MONTHS} month(s)")));
-                    }
-
-                    Ok(Duration::from_secs(months * 30 * 24 * 60))
-                }
-                Err(err) => Err(Error::other(err)),
-            }
-        }
-    }
-}

--- a/crates/ecstore/src/config/mod.rs
+++ b/crates/ecstore/src/config/mod.rs
@@ -16,7 +16,6 @@
 
 mod audit;
 pub mod com;
-#[allow(dead_code)]
 pub mod heal;
 mod notify;
 mod oidc;

--- a/crates/ecstore/src/core/pools.rs
+++ b/crates/ecstore/src/core/pools.rs
@@ -1996,11 +1996,11 @@ impl PoolMeta {
         Ok(false)
     }
 
-    #[allow(dead_code)]
     pub fn validate(&self, pools: Vec<Arc<Sets>>) -> Result<bool> {
         struct PoolInfo {
             position: usize,
             completed: bool,
+            #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
             decom_started: bool,
         }
 
@@ -4958,13 +4958,19 @@ fn is_disk_online_state(state: &str) -> bool {
 }
 
 #[deprecated(since = "0.1.0", note = "Use fallback_total_capacity_dedup instead")]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "superseded by the replacement named in the comment at pools.rs:5071 (backlog#1823)"
+)]
 fn fallback_total_capacity(disks: &[rustfs_madmin::Disk]) -> usize {
     fallback_total_capacity_dedup(disks)
 }
 
 #[deprecated(since = "0.1.0", note = "Use fallback_free_capacity_dedup instead")]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "superseded by the replacement named in the comment at pools.rs:5071 (backlog#1823)"
+)]
 fn fallback_free_capacity(disks: &[rustfs_madmin::Disk]) -> usize {
     fallback_free_capacity_dedup(disks)
 }

--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -6562,7 +6562,7 @@ impl LocalDisk {
         Ok(f)
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn get_metrics(&self) -> DiskMetrics {
         DiskMetrics::default()
     }

--- a/crates/ecstore/src/services/rebalance/types.rs
+++ b/crates/ecstore/src/services/rebalance/types.rs
@@ -132,7 +132,6 @@ impl RebalanceStopPropagationRecord {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub struct DiskStat {
     pub total_space: u64,

--- a/crates/ecstore/src/services/tier/tier_config.rs
+++ b/crates/ecstore/src/services/tier/tier_config.rs
@@ -16,8 +16,16 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, io};
 use tracing::info;
 
+#[allow(
+    dead_code,
+    reason = "tier config wire version stamped by the parity constructors below (backlog#1823)"
+)]
 const C_TIER_CONFIG_VER: &str = "v1";
 
+#[allow(
+    dead_code,
+    reason = "tier-name validation message reached only from the parity constructors below (backlog#1823)"
+)]
 const ERR_TIER_NAME_EMPTY: &str = "remote tier name empty";
 const WASABI_US_EAST_ENDPOINT: &str = "https://s3.wasabisys.com";
 const WASABI_ALTERNATIVE_ENDPOINTS: &[(&str, &str)] = &[
@@ -264,7 +272,6 @@ impl Clone for TierConfig {
     }
 }
 
-#[allow(dead_code)]
 impl TierConfig {
     pub(crate) fn clone_with_credentials(&self) -> Self {
         Self {
@@ -284,6 +291,7 @@ impl TierConfig {
         }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn endpoint(&self) -> String {
         match self.tier_type {
             TierType::S3 => self.s3.as_ref().map(|s| s.endpoint.clone()).unwrap_or_default(),
@@ -303,6 +311,7 @@ impl TierConfig {
         }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn bucket(&self) -> String {
         match self.tier_type {
             TierType::S3 => self.s3.as_ref().map(|s| s.bucket.clone()).unwrap_or_default(),
@@ -322,6 +331,7 @@ impl TierConfig {
         }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn prefix(&self) -> String {
         match self.tier_type {
             TierType::S3 => self.s3.as_ref().map(|s| s.prefix.clone()).unwrap_or_default(),
@@ -341,6 +351,7 @@ impl TierConfig {
         }
     }
 
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn region(&self) -> String {
         match self.tier_type {
             TierType::S3 => self.s3.as_ref().map(|s| s.region.clone()).unwrap_or_default(),
@@ -457,7 +468,7 @@ impl TierWasabi {
 }
 
 impl TierS3 {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn create<F>(
         name: &str,
         access_key: &str,
@@ -528,7 +539,7 @@ pub struct TierMinIO {
 }
 
 impl TierMinIO {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "MinIO-parity surface with no caller in this port (backlog#1823)")]
     fn create<F>(
         name: &str,
         endpoint: &str,

--- a/crates/ecstore/src/services/tier/tier_gen.rs
+++ b/crates/ecstore/src/services/tier/tier_gen.rs
@@ -14,7 +14,6 @@
 
 use crate::services::tier::tier::TierConfigMgr;
 
-#[allow(dead_code)]
 impl TierConfigMgr {
     pub fn msg_size(&self) -> usize {
         100


### PR DESCRIPTION
## What

Batch 3 of the `dead_code` allow adjudication for backlog#1823 step 10, covering `ecstore`. Every bare `#[allow(dead_code)]` in this crate is now either deleted (because it suppressed nothing, or because the code it covered was unreachable) or replaced with a per-item allow carrying a `reason` that says why the item stays.

Batches 1 and 2 landed in #6161 and #6162.

## Changes

**32 bare allows removed.** Most were module-, struct-, or impl-level blankets. A blanket allow silences the lint for every current *and future* member of the item it covers, so each one was replaced by per-item allows on exactly the members that are actually dead — 38 of them, each with a `reason`.

**One dead cluster deleted rather than annotated.** In `config/heal.rs`, `DEFAULT_KVS` is live (`config/mod.rs`, `config/com.rs` register it), but `Config`, its three methods, `RUSTFS_BITROT_CYCLE_IN_MONTHS`, and `parse_bitrot_config` had no callers anywhere and are unreachable outside the crate (`mod config` is private). Annotating them would have preserved a latent defect: `parse_bitrot_config` returns `Duration::from_secs_f64(-1.0)` on the bitrot-disabled path, which panics, and its month arithmetic (`months * 30 * 24 * 60`) yields 12 hours per month rather than 30 days. Dead and broken is a worse thing to keep than dead alone, so the cluster is gone.

**Two `reason` strings corrected.** `Checksum::new` and `PutObjReader::md5_current_hex_string` are methods but carried a field-only rationale ("written but never read back"); both are uncalled parity constructors/accessors and now say so.

The reasons fall into five kinds:

| reason | count |
| --- | --- |
| MinIO-parity surface with no caller in this port | 24 |
| written but never read back | 7 |
| asserted by this file's tests; the lib target cannot see test-only consumers | 3 |
| superseded by the replacement named in the comment | 2 |
| reached only from the parity constructors below | 2 |

The `client/` module is a port of the MinIO Go SDK used by the transition client. Its uncalled members are kept rather than deleted so the surface stays diffable against upstream; the same applies to `ObjSweeper`'s builder methods, whose struct is live (constructed in `transitioned_delete_journal_entry`).

## Verification

`cargo clippy -p rustfs-ecstore --all-targets -- -D warnings` is clean, and `cargo fmt --all` applied.

Clippy with `-D warnings` is the check that matters here, not `cargo check`: `cargo check` does not re-emit warnings for cached compilations, and a `touch` does not reliably rebuild every target, so its warning count is not evidence that a lane is clean. Batch 2 found a genuine suppression that a `cargo check` count had missed for exactly this reason.
