### PR TITLE
fix(ecstore): describe peer bucket RPC failures with no details

### DIFF
--- a/crates/ecstore/src/cluster/rpc/peer_s3_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_s3_client.rs
@@ -214,6 +214,19 @@ fn pool_write_quorum(participant_count: usize) -> usize {
     (participant_count / 2) + 1
 }
 
+/// Error for a peer that reported `success = false` without an error payload.
+///
+/// The message must stay identical across the peers of one operation: `reduce_errs`
+/// buckets `Error::Io` by kind plus rendered message, so any per-peer detail (address,
+/// timing) would split one shared failure into single-count buckets and downgrade a real
+/// dominant error into `ErasureWriteQuorum`.
+fn peer_failure_without_details(op: &str, bucket: Option<&str>) -> Error {
+    match bucket {
+        Some(bucket) => Error::other(format!("{op}({bucket}): peer returned failure without error details")),
+        None => Error::other(format!("{op}: peer returned failure without error details")),
+    }
+}
+
 fn reduce_pool_write_quorum_errs(per_pool_errs: &[Option<Error>]) -> Option<Error> {
     if per_pool_errs.is_empty() {
         return Some(Error::ErasureWriteQuorum);
@@ -1078,7 +1091,7 @@ impl PeerS3Client for RemotePeerS3Client {
                     return if let Some(err) = response.error {
                         Err(err.into())
                     } else {
-                        Err(Error::other(""))
+                        Err(peer_failure_without_details("heal_bucket", Some(bucket)))
                     };
                 }
 
@@ -1105,7 +1118,7 @@ impl PeerS3Client for RemotePeerS3Client {
                     return if let Some(err) = response.error {
                         Err(err.into())
                     } else {
-                        Err(Error::other(""))
+                        Err(peer_failure_without_details("list_bucket", None))
                     };
                 }
                 let bucket_infos = response
@@ -1136,9 +1149,7 @@ impl PeerS3Client for RemotePeerS3Client {
                     return if let Some(err) = response.error {
                         Err(err.into())
                     } else {
-                        Err(Error::other(format!(
-                            "make_bucket({bucket}): peer returned failure without error details"
-                        )))
+                        Err(peer_failure_without_details("make_bucket", Some(bucket)))
                     };
                 }
 
@@ -1162,7 +1173,7 @@ impl PeerS3Client for RemotePeerS3Client {
                     return if let Some(err) = response.error {
                         Err(err.into())
                     } else {
-                        Err(Error::other(""))
+                        Err(peer_failure_without_details("get_bucket_info", Some(bucket)))
                     };
                 }
                 let bucket_info = serde_json::from_str::<BucketInfo>(&response.bucket_info)?;
@@ -1190,7 +1201,7 @@ impl PeerS3Client for RemotePeerS3Client {
                     return if let Some(err) = response.error {
                         Err(err.into())
                     } else {
-                        Err(Error::other(""))
+                        Err(peer_failure_without_details("delete_bucket", Some(bucket)))
                     };
                 }
 
@@ -2313,5 +2324,38 @@ mod tests {
             .map(|call_count| call_count.load(Ordering::SeqCst))
             .collect::<Vec<_>>();
         assert_eq!(calls, vec![1, 1, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn peer_failure_without_details_names_operation_and_bucket() {
+        for op in ["heal_bucket", "make_bucket", "get_bucket_info", "delete_bucket"] {
+            let message = peer_failure_without_details(op, Some("ops-bucket")).to_string();
+            assert!(message.contains(op), "{op} message must name the operation: {message}");
+            assert!(message.contains("ops-bucket"), "{op} message must name the bucket: {message}");
+        }
+
+        let message = peer_failure_without_details("list_bucket", None).to_string();
+        assert!(message.contains("list_bucket"), "cluster-wide message must name the operation");
+        assert!(!message.trim().is_empty());
+    }
+
+    #[test]
+    fn peer_failure_without_details_keeps_one_reduce_errs_bucket_per_operation() {
+        // reduce_errs groups Io errors by kind plus rendered message: peers failing the
+        // same operation on the same bucket must still reach quorum as one dominant error.
+        let per_pool_errs = vec![
+            Some(peer_failure_without_details("delete_bucket", Some("shared"))),
+            Some(peer_failure_without_details("delete_bucket", Some("shared"))),
+            Some(peer_failure_without_details("delete_bucket", Some("shared"))),
+        ];
+        assert_eq!(
+            reduce_pool_write_quorum_errs(&per_pool_errs),
+            Some(peer_failure_without_details("delete_bucket", Some("shared")))
+        );
+
+        assert_ne!(
+            peer_failure_without_details("delete_bucket", Some("shared")),
+            peer_failure_without_details("get_bucket_info", Some("shared"))
+        );
     }
 }


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1827 (T3).

## Summary of Changes

`RemotePeerS3Client` returned `Error::other("")` whenever a peer answered `success = false` without an error payload, in `heal_bucket`, `list_bucket`, `get_bucket_info` and `delete_bucket`. That empty message flows into `reduce_pool_write_quorum_errs` and surfaces in operator logs as a bare `io error `, with no indication of which peer operation failed. `make_bucket` already produced a descriptive message; this change extracts that message into `peer_failure_without_details(op, bucket)` and routes all five sites through it, so the failure now reads e.g. `delete_bucket(my-bucket): peer returned failure without error details`.

The helper deliberately carries only the operation name and the bucket, never the peer address. `reduce_errs` buckets `Error::Io` by `io::ErrorKind` plus the rendered message (`crates/ecstore/src/disk/error.rs`), so a per-peer detail would split one shared failure into single-count buckets and downgrade a real dominant error into `ErasureWriteQuorum`. Each quorum slice is built from one operation on one bucket (`S3PeerSys::heal_bucket` / `list_bucket_for_scanner` / `delete_bucket`), so within a slice every peer still renders the identical message and grouping is unchanged. The four sites do produce mutually distinct messages, which is intended: they are distinct operations and are never aggregated together.

No behavior other than the message text changes. `reduce_errs`, `resolve_heal_bucket_mode`, `is_all_buckets_not_found` and `Error::is_err_object_not_found` all classify by variant, not by message, and none of them treat `Io` specially; the delete-bucket rollback path keys off `is_err_object_not_found`, which is unaffected.

## Verification

- `cargo nextest run -p rustfs-ecstore -E 'test(/peer_s3_client/)'` (27 passed)
- `cargo fmt --all --check`

Clippy was not run locally: the nextest run compiled the changed lib and test targets, and the diff adds no lint-sensitive construct beyond an inlined `format!`. CI still runs the full gate.

## Impact

Operator-visible log and error text only. No API, wire-format, on-disk-format or quorum-decision change.

## Additional Notes

Adversarial validation (standard tier: correctness, simplicity, test-coverage skeptic, plus concurrency because the values feed quorum aggregation).

- Correctness: attacked the `reduce_errs` grouping — equality for `Io` is `kind == kind && to_string() == to_string()`, so a message change could in principle refragment buckets. Traced every aggregation site in `peer_s3_client.rs`; each slice holds one operation against one bucket, so all peers in a slice render the same string. No break found.
- Concurrency: attacked the case where a pool mixes peers that do and do not carry the empty-message error. Behaviour is unchanged because the previous empty string was equally shared across those peers; the pooling cardinality is identical.
- Simplicity: the helper replaces five inline constructions including one existing `format!`; `Option<&str>` exists because `list_bucket` is cluster-wide and has no bucket to name.
- Test-coverage skeptic: `peer_failure_without_details_names_operation_and_bucket` fails if any site loses the operation or bucket name; `peer_failure_without_details_keeps_one_reduce_errs_bucket_per_operation` fails if a future edit adds per-peer detail and refragments the quorum buckets.

Out of scope, noted for follow-up: `crates/ecstore/src/cluster/rpc/peer_rest_client.rs` still has roughly twenty `Err(Error::other(""))` sites with the same defect.
