### PR TITLE
test: assert four leaf-crate smoke tests, and two more census fixes

### DIFF
--- a/crates/io-core/src/io_profile.rs
+++ b/crates/io-core/src/io_profile.rs
@@ -436,30 +436,45 @@ mod tests {
         assert_eq!(unknown_profile.sequential_boost_multiplier, 1.0);
     }
 
-    #[cfg(target_os = "linux")]
+    // What platform probing returns depends on the machine, so these pin the two
+    // rules that do not: the override wins over probing, and probing that is
+    // switched off reports Unknown rather than guessing (rustfs/backlog#1836).
     #[test]
-    fn test_linux_storage_detection_exists() {
-        // This test just verifies the detection function exists and doesn't panic
-        // The actual result depends on the system it's running on
-        let result = detect_storage_media(true, "");
-        // We should get some result (not panic)
-        match result {
-            StorageMedia::Nvme | StorageMedia::Ssd | StorageMedia::Hdd | StorageMedia::Unknown => {
-                // All valid results
-            }
+    fn storage_media_override_wins_over_platform_detection() {
+        for (override_value, expected) in [
+            ("nvme", StorageMedia::Nvme),
+            ("ssd", StorageMedia::Ssd),
+            ("hdd", StorageMedia::Hdd),
+        ] {
+            assert_eq!(detect_storage_media(true, override_value), expected);
+            assert_eq!(
+                detect_storage_media(false, override_value),
+                expected,
+                "an override must be honoured even with detection disabled"
+            );
         }
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
-    fn test_macos_storage_detection_exists() {
-        // This test just verifies the detection function exists and doesn't panic
-        let result = detect_storage_media(true, "");
-        // We should get some result (not panic)
-        match result {
-            StorageMedia::Nvme | StorageMedia::Ssd | StorageMedia::Hdd | StorageMedia::Unknown => {
-                // All valid results
-            }
-        }
+    fn disabled_detection_reports_unknown_instead_of_guessing() {
+        assert_eq!(detect_storage_media(false, ""), StorageMedia::Unknown);
+        assert_eq!(
+            detect_storage_media(false, "not-a-medium"),
+            StorageMedia::Unknown,
+            "an unparseable override falls through to the disabled path"
+        );
+    }
+
+    #[test]
+    fn enabled_detection_returns_a_medium_for_this_platform() {
+        // Whatever this machine reports, it must be one of the known variants and
+        // it must be stable across calls — a probe that flapped would make the
+        // scheduler's profile depend on when it asked.
+        let first = detect_storage_media(true, "");
+        assert!(matches!(
+            first,
+            StorageMedia::Nvme | StorageMedia::Ssd | StorageMedia::Hdd | StorageMedia::Unknown
+        ));
+        assert_eq!(detect_storage_media(true, ""), first);
     }
 }

--- a/crates/notify/src/runtime_facade.rs
+++ b/crates/notify/src/runtime_facade.rs
@@ -527,9 +527,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_facade_stops_empty_replay_workers() {
+    async fn stopping_replay_workers_is_a_no_op_when_there_are_none() {
         let (facade, _, _) = build_facade();
+
         facade.stop_replay_workers().await;
+
+        // The stop path takes the worker list and hands it to the adapter, so an
+        // empty facade must come back with the list still empty and dispatch
+        // released rather than left paused (rustfs/backlog#1836).
+        assert!(facade.replay_workers.read().await.is_empty());
+
+        // Calling it twice must stay harmless: shutdown paths do exactly that.
+        facade.stop_replay_workers().await;
+        assert!(facade.replay_workers.read().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/s3-types/src/event_name.rs
+++ b/crates/s3-types/src/event_name.rs
@@ -873,9 +873,16 @@ mod tests {
     /// now return a finite, non-panicking mask.
     #[test]
     fn test_mask_never_recurses_for_any_variant() {
-        for ev in ALL_EVENT_NAMES {
-            // Must terminate (no infinite recursion / stack overflow).
-            let _ = ev.mask();
+        // Terminating is the point — a regression here overflows the stack rather
+        // than failing an assertion — but the masks are collected and checked so
+        // the loop cannot be optimised into nothing and so a variant that starts
+        // returning an empty mask is caught too (rustfs/backlog#1836).
+        let masks: Vec<u64> = ALL_EVENT_NAMES.iter().map(|ev| ev.mask()).collect();
+
+        assert_eq!(masks.len(), ALL_EVENT_NAMES.len());
+        for (ev, mask) in ALL_EVENT_NAMES.iter().zip(&masks) {
+            assert_ne!(*mask, 0, "{ev:?} must carry at least one bit");
+            assert_eq!(ev.mask(), *mask, "{ev:?} must return the same mask every call");
         }
     }
 

--- a/scripts/find_assertless_tests.py
+++ b/scripts/find_assertless_tests.py
@@ -49,7 +49,7 @@ import sys
 from pathlib import Path
 
 VERIFY_SIGNALS = re.compile(
-    r"assert!|assert_eq!|assert_ne!|debug_assert|panic!\(|\.expect\(|\.unwrap\(|"
+    r"assert[a-z0-9_]*!|debug_assert|panic!\(|\.expect\(|\.unwrap\(|"
     r"unreachable!|matches!\(|insta::|proptest!|\.await\?|\)\?|\?;|should_panic"
 )
 DELEGATION = re.compile(
@@ -70,10 +70,15 @@ SINGLE_CALL_BODY = re.compile(
 # system is the assertion, exactly like the `fn _name()` form below.
 SIGNATURE_GUARD = re.compile(r"\bfn\s+[a-zA-Z0-9_]+\s*(?:<[^>]*>)?\s*\([^;]*\)[^;]*\{", re.S)
 DISCARDED_BINDING = re.compile(r"\blet\s+_\s*=\s*[a-zA-Z_][a-zA-Z0-9_]*\s*;")
+# `let _ = Type::<T>::method;` — a path item referenced but never called can only
+# be a signature guard; the call form (`let _ = x.foo();`) is excluded by the
+# absence of parens before the semicolon.
+DISCARDED_PATH_ITEM = re.compile(r"\blet\s+_\s*=\s*[a-zA-Z_][a-zA-Z0-9_]*(?:::(?:<[^>]*>|[a-zA-Z_][a-zA-Z0-9_]*))+\s*;")
 COMPILE_TIME_CHECK = re.compile(r"\bfn\s+_[a-zA-Z0-9_]*\s*(?:<[^>]*>)?\s*\(")
 TEST_ATTR = re.compile(r"#\[(?:tokio::)?test[\](]")
 TEST_CASE_ATTR = re.compile(r"#\[test_case")
 FN_LINE = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([a-zA-Z0-9_]+)")
+
 
 
 def extract_body(text: str) -> str:
@@ -136,6 +141,7 @@ def scan_file(path: Path):
             DELEGATION.search(text)
             or SINGLE_CALL_BODY.match(inner)
             or (SIGNATURE_GUARD.search(inner) and DISCARDED_BINDING.search(inner))
+            or DISCARDED_PATH_ITEM.search(inner)
         )
         if not VERIFY_SIGNALS.search(text) and not VERIFY_SIGNALS.search(attr_text) and not delegates and not COMPILE_TIME_CHECK.search(text):
             print(f"{path}:{j + 1}: {name}")


### PR DESCRIPTION
## What

Fifth batch of backlog#1836. Stacked on #6241 — review that one first. Two more census heuristics plus four real tests; tree-wide candidates go 32 → 26.

## Census fixes, bisected rather than assumed

Every heuristic change was applied one at a time with the candidate count checked after each, because a "fix" here can just as easily widen the queue:

- **Any `assert*!` macro counts.** `assert_fields_bound!` in `protos` was invisible to a list of three built-ins. The pattern stays a deliberate substring match: an earlier attempt anchored it as `\bassert…`, which quietly stopped matching prefixed macros such as `const_assert!` and pushed the queue from 32 to **55**. The count is what caught it.
- **`let _ = Type::<T>::method;` is a signature guard**, the same shape as the nested-fn form the script already knows — a path item referenced but never called can only be a compile-time check. That is `iam`'s deprecated-API test.

## Four tests that asserted nothing

**`detect_storage_media` (×2).** Both tests called the probe and fed the result into a `match` whose arms were all empty. What a given machine reports is not assertable, but two rules are: an override wins over probing — including when probing is switched off — and disabled probing reports `Unknown` instead of guessing. A third test keeps the real platform call and asserts it yields a known variant *and* the same one twice; a probe that flapped would make the scheduler's profile depend on when it asked.

**`runtime_facade_stops_empty_replay_workers`.** Called the stop path, checked nothing. Now asserts the worker list is empty afterwards and that a second call stays harmless — which is exactly what shutdown paths do.

**`test_mask_never_recurses_for_any_variant`.** Discarded every mask. Termination is still the property (a regression overflows the stack rather than failing an assertion), but the masks are now collected and checked, so the loop cannot fold away and a variant that started returning an empty mask would also be caught.

## Two false positives left in the queue on purpose

`utils/src/string.rs:942` **does** assert. Its input string `"http://:brace-secret@server/{1...2}}"` unbalances the scanner's brace counter, truncating the body before the assertion. Making the counter literal-aware needs a lexer that handles raw strings: a first attempt desynchronised on `r#"{"invalid": json}"#` and pushed the queue to **120**, so it was backed out rather than shipped half-working.

`s3select-api:379` declares a nested exhaustive-match `fn` and never calls it. Recognising that shape without also hiding genuinely empty bodies needs more care than it earns today.

Both are noted here so the next batch does not re-derive them.

## Verification

`cargo nextest run` passes for the touched crates (7 io-core, 8 notify + s3-types), `cargo clippy --all-targets -- -D warnings` clean across all three, `cargo fmt --all` applied.
