### PR TITLE
test(e2e): drop 187 no-op serial markers from the three densest e2e suites

### DIFF
--- a/crates/e2e_test/src/multipart_auth_test.rs
+++ b/crates/e2e_test/src/multipart_auth_test.rs
@@ -30,7 +30,6 @@ use md5::{Digest as Md5Digest, Md5};
 use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
-use serial_test::serial;
 use std::collections::HashMap;
 use std::error::Error;
 use std::io::Cursor;
@@ -356,7 +355,6 @@ async fn run_post_object_policy_case(
 /// smuggles one extra field the policy never declared, and the upload must be
 /// rejected with 403 AccessDenied naming the offending field.
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_fields_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -484,7 +482,6 @@ async fn test_anonymous_post_object_rejects_fields_missing_from_policy_condition
 /// sends a different one, and the upload must be rejected with 400
 /// InvalidPolicyDocument naming the field.
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_exact_condition_policy_mismatches()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -689,7 +686,6 @@ async fn test_anonymous_post_object_rejects_exact_condition_policy_mismatches()
 /// one of them with a different value, and the upload must be rejected with
 /// 400 InvalidPolicyDocument naming the mismatched field.
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_object_lock_policy_mismatches() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -757,7 +753,6 @@ async fn test_anonymous_post_object_rejects_object_lock_policy_mismatches() -> R
 /// exact values, the form sends a different parameter value, and the upload
 /// must be rejected with 400 InvalidPolicyDocument naming the parameter.
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_sse_kms_policy_mismatches() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -839,7 +834,6 @@ async fn test_anonymous_post_object_rejects_sse_kms_policy_mismatches() -> Resul
 /// NotImplemented (SSE-KMS POST uploads are not implemented), not with a
 /// policy error.
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_sse_kms_params_outside_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -894,7 +888,6 @@ async fn test_anonymous_post_object_rejects_sse_kms_params_outside_policy_condit
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_multipart_control_apis_require_auth() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -968,7 +961,6 @@ async fn test_anonymous_multipart_control_apis_require_auth() -> Result<(), Box<
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_requires_auth() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1002,7 +994,6 @@ async fn test_anonymous_post_object_requires_auth() -> Result<(), Box<dyn std::e
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_honors_success_action_status() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1066,7 +1057,6 @@ async fn test_anonymous_post_object_honors_success_action_status() -> Result<(),
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_honors_success_action_redirect() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1139,7 +1129,6 @@ async fn test_anonymous_post_object_honors_success_action_redirect() -> Result<(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_defaults_to_no_content() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1185,7 +1174,6 @@ async fn test_anonymous_post_object_defaults_to_no_content() -> Result<(), Box<d
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_sse_kms() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1232,7 +1220,6 @@ async fn test_anonymous_post_object_rejects_sse_kms() -> Result<(), Box<dyn std:
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_sse_s3() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1290,7 +1277,6 @@ async fn test_anonymous_post_object_accepts_sse_s3() -> Result<(), Box<dyn std::
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_uses_bucket_default_sse_s3() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1363,7 +1349,6 @@ async fn test_anonymous_post_object_uses_bucket_default_sse_s3() -> Result<(), B
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_uses_bucket_default_sse_kms() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1437,7 +1422,6 @@ async fn test_anonymous_post_object_uses_bucket_default_sse_kms() -> Result<(), 
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_sse_s3_policy_mismatch() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -1488,7 +1472,6 @@ async fn test_anonymous_post_object_rejects_sse_s3_policy_mismatch() -> Result<(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_sse_s3_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -1552,7 +1535,6 @@ async fn test_anonymous_post_object_accepts_sse_s3_missing_from_policy_condition
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_storage_class_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -1606,7 +1588,6 @@ async fn test_anonymous_post_object_accepts_storage_class_exact_policy_match()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_storage_class_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -1657,7 +1638,6 @@ async fn test_anonymous_post_object_rejects_storage_class_missing_from_policy_co
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_invalid_storage_class_value() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -1709,7 +1689,6 @@ async fn test_anonymous_post_object_rejects_invalid_storage_class_value() -> Res
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_checksum_algorithm_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -1765,7 +1744,6 @@ async fn test_anonymous_post_object_rejects_checksum_algorithm_missing_from_poli
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_checksum_algorithm_policy_mismatch()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -1822,7 +1800,6 @@ async fn test_anonymous_post_object_rejects_checksum_algorithm_policy_mismatch()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_checksum_auxiliary_fields_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -1886,7 +1863,6 @@ async fn test_anonymous_post_object_rejects_checksum_auxiliary_fields_missing_fr
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_allows_sse_c_fields_outside_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -1963,7 +1939,6 @@ async fn test_anonymous_post_object_allows_sse_c_fields_outside_policy_condition
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_sse_c_exact_policy_mismatch() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -2022,7 +1997,6 @@ async fn test_anonymous_post_object_rejects_sse_c_exact_policy_mismatch() -> Res
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_duplicate_key_form_values() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -2072,7 +2046,6 @@ async fn test_anonymous_post_object_rejects_duplicate_key_form_values() -> Resul
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_invalid_success_action_status() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -2120,7 +2093,6 @@ async fn test_anonymous_post_object_rejects_invalid_success_action_status() -> R
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_invalid_success_action_redirect()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2168,7 +2140,6 @@ async fn test_anonymous_post_object_rejects_invalid_success_action_redirect()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_form_fields_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2223,7 +2194,6 @@ async fn test_anonymous_post_object_rejects_form_fields_missing_from_policy_cond
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_form_fields_covered_by_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2280,7 +2250,6 @@ async fn test_anonymous_post_object_accepts_form_fields_covered_by_policy_condit
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_starts_with_policy_mismatch() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -2335,7 +2304,6 @@ async fn test_anonymous_post_object_rejects_starts_with_policy_mismatch() -> Res
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_content_length_range_violation()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2388,7 +2356,6 @@ async fn test_anonymous_post_object_rejects_content_length_range_violation()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_success_action_status_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2445,7 +2412,6 @@ async fn test_anonymous_post_object_accepts_success_action_status_exact_policy_m
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_success_action_redirect_policy_mismatch()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2502,7 +2468,6 @@ async fn test_anonymous_post_object_rejects_success_action_redirect_policy_misma
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_success_action_redirect_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2568,7 +2533,6 @@ async fn test_anonymous_post_object_accepts_success_action_redirect_exact_policy
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_success_action_redirect_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2621,7 +2585,6 @@ async fn test_anonymous_post_object_rejects_success_action_redirect_missing_from
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_metadata_field_covered_by_starts_with()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2676,7 +2639,6 @@ async fn test_anonymous_post_object_accepts_metadata_field_covered_by_starts_wit
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_content_type_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2734,7 +2696,6 @@ async fn test_anonymous_post_object_accepts_content_type_field_exact_policy_matc
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_content_type_field_covered_by_starts_with()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2792,7 +2753,6 @@ async fn test_anonymous_post_object_accepts_content_type_field_covered_by_starts
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_content_disposition_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2850,7 +2810,6 @@ async fn test_anonymous_post_object_accepts_content_disposition_field_exact_poli
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_cache_control_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2908,7 +2867,6 @@ async fn test_anonymous_post_object_accepts_cache_control_field_exact_policy_mat
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_content_language_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -2966,7 +2924,6 @@ async fn test_anonymous_post_object_accepts_content_language_field_exact_policy_
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_content_encoding_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3024,7 +2981,6 @@ async fn test_anonymous_post_object_accepts_content_encoding_field_exact_policy_
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_website_redirect_location_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3082,7 +3038,6 @@ async fn test_anonymous_post_object_accepts_website_redirect_location_exact_poli
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_expires_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3140,7 +3095,6 @@ async fn test_anonymous_post_object_accepts_expires_field_exact_policy_match()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_object_lock_retention_without_permission()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3196,7 +3150,6 @@ async fn test_anonymous_post_object_rejects_object_lock_retention_without_permis
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_object_lock_retention_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3256,7 +3209,6 @@ async fn test_anonymous_post_object_rejects_object_lock_retention_missing_from_p
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_object_lock_legal_hold_without_permission()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3309,7 +3261,6 @@ async fn test_anonymous_post_object_rejects_object_lock_legal_hold_without_permi
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_object_lock_legal_hold_policy_mismatch()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3368,7 +3319,6 @@ async fn test_anonymous_post_object_rejects_object_lock_legal_hold_policy_mismat
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_object_lock_legal_hold_missing_from_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3426,7 +3376,6 @@ async fn test_anonymous_post_object_rejects_object_lock_legal_hold_missing_from_
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_tagging_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3492,7 +3441,6 @@ async fn test_anonymous_post_object_accepts_tagging_field_exact_policy_match()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_accepts_metadata_field_exact_policy_match()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3551,7 +3499,6 @@ async fn test_anonymous_post_object_accepts_metadata_field_exact_policy_match()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_allows_x_ignore_fields_outside_policy_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3604,7 +3551,6 @@ async fn test_anonymous_post_object_allows_x_ignore_fields_outside_policy_condit
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_sigv4_date_policy_mismatch() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -3657,7 +3603,6 @@ async fn test_anonymous_post_object_rejects_sigv4_date_policy_mismatch() -> Resu
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_mismatched_bucket_form_field() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -3712,7 +3657,6 @@ async fn test_anonymous_post_object_rejects_mismatched_bucket_form_field() -> Re
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_multiple_bucket_values() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -3764,7 +3708,6 @@ async fn test_anonymous_post_object_rejects_multiple_bucket_values() -> Result<(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_post_object_rejects_extra_content_disposition_field()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3820,7 +3763,6 @@ async fn test_anonymous_post_object_rejects_extra_content_disposition_field()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_expands_tar_entries_with_prefix_headers()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3891,7 +3833,6 @@ async fn test_signed_put_object_extract_expands_tar_entries_with_prefix_headers(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_request_metadata_on_extracted_objects()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -3956,7 +3897,6 @@ async fn test_signed_put_object_extract_preserves_request_metadata_on_extracted_
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_sse_s3_and_redirect() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4004,7 +3944,6 @@ async fn test_signed_put_object_extract_preserves_sse_s3_and_redirect() -> Resul
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_storage_class() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4047,7 +3986,6 @@ async fn test_signed_put_object_extract_preserves_storage_class() -> Result<(), 
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_rejects_invalid_storage_class() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4083,7 +4021,6 @@ async fn test_signed_put_object_extract_rejects_invalid_storage_class() -> Resul
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_rejects_write_offset_bytes_header() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4137,7 +4074,6 @@ async fn test_signed_put_object_rejects_write_offset_bytes_header() -> Result<()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_raw_signed_put_object_write_offset_bytes_returns_minio_compatible_error_body()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -4176,7 +4112,6 @@ async fn test_raw_signed_put_object_write_offset_bytes_returns_minio_compatible_
 }
 
 #[tokio::test]
-#[serial]
 async fn test_anonymous_put_object_write_offset_bytes_returns_minio_compatible_error_body()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -4235,7 +4170,6 @@ async fn test_anonymous_put_object_write_offset_bytes_returns_minio_compatible_e
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_uses_bucket_default_sse_s3() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4300,7 +4234,6 @@ async fn test_signed_put_object_extract_uses_bucket_default_sse_s3() -> Result<(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_rejects_bucket_default_sse_kms() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4356,7 +4289,6 @@ async fn test_signed_put_object_extract_rejects_bucket_default_sse_kms() -> Resu
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_sse_c() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4421,7 +4353,6 @@ async fn test_signed_put_object_extract_preserves_sse_c() -> Result<(), Box<dyn 
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_object_lock_legal_hold() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -4476,7 +4407,6 @@ async fn test_signed_put_object_extract_preserves_object_lock_legal_hold() -> Re
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_object_lock_retention() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -4536,7 +4466,6 @@ async fn test_signed_put_object_extract_preserves_object_lock_retention() -> Res
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_pax_retention_overrides_request_retention()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -4600,7 +4529,6 @@ async fn test_signed_put_object_extract_pax_retention_overrides_request_retentio
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_returns_archive_etag() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4634,7 +4562,6 @@ async fn test_signed_put_object_extract_returns_archive_etag() -> Result<(), Box
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_entry_mtime() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -4670,7 +4597,6 @@ async fn test_signed_put_object_extract_preserves_entry_mtime() -> Result<(), Bo
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_pax_metadata_and_version_id()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -4724,7 +4650,6 @@ async fn test_signed_put_object_extract_preserves_pax_metadata_and_version_id()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_authorizes_each_pax_privilege_and_retention_conditions()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -5034,7 +4959,6 @@ async fn test_signed_put_object_extract_authorizes_each_pax_privilege_and_retent
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_accepts_compat_header() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -5076,7 +5000,6 @@ async fn test_signed_put_object_extract_accepts_compat_header() -> Result<(), Bo
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_preserves_directory_markers_by_default()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -5137,7 +5060,6 @@ async fn test_signed_put_object_extract_preserves_directory_markers_by_default()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_expands_tar_gz_archive() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -5189,7 +5111,6 @@ async fn test_signed_put_object_extract_expands_tar_gz_archive() -> Result<(), B
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_expands_tgz_archive() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -5241,7 +5162,6 @@ async fn test_signed_put_object_extract_expands_tgz_archive() -> Result<(), Box<
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_expands_tbz2_archive() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -5293,7 +5213,6 @@ async fn test_signed_put_object_extract_expands_tbz2_archive() -> Result<(), Box
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_expands_txz_archive() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -5345,7 +5264,6 @@ async fn test_signed_put_object_extract_expands_txz_archive() -> Result<(), Box<
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_skips_invalid_entry_when_ignore_errors_enabled()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -5419,7 +5337,6 @@ async fn test_signed_put_object_extract_skips_invalid_entry_when_ignore_errors_e
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_normalizes_prefix_header_value() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -5462,7 +5379,6 @@ async fn test_signed_put_object_extract_normalizes_prefix_header_value() -> Resu
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_expands_tzst_archive() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 
@@ -5514,7 +5430,6 @@ async fn test_signed_put_object_extract_expands_tzst_archive() -> Result<(), Box
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_rejects_missing_archive_extension() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -5548,7 +5463,6 @@ async fn test_signed_put_object_extract_rejects_missing_archive_extension() -> R
 }
 
 #[tokio::test]
-#[serial]
 async fn test_signed_put_object_extract_rejects_invalid_tar_gz_payload() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 

--- a/crates/e2e_test/src/object_lock/object_lock_test.rs
+++ b/crates/e2e_test/src/object_lock/object_lock_test.rs
@@ -33,7 +33,6 @@ use aws_sdk_s3::types::{
     ObjectLockMode, ObjectLockRetentionMode,
 };
 use chrono::{DateTime, Duration, Utc};
-use serial_test::serial;
 use tracing::info;
 
 /// Initialize test logging
@@ -107,7 +106,6 @@ fn parse_s3_datetime(value: &aws_sdk_s3::primitives::DateTime) -> DateTime<Utc> 
 // ============================================================================
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_blocked_by_compliance_retention() {
     init_logging();
     info!("🧪 Test: DeleteObject blocked by COMPLIANCE retention");
@@ -145,7 +143,6 @@ async fn test_delete_object_blocked_by_compliance_retention() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_blocked_by_governance_without_bypass() {
     init_logging();
     info!("🧪 Test: DeleteObject blocked by GOVERNANCE retention without bypass");
@@ -175,7 +172,6 @@ async fn test_delete_object_blocked_by_governance_without_bypass() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_allowed_by_governance_with_bypass() {
     init_logging();
     info!("🧪 Test: DeleteObject allowed by GOVERNANCE retention with bypass");
@@ -215,7 +211,6 @@ async fn test_delete_object_allowed_by_governance_with_bypass() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_creates_delete_marker_for_retained_current_version() {
     init_logging();
     info!("🧪 Test: DeleteObject creates delete marker for retained current version");
@@ -266,7 +261,6 @@ async fn test_delete_object_creates_delete_marker_for_retained_current_version()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_blocked_by_legal_hold() {
     init_logging();
     info!("🧪 Test: DeleteObject blocked by Legal Hold");
@@ -299,7 +293,6 @@ async fn test_delete_object_blocked_by_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_allowed_with_legal_hold_off() {
     init_logging();
     info!("🧪 Test: DeleteObject allowed with Legal Hold OFF");
@@ -335,7 +328,6 @@ async fn test_delete_object_allowed_with_legal_hold_off() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_after_legal_hold_removed() {
     init_logging();
     info!("🧪 Test: DeleteObject succeeds after Legal Hold is removed");
@@ -369,7 +361,6 @@ async fn test_delete_object_after_legal_hold_removed() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_object_legal_hold_returns_updated_status() {
     init_logging();
     info!("🧪 Test: GetObjectLegalHold returns updated status");
@@ -425,7 +416,6 @@ async fn test_get_object_legal_hold_returns_updated_status() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_get_object_retention_returns_configured_values() {
     init_logging();
     info!("🧪 Test: GetObjectRetention returns configured values");
@@ -476,7 +466,6 @@ async fn test_get_object_retention_returns_configured_values() {
 // creating a new current version. The lock protects the existing version
 // from deletion; it never blocks new versions.
 #[tokio::test]
-#[serial]
 async fn test_put_object_overwrite_creates_new_version_under_legal_hold() {
     init_logging();
     info!("🧪 Test: PutObject overwrite of a legal-hold version creates a new version");
@@ -561,7 +550,6 @@ async fn test_put_object_overwrite_creates_new_version_under_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_copy_object_applies_requested_legal_hold() {
     init_logging();
     info!("🧪 Test: CopyObject applies requested Legal Hold");
@@ -613,7 +601,6 @@ async fn test_copy_object_applies_requested_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_copy_object_does_not_inherit_source_legal_hold() {
     init_logging();
     info!("🧪 Test: CopyObject does not inherit source Legal Hold");
@@ -707,7 +694,6 @@ async fn test_copy_object_does_not_inherit_source_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_copy_object_overwrite_creates_new_version_under_legal_hold() {
     init_logging();
     info!("🧪 Test: CopyObject overwrite of a legal-hold destination creates a new version");
@@ -787,7 +773,6 @@ async fn test_copy_object_overwrite_creates_new_version_under_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_create_multipart_upload_applies_requested_legal_hold() {
     init_logging();
     info!("🧪 Test: CreateMultipartUpload applies requested Legal Hold");
@@ -853,7 +838,6 @@ async fn test_create_multipart_upload_applies_requested_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_create_multipart_upload_creates_new_version_under_compliance_retention() {
     init_logging();
     info!("🧪 Test: CreateMultipartUpload over a COMPLIANCE-retained key creates a new version");
@@ -933,7 +917,6 @@ async fn test_create_multipart_upload_creates_new_version_under_compliance_reten
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_completed_multipart_object_blocked_by_legal_hold() {
     init_logging();
     info!("🧪 Test: Delete completed multipart object blocked by Legal Hold");
@@ -993,7 +976,6 @@ async fn test_delete_completed_multipart_object_blocked_by_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_completed_multipart_object_blocked_by_retention() {
     init_logging();
     info!("🧪 Test: Delete completed multipart object blocked by retention");
@@ -1055,7 +1037,6 @@ async fn test_delete_completed_multipart_object_blocked_by_retention() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_complete_multipart_upload_creates_new_version_under_legal_hold() {
     init_logging();
     info!("🧪 Test: CompleteMultipartUpload creates a new version when the current version is under Legal Hold");
@@ -1135,7 +1116,6 @@ async fn test_complete_multipart_upload_creates_new_version_under_legal_hold() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_complete_multipart_upload_creates_new_version_under_compliance_retention() {
     init_logging();
     info!("🧪 Test: CompleteMultipartUpload creates a new version when the current version is under COMPLIANCE retention");
@@ -1209,7 +1189,6 @@ async fn test_complete_multipart_upload_creates_new_version_under_compliance_ret
 }
 
 #[tokio::test]
-#[serial]
 async fn test_write_paths_require_put_object_legal_hold_permission() {
     init_logging();
     info!("🧪 Test: write paths require PutObjectLegalHold permission");
@@ -1273,7 +1252,6 @@ async fn test_write_paths_require_put_object_legal_hold_permission() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_write_paths_require_put_object_retention_permission() {
     init_logging();
     info!("🧪 Test: write paths require PutObjectRetention permission");
@@ -1345,7 +1323,6 @@ async fn test_write_paths_require_put_object_retention_permission() {
 // ============================================================================
 
 #[tokio::test]
-#[serial]
 async fn test_delete_objects_mixed_locked_unlocked() {
     init_logging();
     info!("🧪 Test: DeleteObjects with mixed locked and unlocked objects");
@@ -1427,7 +1404,6 @@ async fn test_delete_objects_mixed_locked_unlocked() {
 // ============================================================================
 
 #[tokio::test]
-#[serial]
 async fn test_put_retention_compliance_cannot_shorten() {
     init_logging();
     info!("🧪 Test: PutObjectRetention cannot shorten COMPLIANCE retention");
@@ -1468,7 +1444,6 @@ async fn test_put_retention_compliance_cannot_shorten() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_put_retention_compliance_can_extend() {
     init_logging();
     info!("🧪 Test: PutObjectRetention can extend COMPLIANCE retention");
@@ -1509,7 +1484,6 @@ async fn test_put_retention_compliance_can_extend() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_put_retention_governance_extend_without_bypass() {
     init_logging();
     info!("🧪 Test: PutObjectRetention on GOVERNANCE can extend without bypass");
@@ -1553,7 +1527,6 @@ async fn test_put_retention_governance_extend_without_bypass() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_put_retention_governance_shorten_requires_bypass() {
     init_logging();
     info!("🧪 Test: PutObjectRetention on GOVERNANCE requires bypass to shorten");
@@ -1615,7 +1588,6 @@ async fn test_put_retention_governance_shorten_requires_bypass() {
 // ============================================================================
 
 #[tokio::test]
-#[serial]
 async fn test_default_retention_applied_to_new_objects() {
     init_logging();
     info!("🧪 Test: Default retention is applied to new objects");
@@ -1685,7 +1657,6 @@ async fn test_default_retention_applied_to_new_objects() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_object_creates_delete_marker_for_default_retained_current_version() {
     init_logging();
     info!("🧪 Test: DeleteObject creates delete marker for default-retained current version");
@@ -1770,7 +1741,6 @@ async fn test_delete_object_creates_delete_marker_for_default_retained_current_v
 }
 
 #[tokio::test]
-#[serial]
 async fn test_put_copy_and_multipart_reject_incomplete_retention_headers() {
     init_logging();
     info!("🧪 Test: write paths reject incomplete Object Lock retention headers");
@@ -1869,7 +1839,6 @@ async fn test_put_copy_and_multipart_reject_incomplete_retention_headers() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_copy_object_retention_uses_destination_policy() {
     init_logging();
     info!("🧪 Test: CopyObject retention follows destination policy");
@@ -2051,7 +2020,6 @@ async fn test_copy_object_retention_uses_destination_policy() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_multipart_default_retention_fixed_at_create() {
     init_logging();
     info!("🧪 Test: multipart default retention is fixed at CreateMultipartUpload");
@@ -2122,7 +2090,6 @@ async fn test_multipart_default_retention_fixed_at_create() {
 // ============================================================================
 
 #[tokio::test]
-#[serial]
 async fn test_unretained_object_lock_object_delete_and_bucket_cleanup() {
     init_logging();
     info!("🧪 Test: Unretained Object Lock object delete and bucket cleanup (Issue #5339)");
@@ -2243,7 +2210,6 @@ async fn test_unretained_object_lock_object_delete_and_bucket_cleanup() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_versioning_auto_enabled_with_object_lock() {
     init_logging();
     info!("🧪 Test: Versioning is auto-enabled when Object Lock is configured");
@@ -2302,7 +2268,6 @@ async fn test_versioning_auto_enabled_with_object_lock() {
 // ============================================================================
 
 #[tokio::test]
-#[serial]
 async fn test_error_message_distinguishes_legal_hold_from_retention() {
     init_logging();
     info!("🧪 Test: Error messages distinguish Legal Hold from Retention");

--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -60,7 +60,6 @@ use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
 use s3s::header::X_AMZ_REPLICATION_STATUS;
-use serial_test::serial;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::convert::Infallible;
@@ -2506,7 +2505,6 @@ async fn build_replication_pair(
 /// metadata was inherited wholesale from the source, so the scanner heal pass
 /// skipped it too — no PENDING/FAILED marker meant nothing to re-drive).
 #[tokio::test]
-#[serial]
 async fn test_copy_object_replicates_to_target() -> TestResult {
     init_logging();
 
@@ -2555,7 +2553,6 @@ async fn test_copy_object_replicates_to_target() -> TestResult {
 /// independent object; every member must replicate to the remote target like a
 /// regular PUT (MinIO PutObjectExtract parity).
 #[tokio::test]
-#[serial]
 async fn test_snowball_extract_replicates_members_to_target() -> TestResult {
     init_logging();
 
@@ -2601,7 +2598,6 @@ async fn test_snowball_extract_replicates_members_to_target() -> TestResult {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_replication_check_succeeds_with_remote_target() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2638,7 +2634,6 @@ async fn test_replication_check_succeeds_with_remote_target() -> Result<(), Box<
 }
 
 #[tokio::test]
-#[serial]
 async fn test_replication_check_rejects_target_without_object_lock() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2692,7 +2687,6 @@ async fn test_replication_check_rejects_target_without_object_lock() -> Result<(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_rejects_unversioned_source_bucket() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2731,7 +2725,6 @@ async fn test_set_remote_target_rejects_unversioned_source_bucket() -> Result<()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_replication_check_rejects_unversioned_source_bucket() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2755,7 +2748,6 @@ async fn test_replication_check_rejects_unversioned_source_bucket() -> Result<()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_replication_check_rejects_missing_replication_config() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2779,7 +2771,6 @@ async fn test_replication_check_rejects_missing_replication_config() -> Result<(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_replication_check_rejects_invalid_bucket() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2798,7 +2789,6 @@ async fn test_replication_check_rejects_invalid_bucket() -> Result<(), Box<dyn E
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_rejects_same_bucket_on_same_deployment() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2842,7 +2832,6 @@ async fn test_set_remote_target_rejects_same_bucket_on_same_deployment() -> Resu
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_rejects_unversioned_target_bucket() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2876,7 +2865,6 @@ async fn test_set_remote_target_rejects_unversioned_target_bucket() -> Result<()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_update_requires_arn() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -2928,7 +2916,6 @@ async fn test_set_remote_target_update_requires_arn() -> Result<(), Box<dyn Erro
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_update_rejects_missing_target() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3017,7 +3004,6 @@ async fn fetch_single_target(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_partial_update_preserves_credentials() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3103,7 +3089,6 @@ async fn test_set_remote_target_partial_update_preserves_credentials() -> Result
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_rejects_invalid_target_url() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3145,7 +3130,6 @@ async fn test_set_remote_target_rejects_invalid_target_url() -> Result<(), Box<d
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_rejects_self_signed_https_target_without_skip_tls_verify()
 -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
@@ -3230,7 +3214,6 @@ async fn test_set_remote_target_rejects_self_signed_https_target_without_skip_tl
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_allows_self_signed_https_target_with_skip_tls_verify() -> Result<(), Box<dyn Error + Send + Sync>>
 {
     init_logging();
@@ -3342,7 +3325,6 @@ async fn test_set_remote_target_allows_self_signed_https_target_with_skip_tls_ve
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_rejects_private_ca_https_target_without_ca_cert_pem() -> Result<(), Box<dyn Error + Send + Sync>>
 {
     init_logging();
@@ -3427,7 +3409,6 @@ async fn test_set_remote_target_rejects_private_ca_https_target_without_ca_cert_
 }
 
 #[tokio::test]
-#[serial]
 async fn test_set_remote_target_allows_private_ca_https_target_with_ca_cert_pem() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3518,7 +3499,6 @@ async fn test_set_remote_target_allows_private_ca_https_target_with_ca_cert_pem(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_list_remote_targets_rejects_empty_bucket() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3538,7 +3518,6 @@ async fn test_list_remote_targets_rejects_empty_bucket() -> Result<(), Box<dyn E
 }
 
 #[tokio::test]
-#[serial]
 async fn test_list_remote_targets_rejects_invalid_bucket() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3557,7 +3536,6 @@ async fn test_list_remote_targets_rejects_invalid_bucket() -> Result<(), Box<dyn
 }
 
 #[tokio::test]
-#[serial]
 async fn test_remove_remote_target_rejects_missing_target() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3598,7 +3576,6 @@ async fn test_remove_remote_target_rejects_missing_target() -> Result<(), Box<dy
 }
 
 #[tokio::test]
-#[serial]
 async fn test_remove_remote_target_rejects_missing_arn() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3623,7 +3600,6 @@ async fn test_remove_remote_target_rejects_missing_arn() -> Result<(), Box<dyn E
 }
 
 #[tokio::test]
-#[serial]
 async fn test_remove_remote_target_rejects_invalid_bucket() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3647,7 +3623,6 @@ async fn test_remove_remote_target_rejects_invalid_bucket() -> Result<(), Box<dy
 }
 
 #[tokio::test]
-#[serial]
 async fn test_remove_remote_target_rejects_target_used_by_replication() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3687,7 +3662,6 @@ async fn test_remove_remote_target_rejects_target_used_by_replication() -> Resul
 }
 
 #[tokio::test]
-#[serial]
 async fn test_delete_bucket_replication_removes_remote_target() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3737,7 +3711,6 @@ async fn test_delete_bucket_replication_removes_remote_target() -> Result<(), Bo
 }
 
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_replicates_put_object_issue_2539() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -3779,7 +3752,6 @@ async fn test_bucket_replication_replicates_put_object_issue_2539() -> Result<()
 }
 
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_converges_delete_marker_and_version_purge() -> TestResult {
     init_logging();
 
@@ -3878,7 +3850,6 @@ async fn test_bucket_replication_converges_delete_marker_and_version_purge() -> 
 }
 
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_disabled_delete_marker_does_not_propagate() -> TestResult {
     init_logging();
 
@@ -3965,7 +3936,6 @@ async fn test_bucket_replication_disabled_delete_marker_does_not_propagate() -> 
 /// interoperability profile for a runner that provisions MinIO credentials
 /// and a reachable endpoint.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_acceptance_matrix_local_dual_targets() -> TestResult {
     init_logging();
 
@@ -4293,7 +4263,6 @@ async fn test_bucket_replication_acceptance_matrix_local_dual_targets() -> TestR
 }
 
 #[tokio::test]
-#[serial]
 async fn test_single_bucket_multipart_replication_fans_out_to_multiple_targets() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -4462,7 +4431,6 @@ async fn test_repl17_failure_observation_helpers() -> TestResult {
 /// the replica is decryptable only with the original customer key. The
 /// backlog#1291 property still holds: never a silent plaintext replica.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_c_contract() -> TestResult {
     init_logging();
 
@@ -4540,7 +4508,6 @@ async fn test_bucket_replication_sse_c_contract() -> TestResult {
 /// part — part boundaries and the encrypted-multipart marker survive so the
 /// replica decrypts each part with its part-derived nonce.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_c_multipart_passthrough() -> TestResult {
     init_logging();
 
@@ -4657,7 +4624,6 @@ async fn test_bucket_replication_sse_c_multipart_passthrough() -> TestResult {
 /// (independent KMS, so success proves target-owned envelopes), preserved
 /// source ETag, and a version that stays stable across scanner cycles.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_s3_contract() -> TestResult {
     init_logging();
     assert_managed_sse_replicates_and_reencrypts("sse-s3", false).await
@@ -4667,7 +4633,6 @@ async fn test_bucket_replication_sse_s3_contract() -> TestResult {
 /// fail closed — replication FAILED, and no plaintext (or any) replica ever
 /// materializes on the target.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_s3_fails_closed_without_target_kms() -> TestResult {
     init_logging();
 
@@ -4711,7 +4676,6 @@ async fn test_bucket_replication_sse_s3_fails_closed_without_target_kms() -> Tes
 /// the ETag comparison sees the preserved source ETag on the replica and does
 /// not rewrite it, so the replica's version stays stable through the resync.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_s3_resync_converges() -> TestResult {
     init_logging();
 
@@ -4768,7 +4732,6 @@ async fn test_bucket_replication_sse_s3_resync_converges() -> TestResult {
 /// re-encrypts under its own default key. The independent-KMS pair proves the
 /// replica's envelope is target-owned.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_kms_contract() -> TestResult {
     init_logging();
     assert_managed_sse_replicates_and_reencrypts("sse-kms", true).await
@@ -4779,7 +4742,6 @@ async fn test_bucket_replication_sse_kms_contract() -> TestResult {
 /// carries the full header set (SSE intent, content-type, user metadata) and
 /// the completed replica preserves the source's multipart ETag.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_s3_multipart_reencrypts() -> TestResult {
     init_logging();
 
@@ -4873,7 +4835,6 @@ async fn test_bucket_replication_sse_s3_multipart_reencrypts() -> TestResult {
 /// still-running source's data scanner (short cycle via [`FAST_SCANNER_ENV`])
 /// re-drives the failed objects once the target is reachable again.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_recovers_after_target_outage() -> TestResult {
     init_logging();
 
@@ -4953,7 +4914,6 @@ async fn test_bucket_replication_recovers_after_target_outage() -> TestResult {
 /// must settle back to zero even though the historical failed counter remains
 /// non-zero.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_backlog_metrics_observe_outage_and_recovery() -> TestResult {
     init_logging();
 
@@ -5087,7 +5047,6 @@ async fn test_bucket_replication_backlog_metrics_observe_outage_and_recovery() -
 /// must converge every persisted failure, including the replayed delete marker
 /// (whose replication decision is re-derived from the live config).
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_replays_failed_entries_after_source_restart() -> TestResult {
     init_logging();
 
@@ -5179,7 +5138,6 @@ async fn test_bucket_replication_replays_failed_entries_after_source_restart() -
 }
 
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_replayed_delete_marker_preserves_source_mtime_without_source_restart() -> TestResult {
     init_logging();
 
@@ -5249,7 +5207,6 @@ async fn test_bucket_replication_replayed_delete_marker_preserves_source_mtime_w
 }
 
 #[tokio::test]
-#[serial]
 async fn test_sequential_bucket_replication_succeeds_for_multiple_buckets() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -5293,7 +5250,6 @@ async fn test_sequential_bucket_replication_succeeds_for_multiple_buckets() -> R
 }
 
 #[tokio::test]
-#[serial]
 async fn test_replication_recovers_after_runtime_target_cache_is_cleared() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -5337,7 +5293,6 @@ async fn test_replication_recovers_after_runtime_target_cache_is_cleared() -> Re
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_allows_self_signed_https_with_skip_tls_verify_real_dual_node() -> TestResult {
     init_logging();
 
@@ -5416,7 +5371,6 @@ async fn test_site_replication_allows_self_signed_https_with_skip_tls_verify_rea
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_allows_private_ca_https_with_ca_cert_pem_real_dual_node() -> TestResult {
     init_logging();
 
@@ -5495,7 +5449,6 @@ async fn test_site_replication_allows_private_ca_https_with_ca_cert_pem_real_dua
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_resync_lifecycle_survives_real_server_restart() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
     let resync_process_env = [
@@ -5715,7 +5668,6 @@ async fn test_site_replication_resync_lifecycle_survives_real_server_restart() -
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_edit_and_status_peer_state_real_three_node() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -5964,7 +5916,6 @@ async fn test_site_replication_edit_and_status_peer_state_real_three_node() -> R
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_remove_all_real_dual_node() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -6084,7 +6035,6 @@ async fn test_site_replication_remove_all_real_dual_node() -> Result<(), Box<dyn
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_state_edit_fresh_and_stale_real_dual_node() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -6193,7 +6143,6 @@ async fn test_site_replication_state_edit_fresh_and_stale_real_dual_node() -> Re
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_replicates_object_with_bucket_versioning_real_dual_node() -> TestResult {
     init_logging();
 
@@ -6284,7 +6233,6 @@ async fn test_site_replication_replicates_object_with_bucket_versioning_real_dua
 /// receiver was dropped with only a debug line, while `replicate status` still reported
 /// "1/1 Buckets in sync" because both configs were byte-identical.
 #[tokio::test]
-#[serial]
 async fn test_site_replication_config_broadcast_keeps_reverse_direction_real_dual_node() -> TestResult {
     init_logging();
 
@@ -6423,7 +6371,6 @@ async fn wait_for_site_replication_rule(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_active_active_converges_without_loops_real_dual_node() -> TestResult {
     init_logging();
 
@@ -6741,7 +6688,6 @@ async fn test_site_replication_active_active_converges_without_loops_real_dual_n
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_replicates_policy_backed_user_access_real_dual_node() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -6829,7 +6775,6 @@ async fn test_site_replication_replicates_policy_backed_user_access_real_dual_no
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_replicates_group_policy_backed_access_real_dual_node() -> Result<(), Box<dyn Error + Send + Sync>>
 {
     init_logging();
@@ -6920,7 +6865,6 @@ async fn test_site_replication_replicates_group_policy_backed_access_real_dual_n
 }
 
 #[tokio::test]
-#[serial]
 async fn test_service_account_policy_from_accountinfo_round_trips_real_single_node() -> TestResult {
     init_logging();
 
@@ -6972,7 +6916,6 @@ async fn test_service_account_policy_from_accountinfo_round_trips_real_single_no
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_replicates_multiple_service_accounts_real_dual_node() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 
@@ -7073,7 +7016,6 @@ async fn test_site_replication_replicates_multiple_service_accounts_real_dual_no
 }
 
 #[tokio::test]
-#[serial]
 async fn test_site_replication_replicates_service_accounts_created_from_sts_session_real_dual_node() -> TestResult {
     init_logging();
 
@@ -7214,7 +7156,6 @@ async fn wait_for_target_request_version_id(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_bucket_resync_restart_revisits_objects_before_out_of_order_checkpoint() -> TestResult {
     init_logging();
 
@@ -7333,7 +7274,6 @@ async fn test_bucket_resync_restart_revisits_objects_before_out_of_order_checkpo
 /// CreateMultipartUpload (the version is decided at initiate time) must both
 /// carry the source version as `?versionId=`.
 #[tokio::test]
-#[serial]
 async fn test_replication_put_and_create_multipart_carry_source_version_id_query() -> TestResult {
     init_logging();
 
@@ -7448,7 +7388,6 @@ async fn test_replication_put_and_create_multipart_carry_source_version_id_query
 /// flow to the onward bucket, proving B's outbound replication and scanner
 /// are live.
 #[tokio::test]
-#[serial]
 async fn test_scanner_never_cascades_inbound_replicas() -> TestResult {
     init_logging();
 
@@ -7529,7 +7468,6 @@ async fn test_scanner_never_cascades_inbound_replicas() -> TestResult {
 /// version ids and still mint its own there — the check must not report OK
 /// while multipart deletes and heals would silently miss.
 #[tokio::test]
-#[serial]
 async fn test_replication_check_flags_multipart_only_version_minting_target() -> TestResult {
     init_logging();
 
@@ -7602,7 +7540,6 @@ async fn test_replication_check_flags_multipart_only_version_minting_target() ->
 }
 
 #[tokio::test]
-#[serial]
 async fn test_replication_check_aborts_failed_multipart_probes() -> TestResult {
     init_logging();
 
@@ -7765,7 +7702,6 @@ async fn test_replication_check_aborts_failed_multipart_probes() -> TestResult {
 /// BucketRemoteTargetVersionMismatch — while still cleaning up the probe
 /// object via the version id the target actually assigned.
 #[tokio::test]
-#[serial]
 async fn test_replication_check_flags_version_minting_target() -> TestResult {
     init_logging();
 
@@ -8006,7 +7942,6 @@ async fn wait_for_target_marker_purged(
 /// the target forever. Contract under test: a failed purge attempt is retried
 /// within the watch window and converges once the fault clears.
 #[tokio::test]
-#[serial]
 async fn test_delayed_delete_marker_purge_retries_after_transient_target_failure() -> TestResult {
     init_logging();
     let source_bucket = "delayed-purge-retry-src";
@@ -8066,7 +8001,6 @@ async fn test_delayed_delete_marker_purge_retries_after_transient_target_failure
 /// with an idempotent 204, which used to look like success and strand the
 /// real marker on the target forever.
 #[tokio::test]
-#[serial]
 async fn test_delayed_delete_marker_purge_uses_target_assigned_version() -> TestResult {
     init_logging();
     let source_bucket = "delayed-purge-mint-src";
@@ -8099,7 +8033,6 @@ async fn test_delayed_delete_marker_purge_uses_target_assigned_version() -> Test
 /// replayed purge succeeds, the entry must be acknowledged instead of being
 /// retained as Missed forever.
 #[tokio::test]
-#[serial]
 async fn test_delayed_delete_marker_purge_exhaustion_persists_to_mrf_and_replays_on_restart() -> TestResult {
     init_logging();
     let source_bucket = "delayed-purge-mrf-src";
@@ -8236,7 +8169,6 @@ async fn build_scanner_compensation_pair(
 /// nil-version objects entirely (`scanner_folder.rs` heal_replication), so it
 /// must NEVER be compensated.
 #[tokio::test]
-#[serial]
 async fn test_scanner_compensates_existing_objects_across_write_paths() -> TestResult {
     init_logging();
     let source_bucket = "scanner-comp-src";
@@ -8352,7 +8284,6 @@ async fn test_scanner_compensates_existing_objects_across_write_paths() -> TestR
 /// written after the rule replicate normally (the setting only gates the
 /// existing-object resync path).
 #[tokio::test]
-#[serial]
 async fn test_scanner_never_compensates_when_existing_object_replication_disabled() -> TestResult {
     init_logging();
     let source_bucket = "scanner-disabled-src";


### PR DESCRIPTION
## Summary

First batch of the `#[serial]` sweep tracked in backlog#1846 (T1), scoped to the
three most marker-dense modules of `crates/e2e_test`.

`serial_test`'s `#[serial]` is an **in-process** mutex. `cargo-nextest` — this
repo's authoritative runner — executes every test in its own process, so the
mutex is never contended and the attribute is a documented no-op. This is
already written down in two places:

- `docs/testing/README.md`, "Serial execution & nextest profiles": *"nextest
  runs every test in its own process, so `serial_test`'s in-process `#[serial]`
  mutex does not serialize tests against each other."*
- `.config/nextest.toml` header, and again in the `e2e-repl-nightly` profile
  comment, which says of `replication_extension_test` specifically: *"`#[serial]`
  does NOT serialize under nextest (process-per-test). These tests need no
  cross-test serialization: each spawns its own server(s) on random ports with
  isolated temp dirs, so they are parallel-safe by construction."*

The mechanism that actually serializes across nextest's process boundary is a
`[test-groups]` entry with `max-threads = 1`. **None of the three modules touched
here is in any test-group**, and this PR does not add or change one — so the
markers removed were carrying no isolation for any lane.

## What changed

Pure deletion. Zero added lines, no test renamed, no behaviour touched.

| File | `#[serial]` removed | Tests in file |
| --- | --- | --- |
| `crates/e2e_test/src/multipart_auth_test.rs` | 85 | 85 |
| `crates/e2e_test/src/replication_extension_test.rs` | 68 | 69 |
| `crates/e2e_test/src/object_lock/object_lock_test.rs` | 34 | 34 |
| **Total** | **187** | |

Plus the 3 now-unused `use serial_test::serial;` imports. Full diff:

```
187 -#[serial]
  3 -use serial_test::serial;
```

`serial_test` stays in `crates/e2e_test/Cargo.toml`: 338 markers across 90 other
files in the crate still reference it. The dev-dependency is removed only once
the whole crate reaches zero.

**One unrelated 2-line `Cargo.lock` hunk is included, disclosed here so it is
not a surprise in review.** `crates/heal/Cargo.toml` declares `bytes` and
`crc-fast`, but `Cargo.lock` on `main` does not record them under the
`rustfs-heal` package. Any `cargo build` regenerates those two lines, so the
drift is pre-existing on `main` and independent of this PR — I kept the
correction rather than reverting it, since reverting would only have CI
regenerate it. Happy to split it out if you'd prefer the diff be Rust-only.

## Nothing was retained-with-reason in these three files

The sweep checklist for this batch (mutating process env / binding a fixed port /
already covered by a `[test-groups]` entry) produced **no exclusions** here —
every one of the 187 markers was safe to delete outright:

- **No process-env mutation.** `grep` for `env::set_var` / `remove_var` /
  `temp_env` over all three files: zero hits. The replication suite does set
  `RUSTFS_REPLICATION_ALLOW_LOOPBACK_TARGET`, but as **child-process** env
  handed to `start_rustfs_server_with_env(..)` / `Command::env(..)` — it never
  touches the test process's own environment, so it is not cross-thread unsafe.
- **No fixed ports.** Zero hits for `:9000` / `:8200` / any literal port. Every
  listener in the replication suite binds `127.0.0.1:0` or a port already
  allocated by the harness.
- **No test-group coverage to preserve.** The three e2e test-groups in
  `.config/nextest.toml` (`e2e-reliability`, `e2e-inline-boundaries`,
  `e2e-vault`) select `reliability_disk_fault` / `degraded_read_eof_regression` /
  `replacement_privileged_e2e` / `inline_fast_path_cluster` / `kms::kms_vault` —
  none of the modules in this PR.
- **No named groups.** All 187 were bare `#[serial]`; the crate has zero
  `#[serial(name)]` forms, so no group semantics were dropped.

## Adversarial validation

### Role: concurrency / durability reviewer — are these tests genuinely self-isolating?

Evidence, not assertion. Every test in all three files builds its own server
instance through `RustFSTestEnvironment::new()` (`crates/e2e_test/src/common.rs`),
which gives three independent isolation axes:

1. **Unique on-disk root** — `let temp_dir = format!("/tmp/rustfs_e2e_test_{}", Uuid::new_v4())`,
   created per instance and `remove_dir_all`'d on `Drop`. Two tests can never
   see each other's objects, xl.meta, or bucket metadata.
2. **Uniquely allocated port** — `find_available_port()` walks a shared counter
   and confirms each candidate with a real `TcpListener::bind` before handing it
   out.
3. **Independent bucket namespace** — bucket names are hard-coded per test
   (`test-compliance-delete`, …) but they live inside that test's own server and
   own temp dir, so a duplicate name across tests is not a collision.

Instance counts confirm the 1:1 mapping rather than a shared fixture:
`object_lock_test.rs` has 34 tests and 34 `ObjectLockTestEnvironment::new()`
calls (which wraps `RustFSTestEnvironment`); `multipart_auth_test.rs` has 85
tests and 81 direct `RustFSTestEnvironment::new()` calls — the remaining 4 are
table-driven cases that construct their env inside a shared helper, so still one
server per test.

Also worth stating explicitly: the port allocator's own safety **never depended
on `#[serial]`**. It is guarded by a mkdir-based **filesystem** mutex
(`/tmp/rustfs_e2e_port_allocator.lock`, with stale-lock reaping) plus a counter
file — i.e. deliberately built for the *cross-process* regime, which is exactly
the regime an in-process `serial_test` mutex cannot reach. Under nextest the
`#[serial]` mutex was uncontended by construction; the filesystem lock was doing
all the work before this PR and continues to do all of it after.

### Role: test skeptic — if one of these actually needed serialization, how would it fail, and how do we know it won't?

The honest failure modes and why each is closed:

- **Port collision → server fails to bind, test fails at startup.** Closed:
  serialization here was already provided by the cross-process filesystem lock
  described above, not by `#[serial]`. Deleting an uncontended in-process mutex
  cannot change contention on a filesystem lock.
- **Shared on-disk state → cross-test data bleed, flaky assertions.** Closed:
  per-instance UUID temp dir; no test in these files writes to any path outside
  it (`grep` for literal `/tmp`, `current_dir`, `home_dir`: zero hits in all
  three files).
- **Process-global singleton (`OnceLock`/`static`) mutated by two tests.** Closed:
  no `static mut`, `lazy_static`, or `OnceLock` in these files. The `AtomicU64` /
  `tokio::sync::Mutex` in `replication_extension_test.rs` are per-test values
  constructed inside the test body (fake-target request counters), not module
  statics.
- **Process env raced across threads.** Closed: no env mutation at all (above).

The strongest structural argument is that **this change cannot regress CI at
all**: under nextest — every lane RustFS runs, `default` / `ci` / `e2e-smoke` /
`e2e-repl-nightly` / `e2e-full` — the removed attribute had no runtime effect,
so pre- and post-PR execution are bit-for-bit identical. The only execution mode
where `#[serial]` did anything is the `RUSTFS_ALLOW_CARGO_TEST_FALLBACK=1`
`cargo test` escape hatch, which `docs/testing/README.md` explicitly declares
**not authoritative** ("serialization semantics differ from CI and
`[test-groups]` do not apply"). Under that fallback these tests remain safe for
the same reason CI is safe: temp-dir + port isolation is real isolation, and the
filesystem port lock works there too.

If a real race is ever surfaced by load, the correct remedy per `ci-10` /
backlog#937 policy is a `[test-groups]` entry or a quarantine with an OPEN issue
link — never re-adding a marker the runner ignores.

## Verification

```
cargo fmt --all --check                       # clean
cargo check -p e2e_test --all-targets         # clean
cargo nextest run -p e2e_test \
  -E 'test(/^(multipart_auth_test|object_lock::object_lock_test)::/)'
cargo nextest run --profile e2e-smoke -p e2e_test \
  -E 'test(/^replication_extension_test::/)'
```

Results on this branch (macOS aarch64, nextest 0.9.140):

| Lane | Result |
| --- | --- |
| `object_lock::object_lock_test::` (default profile) | **34 run, 34 passed** — 27.2s |
| `multipart_auth_test::` (default profile) | 85 run, **84 passed, 1 failed** — the pre-existing failure below |
| `multipart_auth_test::` minus that one test | **84 run, 84 passed** — 26.1s |
| `replication_extension_test::` under `--profile e2e-smoke` | **20 run, 20 passed** — 7.7s |
| `--profile e2e-repl-nightly` (the other 49 replication tests) | **49 run, 49 passed** — 54.2s |

**Pre-existing failure, not caused by this PR:**
`multipart_auth_test::test_signed_put_object_extract_skips_invalid_entry_when_ignore_errors_enabled`
fails with `InvalidArgument: Archive entry path exceeds limit ... length=1126, limit=1024`.
This is **rustfs#4843**, already excluded by name in the `e2e-full` profile's
`default-filter` with that issue cited. It is a product-behaviour failure in
over-limit archive-entry handling and is entirely unrelated to test
attributes — this PR adds no lines at all.

Worth highlighting for the reviewer: the `e2e-repl-nightly` run above executed
**all 49 slow replication tests fully in parallel with no `#[serial]` at all** —
including the 12 `_real_dual_node` and 1 `_real_three_node` site-replication
tests that each spawn 2–3 complete rustfs servers — and finished green in 54
seconds. That is the empirical counterpart to the structural argument: if any of
these had depended on serialization, this is the run that would have exposed it.

## Scope

`crates/e2e_test` only, and only the three densest modules. The remaining 338
markers in the crate (90 files), plus the `ecstore` / `rustfs` crates and
backlog#1846 T2–T9, are out of scope for this PR and follow separately.

Refs: backlog#1846 (T1).
