### PR TITLE
test(audit,heal): assert three more smoke tests

### DIFF
--- a/crates/audit/tests/pipeline_layer_test.rs
+++ b/crates/audit/tests/pipeline_layer_test.rs
@@ -236,12 +236,19 @@ async fn audit_pipeline_reports_empty_runtime_snapshots() {
 }
 
 #[tokio::test]
-async fn audit_runtime_facade_stops_empty_replay_workers() {
+async fn stopping_audit_replay_workers_is_a_no_op_when_there_are_none() {
     let registry = Arc::new(Mutex::new(AuditRegistry::new()));
     let replay_workers = Arc::new(RwLock::new(rustfs_targets::ReplayWorkerManager::new()));
-    let facade = AuditRuntimeFacade::new(registry, replay_workers);
+    let facade = AuditRuntimeFacade::new(registry, Arc::clone(&replay_workers));
 
     facade.stop_replay_workers().await;
+
+    // The stop path takes the manager's workers and hands them to the adapter,
+    // so an empty facade must leave it empty rather than wedge it, and a second
+    // call — which shutdown paths make — must stay harmless (rustfs/backlog#1836).
+    assert!(replay_workers.read().await.is_empty());
+    facade.stop_replay_workers().await;
+    assert!(replay_workers.read().await.is_empty());
 }
 
 #[tokio::test]

--- a/crates/heal/tests/heal_bug_fixes_test.rs
+++ b/crates/heal/tests/heal_bug_fixes_test.rs
@@ -117,13 +117,16 @@ fn test_format_set_disk_id_from_i32_valid() {
     assert_eq!(result.unwrap(), "pool_0_set_1");
 }
 
+/// A wall-clock lower bound for "the timestamp was actually read from the
+/// clock": 2020-01-01. `unwrap_or_default()` on a pre-epoch clock yields 0, and
+/// the old versions of these tests bound the fields to `_` and so could not tell
+/// that apart from a real reading (rustfs/backlog#1836).
+const SANE_EPOCH_SECS: u64 = 1_577_836_800;
+
 #[test]
 fn test_resume_state_timestamp_handling() {
     use rustfs_heal::heal::resume::ResumeState;
 
-    // Test that ResumeState creation doesn't panic even if system time is before epoch
-    // This is a theoretical test - in practice, system time should never be before epoch
-    // But we want to ensure unwrap_or_default handles edge cases
     let state = ResumeState::new(
         "test-task".to_string(),
         "test-type".to_string(),
@@ -131,22 +134,30 @@ fn test_resume_state_timestamp_handling() {
         vec!["bucket1".to_string()],
     );
 
-    // Verify fields are initialized (u64 is always >= 0)
-    // The important thing is that unwrap_or_default prevents panic
-    let _ = state.start_time;
-    let _ = state.last_update;
+    assert!(
+        state.start_time > SANE_EPOCH_SECS,
+        "start_time fell back to the default instead of reading the clock: {}",
+        state.start_time
+    );
+    assert!(
+        state.last_update >= state.start_time,
+        "last_update {} must not predate start_time {}",
+        state.last_update,
+        state.start_time
+    );
 }
 
 #[test]
 fn test_resume_checkpoint_timestamp_handling() {
     use rustfs_heal::heal::resume::ResumeCheckpoint;
 
-    // Test that ResumeCheckpoint creation doesn't panic
     let checkpoint = ResumeCheckpoint::new("test-task".to_string());
 
-    // Verify field is initialized (u64 is always >= 0)
-    // The important thing is that unwrap_or_default prevents panic
-    let _ = checkpoint.checkpoint_time;
+    assert!(
+        checkpoint.checkpoint_time > SANE_EPOCH_SECS,
+        "checkpoint_time fell back to the default instead of reading the clock: {}",
+        checkpoint.checkpoint_time
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Sixth batch of backlog#1836. Three more smoke tests get assertions; a fourth turned out to need more than one. Follows #6238, #6241 and #6242.

## The three

**`audit_runtime_facade_stops_empty_replay_workers`** called the stop path and checked nothing — the same shape as the notify facade test in #6242. It now asserts the worker manager is empty afterwards, and that a second call stays harmless, which is what shutdown paths actually do.

**The two heal timestamp tests** bound their fields to `_`:

```rust
let _ = state.start_time;
let _ = state.last_update;
```

Both values come from `SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default()`, so a pre-epoch clock silently yields `0`. Binding to `_` cannot tell that apart from a real reading — which is precisely the edge the tests' own comments said they were guarding. They now require the value to be past 2020-01-01, and `last_update` not to predate `start_time`.

## The fourth: left alone, and why

`test_config_parsing_with_multiple_instances` builds three webhook instances and matches on the result with **every arm accepting**, including the parse-failure arm. Trying to assert on it turned up two things:

- its comment claims the call should fail with `StorageNotAvailable` because no server storage is initialised. That is stale — the call returns `Ok`.
- the returned target list is **empty**, not the two enabled instances. A test named for multi-instance config parsing has never parsed an instance, and could not have noticed.

The section name is right (`audit_webhook` matches `format!("{route_prefix}{target_type}")`) and `enable`'s `on`/`off` parse correctly, so the instances are being rejected further in — but `create_audit_targets_from_config` returns only the targets it built and drops failures after an `error!` log (`crates/targets/src/plugin.rs:355-358`). A caller cannot distinguish "every instance was rejected" from "there were no instances", which is why this went unnoticed.

Pinning the assertion to the current behaviour would freeze a probable defect into a contract, so the test is left as it was and the finding is filed on the issue instead. Fixing it properly means identifying the webhook plugin's required fields and deciding whether that API should surface its failures.

## Verification

`cargo nextest run -p rustfs-audit -p rustfs-heal` passes for the three touched tests, `cargo clippy -p rustfs-audit -p rustfs-heal --all-targets -- -D warnings` clean, `cargo fmt --all` applied.
