### PR TITLE
refactor: import x-amz-checksum header names from the shared constants

### DIFF
--- a/crates/ecstore/src/client/api_get_options.rs
+++ b/crates/ecstore/src/client/api_get_options.rs
@@ -20,6 +20,7 @@
 #![allow(clippy::all)]
 
 use http::{HeaderMap, HeaderName, HeaderValue};
+use rustfs_utils::http::headers::AMZ_CHECKSUM_MODE;
 use std::collections::HashMap;
 use time::OffsetDateTime;
 use tracing::warn;
@@ -76,7 +77,7 @@ impl GetObjectOptions {
             }
         }
         if self.checksum {
-            headers.insert(HeaderName::from_static("x-amz-checksum-mode"), HeaderValue::from_static("ENABLED"));
+            headers.insert(HeaderName::from_static(AMZ_CHECKSUM_MODE), HeaderValue::from_static("ENABLED"));
         }
         headers
     }

--- a/crates/ecstore/src/client/transition_api.rs
+++ b/crates/ecstore/src/client/transition_api.rs
@@ -54,6 +54,10 @@ use rustfs_config::MAX_S3_CLIENT_RESPONSE_SIZE;
 use rustfs_rio::HashReader;
 use rustfs_utils::HashAlgorithm;
 use rustfs_utils::{
+    http::headers::{
+        AMZ_CHECKSUM_CRC32, AMZ_CHECKSUM_CRC32C, AMZ_CHECKSUM_CRC64NVME, AMZ_CHECKSUM_MODE, AMZ_CHECKSUM_SHA1,
+        AMZ_CHECKSUM_SHA256,
+    },
     net::get_endpoint_url,
     retry::{DEFAULT_RETRY_CAP, DEFAULT_RETRY_UNIT, MAX_JITTER, MAX_RETRY, RetryTimer},
 };
@@ -1383,12 +1387,12 @@ pub(crate) fn to_object_info_for_provider(
     };
 
     // Extract checksums
-    let checksum_crc32 = get_header("x-amz-checksum-crc32");
-    let checksum_crc32c = get_header("x-amz-checksum-crc32c");
-    let checksum_sha1 = get_header("x-amz-checksum-sha1");
-    let checksum_sha256 = get_header("x-amz-checksum-sha256");
-    let checksum_crc64nvme = get_header("x-amz-checksum-crc64nvme");
-    let checksum_mode = get_header("x-amz-checksum-mode");
+    let checksum_crc32 = get_header(AMZ_CHECKSUM_CRC32);
+    let checksum_crc32c = get_header(AMZ_CHECKSUM_CRC32C);
+    let checksum_sha1 = get_header(AMZ_CHECKSUM_SHA1);
+    let checksum_sha256 = get_header(AMZ_CHECKSUM_SHA256);
+    let checksum_crc64nvme = get_header(AMZ_CHECKSUM_CRC64NVME);
+    let checksum_mode = get_header(AMZ_CHECKSUM_MODE);
 
     // Build and return the ObjectInfo struct
     Ok(ObjectInfo {

--- a/rustfs/src/admin/router.rs
+++ b/rustfs/src/admin/router.rs
@@ -67,6 +67,9 @@ use rustfs_policy::policy::action::{Action, S3Action};
 use rustfs_s3_types::EventName;
 use rustfs_signer::pre_sign_v4;
 use rustfs_utils::egress::{OutboundDnsResolver, OutboundPolicy};
+use rustfs_utils::http::headers::{
+    AMZ_CHECKSUM_CRC32, AMZ_CHECKSUM_CRC32C, AMZ_CHECKSUM_CRC64NVME, AMZ_CHECKSUM_SHA1, AMZ_CHECKSUM_SHA256, AMZ_CHECKSUM_TYPE,
+};
 use rustfs_utils::http::{
     SUFFIX_SOURCE_DELETEMARKER, SUFFIX_SOURCE_MTIME, SUFFIX_SOURCE_REPLICATION_CHECK, SUFFIX_SOURCE_REPLICATION_REQUEST,
     SUFFIX_SOURCE_VERSION_ID, get_source_scheme, insert_header,
@@ -1031,28 +1034,24 @@ fn build_get_object_response_headers(output: &GetObjectOutput, base_headers: &He
         )?;
     }
     if let Some(checksum_crc32) = &output.checksum_crc32 {
-        insert_string_header(&mut headers, HeaderName::from_static("x-amz-checksum-crc32"), checksum_crc32.clone())?;
+        insert_string_header(&mut headers, HeaderName::from_static(AMZ_CHECKSUM_CRC32), checksum_crc32.clone())?;
     }
     if let Some(checksum_crc32c) = &output.checksum_crc32c {
-        insert_string_header(&mut headers, HeaderName::from_static("x-amz-checksum-crc32c"), checksum_crc32c.clone())?;
+        insert_string_header(&mut headers, HeaderName::from_static(AMZ_CHECKSUM_CRC32C), checksum_crc32c.clone())?;
     }
     if let Some(checksum_crc64nvme) = &output.checksum_crc64nvme {
-        insert_string_header(
-            &mut headers,
-            HeaderName::from_static("x-amz-checksum-crc64nvme"),
-            checksum_crc64nvme.clone(),
-        )?;
+        insert_string_header(&mut headers, HeaderName::from_static(AMZ_CHECKSUM_CRC64NVME), checksum_crc64nvme.clone())?;
     }
     if let Some(checksum_sha1) = &output.checksum_sha1 {
-        insert_string_header(&mut headers, HeaderName::from_static("x-amz-checksum-sha1"), checksum_sha1.clone())?;
+        insert_string_header(&mut headers, HeaderName::from_static(AMZ_CHECKSUM_SHA1), checksum_sha1.clone())?;
     }
     if let Some(checksum_sha256) = &output.checksum_sha256 {
-        insert_string_header(&mut headers, HeaderName::from_static("x-amz-checksum-sha256"), checksum_sha256.clone())?;
+        insert_string_header(&mut headers, HeaderName::from_static(AMZ_CHECKSUM_SHA256), checksum_sha256.clone())?;
     }
     if let Some(checksum_type) = &output.checksum_type {
         insert_string_header(
             &mut headers,
-            HeaderName::from_static("x-amz-checksum-type"),
+            HeaderName::from_static(AMZ_CHECKSUM_TYPE),
             checksum_type.as_str().to_string(),
         )?;
     }
@@ -1114,12 +1113,12 @@ fn clear_object_lambda_variant_headers(headers: &mut HeaderMap) {
         http::header::ETAG,
         http::header::LAST_MODIFIED,
         http::header::EXPIRES,
-        HeaderName::from_static("x-amz-checksum-crc32"),
-        HeaderName::from_static("x-amz-checksum-crc32c"),
-        HeaderName::from_static("x-amz-checksum-crc64nvme"),
-        HeaderName::from_static("x-amz-checksum-sha1"),
-        HeaderName::from_static("x-amz-checksum-sha256"),
-        HeaderName::from_static("x-amz-checksum-type"),
+        HeaderName::from_static(AMZ_CHECKSUM_CRC32),
+        HeaderName::from_static(AMZ_CHECKSUM_CRC32C),
+        HeaderName::from_static(AMZ_CHECKSUM_CRC64NVME),
+        HeaderName::from_static(AMZ_CHECKSUM_SHA1),
+        HeaderName::from_static(AMZ_CHECKSUM_SHA256),
+        HeaderName::from_static(AMZ_CHECKSUM_TYPE),
         HeaderName::from_static("x-amz-tagging-count"),
         HeaderName::from_static("x-amz-request-route"),
         HeaderName::from_static("x-amz-request-token"),


### PR DESCRIPTION
## Related Issues

Follow-up to rustfs/backlog#1833 PR6 (#6024), which registered the three checksum registries with bidirectional comments and deliberately kept the `rustfs-checksums` leaf crate free of internal dependencies.

## Summary of Changes

Replaces 19 bare `x-amz-checksum-*` header-name literals at consumer sites with the canonical constants that already exist in `crates/utils/src/http/headers.rs` (`AMZ_CHECKSUM_CRC32`, `_CRC32C`, `_SHA1`, `_SHA256`, `_CRC64NVME`, `_MODE`, `_TYPE`). Touched: `crates/ecstore/src/client/api_get_options.rs`, `crates/ecstore/src/client/transition_api.rs`, `rustfs/src/admin/router.rs` — all three already depend on `rustfs-utils`, so no dependency edges change.

This does not revisit #6024's boundary decision: the constants are not moved, and `rustfs-checksums` is untouched. It only stops consumers from re-spelling wire strings that a canonical constant already names, per the AGENTS.md "Reuse Before You Write" rule on constants and fixed tokens.

Deliberately left as literals, with reasons: prefix matches that are not full header names (`api_put_object_streaming.rs`, `client/utils.rs` use `starts_with("x-amz-checksum-")`); the RustFS extension names md5/sha512/xxhash3/xxhash64/xxhash128 in `app/object_usecase.rs`, which are owned by `crates/checksums/src/http.rs` rather than utils; and test-body literals, where spelling the wire string is the point of the assertion.

Adversarial validation (mechanical tier): correctness — each replacement compared byte-for-byte against the constant's value, no behavior change possible; simplicity — no new abstraction, strictly fewer magic strings.

## Verification

- `cargo check -p rustfs-ecstore -p rustfs`
- `cargo fmt --all --check`
- `bash scripts/check_architecture_migration_rules.sh`

## Impact

None. Pure constant substitution with identical values; no wire behavior, dependency graph, or public API changes.

## Additional Notes

Part of the pre-1.0 cleanup program tracked in rustfs/backlog#1820.
