### PR TITLE
fix(e2e): add missing serial_test import in replication_extension_test

### DIFF
--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -60,6 +60,7 @@ use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
 use s3s::header::X_AMZ_REPLICATION_STATUS;
+use serial_test::serial;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::convert::Infallible;


### PR DESCRIPTION
## Problem

`make pre-pr` fails with compilation error after commit 1cf0f7af1:

```
error: cannot find attribute `serial` in this scope
    --> crates/e2e_test/src/replication_extension_test.rs:4632:3
```

6 occurrences across the file. Commit 1cf0f7af1 (`feat(replication): split oversized hot-path functions...`) added 6 new `#[serial]` attributes to SSE-C and proxy-read replication tests but omitted the required `use serial_test::serial;` import.

## Fix

Added `use serial_test::serial;` to the import block in `crates/e2e_test/src/replication_extension_test.rs` (1 line).

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p e2e_test -- -D warnings` ✅
- `make clippy-check` ✅

Note: `make pre-pr` reports 2 pre-existing flaky performance tests (`test_event_name_expansion_performance`, `test_event_name_mask_performance`) that pass when run individually but fail under parallel load — unrelated to this fix.
