### PR TITLE
fix(ecstore): classify a missing data-usage cache by the error that arrives

### DIFF
--- a/crates/ecstore/src/data_usage/mod.rs
+++ b/crates/ecstore/src/data_usage/mod.rs
@@ -2026,8 +2026,17 @@ enum DataUsageCacheRead {
 
 /// True when the error means the cache object does not exist, as opposed to a
 /// transient failure that is worth another attempt.
+///
+/// `SetDisks::get_object_reader` runs its failures through `to_object_err`,
+/// which rewrites `FileNotFound` to `ObjectNotFound` and `VolumeNotFound` to
+/// `BucketNotFound`, so those are the variants that actually arrive here. The
+/// raw pair is matched too because callers reading through a different layer
+/// can still surface it.
 fn is_data_usage_cache_absent(err: &Error) -> bool {
-    matches!(err, Error::FileNotFound | Error::VolumeNotFound)
+    matches!(
+        err,
+        Error::FileNotFound | Error::VolumeNotFound | Error::ObjectNotFound(..) | Error::BucketNotFound(..)
+    )
 }
 
 async fn read_data_usage_cache_object<S>(store: &S, key: &str) -> crate::error::Result<DataUsageCacheRead>
@@ -2511,7 +2520,10 @@ mod tests {
                 *remaining -= 1;
                 return Err(Error::other("transient read failure"));
             }
-            Err(Error::FileNotFound)
+            // `SetDisks::get_object_reader` reports a missing object through
+            // `to_object_err`, so the absence that reaches the caller is
+            // `ObjectNotFound`, not the raw `FileNotFound`.
+            Err(Error::ObjectNotFound(RUSTFS_META_BUCKET.to_string(), object.to_string()))
         }
 
         async fn put_object(
@@ -2531,6 +2543,23 @@ mod tests {
             .to_str()
             .expect("utf-8 path")
             .to_string()
+    }
+
+    #[test]
+    fn data_usage_cache_absence_covers_the_variants_that_actually_arrive() {
+        // `to_object_err` rewrites the raw storage variants before they reach
+        // `load_data_usage_cache`; classifying only the raw pair would treat a
+        // missing cache as a transient failure and retry it.
+        assert!(is_data_usage_cache_absent(&Error::ObjectNotFound(
+            "bucket".to_string(),
+            "object".to_string()
+        )));
+        assert!(is_data_usage_cache_absent(&Error::BucketNotFound("bucket".to_string())));
+        assert!(is_data_usage_cache_absent(&Error::FileNotFound));
+        assert!(is_data_usage_cache_absent(&Error::VolumeNotFound));
+
+        assert!(!is_data_usage_cache_absent(&Error::other("transient read failure")));
+        assert!(!is_data_usage_cache_absent(&Error::DiskNotFound));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Follow-up to #6229 (backlog#1828 T5). That PR replaced an inert retry loop with a real one, but classified absence by the wrong error variants, so the retry fires on a case it should skip.

## The defect

`is_data_usage_cache_absent` matched `FileNotFound | VolumeNotFound`. `SetDisks::get_object_reader` ends its failure path in `to_object_err` (`crates/ecstore/src/error/mod.rs:990`), which rewrites those two:

- `FileNotFound` → `ObjectNotFound(bucket, object)` (`:994`)
- `VolumeNotFound` → `BucketNotFound(bucket)` (`:1024`)

So the raw variants never reach `load_data_usage_cache` through a `SetDisks`, and a cache object that simply does not exist was classified as transient: five attempts with capped backoff (~1.5s) and then an error, where an empty cache should have been returned immediately. Admin server-info resolves one cache per erasure set, so the cost multiplies by set count on any cluster whose scanner has not written a cache yet.

The end state the caller reaches is the same either way — `diagnostics/admin_server_info.rs` maps both an `Err` and an empty cache to `usage_error = DATA_USAGE_UNAVAILABLE` — so this shows up as latency rather than a wrong answer.

The same rewrite explains a detail noted in #6229: the old loop's `FileNotFound | VolumeNotFound` arm never fired either, which is why the legacy-key fallback nested inside it was unreachable. That fallback now runs when the prefixed key is genuinely absent.

## Changes

The classifier covers `ObjectNotFound` and `BucketNotFound` alongside the raw pair — the raw pair stays because a caller reading through a different layer can still surface it. The test store now reports absence the way `to_object_err` does, and a new unit test pins which variants must be treated as absence and which must not (`Error::other`, `DiskNotFound`).

## Verification

`cargo nextest run -p rustfs-ecstore --lib -E 'test(data_usage_cache)'` — 8 passed, including the three behavioural tests from #6229 and the new classifier test. `cargo fmt --all` applied.
