### PR TITLE
docs(architecture): describe io-core by its surviving surface

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,7 @@ rustfs/                      # Workspace root (virtual manifest)
 ├── crates/                  # library crates (authoritative list: Cargo.toml [workspace].members)
 │   ├── ecstore/             # Erasure-coded storage engine
 │   ├── rio/                 # Reader I/O pipeline (encrypt, compress, hash)
-│   ├── io-core/             # Buffer pool, storage profiling, admission control
+│   ├── io-core/             # Buffer pool, storage profiling, backpressure/deadlock policy, lock optimizer, operation progress
 │   ├── io-metrics/          # I/O metrics collection
 │   ├── common/              # Shared runtime state, globals, data usage types
 │   ├── config/              # Configuration types and parsing


### PR DESCRIPTION
## What

PR6 of backlog#1824 — the last item on that issue. The ARCHITECTURE.md Code Map still described `io-core` as "Buffer pool, storage profiling, admission control", which was written before #6201 removed eight zero-consumer modules from the crate.

## Changes

The surviving surface is `pool`, `io_profile`, `config`, `backpressure`, `deadlock_detector`, `lock_optimizer`, and `progress`. The old summary covered only the first three roles, leaving the deadlock/lock helpers and the `OperationProgress` type — which `rustfs-concurrency` re-exports for stale-transfer detection — undocumented. The entry now names them.

Nothing else in `ARCHITECTURE.md` or `docs/` referenced the removed modules (`reader`, `writer`, `bufreader_optimizer`, `shared_memory`, `direct_io`, `timeout_wrapper`, `io_priority_queue`, `scheduler`), so no other line needed correcting. The write-path flow diagram keeps its shorter phrasing, which describes io-core's role in that specific path rather than the crate's whole surface.

## Verification

`scripts/check_doc_paths.sh` passes. Docs-only change; no code touched.
