### PR TITLE
test(lifecycle,scanner): drop 47 no-op #[serial] markers (backlog#1846 T1)

### DIFF
--- a/crates/lifecycle/src/core.rs
+++ b/crates/lifecycle/src/core.rs
@@ -1199,7 +1199,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_zero_expiration_days() {
         // S3 compatibility: Expiration.Days must be a positive integer (>= 1). AWS and
         // the ceph s3-tests `test_lifecycle_expiration_days0` case reject Days == 0 with
@@ -1233,7 +1232,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_negative_expiration_days() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1263,7 +1261,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_accepts_positive_expiration_days() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1290,7 +1287,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_accepts_one_day_boundary_values() {
         // Pin the exact >= 1 boundary: a value of 1 is the smallest legal positive
         // integer and must be accepted for every day-count field tightened for S3
@@ -1325,7 +1321,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn has_active_rules_accepts_zero_day_expiration() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1350,7 +1345,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_zero_noncurrent_expiration_days() {
         // S3 compatibility: NoncurrentVersionExpiration.NoncurrentDays must be a positive
         // integer (>= 1); AWS rejects 0 with InvalidArgument.
@@ -1382,7 +1376,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_negative_noncurrent_expiration_days() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1412,7 +1405,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_accepts_abort_incomplete_multipart_upload_only_rule() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1438,7 +1430,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_zero_abort_incomplete_multipart_upload_days() {
         // S3 compatibility: AbortIncompleteMultipartUpload.DaysAfterInitiation must be a
         // positive integer (>= 1); AWS rejects 0 with InvalidArgument.
@@ -1469,7 +1460,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_missing_abort_incomplete_multipart_upload_days() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1495,7 +1485,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_negative_abort_incomplete_multipart_upload_days() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1556,7 +1545,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_non_midnight_expiration_date() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1638,7 +1626,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_accepts_multiple_rules_without_ids() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1682,7 +1669,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_rule_id_too_long() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1709,7 +1695,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_duplicate_rule_ids() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1752,7 +1737,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_transition_without_storage_class() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1780,7 +1764,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_transition_without_date_or_days() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -1808,7 +1791,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_noncurrent_transition_without_days() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -2365,7 +2347,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn noncurrent_versions_expiration_limit_returns_configured_limits() {
         let lc = Arc::new(BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -2456,7 +2437,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_invalid_status_case_sensitive() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -2483,7 +2463,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn filter_rules_respects_filter_prefix() {
         let filter = LifecycleRuleFilter {
             prefix: Some("prefix".to_string()),
@@ -2528,7 +2507,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn filter_rules_respects_filter_and_prefix() {
         let and = s3s::dto::LifecycleRuleAndOperator {
             prefix: Some("prefix".to_string()),
@@ -2578,7 +2556,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn filter_rules_respects_filter_tag() {
         let filter = LifecycleRuleFilter {
             tag: Some(s3s::dto::Tag {
@@ -2632,7 +2609,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn filter_rules_respects_filter_and_tags() {
         let filter = LifecycleRuleFilter {
             and: Some(s3s::dto::LifecycleRuleAndOperator {
@@ -3086,7 +3062,6 @@ mod tests {
     // --- TASK-002 tests: Object Lock + ExpiredObjectDeleteMarker compatibility ---
 
     #[tokio::test]
-    #[serial]
     async fn validate_allows_expired_object_delete_marker_on_locked_bucket() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3118,7 +3093,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_allows_expired_object_delete_marker_on_unlocked_bucket() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3146,7 +3120,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_allows_non_delete_marker_expiration_on_locked_bucket() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3179,7 +3152,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_del_marker_expiration_on_locked_bucket() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3210,7 +3182,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_zero_day_del_marker_expiration_on_locked_bucket() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3594,7 +3565,6 @@ mod tests {
     // --- TASK-007 tests: Legacy Prefix/Filter conflict ---
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_prefix_and_filter_both_present() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3623,7 +3593,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_allows_prefix_without_filter() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3650,7 +3619,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_allows_filter_without_prefix() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3680,7 +3648,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_allows_empty_prefix_with_filter() {
         // Empty prefix should be treated as "not set"
         let lc = BucketLifecycleConfiguration {
@@ -3713,7 +3680,6 @@ mod tests {
     // --- TASK-004 tests: ExpiredObjectAllVersions ---
 
     #[tokio::test]
-    #[serial]
     async fn validate_rejects_expired_object_all_versions_on_locked_bucket() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,
@@ -3745,7 +3711,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn validate_allows_expired_object_all_versions_on_unlocked_bucket() {
         let lc = BucketLifecycleConfiguration {
             expiry_updated_at: None,

--- a/crates/scanner/src/scanner.rs
+++ b/crates/scanner/src/scanner.rs
@@ -4574,7 +4574,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_randomized_cycle_delay_keeps_configured_start_delay() {
         // 120s with ±10% jitter should stay clearly above the historic 30s cap.
         let delay = randomized_cycle_delay_for(Duration::from_secs(120));
@@ -4593,7 +4592,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_initial_scanner_delay_uses_configured_start_delay() {
         let delay = initial_scanner_delay_for(Some(120));
         assert!(delay >= Duration::from_secs(108));
@@ -4613,14 +4611,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_initial_scanner_delay_skips_for_cold_usage_cache_with_buckets() {
         let delay = initial_scanner_delay_for_startup(Some(120), true, true, false);
         assert_eq!(delay, Duration::ZERO);
     }
 
     #[test]
-    #[serial]
     fn test_initial_scanner_delay_keeps_configured_delay_for_warm_usage_cache_no_replication() {
         let delay = initial_scanner_delay_for_startup(Some(120), false, true, false);
         assert!(delay >= Duration::from_secs(108));
@@ -4628,14 +4624,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_initial_scanner_delay_skips_for_cold_usage_cache_without_buckets() {
         let delay = initial_scanner_delay_for_startup(Some(120), true, false, false);
         assert_eq!(delay, Duration::ZERO);
     }
 
     #[test]
-    #[serial]
     fn test_initial_scanner_delay_skips_for_active_replication_warm_cache() {
         // Warm cache + active replication rules → skip startup delay so that FAILED-status objects
         // from a crash are healed on the first cycle, not after a 27-33 min sleep.
@@ -4644,7 +4638,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_initial_scanner_delay_keeps_delay_for_replication_without_buckets() {
         // Active replication but no buckets → no objects to scan, keep normal delay.
         let delay = initial_scanner_delay_for_startup(Some(120), false, false, true);
@@ -7399,7 +7392,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn clean_idle_cap_allows_policy_max_when_bitrot_is_disabled() {
         let config = ScannerRuntimeConfig {
             bitrot_cycle: None,
@@ -7515,7 +7507,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_randomized_cycle_delay_handles_small_start_delay() {
         // 0 is treated as minimum 1 second before jitter, with lower bound preserved.
         let delay = randomized_cycle_delay_for(Duration::from_secs(0));
@@ -8174,7 +8165,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_background_heal_info_for_scan_complete_marks_deep_idle() {
         let started_at = Utc::now();
         let info = BackgroundHealInfo {
@@ -8192,7 +8182,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_background_heal_info_for_scan_complete_leaves_normal_scan_unchanged() {
         let info = BackgroundHealInfo {
             bitrot_start_time: Some(Utc::now()),
@@ -8204,7 +8193,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_background_heal_info_for_failed_scan_preserves_deep_mode() {
         let info = BackgroundHealInfo {
             bitrot_start_time: Some(Utc::now()),


### PR DESCRIPTION
## Summary

Second batch of the `#[serial]` sweep for backlog#1846 T1, following #6209 (which removed 187 markers from the three densest `crates/e2e_test` files).

`cargo-nextest` is this repository's authoritative runner and executes **every test in its own process**, so `serial_test`'s in-process mutex cannot serialize tests against each other. `docs/testing/README.md` states this explicitly, and the mechanism that actually serializes across nextest's process boundary is a `.config/nextest.toml` `[test-groups]` entry with `max-threads = 1`. The surviving effect of `#[serial]` is confined to the `RUSTFS_ALLOW_CARGO_TEST_FALLBACK=1` / plain `cargo test` path.

The first batch was a safe blanket deletion because e2e tests are process-isolated and build their own resources. **This batch is different**: these are in-crate unit tests that can genuinely share process state under the fallback runner. Every marker was therefore reviewed individually, and a marker was removed only where the test provably touches neither the process environment nor a process-global. The retention ratio here is deliberately high.

**47 markers removed, all pure deletions — no test body, name, or attribute other than `#[serial]` was touched.**

| File | Removed | Retained |
|---|---|---|
| `crates/lifecycle/src/core.rs` | 35 | 44 |
| `crates/scanner/src/scanner.rs` | 12 | 53 |
| `crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs` | **0** | **101 (all)** |

No `#[serial(name)]` named form exists in any of the three files, so no grouping semantics were lost. No `.config/nextest.toml` override filter references any of the 47 removed tests, so no test lost `[test-groups]` coverage.

## What was removed, and why it is safe

### `crates/lifecycle/src/core.rs` (35)

All 35 sit on `validate_*` / `filter_rules_*` / `has_active_rules_*` / `noncurrent_versions_expiration_limit_*` tests. Each constructs a local `BucketLifecycleConfiguration` value and calls a `&self` method that walks only that value's own rules (`validate`, `filter_rules`, `has_active_rules`, `noncurrent_versions_expiration_limit`). None reaches `std::env::var`, `temp_env`, a `OnceLock`, or any `static`.

The env-sensitive path in this file is `ilm_day_secs()` → `resolve_ilm_day_secs()` → `std::env::var(ENV_ILM_DEBUG_DAY_SECS)`. Note that under `#[cfg(test)]` it **deliberately bypasses** the production `OnceLock` cache and re-reads the environment on every call (the in-tree comment: *"the environment is re-read on every call so `temp_env`-style tests remain deterministic and cannot poison each other across a shared process"*). That makes any test whose result depends on it env-order-sensitive, so every such test keeps its marker.

### `crates/scanner/src/scanner.rs` (12)

- **8 delay tests** — `randomized_cycle_delay_for` is pure (`rand` + two `const` clamps against `MAX_SCANNER_SCHEDULE_DELAY`). `initial_scanner_delay_for(Some(secs))` forwards straight to it; only the `None` branch (`randomized_cycle_delay()`) reads runtime config, and none of the removed tests takes that branch. `initial_scanner_delay_for_startup` likewise, all removed callers passing `Some(120)`.
- **`clean_idle_cap_allows_policy_max_when_bitrot_is_disabled`** — sets `bitrot_cycle: None`, which takes `scanner_clean_idle_max_interval`'s first early return (`policy_max`, two consts) *before* the `heal_object_select_prob()` env read further down the function.
- **3 `background_heal_info_*` tests** — `background_heal_info_for_scan_complete` and `background_heal_info_for_scan_result` are pure field comparisons on a caller-owned `BackgroundHealInfo`.

## Retained items and reasons

### `crates/ecstore/src/bucket/lifecycle/bucket_lifecycle_ops.rs` — all 101 retained, zero removals

This file's tests genuinely share process-global state, and the code says so itself. The test module caches:

```rust
static STALE_MULTIPART_TEST_ENV: OnceLock<(Vec<PathBuf>, Arc<ECStore>)> = OnceLock::new();
```

and its own helper carries this in-tree note:

> Re-register the cached environment's disks into its (shared bootstrap) context registry. Other `#[serial]` tests reset or reshape that registry (`reset_local_disk_test_state`, their own `init_local_disks`), and the peer-sys bucket operations of this env resolve local disks through it at call time — without this repair, a lifecycle test that runs after such a test fails bucket creation on write quorum.

That is a first-party statement that these tests mutate and repair a shared local-disk registry for each other. On top of that the file has heavy direct `env::set_var` / `env::remove_var` scopes (`with_transition_worker_env`, `with_expiry_worker_env`, `with_transition_queue_env` and their `_async` variants, plus `RECOVERY_JITTER_CALLS` / `temp_env::async_with_vars` in the tier-recovery family). Removing markers here would introduce a real race on the fallback runner, so the whole file is left untouched. Six of its tests are additionally routed through `ecstore-serial-flaky` in `.config/nextest.toml`, which is what actually serializes them under nextest.

### `crates/lifecycle/src/core.rs` — 44 retained

Every `expected_expiry_time_*`, `ilm_day_secs_*`, `eval_inner_*`, `abort_incomplete_multipart_upload_due_*`, `predict_expiration_*`, and the two proptest groups. All transitively reach `ilm_day_secs()` / `expected_expiry_time()` and therefore read `RUSTFS_ILM_DEBUG_DAY_SECS` / `RUSTFS_ILM_PROCESS_TIME` at call time.

### `crates/scanner/src/scanner.rs` — 53 retained

- **Env readers** (`with_var` / `with_var_unset` scopes, or transitive env reads): the `test_cycle_interval_*`, `test_scanner_cycle_max_duration_*`, `test_scanner_cycle_budget_config_*`, `test_get_cycle_scan_mode_*` families.
- **Process-globals**: every test publishing through `global_metrics()` (the `scanner_cycle_metrics_guard_*`, `test_wait_for_next_scanner_cycle_*`, `distributed_clean_idle_wait_*`, `scanner_activity_probe_wait_*`, `finalize_partial_scan_cycle_*` families).
- **Three near-misses caught in review** that a naive pure-deletion pass would have dropped, called out because they are exactly the failure this batch had to avoid:
  - `scanner_cycle_schedule_status_reports_effective_backoff` — `record_scanner_cycle_schedule` / `reset_scanner_cycle_schedule` write the `SCANNER_CYCLE_SCHEDULE` static `RwLock`.
  - `test_background_heal_info_for_scan_start_marks_deep_active` — calls `bitrot_scan_cycle()`, an env reader (its sibling at the next test wraps the same call in `with_var_unset(ENV_SCANNER_BITROT_CYCLE_SECS, ..)`, confirming the env matters).
  - `evaluator_honors_newer_noncurrent_versions_retention_count` — reaches `eval` → `expected_expiry_time` → `ilm_day_secs`.

## Verification

Both runners were exercised, because the fallback runner is the only place `#[serial]` still has any effect.

```
cargo nextest run -p rustfs-lifecycle          # 109 tests run: 109 passed, 0 skipped
cargo nextest run -p rustfs-scanner            # 453 tests run: 453 passed, 19 skipped

cargo test -p rustfs-lifecycle --lib           # 109 passed (run 2x, both green)
cargo test -p rustfs-scanner  --lib            # 452 passed (run 3x, all green)

cargo fmt --all --check                        # clean
git diff | grep -v '^-\s*#\[serial\]$' ...     # empty -> diff is nothing but #[serial] deletions
```

`cargo test` was used deliberately here despite the repo guidance, precisely because it is the runner under which `#[serial]` is not a no-op. It was *not* run against `rustfs-ecstore`: the `tier_free_version_recovery_*` family in `bucket_lifecycle_ops.rs` is known to hang under the thread-based runner — which is moot for this PR, since that file has zero changes.

## Adversarial validation

**Concurrency/durability reviewer.** For each removed marker, the test's full transitive callee set was resolved down to functions that either return a constant or read only their own arguments. Two independent static passes were run — a file-local attribute→body scan and a crate-wide call-graph taint propagation seeded on `std::env`/`temp_env`/`OnceLock`/`static` — and the removal set is the **intersection** of the two passes' "safe" sets, further narrowed by hand-reading each implicated function's source. Where the two passes disagreed, the conservative verdict won; three such disagreements are listed as near-misses above. Result: none of the 47 removed tests shares process-scoped state with any sibling.

**Test skeptic.** *If one of these markers were actually load-bearing, how would it fail, and why am I confident it will not?* The failure mode would be an environment-variable or global read observing a value a concurrent test set mid-flight, producing a non-deterministic assertion failure — and it would surface **only** under `cargo test`, since nextest's process-per-test isolation makes `#[serial]` inert regardless. Three things bound that risk: (1) the removed tests do not perform such a read at all, verified by source inspection and not merely by pattern matching; (2) the fallback runner — the sole runner where the attribute matters — was run repeatedly (3× scanner, 2× lifecycle) with the markers gone, all green; (3) the highest-risk file, `bucket_lifecycle_ops.rs`, was excluded entirely rather than partially swept, so the shared-`ECStore`-fixture family is untouched. Residual risk is concentrated in the scanner delay tests, whose only non-determinism is `rand::random` jitter bounded by assertions with a ±10% margin — a property that is independent of execution order and unchanged by this diff.

## Remaining work for backlog#1846 T1

`#[serial]` markers still outstanding elsewhere (top offenders after this PR): `crates/e2e_test/src/multipart_auth_test.rs` (85), `crates/e2e_test/src/replication_extension_test.rs` (68), `crates/ecstore/src/set_disk/ops/object.rs` (54), `crates/ecstore/src/store/init.rs` (49), `rustfs/src/app/lifecycle_transition_api_test.rs` (47), `crates/ecstore/src/data_usage/mod.rs` (37). Those are follow-up batches.

Refs: backlog#1846, backlog#1839, backlog#1153 (infra-7), #6209.
