### PR TITLE
test(io-schedule): drop 24 no-op serial markers from the IO scheduler unit tests

### DIFF
--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -1766,11 +1766,9 @@ mod tests {
     };
     use rustfs_io_core::io_profile::{AccessPattern, StorageMedia};
     use rustfs_io_metrics::bandwidth::{BandwidthSnapshot, BandwidthTier};
-    use serial_test::serial;
     use std::time::Duration;
 
     #[tokio::test]
-    #[serial]
     async fn test_io_priority_queue_basic() {
         let config = IoPriorityQueueConfig::default();
         let queue = IoPriorityQueue::new(config);
@@ -1789,7 +1787,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_priority_queue_dequeue_order() {
         let config = IoPriorityQueueConfig::default();
         let queue = IoPriorityQueue::new(config);
@@ -1817,7 +1814,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_priority_queue_status() {
         let config = IoPriorityQueueConfig::default();
         let queue = IoPriorityQueue::new(config);
@@ -1835,7 +1831,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_priority_queue_starvation_prevention() {
         let config = IoPriorityQueueConfig {
             starvation_threshold_secs: 1,
@@ -1859,7 +1854,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_priority_from_size() {
         // High priority: < 1MB
         assert_eq!(IoPriority::from_size(100 * 1024), IoPriority::High);
@@ -1875,7 +1869,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_load_level_from_wait_duration() {
         use std::time::Duration;
 
@@ -1893,7 +1886,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_scheduler_config_default() {
         let config = IoSchedulerConfig::default();
 
@@ -1907,7 +1899,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_scheduler_config_to_core_config() {
         let config = IoSchedulerConfig::default();
         let core = config.to_core_config();
@@ -1923,7 +1914,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_priority_queue_config_to_core_config() {
         let config = IoPriorityQueueConfig::default();
         let core = config.to_core_config();
@@ -1935,7 +1925,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_io_priority_queue_config_from_scheduler_config() {
         let scheduler_config = IoSchedulerConfig {
             queue_high_capacity: 128,
@@ -1958,7 +1947,6 @@ mod tests {
     // ============================================
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_nvme_sequential_low_load() {
         // NVMe + Sequential + Low load = maximum buffer size
         let context = IoSchedulingContext {
@@ -1985,7 +1973,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_hdd_random_high_load() {
         // HDD + Random + High load = conservative buffer size
         let context = IoSchedulingContext {
@@ -2012,7 +1999,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_ssd_mixed_medium_load() {
         // SSD + Mixed + Medium load = moderate buffer
         let context = IoSchedulingContext {
@@ -2040,7 +2026,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_critical_load_disables_features() {
         // Any media + Critical load = minimal features
         let context = IoSchedulingContext {
@@ -2065,7 +2050,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_buffer_cap_enforcement() {
         // Test that storage media caps are enforced
         let context = IoSchedulingContext {
@@ -2090,7 +2074,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_applies_sequential_hint_when_pattern_unknown() {
         let context = IoSchedulingContext {
             file_size: 2 * 1024 * 1024 * 1024,              // 2GiB
@@ -2115,7 +2098,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_bandwidth_low_reduces_buffer() {
         // Low bandwidth should reduce buffer
         let context = IoSchedulingContext {
@@ -2139,7 +2121,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_high_concurrency_reduction() {
         // High concurrency should reduce buffer
         let context = IoSchedulingContext {
@@ -2162,7 +2143,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_sequential_boost() {
         // Sequential reads should get boost
         let sequential_context = IoSchedulingContext {
@@ -2204,7 +2184,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_unknown_media_conservative() {
         // Unknown media should be conservative
         let context = IoSchedulingContext {
@@ -2230,7 +2209,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_priority_classification() {
         // Test priority classification based on file size
         let small_context = IoSchedulingContext {
@@ -2277,7 +2255,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_readahead_decision_matrix() {
         // Test readahead enable/disable logic
         let configs = vec![
@@ -2363,7 +2340,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_buffer_multiplier_stages() {
         // Test that all multiplier stages are applied
         let context = IoSchedulingContext {
@@ -2398,7 +2374,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_multi_factor_strategy_compatibility_path() {
         // Test that compatibility path (from_wait_duration) still works
         let wait_duration = Duration::from_millis(50);


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1846 (T1, batch 3). Follow-up to #6209 (batch 1, e2e) and #6213
(batch 2, lifecycle/scanner/bucket_lifecycle_ops).

## Summary of Changes

Removes the 24 `#[serial]` markers (and the now-unused `use serial_test::serial;`)
from `rustfs/src/storage/concurrency/io_schedule.rs`. No test bodies changed.

`serial_test`'s `#[serial]` is a no-op under nextest — the authoritative runner
executes every test in its own process, so the in-process mutex never serializes
two tests against each other (`docs/testing/README.md`, "Serial execution &
nextest profiles"). The only runner where it still has an effect is the
`cargo test` fallback, so a marker may only be deleted when the test provably
shares no process-wide state. `io_schedule`'s test module is the one remaining
`#[serial]` hotspot in the `rustfs` crate that meets that bar:

- `IoPriorityQueue` is entirely instance-local — every queue, its stats and its
  starvation clock are `Arc<Mutex<..>>` fields created by `IoPriorityQueue::new`.
  There is no static queue registry.
- `IoStrategy::from_context_with_config` is a pure function of the caller-supplied
  `IoSchedulingContext` and `IoSchedulerConfig`. All 15 multi-factor tests build
  their own context and pass `concurrent_requests` explicitly, so none of them
  reads the process-global `ACTIVE_GET_REQUESTS` counter.
- `IoSchedulerConfig::default()` and `IoPriorityQueueConfig::default()` read
  `rustfs_config::DEFAULT_*` constants only. `IoPriorityQueueConfig::from_env()`
  exists but no test calls it, so no test result depends on process env.
- `IoPriority::from_size` and `IoLoadLevel::from_wait_duration` resolve their
  thresholds from compile-time constants.
- No `temp_env`, no `env::set_var` / `env::remove_var`, no `OnceLock` /
  `LazyLock` / shared fixture anywhere in the module.

Single exception worth naming: `test_multi_factor_strategy_compatibility_path`
calls `IoStrategy::from_wait_duration`, which *does* load the global
`ACTIVE_GET_REQUESTS` into the returned `concurrent_requests` field. That field
is not asserted; the assertions cover `load_level`, `storage_media`,
`access_pattern`, and `buffer_size > 0`, and in that code path `buffer_size` is
`clamp(base * load_multiplier, 32 KiB, 1 MiB)` — independent of the counter.

`.config/nextest.toml` has no override or `[test-groups]` entry naming any
`io_schedule` test, so nothing in the nextest wiring depended on these markers.

### Retained in this pass (surveyed, deliberately not touched)

| File | `#[serial]` | Why it stays |
|---|---|---|
| `rustfs/src/app/lifecycle_transition_api_test.rs` | 45 | Every test calls `setup_test_env()`, which lazily initialises a `static GLOBAL_ENV: OnceLock<(Vec<PathBuf>, Arc<ECStore>)>` plus `init_local_disks` (process-global disk registry), `init_bucket_metadata_sys` and `install_test_app_context`. Three tests additionally mutate process env (`with_forced_immediate_enqueue_timeout` uses `unsafe env::set_var` with a SAFETY comment that explicitly names `#[serial]`; two more use `temp_env::async_with_vars`). Under the fallback runner, concurrent first-callers of `setup_test_env()` would double-initialise the global disk registry — the backlog#937 `InsufficientWriteQuorum` shape. |
| `rustfs/src/storage/concurrency/manager.rs` | 22 | `calculate_io_strategy_with_context` reads the process-global `ACTIVE_GET_REQUESTS`; `put_object_admission_snapshot` reads `ACTIVE_PUT_REQUESTS`. `test_..._high_concurrency` holds 20 `GetObjectGuard`s and `test_..._tracks_put_requests` calls `reset_active_put_requests()`, i.e. they mutate exactly the counters their siblings assert on. |
| `rustfs/src/storage/multi_factor_scheduler_integration_test.rs` | 10 | Same coupling: `ConcurrencyManager::track_request()` bumps `ACTIVE_GET_REQUESTS` while `calculate_io_strategy_with_context` reads it. Forms one serial group with `manager.rs`. |
| `crates/object-capacity/src/capacity_manager.rs` | 33 | `record_global_dirty_scope` / `drain_global_dirty_scopes` is a process-global registry drained inside `update_capacity` / `get_dirty_disks`, so any two tests touching capacity refresh see each other's scopes. Also `temp_env` config tests. |
| `crates/ecstore/src/erasure/coding/{decode,encode}.rs` | 25 + 11 | Almost every marker guards a `temp_env` window over `RUSTFS_GET_*` / `ENV_OBJECT_DISK_WRITE_*`, plus `encode.rs`'s `OnceLock`-cached config latches. |
| `crates/ecstore/src/set_disk/ops/object.rs` | 53 | Process-global test probes/barriers (`RESTORE_MULTIPART_FAILURE_POINT`, `TRANSITION_*_BARRIER`, `PUT_OBJECT_COMMIT_BARRIER`, …) plus `temp_env`. |
| `crates/ecstore/src/store/init.rs` | 49 | `temp_env` throughout. |
| `crates/ecstore/src/disk/os.rs` | 20 | Global fsync hook/recorder registries and a `LazyLock` group-commit singleton. |
| `rustfs/src/config/config_test.rs`, `rustfs/src/admin/console_test.rs`, `rustfs/src/admin/service/config.rs`, `rustfs/src/admin/handlers/{audit,event,health}.rs`, `rustfs/src/server/{layer,readiness,tls_material,module_switch}.rs`, `rustfs/src/admin/route_registration_test.rs` | 22 / 5 / 14 / 11+11+4 / 12+4+4+9 / 5 | All either use `temp_env` directly or call `Opt::parse_from`, which runs `apply_external_env_compat()` → `unsafe env::set_var` on the live process environment. |
| `rustfs/src/app/object_usecase.rs`, `rustfs/src/app/*_gating_test.rs`, `rustfs/src/storage/access.rs`, `crates/s3select-api/src/object_store.rs` | 38 / 11+4+3+2 / 6 / 12 | Shared store fixtures (`shared_gating_ecstore`, "global store" constructors) and `OnceLock` test hooks / cached env. |

`crates/e2e_test` was left alone on purpose: #6209 and #6239 are sweeping it in
parallel.

## Verification

```bash
# authoritative runner
cargo nextest run -p rustfs --lib -E 'test(/^storage::concurrency::io_schedule::tests::/)'
#   => Summary [2.060s] 24 tests run: 24 passed, 3652 skipped

# fallback runner (the ONLY runner where #[serial] still does anything).
# Filter deliberately widened to storage::concurrency:: so the de-serialised
# io_schedule tests run genuinely concurrently with the still-serial
# manager.rs / request_guard tests that mutate ACTIVE_GET_REQUESTS and
# ACTIVE_PUT_REQUESTS. Run 3x:
cargo test -p rustfs --lib storage::concurrency::
#   => 53 passed; 0 failed  (x3, ~2.3-2.7s each)

# widened once more to pull in the 10 global-counter integration scenarios, 2x:
cargo test -p rustfs --lib -- storage::concurrency:: storage::multi_factor_scheduler_integration_test::
#   => 63 passed; 0 failed  (x2)

cargo fmt --all --check                        # clean
scripts/check_layer_dependencies.sh            # passed
scripts/check_architecture_migration_rules.sh  # passed
scripts/check_unsafe_code_allowances.sh        # passed
scripts/check_logging_guardrails.sh            # passed
```

## Impact

None. Test-attribute-only change; no production code, no test logic, no CI
wiring touched. Under nextest (CI) behaviour is bit-identical because the
attribute was already inert there. Under the `cargo test` fallback these 24
tests now run in parallel with the rest of the `rustfs` lib suite instead of
queuing behind the process-wide `serial_test` mutex — including
`test_io_priority_queue_starvation_prevention`, which sleeps 2 s of real time
and previously blocked every other `#[serial]` test in the binary for that
duration.

## Additional Notes

### Adversarial validation

**Concurrency / durability reviewer.** Per-test evidence that nothing in the
module is shared across tests:

- `test_io_priority_queue_{basic,dequeue_order,status,starvation_prevention}` —
  each constructs its own `IoPriorityQueue::new(config)`. All mutable state
  (`high/normal/low_queue`, `stats`, `last_starvation_check`) is behind that
  instance's own `Arc<Mutex<..>>`. `enqueue`/`dequeue`/`check_starvation`/
  `record_dequeue`/`status`/`len` touch nothing else — no metrics assertion, no
  static.
- `test_io_priority_from_size`, `test_io_load_level_from_wait_duration` — pure
  functions over compile-time constants.
- `test_io_scheduler_config_default`, `..._to_core_config`,
  `test_io_priority_queue_config_{to_core_config,from_scheduler_config}` — struct
  construction and field copies; `Default` reads `rustfs_config::DEFAULT_*`
  constants, never `get_env_*`.
- The 15 `test_multi_factor_strategy_*` tests — all go through
  `IoStrategy::from_context_with_config(&context, &config)` with a
  locally-built context and `IoSchedulerConfig::default()`. Reading the
  function end to end: every input is a field of those two arguments; there is
  no `env::var`, no static read, no lock.
- `test_multi_factor_strategy_compatibility_path` — the one global read
  (`ACTIVE_GET_REQUESTS`) lands in a field no assertion inspects, as detailed
  above.

**Test-sceptic.** *If one of these actually needed serialisation, how would it
fail, and how do I know it will not?*

1. *Shared queue state leaking between tests* → would show as a wrong
   `len()`/`status()` count. Impossible: the queue is a local binding, dropped
   at end of test; nothing publishes it.
2. *A concurrent test flipping an env var that changes a threshold* → would show
   as an off-by-a-multiplier `buffer_size`. The only env-sensitive entry points
   in this file are `IoPriorityQueueConfig::from_env`,
   `load_concurrency_thresholds`, `get_concurrency_aware_buffer_size`,
   `get_put_concurrency_aware_buffer_size` and `get_advanced_buffer_size`. Grep
   confirms **no test calls any of them** — the last three are imported by the
   test module but unused (the module carries `#[allow(unused_imports)]`).
3. *A concurrent test inflating `ACTIVE_GET_REQUESTS` and shrinking an asserted
   buffer* → this is the real hazard in `manager.rs`, which is exactly why its
   markers are retained. In `io_schedule` the concurrency input is an explicit
   struct field, so the global cannot reach the assertions. The one path that
   does read it feeds a field nobody asserts.
4. *Timing flake in `test_io_priority_queue_starvation_prevention`* → it sleeps
   2 s against a 1 s starvation threshold and asserts the request was boosted.
   Extra parallel load can only make the observed wait longer, i.e. push the
   assertion further into the true direction; it cannot make 2 s look like
   < 1 s.
5. *Residual doubt about the fallback runner* → covered empirically: 5 fallback
   runs (3 narrow + 2 widened to include the still-serial global-counter tests),
   all green.

Anything I could not discharge this way was retained — see the table above.
That is why this batch is 24 deletions rather than a larger sweep: the
`#[serial]` markers that remain in this repo are, overwhelmingly, guarding real
process-wide state (`temp_env`, `unsafe env::set_var`, `OnceLock` fixtures,
global registries), and deleting them would introduce genuine races on the
`cargo test` fallback path.
