### PR TITLE
fix(deps): record heal's bytes and crc-fast in the lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9539,6 +9539,8 @@ version = "1.0.0-rc.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
+ "bytes",
+ "crc-fast",
  "futures",
  "hotpath",
  "http 1.5.0",


### PR DESCRIPTION
## Related Issues

N/A — found while verifying rustfs/backlog#1846.

## Summary of Changes

Records `bytes` and `crc-fast` under `rustfs-heal` in `Cargo.lock`. `crates/heal/Cargo.toml` declared both in #6189 (`a08de9229`, "feat(heal): wire MRF intents with durable repair journal (HS-01)") without regenerating the lockfile, so `main`'s lockfile no longer matches its manifests.

This is not cosmetic: `.github/workflows/nightly-gnu.yml:57` runs `cargo build --release --locked`, and `--locked` refuses to proceed when the lockfile needs updating. On current `main`:

```
$ cargo metadata --locked --format-version 1
error: cannot update the lock file … because --locked was passed to prevent this
(exit 101)
```

After this change the same command exits 0. Every local `cargo build` also regenerates these two lines today, so the drift shows up as unrelated noise in unrelated PRs until it is recorded.

The diff is exactly the two lines `cargo` itself generates — no dependency versions change, nothing is added or removed from any manifest.

## Verification

- `cargo metadata --locked --format-version 1` → exit 101 before, exit 0 after
- Diff confirmed to be `+ "bytes",` and `+ "crc-fast",` under the `rustfs-heal` package entry only

## Impact

Unblocks the `--locked` nightly GNU release build. No dependency resolution changes: both crates were already in the graph via other packages, this only records them for `rustfs-heal`.

## Additional Notes

N/A
