### PR TITLE
refactor(admin): route kms management auth through shared gate

### DIFF
--- a/rustfs/src/admin/handlers/kms_management.rs
+++ b/rustfs/src/admin/handlers/kms_management.rs
@@ -16,13 +16,12 @@
 
 use super::kms_dynamic::current_kms_config_fingerprint;
 use super::kms_keys::{CreateKeyHandler, DescribeKeyHandler, GenerateDataKeyHandler, ListKeysHandler};
-use crate::admin::auth::validate_admin_request;
+use crate::admin::auth::authorize_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::runtime_sources::{
     current_kms_runtime_service_manager, current_notification_system, current_or_init_kms_runtime_service_manager,
 };
-use crate::auth::{check_key_valid, get_session_token};
-use crate::server::{ADMIN_PREFIX, RemoteAddr};
+use crate::server::ADMIN_PREFIX;
 use hyper::{HeaderMap, Method, StatusCode};
 use matchit::Params;
 use rustfs_kms::KmsBackend;
@@ -67,6 +66,18 @@ fn kms_configure_actions() -> Vec<Action> {
 
 fn kms_clear_cache_actions() -> Vec<Action> {
     vec![Action::KmsAction(KmsAction::ClearCacheAction)]
+}
+
+/// Admin gate for the KMS management endpoints, none of which act on a key.
+///
+/// The pre-check keeps these endpoints' historical missing-credentials message;
+/// the shared gate reports "get cred failed".
+async fn authorize_kms_management_request(req: &S3Request<Body>, actions: Vec<Action>) -> S3Result<()> {
+    if req.credentials.is_none() {
+        return Err(s3_error!(InvalidRequest, "authentication required"));
+    }
+    authorize_admin_request(req, actions).await?;
+    Ok(())
 }
 
 /// Response of `POST /kms/clear-cache`.
@@ -260,22 +271,7 @@ pub struct KmsStatusHandler {}
 #[async_trait::async_trait]
 impl Operation for KmsStatusHandler {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
-        let Some(cred) = req.credentials else {
-            return Err(s3_error!(InvalidRequest, "authentication required"));
-        };
-
-        let (cred, owner) =
-            check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &cred.access_key).await?;
-
-        validate_admin_request(
-            &req.headers,
-            &cred,
-            owner,
-            false,
-            kms_service_control_actions(),
-            req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-        )
-        .await?;
+        authorize_kms_management_request(&req, kms_service_control_actions()).await?;
 
         let Some(service) = kms_encryption_service_from_context().await else {
             return Err(s3_error!(InternalError, "KMS service not initialized"));
@@ -326,22 +322,7 @@ pub struct KmsConfigHandler {}
 #[async_trait::async_trait]
 impl Operation for KmsConfigHandler {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
-        let Some(cred) = req.credentials else {
-            return Err(s3_error!(InvalidRequest, "authentication required"));
-        };
-
-        let (cred, owner) =
-            check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &cred.access_key).await?;
-
-        validate_admin_request(
-            &req.headers,
-            &cred,
-            owner,
-            false,
-            kms_configure_actions(),
-            req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-        )
-        .await?;
+        authorize_kms_management_request(&req, kms_configure_actions()).await?;
 
         let Some(service) = kms_encryption_service_from_context().await else {
             return Err(s3_error!(InternalError, "KMS service not initialized"));
@@ -375,22 +356,7 @@ pub struct KmsClearCacheHandler {}
 #[async_trait::async_trait]
 impl Operation for KmsClearCacheHandler {
     async fn call(&self, req: S3Request<Body>, _params: Params<'_, '_>) -> S3Result<S3Response<(StatusCode, Body)>> {
-        let Some(cred) = req.credentials else {
-            return Err(s3_error!(InvalidRequest, "authentication required"));
-        };
-
-        let (cred, owner) =
-            check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &cred.access_key).await?;
-
-        validate_admin_request(
-            &req.headers,
-            &cred,
-            owner,
-            false,
-            kms_clear_cache_actions(),
-            req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-        )
-        .await?;
+        authorize_kms_management_request(&req, kms_clear_cache_actions()).await?;
 
         let Some(service) = kms_encryption_service_from_context().await else {
             return Err(s3_error!(InternalError, "KMS service not initialized"));
@@ -422,9 +388,14 @@ impl Operation for KmsClearCacheHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::{KmsClearCacheResponse, kms_clear_cache_actions, kms_configure_actions, kms_service_control_actions};
+    use super::{
+        KmsClearCacheResponse, authorize_kms_management_request, kms_clear_cache_actions, kms_configure_actions,
+        kms_service_control_actions,
+    };
     use crate::admin::handlers::kms_keys::stable_json_value;
+    use hyper::HeaderMap;
     use rustfs_policy::policy::action::{Action, AdminAction, KmsAction};
+    use s3s::{Body, S3Request};
 
     fn assert_has_action(actions: &[Action], action: Action) {
         assert!(actions.contains(&action), "expected action list to contain {action:?}");
@@ -432,6 +403,58 @@ mod tests {
 
     fn assert_lacks_action(actions: &[Action], action: Action) {
         assert!(!actions.contains(&action), "expected action list not to contain {action:?}");
+    }
+
+    /// These endpoints authorize through the shared admin gate, which reports
+    /// "get cred failed" for a credential-less request. The pre-check keeps the
+    /// message these endpoints have always returned (rustfs/backlog#1829).
+    #[tokio::test]
+    async fn kms_management_gate_keeps_its_missing_credentials_message() {
+        let req = S3Request {
+            input: Body::from(String::new()),
+            method: http::Method::GET,
+            uri: "/rustfs/admin/v3/kms/status".parse().expect("uri should parse"),
+            headers: HeaderMap::new(),
+            extensions: http::Extensions::new(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let err = authorize_kms_management_request(&req, kms_service_control_actions())
+            .await
+            .expect_err("a request without credentials must be rejected");
+        assert_eq!(err.code(), &s3s::S3ErrorCode::InvalidRequest);
+        assert_eq!(err.message(), Some("authentication required"));
+    }
+
+    /// Every management endpoint must reach the shared gate, each with its own
+    /// action set. The action lists are pinned above, but nothing else checks
+    /// which handler asks for which, and a handler that lost its gate entirely
+    /// would still serve its response.
+    #[test]
+    fn management_handlers_authorize_with_their_dedicated_actions() {
+        let src = include_str!("kms_management.rs");
+
+        for (handler, actions) in [
+            ("KmsStatusHandler", "kms_service_control_actions()"),
+            ("KmsConfigHandler", "kms_configure_actions()"),
+            ("KmsClearCacheHandler", "kms_clear_cache_actions()"),
+        ] {
+            let block = src
+                .split_once(&format!("impl Operation for {handler}"))
+                .unwrap_or_else(|| panic!("{handler} impl should exist"))
+                .1;
+            let end = block
+                .find("\nimpl Operation for")
+                .or_else(|| block.find("\n#[cfg(test)]"))
+                .unwrap_or(block.len());
+            assert!(
+                block[..end].contains(&format!("authorize_kms_management_request(&req, {actions})")),
+                "{handler} must authorize through the shared gate with {actions}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1829 (T2, KMS group).

## Summary of Changes

T1 added `authorize_admin_request` in `rustfs/src/admin/auth.rs`: it extracts the request credentials, authenticates them, and authorizes the caller against a list of admin actions with `deny_only = false` and the `RemoteAddr` taken from the request extensions. This PR routes the KMS **management** endpoints (`GET /kms/status`, `GET /kms/config`, `POST /kms/clear-cache`) through that gate, replacing three copies of the same inline preamble in `rustfs/src/admin/handlers/kms_management.rs`.

The file-local `authorize_kms_management_request` keeps a credentials pre-check ahead of the shared gate, because these endpoints answer a credential-less request with `InvalidRequest: authentication required` while the shared gate reports `get cred failed`. This mirrors the pre-check `validate_config_admin_request` already carries in `config_admin.rs`. For every other input class — unknown access key, bad session token, valid credentials without the required KMS action — the status code, error code, and message are unchanged, because the helper performs exactly the calls it replaces (`check_key_valid(get_session_token(..).unwrap_or_default(), &cred.access_key)` then `validate_admin_request(headers, cred, owner, false, actions, remote_addr)`) with the identical `RemoteAddr` extraction and the same per-handler action list.

**Sites deliberately left unchanged** (converting them would change authorization or audit semantics, so they are not part of this sweep):

| Site | Why it is excluded |
| --- | --- |
| `kms_keys.rs` — `DescribeKeyHandler`, `GenerateDataKeyHandler`, `DeleteKmsKeyHandler`, `CancelKmsKeyDeletionHandler`, `DescribeKmsKeyHandler` | They authorize through `validate_admin_request_with_kms_key`, which scopes the decision to the requested key id. The shared gate is unscoped, so routing them through it would silently widen a policy limited to `arn:aws:kms:::key/<id>`. |
| `kms_key_lifecycle.rs`, `kms_key_metadata.rs` | Same reason: single-key endpoints on the KMS-scoped gate. |
| `kms_keys.rs` — `CreateKeyHandler`, `ListKeysHandler`, `CreateKmsKeyHandler`, `ListKmsKeysHandler` | Unscoped, but each wraps the authorization result in `KmsAdminAudit::gate(..)`, which emits a KMS audit entry on denial. The audit context is built from the *authenticated* credential, i.e. between the two halves the shared gate fuses together, so there is no seam left to build it in and denied requests would stop being audited. |
| `kms_backup.rs` — `authorize(..)` | Same audit-gate reason (`gate_admin`). |
| `kms_dynamic.rs` | Owned by a concurrent change; untouched here to avoid a conflict. |
| `kms.rs`, `kms_audit.rs` | No authorization preamble. |

Source-text assertion tests (backlog#1839 class) were checked: `single_key_handlers_authorize_through_the_kms_scoped_gate` in `kms_keys.rs`, and the equivalents in `kms_key_lifecycle.rs` / `kms_key_metadata.rs`, grep for `validate_admin_request_with_kms_key(` in handlers this PR does not touch, and its negative assertion for the four unscoped `kms_keys.rs` handlers still holds. None of them assert on the preamble that changed, so no assertion needed updating.

Two tests are added in the same diff: one pins the divergent missing-credentials message that the pre-check exists to preserve, the other pins that each management handler still reaches the gate with its own action set (nothing else covered which handler asks for which, and the wiring is now a single argument).

## Verification

- `cargo nextest run -p rustfs -E 'test(/admin/)'` — 1428 passed, 0 failed
- `cargo check -p rustfs --lib`
- `cargo fmt --all --check`

Clippy and the workspace suite are left to CI: the diff is one file, has no new dependency or API surface, and the admin suite above already builds and exercises every changed target.

## Impact

No user-facing change intended. The three KMS management endpoints keep their HTTP status codes, S3 error codes, and error messages for missing, unknown, and unauthorized credentials, and keep the same action sets (`kms:ServiceControl`, `kms:Configure`, `kms:ClearCache`). The one observable difference is internal logging: authentication failures on these three endpoints now also pass through `authenticate_request`, which logs a `warn` with the access key, matching every other endpoint already on the shared gate. No key material or secret is logged.

## Additional Notes

Adversarial review (high-risk tier — auth path), one line per role:

- **Correctness** — attacked the missing-credential, unknown-access-key, bad-session-token, and allowed/denied paths of all three endpoints; the helper issues the same two calls in the same order with the same arguments, and the pre-check restores the only divergence. No break found.
- **Simplicity** — attacked the new wrapper: three callers, removes 45 duplicated lines, and states the message divergence once instead of three times; inlining it would repeat the rationale per handler.
- **Security** — attacked scope and audit loss: all three endpoints take no key parameter and were already unscoped (`bucket = ""`, `object = ""`), so no resource scope is dropped; every site that would have lost a key scope or an audit denial record is excluded above. `deny_only` stays `false` at every converted site.
- **Concurrency/durability** — no shared state, locks, or IO ordering touched; the gate is a per-request read path.
- **Compatibility** — no route, request shape, response shape, or error contract changes; the console-visible clear-cache payload test is untouched and still green.
- **Performance** — same number of IAM lookups per request; the removed code was duplication, not work.
- **Test-coverage skeptic** — a revert of the pre-check is caught by `kms_management_gate_keeps_its_missing_credentials_message`; dropping a handler's gate or swapping in the wrong action set is caught by `management_handlers_authorize_with_their_dedicated_actions`. Residual risk: neither test drives a live IAM decision through the HTTP layer, which is what the existing `rustfs/src/admin/auth.rs` gate tests already cover.
