### PR TITLE
fix(ecstore): group inline dst dir fsync

### DIFF
--- a/crates/ecstore/src/disk/local.rs
+++ b/crates/ecstore/src/disk/local.rs
@@ -9745,7 +9745,8 @@ impl DiskAPI for LocalDisk {
                 {
                     let fsync_started = rustfs_io_metrics::put_stage_timer();
                     if let Err(err) =
-                        os::fsync_dir_with_namespace_file_sync_limit(dst_parent, mutation_lease.clone(), admission).await
+                        os::fsync_dst_dir_group_commit_or_namespace_file_sync_limit(dst_parent, mutation_lease.clone(), admission)
+                            .await
                     {
                         rustfs_io_metrics::record_put_object_stage_duration_from(
                             rustfs_io_metrics::PUT_STAGE_SET_DISK_RENAME_DST_DIR_FSYNC,
@@ -13089,6 +13090,80 @@ mod test {
         assert!(
             !dst_meta_parent.join(new_data_dir.to_string()).exists(),
             "fresh PUT rollback must remove the committed data dir after grouped dst dir fsync failure"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(dst_dir_fsync_group_commit)]
+    async fn rename_data_inline_uses_dst_dir_fsync_group_commit_when_enabled() {
+        use tempfile::tempdir;
+
+        let _group_commit = os::set_dst_dir_fsync_group_commit_for_test(true);
+        let _mode = durability_mode_override::set(DurabilityMode::Strict);
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        let bucket = "grouped-inline-dst-fsync-bucket";
+        let object = "dir/inline-object";
+        let tmp_object = "tmp-grouped-inline-dst-fsync";
+        ensure_test_volume(&disk, bucket).await;
+        ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
+
+        let version_id = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").expect("version id should parse");
+        let new_fi = test_file_info(object, version_id, None, Some(Bytes::from_static(b"inline-payload")));
+        disk.rename_data(RUSTFS_META_TMP_BUCKET, tmp_object, new_fi, bucket, object)
+            .await
+            .expect("inline rename_data should commit");
+
+        let dst_meta_parent = disk
+            .get_object_path(bucket, &format!("{object}/{STORAGE_FORMAT_FILE}"))
+            .expect("dst meta path should resolve")
+            .parent()
+            .expect("dst meta should have a parent")
+            .to_path_buf();
+        assert_eq!(
+            os::fsync_dir_recorder::grouped_batch_sizes(&dst_meta_parent),
+            vec![1],
+            "enabled inline rename_data must route the dst parent fsync through the group commit coordinator"
+        );
+        assert!(
+            !os::fsync_dir_recorder::was_limited(&dst_meta_parent),
+            "enabled grouped dst parent fsync must not also run the direct file-sync limited path"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(dst_dir_fsync_group_commit)]
+    async fn rename_data_inline_dst_dir_fsync_group_commit_failure_rolls_back_fresh_put() {
+        use tempfile::tempdir;
+
+        let _group_commit = os::set_dst_dir_fsync_group_commit_for_test(true);
+        let _mode = durability_mode_override::set(DurabilityMode::Strict);
+        let dir = tempdir().expect("temp dir should be created");
+        let endpoint = Endpoint::try_from(dir.path().to_str().expect("temp dir should be utf8")).expect("endpoint should parse");
+        let disk = LocalDisk::new(&endpoint, false).await.expect("local disk should be created");
+        let bucket = "grouped-inline-dst-fsync-failure-bucket";
+        let object = "dir/inline-object";
+        let tmp_object = "tmp-grouped-inline-dst-fsync-failure";
+        ensure_test_volume(&disk, bucket).await;
+        ensure_test_volume(&disk, RUSTFS_META_TMP_BUCKET).await;
+
+        let dst_meta_parent = dir.path().join(bucket).join(object);
+        os::fsync_dir_recorder::set_grouped_failure(&dst_meta_parent, io::ErrorKind::PermissionDenied);
+        let version_id = Uuid::parse_str("cccccccc-cccc-cccc-cccc-cccccccccccc").expect("version id should parse");
+        let new_fi = test_file_info(object, version_id, None, Some(Bytes::from_static(b"inline-payload")));
+        let err = disk
+            .rename_data(RUSTFS_META_TMP_BUCKET, tmp_object, new_fi, bucket, object)
+            .await
+            .expect_err("grouped dst dir fsync failure must fail the fresh inline PUT");
+
+        assert!(
+            matches!(err, DiskError::Io(ref io_err) if io_err.kind() == io::ErrorKind::PermissionDenied),
+            "grouped dst dir fsync failure must propagate the injected permission error"
+        );
+        assert!(
+            !dst_meta_parent.join(STORAGE_FORMAT_FILE).exists(),
+            "fresh inline PUT rollback must remove the committed xl.meta after grouped dst dir fsync failure"
         );
     }
 

--- a/crates/ecstore/src/disk/os.rs
+++ b/crates/ecstore/src/disk/os.rs
@@ -676,6 +676,18 @@ pub(crate) async fn fsync_dst_dir_group_commit(dir: impl AsRef<Path>) -> io::Res
     fsync_dst_dir_group_commit_with_enabled(dir, dst_dir_fsync_group_commit_enabled()).await
 }
 
+pub(crate) async fn fsync_dst_dir_group_commit_or_namespace_file_sync_limit(
+    dir: impl AsRef<Path>,
+    lease: Arc<NamespaceMutationLease>,
+    admission: &FileSyncAdmission,
+) -> io::Result<()> {
+    if dst_dir_fsync_group_commit_enabled() {
+        fsync_dst_dir_group_commit_with_enabled(dir, true).await
+    } else {
+        fsync_dir_with_namespace_file_sync_limit(dir, lease, admission).await
+    }
+}
+
 #[cfg(test)]
 pub(crate) async fn fsync_dst_dir_group_commit_for_test(dir: impl AsRef<Path>, enabled: bool) -> io::Result<()> {
     fsync_dst_dir_group_commit_with_enabled(dir, enabled).await


### PR DESCRIPTION
## Related Issues
Related to rustfs/backlog#925 and rustfs/backlog#1856.

## Summary of Changes
This PR closes a small coverage gap in the default-off dst-dir fsync group-commit experiment. The non-inline `rename_data` commit path already routed the strict dst-parent fsync through the group-commit coordinator when `RUSTFS_EXPERIMENTAL_DST_DIR_FSYNC_GROUP_COMMIT_ENABLE=true`; the inline commit path still used the direct namespace file-sync limited fsync path.

The new helper preserves the existing default-off behavior by continuing to use `fsync_dir_with_namespace_file_sync_limit` unless the experiment flag is enabled. When enabled, strict inline `rename_data` uses the same dst-dir group-commit coordinator as the non-inline path.

Added regression tests prove the enabled inline path reaches the grouped coordinator and that an injected grouped dst-dir fsync failure fails and rolls back a fresh inline PUT.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-ecstore dst_dir_fsync_group_commit -- --nocapture`
- `cargo test -p rustfs-ecstore strict_inline_rename_retains_admission_until_commit_fsync -- --nocapture`
- `cargo test -p rustfs-ecstore test_rename_data_writes_old_metadata_backup_for_inline_overwrite -- --nocapture`

High-risk adversarial validation:
- Correctness: attacked enabled inline commit fsync success/failure, fresh rollback, and default-off behavior; no break found.
- Simplicity: attacked the helper as avoidable abstraction; kept it because it centralizes the two required semantics without exposing the private flag or duplicating durability routing; no smaller equivalent with the same boundary found.
- Security: attacked path traversal/secret/logging/RPC auth surfaces; no new untrusted input, authz, path parsing, or logging surface added.
- Concurrency/durability: attacked default-off admission retention, enabled grouped failure propagation, cancellation/late-join/inode/overflow coverage from existing coordinator tests; no break found.
- Compatibility: no S3 wire, RPC wire, xl.meta, or on-disk format change; remote NodeService still resolves local DiskStore and dispatches through DiskAPI.
- Performance: default-off path is unchanged; enabled inline path replaces direct per-inline dst-parent fsync with the existing group coordinator and adds no hot-path logging.
- Test coverage: reverting the inline call to the old direct helper fails `rename_data_inline_uses_dst_dir_fsync_group_commit_when_enabled`; swallowing grouped fsync failure or skipping rollback fails `rename_data_inline_dst_dir_fsync_group_commit_failure_rolls_back_fresh_put`.

## Impact
Default behavior is unchanged because the group-commit experiment remains default-off. When `RUSTFS_EXPERIMENTAL_DST_DIR_FSYNC_GROUP_COMMIT_ENABLE=true`, strict inline `rename_data` dst-parent fsync now follows the same grouped path as non-inline `rename_data`.

This PR does not claim final performance improvement. The explicit 4-node clean-data 1MiB PUT c16 probe for #925/#1856 should be rerun only after this PR becomes a merge candidate, using the same stage histogram plus strace/perf sidecar setup and without expanding the size matrix.

## Additional Notes
The code-path audit did not find evidence that remote `rename_data` RPC bypasses `LocalDisk`: `NodeService::find_disk()` returns the local `DiskStore`, `handle_rename_data` calls `StorageDiskRpcExt::rename_data`, and that delegates to `ecstore_disk::DiskAPI::rename_data`. The prior #1856 probe's remote-node `dst_dir_fsync` shape therefore still needs candidate-binary validation to distinguish runtime/config/metrics attribution from an additional code-path gap.
