### PR TITLE
test(crypto): replace the one-file key scan with a repo-wide guard

### DIFF
--- a/.config/make/lint-fmt.mak
+++ b/.config/make/lint-fmt.mak
@@ -70,6 +70,11 @@ fips-wording-check: ## Check docs and crates/kms do not over-claim crypto capabi
 	@echo "📣 Checking cryptographic capability wording guard..."
 	./scripts/check_fips_wording.sh
 
+.PHONY: embedded-secrets-check
+embedded-secrets-check: ## Check no private key material or credential literal is committed
+	@echo "🔑 Checking embedded secret material guard..."
+	./scripts/check_embedded_secrets.sh
+
 .PHONY: log-analyzer-rules-check
 log-analyzer-rules-check: core-deps ## Check log-analyzer rule anchors still exist verbatim in source
 	@echo "🩺 Checking log-analyzer rule anchors..."

--- a/.config/make/pre-commit.mak
+++ b/.config/make/pre-commit.mak
@@ -19,13 +19,13 @@ planning-docs-check: ## Check that no planning-type documents are committed
 	./scripts/check_no_planning_docs.sh
 
 .PHONY: pre-commit
-pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check s3s-footprint-check fips-wording-check doc-paths-check planning-docs-check quick-check ## Run fast pre-commit checks without clippy/full tests
+pre-commit: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check s3s-footprint-check fips-wording-check embedded-secrets-check doc-paths-check planning-docs-check quick-check ## Run fast pre-commit checks without clippy/full tests
 	@echo "✅ All pre-commit checks passed!"
 
 .PHONY: pre-pr
-pre-pr: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check s3s-footprint-check fips-wording-check doc-paths-check planning-docs-check log-analyzer-rules-check clippy-check test ## Run full pre-PR checks with clippy and tests
+pre-pr: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check s3s-footprint-check fips-wording-check embedded-secrets-check doc-paths-check planning-docs-check log-analyzer-rules-check clippy-check test ## Run full pre-PR checks with clippy and tests
 	@echo "✅ All pre-PR checks passed!"
 
 .PHONY: dev-check
-dev-check: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check s3s-footprint-check fips-wording-check doc-paths-check planning-docs-check quick-check ## Run fast local development checks
+dev-check: fmt-check unsafe-code-check architecture-migration-check logging-guardrails-check tokio-io-uring-check extension-schema-check body-cache-whitelist-check s3s-footprint-check fips-wording-check embedded-secrets-check doc-paths-check planning-docs-check quick-check ## Run fast local development checks
 	@echo "✅ Fast development checks passed!"

--- a/.config/make/tests.mak
+++ b/.config/make/tests.mak
@@ -34,6 +34,7 @@ script-tests: ## Run shell script tests
 	./scripts/test_exact_1mib_handoff_abba.sh
 	./scripts/test_pinned_paired_abba_bench.sh
 	./scripts/test_manual_transition_runbooks.sh
+	./scripts/check_embedded_secrets.sh --self-test
 	bash -n ./scripts/validate_object_data_cache_cold_stampede.sh
 	python3 ./scripts/check_object_data_cache_follower_samples.py --self-test
 	./scripts/validate_object_data_cache_cold_stampede.sh --self-test

--- a/.github/workflows/ci-docs-only.yml
+++ b/.github/workflows/ci-docs-only.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Check cryptographic capability wording
         run: ./scripts/check_fips_wording.sh
 
+      - name: Check no embedded secret material
+        run: ./scripts/check_embedded_secrets.sh
+
       - name: Check no planning docs committed
         run: ./scripts/check_no_planning_docs.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
       - name: Check cryptographic capability wording
         run: ./scripts/check_fips_wording.sh
 
+      - name: Check no embedded secret material
+        run: ./scripts/check_embedded_secrets.sh
+
       - name: Check no planning docs committed
         run: ./scripts/check_no_planning_docs.sh
 

--- a/crates/crypto/src/license_token.rs
+++ b/crates/crypto/src/license_token.rs
@@ -204,14 +204,6 @@ mod tests {
     }
 
     #[test]
-    fn test_source_does_not_embed_private_key() {
-        let source = include_str!("license_token.rs");
-        let forbidden = ["BEGIN", "PRIVATE KEY"].join(" ");
-
-        assert!(!source.contains(&forbidden));
-    }
-
-    #[test]
     fn test_parse_signed_license_token_rejects_invalid_token() {
         let mut rng = rand::rng();
         let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("Failed to generate private key");

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,7 @@ their issue closes.
 | `check_architecture_migration_rules.sh` | ci-gate | Architecture-boundary anti-regression guard | ci.yml Quick Checks; `make pre-commit` |
 | `check_body_cache_whitelist.sh` | ci-gate | Keeps the app-layer body-cache eligibility gate fail-closed | ci.yml Quick Checks |
 | `check_doc_paths.sh` | ci-gate | Fails when instruction/architecture docs reference repo paths that no longer exist | `make pre-commit` / `pre-pr` |
+| `check_embedded_secrets.sh` | ci-gate | Repo-wide scan blocking committed private key material and provider credential literals | ci.yml Quick Checks; `make pre-commit` / `pre-pr` |
 | `check_extension_schema_boundaries.sh` | ci-gate | Extension-schema crate boundary guard | ci.yml Quick Checks; `make pre-commit` |
 | `check_layer_dependencies.sh` | ci-gate | Crate-layering DAG guard (reads `layer-dependency-baseline.txt`) | ci.yml Quick Checks |
 | `check_logging_guardrails.sh` | ci-gate | Blocks legacy logging patterns from returning | `make pre-commit` / `pre-pr` |

--- a/scripts/check_embedded_secrets.sh
+++ b/scripts/check_embedded_secrets.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard: no private key material and no long-lived provider credential may
+# exist as a literal anywhere in the repository — see AGENTS.md "Security
+# Baseline" ("Never commit secrets, credentials, or key material") and
+# .agents/skills/security-advisory-lessons ("Do not ship hard-coded shared
+# tokens, HMAC secrets, private keys, or production test keys").
+#
+# This replaces the unit test `test_source_does_not_embed_private_key` that
+# used to live in crates/crypto/src/license_token.rs (rustfs/backlog#1884).
+# That test read its own file with include_str! and asserted the file did not
+# contain a PEM private-key header, protecting exactly one invariant: the RSA
+# key that signs license tokens must never be checked in, because verification
+# only ever needs the public key (crates/crypto/src/license_token.rs exposes
+# `parse_signed_license_token`, and rustfs/src/license.rs reads the public key
+# from RUSTFS_LICENSE_PUBLIC_KEY at runtime — no key material belongs in the
+# tree at all). Its coverage was one file: moving the key one file sideways,
+# even inside the same crate, passed silently, and renaming license_token.rs
+# stopped the guard from compiling rather than reporting anything.
+#
+# This scan covers every tracked — and every not-yet-added, non-ignored — text
+# file in the repository, so it is a strict superset of the retired assertion:
+# the same needle, everywhere, plus the algorithm variants and the credential
+# formats below.
+#
+# It deliberately does not exclude the paths .github/secret_scanning.yml tells
+# GitHub push protection to ignore (crates/e2e_test, **/tests, **/benches,
+# .docker, .vscode). Those exclusions exist because pasted test credentials are
+# expected there, which is exactly where a real key is most likely to arrive
+# unnoticed; this guard is the CI-side gate that still looks.
+#
+# Only literals are in scope. Key material injected at build time is out of
+# scope on purpose: no build.rs in the workspace embeds key material and the
+# license public key is read from the environment at startup, so an artifact
+# scan would add a release build to a compile-free check job for no reachable
+# failure mode today. Revisit if a build script ever bakes in key material.
+# Binary files are skipped (`git grep -I`), and a key stored as bare base64
+# with its header stripped is not detected — the same two blind spots the
+# retired test had.
+#
+# Every needle below is assembled around a variable so that the script's own
+# text does not match the pattern it defines (the retired test used the same
+# trick with ["BEGIN", "PRIVATE KEY"].join(" ")). That is what lets this script
+# scan itself along with everything else instead of carving out a blind spot.
+#
+# `--self-test` builds throwaway fixture repositories and asserts every pattern
+# family fires and every exemption holds; it is wired into `make script-tests`.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${CHECK_EMBEDDED_SECRETS_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+BEGIN_MARK="BEGIN"
+KEY_MARK="Key"
+
+# The file the retired test pinned with include_str!. It stays listed so that
+# renaming or moving it is reported here explicitly instead of quietly ending
+# the license-key invariant, which is how the test failed.
+PINNED_SOURCES=(
+    "crates/crypto/src/license_token.rs"
+)
+
+# "<name>|<extended regex>". The name is free of "|", so the first "|" splits.
+#
+# The private-key family matches the header phrase without requiring the PEM
+# dashes, so a key pasted into a JSON/YAML string, a doc block, or a Rust
+# string built without the delimiters is still caught. The credential family is
+# format-anchored — fixed prefix plus fixed-width charset — so a match is a
+# credential shape and not prose.
+PATTERNS=(
+    "PEM private key header|${BEGIN_MARK}[[:space:]]+([A-Z0-9]+[[:space:]]+)*PRIVATE KEY"
+    "PuTTY private key file|PuTTY-User-${KEY_MARK}-File"
+    "AWS access key id|(A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"
+    "GitHub token|gh[pousr]_[A-Za-z0-9]{36}"
+    "GitHub fine-grained token|github_pat_[A-Za-z0-9_]{22,}"
+    "Slack token|xox[abprs]-[A-Za-z0-9-]{10,}"
+    "Stripe live key|sk_live_[0-9a-zA-Z]{20,}"
+    "Google API key|AIza[0-9A-Za-z_-]{35}"
+    "SendGrid API key|SG\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}"
+    "npm access token|npm_[A-Za-z0-9]{36}"
+    "PyPI upload token|pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{50,}"
+)
+
+# Exact strings that carry no secret wherever they appear. A hit is excused
+# only if the line stops matching once these exact strings are removed, so a
+# line holding both an example value and a real credential still fails, and
+# editing an entry — swapping a placeholder body for real key material — makes
+# the guard fire again. Entries that stop matching anything are reported as
+# stale, so the list cannot decay into a blanket exclusion.
+#
+# 1-2: rustfs/src/admin/handlers/site_replication.rs negative fixtures for
+#      `validate_peer_connection_inner`, which must reject a private key
+#      submitted where a peer CA certificate is expected. Asserting on the
+#      rejection requires the header in the input; the key bodies are the
+#      literal word "secret".
+# 3-4: AWS's own documented example access key id from the SigV4 test vectors,
+#      which this repository pairs with the equally documented example secret
+#      key across signer, IAM, madmin, and auth tests, plus the deliberate
+#      one-character variant rustfs/src/auth.rs uses to prove key comparison
+#      distinguishes near-identical ids.
+AWS_EXAMPLE_STEM="AKIAIOSFODNN7EXAMPL"
+NON_SECRET_LITERALS=(
+    "-----${BEGIN_MARK} PRIVATE KEY-----\\nsecret\\n-----END PRIVATE KEY-----"
+    "-----${BEGIN_MARK} RSA PRIVATE KEY-----\\nsecret\\n-----END RSA PRIVATE KEY-----"
+    "${AWS_EXAMPLE_STEM}E"
+    "${AWS_EXAMPLE_STEM}F"
+)
+
+run_scan() {
+    cd "$ROOT_DIR"
+
+    # Without this, a scan run outside a work tree would make every `git grep`
+    # fail and the guard would report success having read nothing.
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        printf 'Embedded secret guard failed: %s is not a git work tree, so the scan cannot enumerate files\n' \
+            "$ROOT_DIR" >&2
+        return 1
+    fi
+
+    local literal_used=()
+    local i
+    for ((i = 0; i < ${#NON_SECRET_LITERALS[@]}; i++)); do
+        literal_used[i]="0"
+    done
+
+    local status=0
+    local source
+    for source in "${PINNED_SOURCES[@]}"; do
+        if [[ ! -f "$source" ]]; then
+            printf 'Embedded secret guard failed: %s is missing; update PINNED_SOURCES in scripts/check_embedded_secrets.sh after moving it\n' \
+                "$source" >&2
+            status=1
+        fi
+    done
+
+    local entry name pattern hits grep_status hit file rest line_no text trimmed sanitized
+    for entry in "${PATTERNS[@]}"; do
+        name="${entry%%|*}"
+        pattern="${entry#*|}"
+
+        hits=""
+        grep_status=0
+        hits="$(git grep --untracked -I -n -E -e "$pattern" -- .)" || grep_status=$?
+        if [[ "$grep_status" -gt 1 ]]; then
+            printf 'Embedded secret guard failed: git grep exited %s while scanning for %s\n' "$grep_status" "$name" >&2
+            status=1
+            continue
+        fi
+
+        while IFS= read -r hit; do
+            [[ -z "$hit" ]] && continue
+            file="${hit%%:*}"
+            rest="${hit#*:}"
+            line_no="${rest%%:*}"
+            text="${rest#*:}"
+            trimmed="$(printf '%s' "$text" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+            sanitized="$trimmed"
+            for ((i = 0; i < ${#NON_SECRET_LITERALS[@]}; i++)); do
+                if [[ "$sanitized" == *"${NON_SECRET_LITERALS[i]}"* ]]; then
+                    sanitized="${sanitized//"${NON_SECRET_LITERALS[i]}"/}"
+                    literal_used[i]="1"
+                fi
+            done
+
+            if ! printf '%s' "$sanitized" | grep -q -E -e "$pattern"; then
+                continue
+            fi
+
+            printf 'Embedded secret guard failed: %s at %s:%s\n    %s\n' "$name" "$file" "$line_no" "$trimmed" >&2
+            status=1
+        done <<<"$hits"
+    done
+
+    for ((i = 0; i < ${#NON_SECRET_LITERALS[@]}; i++)); do
+        if [[ "${literal_used[i]}" != "1" ]]; then
+            printf 'Embedded secret guard failed: stale exemption, nothing matches it any more: %s\n' \
+                "${NON_SECRET_LITERALS[i]}" >&2
+            status=1
+        fi
+    done
+
+    if [[ "$status" -ne 0 ]]; then
+        printf '\nRemove the key material or credential above, and rotate anything that was committed even briefly.\n' >&2
+        printf 'A genuine non-secret match is excused by adding its exact text to NON_SECRET_LITERALS in scripts/check_embedded_secrets.sh with a reason.\n' >&2
+        return 1
+    fi
+
+    printf 'Embedded secret guard passed (no private key material or provider credential literal in the tree).\n'
+    return 0
+}
+
+# One synthetic value per pattern family, assembled from a filler so this
+# function does not match the patterns it exercises.
+self_test_violation_lines() {
+    local fill="QWERTYUIOPASDFGHJKLZXCVBNM0123456789"
+    printf '%s\n' \
+        "-----${BEGIN_MARK} PRIVATE KEY-----" \
+        "PuTTY-User-${KEY_MARK}-File: ssh-rsa" \
+        "AKIA${fill:0:16}" \
+        "ghp_${fill:0:36}" \
+        "github_pat_${fill:0:22}" \
+        "xoxb-${fill:0:12}" \
+        "sk_live_${fill:0:20}" \
+        "AIza${fill:0:35}" \
+        "SG.${fill:0:20}.${fill:0:20}" \
+        "npm_${fill:0:36}" \
+        "pypi-AgEIcHlwaS5vcmc${fill}${fill:0:14}"
+}
+
+self_test_fixture() {
+    local dir="$1" i
+    mkdir -p "${dir}/crates/crypto/src"
+    : >"${dir}/crates/crypto/src/license_token.rs"
+    # Every exemption must appear, or the stale-exemption check fires and the
+    # fixture would fail for a reason the case under test is not about.
+    for ((i = 0; i < ${#NON_SECRET_LITERALS[@]}; i++)); do
+        printf 'excused %s\n' "${NON_SECRET_LITERALS[i]}" >>"${dir}/excused.txt"
+    done
+    git -C "$dir" init -q
+}
+
+SELF_TEST_TMP=""
+
+self_test() {
+    SELF_TEST_TMP="$(mktemp -d)"
+    trap 'rm -rf "$SELF_TEST_TMP"' EXIT
+
+    local failures=0 out scan_status
+    local clean="${SELF_TEST_TMP}/clean" dirty="${SELF_TEST_TMP}/dirty" renamed="${SELF_TEST_TMP}/renamed"
+
+    self_test_fixture "$clean"
+    if out="$(CHECK_EMBEDDED_SECRETS_ROOT="$clean" "$0" 2>&1)"; then
+        printf 'self-test ok: clean fixture with every exemption present passes\n'
+    else
+        printf 'self-test FAILED: clean fixture should pass but reported:\n%s\n' "$out" >&2
+        failures=$((failures + 1))
+    fi
+
+    self_test_fixture "$dirty"
+    self_test_violation_lines >"${dirty}/leaked.txt"
+    scan_status=0
+    out="$(CHECK_EMBEDDED_SECRETS_ROOT="$dirty" "$0" 2>&1)" || scan_status=$?
+    if [[ "$scan_status" -eq 0 ]]; then
+        printf 'self-test FAILED: fixture holding one value per pattern family should fail\n' >&2
+        failures=$((failures + 1))
+    fi
+    local entry name
+    for entry in "${PATTERNS[@]}"; do
+        name="${entry%%|*}"
+        if ! printf '%s' "$out" | grep -q -F -- "$name"; then
+            printf 'self-test FAILED: pattern family "%s" did not fire on its own probe value\n' "$name" >&2
+            failures=$((failures + 1))
+        fi
+    done
+    [[ "$failures" -eq 0 ]] && printf 'self-test ok: all %s pattern families fire\n' "${#PATTERNS[@]}"
+
+    self_test_fixture "$renamed"
+    rm -f "${renamed}/crates/crypto/src/license_token.rs"
+    if CHECK_EMBEDDED_SECRETS_ROOT="$renamed" "$0" >/dev/null 2>&1; then
+        printf 'self-test FAILED: a moved pinned source should be reported\n' >&2
+        failures=$((failures + 1))
+    else
+        printf 'self-test ok: moving a pinned source is reported\n'
+    fi
+
+    if [[ "$failures" -ne 0 ]]; then
+        printf '%s self-test assertion(s) failed\n' "$failures" >&2
+        return 1
+    fi
+    printf 'Embedded secret guard self-test passed.\n'
+    return 0
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    self_test
+else
+    run_scan
+fi


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1884 (the `crates/crypto` site; the four `crates/kms` sites landed in #6215). The remaining tiers of that issue — protos 2, ecstore hotpath 8, protocols/targets 4, obs 7 — are untouched here.

## Summary of Changes

`crates/crypto/src/license_token.rs` carried `test_source_does_not_embed_private_key`: it read its own file with `include_str!` and asserted the text did not contain a PEM private-key header. What it protected is real — the RSA key that signs license tokens must never be checked in, because verification only ever needs the public key (`parse_signed_license_token`, with `rustfs/src/license.rs` reading `RUSTFS_LICENSE_PUBLIC_KEY` from the environment at runtime), so no key material belongs in the tree at all. What it covered was one file: the key moved one file sideways, even inside the same crate, passed silently, and renaming `license_token.rs` stopped the guard from compiling rather than reporting anything. #1884's classification comment calls it the weakest guard in the repository for exactly this reason.

`scripts/check_embedded_secrets.sh` replaces it. It scans every tracked — and every not-yet-added, non-ignored — text file for the same needle, plus every other private-key header form and nine provider credential formats. It deliberately does not skip the paths `.github/secret_scanning.yml` tells GitHub push protection to ignore (`crates/e2e_test`, `**/tests`, `**/benches`, `.docker`, `.vscode`): those exclusions exist because pasted test credentials are expected there, which is where a real key is most likely to arrive unnoticed.

Design points worth a reviewer's attention:

- **A new script rather than a block inside `check_fips_wording.sh`.** #6215 folded the KMS site into that script because both are *wording* invariants over prose in two docs and one crate. This is key *material* over the whole tree — a different failure class with a different scan target — so it gets its own gate. (`check_fips_wording.sh` is still missing from the `scripts/README.md` index table; not fixed here to keep the diff scoped.)
- **Exemptions are exact literals, never path globs.** A hit is excused only if the line stops matching once the exact non-secret string is removed, so a line holding both an example value and a real credential still fails, and swapping a placeholder body for real key material makes the guard fire again. An exemption that stops matching anything is reported as stale, so the list cannot decay into a blanket exclusion.
- **The script scans itself.** Every needle is assembled around a variable so the pattern text does not match the pattern it defines — the same trick the retired test used with `["BEGIN", "PRIVATE KEY"].join(" ")`. No path is carved out, including this file.
- **Out of scope on purpose:** build-time injection (no `build.rs` in the workspace embeds key material and the license public key comes from the environment, so an artifact scan would add a release build to a compile-free check job for no reachable failure mode), binary files (`git grep -I`), and a key stored as bare base64 with its header stripped. The last two are the same blind spots the retired test had.

Wired into `ci.yml` and `ci-docs-only.yml` Quick Checks (byte-for-byte mirrored, as that job requires), `make pre-commit` / `pre-pr` / `dev-check`, and `--self-test` into `make script-tests`. Runtime is ~2s.

## Scan hit list and disposition

Widening the scan from one file to the whole tree produced 34 source hits plus one defect in the guard itself. **No real secret was found, so no new security issue was opened.**

| # | Hit | Verdict | Disposition |
|---|---|---|---|
| 1-2 | `rustfs/src/admin/handlers/site_replication.rs:11954-11955` — a PKCS#8 and an RSA private-key header | False positive | Negative fixtures for `validate_peer_connection_inner`, which must reject a private key submitted where a peer CA certificate is expected; asserting on the rejection requires the header in the input, and the key bodies are the literal word `secret`. Excused by two exact literals that include the placeholder body, so replacing it with real key material fires the guard. |
| 3-33 | `AKIAIOSFODNN7EXAMPLE`, 31 lines across `crates/ecstore/src/bucket/target/bucket_target.rs`, `crates/iam/src/manager.rs`, `crates/madmin/src/user.rs`, `crates/obs/src/logging.rs`, `crates/policy/src/auth/credentials.rs`, `crates/signer/src/request_signature_v4.rs`, `crates/utils/src/logging.rs`, `rustfs/src/auth.rs` | False positive | AWS's own documented example access key id from the SigV4 test vectors, paired throughout this repository with the equally documented example secret key. Excused by exact literal rather than by file, so the exemption cannot cover any other 20-character AWS id. |
| 34 | `rustfs/src/auth.rs:1913` — `AKIAIOSFODNN7EXAMPLF` | False positive | The deliberate one-character variant that test uses to prove key comparison distinguishes near-identical ids. Excused by exact literal. |
| — | `scripts/check_embedded_secrets.sh` matching its own PuTTY needle on the first run | Guard defect | Fixed in the guard, not excused: the needle is now assembled around a variable, so the script stays inside its own scan. |

## Verification

- `./scripts/check_embedded_secrets.sh` — passes, exit 0, ~2.2s
- `./scripts/check_embedded_secrets.sh --self-test` — passes (clean fixture, all 11 pattern families fire, moved pinned source reported)
- `make embedded-secrets-check` — passes
- `./scripts/check_ci_paths_sync.sh` — `OK: ci.yml and ci-docs-only.yml path lists agree (16 entries)`
- `./scripts/check_doc_paths.sh` — passes
- `cargo nextest run -p rustfs-crypto` — 65 tests run, 65 passed
- `cargo fmt --all --check` — clean
- `shellcheck scripts/check_embedded_secrets.sh` — clean; `bash 3.2.57` and `bash -n` both fine

### Mutation probes

The only evidence a guard is live is watching it fail. Five probes, each reverted:

1. Appended a fake PKCS#8 header plus body to `crates/crypto/src/license_token.rs` — `Embedded secret guard failed: PEM private key header at crates/crypto/src/license_token.rs:240`, exit 1.
2. Appended `AKIAZZ4RB7QQEXAMPLE9` (AWS-shaped, not the documented example) to the same file — `Embedded secret guard failed: AWS access key id at crates/crypto/src/license_token.rs:241`, exit 1. Confirms the AWS exemption is per-literal, not per-format.
3. Swapped the excused fixture's `secret` body for base64-looking bytes — the line was reported *and* the now-unused exemption was reported stale, exit 1.
4. The `sed` backup left by probe 3 as an untracked file was itself scanned and reported, confirming that a file which has not been `git add`ed yet is covered.
5. `git mv crates/crypto/src/license_token.rs …_renamed.rs` — `crates/crypto/src/license_token.rs is missing; update PINNED_SOURCES`, exit 1. This is the case the retired test could only turn into a compile error.

Probes 1, 2 and 5 are also encoded permanently in `--self-test`, which additionally asserts each of the 11 pattern families fires on its own probe value, so removing or weakening a pattern turns `make script-tests` red.

## Impact

CI adds one compile-free ~2s step to Quick Checks in both workflows. No runtime, API, on-disk, or on-wire change. Contributors who paste a provider credential or a private key into any file — including the test, bench, e2e and `.docker` paths that GitHub push protection ignores — now get a local `make pre-commit` failure naming the file, line, matched text, and credential family.

## Additional Notes

Adversarial Validation, standard tier plus the security reviewer:

- **Correctness adversary** — attacked a non-git `ROOT_DIR` (the first draft would have passed vacuously, since every `git grep` fails and `|| true` swallowed it; now an explicit work-tree check plus a fatal `git grep` exit > 1), colon-bearing paths (none tracked, and file and line are split off the first two fields so colons inside matched text survive), an emptied exemption list under `set -u` (index-based loops, so bash 3.2 does not abort on an empty array), and CRLF plus leading-whitespace lines. No remaining break.
- **Simplicity adversary** — collapsed two exemption mechanisms (a per-line `path:::text` allow-list and a per-value literal list) into one exact-literal list, removing roughly 35 lines and one stale-check loop with no coverage loss, since the fixture bodies are themselves non-secret anywhere; and rejected a separate `scripts/test_check_embedded_secrets.sh` in favour of the repository's existing `--self-test` flag convention.
- **Security reviewer** — literal set: the retired guard covered one phrase in one file, this covers that phrase with any algorithm token plus PuTTY key files and nine credential formats over every text file. Trigger: the retired guard fired only if the needle landed in `license_token.rs` and turned a rename into a compile error, this fires anywhere and reports a rename explicitly. Visibility: the retired guard was a bare `assert!` with no message inside a crate test run, this prints family, file, line and matched text from a step that also runs on docs-only PRs. Newly detectable: the key moved to any other file or crate, a key in a non-Rust file, EC/OpenSSH/PGP/PuTTY forms, and a provider credential in the five path globs push protection is configured to ignore. Sanitizing a line before re-matching cannot mask a real credential, because only the exact non-secret strings are removed.
- **Test-coverage skeptic** — `--self-test` names every pattern family and fails if any stops firing, so deleting a pattern, loosening a needle, or breaking the exemption logic turns `make script-tests` red. Residual risk: a key stored as bare base64 with its header stripped, or inside a binary file, is still undetected — unchanged from the retired test and stated in the script header.
