### PR TITLE
refactor(admin): route plugin handler auth through authorize_admin_request

### DIFF
--- a/rustfs/src/admin/handlers/cluster_snapshot.rs
+++ b/rustfs/src/admin/handlers/cluster_snapshot.rs
@@ -14,7 +14,7 @@
 
 use crate::admin::storage_api::cluster::{CapabilityState, CapabilityStatus, ObservabilitySnapshot, TopologySnapshot};
 use crate::admin::{
-    auth::validate_admin_request,
+    auth::authorize_admin_request,
     router::{AdminOperation, Operation, S3Router},
     runtime_sources::default_admin_usecase,
     storage_api::cluster::{
@@ -24,11 +24,10 @@ use crate::admin::{
     },
     system,
 };
-use crate::auth::{check_key_valid, get_session_token};
 use crate::cluster_snapshot::{
     ClusterReadOnlySnapshot, ClusterRuntimeReadinessState, ClusterRuntimeStatusSnapshot, cluster_has_actionable_pressure,
 };
-use crate::server::{ADMIN_PREFIX, ReadinessDegradedReason, RemoteAddr};
+use crate::server::{ADMIN_PREFIX, ReadinessDegradedReason};
 use http::{HeaderMap, HeaderValue, StatusCode};
 use hyper::Method;
 use matchit::Params;
@@ -66,23 +65,15 @@ pub(crate) struct ClusterSnapshotDiscoveryResponse {
     pub components: Option<ClusterComponentStatusView>,
 }
 
+/// The pre-check keeps this endpoint's historical missing-credentials message;
+/// the shared gate reports "get cred failed".
 async fn authorize_cluster_snapshot_request(req: &S3Request<Body>) -> S3Result<()> {
-    let Some(input_cred) = &req.credentials else {
+    if req.credentials.is_none() {
         return Err(s3_error!(InvalidRequest, "authentication required"));
-    };
+    }
 
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-
-    validate_admin_request(
-        &req.headers,
-        &cred,
-        owner,
-        false,
-        vec![Action::AdminAction(AdminAction::ServerInfoAdminAction)],
-        req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-    )
-    .await
+    authorize_admin_request(req, vec![Action::AdminAction(AdminAction::ServerInfoAdminAction)]).await?;
+    Ok(())
 }
 
 fn build_json_response(
@@ -951,6 +942,30 @@ mod tests {
             auth_block.contains("AdminAction::ServerInfoAdminAction"),
             "cluster snapshot should require server info admin permission"
         );
+    }
+
+    /// This endpoint authorizes through the shared admin gate, which reports
+    /// "get cred failed" for a credential-less request. The pre-check keeps the
+    /// message it has always returned (rustfs/backlog#1829).
+    #[tokio::test]
+    async fn cluster_snapshot_gate_keeps_its_missing_credentials_message() {
+        let req = s3s::S3Request {
+            input: s3s::Body::from(String::new()),
+            method: http::Method::GET,
+            uri: http::Uri::from_static("/rustfs/admin/v4/cluster/snapshot"),
+            headers: http::HeaderMap::new(),
+            extensions: http::Extensions::new(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let err = super::authorize_cluster_snapshot_request(&req)
+            .await
+            .expect_err("a request without credentials must be rejected");
+        assert_eq!(err.code(), &s3s::S3ErrorCode::InvalidRequest);
+        assert_eq!(err.message(), Some("authentication required"));
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/extensions.rs
+++ b/rustfs/src/admin/handlers/extensions.rs
@@ -14,7 +14,7 @@
 
 use crate::admin::storage_api::cluster::CapabilityStatus;
 use crate::admin::{
-    auth::validate_admin_request,
+    auth::authorize_admin_request,
     handlers::{cluster_snapshot, plugins_instances, system},
     plugin_contract::{
         PluginContractDomain, PluginInstanceDiagnosticCode, PluginInstanceDiagnosticCount, PluginInstanceEntry,
@@ -22,8 +22,7 @@ use crate::admin::{
     },
     router::{AdminOperation, Operation, S3Router},
 };
-use crate::auth::{check_key_valid, get_session_token};
-use crate::server::{ADMIN_PREFIX, RemoteAddr};
+use crate::server::ADMIN_PREFIX;
 use http::{HeaderMap, HeaderValue, StatusCode};
 use hyper::Method;
 use matchit::Params;
@@ -183,42 +182,26 @@ fn map_extension_instance(instance: PluginInstanceEntry) -> ExtensionInstanceEnt
     }
 }
 
+/// The pre-check keeps this endpoint's historical missing-credentials message;
+/// the shared gate reports "get cred failed".
 async fn authorize_extension_catalog_request(req: &S3Request<Body>) -> S3Result<()> {
-    let Some(input_cred) = &req.credentials else {
+    if req.credentials.is_none() {
         return Err(s3_error!(InvalidRequest, "authentication required"));
-    };
+    }
 
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-
-    validate_admin_request(
-        &req.headers,
-        &cred,
-        owner,
-        false,
-        vec![Action::AdminAction(AdminAction::ServerInfoAdminAction)],
-        req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-    )
-    .await
+    authorize_admin_request(req, vec![Action::AdminAction(AdminAction::ServerInfoAdminAction)]).await?;
+    Ok(())
 }
 
+/// The pre-check keeps this endpoint's historical missing-credentials message;
+/// the shared gate reports "get cred failed".
 async fn authorize_extension_instance_request(req: &S3Request<Body>) -> S3Result<()> {
-    let Some(input_cred) = &req.credentials else {
+    if req.credentials.is_none() {
         return Err(s3_error!(InvalidRequest, "authentication required"));
-    };
+    }
 
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-
-    validate_admin_request(
-        &req.headers,
-        &cred,
-        owner,
-        false,
-        vec![Action::AdminAction(AdminAction::GetBucketTargetAction)],
-        req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-    )
-    .await
+    authorize_admin_request(req, vec![Action::AdminAction(AdminAction::GetBucketTargetAction)]).await?;
+    Ok(())
 }
 
 fn build_json_response(
@@ -318,6 +301,36 @@ mod tests {
             instance_auth.contains("AdminAction::GetBucketTargetAction"),
             "extension instances should require target read permission"
         );
+    }
+
+    /// Both extension gates authorize through the shared admin gate, which reports
+    /// "get cred failed" for a credential-less request. The pre-check keeps the
+    /// message these endpoints have always returned (rustfs/backlog#1829).
+    #[tokio::test]
+    async fn extension_gates_keep_their_missing_credentials_message() {
+        let credential_less_request = || s3s::S3Request {
+            input: s3s::Body::from(String::new()),
+            method: http::Method::GET,
+            uri: http::Uri::from_static("/rustfs/admin/v4/extensions/catalog"),
+            headers: http::HeaderMap::new(),
+            extensions: http::Extensions::new(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        for err in [
+            super::authorize_extension_catalog_request(&credential_less_request())
+                .await
+                .expect_err("a request without credentials must be rejected"),
+            super::authorize_extension_instance_request(&credential_less_request())
+                .await
+                .expect_err("a request without credentials must be rejected"),
+        ] {
+            assert_eq!(err.code(), &s3s::S3ErrorCode::InvalidRequest);
+            assert_eq!(err.message(), Some("authentication required"));
+        }
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/object_data_cache.rs
+++ b/rustfs/src/admin/handlers/object_data_cache.rs
@@ -21,12 +21,11 @@
 //! that bucket, and with `bucket`+`object` it flushes that one identity — the
 //! only remediation for a poisoned entry short of a node restart.
 
-use crate::admin::auth::validate_admin_request;
+use crate::admin::auth::authorize_admin_request;
 use crate::admin::router::{AdminOperation, Operation, S3Router};
 use crate::admin::runtime_sources::current_object_data_cache;
 use crate::app::object_data_cache::ObjectDataCacheAdapter;
-use crate::auth::{check_key_valid, get_session_token};
-use crate::server::{ADMIN_PREFIX, RemoteAddr};
+use crate::server::ADMIN_PREFIX;
 use http::{HeaderMap, HeaderValue};
 use hyper::{Method, StatusCode};
 use matchit::Params;
@@ -76,17 +75,14 @@ pub fn register_object_data_cache_route(r: &mut S3Router<AdminOperation>) -> std
     Ok(())
 }
 
+/// The pre-check keeps these endpoints' historical missing-credentials message;
+/// the shared gate reports "get cred failed".
 async fn authorize(req: &S3Request<Body>, action: AdminAction) -> S3Result<()> {
-    let Some(input_cred) = req.credentials.as_ref() else {
+    if req.credentials.is_none() {
         return Err(s3_error!(InvalidRequest, "missing credentials"));
-    };
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-    let remote_addr = req
-        .extensions
-        .get::<Option<RemoteAddr>>()
-        .and_then(|opt| opt.map(|addr| addr.0));
-    validate_admin_request(&req.headers, &cred, owner, false, vec![Action::AdminAction(action)], remote_addr).await
+    }
+    authorize_admin_request(req, vec![Action::AdminAction(action)]).await?;
+    Ok(())
 }
 
 fn json_response<T: Serialize>(body: &T) -> S3Result<S3Response<(StatusCode, Body)>> {
@@ -206,6 +202,30 @@ mod tests {
             ("removed", 3)
         );
         assert_eq!(invalidation_outcome(&ObjectDataCacheInvalidationResult::NoOp), ("noop", 0));
+    }
+
+    /// These endpoints authorize through the shared admin gate, which reports
+    /// "get cred failed" for a credential-less request. The pre-check keeps the
+    /// message they have always returned (rustfs/backlog#1829).
+    #[tokio::test]
+    async fn authorize_keeps_its_missing_credentials_message() {
+        let req = S3Request {
+            input: Body::from(String::new()),
+            method: Method::GET,
+            uri: "/rustfs/admin/v3/object-data-cache/stats".parse().expect("uri should parse"),
+            headers: HeaderMap::new(),
+            extensions: http::Extensions::new(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let err = authorize(&req, AdminAction::ServerInfoAdminAction)
+            .await
+            .expect_err("a request without credentials must be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
+        assert_eq!(err.message(), Some("missing credentials"));
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/plugins_catalog.rs
+++ b/rustfs/src/admin/handlers/plugins_catalog.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::{
-    auth::validate_admin_request,
+    auth::authorize_admin_request,
     plugin_contract::{
         PluginCatalogAdminDiscovery, PluginCatalogDomainEntry, PluginCatalogEntry, PluginCatalogResponse, PluginContractDomain,
         PluginContractEntrypointKind, PluginContractPackaging, PluginDistributionContract, PluginRuntimeContract,
@@ -21,8 +21,7 @@ use crate::admin::{
     router::{AdminOperation, Operation, S3Router},
     runtime_sources::default_admin_usecase,
 };
-use crate::auth::{check_key_valid, get_session_token};
-use crate::server::{ADMIN_PREFIX, RemoteAddr};
+use crate::server::ADMIN_PREFIX;
 use http::{HeaderMap, HeaderValue, StatusCode};
 use hyper::Method;
 use matchit::Params;
@@ -114,23 +113,15 @@ fn merge_catalog_descriptor(plugins: &mut HashMap<&'static str, PluginCatalogEnt
     }
 }
 
+/// The pre-check keeps this endpoint's historical missing-credentials message;
+/// the shared gate reports "get cred failed".
 async fn authorize_plugin_catalog_request(req: &S3Request<Body>) -> S3Result<()> {
-    let Some(input_cred) = &req.credentials else {
+    if req.credentials.is_none() {
         return Err(s3_error!(InvalidRequest, "authentication required"));
-    };
+    }
 
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-
-    validate_admin_request(
-        &req.headers,
-        &cred,
-        owner,
-        false,
-        vec![Action::AdminAction(AdminAction::ServerInfoAdminAction)],
-        req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-    )
-    .await
+    authorize_admin_request(req, vec![Action::AdminAction(AdminAction::ServerInfoAdminAction)]).await?;
+    Ok(())
 }
 
 fn build_json_response(
@@ -173,6 +164,30 @@ mod tests {
             handler_block.contains("authorize_plugin_catalog_request(&req).await?;"),
             "plugin catalog GET should require admin authorization"
         );
+    }
+
+    /// This endpoint authorizes through the shared admin gate, which reports
+    /// "get cred failed" for a credential-less request. The pre-check keeps the
+    /// message it has always returned (rustfs/backlog#1829).
+    #[tokio::test]
+    async fn plugin_catalog_gate_keeps_its_missing_credentials_message() {
+        let req = s3s::S3Request {
+            input: s3s::Body::from(String::new()),
+            method: http::Method::GET,
+            uri: http::Uri::from_static("/rustfs/admin/v4/plugins/catalog"),
+            headers: http::HeaderMap::new(),
+            extensions: http::Extensions::new(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        let err = super::authorize_plugin_catalog_request(&req)
+            .await
+            .expect_err("a request without credentials must be rejected");
+        assert_eq!(err.code(), &s3s::S3ErrorCode::InvalidRequest);
+        assert_eq!(err.message(), Some("authentication required"));
     }
 
     #[test]

--- a/rustfs/src/admin/handlers/plugins_instances.rs
+++ b/rustfs/src/admin/handlers/plugins_instances.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::admin::{
-    auth::validate_admin_request,
+    auth::authorize_admin_request,
     handlers::audit_runtime_config::{load_server_config_from_store, remove_audit_target_config, set_audit_target_config},
     handlers::notify_runtime_access::{
         load_notification_config_snapshot, remove_notification_target_config, set_notification_target_config,
@@ -29,10 +29,9 @@ use crate::admin::{
     },
     router::{AdminOperation, Operation, S3Router},
 };
-use crate::auth::{check_key_valid, get_session_token};
 use crate::server::{
-    ADMIN_PREFIX, RemoteAddr, is_audit_module_enabled, is_notify_module_enabled, refresh_audit_module_enabled,
-    refresh_notify_module_enabled, refresh_persisted_module_switches_from_store,
+    ADMIN_PREFIX, is_audit_module_enabled, is_notify_module_enabled, refresh_audit_module_enabled, refresh_notify_module_enabled,
+    refresh_persisted_module_switches_from_store,
 };
 use hyper::{Method, StatusCode};
 use matchit::Params;
@@ -563,42 +562,26 @@ fn plugin_instance_matches_query(instance: &PluginInstanceEntry, query: &str) ->
     .any(|field| field.to_ascii_lowercase().contains(&query))
 }
 
+/// The pre-check keeps this endpoint's historical missing-credentials message;
+/// the shared gate reports "get cred failed".
 async fn authorize_plugin_instance_request(req: &S3Request<Body>) -> S3Result<()> {
-    let Some(input_cred) = &req.credentials else {
+    if req.credentials.is_none() {
         return Err(s3_error!(InvalidRequest, "authentication required"));
-    };
+    }
 
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-
-    validate_admin_request(
-        &req.headers,
-        &cred,
-        owner,
-        false,
-        vec![Action::AdminAction(AdminAction::GetBucketTargetAction)],
-        req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-    )
-    .await
+    authorize_admin_request(req, vec![Action::AdminAction(AdminAction::GetBucketTargetAction)]).await?;
+    Ok(())
 }
 
+/// The pre-check keeps this endpoint's historical missing-credentials message;
+/// the shared gate reports "get cred failed".
 async fn authorize_plugin_instance_write_request(req: &S3Request<Body>) -> S3Result<()> {
-    let Some(input_cred) = &req.credentials else {
+    if req.credentials.is_none() {
         return Err(s3_error!(InvalidRequest, "authentication required"));
-    };
+    }
 
-    let (cred, owner) =
-        check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?;
-
-    validate_admin_request(
-        &req.headers,
-        &cred,
-        owner,
-        false,
-        vec![Action::AdminAction(AdminAction::SetBucketTargetAction)],
-        req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)),
-    )
-    .await
+    authorize_admin_request(req, vec![Action::AdminAction(AdminAction::SetBucketTargetAction)]).await?;
+    Ok(())
 }
 
 fn plugin_instance_mutation_block_reason(
@@ -940,6 +923,36 @@ mod tests {
             read_auth_block.contains("AdminAction::GetBucketTargetAction"),
             "plugin instance read routes should require GetBucketTargetAction"
         );
+    }
+
+    /// Both instance gates authorize through the shared admin gate, which reports
+    /// "get cred failed" for a credential-less request. The pre-check keeps the
+    /// message these endpoints have always returned (rustfs/backlog#1829).
+    #[tokio::test]
+    async fn plugin_instance_gates_keep_their_missing_credentials_message() {
+        let credential_less_request = || S3Request {
+            input: Body::from(String::new()),
+            method: Method::GET,
+            uri: Uri::from_static("/rustfs/admin/v4/plugins/instances"),
+            headers: HeaderMap::new(),
+            extensions: Extensions::new(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+
+        for err in [
+            super::authorize_plugin_instance_request(&credential_less_request())
+                .await
+                .expect_err("a request without credentials must be rejected"),
+            super::authorize_plugin_instance_write_request(&credential_less_request())
+                .await
+                .expect_err("a request without credentials must be rejected"),
+        ] {
+            assert_eq!(err.code(), &s3s::S3ErrorCode::InvalidRequest);
+            assert_eq!(err.message(), Some("authentication required"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Related Issues

rustfs/backlog#1829 (T3 batch P1 — plugin/extension family). Follows PR #6020 (T1, shared gate landed) and PR #6194 (T2, KMS management group).

## Summary of Changes

The plugin/extension admin family carried seven byte-near copies of the admin auth preamble — extract `req.credentials`, `check_key_valid(get_session_token(...))`, dig `RemoteAddr` out of `req.extensions`, call `validate_admin_request`. Every copy is a place the gate can drift, and a drifted copy is an endpoint with different authorization than its siblings.

All seven are per-file `authorize_*` wrappers with **no resource scope** and **no audit seam**, so they fold onto the shared `authorize_admin_request` gate (`rustfs/src/admin/auth.rs:302`) without changing the decision. Only the wrapper bodies change; every handler call site is untouched.

Sites converted (7/7 of the batch classified in rustfs/backlog#1829):

| File | Wrapper | Action set (unchanged) | Missing-cred message (preserved) |
|---|---|---|---|
| `handlers/extensions.rs` | `authorize_extension_catalog_request` | `ServerInfoAdminAction` | `InvalidRequest "authentication required"` |
| `handlers/extensions.rs` | `authorize_extension_instance_request` | `GetBucketTargetAction` | `InvalidRequest "authentication required"` |
| `handlers/plugins_catalog.rs` | `authorize_plugin_catalog_request` | `ServerInfoAdminAction` | `InvalidRequest "authentication required"` |
| `handlers/plugins_instances.rs` | `authorize_plugin_instance_request` | `GetBucketTargetAction` | `InvalidRequest "authentication required"` |
| `handlers/plugins_instances.rs` | `authorize_plugin_instance_write_request` | `SetBucketTargetAction` | `InvalidRequest "authentication required"` |
| `handlers/object_data_cache.rs` | `authorize` (parameterized) | caller-supplied `AdminAction` | `InvalidRequest "missing credentials"` |
| `handlers/cluster_snapshot.rs` | `authorize_cluster_snapshot_request` | `ServerInfoAdminAction` | `InvalidRequest "authentication required"` |

The shared gate reports `InvalidRequest "get cred failed"` for a credential-less request, which differs from what all seven endpoints have always returned. Each wrapper therefore keeps an explicit `if req.credentials.is_none()` pre-check returning **its own historical error**, the pattern established by T2 in `kms_management.rs:75-81`. Five new tests pin those messages byte-for-byte.

## Per-site response-equivalence argument

Three request classes, per site:

1. **No credentials** (`req.credentials == None`). Before: `s3_error!(InvalidRequest, "<site message>")`. After: the pre-check returns that same expression before the shared gate is reached. Identical code, identical message. Pinned by the five new `*_keeps_its_missing_credentials_message` / `*_keep_their_missing_credentials_message` tests.
2. **Wrong credentials** (`check_key_valid` fails). Before: `check_key_valid(get_session_token(&req.uri, &req.headers).unwrap_or_default(), &input_cred.access_key).await?`. After: `authorize_admin_request` → `authenticate_request(&req.headers, &req.uri, input_cred)` (`auth.rs:256`), whose body is `check_key_valid(get_session_token(uri, headers).unwrap_or_default(), &credentials.access_key).await` and which returns `result` unmodified. Same token source, same access key, same `S3Error` propagated through `?`. The only difference is that `authenticate_request` emits a `debug!`/`warn!` trace event — log output, not response bytes.
3. **Authenticated but unauthorized.** Before: `validate_admin_request(&req.headers, &cred, owner, false, vec![Action::AdminAction(X)], req.extensions.get::<Option<RemoteAddr>>().and_then(|opt| opt.map(|a| a.0)))`. After: the gate calls `validate_admin_request(&req.headers, &cred, owner, false, actions, remote_addr)` with `remote_addr` computed by the identical expression. Same six arguments, same `deny_only = false`, same action vector per site, same empty `bucket`/`object` resource slots. `validate_admin_request` returns `S3Result<()>`; the gate's extra `Ok(cred)` is dropped by `.await?; Ok(())` in the wrapper, so the wrapper signature and its success/error values are unchanged.

No site gained or lost an action, changed an action, gained a resource scope, or changed `deny_only`. No status code changes: all three classes return exactly the error they returned before.

## Sites deliberately excluded

None from this batch — all seven classified sites converted. For the record, the wider issue's excluded classes are untouched here: key/bucket-scoped gates (`kms_keys`, `kms_key_lifecycle`, `kms_key_metadata`, `quota`), audit-wrapped gates (`KmsAdminAudit::gate`/`gate_admin`), `deny_only`-dynamic sites (`user.rs:228/628`, `sts.rs:195`), and the E-class one-offs. Batches P2–P6 of the inventory remain to be done.

## Verification

- `cargo check -p rustfs` — clean
- `cargo clippy -p rustfs --lib --tests -- -D warnings` — clean
- `cargo nextest run -p rustfs -E 'test(/admin/)'` — 1435 passed, 0 failed
- `cargo nextest run -p rustfs -E 'binary(rustfs) and test(/admin::handlers::(plugins_catalog|plugins_instances|extensions|cluster_snapshot|object_data_cache)::/)'` — 57 passed
- `cargo fmt --all --check`
- `scripts/check_layer_dependencies.sh`, `scripts/check_architecture_migration_rules.sh`, `scripts/check_unsafe_code_allowances.sh`, `scripts/check_logging_guardrails.sh`, `scripts/check_no_planning_docs.sh` — all pass

### `include_str!` source-text assertions (plugin-contract-guard)

All five touched files are read by their own `include_str!` contract tests. Every one was re-run and passes unmodified — the assertions target handler **call sites** (unchanged) and the `AdminAction::*` constant inside each wrapper body (retained):

- `extensions::tests::extension_handlers_require_admin_authorization_contract`
- `plugins_catalog::tests::plugin_catalog_handlers_require_admin_authorization_contract`
- `plugins_instances::tests::plugin_instance_handlers_require_admin_authorization_contract`
- `object_data_cache::tests::stats_handler_requires_server_info_action`
- `cluster_snapshot::tests::cluster_snapshot_handler_requires_server_info_admin_permission`

No source-text assertion needed updating.

## Impact

None user-facing. Authorization decisions, HTTP status codes, error codes, and error messages are unchanged for every one of the seven endpoints. The only observable difference is two additional `tracing` events (`debug!` on authentication attempt/success, `warn!` on authentication failure) emitted by the shared gate, matching the six admin files already routed through it. No API, config, deployment, or on-disk impact.

## Additional Notes

### Adversarial Validation — Standard tier + security reviewer

- **Correctness adversary** — attacked the three request classes per site (absent / invalid / unauthorized credentials), the `deny_only` value, the `RemoteAddr` extension lookup (present, absent, and `Some(None)`), the wrapper return type (`S3Result<()>` vs the gate's `S3Result<Credentials>`), and gate-vs-body ordering (all seven wrappers are called at the top of `call` before `req.input` is consumed, and stay there). No break found.
- **Simplicity adversary** — production code shrinks (seven ~15-line preamble copies become seven 4-line wrappers, plus four now-dead imports removed); no new helper, type, or branch is introduced, and the pre-check is not a speculative guard: it has a nameable trigger (an unsigned request reaching an admin route) and a named consequence (message drift). Attacked whether the pre-check could be dropped in favour of the shared gate's own `None` arm — it cannot without changing 7 responses. No break found.
- **Security reviewer** — grepped each `AdminAction::*` constant against the operation its handler performs: catalogs and cluster snapshot are reads under `ServerInfoAdminAction`, instance reads under `GetBucketTargetAction`, instance writes under `SetBucketTargetAction`, matching the `plugin-contract-guard` read/write split; the object-data-cache stats/flush pair keeps its `ServerInfoAdminAction`/`ConfigUpdateAdminAction` asymmetry. No action set widened, no `deny_only` flipped, no scope dropped, no read endpoint downgraded to a credentials-exist check, and the `AccessDenied → InvalidRequest` status-code hazard flagged in the inventory does not arise here (none of the seven used `AccessDenied`). No break found.
- **Test-coverage skeptic** — a revert of any wrapper to a different missing-credentials message is caught by the five new pin tests; a revert of the action constant is caught by the pre-existing `include_str!` contract tests; a dropped gate call is caught by the same contract tests. Residual risk: the authenticated-but-unauthorized path has no unit test here because `validate_admin_request` requires a ready IAM handle — it is covered by argument-identity inspection above and by `auth::tests::authorize_admin_request_without_credentials_is_rejected` plus the gate's own allow/deny unit suite in `auth.rs`. No break found.
- Concurrency/durability, compatibility, and performance roles are not applicable: no shared state, no format or API-shape change, no per-request hot path (admin routes only).
