### PR TITLE
fix(e2e): import serial test attribute

### DIFF
--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -60,6 +60,7 @@ use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
 use s3s::header::X_AMZ_REPLICATION_STATUS;
+use serial_test::serial;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::convert::Infallible;


### PR DESCRIPTION
## Related Issues
N/A

## Summary of Changes
Added the missing `serial_test::serial` import in the replication extension e2e module so its existing `#[serial]` attributes resolve during test compilation.

Root cause: the crate already depends on `serial_test`, and this module already used `#[serial]`, but the attribute macro was not imported into the module scope.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `cargo check --package e2e_test --tests`

## Impact
Fixes compilation of the affected e2e test module. No runtime, API, compatibility, deployment, or configuration impact is expected.

## Additional Notes
Adversarial validation: mechanical tier. Correctness attacked attribute resolution, simplicity attacked smaller equivalent fixes, and coverage attacked revert detection via test compilation; no break found.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)). If this is your first contribution, review the [CLA document](https://github.com/rustfs/cla/blob/main/cla/v2.md) and sign it by commenting `I have read and agree to the CLA.` on the PR.
