### PR TITLE
test(e2e): finish the serial sweep, leaving only markers that mean something

### DIFF
--- a/crates/e2e_test/src/admin_auth_test.rs
+++ b/crates/e2e_test/src/admin_auth_test.rs
@@ -38,7 +38,6 @@ mod tests {
     use rustfs_signer::constants::UNSIGNED_PAYLOAD;
     use rustfs_signer::sign_v4;
     use s3s::Body;
-    use serial_test::serial;
     use std::error::Error;
     use std::io::Read;
     use std::process::{Command, Stdio};
@@ -162,7 +161,6 @@ mod tests {
     /// A fully authenticated but non-admin credential must be rejected with
     /// `403 AccessDenied` on an admin API, while the root credential succeeds.
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn non_admin_credential_denied_on_admin_api() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;
@@ -198,7 +196,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn non_admin_credential_denied_on_manual_transition_run() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;
@@ -326,7 +323,6 @@ mod tests {
     /// credential is accepted and the old one is rejected, on both the S3 data
     /// plane and the admin plane.
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn root_credential_rotation_takes_effect() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;
@@ -389,7 +385,6 @@ mod tests {
     /// runtime. We capture the child's stdout/stderr directly (the shared
     /// harness inherits stdio) and poll for the warning until it appears.
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn default_credentials_emit_startup_warning() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
 

--- a/crates/e2e_test/src/admin_iam_crud_test.rs
+++ b/crates/e2e_test/src/admin_iam_crud_test.rs
@@ -33,7 +33,6 @@ use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};
 use reqwest::StatusCode;
-use serial_test::serial;
 use std::error::Error;
 use tokio::time::{Duration, sleep};
 
@@ -178,7 +177,6 @@ async fn assert_admin_status(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_update_service_account_enforces_owner_and_parent_scope() -> TestResult {
     init_logging();
 
@@ -348,7 +346,6 @@ async fn test_update_service_account_enforces_owner_and_parent_scope() -> TestRe
 /// Full user -> policy -> service-account lifecycle, proving each management
 /// call takes effect on the data plane, not just that the endpoint answers 200.
 #[tokio::test]
-#[serial]
 async fn test_admin_user_policy_service_account_crud_lifecycle() -> TestResult {
     init_logging();
 
@@ -573,7 +570,6 @@ async fn test_admin_user_policy_service_account_crud_lifecycle() -> TestResult {
 /// non-admin credential with 403 AccessDenied (sec-4 assertion pattern; the
 /// gate implementation itself is owned by sec-4 / admin_auth_test).
 #[tokio::test]
-#[serial]
 async fn test_admin_iam_endpoints_deny_non_admin_credential() -> TestResult {
     init_logging();
 

--- a/crates/e2e_test/src/admin_timeout_regression_test.rs
+++ b/crates/e2e_test/src/admin_timeout_regression_test.rs
@@ -21,7 +21,6 @@ use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
 use serde::Deserialize;
-use serial_test::serial;
 use std::error::Error;
 use std::process::Command;
 use tokio::time::{Duration, sleep, timeout};
@@ -100,7 +99,6 @@ fn offline_server_count(info: &InfoMessage) -> usize {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[serial]
 async fn test_single_admin_timeout_does_not_immediately_mark_peer_offline() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 

--- a/crates/e2e_test/src/anonymous_access_test.rs
+++ b/crates/e2e_test/src/anonymous_access_test.rs
@@ -18,7 +18,6 @@
 
 use crate::common::{RustFSTestEnvironment, init_logging, local_http_client};
 use aws_sdk_s3::types::PublicAccessBlockConfiguration;
-use serial_test::serial;
 use tracing::info;
 
 async fn setup_public_bucket(
@@ -73,7 +72,6 @@ async fn anonymous_get_object(
 /// Issue #2036: Anonymous GetObject should succeed when bucket policy allows it
 /// and no PublicAccessBlock configuration exists (ConfigNotFound).
 #[tokio::test]
-#[serial]
 async fn test_anonymous_access_allowed_when_public_access_block_missing() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 {
     init_logging();
@@ -100,7 +98,6 @@ async fn test_anonymous_access_allowed_when_public_access_block_missing() -> Res
 
 /// Anonymous GetObject should be denied when RestrictPublicBuckets is true.
 #[tokio::test]
-#[serial]
 async fn test_anonymous_access_denied_when_restrict_public_buckets_enabled()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -137,7 +134,6 @@ async fn test_anonymous_access_denied_when_restrict_public_buckets_enabled()
 /// Anonymous GetObject should succeed when PublicAccessBlock exists but
 /// RestrictPublicBuckets is explicitly false.
 #[tokio::test]
-#[serial]
 async fn test_anonymous_access_allowed_when_restrict_public_buckets_disabled()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -176,7 +172,6 @@ async fn test_anonymous_access_allowed_when_restrict_public_buckets_disabled()
 /// reaches authorization through a fallback branch, and that branch has to apply the
 /// same public-access gate as a direct grant.
 #[tokio::test]
-#[serial]
 async fn ghsa_x298_anonymous_list_object_versions_denied_when_restrict_public_buckets_enabled()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();

--- a/crates/e2e_test/src/api_rate_limit_test.rs
+++ b/crates/e2e_test/src/api_rate_limit_test.rs
@@ -18,13 +18,11 @@
 //! completely inert with default configuration.
 
 use crate::common::{RustFSTestEnvironment, init_logging, local_http_client};
-use serial_test::serial;
 use tracing::info;
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
 #[tokio::test]
-#[serial]
 async fn api_rate_limit_enforces_429_with_retry_after_when_enabled() -> TestResult {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -87,7 +85,6 @@ async fn api_rate_limit_enforces_429_with_retry_after_when_enabled() -> TestResu
 }
 
 #[tokio::test]
-#[serial]
 async fn api_rate_limit_bucket_dimension_throttles_per_bucket() -> TestResult {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -133,7 +130,6 @@ async fn api_rate_limit_bucket_dimension_throttles_per_bucket() -> TestResult {
 }
 
 #[tokio::test]
-#[serial]
 async fn api_rate_limit_stays_inert_by_default() -> TestResult {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/bucket_logging_test.rs
+++ b/crates/e2e_test/src/bucket_logging_test.rs
@@ -24,11 +24,9 @@ mod tests {
     };
     use http::Method;
     use http::header::CONTENT_TYPE;
-    use serial_test::serial;
     use tracing::info;
 
     #[tokio::test]
-    #[serial]
     async fn test_dummy_bucket_compatibility_endpoints() {
         init_logging();
         info!("Starting test: dummy-compat bucket APIs should match S3-compatible behavior");
@@ -236,7 +234,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_dummy_bucket_compatibility_endpoints_no_such_bucket() {
         init_logging();
         info!("Starting test: dummy-compat bucket APIs should return NoSuchBucket for missing bucket");
@@ -392,7 +389,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_dummy_bucket_endpoints_http_contracts() {
         init_logging();
         info!("Starting test: dummy-compat bucket API HTTP contracts");

--- a/crates/e2e_test/src/bucket_policy_check_test.rs
+++ b/crates/e2e_test/src/bucket_policy_check_test.rs
@@ -18,7 +18,6 @@
 use crate::common::{RustFSTestEnvironment, init_logging};
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::{Client, Config};
-use serial_test::serial;
 use tracing::info;
 
 async fn create_user(
@@ -51,7 +50,6 @@ fn create_user_client(env: &RustFSTestEnvironment, access_key: &str, secret_key:
 }
 
 #[tokio::test]
-#[serial]
 async fn test_bucket_policy_authenticated_user() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     if !crate::common::awscurl_available() {

--- a/crates/e2e_test/src/bucket_stats_regression_test.rs
+++ b/crates/e2e_test/src/bucket_stats_regression_test.rs
@@ -35,7 +35,6 @@ mod tests {
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
     use rustfs_data_usage::DataUsageInfo;
-    use serial_test::serial;
     use std::error::Error;
     use tokio::time::{Duration, sleep};
     use tracing::info;
@@ -59,7 +58,6 @@ mod tests {
     /// 3. Query admin data usage API
     /// 4. Verify object count > 0
     #[tokio::test]
-    #[serial]
     async fn test_bucket_object_count_updates_after_put() -> TestResult {
         init_logging();
         info!("RT-09: bucket object count updates after PUT");
@@ -126,7 +124,6 @@ mod tests {
     /// Regression pattern: stats remain unchanged after objects are deleted
     /// (rustfs#5615).
     #[tokio::test]
-    #[serial]
     async fn test_bucket_object_count_updates_after_delete() -> TestResult {
         init_logging();
         info!("RT-09b: bucket object count updates after DELETE");
@@ -220,7 +217,6 @@ mod tests {
     /// Regression pattern: DataUsageInfo undercounts versioned bucket versions
     /// and delete markers (rustfs#3898).
     #[tokio::test]
-    #[serial]
     async fn test_versioned_bucket_stats_count_all_versions() -> TestResult {
         init_logging();
         info!("RT-09c: versioned bucket stats count all versions");

--- a/crates/e2e_test/src/checksum_upload_test.rs
+++ b/crates/e2e_test/src/checksum_upload_test.rs
@@ -26,7 +26,6 @@ mod tests {
     use base64::Engine;
     use md5::{Digest as Md5Digest, Md5};
     use rustfs_rio::{Checksum, ChecksumType as RioChecksumType};
-    use serial_test::serial;
     use sha2::Sha256;
     use tracing::info;
 
@@ -90,7 +89,6 @@ mod tests {
 
     /// PutObject with Content-MD5: upload succeeds and GetObject returns same content.
     #[tokio::test]
-    #[serial]
     async fn test_put_object_with_content_md5() {
         init_logging();
         info!("TEST: PutObject with Content-MD5");
@@ -126,7 +124,6 @@ mod tests {
 
     /// PutObject with x-amz-checksum-sha256: upload succeeds and GetObject returns same content.
     #[tokio::test]
-    #[serial]
     async fn test_put_object_with_checksum_sha256() {
         init_logging();
         info!("TEST: PutObject with x-amz-checksum-sha256");
@@ -164,7 +161,6 @@ mod tests {
     /// PutObject with a SHA256 checksum that does NOT match the body must be
     /// rejected (BadDigest / checksum mismatch), NOT accepted with HTTP 200.
     #[tokio::test]
-    #[serial]
     async fn test_put_object_rejects_mismatched_sha256() {
         init_logging();
         info!("TEST: PutObject rejects mismatched x-amz-checksum-sha256 (issue #4341)");
@@ -212,7 +208,6 @@ mod tests {
     /// After PutObject with a correct SHA256 checksum, HeadObject with
     /// ChecksumMode=ENABLED must return that stored base64 SHA256 digest.
     #[tokio::test]
-    #[serial]
     async fn test_head_object_returns_stored_sha256() {
         init_logging();
         info!("TEST: HeadObject returns stored SHA256 with ChecksumMode=ENABLED (issue #4341)");
@@ -258,7 +253,6 @@ mod tests {
     /// Multipart upload with checksum: CreateMultipartUpload, UploadPart(s) with checksum_sha256, CompleteMultipartUpload; then GetObject verifies content.
     /// Uses part size >= 5MB (server minimum) for two parts.
     #[tokio::test]
-    #[serial]
     async fn test_multipart_upload_with_checksum() {
         init_logging();
         info!("TEST: MultipartUpload with checksum (checksum_sha256 on parts)");
@@ -356,7 +350,6 @@ mod tests {
     /// Regression test for issue #2282:
     /// CRC64NVME full-object checksum should match between direct PutObject and multipart upload.
     #[tokio::test]
-    #[serial]
     async fn test_crc64nvme_matches_between_put_object_and_multipart_upload() {
         init_logging();
         info!("TEST: CRC64NVME matches between direct PutObject and multipart upload");
@@ -492,7 +485,6 @@ mod tests {
     /// value is rejected with BadDigest and nothing is stored. Full HEAD/GET header
     /// echo round-trip is additionally exercised by the boto3+awscrt e2e.
     #[tokio::test]
-    #[serial]
     async fn test_additional_checksums_verify_on_write() {
         init_logging();
         info!("TEST: additional checksums (XXHash3/64/128, SHA-512, MD5) verify-on-write");

--- a/crates/e2e_test/src/cluster_concurrency_test.rs
+++ b/crates/e2e_test/src/cluster_concurrency_test.rs
@@ -16,7 +16,6 @@ use crate::common::RustFSTestClusterEnvironment;
 use aws_sdk_s3::Client;
 use aws_sdk_s3::error::SdkError;
 use bytes::Bytes;
-use serial_test::serial;
 use std::sync::Arc;
 use tokio::sync::Barrier;
 use tracing::{info, warn};
@@ -135,7 +134,6 @@ async fn run_race_iteration(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_conditional_put_race_cluster() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     crate::common::init_logging();
     info!("Starting conditional PUT race test with auto cluster");
@@ -192,7 +190,6 @@ async fn test_conditional_put_race_cluster() -> Result<(), Box<dyn std::error::E
 }
 
 #[tokio::test]
-#[serial]
 async fn test_conditional_put_basic_cluster() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     crate::common::init_logging();
     info!("Starting basic conditional PUT test with auto cluster");

--- a/crates/e2e_test/src/cluster_multidrive_pool_test.rs
+++ b/crates/e2e_test/src/cluster_multidrive_pool_test.rs
@@ -31,7 +31,6 @@
 //! (toxiproxy / socket proxy) and 5GiB large-object budgets.
 
 use crate::common::{ClusterTopology, RustFSTestClusterEnvironment};
-use serial_test::serial;
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -58,7 +57,6 @@ async fn put_get_roundtrip(cluster: &RustFSTestClusterEnvironment, key: &str, pa
 
 /// 4 nodes x 2 drives, single pool: the multi-drive layout boots and round-trips.
 #[tokio::test]
-#[serial]
 async fn cluster_multidrive_single_pool_smoke() -> TestResult {
     crate::common::init_logging();
 
@@ -81,7 +79,6 @@ async fn cluster_multidrive_single_pool_smoke() -> TestResult {
 /// Two single-node pools, 2 drives each: the multi-pool layout boots and
 /// round-trips. Every pool is a distinct erasure pool (`pool_idx` 0 and 1).
 #[tokio::test]
-#[serial]
 async fn cluster_two_pool_smoke() -> TestResult {
     crate::common::init_logging();
 

--- a/crates/e2e_test/src/compression_test.rs
+++ b/crates/e2e_test/src/compression_test.rs
@@ -3,7 +3,6 @@
 use crate::common::{RustFSTestEnvironment, init_logging, rustfs_binary_path};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
-use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -102,7 +101,6 @@ async fn start_rustfs_with_compression(env: &mut RustFSTestEnvironment) -> Resul
 }
 
 #[tokio::test]
-#[serial]
 async fn test_compression_roundtrip() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Starting compression roundtrip test");
@@ -230,7 +228,6 @@ async fn fetch_range(
 /// (rustfs/rustfs#5957: multipart uploads previously bypassed disk compression
 /// entirely).
 #[tokio::test]
-#[serial]
 async fn test_compression_multipart_roundtrip() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Starting multipart compression roundtrip test");
@@ -349,7 +346,6 @@ const MPU_HIGH_RATIO_BUCKET: &str = "compression-mpu-high-ratio-bucket";
 /// reproduced the mid-payload Pending truncation (rustfs/rustfs#5957). Every GET shape must return
 /// the exact original bytes, and the stored size must show the data really was compressed.
 #[tokio::test]
-#[serial]
 async fn test_compression_multipart_high_ratio_binary_roundtrip() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Starting multipart high-ratio binary compression roundtrip test");
@@ -446,7 +442,6 @@ const MPU_COPY_RANGE_LEN: usize = 5 * 1024 * 1024;
 /// range must be decompressed on read and re-compressed into the destination part, so the final
 /// object has to match "source prefix + uploaded tail" byte for byte.
 #[tokio::test]
-#[serial]
 async fn test_compression_multipart_upload_part_copy_roundtrip() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Starting multipart upload-part-copy compression roundtrip test");
@@ -570,7 +565,6 @@ const MPU_THREE_PARTS_TAIL_SIZE: usize = 512 * 1024;
 /// Three-part upload with uneven part sizes: each partNumber GET must map back to exactly one
 /// compressed part stream, and a suffix range must resolve inside the trailing part.
 #[tokio::test]
-#[serial]
 async fn test_compression_multipart_three_parts_part_number_gets() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Starting three-part multipart compression partNumber test");
@@ -689,7 +683,6 @@ async fn start_rustfs_with_compression_and_sse(
 /// shape must still return the original plaintext bytes. Physical size must shrink because the
 /// compression runs before encryption.
 #[tokio::test]
-#[serial]
 async fn test_compression_multipart_sse_s3_roundtrip() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use aws_sdk_s3::types::ServerSideEncryption;
 

--- a/crates/e2e_test/src/connection_cap_test.rs
+++ b/crates/e2e_test/src/connection_cap_test.rs
@@ -18,7 +18,6 @@
 //! concurrency — a queued connection is served only after a held one closes.
 
 use crate::common::{RustFSTestEnvironment, init_logging};
-use serial_test::serial;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -57,7 +56,6 @@ async fn read_response_head(stream: &mut TcpStream, dur: Duration) -> Option<Str
 }
 
 #[tokio::test]
-#[serial]
 async fn connection_cap_releases_permits_on_close() -> TestResult {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -89,7 +87,6 @@ async fn open_and_stall(addr: &str) -> std::io::Result<TcpStream> {
 }
 
 #[tokio::test]
-#[serial]
 async fn connection_cap_blocks_excess_connections_until_permits_free() -> TestResult {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/console_smoke_test.rs
+++ b/crates/e2e_test/src/console_smoke_test.rs
@@ -33,7 +33,6 @@
 //!     serve the unauthenticated console endpoints at all.
 
 use crate::common::{RustFSTestEnvironment, init_logging, local_http_client};
-use serial_test::serial;
 use std::error::Error;
 use tokio::time::{Duration, sleep};
 
@@ -58,7 +57,6 @@ async fn wait_for_console_ready(console_base: &str) -> Result<reqwest::Response,
 }
 
 #[tokio::test]
-#[serial]
 async fn test_console_over_the_wire_smoke() -> TestResult {
     init_logging();
 

--- a/crates/e2e_test/src/content_encoding_test.rs
+++ b/crates/e2e_test/src/content_encoding_test.rs
@@ -22,12 +22,10 @@
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::primitives::ByteStream;
-    use serial_test::serial;
     use tracing::info;
 
     /// Verify Content-Encoding header roundtrips through PUT, GET, and HEAD operations
     #[tokio::test]
-    #[serial]
     async fn test_content_encoding_roundtrip() {
         init_logging();
         info!("Starting Content-Encoding roundtrip test");
@@ -105,7 +103,6 @@ mod tests {
     /// Issue #1857: Content-Encoding "aws-chunked" is used by SigV4 streaming clients and must
     /// not be stored or returned. Upload with aws-chunked and verify GET/HEAD do not return it.
     #[tokio::test]
-    #[serial]
     async fn test_content_encoding_aws_chunked_not_returned_issue_1857() {
         init_logging();
         info!("Issue #1857: aws-chunked must not be persisted or returned");
@@ -161,7 +158,6 @@ mod tests {
     /// Issue #2475 / Route A: when aws-chunked is combined with an effective object encoding,
     /// only the effective encoding should roundtrip through GET/HEAD.
     #[tokio::test]
-    #[serial]
     async fn test_content_encoding_aws_chunked_with_effective_encoding_roundtrip() {
         init_logging();
         info!("aws-chunked,gzip should persist only gzip");

--- a/crates/e2e_test/src/copy_object_checksum_test.rs
+++ b/crates/e2e_test/src/copy_object_checksum_test.rs
@@ -30,7 +30,6 @@ mod tests {
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD as BASE64;
     use rustfs_rio::{Checksum, ChecksumType as RioChecksumType};
-    use serial_test::serial;
     use sha2::{Digest, Sha256};
     use tracing::info;
 
@@ -114,7 +113,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_copy_supports_all_checksum_algorithms() {
         init_logging();
 
@@ -196,7 +194,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_copy_without_algorithm_preserves_every_supported_source_checksum() {
         init_logging();
 
@@ -262,7 +259,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_copy_without_algorithm_preserves_composite_checksum_type() {
         init_logging();
 
@@ -352,7 +348,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_copy_rejects_unknown_algorithm_without_destination_mutation() {
         init_logging();
 
@@ -453,7 +448,6 @@ mod tests {
     /// bytes, return it in `CopyObjectResult.ChecksumSHA256`, and persist it so a checksum-mode
     /// HEAD on the destination returns the identical value.
     #[tokio::test]
-    #[serial]
     async fn test_copy_with_checksum_algorithm_returns_and_persists_sha256() {
         init_logging();
         info!("Issue #4996: CopyObject with ChecksumAlgorithm=SHA256 must return and persist the checksum");
@@ -523,7 +517,6 @@ mod tests {
     /// No algorithm requested: when the source object already carries a checksum, the copy must
     /// preserve it on the destination (AWS default), visible via a checksum-mode HEAD.
     #[tokio::test]
-    #[serial]
     async fn test_copy_without_algorithm_preserves_source_checksum() {
         init_logging();
         info!("Issue #4996: CopyObject without ChecksumAlgorithm must preserve the source object's checksum");
@@ -603,7 +596,6 @@ mod tests {
     /// checksum-not-inherited path, and exercises the CRC32 code path (a different branch of
     /// ChecksumType::from_string than SHA256).
     #[tokio::test]
-    #[serial]
     async fn test_copy_requested_algorithm_overrides_source_checksum() {
         init_logging();
         info!("Issue #4996: a requested CopyObject checksum algorithm must override the source object's algorithm");

--- a/crates/e2e_test/src/copy_object_metadata_test.rs
+++ b/crates/e2e_test/src/copy_object_metadata_test.rs
@@ -22,11 +22,9 @@ mod tests {
     use aws_sdk_s3::types::{
         BucketVersioningStatus, CompletedMultipartUpload, CompletedPart, MetadataDirective, StorageClass, VersioningConfiguration,
     };
-    use serial_test::serial;
     use tracing::info;
 
     #[tokio::test]
-    #[serial]
     async fn copy_object_standard_metadata_copy_replace_and_clear() {
         init_logging();
         info!("Issue #2789: self-copy metadata replacement must preserve object data");
@@ -300,7 +298,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn copy_object_replace_accepts_each_standard_field_independently() {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await.expect("Failed to create test environment");
@@ -416,7 +413,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn copy_object_replace_handles_versioned_multipart_source() {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await.expect("Failed to create test environment");
@@ -530,7 +526,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn invalid_replacement_metadata_does_not_mutate_destination() {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await.expect("Failed to create test environment");

--- a/crates/e2e_test/src/copy_object_tagging_test.rs
+++ b/crates/e2e_test/src/copy_object_tagging_test.rs
@@ -21,7 +21,6 @@ mod tests {
     use aws_sdk_s3::error::ProvideErrorMetadata;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, MetadataDirective, TaggingDirective, VersioningConfiguration};
-    use serial_test::serial;
     use std::collections::BTreeMap;
 
     async fn object_tags(client: &Client, bucket: &str, key: &str) -> BTreeMap<String, String> {
@@ -39,7 +38,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn copy_object_applies_copy_replace_and_empty_tagging_directives() {
         init_logging();
         let mut env = RustFSTestEnvironment::new()
@@ -305,7 +303,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn copy_object_tag_replacement_honors_request_tag_policy_denial() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
     {
         init_logging();

--- a/crates/e2e_test/src/copy_object_version_restore_test.rs
+++ b/crates/e2e_test/src/copy_object_version_restore_test.rs
@@ -21,11 +21,9 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
-    use serial_test::serial;
     use tracing::info;
 
     #[tokio::test]
-    #[serial]
     async fn test_self_copy_of_historical_version_restores_data_and_metadata() {
         init_logging();
         info!("Issue #4238: self-copy of a historical version must be allowed and preserve metadata");
@@ -165,7 +163,6 @@ mod tests {
     /// version copied via `x-amz-copy-source-version-id` (SDK `CopySourceVersionId`), kept distinct
     /// from the newly created destination `x-amz-version-id`.
     #[tokio::test]
-    #[serial]
     async fn test_copy_of_non_latest_source_version_returns_copy_source_version_id() {
         init_logging();
         info!("Issue #4976: versioned CopyObject must return x-amz-copy-source-version-id for the exact source version");

--- a/crates/e2e_test/src/copy_source_invalid_date_test.rs
+++ b/crates/e2e_test/src/copy_source_invalid_date_test.rs
@@ -47,7 +47,6 @@ mod tests {
     use rustfs_signer::constants::UNSIGNED_PAYLOAD;
     use rustfs_signer::sign_v4;
     use s3s::Body;
-    use serial_test::serial;
     use std::error::Error;
 
     /// Signed raw `PUT` copy request with an explicit copy-source conditional
@@ -84,7 +83,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_copy_source_if_unmodified_since_valid_and_invalid() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/create_bucket_region_test.rs
+++ b/crates/e2e_test/src/create_bucket_region_test.rs
@@ -25,13 +25,11 @@
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::types::{BucketLocationConstraint, CreateBucketConfiguration};
-    use serial_test::serial;
     use std::error::Error;
 
     /// `CreateBucket` with a `LocationConstraint` body must pass SigV4 validation
     /// and create the bucket, mirroring `minio-go` `MakeBucket(bucket, "us-east-1")`.
     #[tokio::test]
-    #[serial]
     async fn test_create_bucket_with_us_east_1_location_constraint() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;
@@ -62,7 +60,6 @@ mod tests {
     /// A plain `CreateBucket` (no body) must also succeed; guards against a
     /// regression where an empty body would be hashed incorrectly during SigV4.
     #[tokio::test]
-    #[serial]
     async fn test_create_bucket_without_location_constraint() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/data_usage_test.rs
+++ b/crates/e2e_test/src/data_usage_test.rs
@@ -15,7 +15,6 @@
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
 use rustfs_data_usage::DataUsageInfo;
-use serial_test::serial;
 use tokio::time::{Duration, sleep};
 
 use crate::common::{FAST_DATA_USAGE_SCANNER_ENV, RustFSTestEnvironment, TEST_BUCKET, awscurl_get, init_logging};
@@ -60,7 +59,6 @@ where
 /// Regression test for data usage accuracy (issue #1012).
 /// Launches rustfs, writes 1000 objects, then asserts admin data usage reports the full count.
 #[tokio::test(flavor = "multi_thread")]
-#[serial]
 #[ignore = "Starts a rustfs server and requires awscurl; enable when running full E2E"]
 async fn data_usage_reports_all_objects() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -118,7 +116,6 @@ async fn data_usage_reports_all_objects() -> Result<(), Box<dyn std::error::Erro
 /// Regression test for issue #3898.
 /// Versioned buckets should expose versions and delete markers through admin data usage.
 #[tokio::test(flavor = "multi_thread")]
-#[serial]
 #[ignore = "Starts a rustfs server and requires awscurl; enable when running full E2E"]
 async fn data_usage_reports_versioned_objects_and_delete_markers() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();

--- a/crates/e2e_test/src/delete_marker_migration_semantics_test.rs
+++ b/crates/e2e_test/src/delete_marker_migration_semantics_test.rs
@@ -18,7 +18,6 @@ mod tests {
     use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
-    use serial_test::serial;
 
     async fn create_versioned_bucket(client: &Client, bucket: &str) {
         client
@@ -72,7 +71,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_versioning_only_delete_marker_has_minio_compatible_visibility_for_migration_proof() {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await.expect("create test environment");
@@ -113,7 +111,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_versioning_delete_marker_plus_history_remains_visible_for_migration_proof() {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await.expect("create test environment");

--- a/crates/e2e_test/src/delete_object_no_content_length_test.rs
+++ b/crates/e2e_test/src/delete_object_no_content_length_test.rs
@@ -24,7 +24,6 @@ mod tests {
     use rustfs_signer::constants::UNSIGNED_PAYLOAD;
     use rustfs_signer::sign_v4;
     use s3s::Body;
-    use serial_test::serial;
     use std::error::Error;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
@@ -92,7 +91,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_delete_object_version_without_content_length_succeeds() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         info!("🧪 TEST: signed DELETE Object?versionId succeeds without Content-Length");

--- a/crates/e2e_test/src/delete_objects_versioning_test.rs
+++ b/crates/e2e_test/src/delete_objects_versioning_test.rs
@@ -29,7 +29,6 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::Client;
     use aws_sdk_s3::types::{BucketVersioningStatus, Delete, ObjectIdentifier, VersioningConfiguration};
-    use serial_test::serial;
     use tracing::info;
 
     fn create_s3_client(env: &RustFSTestEnvironment) -> Client {
@@ -42,7 +41,6 @@ mod tests {
     /// a versioned bucket, calling `list_object_versions` **immediately** (with
     /// no sleep) returns the newly-created DeleteMarker with `is_latest = true`.
     #[tokio::test]
-    #[serial]
     async fn test_delete_objects_delete_marker_immediately_visible() {
         init_logging();
         info!("🧪 TEST: DeleteMarker from delete_objects is immediately visible via list_object_versions");
@@ -190,7 +188,6 @@ mod tests {
     /// a single `delete_objects` call all have their delete markers visible
     /// immediately afterwards.
     #[tokio::test]
-    #[serial]
     async fn test_delete_objects_multiple_keys_delete_markers_immediately_visible() {
         init_logging();
         info!("🧪 TEST: Multiple delete markers from delete_objects are immediately visible");

--- a/crates/e2e_test/src/delete_regression_test.rs
+++ b/crates/e2e_test/src/delete_regression_test.rs
@@ -33,7 +33,6 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, Delete, ObjectIdentifier, VersioningConfiguration};
-    use serial_test::serial;
     use std::error::Error;
     use tracing::info;
 
@@ -51,7 +50,6 @@ mod tests {
     /// 4. Verify the object is NOT in LIST
     /// 5. Verify HEAD returns 404
     #[tokio::test]
-    #[serial]
     async fn test_delete_removes_object_from_list() -> TestResult {
         init_logging();
         info!("RT-05: delete removes object from list");
@@ -132,7 +130,6 @@ mod tests {
     /// Regression pattern: batch delete returns success but some objects
     /// remain in LIST.
     #[tokio::test]
-    #[serial]
     async fn test_batch_delete_removes_all_objects() -> TestResult {
         init_logging();
         info!("RT-05c: batch delete removes all objects");
@@ -212,7 +209,6 @@ mod tests {
     /// Covers the pattern where permanent deletion of a specific version
     /// fails with FileAccessDenied (rustfs#4978).
     #[tokio::test]
-    #[serial]
     async fn test_versioned_permanent_delete() -> TestResult {
         init_logging();
         info!("RT-05d: versioned permanent delete");
@@ -283,7 +279,6 @@ mod tests {
     /// Covers the pattern where creating a delete marker and then listing
     /// versions shows incorrect state (rustfs#760).
     #[tokio::test]
-    #[serial]
     async fn test_versioned_delete_marker_and_list_consistency() -> TestResult {
         init_logging();
         info!("RT-05e: versioned delete marker and list consistency");
@@ -379,7 +374,6 @@ mod tests {
     /// Regression pattern: after delete, the object data files remain on disk
     /// (rustfs#5029: Node Does Not Remove Files After Reconnect).
     #[tokio::test]
-    #[serial]
     async fn test_delete_removes_object_head_returns_404() -> TestResult {
         init_logging();
         info!("RT-05f: delete → HEAD 404 consistency");

--- a/crates/e2e_test/src/distributed_startup_regression_test.rs
+++ b/crates/e2e_test/src/distributed_startup_regression_test.rs
@@ -32,7 +32,6 @@
 mod tests {
     use crate::common::{RustFSTestClusterEnvironment, init_logging};
     use aws_sdk_s3::primitives::ByteStream;
-    use serial_test::serial;
     use std::error::Error;
     use tokio::time::{Duration, sleep};
     use tracing::info;
@@ -50,7 +49,6 @@ mod tests {
     /// 3. Verify all nodes report healthy
     /// 4. Verify S3 operations work through any node
     #[tokio::test]
-    #[serial]
     async fn test_four_node_cluster_startup_and_health() -> TestResult {
         init_logging();
         info!("RT-10: 4-node cluster startup and health");
@@ -103,7 +101,6 @@ mod tests {
     /// Regression pattern: after a node restart, it cannot rejoin the cluster
     /// or enters a faulty state (rustfs#2601).
     #[tokio::test]
-    #[serial]
     async fn test_cluster_survives_node_restart() -> TestResult {
         init_logging();
         info!("RT-10b: cluster survives node restart");
@@ -168,7 +165,6 @@ mod tests {
     /// Regression pattern: bucket metadata is not replicated to all nodes,
     /// causing NoSuchBucket errors on some nodes (rustfs#3191).
     #[tokio::test]
-    #[serial]
     async fn test_bucket_visible_from_all_nodes() -> TestResult {
         init_logging();
         info!("RT-10c: bucket visible from all nodes");

--- a/crates/e2e_test/src/existing_object_tag_policy_test.rs
+++ b/crates/e2e_test/src/existing_object_tag_policy_test.rs
@@ -23,7 +23,6 @@ use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{Delete, ObjectIdentifier, Tag, Tagging};
 use aws_sdk_s3::{Client, Config};
-use serial_test::serial;
 use tracing::info;
 use uuid::Uuid;
 
@@ -174,7 +173,6 @@ async fn cleanup_bucket_and_object(admin: &Client, bucket: &str, key: &str) {
 
 /// IAM identity policy: GetObject allowed only when `s3:ExistingObjectTag/security` == `public`.
 #[tokio::test]
-#[serial]
 async fn test_e2e_iam_policy_existing_object_tag_get_object() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     if !awscurl_available() {
@@ -233,7 +231,6 @@ async fn test_e2e_iam_policy_existing_object_tag_get_object() -> Result<(), Box<
 
 /// Bucket policy: same `ExistingObjectTag` condition; user has no canned IAM policy attached.
 #[tokio::test]
-#[serial]
 async fn test_e2e_bucket_policy_existing_object_tag_get_object() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     if !awscurl_available() {
@@ -295,7 +292,6 @@ async fn test_e2e_bucket_policy_existing_object_tag_get_object() -> Result<(), B
 
 /// STS `AssumeRole` with inline `Policy` (session policy): GetObject only when `ExistingObjectTag/security` is `public`.
 #[tokio::test]
-#[serial]
 async fn test_e2e_sts_assume_role_session_policy_existing_object_tag() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     if !awscurl_available() {
@@ -372,7 +368,6 @@ async fn test_e2e_sts_assume_role_session_policy_existing_object_tag() -> Result
 
 /// STS inline session policy: DeleteObjects must evaluate `s3:DeleteObject` per requested object key.
 #[tokio::test]
-#[serial]
 async fn test_e2e_sts_session_policy_delete_objects_object_prefix_only() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     if !awscurl_available() {

--- a/crates/e2e_test/src/get_codec_streaming_compat_test.rs
+++ b/crates/e2e_test/src/get_codec_streaming_compat_test.rs
@@ -66,7 +66,6 @@ mod tests {
     use aws_sdk_s3::error::ProvideErrorMetadata;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
-    use serial_test::serial;
     use sha2::{Digest, Sha256};
     use std::collections::BTreeMap;
     use std::error::Error;
@@ -277,7 +276,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn codec_streaming_matches_legacy_duplex_body_and_headers() -> TestResult {
         init_logging();
 

--- a/crates/e2e_test/src/group_delete_test.rs
+++ b/crates/e2e_test/src/group_delete_test.rs
@@ -17,7 +17,6 @@
 use crate::common::{RustFSTestEnvironment, admin_request, awscurl_delete, awscurl_get, awscurl_put, init_logging};
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::{Client, Config};
-use serial_test::serial;
 use tracing::info;
 
 fn create_user_s3_client(env: &RustFSTestEnvironment, access_key: &str, secret_key: &str) -> Client {
@@ -84,7 +83,6 @@ async fn update_group_members_rejects_invalid_new_group_names() -> Result<(), Bo
 
 /// Test that deleting a group with members fails, and deleting an empty group succeeds.
 #[tokio::test(flavor = "multi_thread")]
-#[serial]
 #[ignore = "requires awscurl and spawns a real RustFS server"]
 async fn test_delete_group_requires_empty_membership() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -144,7 +142,6 @@ async fn test_delete_group_requires_empty_membership() -> Result<(), Box<dyn std
 /// Test that a user with only group membership (no explicit user policy) gets group policies
 /// and can perform actions allowed by the group (regression test for #2028.1).
 #[tokio::test(flavor = "multi_thread")]
-#[serial]
 #[ignore = "requires awscurl and spawns a real RustFS server"]
 async fn test_user_with_only_group_gets_group_policies() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
@@ -212,7 +209,6 @@ async fn test_user_with_only_group_gets_group_policies() -> Result<(), Box<dyn s
 /// Test that after deleting a user who was the only member of a group, the group can be deleted
 /// (regression test for #2028.2: delete group uses backend membership, not stale cache).
 #[tokio::test(flavor = "multi_thread")]
-#[serial]
 #[ignore = "requires awscurl and spawns a real RustFS server"]
 async fn test_delete_group_after_deleting_user() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();

--- a/crates/e2e_test/src/head_object_consistency_test.rs
+++ b/crates/e2e_test/src/head_object_consistency_test.rs
@@ -16,7 +16,6 @@ use crate::common::{RustFSTestEnvironment, init_logging, local_http_client};
 use aws_sdk_s3::presigning::PresigningConfig;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
-use serial_test::serial;
 use std::time::Duration;
 use tracing::info;
 
@@ -29,7 +28,6 @@ fn list_contains_key(output: &aws_sdk_s3::operation::list_objects_v2::ListObject
 }
 
 #[tokio::test]
-#[serial]
 async fn head_object_consistency_after_write_and_multipart_and_presigned_head()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();

--- a/crates/e2e_test/src/head_object_range_test.rs
+++ b/crates/e2e_test/src/head_object_range_test.rs
@@ -1,6 +1,5 @@
 use crate::common::{RustFSTestEnvironment, init_logging};
 use aws_sdk_s3::primitives::ByteStream;
-use serial_test::serial;
 use tracing::info;
 
 const RANGE_HEAD_BUCKET: &str = "range-head-test-bucket";
@@ -8,7 +7,6 @@ const RANGE_HEAD_KEY: &str = "range-head-object.bin";
 const ACCEPT_RANGES_BYTES: &str = "bytes";
 
 #[tokio::test]
-#[serial]
 async fn head_object_advertises_accept_ranges() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Starting HeadObject Accept-Ranges regression test");

--- a/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
+++ b/crates/e2e_test/src/heal_erasure_disk_rebuild_test.rs
@@ -19,7 +19,6 @@ mod tests {
     use crate::chaos::signed_admin_post;
     use crate::common::{RustFSTestClusterEnvironment, RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::primitives::ByteStream;
-    use serial_test::serial;
     use std::collections::HashSet;
     use std::error::Error;
     use std::path::{Path, PathBuf};
@@ -63,7 +62,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_auto_heal_rebuilds_runtime_wiped_disk_without_restart() {
         init_logging();
         info!("Issue #1533: auto heal should rebuild a runtime-wiped disk in a 4-disk single-node erasure set without restart");
@@ -182,7 +180,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_admin_deep_heal_rebuilds_cleared_disk_in_single_node_erasure_set() {
         init_logging();
         info!("Discussion #2964: admin deep heal should rebuild a wiped disk in a 4-disk single-node erasure set");
@@ -332,7 +329,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn test_cluster_root_heal_rebuilds_replaced_remote_disk() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         info!("Root recursive heal should rebuild data on a remote node after its disk is replaced and the node rejoins");
@@ -444,7 +440,6 @@ mod tests {
     /// topology early-return or the merge hard-fail) turns the down-window
     /// response into a 500 and fails this test.
     #[tokio::test]
-    #[serial]
     async fn test_background_heal_status_degrades_while_peer_down_and_recovers_after_rejoin()
     -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();

--- a/crates/e2e_test/src/internode_rpc_signature_e2e_test.rs
+++ b/crates/e2e_test/src/internode_rpc_signature_e2e_test.rs
@@ -101,7 +101,6 @@ use rustfs_config::{
 };
 use rustfs_protos::canonical_make_volume_request_body;
 use rustfs_protos::proto_gen::node_service::{MakeVolumeRequest, MakeVolumeResponse, PingRequest, PingResponse};
-use serial_test::serial;
 use sha2::{Digest, Sha256};
 use std::error::Error;
 use tonic::{Code, Request, Response, Status};
@@ -397,7 +396,6 @@ fn assert_rejected(result: Result<MakeVolumeResponse, Status>, expected: Code, e
 /// Grouped into one server start because each case is independent and spawning
 /// a `rustfs` process per assertion would dominate the runtime.
 #[tokio::test]
-#[serial]
 async fn internode_rpc_signature_default_posture_e2e() -> TestResult {
     init_logging();
     align_rpc_secret_with_server();
@@ -424,7 +422,6 @@ async fn internode_rpc_signature_default_posture_e2e() -> TestResult {
 /// epoch is learned from a real response, then the same server is restarted in place to prove its
 /// replacement epoch rejects the captured request even though the nonce cache is necessarily new.
 #[tokio::test]
-#[serial]
 async fn replay_scope_rejects_replay_path_transplant_and_stale_epoch_e2e() -> TestResult {
     init_logging();
     align_rpc_secret_with_server();
@@ -497,7 +494,6 @@ async fn replay_scope_rejects_replay_path_transplant_and_stale_epoch_e2e() -> Te
 /// A mutating v2 request cannot use that lane; once the epoch proof is returned, the first v3
 /// mutation succeeds. This protects a server restart without reopening a general downgrade path.
 #[tokio::test]
-#[serial]
 async fn replay_scope_strict_requires_v3_after_ping_bootstrap_e2e() -> TestResult {
     init_logging();
     align_rpc_secret_with_server();
@@ -704,7 +700,6 @@ async fn legacy_only_signature_is_accepted_in_default_posture(url: &str) {
 ///
 /// The paired v2 positive control rules out "strict simply breaks everything".
 #[tokio::test]
-#[serial]
 async fn signature_strict_rejects_legacy_only_downgrade() -> TestResult {
     init_logging();
     align_rpc_secret_with_server();
@@ -741,7 +736,6 @@ async fn signature_strict_rejects_legacy_only_downgrade() -> TestResult {
 /// takes the still-open legacy lane), which is what pins the rejection to the
 /// handler's digest gate; the cited message confirms which check spoke.
 #[tokio::test]
-#[serial]
 async fn body_digest_strict_rejects_digestless_mutation() -> TestResult {
     init_logging();
     align_rpc_secret_with_server();

--- a/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
+++ b/crates/e2e_test/src/kms/bucket_default_encryption_test.rs
@@ -27,12 +27,10 @@ use aws_sdk_s3::types::{
     ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration, ServerSideEncryptionRule,
 };
 use rustfs_rio::{Checksum, ChecksumType};
-use serial_test::serial;
 use tracing::{debug, info, warn};
 
 /// Test 1: When bucket is configured with default SSE-S3 encryption, put_object should automatically apply encryption
 #[tokio::test]
-#[serial]
 async fn test_bucket_default_sse_s3_put_object() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Testing bucket default SSE-S3 encryption impact on put_object");
@@ -155,7 +153,6 @@ async fn test_bucket_default_sse_s3_put_object() -> Result<(), Box<dyn std::erro
 
 /// Test 2: When bucket is configured with default SSE-KMS encryption, put_object should automatically apply encryption and use the specified KMS key
 #[tokio::test]
-#[serial]
 async fn test_bucket_default_sse_kms_put_object() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Testing bucket default SSE-KMS encryption impact on put_object");
@@ -275,7 +272,6 @@ async fn test_bucket_default_sse_kms_put_object() -> Result<(), Box<dyn std::err
 
 /// Test 3: When bucket is configured with default encryption, create_multipart_upload should inherit the configuration
 #[tokio::test]
-#[serial]
 async fn test_bucket_default_sse_kms_multipart_crc32() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Testing bucket default encryption impact on create_multipart_upload");
@@ -473,7 +469,6 @@ async fn test_bucket_default_sse_kms_multipart_crc32() -> Result<(), Box<dyn std
 
 /// Test 4: Explicitly specified encryption parameters in requests should override bucket default configuration
 #[tokio::test]
-#[serial]
 async fn test_explicit_encryption_overrides_bucket_default() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Testing explicitly specified encryption parameters override bucket default configuration");
@@ -569,7 +564,6 @@ async fn test_explicit_encryption_overrides_bucket_default() -> Result<(), Box<d
 /// Test 5: Setting SSE-KMS without a specific key ID should auto-populate the
 /// default KMS key ID so that GetBucketEncryption returns it (issue #3039).
 #[tokio::test]
-#[serial]
 async fn test_sse_kms_without_key_id_populates_default() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Testing SSE-KMS without explicit key ID populates default key");

--- a/crates/e2e_test/src/kms/configured_roundtrip_test.rs
+++ b/crates/e2e_test/src/kms/configured_roundtrip_test.rs
@@ -20,7 +20,6 @@ use super::common::{
 };
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{BucketVersioningStatus, ServerSideEncryption, VersioningConfiguration};
-use serial_test::serial;
 use std::error::Error;
 use uuid::Uuid;
 
@@ -386,7 +385,6 @@ async fn assert_versioned_sse_kms_roundtrip_and_cleanup(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_configured_local_kms_admin_and_versioned_cleanup() -> TestResult {
     let mut env = LocalKMSTestEnvironment::new().await?;
     env.base_env.start_rustfs_server(Vec::new()).await?;
@@ -434,7 +432,6 @@ async fn test_configured_local_kms_admin_and_versioned_cleanup() -> TestResult {
 }
 
 #[tokio::test]
-#[serial]
 #[ignore = "requires a Vault binary"]
 async fn test_configured_vault_kms_admin_and_versioned_cleanup() -> TestResult {
     let mut env = VaultTestEnvironment::new().await?;

--- a/crates/e2e_test/src/kms/copy_object_self_copy_sse_test.rs
+++ b/crates/e2e_test/src/kms/copy_object_self_copy_sse_test.rs
@@ -32,11 +32,9 @@ use aws_sdk_s3::types::{
     MetadataDirective, ServerSideEncryption, ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration,
     ServerSideEncryptionRule,
 };
-use serial_test::serial;
 use tracing::info;
 
 #[tokio::test]
-#[serial]
 async fn test_metadata_replace_self_copy_of_sse_object_stays_decryptable() {
     init_logging();
     info!("same-key CopyObject with REPLACE metadata must not re-key an SSE-S3 object");
@@ -136,7 +134,6 @@ async fn test_metadata_replace_self_copy_of_sse_object_stays_decryptable() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_metadata_replace_self_copy_dropping_sse_rewrites_plaintext() {
     init_logging();
     info!("same-key CopyObject that drops SSE must rewrite the data, not orphan the ciphertext");
@@ -233,7 +230,6 @@ async fn test_metadata_replace_self_copy_dropping_sse_rewrites_plaintext() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_metadata_replace_self_copy_under_bucket_default_sse_stays_decryptable() {
     init_logging();
     info!("bucket default encryption must also keep a same-key copy off the metadata-only path");

--- a/crates/e2e_test/src/kms/copy_object_version_restore_sse_test.rs
+++ b/crates/e2e_test/src/kms/copy_object_version_restore_sse_test.rs
@@ -25,11 +25,9 @@ use super::common::{LocalKMSTestEnvironment, create_key_with_specific_id};
 use crate::common::init_logging;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{BucketVersioningStatus, ServerSideEncryption, VersioningConfiguration};
-use serial_test::serial;
 use tracing::info;
 
 #[tokio::test]
-#[serial]
 async fn test_self_copy_of_historical_sse_s3_version_is_readable() {
     init_logging();
     info!("Issue #4238 (SSE): restoring an encrypted historical version must stay decryptable");

--- a/crates/e2e_test/src/kms/encryption_metadata_test.rs
+++ b/crates/e2e_test/src/kms/encryption_metadata_test.rs
@@ -22,7 +22,6 @@ use aws_sdk_s3::types::{
     CompletedMultipartUpload, CompletedPart, ServerSideEncryption, ServerSideEncryptionByDefault,
     ServerSideEncryptionConfiguration, ServerSideEncryptionRule,
 };
-use serial_test::serial;
 use std::collections::{HashMap, VecDeque};
 use tracing::info;
 
@@ -82,7 +81,6 @@ pub(super) fn assert_storage_encrypted(storage_root: &std::path::Path, bucket: &
 }
 
 #[tokio::test]
-#[serial]
 async fn test_head_reports_managed_metadata_for_sse_s3() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Validating SSE-S3 managed encryption metadata exposure");
@@ -143,7 +141,6 @@ async fn test_head_reports_managed_metadata_for_sse_s3() -> Result<(), Box<dyn s
 }
 
 #[tokio::test]
-#[serial]
 async fn test_head_reports_managed_metadata_for_sse_kms_and_copy() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Validating SSE-KMS managed encryption metadata (including copy)");
@@ -247,7 +244,6 @@ async fn test_head_reports_managed_metadata_for_sse_kms_and_copy() -> Result<(),
 }
 
 #[tokio::test]
-#[serial]
 async fn test_multipart_upload_writes_encrypted_data() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("Validating ciphertext persistence for multipart SSE-KMS uploads");

--- a/crates/e2e_test/src/kms/kms_authorization_negative_matrix_test.rs
+++ b/crates/e2e_test/src/kms/kms_authorization_negative_matrix_test.rs
@@ -35,7 +35,6 @@ use aws_sdk_s3::config::{Config, Credentials, Region};
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::ServerSideEncryption;
-use serial_test::serial;
 use std::time::Duration;
 use tracing::info;
 
@@ -209,7 +208,6 @@ fn disable_body(key_id: &str) -> String {
 
 /// Data-path matrix: SSE-KMS writes and reads are authorized against the resolved key.
 #[tokio::test]
-#[serial]
 async fn sse_kms_per_key_authorization_negative_matrix() -> TestResult {
     init_logging();
 
@@ -355,7 +353,6 @@ async fn sse_kms_per_key_authorization_negative_matrix() -> TestResult {
 /// Runs without the SSE enforcement switch: admin scoping is unconditional, and
 /// leaving the switch off proves the two planes are independent.
 #[tokio::test]
-#[serial]
 async fn kms_admin_per_key_authorization_negative_matrix() -> TestResult {
     init_logging();
 

--- a/crates/e2e_test/src/kms/kms_comprehensive_test.rs
+++ b/crates/e2e_test/src/kms/kms_comprehensive_test.rs
@@ -24,13 +24,11 @@ use super::common::{
     test_sse_kms_encryption, test_sse_s3_encryption,
 };
 use crate::common::{TEST_BUCKET, init_logging};
-use serial_test::serial;
 use tokio::time::{Duration, sleep};
 use tracing::info;
 
 /// Comprehensive test: Full KMS workflow with all encryption types
 #[tokio::test]
-#[serial]
 async fn test_comprehensive_kms_full_workflow() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🏁 Start the KMS full-featured synthesis test");
@@ -99,7 +97,6 @@ async fn test_mixed_encryption_workload(
 
 /// Comprehensive stress test: Large dataset with multiple encryption types
 #[tokio::test]
-#[serial]
 async fn test_comprehensive_stress_test() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("💪 Start the KMS stress test");
@@ -134,7 +131,6 @@ async fn test_comprehensive_stress_test() -> Result<(), Box<dyn std::error::Erro
 
 /// Test encryption key isolation and security
 #[tokio::test]
-#[serial]
 async fn test_comprehensive_key_isolation() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🔐 Begin the comprehensive test of encryption key isolation");
@@ -206,7 +202,6 @@ async fn test_comprehensive_key_isolation() -> Result<(), Box<dyn std::error::Er
 
 /// Test concurrent encryption operations
 #[tokio::test]
-#[serial]
 async fn test_comprehensive_concurrent_operations() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("⚡ Started comprehensive testing of concurrent encryption operations");
@@ -252,7 +247,6 @@ async fn test_comprehensive_concurrent_operations() -> Result<(), Box<dyn std::e
 
 /// Test encryption/decryption performance with different file sizes
 #[tokio::test]
-#[serial]
 async fn test_comprehensive_performance_benchmark() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("📊 Start KMS performance benchmarking");

--- a/crates/e2e_test/src/kms/kms_edge_cases_test.rs
+++ b/crates/e2e_test/src/kms/kms_edge_cases_test.rs
@@ -26,7 +26,6 @@ use crate::common::{TEST_BUCKET, init_logging};
 use aws_sdk_s3::types::ServerSideEncryption;
 use base64::Engine;
 use md5::{Digest as Md5Digest, Md5};
-use serial_test::serial;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tracing::{info, warn};
@@ -39,7 +38,6 @@ fn md5_hex(input: impl AsRef<[u8]>) -> String {
 
 /// Test encryption of zero-byte files (empty files)
 #[tokio::test]
-#[serial]
 async fn test_kms_zero_byte_file_encryption() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS encryption with zero-byte files");
@@ -113,7 +111,6 @@ async fn test_kms_zero_byte_file_encryption() -> Result<(), Box<dyn std::error::
 
 /// Test encryption of single-byte files
 #[tokio::test]
-#[serial]
 async fn test_kms_single_byte_file_encryption() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS encryption with single-byte files");
@@ -206,7 +203,6 @@ async fn test_kms_single_byte_file_encryption() -> Result<(), Box<dyn std::error
 
 /// Test multipart upload boundary conditions (minimum 5MB part size)
 #[tokio::test]
-#[serial]
 async fn test_kms_multipart_boundary_conditions() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS multipart upload boundary conditions");
@@ -282,7 +278,6 @@ async fn test_kms_multipart_boundary_conditions() -> Result<(), Box<dyn std::err
 
 /// Test invalid key scenarios and error handling
 #[tokio::test]
-#[serial]
 async fn test_kms_invalid_key_scenarios() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS invalid key scenarios and error handling");
@@ -370,7 +365,6 @@ async fn test_kms_invalid_key_scenarios() -> Result<(), Box<dyn std::error::Erro
 
 /// Test concurrent encryption operations
 #[tokio::test]
-#[serial]
 async fn test_kms_concurrent_encryption() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS concurrent encryption operations");
@@ -478,7 +472,6 @@ async fn test_kms_concurrent_encryption() -> Result<(), Box<dyn std::error::Erro
 
 /// Test key validation and security properties
 #[tokio::test]
-#[serial]
 async fn test_kms_key_validation_security() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS key validation and security properties");

--- a/crates/e2e_test/src/kms/kms_fault_recovery_test.rs
+++ b/crates/e2e_test/src/kms/kms_fault_recovery_test.rs
@@ -24,7 +24,6 @@
 use super::common::LocalKMSTestEnvironment;
 use crate::common::{TEST_BUCKET, init_logging};
 use aws_sdk_s3::types::ServerSideEncryption;
-use serial_test::serial;
 use std::fs;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -32,7 +31,6 @@ use tracing::{info, warn};
 
 /// Test KMS behavior when key directory is temporarily unavailable
 #[tokio::test]
-#[serial]
 async fn test_kms_key_directory_unavailable() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS behavior with unavailable key directory");
@@ -123,7 +121,6 @@ async fn test_kms_key_directory_unavailable() -> Result<(), Box<dyn std::error::
 
 /// Test handling of corrupted key files
 #[tokio::test]
-#[serial]
 async fn test_kms_corrupted_key_files() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS behavior with corrupted key files");
@@ -215,7 +212,6 @@ async fn test_kms_corrupted_key_files() -> Result<(), Box<dyn std::error::Error 
 
 /// Test multipart upload interruption and recovery
 #[tokio::test]
-#[serial]
 async fn test_kms_multipart_upload_interruption() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS multipart upload interruption and recovery");
@@ -399,7 +395,6 @@ async fn test_kms_multipart_upload_interruption() -> Result<(), Box<dyn std::err
 
 /// Test KMS resilience to temporary resource constraints
 #[tokio::test]
-#[serial]
 async fn test_kms_resource_constraints() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Testing KMS behavior under resource constraints");

--- a/crates/e2e_test/src/kms/kms_ilm_sse_kms_test.rs
+++ b/crates/e2e_test/src/kms/kms_ilm_sse_kms_test.rs
@@ -51,7 +51,6 @@ use aws_sdk_s3::types::{
     TransitionStorageClass,
 };
 use serde::Deserialize;
-use serial_test::serial;
 use std::time::{Duration as StdDuration, Instant};
 use tracing::info;
 
@@ -424,7 +423,6 @@ async fn wait_for_restore_complete(client: &Client, bucket: &str, key: &str, dea
 /// filter as the cause of the deletion and proves the encrypted bucket stays
 /// readable end to end after the scanner has run.
 #[tokio::test]
-#[serial]
 async fn ilm_expiration_on_sse_kms_bucket_under_enforcement() -> TestResult {
     init_logging();
 
@@ -485,7 +483,6 @@ async fn ilm_expiration_on_sse_kms_bucket_under_enforcement() -> TestResult {
 /// (the mechanism `reliant/tiering.rs` established), so the test does not
 /// depend on scanner scheduling; the 1s scanner cycle stays on as a backstop.
 #[tokio::test]
-#[serial]
 async fn ilm_transition_on_sse_kms_bucket_under_enforcement_reads_back() -> TestResult {
     init_logging();
 

--- a/crates/e2e_test/src/kms/kms_local_test.rs
+++ b/crates/e2e_test/src/kms/kms_local_test.rs
@@ -24,11 +24,9 @@ use super::common::{
     test_kms_key_management, test_sse_c_encryption,
 };
 use crate::common::{TEST_BUCKET, init_logging};
-use serial_test::serial;
 use tracing::{error, info};
 
 #[tokio::test]
-#[serial]
 async fn test_local_kms_end_to_end() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     if skip_if_kms_admin_tool_unavailable("test_local_kms_end_to_end") {
@@ -114,7 +112,6 @@ async fn test_local_kms_end_to_end() -> Result<(), Box<dyn std::error::Error + S
 }
 
 #[tokio::test]
-#[serial]
 async fn test_local_kms_key_isolation() {
     init_logging();
     info!("Starting Local KMS Key Isolation Test");
@@ -215,7 +212,6 @@ async fn test_local_kms_key_isolation() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_local_kms_large_file() {
     init_logging();
     info!("Starting Local KMS Large File Test");
@@ -298,7 +294,6 @@ async fn test_local_kms_large_file() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_local_kms_multipart_upload() {
     init_logging();
     info!("Starting Local KMS Multipart Upload Test");

--- a/crates/e2e_test/src/kms/multipart_encryption_test.rs
+++ b/crates/e2e_test/src/kms/multipart_encryption_test.rs
@@ -23,12 +23,10 @@
 
 use super::common::{LocalKMSTestEnvironment, sse_customer_key_md5_base64};
 use crate::common::{TEST_BUCKET, init_logging};
-use serial_test::serial;
 use tracing::{debug, info};
 
 /// Step 1: Test the basic single-file encryption function (ensure that SSE-S3 works properly in non-sharded scenarios)
 #[tokio::test]
-#[serial]
 async fn test_step1_basic_single_file_encryption() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Step 1: Test the basic single-file encryption function");
@@ -85,7 +83,6 @@ async fn test_step1_basic_single_file_encryption() -> Result<(), Box<dyn std::er
 
 /// Step 2: Test the unencrypted shard upload (make sure the shard upload base is working properly)
 #[tokio::test]
-#[serial]
 async fn test_step2_basic_multipart_upload_without_encryption() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Step 2: Test unencrypted shard uploads");
@@ -184,7 +181,6 @@ async fn test_step2_basic_multipart_upload_without_encryption() -> Result<(), Bo
 
 /// Step 3: Test Shard Upload + SSE-S3 Encryption (Focus Test)
 #[tokio::test]
-#[serial]
 async fn test_step3_multipart_upload_with_sse_s3() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Step 3: Test Shard Upload + SSE-S3 Encryption");
@@ -308,7 +304,6 @@ async fn test_step3_multipart_upload_with_sse_s3() -> Result<(), Box<dyn std::er
 
 /// Step 4: test larger multipart uploads (streaming encryption)
 #[tokio::test]
-#[serial]
 async fn test_step4_large_multipart_upload_with_encryption() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Step 4: test large-file multipart encryption");
@@ -434,7 +429,6 @@ async fn test_step4_large_multipart_upload_with_encryption() -> Result<(), Box<d
 
 /// Step 5: test multipart uploads for every encryption mode
 #[tokio::test]
-#[serial]
 async fn test_step5_all_encryption_types_multipart() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     info!("🧪 Step 5: test multipart uploads for every encryption mode");

--- a/crates/e2e_test/src/kms/test_runner.rs
+++ b/crates/e2e_test/src/kms/test_runner.rs
@@ -19,7 +19,6 @@
 //! filtering, and comprehensive reporting capabilities.
 
 use crate::common::init_logging;
-use serial_test::serial;
 use std::time::Instant;
 use tokio::time::{Duration, sleep};
 use tracing::{debug, error, info, warn};
@@ -458,7 +457,6 @@ impl KMSTestSuite {
 
 /// Quick test suite for critical tests only
 #[tokio::test]
-#[serial]
 async fn test_kms_critical_suite() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = TestSuiteConfig {
         categories: vec![TestCategory::CoreFunctionality, TestCategory::MultipartEncryption],
@@ -481,7 +479,6 @@ async fn test_kms_critical_suite() -> Result<(), Box<dyn std::error::Error + Sen
 
 /// Full comprehensive test suite
 #[tokio::test]
-#[serial]
 async fn test_kms_full_suite() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let suite = KMSTestSuite::new();
     let results = suite.run_test_suite().await;

--- a/crates/e2e_test/src/leading_slash_key_test.rs
+++ b/crates/e2e_test/src/leading_slash_key_test.rs
@@ -24,7 +24,6 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
-    use serial_test::serial;
     use std::error::Error;
     use tracing::info;
 
@@ -36,7 +35,6 @@ mod tests {
     /// PUT with a leading-slash key must succeed and the object must be
     /// readable under the normalized key (leading slash stripped).
     #[tokio::test]
-    #[serial]
     async fn test_put_object_with_leading_slash_key() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         info!("Starting test: PUT object with leading slash in key (Issue #2427)");
@@ -94,7 +92,6 @@ mod tests {
 
     /// Duplicate and repeated slashes after a leading slash collapse MinIO-style.
     #[tokio::test]
-    #[serial]
     async fn test_put_object_with_duplicate_slashes_normalized() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         info!("Starting test: duplicate slash normalization (Issue #2427)");

--- a/crates/e2e_test/src/lifecycle_regression_test.rs
+++ b/crates/e2e_test/src/lifecycle_regression_test.rs
@@ -36,7 +36,6 @@ mod tests {
         BucketLifecycleConfiguration, BucketVersioningStatus, ExpirationStatus, LifecycleExpiration, LifecycleRule,
         LifecycleRuleFilter, NoncurrentVersionExpiration, VersioningConfiguration,
     };
-    use serial_test::serial;
     use std::error::Error;
     use tracing::info;
 
@@ -80,7 +79,6 @@ mod tests {
     ///
     /// This tests the rule persistence path (rustfs#4963: 3 days → 0 days).
     #[tokio::test]
-    #[serial]
     async fn test_lifecycle_expiration_rule_persists_correctly() -> TestResult {
         init_logging();
         info!("RT-03: lifecycle expiration rule persists correctly");
@@ -148,7 +146,6 @@ mod tests {
     /// Covers the pattern where noncurrent version expiration rules are
     /// accepted but old versions are never cleaned up.
     #[tokio::test]
-    #[serial]
     async fn test_lifecycle_noncurrent_version_expiration_rule_persists() -> TestResult {
         init_logging();
         info!("RT-03b: noncurrent version expiration rule persists");
@@ -233,7 +230,6 @@ mod tests {
     /// after restart. Transition rules require a configured remote tier
     /// (tested in reliant/tiering.rs), so this test uses expiration only.
     #[tokio::test]
-    #[serial]
     async fn test_lifecycle_prefix_rule_persists() -> TestResult {
         init_logging();
         info!("RT-04: lifecycle prefix rule persists");
@@ -294,7 +290,6 @@ mod tests {
     /// Regression pattern: DELETE on a versioned object fails or does not
     /// create a delete marker, or the delete marker is not visible in LIST.
     #[tokio::test]
-    #[serial]
     async fn test_delete_marker_creation_and_visibility() -> TestResult {
         init_logging();
         info!("RT-05b: delete marker creation and visibility");

--- a/crates/e2e_test/src/list_buckets_double_slash_test.rs
+++ b/crates/e2e_test/src/list_buckets_double_slash_test.rs
@@ -27,7 +27,6 @@ mod tests {
     use rustfs_signer::constants::UNSIGNED_PAYLOAD;
     use rustfs_signer::sign_v4;
     use s3s::Body;
-    use serial_test::serial;
     use std::error::Error;
 
     /// Sends a SigV4-signed `GET` where the signature is computed over `sign_path`
@@ -67,7 +66,6 @@ mod tests {
 
     /// `GET /` (path-style service call) returns `ListBuckets`.
     #[tokio::test]
-    #[serial]
     async fn test_list_buckets_single_slash() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;
@@ -86,7 +84,6 @@ mod tests {
     /// compat layer rewrites `//` to `/` before `s3s` parses/verifies the request,
     /// so both routing and signature verification operate on `/`.
     #[tokio::test]
-    #[serial]
     async fn test_list_buckets_double_slash_browser_compat() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;
@@ -105,7 +102,6 @@ mod tests {
     /// (`GET //bucket`) must be left untouched by the compat layer — it is not a
     /// `ListBuckets` request and s3s continues to reject the empty bucket name.
     #[tokio::test]
-    #[serial]
     async fn test_double_slash_rewrite_is_narrowly_scoped() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
         let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/list_buckets_iam_filter_test.rs
+++ b/crates/e2e_test/src/list_buckets_iam_filter_test.rs
@@ -15,7 +15,6 @@
 use crate::common::{RustFSTestEnvironment, admin_ok, build_test_s3_config, build_test_sts_client, init_logging};
 use aws_sdk_s3::Client;
 use aws_sdk_s3::error::ProvideErrorMetadata;
-use serial_test::serial;
 use tokio::time::{Duration, Instant};
 
 fn user_client(env: &RustFSTestEnvironment, access_key: &str, secret_key: &str, session_token: Option<&str>) -> Client {
@@ -76,7 +75,6 @@ async fn create_service_account(
 }
 
 #[tokio::test]
-#[serial]
 async fn list_buckets_filters_with_iam_bucket_resources() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/list_object_versions_metadata_extension_test.rs
+++ b/crates/e2e_test/src/list_object_versions_metadata_extension_test.rs
@@ -24,7 +24,6 @@ mod tests {
     use rustfs_signer::constants::UNSIGNED_PAYLOAD;
     use rustfs_signer::sign_v4;
     use s3s::Body;
-    use serial_test::serial;
     use std::error::Error;
     use tracing::info;
 
@@ -54,7 +53,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_list_object_versions_metadata_extension_returns_metadata_tags_and_internal()
     -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();

--- a/crates/e2e_test/src/list_object_versions_regression_test.rs
+++ b/crates/e2e_test/src/list_object_versions_regression_test.rs
@@ -21,7 +21,6 @@ mod tests {
     use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
-    use serial_test::serial;
     use tracing::info;
 
     fn create_s3_client(env: &RustFSTestEnvironment) -> Client {
@@ -29,7 +28,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_list_object_versions_immediately_returns_latest_put_after_delete_marker() {
         init_logging();
         info!("🧪 TEST: ListObjectVersions returns the newest version immediately after put -> delete -> put");
@@ -182,7 +180,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_list_object_versions_prefix_with_marker_object_returns_children() {
         init_logging();
         info!("🧪 TEST: ListObjectVersions returns prefix children when a marker object also exists");

--- a/crates/e2e_test/src/list_objects_duplicates_test.rs
+++ b/crates/e2e_test/src/list_objects_duplicates_test.rs
@@ -17,7 +17,6 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::Client;
     use aws_sdk_s3::primitives::ByteStream;
-    use serial_test::serial;
     use tracing::info;
 
     /// Helper function to create an S3 client for testing
@@ -60,7 +59,6 @@ mod tests {
     /// The bug was that "folder/" (the object) and "folder/" (derived prefix) were both added to CommonPrefixes
     /// when delimiter was "/" because the deduplication check was explicitly skipped for "/" delimiter.
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_unique_common_prefixes() {
         init_logging();
         info!("Starting test: ListObjectsV2 should return unique CommonPrefixes");
@@ -140,7 +138,6 @@ mod tests {
     /// When both "marker/subdir/" and "marker/subdir/file.txt" exist, listing with
     /// Prefix="marker/" must not duplicate "marker/subdir/file.txt" in Contents.
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_unique_contents_with_explicit_directory_markers() {
         init_logging();
         info!("Starting test: ListObjectsV2 should return unique keys with explicit directory markers");
@@ -208,7 +205,6 @@ mod tests {
     /// and never produce the prefix entry `a/`. Delimiter="/" listings then
     /// returned Contents `a` but silently dropped CommonPrefix `a/`.
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_object_and_same_named_prefix_coexist() {
         init_logging();
         info!("Starting test: ListObjectsV2 should return both object `a` and CommonPrefix `a/`");

--- a/crates/e2e_test/src/list_objects_v2_metadata_extension_test.rs
+++ b/crates/e2e_test/src/list_objects_v2_metadata_extension_test.rs
@@ -23,7 +23,6 @@ mod tests {
     use rustfs_signer::constants::UNSIGNED_PAYLOAD;
     use rustfs_signer::sign_v4;
     use s3s::Body;
-    use serial_test::serial;
     use std::error::Error;
     use tracing::info;
 
@@ -53,7 +52,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_metadata_extension_returns_metadata_tags_and_internal()
     -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();

--- a/crates/e2e_test/src/listing_regression_test.rs
+++ b/crates/e2e_test/src/listing_regression_test.rs
@@ -31,7 +31,6 @@
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::primitives::ByteStream;
-    use serial_test::serial;
     use std::collections::HashSet;
     use std::error::Error;
     use tracing::info;
@@ -49,7 +48,6 @@ mod tests {
     /// 3. Verify all 100 keys are returned exactly once
     /// 4. Verify no duplicates or skipped keys
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_completeness_100_objects() -> TestResult {
         init_logging();
         info!("RT-06: listing completeness with 100 objects");
@@ -133,7 +131,6 @@ mod tests {
     /// Regression pattern: prefix filter returns empty or includes wrong keys
     /// (rustfs#5051: empty results for shallow prefixes).
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_prefix_filter_correctness() -> TestResult {
         init_logging();
         info!("RT-06b: prefix filter correctness");
@@ -233,7 +230,6 @@ mod tests {
     /// Regression pattern: delimiter handling produces incorrect CommonPrefixes
     /// or misses objects at the delimiter boundary.
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_delimiter_common_prefixes() -> TestResult {
         init_logging();
         info!("RT-06c: delimiter and CommonPrefixes");
@@ -290,7 +286,6 @@ mod tests {
     /// Regression pattern: IsTruncated=false when there are more objects
     /// (rustfs#4810: walk_dir timeout truncation with false IsTruncated).
     #[tokio::test]
-    #[serial]
     async fn test_list_objects_v2_is_truncated_correctness() -> TestResult {
         init_logging();
         info!("RT-06d: IsTruncated correctness");

--- a/crates/e2e_test/src/mc_mirror_small_bucket_test.rs
+++ b/crates/e2e_test/src/mc_mirror_small_bucket_test.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::common::{DEFAULT_ACCESS_KEY, DEFAULT_SECRET_KEY, RustFSTestEnvironment};
-use serial_test::serial;
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
@@ -73,7 +72,6 @@ fn count_files(root: &Path) -> usize {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_mc_mirror_small_bucket_completes_without_list_timeout() -> TestResult {
     crate::common::init_logging();
     info!("Starting issue #3107 mc mirror regression test");

--- a/crates/e2e_test/src/namespace_lock_quorum_test.rs
+++ b/crates/e2e_test/src/namespace_lock_quorum_test.rs
@@ -16,7 +16,6 @@ use crate::common::RustFSTestClusterEnvironment;
 use aws_sdk_s3::Client;
 use aws_sdk_s3::error::SdkError;
 use bytes::Bytes;
-use serial_test::serial;
 use std::sync::Arc;
 use tokio::sync::Barrier;
 use tracing::{info, warn};
@@ -51,7 +50,6 @@ fn format_s3_error(err: SdkError<aws_sdk_s3::operation::put_object::PutObjectErr
 }
 
 #[tokio::test]
-#[serial]
 async fn test_concurrent_cluster_overwrites_do_not_fail_namespace_lock_quorum() -> TestResult {
     crate::common::init_logging();
     info!("Starting namespace lock quorum regression test with auto cluster");
@@ -128,7 +126,6 @@ async fn test_concurrent_cluster_overwrites_do_not_fail_namespace_lock_quorum() 
 /// `StorageError::other(...)` → `StorageError::Io(...)`, which fell through to
 /// `S3ErrorCode::InternalError` (500) in the error mapping.
 #[tokio::test]
-#[serial]
 async fn test_concurrent_put_same_key_never_returns_500() -> TestResult {
     crate::common::init_logging();
     info!("Starting concurrent PUT 500 regression test");

--- a/crates/e2e_test/src/negative_sigv4_test.rs
+++ b/crates/e2e_test/src/negative_sigv4_test.rs
@@ -37,7 +37,6 @@ use crate::common::{RustFSTestEnvironment, init_logging, local_http_client};
 use aws_sdk_s3::primitives::ByteStream;
 use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::request_signature_v4::{SIGN_V4_ALGORITHM, get_scope, get_signature, get_signing_key};
-use serial_test::serial;
 use std::fmt::Write as _;
 use time::macros::format_description;
 use time::{Duration, OffsetDateTime};
@@ -183,7 +182,6 @@ async fn setup(env: &mut RustFSTestEnvironment) -> Result<(), Box<dyn std::error
 /// this, every negative assertion below could pass for the wrong reason (a
 /// broken signer that never produces a valid signature).
 #[tokio::test]
-#[serial]
 async fn valid_header_sigv4_request_succeeds() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -214,7 +212,6 @@ async fn valid_header_sigv4_request_succeeds() -> Result<(), Box<dyn std::error:
 /// (a) Tampering the `Signature=` component must be rejected with
 /// SignatureDoesNotMatch / 403.
 #[tokio::test]
-#[serial]
 async fn tampered_signature_returns_signature_does_not_match() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -254,7 +251,6 @@ async fn tampered_signature_returns_signature_does_not_match() -> Result<(), Box
 /// (b) A valid AccessKeyId paired with the wrong secret key must be rejected
 /// with SignatureDoesNotMatch / 403.
 #[tokio::test]
-#[serial]
 async fn wrong_secret_key_returns_signature_does_not_match() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -279,7 +275,6 @@ async fn wrong_secret_key_returns_signature_does_not_match() -> Result<(), Box<d
 /// signature itself is valid (it covers the *declared* hash), so the server is
 /// forced to detect the payload/hash mismatch while streaming the body.
 #[tokio::test]
-#[serial]
 async fn tampered_payload_is_rejected() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -320,7 +315,6 @@ async fn tampered_payload_is_rejected() -> Result<(), Box<dyn std::error::Error 
 /// x-amz-date both derive from the same skewed timestamp, so skew — not a
 /// signature mismatch — is the failure.
 #[tokio::test]
-#[serial]
 async fn skewed_date_returns_request_time_too_skewed() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -344,7 +338,6 @@ async fn skewed_date_returns_request_time_too_skewed() -> Result<(), Box<dyn std
 /// structurally invalid SigV4 header that must be rejected before any
 /// credential/service handling.
 #[tokio::test]
-#[serial]
 async fn malformed_authorization_header_returns_clean_4xx() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/notification_startup_regression_test.rs
+++ b/crates/e2e_test/src/notification_startup_regression_test.rs
@@ -32,7 +32,6 @@
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
-    use serial_test::serial;
     use std::error::Error;
     use tracing::info;
 
@@ -47,7 +46,6 @@ mod tests {
     /// starts successfully with notification enabled and can serve S3 requests.
     /// A full webhook delivery test is in notification_webhook_test.rs.
     #[tokio::test]
-    #[serial]
     async fn test_notification_enabled_server_starts_cleanly() -> TestResult {
         init_logging();
         info!("RT-01: notification enabled server starts cleanly");
@@ -92,7 +90,6 @@ mod tests {
     /// 3. Restart server
     /// 4. Verify notification config still exists
     #[tokio::test]
-    #[serial]
     async fn test_notification_config_survives_restart() -> TestResult {
         init_logging();
         info!("RT-02: notification config survives restart");

--- a/crates/e2e_test/src/notification_webhook_test.rs
+++ b/crates/e2e_test/src/notification_webhook_test.rs
@@ -47,7 +47,6 @@ use rustfs_utils::egress::ENV_OUTBOUND_ALLOW_ORIGINS;
 use rustfs_utils::http::headers::{AMZ_REQUEST_ID, REQUEST_ID_HEADER};
 use s3s::Body;
 use serde_json::Value;
-use serial_test::serial;
 use std::error::Error;
 use std::io::Cursor;
 use std::path::Path;
@@ -625,7 +624,6 @@ fn assert_generated_request_id_correlation(record: &Value, request_id: &str) {
 /// RUSTFS_NOTIFY_ENABLE, an HTTPS webhook using a configured CA must become
 /// online and receive a real S3 event POST.
 #[tokio::test]
-#[serial]
 async fn test_https_webhook_target_delivers_event_with_notify_env_enabled() -> TestResult {
     init_logging();
 
@@ -680,7 +678,6 @@ async fn test_https_webhook_target_delivers_event_with_notify_env_enabled() -> T
 /// PUT / multipart-complete / DELETE each deliver one event with correct fields,
 /// and the prefix/suffix filter drops non-matching keys.
 #[tokio::test]
-#[serial]
 async fn test_webhook_event_delivery_and_filtering() -> TestResult {
     init_logging();
 
@@ -900,7 +897,6 @@ async fn test_webhook_event_delivery_and_filtering() -> TestResult {
 /// An event queued while the target endpoint rejects delivery survives on the
 /// durable store and is redelivered once the endpoint comes back.
 #[tokio::test]
-#[serial]
 async fn test_webhook_redelivers_event_after_target_recovers() -> TestResult {
     init_logging();
 

--- a/crates/e2e_test/src/overwrite_cleanup_regression_test.rs
+++ b/crates/e2e_test/src/overwrite_cleanup_regression_test.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use aws_sdk_s3::primitives::ByteStream;
-use serial_test::serial;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -24,7 +23,6 @@ const TEST_OBJECT: &str = "large-object.bin";
 const PAYLOAD_SIZE: usize = 512 * 1024;
 
 #[tokio::test(flavor = "multi_thread")]
-#[serial]
 async fn unversioned_overwrite_removes_previous_physical_data_dir() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
 

--- a/crates/e2e_test/src/presigned_negative_test.rs
+++ b/crates/e2e_test/src/presigned_negative_test.rs
@@ -43,7 +43,6 @@ use aws_sdk_s3::presigning::{PresignedRequest, PresigningConfig};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};
 use aws_smithy_http_client::Builder as SmithyHttpClientBuilder;
-use serial_test::serial;
 use std::time::{Duration, SystemTime};
 use tracing::info;
 
@@ -157,7 +156,6 @@ async fn setup(env: &mut RustFSTestEnvironment) -> Result<(), Box<dyn std::error
 /// stored bytes. Without this, every negative assertion could pass for the
 /// wrong reason (a server that rejects all presigned URLs).
 #[tokio::test]
-#[serial]
 async fn valid_presigned_get_succeeds() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -182,7 +180,6 @@ async fn valid_presigned_get_succeeds() -> Result<(), Box<dyn std::error::Error 
 /// Positive control (PUT): a valid presigned PUT must store the object, which we
 /// verify with a follow-up authenticated HEAD.
 #[tokio::test]
-#[serial]
 async fn valid_presigned_put_succeeds() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -211,7 +208,6 @@ async fn valid_presigned_put_succeeds() -> Result<(), Box<dyn std::error::Error 
 /// ("Request has expired"). s3s checks expiry BEFORE the signature, so the
 /// signature here is otherwise valid — only the elapsed window is at fault.
 #[tokio::test]
-#[serial]
 async fn expired_presigned_get_is_rejected() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -236,7 +232,6 @@ async fn expired_presigned_get_is_rejected() -> Result<(), Box<dyn std::error::E
 /// (b) Tampering the `X-Amz-Signature` query value must be rejected with 403 /
 /// SignatureDoesNotMatch.
 #[tokio::test]
-#[serial]
 async fn tampered_signature_returns_signature_does_not_match() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -262,7 +257,6 @@ async fn tampered_signature_returns_signature_does_not_match() -> Result<(), Box
 /// (c) A presigned URL generated with the WRONG secret (but the real access key
 /// id) must be rejected with 403 / SignatureDoesNotMatch.
 #[tokio::test]
-#[serial]
 async fn wrong_secret_key_returns_signature_does_not_match() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -290,7 +284,6 @@ async fn wrong_secret_key_returns_signature_does_not_match() -> Result<(), Box<d
 /// check runs during auth, before any object lookup, so the swapped key need
 /// not even exist.
 #[tokio::test]
-#[serial]
 async fn tampered_target_key_returns_signature_does_not_match() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -325,7 +318,6 @@ async fn tampered_target_key_returns_signature_does_not_match() -> Result<(), Bo
 /// (e / acceptance 4 negative half) Tampering the signature of a presigned PUT
 /// must be rejected with 403 / SignatureDoesNotMatch — the write must not land.
 #[tokio::test]
-#[serial]
 async fn tampered_presigned_put_returns_signature_does_not_match() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;

--- a/crates/e2e_test/src/protocols/test_runner.rs
+++ b/crates/e2e_test/src/protocols/test_runner.rs
@@ -22,7 +22,6 @@ use crate::protocols::sftp_compliance::{
 };
 use crate::protocols::sftp_core::{test_sftp_core_operations, test_sftp_idle_timeout_disconnects};
 use crate::protocols::webdav_core::test_webdav_core_operations;
-use serial_test::serial;
 use std::time::Instant;
 use tokio::time::{Duration, sleep};
 use tracing::{error, info};
@@ -229,7 +228,6 @@ fn all_protocol_tests() -> Vec<TestDefinition> {
 
 /// Test suite
 #[tokio::test]
-#[serial]
 async fn test_protocol_core_suite() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let suite = ProtocolTestSuite::new();
     let results = suite.run_test_suite().await;

--- a/crates/e2e_test/src/reliant/conditional_writes.rs
+++ b/crates/e2e_test/src/reliant/conditional_writes.rs
@@ -6,7 +6,6 @@ use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use bytes::Bytes;
-use serial_test::serial;
 use std::error::Error;
 
 const ENDPOINT: &str = "http://localhost:9000";
@@ -89,7 +88,6 @@ fn generate_test_key(prefix: &str) -> String {
 }
 
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_conditional_put_okay() -> Result<(), Box<dyn std::error::Error>> {
     let client = create_aws_s3_client().await?;
@@ -132,7 +130,6 @@ async fn test_conditional_put_okay() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_conditional_put_failed() -> Result<(), Box<dyn std::error::Error>> {
     let client = create_aws_s3_client().await?;
@@ -195,7 +192,6 @@ async fn test_conditional_put_failed() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_conditional_put_when_object_does_not_exist() -> Result<(), Box<dyn std::error::Error>> {
     let client = create_aws_s3_client().await?;
@@ -240,7 +236,6 @@ async fn test_conditional_put_when_object_does_not_exist() -> Result<(), Box<dyn
 }
 
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_conditional_multi_part_upload() -> Result<(), Box<dyn std::error::Error>> {
     let client = create_aws_s3_client().await?;

--- a/crates/e2e_test/src/reliant/get_deleted_object_test.rs
+++ b/crates/e2e_test/src/reliant/get_deleted_object_test.rs
@@ -24,7 +24,6 @@ use aws_sdk_s3::Client;
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::error::SdkError;
 use bytes::Bytes;
-use serial_test::serial;
 use std::error::Error;
 use tracing::info;
 
@@ -70,7 +69,6 @@ async fn setup_test_bucket(client: &Client) -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_get_deleted_object_returns_nosuchkey() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
@@ -144,7 +142,6 @@ async fn test_get_deleted_object_returns_nosuchkey() -> Result<(), Box<dyn std::
 
 /// Test that HeadObject on a deleted object also returns NoSuchKey
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_head_deleted_object_returns_nosuchkey() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt()
@@ -196,7 +193,6 @@ async fn test_head_deleted_object_returns_nosuchkey() -> Result<(), Box<dyn std:
 
 /// Test GetObject with non-existent key (never existed)
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_get_nonexistent_object_returns_nosuchkey() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt()
@@ -233,7 +229,6 @@ async fn test_get_nonexistent_object_returns_nosuchkey() -> Result<(), Box<dyn s
 /// Test multiple consecutive GetObject calls on deleted object
 /// This ensures the fix is stable and doesn't have race conditions
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_multiple_gets_deleted_object() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt()

--- a/crates/e2e_test/src/reliant/head_deleted_object_versioning_test.rs
+++ b/crates/e2e_test/src/reliant/head_deleted_object_versioning_test.rs
@@ -25,7 +25,6 @@ use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
 use bytes::Bytes;
-use serial_test::serial;
 use std::error::Error;
 use tracing::info;
 
@@ -85,7 +84,6 @@ async fn setup_test_bucket(client: &Client) -> Result<(), Box<dyn Error>> {
 
 /// Test that HeadObject on a deleted object returns NoSuchKey when versioning is enabled
 #[tokio::test]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_head_deleted_object_versioning_returns_nosuchkey() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt()

--- a/crates/e2e_test/src/reliant/head_tls_bodyless_test.rs
+++ b/crates/e2e_test/src/reliant/head_tls_bodyless_test.rs
@@ -30,7 +30,6 @@ use reqwest::{Certificate, Client, Response, StatusCode};
 use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
-use serial_test::serial;
 use std::error::Error;
 use std::path::Path;
 use std::process::Command;
@@ -157,7 +156,6 @@ async fn start_tls_rustfs_server(env: &mut RustFSTestEnvironment, tls_dir: &Path
 }
 
 #[tokio::test]
-#[serial]
 async fn test_head_missing_object_over_tls_http2_is_bodyless() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
 

--- a/crates/e2e_test/src/reliant/sql.rs
+++ b/crates/e2e_test/src/reliant/sql.rs
@@ -20,7 +20,6 @@ use aws_sdk_s3::types::{
     CsvInput, CsvOutput, ExpressionType, FileHeaderInfo, InputSerialization, JsonInput, JsonOutput, JsonType, OutputSerialization,
 };
 use bytes::Bytes;
-use serial_test::serial;
 use std::error::Error;
 
 const ENDPOINT: &str = "http://localhost:9000";
@@ -118,7 +117,6 @@ async fn process_select_response(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_select_object_content_csv_basic() -> Result<(), Box<dyn Error>> {
     let client = create_aws_s3_client().await?;
@@ -160,7 +158,6 @@ async fn test_select_object_content_csv_basic() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_select_object_content_csv_aggregation() -> Result<(), Box<dyn Error>> {
     let client = create_aws_s3_client().await?;
@@ -206,7 +203,6 @@ async fn test_select_object_content_csv_aggregation() -> Result<(), Box<dyn Erro
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_select_object_content_json_basic() -> Result<(), Box<dyn Error>> {
     let client = create_aws_s3_client().await?;
@@ -248,7 +244,6 @@ async fn test_select_object_content_json_basic() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_select_object_content_csv_limit() -> Result<(), Box<dyn Error>> {
     let client = create_aws_s3_client().await?;
@@ -291,7 +286,6 @@ async fn test_select_object_content_csv_limit() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_select_object_content_csv_order_by() -> Result<(), Box<dyn Error>> {
     let client = create_aws_s3_client().await?;
@@ -337,7 +331,6 @@ async fn test_select_object_content_csv_order_by() -> Result<(), Box<dyn Error>>
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_select_object_content_error_handling() -> Result<(), Box<dyn Error>> {
     let client = create_aws_s3_client().await?;
@@ -373,7 +366,6 @@ async fn test_select_object_content_error_handling() -> Result<(), Box<dyn Error
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[serial]
 #[ignore = "requires running RustFS server at localhost:9000"]
 async fn test_select_object_content_nonexistent_object() -> Result<(), Box<dyn Error>> {
     let client = create_aws_s3_client().await?;

--- a/crates/e2e_test/src/replication_extension_test.rs
+++ b/crates/e2e_test/src/replication_extension_test.rs
@@ -60,7 +60,6 @@ use rustfs_signer::constants::UNSIGNED_PAYLOAD;
 use rustfs_signer::sign_v4;
 use s3s::Body;
 use s3s::header::X_AMZ_REPLICATION_STATUS;
-use serial_test::serial;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::convert::Infallible;
@@ -4630,7 +4629,6 @@ async fn test_bucket_replication_sse_c_multipart_passthrough() -> TestResult {
 /// fails without any PUT reaching the target (capability cache, proven from
 /// the target journal); plaintext objects still replicate COMPLETED.
 #[tokio::test]
-#[serial]
 async fn test_ssec_replication_fails_closed_when_target_drops_passthrough_headers() -> TestResult {
     init_logging();
 
@@ -4740,7 +4738,6 @@ async fn test_ssec_replication_fails_closed_when_target_drops_passthrough_header
 /// a capability limit, and a plaintext-only deployment against a MinIO-like
 /// target must not turn red.
 #[tokio::test]
-#[serial]
 async fn test_replication_check_flags_ssec_passthrough_dropping_target() -> TestResult {
     init_logging();
 
@@ -4831,7 +4828,6 @@ async fn test_replication_check_flags_ssec_passthrough_dropping_target() -> Test
 /// HEAD-back audit against the recovered RustFS target — and the replica must
 /// be readable with the customer key.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_c_heals_after_target_outage() -> TestResult {
     init_logging();
 
@@ -4924,7 +4920,6 @@ async fn test_bucket_replication_sse_c_heals_after_target_outage() -> TestResult
 /// the existing-object resync (`replicate_all` transport, N2-audited), land as
 /// a REPLICA, and read back with the customer key.
 #[tokio::test]
-#[serial]
 async fn test_bucket_replication_sse_c_existing_object_resync() -> TestResult {
     init_logging();
 
@@ -8819,7 +8814,6 @@ async fn start_read_proxy_lab(
 /// headers are forwarded verbatim, and an inbound request that was itself
 /// proxied is answered locally (404) without touching the target.
 #[tokio::test]
-#[serial]
 async fn test_get_and_head_proxy_unreplicated_object_to_replication_target() -> TestResult {
     init_logging();
 
@@ -9002,7 +8996,6 @@ async fn test_get_and_head_proxy_unreplicated_object_to_replication_target() -> 
 /// proxied to the replication target with the anti-loop marker, mirroring
 /// MinIO `proxyGetTaggingToRepTarget`.
 #[tokio::test]
-#[serial]
 async fn test_get_object_tagging_proxies_unreplicated_object_to_replication_target() -> TestResult {
     init_logging();
 

--- a/crates/e2e_test/src/security_boundary_test.rs
+++ b/crates/e2e_test/src/security_boundary_test.rs
@@ -25,7 +25,6 @@ use crate::common::{RustFSTestEnvironment, awscurl_available, awscurl_put, init_
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart, Tag, Tagging};
-use serial_test::serial;
 use std::error::Error;
 use tracing::info;
 
@@ -36,7 +35,6 @@ use tracing::info;
 /// far beyond that limit and assert the server rejects it with the specific
 /// error, rather than accepting an arbitrarily large control-plane body.
 #[tokio::test]
-#[serial]
 async fn test_large_xml_body_rejection() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -92,7 +90,6 @@ async fn test_large_xml_body_rejection() -> Result<(), Box<dyn Error + Send + Sy
 
 /// Excessive multipart parts must be rejected.
 #[tokio::test]
-#[serial]
 async fn test_excessive_multipart_parts() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -149,7 +146,6 @@ async fn test_excessive_multipart_parts() -> Result<(), Box<dyn Error + Send + S
 /// (last-writer-wins, no torn/garbage state) and that it is absent after a
 /// subsequent delete.
 #[tokio::test]
-#[serial]
 async fn test_concurrent_object_operations() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
     let mut env = RustFSTestEnvironment::new().await?;
@@ -232,7 +228,6 @@ async fn test_concurrent_object_operations() -> Result<(), Box<dyn Error + Send 
 /// pattern used by the other admin-API E2E tests in this crate; the test is
 /// skipped when `awscurl` is not installed.
 #[tokio::test]
-#[serial]
 async fn test_tiering_url_validation() -> Result<(), Box<dyn Error + Send + Sync>> {
     init_logging();
     if !awscurl_available() {

--- a/crates/e2e_test/src/server_startup_failfast_test.rs
+++ b/crates/e2e_test/src/server_startup_failfast_test.rs
@@ -23,7 +23,6 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging, rustfs_binary_path};
-    use serial_test::serial;
     use std::net::TcpListener;
     use std::time::{Duration, Instant};
 
@@ -31,7 +30,6 @@ mod tests {
     /// while :9001 is occupied: the server exits at startup, and the harness
     /// must surface that promptly rather than waiting out the 60s timeout.
     #[tokio::test]
-    #[serial]
     async fn test_start_fails_fast_when_server_exits_during_startup() {
         init_logging();
 

--- a/crates/e2e_test/src/snowball_auto_extract_test.rs
+++ b/crates/e2e_test/src/snowball_auto_extract_test.rs
@@ -17,7 +17,6 @@ mod tests {
     use crate::common::{RustFSTestEnvironment, init_logging};
     use aws_sdk_s3::error::ProvideErrorMetadata;
     use aws_sdk_s3::primitives::ByteStream;
-    use serial_test::serial;
     use std::error::Error;
     use std::io::Cursor;
 
@@ -101,7 +100,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn snowball_auto_extract_supports_minio_prefix_and_directory_markers() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
 
@@ -138,7 +136,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn snowball_auto_extract_supports_standard_headers_with_combined_extract_options()
     -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
@@ -229,7 +226,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn snowball_auto_extract_ignores_directories_when_requested() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
 
@@ -268,7 +264,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn snowball_auto_extract_ignores_invalid_entries_when_requested() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
 
@@ -304,7 +299,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn snowball_auto_extract_rejects_parent_dir_entry_without_cross_bucket_write()
     -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
@@ -347,7 +341,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn snowball_auto_extract_prefers_exact_minio_prefix_over_suffix_fallback() -> Result<(), Box<dyn Error + Send + Sync>> {
         init_logging();
 

--- a/crates/e2e_test/src/stale_multipart_cleanup_cluster_test.rs
+++ b/crates/e2e_test/src/stale_multipart_cleanup_cluster_test.rs
@@ -16,7 +16,6 @@ use crate::common::{RustFSTestClusterEnvironment, init_logging};
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::CompletedMultipartUpload;
-use serial_test::serial;
 use tokio::time::{Duration, sleep};
 use tracing::info;
 use uuid::Uuid;
@@ -101,7 +100,6 @@ async fn wait_for_cleanup_on_all_nodes(
 }
 
 #[tokio::test]
-#[serial]
 async fn test_stale_multipart_cleanup_removes_incomplete_upload_across_cluster()
 -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     init_logging();

--- a/crates/e2e_test/src/sts_query_compat_test.rs
+++ b/crates/e2e_test/src/sts_query_compat_test.rs
@@ -25,7 +25,6 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
 use serde_json::Value;
-use serial_test::serial;
 use std::collections::BTreeSet;
 use std::convert::Infallible;
 use std::error::Error;
@@ -350,7 +349,6 @@ impl Drop for OpaMock {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_sts_query_responses_are_aws_sdk_compatible() -> TestResult {
     init_logging();
 
@@ -487,7 +485,6 @@ async fn test_sts_query_responses_are_aws_sdk_compatible() -> TestResult {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_sts_assume_role_opa_contract() -> TestResult {
     init_logging();
 
@@ -559,7 +556,6 @@ async fn test_sts_assume_role_opa_contract() -> TestResult {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_list_buckets_opa_contract() -> TestResult {
     init_logging();
 
@@ -645,7 +641,6 @@ async fn test_list_buckets_opa_contract() -> TestResult {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_sts_and_list_buckets_fail_closed_while_opa_is_initializing() -> TestResult {
     init_logging();
 
@@ -662,7 +657,6 @@ async fn test_sts_and_list_buckets_fail_closed_while_opa_is_initializing() -> Te
 }
 
 #[tokio::test]
-#[serial]
 async fn test_sts_and_list_buckets_fail_closed_after_opa_validation_failure() -> TestResult {
     init_logging();
 
@@ -679,7 +673,6 @@ async fn test_sts_and_list_buckets_fail_closed_after_opa_validation_failure() ->
 }
 
 #[tokio::test]
-#[serial]
 async fn test_sts_query_rate_limit_error_is_aws_sdk_compatible() -> TestResult {
     init_logging();
 

--- a/crates/e2e_test/src/tier_transition_regression_test.rs
+++ b/crates/e2e_test/src/tier_transition_regression_test.rs
@@ -30,7 +30,6 @@
 mod tests {
     use crate::common::{RustFSTestEnvironment, admin_ok, init_logging};
     use serde_json::Value;
-    use serial_test::serial;
     use std::error::Error;
     use tracing::info;
 
@@ -42,7 +41,6 @@ mod tests {
     /// validates that an expiration-only rule (the persistence path) survives
     /// a server restart.
     #[tokio::test]
-    #[serial]
     async fn test_lifecycle_rule_persists_after_restart() -> TestResult {
         init_logging();
         info!("RT-13: lifecycle rule persists after restart");
@@ -105,7 +103,6 @@ mod tests {
     /// Regression pattern: tier add/verify/delete API fails or the tier
     /// configuration is not persisted (rustfs#5218).
     #[tokio::test]
-    #[serial]
     async fn test_admin_tier_list_endpoint_returns_json() -> TestResult {
         init_logging();
         info!("RT-13b: admin tier list endpoint returns JSON");
@@ -135,7 +132,6 @@ mod tests {
     /// is not persisted (rustfs#5013), causing the scanner to not run or
     /// use stale settings.
     #[tokio::test]
-    #[serial]
     async fn test_scanner_config_persists_after_restart() -> TestResult {
         init_logging();
         info!("RT-13c: scanner config persists after restart");

--- a/crates/e2e_test/src/tls_hot_reload_test.rs
+++ b/crates/e2e_test/src/tls_hot_reload_test.rs
@@ -34,7 +34,6 @@ use rcgen::generate_simple_self_signed;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{ClientConfig, ClientConnection, DigitallySignedStruct, Error as RustlsError, SignatureScheme, StreamOwned};
-use serial_test::serial;
 use sha2::{Digest, Sha256};
 use std::error::Error;
 use std::io::{Read, Write};
@@ -242,7 +241,6 @@ async fn roundtrip_and_return(mut session: TlsSession) -> Result<TlsSession, Box
 }
 
 #[tokio::test]
-#[serial]
 async fn test_tls_certificate_hot_reload_live_listener() -> TestResult {
     init_logging();
     // Install the process-wide rustls crypto provider (idempotent).


### PR DESCRIPTION
## What

Finishes backlog#1846 T1 for `crates/e2e_test`. Stacked on #6239; together the two take the crate from 345 `#[serial]` markers to 36. This one removes 230 markers across 77 files plus the 77 imports that went with them.

Base this on #6239 — review that one first.

## What is left, and why

Same reasoning as #6209: `#[serial]` is an in-process mutex, cargo-nextest gives every test its own process, and only a `[test-groups]` entry with `max-threads = 1` serializes across processes. Every marker that survives now has a reason:

| file | markers | reason |
| --- | --- | --- |
| `inline_fast_path_cluster_test` | 14 | test-group `e2e-inline-boundaries` |
| `policy/policy_variables_test` | 6 | binds a fixed port |
| `kms/kms_vault_test` | 5 | test-group `e2e-vault` |
| `reliability_disk_fault_test` | 4 | test-group `e2e-reliability` |
| `degraded_read_eof_regression_test` | 3 | test-group `e2e-reliability` |
| `replacement_privileged_e2e_test` | 2 | test-group `e2e-reliability` |
| `protocols/webdav_core` | 1 | binds fixed ports |
| `policy/test_runner` | 1 | binds a fixed port |

## The three fixed-port files are a finding, not an oversight

`PolicyTestEnvironment::with_address("127.0.0.1:9000")` (policy_variables_test, test_runner) and `WEBDAV_ADDRESS = "127.0.0.1:9080"` / `S3_TEST_ADDRESS = "127.0.0.1:9010"` (webdav_core) bind fixed ports. An in-process mutex cannot stop a second *process* from binding the same port, so under nextest these tests are not actually protected today — the marker reads like isolation without providing any.

Removing the markers would not make that worse, but it would erase the only signal that these tests want serialization, so they are held back. The real fix is a `[test-groups]` binding, which is a config change rather than a deletion; it is filed on backlog#1846 for a follow-up.

`security_boundary_test` looked like a fourth case and is not: its `127.0.0.1:8080` and `[::1]:8080` strings are SSRF targets handed to AddTier in a negative test, not ports it binds. It uses `RustFSTestEnvironment::new()` like the rest and was swept.

## Verification

`cargo check -p e2e_test --tests` clean, `cargo fmt --all` applied, and `cargo nextest run -p e2e_test -E 'test(/^(special_chars|list_buckets_auth|head_object_range)_test::/)'` passes 16/16 against a locally built server. Pure deletion — no test renamed, no behaviour changed. Each file's `use serial_test::serial;` was removed only when that file's last marker went, which is the bookkeeping that needed follow-up fixes in #6222 and #6224.
