### PR TITLE
fix(ecstore): give peer REST failures op and bucket context

### DIFF
--- a/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_rest_client.rs
@@ -86,6 +86,25 @@ const PEER_REST_RECOVERY_MAX_BACKOFF: Duration = Duration::from_secs(30);
 const SCANNER_ACTIVITY_MAX_MESSAGE_SIZE: usize = 1024;
 const REPLICATION_STATS_MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024;
 
+/// Error for a peer that reported `success = false` without an `error_info` payload.
+///
+/// Same shape as `peer_s3_client::peer_failure_without_details`, over `StorageError`
+/// instead of `DiskError`. The message names the operation (and the bucket, where the
+/// operation has one) and nothing else, for two reasons:
+///
+/// - `finalize_result` classifies failures by message substring, so any text matching
+///   `message_has_network_needle` would take an answering peer offline and evict its
+///   connection over a plain application-level rejection.
+/// - Quorum aggregation (`reduce_errs`) buckets `Io` errors by kind plus rendered
+///   message, so a per-peer detail such as the peer address would split one shared
+///   failure into single-count buckets and downgrade the dominant error.
+fn peer_failure_without_details(op: &str, bucket: Option<&str>) -> Error {
+    match bucket {
+        Some(bucket) => Error::other(format!("{op}({bucket}): peer returned failure without error details")),
+        None => Error::other(format!("{op}: peer returned failure without error details")),
+    }
+}
+
 fn decode_bucket_stats_response(response: GetBucketStatsDataResponse) -> Result<BucketStats> {
     if !response.success {
         return Err(Error::other(
@@ -696,7 +715,7 @@ impl PeerRestClient {
             if let Some(msg) = response.error_info {
                 return Err(Error::other(msg));
             }
-            return Err(Error::other(""));
+            return Err(peer_failure_without_details("local_storage_info", None));
         }
         let data = response.storage_info;
 
@@ -719,7 +738,7 @@ impl PeerRestClient {
             if let Some(msg) = response.error_info {
                 return Err(Error::other(msg));
             }
-            return Err(Error::other(""));
+            return Err(peer_failure_without_details("server_info", None));
         }
         let data = response.server_properties;
 
@@ -742,7 +761,7 @@ impl PeerRestClient {
             if let Some(msg) = response.error_info {
                 return Err(Error::other(msg));
             }
-            return Err(Error::other(""));
+            return Err(peer_failure_without_details("get_cpus", None));
         }
         let data = response.cpus;
 
@@ -765,7 +784,7 @@ impl PeerRestClient {
             if let Some(msg) = response.error_info {
                 return Err(Error::other(msg));
             }
-            return Err(Error::other(""));
+            return Err(peer_failure_without_details("get_net_info", None));
         }
         let data = response.net_info;
 
@@ -788,7 +807,7 @@ impl PeerRestClient {
             if let Some(msg) = response.error_info {
                 return Err(Error::other(msg));
             }
-            return Err(Error::other(""));
+            return Err(peer_failure_without_details("get_partitions", None));
         }
         let data = response.partitions;
 
@@ -811,7 +830,7 @@ impl PeerRestClient {
             if let Some(msg) = response.error_info {
                 return Err(Error::other(msg));
             }
-            return Err(Error::other(""));
+            return Err(peer_failure_without_details("get_os_info", None));
         }
         let data = response.os_info;
 
@@ -832,7 +851,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("get_se_linux_info", None));
                 }
                 let data = response.sys_services;
 
@@ -857,7 +876,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("get_sys_config", None));
                 }
                 let data = response.sys_config;
 
@@ -882,7 +901,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("get_sys_errors", None));
                 }
                 let data = response.sys_errors;
 
@@ -907,7 +926,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("get_mem_info", None));
                 }
                 let data = response.mem_info;
 
@@ -939,7 +958,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("get_metrics", None));
                 }
                 let data = response.realtime_metrics;
 
@@ -964,7 +983,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("get_live_events", None));
                 }
 
                 Ok(PeerLiveEventsBatch {
@@ -989,7 +1008,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("get_proc_info", None));
                 }
                 let data = response.proc_info;
 
@@ -1016,7 +1035,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("start_profiling", None));
                 }
                 Ok(())
             }
@@ -1323,7 +1342,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("load_bucket_metadata", Some(bucket)));
                 }
                 Ok(())
             }
@@ -1346,7 +1365,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("delete_bucket_metadata", Some(bucket)));
                 }
                 Ok(())
             }
@@ -1369,7 +1388,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("delete_policy", None));
                 }
                 Ok(())
             }
@@ -1392,7 +1411,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("load_policy", None));
                 }
                 Ok(())
             }
@@ -1417,7 +1436,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("load_policy_mapping", None));
                 }
                 Ok(())
             }
@@ -1440,7 +1459,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("delete_user", None));
                 }
                 Ok(())
             }
@@ -1463,7 +1482,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("delete_service_account", None));
                 }
                 Ok(())
             }
@@ -1487,7 +1506,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("load_user", None));
                 }
                 Ok(())
             }
@@ -1510,7 +1529,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("load_service_account", None));
                 }
                 Ok(())
             }
@@ -1533,7 +1552,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("load_group", None));
                 }
                 Ok(())
             }
@@ -1554,7 +1573,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("reload_site_replication_config", None));
                 }
                 Ok(())
             }
@@ -1597,7 +1616,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("signal_service", None));
                 }
                 validate_signal_service_protocol(sig, sub_sys, response.protocol_version)?;
                 Ok(response)
@@ -1667,7 +1686,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("reload_pool_meta", None));
                 }
 
                 Ok(())
@@ -1691,7 +1710,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("stop_rebalance", None));
                 }
 
                 Ok(())
@@ -1725,7 +1744,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("load_rebalance_meta", None));
                 }
 
                 Ok(())
@@ -1753,7 +1772,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("start_decommission", None));
                 }
 
                 Ok(())
@@ -1777,7 +1796,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("decommission_cancel", None));
                 }
 
                 Ok(())
@@ -1801,7 +1820,7 @@ impl PeerRestClient {
                     if let Some(msg) = response.error_info {
                         return Err(Error::other(msg));
                     }
-                    return Err(Error::other(""));
+                    return Err(peer_failure_without_details("clear_decommission", None));
                 }
 
                 Ok(())
@@ -1947,6 +1966,8 @@ fn tier_config_reload_status_outcome(status: tonic::Status) -> TierConfigReloadO
 mod tests {
     use super::*;
     use crate::config::com::STORAGE_CLASS_SUB_SYS;
+    use crate::disk::error::DiskError;
+    use crate::disk::error_reduce::reduce_errs;
     use crate::layout::{disks_layout::DisksLayout, endpoints::SetupType};
     use rustfs_config::{ENV_KUBERNETES_SERVICE_HOST, ENV_LOCAL_ENDPOINT_HOST, ENV_STARTUP_TOPOLOGY_WAIT_MODE};
     use serde_json::Value;
@@ -3097,5 +3118,116 @@ mod tests {
             span.get("name").and_then(Value::as_str) == Some("request-span")
                 && span.get("request_id").and_then(Value::as_str) == Some("req-peer-rest")
         }));
+    }
+
+    /// Every operation name passed to `peer_failure_without_details` in this file.
+    const PEER_FAILURE_OPS: &[&str] = &[
+        "local_storage_info",
+        "server_info",
+        "get_cpus",
+        "get_net_info",
+        "get_partitions",
+        "get_os_info",
+        "get_se_linux_info",
+        "get_sys_config",
+        "get_sys_errors",
+        "get_mem_info",
+        "get_metrics",
+        "get_live_events",
+        "get_proc_info",
+        "start_profiling",
+        "load_bucket_metadata",
+        "delete_bucket_metadata",
+        "delete_policy",
+        "load_policy",
+        "load_policy_mapping",
+        "delete_user",
+        "delete_service_account",
+        "load_user",
+        "load_service_account",
+        "load_group",
+        "reload_site_replication_config",
+        "signal_service",
+        "reload_pool_meta",
+        "stop_rebalance",
+        "load_rebalance_meta",
+        "start_decommission",
+        "decommission_cancel",
+        "clear_decommission",
+    ];
+
+    #[test]
+    fn peer_failure_without_details_names_operation_and_bucket() {
+        for op in PEER_FAILURE_OPS {
+            let message = peer_failure_without_details(op, None).to_string();
+            assert!(message.contains(op), "{op} message must name the operation: {message}");
+        }
+
+        for op in ["load_bucket_metadata", "delete_bucket_metadata"] {
+            let message = peer_failure_without_details(op, Some("ops-bucket")).to_string();
+            assert!(message.contains(op), "{op} message must name the operation: {message}");
+            assert!(message.contains("ops-bucket"), "{op} message must name the bucket: {message}");
+        }
+    }
+
+    #[test]
+    fn peer_failure_without_details_keeps_one_reduce_errs_bucket_per_operation() {
+        // reduce_errs groups Io errors by kind plus rendered message: peers failing the
+        // same operation must stay a single dominant error instead of one bucket per peer.
+        let per_peer_errs = (0..4)
+            .map(|_| Some(DiskError::from(peer_failure_without_details("load_bucket_metadata", Some("shared")))))
+            .collect::<Vec<_>>();
+        let (count, dominant) = reduce_errs(&per_peer_errs, &[]);
+        assert_eq!(count, 4, "one shared failure must not split into per-peer buckets");
+        assert_eq!(
+            dominant,
+            Some(DiskError::from(peer_failure_without_details("load_bucket_metadata", Some("shared"))))
+        );
+
+        assert_ne!(
+            peer_failure_without_details("load_bucket_metadata", Some("shared")).to_string(),
+            peer_failure_without_details("delete_bucket_metadata", Some("shared")).to_string()
+        );
+        assert_ne!(
+            peer_failure_without_details("load_bucket_metadata", Some("bucket-a")).to_string(),
+            peer_failure_without_details("load_bucket_metadata", Some("bucket-b")).to_string()
+        );
+    }
+
+    #[test]
+    fn peer_failure_without_details_never_reads_as_a_network_failure() {
+        // `finalize_result` marks the peer offline and evicts its connection whenever the
+        // message matches a network needle. A peer that answered `success = false` is alive,
+        // so no operation or bucket name may push this text over that classifier.
+        for op in PEER_FAILURE_OPS {
+            let err = peer_failure_without_details(op, None);
+            assert!(
+                !PeerRestClient::is_network_like_error(&err),
+                "{op} must not read as a transport failure: {err}"
+            );
+
+            let scoped = peer_failure_without_details(op, Some("bucket-name"));
+            assert!(
+                !PeerRestClient::is_network_like_error(&scoped),
+                "{op} must not read as a transport failure: {scoped}"
+            );
+        }
+
+        // The bucket name is caller-supplied. Every needle carries a space, which S3 bucket
+        // names cannot, and the name is closed by `)` before the literal text resumes, so no
+        // needle can straddle the boundary either.
+        for bucket in [
+            "timed-out",
+            "connection-reset",
+            "transport-error",
+            "broken-pipe",
+            "unavailable-logs",
+        ] {
+            let err = peer_failure_without_details("load_bucket_metadata", Some(bucket));
+            assert!(
+                !PeerRestClient::is_network_like_error(&err),
+                "bucket {bucket} must not push the message over the network classifier: {err}"
+            );
+        }
     }
 }

--- a/crates/ecstore/src/cluster/rpc/peer_s3_client.rs
+++ b/crates/ecstore/src/cluster/rpc/peer_s3_client.rs
@@ -220,6 +220,8 @@ fn pool_write_quorum(participant_count: usize) -> usize {
 /// buckets `Error::Io` by kind plus rendered message, so any per-peer detail (address,
 /// timing) would split one shared failure into single-count buckets and downgrade a real
 /// dominant error into `ErasureWriteQuorum`.
+///
+/// `peer_rest_client` carries the same helper over `StorageError` for the same response shape.
 fn peer_failure_without_details(op: &str, bucket: Option<&str>) -> Error {
     match bucket {
         Some(bucket) => Error::other(format!("{op}({bucket}): peer returned failure without error details")),


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1883

## Summary of Changes

`PeerRestClient` collapsed every "peer answered `success = false` but sent no `error_info`" case into `Err(Error::other(""))`, at 32 call sites. `StorageError::Io` renders as `Io error: {0}`, so all 32 distinct RPC failures arrived at `NotificationSys` as the bare string `Io error: `, and its joined report read `peer 10.0.0.4 load_bucket_metadata(b) failed: ` with nothing after the colon. An operator reading that log learned only that something failed, never which RPC.

Each site now goes through a small `peer_failure_without_details(op, bucket)` helper that names the operation, plus the bucket for the two bucket-scoped operations. `bucket` is `Option<&str>` because most of these RPCs are node- or cluster-scoped and have no bucket.

The message is deliberately a pure function of `(op, bucket)` and contains no peer address, timing, or counter. Two independent reasons, both verified against this file's consumers:

- `PeerRestClient::finalize_result` classifies failures by message substring (`message_has_network_needle`). Text matching a needle marks an answering peer offline and evicts its connection, turning a plain application-level rejection into a spurious partition.
- Quorum aggregation (`reduce_errs`) buckets `Io` errors by kind plus rendered message, so any per-peer detail would split one shared failure into single-count buckets and downgrade a real dominant error.

This is the same fix and the same helper shape that #6190 landed in the sibling `peer_s3_client.rs`. The helper is duplicated rather than shared because the two modules are typed over different error enums: `peer_s3_client` aliases `Error` to `DiskError`, `peer_rest_client` to `StorageError`. Sharing would have required an `.into()` at all 32 sites. A doc comment in each file cross-references the other.

Site-to-operation mapping, cross-checked mechanically against each site's enclosing method:

| Operation | Bucket | Operation | Bucket |
| --- | --- | --- | --- |
| `local_storage_info` | None | `load_policy_mapping` | None |
| `server_info` | None | `delete_user` | None |
| `get_cpus` | None | `delete_service_account` | None |
| `get_net_info` | None | `load_user` | None |
| `get_partitions` | None | `load_service_account` | None |
| `get_os_info` | None | `load_group` | None |
| `get_se_linux_info` | None | `reload_site_replication_config` | None |
| `get_sys_config` | None | `signal_service` | None |
| `get_sys_errors` | None | `reload_pool_meta` | None |
| `get_mem_info` | None | `stop_rebalance` | None |
| `get_metrics` | None | `load_rebalance_meta` | None |
| `get_live_events` | None | `start_decommission` | None |
| `get_proc_info` | None | `decommission_cancel` | None |
| `start_profiling` | None | `clear_decommission` | None |
| `load_bucket_metadata` | `Some(bucket)` | `delete_policy` | None |
| `delete_bucket_metadata` | `Some(bucket)` | `load_policy` | None |

Six sites sit in a private `*_inner` or `*_checked` method; those carry the public operator-facing name (`local_storage_info`, `server_info`, `get_cpus`, `get_net_info`, `get_partitions`, `get_os_info`, `signal_service`).

## Verification

- `cargo nextest run -p rustfs-ecstore -E 'test(/peer_rest_client/) or test(/peer_s3_client/)'` — 66 passed
- `cargo check -p rustfs-ecstore -p rustfs`
- `cargo clippy -p rustfs-ecstore --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `scripts/check_layer_dependencies.sh`, `scripts/check_architecture_migration_rules.sh`, `scripts/check_unsafe_code_allowances.sh`, `scripts/check_logging_guardrails.sh`, `scripts/check_doc_paths.sh`
- Mutation probe: rewriting the helper text to embed `connection reset` makes `peer_failure_without_details_never_reads_as_a_network_failure` fail with `local_storage_info must not read as a transport failure`, confirming the new test is load-bearing rather than decorative. Reverted after the probe.

## Impact

Log and error-string content only. No API, wire-format, configuration, or control-flow change. Error variant is unchanged (`StorageError::Io` before and after), so every caller that classifies by variant behaves identically. Operators reading peer RPC failure logs now see which operation failed instead of an empty tail.

## Additional Notes

**Aggregation-slice check.** Every one of these errors is produced inside a per-peer fan-out in `crates/ecstore/src/services/notification_sys.rs`, and each slice is single-operation with a single argument set — the bucket, policy name, access key, or signal is cloned once and handed to every peer. So all peers within a slice render an identical string; no slice can mix operations or buckets. Two aggregation shapes exist, and neither counts buckets today: `Vec<NotificationPeerErr>` keys each error by its own `host` field, and `aggregate_notification_failures` joins pre-formatted per-peer strings. The `reduce_errs` hazard is therefore latent rather than live on this path; the new test pins the invariant so a future consumer that does reduce these errors inherits correct behavior instead of silently degrading to `ErasureWriteQuorum`.

**Variant-classified helpers are unaffected.** `is_err_object_not_found`, `is_err_version_not_found`, `is_err_bucket_not_found`, `is_err_bucket_exists`, and `is_err_read_quorum` (`crates/ecstore/src/error/mod.rs:858-894`) all use `matches!` against enum variants. `is_all_buckets_not_found` (`crates/ecstore/src/disk/error_reduce.rs:169`) compares against the unit variants `DiskNotFound` and `VolumeNotFound`, which route through `to_u32()` equality rather than message equality — only the `Io`/`Io` arm of `PartialEq` reads rendered text. All 32 sites produce `Io`, whose Display string none of these helpers inspects. `rg` also confirms no test anywhere asserted on the old empty message.

**Adversarial validation, one line per role.**

- Correctness: all 32 operation names were cross-checked mechanically against their enclosing method via an `awk` pass over the file rather than by eye; the two bucket-scoped sites capture the in-scope `bucket: &str` parameter, and the rest are node- or cluster-scoped and correctly pass `None`.
- Minimalism: one six-line helper, 32 one-line call-site rewrites, three tests; no new branch, dependency, or allocation on any success path, and the sharing-versus-duplicating tradeoff was resolved on a hard type constraint rather than taste.
- Concurrency and durability: the message is peer-independent by construction, so `reduce_errs` still sees one bucket per shared failure; the live `NotificationSys` paths do not bucket at all, so no current quorum decision changes.
- Test skeptic: the mistake the old suite could not catch was an operation name that trips `message_has_network_needle` and gates a healthy peer out of every unrelated RPC — nothing pinned that before, and `peer_failure_without_details_never_reads_as_a_network_failure` now covers all 32 names in both the bucketless and bucket-scoped forms, with the mutation probe above proving it fails when it should.

**Hostile bucket names.** The bucket name is caller-supplied and reaches a substring classifier, so it was checked explicitly. Every needle in `message_has_network_needle` contains a space, which S3 bucket names cannot; and the name is closed by `)` before the literal text resumes, so no needle can straddle the boundary either. The test pins this with bucket names chosen to be as close to a needle as valid S3 naming allows (`timed-out`, `connection-reset`, `transport-error`, `broken-pipe`, `unavailable-logs`).
