### PR TITLE
fix(package): declare /etc/default/rustfs as a deb conffile

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -290,6 +290,12 @@ jobs:
           Homepage: https://rustfs.com
           EOF
 
+          # Declare /etc/default/rustfs as a conffile so dpkg preserves user
+          # modifications on upgrade instead of silently overwriting them.
+          cat > "${PKG_DIR}/DEBIAN/conffiles" << 'CONFFILES'
+          /etc/default/rustfs
+          CONFFILES
+
           cat > "${PKG_DIR}/DEBIAN/postinst" << 'POSTINST'
           #!/bin/bash
           set -e


### PR DESCRIPTION
## What

The DEB package built by this workflow ships /etc/default/rustfs but never declares it as a conffile (the control archive only contains control, postinst, postrm and prerm). As a result, when users upgrade with dpkg -i, dpkg treats the file as a regular package file and silently overwrites their custom configuration, without the usual conffile prompt or .dpkg-old backup.

## Fix

Write DEBIAN/conffiles listing /etc/default/rustfs during the DEB build step. After this change:

- dpkg -i upgrades will detect user-modified config and ask whether to keep it (or preserve it), instead of silently overwriting;
- dpkg -r will keep the config file, dpkg -P will remove it;
- behavior matches the RPM side, which already passes --config-files /etc/default/rustfs to fpm.