### PR TITLE
chore(rustfs): adjudicate all 73 bare dead_code allows

### DIFF
--- a/rustfs/src/admin/console.rs
+++ b/rustfs/src/admin/console.rs
@@ -119,6 +119,10 @@ async fn static_handler(uri: Uri) -> impl IntoResponse {
 #[derive(Debug, Serialize, Clone)]
 pub(crate) struct Config {
     #[serde(skip)]
+    #[allow(
+        dead_code,
+        reason = "reachable only from this file's tests: no route registers config_handler (backlog#1823)"
+    )]
     port: u16,
     api: Api,
     s3: S3,
@@ -176,11 +180,14 @@ impl Config {
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "reachable only from this file's tests: no route registers config_handler (backlog#1823)"
+    )]
     fn to_json(&self) -> String {
         serde_json::to_string(self).unwrap_or_default()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn version_info(&self) -> String {
         format!(
             "RELEASE.{}@{} (rust {} {})",
@@ -189,21 +196,6 @@ impl Config {
             build::RUST_VERSION,
             build::BUILD_TARGET
         )
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn version(&self) -> String {
-        self.release.version.clone()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn license(&self) -> String {
-        format!("{} {}", self.license.name.clone(), self.license.url.clone())
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn doc(&self) -> String {
-        self.doc.clone()
     }
 }
 
@@ -353,7 +345,10 @@ async fn version_handler() -> impl IntoResponse {
 /// - 200 OK with JSON body containing the console configuration if initialized.
 /// - 500 Internal Server Error if configuration is not initialized.
 #[instrument(fields(uri))]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "reachable only from this file's tests: no route registers it (backlog#1823)"
+)]
 async fn config_handler(uri: Uri, headers: HeaderMap) -> impl IntoResponse {
     // Get the scheme from the headers or use the URI scheme
     let scheme = headers

--- a/rustfs/src/admin/handlers/tier.rs
+++ b/rustfs/src/admin/handlers/tier.rs
@@ -53,25 +53,18 @@ const EVENT_ADMIN_TIER_STATE: &str = "admin_tier_state";
 #[derive(Debug, Clone, serde::Deserialize, Default)]
 pub struct AddTierQuery {
     #[serde(rename = "accessKey")]
-    #[allow(dead_code)]
     pub access_key: Option<String>,
-    #[allow(dead_code)]
     pub status: Option<String>,
     #[serde(rename = "secretKey")]
-    #[allow(dead_code)]
     pub secret_key: Option<String>,
     #[serde(rename = "serviceName")]
-    #[allow(dead_code)]
     pub service_name: Option<String>,
     #[serde(rename = "sessionToken")]
-    #[allow(dead_code)]
     pub session_token: Option<String>,
     pub tier: Option<String>,
     #[serde(rename = "tierName")]
-    #[allow(dead_code)]
     pub tier_name: Option<String>,
     #[serde(rename = "tierType")]
-    #[allow(dead_code)]
     pub tier_type: Option<String>,
     pub force: Option<String>,
 }
@@ -532,7 +525,6 @@ impl Operation for EditTier {
 #[derive(Debug, Clone, serde::Deserialize, Default)]
 pub struct BucketQuery {
     #[serde(rename = "bucket")]
-    #[allow(dead_code)]
     pub bucket: String,
 }
 pub struct ListTiers {}

--- a/rustfs/src/auth.rs
+++ b/rustfs/src/auth.rs
@@ -812,12 +812,10 @@ fn is_reserved_condition_key(key: &str, server_derived: &HashMap<String, Vec<Str
 /// # Returns
 /// * `AuthType` - The determined authentication type
 ///
-#[allow(dead_code)]
 pub fn get_request_auth_type(header: &HeaderMap) -> AuthType {
     get_request_auth_type_with_query(header, None)
 }
 
-#[allow(dead_code)]
 pub(crate) fn get_request_auth_type_with_query(header: &HeaderMap, query: Option<&str>) -> AuthType {
     if is_request_signature_v2(header) {
         AuthType::SignedV2
@@ -846,20 +844,6 @@ pub(crate) fn get_request_auth_type_with_query(header: &HeaderMap, query: Option
     }
 }
 
-/// Helper function to determine auth type and signature version
-///
-/// # Arguments
-/// * `header` - HTTP headers of the request
-///
-/// # Returns
-/// * `(String, String)` - Tuple of auth type and signature version
-///
-#[allow(dead_code)]
-fn determine_auth_type_and_version(header: &HeaderMap) -> (String, String) {
-    determine_auth_type_and_version_with_query(header, None)
-}
-
-#[allow(dead_code)]
 fn determine_auth_type_and_version_with_query(header: &HeaderMap, query: Option<&str>) -> (String, String) {
     match get_request_auth_type_with_query(header, query) {
         AuthType::JWT => ("JWT".to_string(), String::new()),
@@ -923,18 +907,6 @@ fn is_request_signature_v2(header: &HeaderMap) -> bool {
         return !auth_str.starts_with(SIGN_V4_ALGORITHM) && auth_str.starts_with(SIGN_V2_ALGORITHM);
     }
     false
-}
-
-/// Verify if request has AWS PreSign Version '4'
-///
-/// # Arguments
-/// * `header` - HTTP headers of the request
-///
-/// # Returns
-/// * `bool` - True if request has AWS PreSign Version '4', false otherwise
-#[allow(dead_code)]
-pub(crate) fn is_request_presigned_signature_v4(header: &HeaderMap) -> bool {
-    is_request_presigned_signature_v4_with_query(header, None)
 }
 
 pub(crate) fn is_request_presigned_signature_v4_with_query(header: &HeaderMap, query: Option<&str>) -> bool {

--- a/rustfs/src/storage/concurrency/io_schedule.rs
+++ b/rustfs/src/storage/concurrency/io_schedule.rs
@@ -72,7 +72,6 @@ impl IoLoadLevel {
     }
 
     /// Get the load level as a string for metrics labels.
-    #[allow(dead_code)]
     pub fn as_str(&self) -> &'static str {
         match self {
             IoLoadLevel::Low => "low",
@@ -83,7 +82,6 @@ impl IoLoadLevel {
     }
 
     /// Get the load level as a numeric index (0=Low, 1=Medium, 2=High, 3=Critical).
-    #[allow(dead_code)]
     pub fn level_index(&self) -> u8 {
         match self {
             IoLoadLevel::Low => 0,
@@ -118,7 +116,6 @@ pub enum IoPriority {
 
 impl IoPriority {
     /// Determine priority from request size using scheduler config thresholds.
-    #[allow(dead_code)]
     pub fn from_size(size: i64) -> Self {
         Self::from_size_with_thresholds(
             size,
@@ -152,19 +149,16 @@ impl IoPriority {
     }
 
     /// Check if this is high priority.
-    #[allow(dead_code)]
     pub fn is_high(&self) -> bool {
         matches!(self, IoPriority::High)
     }
 
     /// Check if this is normal priority.
-    #[allow(dead_code)]
     pub fn is_normal(&self) -> bool {
         matches!(self, IoPriority::Normal)
     }
 
     /// Check if this is low priority.
-    #[allow(dead_code)]
     pub fn is_low(&self) -> bool {
         matches!(self, IoPriority::Low)
     }
@@ -403,7 +397,6 @@ impl IoSchedulerConfig {
 
 /// I/O queue status for monitoring.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)]
 pub struct IoQueueStatus {
     /// Total permits available.
     pub total_permits: usize,
@@ -520,7 +513,6 @@ pub struct IoStrategyCore {
 
 impl IoStrategyCore {
     /// Create a minimal IoStrategyCore with essential fields only.
-    #[allow(dead_code)]
     pub fn new(storage_media: StorageMedia, access_pattern: AccessPattern, buffer_size: usize) -> Self {
         Self {
             storage_media,
@@ -1194,7 +1186,6 @@ impl IoStrategy {
     }
 
     /// Get a human-readable description of the current I/O strategy.
-    #[allow(dead_code)]
     pub fn description(&self) -> String {
         format!(
             "IoStrategy[{:?}]: buffer={}KB, multiplier={:.2}, readahead={}, wait={:?}",
@@ -1280,14 +1271,6 @@ impl IoLoadMetrics {
     /// Get the smoothed load level based on recent observations
     pub(crate) fn smoothed_load_level(&self) -> IoLoadLevel {
         IoLoadLevel::from_wait_duration(self.average_wait())
-    }
-
-    /// Get the overall average wait since startup
-    #[allow(dead_code)]
-    pub(crate) fn lifetime_average_wait(&self) -> Duration {
-        let total = self.total_wait_ns.load(Ordering::Relaxed);
-        let count = self.observation_count.load(Ordering::Relaxed);
-        total.checked_div(count).map(Duration::from_nanos).unwrap_or(Duration::ZERO)
     }
 
     /// Get the total observation count
@@ -1450,13 +1433,13 @@ use tracing::warn;
 
 /// Queued I/O request with metadata.
 #[derive(Debug)]
-#[allow(dead_code)]
 struct QueuedRequest<T> {
     /// The actual request payload.
     request: T,
     /// Time when the request was enqueued.
     enqueue_time: Instant,
     /// Original priority assigned to the request.
+    #[allow(dead_code, reason = "written but never read back (backlog#1823)")]
     original_priority: IoPriority,
     /// Current priority (may be boosted for starvation prevention).
     current_priority: IoPriority,
@@ -1466,7 +1449,6 @@ struct QueuedRequest<T> {
 
 /// Queue statistics for monitoring.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)]
 struct QueueStats {
     /// Number of high priority requests processed.
     high_processed: u64,
@@ -1552,7 +1534,6 @@ impl Default for IoPriorityQueueConfig {
 
 impl IoPriorityQueueConfig {
     /// Load configuration from environment.
-    #[allow(dead_code)]
     pub fn from_env() -> Self {
         Self {
             queue_high_capacity: rustfs_utils::get_env_usize(
@@ -1603,7 +1584,6 @@ impl IoPriorityQueueConfig {
 
 impl<T> IoPriorityQueue<T> {
     /// Create a new priority queue with the given configuration.
-    #[allow(dead_code)]
     pub fn new(config: IoPriorityQueueConfig) -> Self {
         let config_clone = config.clone();
         Self {
@@ -1617,7 +1597,6 @@ impl<T> IoPriorityQueue<T> {
     }
 
     /// Enqueue a request with the given priority.
-    #[allow(dead_code)]
     pub async fn enqueue(&self, priority: IoPriority, request: T) {
         let queued = QueuedRequest {
             request,
@@ -1638,7 +1617,6 @@ impl<T> IoPriorityQueue<T> {
     ///
     /// This method performs starvation prevention checks before dequeuing.
     /// Returns `None` if all queues are empty.
-    #[allow(dead_code)]
     pub async fn dequeue(&self) -> Option<(T, IoPriority)> {
         // 1. Check for starvation prevention
         self.check_starvation().await;
@@ -1716,7 +1694,6 @@ impl<T> IoPriorityQueue<T> {
     }
 
     /// Get current queue status for monitoring.
-    #[allow(dead_code)]
     pub async fn status(&self) -> IoQueueStatus {
         let high_queue = self.high_queue.lock().await;
         let normal_queue = self.normal_queue.lock().await;
@@ -1737,7 +1714,6 @@ impl<T> IoPriorityQueue<T> {
     }
 
     /// Get the total number of queued requests.
-    #[allow(dead_code)]
     pub async fn len(&self) -> usize {
         let high_queue = self.high_queue.lock().await;
         let normal_queue = self.normal_queue.lock().await;
@@ -1747,7 +1723,6 @@ impl<T> IoPriorityQueue<T> {
     }
 
     /// Check if all queues are empty.
-    #[allow(dead_code)]
     pub async fn is_empty(&self) -> bool {
         self.len().await == 0
     }


### PR DESCRIPTION
## What

Step 10 of backlog#1823 for the `rustfs` crate, in two commits — the four densest files (37 allows), then the 36 spread across 23 more. After this, **`rustfs/src` has no bare `#[allow(dead_code)]` left**. Seven remain, each carrying a trailing `//` justification (`// used in config_test`, `// kept for backward compatibility`); turning those into `reason =` is a separate question, untouched here.

Method is the one the library batches (#6161, #6162, #6173, #6187) settled on: strip every allow first, then ask clippy which ones the compiler actually missed. **49 of the 73 were inert** — including all eight in `admin/handlers/tier.rs` and seventeen of the nineteen in `storage/concurrency/io_schedule.rs`.

## Sixteen deletions, in recurring shapes

**No-argument shims (5).** `auth.rs`'s `determine_auth_type_and_version` and `is_request_presigned_signature_v4`, and `storage/options.rs`'s `get_content_sha256`, `skip_content_sha256_cksum` and `get_content_sha256_cksum`. Each forwards to a `_with_query` variant that carries live callers (2, 5, 8, 2, 2); none of the shims had one. Threading the `query` parameter through left the old signatures behind.

**A local shadow (1).** `admin/handlers/replication.rs::is_local_host` was never called — the one call site that looks like its own uses `rustfs_utils::net::is_local_host`.

**A dead cluster (2).** `cache_clear` is reachable only from `invalidate_all_bucket_validation_cache`, which nothing calls.

**Unused accessors and helpers (8).** `io_schedule.rs::lifetime_average_wait` (its siblings `observation_count`, `average_wait`, `smoothed_load_level` are all consumed), `console.rs::version()`/`license()`/`doc()` (the live one is `version_info()`), `head_prefix.rs::is_prefix_key`, `startup_iam.rs::reset_test_failure_counter` (no consumer anywhere, including `rustfs/tests` and `crates/e2e_test`, despite its doc claiming integration-test use), and `init.rs::spawn_server`.

## Six kept with a reason

Test-only consumers the lib target cannot see: `admin/route_policy.rs::validate_admin_route_policy_specs`, `storage/ecfs_extend.rs::get_adaptive_buffer_size_with_profile`.

Written and never read back: `io_schedule.rs::original_priority`, `app/object_usecase.rs::io_strategy`, `storage/access.rs::region`, `storage/concurrency/manager.rs::priority_queue`.

## One finding worth a maintainer's eye

`console.rs::config_handler` is a complete handler with a test (`console_config_handler_serializes_admin_discovery_paths`) — but **no route registers it**. The console router wires favicon, license, version, health and a static fallback; nothing serves `/rustfs/console/api/v1/config`, so that path falls through to the SPA's `static_handler` and returns index.html rather than the JSON config. `Config::port` and `Config::to_json()` are used only by this handler, so the cluster hangs off an unreachable entry point.

It is kept rather than deleted: the test says the endpoint is meant to exist, which makes a dropped route the likelier explanation, and deleting the code would erase that signal. Filed on backlog#1823 for whoever knows whether the console still needs it.

## Verification

`cargo clippy -p rustfs --all-targets -- -D warnings` clean, `cargo nextest run -p rustfs --lib` — **3650 passed**, `cargo fmt --all` applied, all four guard scripts pass.
